### PR TITLE
Machine ID Docs Refactor: Kubernetes Platform Guide + some AWS/GCP

### DIFF
--- a/docs/pages/includes/machine-id/blank-role.mdx
+++ b/docs/pages/includes/machine-id/blank-role.mdx
@@ -1,0 +1,24 @@
+Now, a role must be created that will be encoded into the credentials output by
+`tbot`. This role will specify what the credentials will grant access to.
+For now, this role will be "empty" - the access guides you complete after this
+platform guide will instruct you to modify this role to grant the correct
+privileges.
+
+Create `bot-role.yaml`:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: example-bot
+spec:
+  allow: {}
+  deny: {}
+  options: {}
+```
+
+Use `tctl` to apply this file:
+
+```code
+$ tctl create -f bot-role.yaml
+```

--- a/docs/pages/includes/machine-id/blank-role.mdx
+++ b/docs/pages/includes/machine-id/blank-role.mdx
@@ -4,8 +4,6 @@ For now, this role will be "empty" - the access guides you complete after this
 platform guide will instruct you to modify this role to grant the correct
 privileges.
 
-TODO: Ensure its clear this role is not for the bot, but for the outputs
-
 Create `bot-role.yaml`:
 
 ```yaml

--- a/docs/pages/includes/machine-id/blank-role.mdx
+++ b/docs/pages/includes/machine-id/blank-role.mdx
@@ -4,6 +4,8 @@ For now, this role will be "empty" - the access guides you complete after this
 platform guide will instruct you to modify this role to grant the correct
 privileges.
 
+TODO: Ensure its clear this role is not for the bot, but for the outputs
+
 Create `bot-role.yaml`:
 
 ```yaml

--- a/docs/pages/machine-id/platform-guides/aws.mdx
+++ b/docs/pages/machine-id/platform-guides/aws.mdx
@@ -38,6 +38,33 @@ This guide will...
 
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
+Create `bot-token.yaml`:
+
+```yaml
+kind: token
+version: v2
+metadata:
+  # name will be specified in the `tbot` to use this token
+  name: example-bot
+spec:
+  roles: [Bot]
+  # bot_name will match the name of the bot created later in this guide.
+  bot_name: example
+  join_method: iam
+  # Restrict the AWS account and (optionally) ARN that can use this token.
+  # This information can be obtained from running the
+  # "aws sts get-caller-identity" command from the CLI.
+  allow:
+    - aws_account: "111111111111"
+      aws_arn: "arn:aws:sts::111111111111:assumed-role/teleport-bot-role/i-*"
+```
+
+Use `tctl` to apply this file:
+
+```code
+$ tctl create -f bot-token.yaml
+```
+
 ### Step 3/3. Configure `tbot`
 
 ### Step 4/4. Configure Outputs

--- a/docs/pages/machine-id/platform-guides/aws.mdx
+++ b/docs/pages/machine-id/platform-guides/aws.mdx
@@ -65,6 +65,12 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
+Create the bot, specifying the token and role that you have created:
+
+```code
+$ tctl bots add example --token example-bot --roles example-bot
+```
+
 ### Step 3/3. Configure `tbot`
 
 ### Step 4/4. Configure Outputs

--- a/docs/pages/machine-id/platform-guides/aws.mdx
+++ b/docs/pages/machine-id/platform-guides/aws.mdx
@@ -3,4 +3,40 @@ title: Deploying Machine ID on AWS
 description: How to install and configure Machine ID on an AWS EC2 instance
 ---
 
-TODO
+Google Cloud Platform is a blah blah blah. This document covers deploying
+Machine ID onto
+
+## Background
+
+TODO: Introduce AWS IAM Concepts
+
+### Elastic Kubernetes Service
+
+TODO: Explain how this guide can be modified to work with GKE and also point
+towards the Kubernetes guide.
+
+## Guide
+
+This guide will...
+
+### Before you start
+
+### Step 1/3. Assign a GCP Service Account to a VM
+
+### Step 2/3. Create a role and bot user
+
+(!docs/pages/includes/machine-id/blank-role.mdx!)
+
+### Step 3/3. Configure `tbot`
+
+### Step 4/4. Configure Outputs
+
+Follow one of the [access guides](../access-guides.mdx) to configure an output
+that meets your access needs.
+
+## Next steps
+
+- Follow the [access guides](../access-guides.mdx) to finish configuring `tbot` for
+  your environment.
+- Read the [configuration reference](../reference/configuration.mdx) to explore
+  all the available configuration options.

--- a/docs/pages/machine-id/platform-guides/aws.mdx
+++ b/docs/pages/machine-id/platform-guides/aws.mdx
@@ -3,17 +3,28 @@ title: Deploying Machine ID on AWS
 description: How to install and configure Machine ID on an AWS EC2 instance
 ---
 
-Google Cloud Platform is a blah blah blah. This document covers deploying
-Machine ID onto
+This page contains relevant background information and specific steps for
+deploying Machine ID on Amazon Web Services.
 
 ## Background
 
-TODO: Introduce AWS IAM Concepts
+### The `iam` join method
+
+TODO: Brief overview of how the join method works for this platform.
 
 ### Elastic Kubernetes Service
 
-TODO: Explain how this guide can be modified to work with GKE and also point
-towards the Kubernetes guide.
+Whilst the guide on this page focuses explicitly on deploying Machine ID on an
+EC2 instance, it is also possible to use the `iam` join method with
+workloads (e.g Pods) running on an EKS Kubernetes cluster.
+
+It is a requirement that
+[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+has been configured for the cluster and the Kubernetes service account that will
+be used by the `tbot` pod.
+
+See the [Kubernetes platform guide](../kubernetes.mdx) for further guidance
+on deploying Machine ID as a workload on Kubernetes.
 
 ## Guide
 

--- a/docs/pages/machine-id/platform-guides/aws.mdx
+++ b/docs/pages/machine-id/platform-guides/aws.mdx
@@ -23,7 +23,7 @@ It is a requirement that
 has been configured for the cluster and the Kubernetes service account that will
 be used by the `tbot` pod.
 
-See the [Kubernetes platform guide](../kubernetes.mdx) for further guidance
+See the [Kubernetes platform guide](kubernetes.mdx) for further guidance
 on deploying Machine ID as a workload on Kubernetes.
 
 ## Guide

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -3,4 +3,33 @@ title: Deploying Machine ID on GCP
 description: How to install and configure Machine ID on a GCP VM
 ---
 
-TODO
+Google Cloud Platform is a blah blah blah. This document covers deploying
+Machine ID onto
+
+## Background
+
+INTRODUCE GCP IAM.
+
+### Google Kubernetes Engine
+
+## Guide
+
+### Before you start
+
+### Step 1/3. Create a join token
+
+### Step 2/3. Create a role and bot user
+
+### Step 3/3. Configure `tbot`
+
+### Step 4/4. Configure Outputs
+
+Follow one of the [access guides](../access-guides.mdx) to configure an output
+that meets your access needs.
+
+## Next steps
+
+- Follow the [access guides](../access-guides.mdx) to finish configuring `tbot` for
+  your environment.
+- Read the [configuration reference](../reference/configuration.mdx) to explore
+  all the available configuration options.

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -25,6 +25,8 @@ This guide will...
 
 ### Step 2/3. Create a role and bot user
 
+(!docs/pages/includes/machine-id/blank-role.mdx!)
+
 ### Step 3/3. Configure `tbot`
 
 ### Step 4/4. Configure Outputs

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -32,13 +32,49 @@ This guide will...
 
 ### Before you start
 
-### Step 1/3. Assign a GCP Service Account to a VM
+### Step 1/4. Assign a GCP Service Account to a VM
 
-### Step 2/3. Create a role and bot user
+### Step 2/4. Create a join token, role and bot user
 
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
-### Step 3/3. Configure `tbot`
+Create `bot-token.yaml`:
+
+```yaml
+kind: token
+version: v2
+metadata:
+  # name will be specified in the `tbot` to use this token
+  name: example-bot
+spec:
+  roles: [Bot]
+  # bot_name will match the name of the bot created later in this guide.
+  bot_name: example
+  join_method: gcp
+  gcp:
+    # allow specifies the rules by which the Auth Server determines if `tbot`
+    # should be allowed to join.
+    allow:
+    - project_ids:
+        - my-project-123456
+      service_accounts:
+        # This should be the full "name" of a GCP service account. The default
+        # compute service account is not supported.
+        - my-service-account@my-project-123456.iam.gserviceaccount.com
+```
+
+Replace:
+- `my-project-123456` with the ID of your GCP project
+- `my-service-account@my-project-123456.iam.gserviceaccount.com` with the email
+  of the service account configured in the previous step.
+
+Use `tctl` to apply this file:
+
+```code
+$ tctl create -f bot-token.yaml
+```
+
+### Step 3/4. Configure `tbot`
 
 ### Step 4/4. Configure Outputs
 

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -8,15 +8,20 @@ Machine ID onto
 
 ## Background
 
-INTRODUCE GCP IAM.
+TODO: Introduce GCP IAM Concepts
 
 ### Google Kubernetes Engine
 
+TODO: Explain how this guide can be modified to work with GKE and also point
+towards the Kubernetes guide.
+
 ## Guide
+
+This guide will...
 
 ### Before you start
 
-### Step 1/3. Create a join token
+### Step 1/3. Assign a GCP Service Account to a VM
 
 ### Step 2/3. Create a role and bot user
 

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -3,17 +3,28 @@ title: Deploying Machine ID on GCP
 description: How to install and configure Machine ID on a GCP VM
 ---
 
-Google Cloud Platform is a blah blah blah. This document covers deploying
-Machine ID onto
+This page contains relevant background information and specific steps for
+deploying Machine ID on Google Cloud Platform.
 
 ## Background
 
-TODO: Introduce GCP IAM Concepts
+### The `gcp` join method
+
+TODO: Introduce GCP IAM Concepts and overview of the join method
 
 ### Google Kubernetes Engine
 
-TODO: Explain how this guide can be modified to work with GKE and also point
-towards the Kubernetes guide.
+Whilst the guide on this page focuses explicitly on deploying Machine ID on a
+GCP Virtual Machine, it is also possible to use the `gcp` join method with
+workloads (e.g Pods) running on a GKE Kubernetes cluster.
+
+It is a requirement that
+[GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+has been configured for the cluster and the Kubernetes service account that will
+be used by the `tbot` pod.
+
+See the [Kubernetes platform guide](../kubernetes.mdx) for further guidance
+on deploying Machine ID as a workload on Kubernetes.
 
 ## Guide
 

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -23,7 +23,7 @@ It is a requirement that
 has been configured for the cluster and the Kubernetes service account that will
 be used by the `tbot` pod.
 
-See the [Kubernetes platform guide](../kubernetes.mdx) for further guidance
+See the [Kubernetes platform guide](kubernetes.mdx) for further guidance
 on deploying Machine ID as a workload on Kubernetes.
 
 ## Guide

--- a/docs/pages/machine-id/platform-guides/gcp.mdx
+++ b/docs/pages/machine-id/platform-guides/gcp.mdx
@@ -74,6 +74,12 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
+Create the bot, specifying the token and role that you have created:
+
+```code
+$ tctl bots add example --token example-bot --roles example-bot
+```
+
 ### Step 3/4. Configure `tbot`
 
 ### Step 4/4. Configure Outputs

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -309,7 +309,7 @@ Replace `example.teleport.sh` with the name of your Teleport cluster - this is
 not necessarily the public address (the port should not be included).
 
 This is an example manifest, consider modifying it to fit within the conventions
-of deployments to your clusters (e.g customising labels).
+of deployments to your clusters (e.g customizing labels).
 
 Apply this file to your Kubernetes cluster:
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -24,29 +24,9 @@ Due to the current limited support in Kubernetes for sidecars, we recommend that
 the Standalone Deployment style is used. This style will be covered later in
 this guide.
 
-## Guide
+## Before you start
 
-### Before you start
-
-###
-
-```yaml
-kind: token
-version: v2
-metadata:
-  name: kubernetes-bot
-spec:
-  roles: [Bot]
-  bot_name: docker-desktop
-  join_method: kubernetes
-  kubernetes:
-    type: static_jwks
-    static_jwks:
-      jwks: |
-        {"keys":[{"use":"sig","kty":"RSA","kid":"KCk4tlf5yXj7GJ20L9XcvviNIiCf1QaUhw1Cyzd5VjA","alg":"RS256","n":"vYiAKomeNl--3-HaQ24DhJLlgg05gWIKmYRUxPx5vg4NLTdezUHxl70mygFNSYQrSgRqGpUp1j3_fOQYVKhWOVMPLtIYz4pnH-3mUBhNhpfLZiyMUqtjhijekqGOhlbEwHDvCm0tAMESSJBNHneR2tqEugsnDOpPmi3Z220MPJFO9FotFNd4vhmwEp9raWEIRSW3tRZiBoZ_1DAgR5LlO4q__sr125WL0n3s9exVrjQJxpkkUD4ECdO9020VtgPXL3sw__bE0UMuOWDvAY2sCb6rIN76rRLUbGc_IIP1ahLoFVDqdef-tsFM4pW_dbXu77YpfTfK_sTKOEVeGtKBJQ","e":"AQAB"}]}
-    allow:
-    - service_account: "default:tbot"
-```
+## Step 1/4. Prepare Kubernetes RBAC
 
 ```yaml
 apiVersion: v1
@@ -77,6 +57,46 @@ rules:
     verbs: ["*"]
 ```
 
+
+## Step 2/4. Create a join token and bot user
+
+```yaml
+kind: token
+version: v2
+metadata:
+  name: bot-kubernetes
+spec:
+  roles: [Bot]
+  bot_name: docker-desktop
+  join_method: kubernetes
+  kubernetes:
+    type: static_jwks
+    static_jwks:
+      jwks: |
+        {"keys":[{"use":"sig","kty":"RSA","kid":"KCk4tlf5yXj7GJ20L9XcvviNIiCf1QaUhw1Cyzd5VjA","alg":"RS256","n":"vYiAKomeNl--3-HaQ24DhJLlgg05gWIKmYRUxPx5vg4NLTdezUHxl70mygFNSYQrSgRqGpUp1j3_fOQYVKhWOVMPLtIYz4pnH-3mUBhNhpfLZiyMUqtjhijekqGOhlbEwHDvCm0tAMESSJBNHneR2tqEugsnDOpPmi3Z220MPJFO9FotFNd4vhmwEp9raWEIRSW3tRZiBoZ_1DAgR5LlO4q__sr125WL0n3s9exVrjQJxpkkUD4ECdO9020VtgPXL3sw__bE0UMuOWDvAY2sCb6rIN76rRLUbGc_IIP1ahLoFVDqdef-tsFM4pW_dbXu77YpfTfK_sTKOEVeGtKBJQ","e":"AQAB"}]}
+    allow:
+    - service_account: "default:tbot"
+```
+
+## Step 3/4. Create a `tbot` deployment
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tbot-config
+data:
+  tbot.yaml: |
+    version: v2
+    onboarding:
+      join_method: kubernetes
+      token: bot-kubernetes
+    storage:
+      type: memory
+    auth_server: example.teleport.sh:443
+    outputs: [] # This section will be filled later in the guide.
+```
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -96,7 +116,7 @@ spec:
     spec:
       containers:
         - name: tbot
-          image: public.ecr.aws/gravitational/teleport:14.0.0
+          image: public.ecr.aws/gravitational/teleport:(=teleport.version=)
           command:
             - tbot
           args:
@@ -126,33 +146,50 @@ spec:
               - serviceAccountToken:
                   path: join-sa-token
                   expirationSeconds: 600
-                  audience: leaf.tele.ottr.sh
+                  audience: example.teleport.sh
 ```
+
+## Step 4/4. Configure Outputs
+
+Follow one of the access guides to configure an output that produces the type
+of credentials.
+
+When configuring the outputs, use a Kubernetes secret destination (e.g):
+
+```yaml
+outputs:
+  - type: identity
+    destination:
+      type: kubernetes_secret
+      secret_name: identity-output
+```
+
+The output can then be consumed by mounting this secret within another pod:
 
 ```yaml
 apiVersion: v1
-kind: ConfigMap
+kind: Pod
 metadata:
-  name: tbot-config
-data:
-  tbot.yaml: |
-    version: v2
-    onboarding:
-      join_method: kubernetes
-      token: bot-kubernetes
-    storage:
-      type: memory
-    auth_server: example.teleport.sh:443
-    outputs:
-      # Replace this output with the appropriate one determined in the access
-      # guide you follow after this guide. Retain the `destination` field to
-      # write to a secret.
-      - type: identity
-        destination:
-          type: kubernetes_secret
-          secret_name: output-secret
+  name: tsh
+spec:
+  containers:
+    - name: tsh
+      image: public.ecr.aws/gravitational/teleport:(=teleport.version=)
+      command:
+        - tsh
+      args:
+       - -i
+       - /identity-output/identity
+       - --proxy
+       - example.teleport.sh:443
+       - ls
+      volumeMounts:
+        - name: identity-output
+          mountPath: /identity-output
+  volumes:
+    - name: identity-output
+      secret:
+        secretName: identity-output
 ```
 
-## Next steps
-
-TODO: Follow an access guide to configure access >:3
+## Further steps

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -141,12 +141,13 @@ $ kubectl apply -f ./k8s-rbac.yaml
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
 Next, a join token needs to be configured. This will be used by `tbot` to join
-the cluster. As the `kubernetes` join method will be used, the JWKS of the
-Kubernetes Cluster must first be determined. This will allow the Teleport
-Auth Server to verify that the Service Account token presented by `tbot` is
-signed legitimately by the Kubernetes cluster.
+the cluster. As the `kubernetes` join method will be used, the public key of the
+Kubernetes cluster must first be determined. The public key used to sign JWTs
+is exposed on the "JWKS" endpoint of the Kubernetes API server. This public key
+can then be used by the Teleport Auth  to verify that the Service Account JWT
+presented by `tbot` is signed legitimately by the Kubernetes cluster.
 
-Run the following commands to determine the JWKS:
+Run the following commands to determine the JWKS formatted public key:
 
 ```code
 $ kubectl proxy -p 8080
@@ -161,18 +162,31 @@ in `spec.kubernetes.static_jwks.jwks`:
 kind: token
 version: v2
 metadata:
+  # name will be specified in the `tbot` to use this token
   name: example-bot
 spec:
   roles: [Bot]
+  # bot_name will match the name of the bot created later in this guide.
   bot_name: example
   join_method: kubernetes
   kubernetes:
+    # static_jwks configures the Auth Server to validate the JWT presented by
+    # `tbot` using the public key from a statically configured JWKS.
     type: static_jwks
     static_jwks:
       jwks: |
-        {"keys":[--snip--]} # Place the data returned by the curl command here
+        # Place the data returned by the curl command here
+        {"keys":[--snip--]}
+    # allow specifies the rules by which the Auth Server determines if `tbot`
+    # should be allowed to join.
     allow:
-    - service_account: "default:tbot" # In the format of `namespace:service_account_name`
+    - service_account: "default:tbot" # service_account
+```
+
+Use `tctl` to apply this file:
+
+```code
+$ tctl create -f bot-token.yaml
 ```
 
 Create the bot, specifying the token and role that you have created:

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -134,7 +134,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-Apply this file to your Kubernetes Cluster:
+Apply this file to your Kubernetes cluster:
 
 ```code
 $ kubectl apply -f ./k8s-rbac.yaml
@@ -232,17 +232,15 @@ data:
     outputs: []
 ```
 
-Apply this file to your Kubernetes Cluster:
+Apply this file to your Kubernetes cluster:
 
 ```code
 $ kubectl apply -f k8s-deployment-config.yaml
 ```
 
 With the ConfigMap created, you can now create the `tbot` deployment itself.
-For this
 
-Create `k8s-deployment.yaml`, replacing `example.teleport.sh` with the name
-of your Teleport cluster:
+Create `k8s-deployment.yaml`:
 
 ```yaml
 apiVersion: apps/v1
@@ -307,20 +305,27 @@ spec:
                   audience: example.teleport.sh
 ```
 
-Apply this file to your Kubernetes Cluster:
+Replace `example.teleport.sh` with the name of your Teleport cluster - this is
+not necessarily the public address (the port should not be included).
+
+This is an example manifest, consider modifying it to fit within the conventions
+of deployments to your clusters (e.g customising labels).
+
+Apply this file to your Kubernetes cluster:
 
 ```code
 $ kubectl apply -f ./k8s-deployment.yaml
 ```
 
-TODO: How to check it's running happily
+Use `kubectl` to verify that the deployment is healthy:
 
 ```code
 $ kubectl describe deployment/tbot
 $ kubectl logs deployment/tbot
 ```
 
-TODO: Explain at this point that its not doing much.
+With this complete, `tbot` is now successfully deployed to your cluster.
+However, it is not yet producing any useful output.
 
 ### Step 4/4. Configure Outputs
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -9,10 +9,11 @@ to other workloads running in the same Kubernetes namespace.
 
 ## Background
 
-There are typically two deployment styles when it comes to workloads such as
-`tbot` which provide a service to other workloads in your cluster.
+### Deployment vs Sidecar
 
-**Standalone Deployment**: `tbot` runs as a Kubernetes deployment, writing the
+When deploying `tbot` into your Kubernetes cluster, there are two main options:
+
+**Deployment**: `tbot` runs as a Kubernetes deployment, writing the
 output credentials to a Kubernetes secret, which can then be mounted in the pods
 that need to use the credentials.
 
@@ -24,12 +25,41 @@ Due to the current limited support in Kubernetes for sidecars, we recommend that
 the Standalone Deployment style is used. This style will be covered later in
 this guide.
 
-## Before you start
+### Join Method
 
-This guide will deploy the resources to the `default` Kubernetes Namespace.
-Modify this value to deploy Machine ID into a Namespace of your choosing.
+In order for `tbot` to join your Teleport cluster, a join token must be
+configured. A join token is configured with a join method that specifies how
+`tbot` can perform the initial authentication. These join methods are platform
+specific in order to leverage forms of identity available on that platform.
 
-## Step 1/4. Prepare Kubernetes RBAC
+When deploying `tbot` to a Teleport cluster, it is generally recommended to use
+the `kubernetes` join method. This will work with most Kubernetes clusters.
+The guide that follows will demonstrate configuring this join method.
+
+However, when using certain cloud Kubernetes services, it is possible to use the
+join method associated with that platform rather than the `kubernetes` join
+method. This may be beneficial if you wish to manage the joining of `tbot`
+within the Kubernetes clusters and on standard VMs on the same platform with
+a single join token. These services are:
+
+- Google Kubernetes Engine: Where
+  [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+  is configured for the cluster, it is possible to use the `gcp` join method.
+  See the [GCP Platform Guide](./gcp.mdx) for further information.
+- AWS Elastic Kubernetes Service: Where
+  [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+  is configured for the cluster, it is possible to use the `iam` join method.
+  See the [AWS Platform Guide](./aws.mdx) for further information.
+
+## Guide
+
+### Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+- `kubectl` configured to access the cluster you wish to deploy `tbot` into.
+- TODO: K8S version
+
+### Step 1/4. Prepare Kubernetes RBAC
 
 In order to prepare the Kubernetes cluster for Machine ID, several Kubernetes
 RBAC resources must be created.
@@ -82,7 +112,7 @@ Apply this file to your Kubernetes Cluster:
 $ kubectl apply -f ./k8s-rbac.yaml
 ```
 
-## Step 2/4. Create a join token and bot user
+### Step 2/4. Create a join token and bot user
 
 ```code
 $ kubectl proxy -p 8080
@@ -93,7 +123,7 @@ $ curl http://localhost:8080/openid/v1/jwks
 kind: token
 version: v2
 metadata:
-  name: bot-kubernetes
+  name: bot-kubernetes-demo
 spec:
   roles: [Bot]
   bot_name: docker-desktop
@@ -107,7 +137,11 @@ spec:
     - service_account: "default:tbot" # In the format of `namespace:service_account_name`
 ```
 
-## Step 3/4. Create a `tbot` deployment
+```code
+$ tctl bots add kubernetes-demo --token bot-kubernetes-demo --roles TODO-THEYNEEDAROLEHEREBUTWEDONTKNOWWHATTHJEROLENEEDSUNTILACCESS
+```
+
+### Step 3/4. Create a `tbot` deployment
 
 ```yaml
 apiVersion: v1
@@ -185,12 +219,14 @@ $ kubectl apply -f ./k8s-deployment-config.yaml
 $ kubectl apply -f ./k8s-deployment.yaml
 ```
 
-## Step 4/4. Configure Outputs
+### Step 4/4. Configure Outputs
 
-Follow one of the access guides to configure an output that produces the type
-of credentials.
+Follow one of the [access guides](../access-guides.mdx) to configure an output
+that meets your access needs.
 
-When configuring the outputs, use a Kubernetes secret destination (e.g):
+In order to adjust the access guide to work well with Kubernetes, use the
+Kubernetes Secret destination type. This will write the generated artifacts
+to a specified Kubernetes Secret, for example:
 
 ```yaml
 outputs:
@@ -229,4 +265,7 @@ spec:
         secretName: identity-output
 ```
 
-## Further steps
+## Next steps
+
+REFERENCE
+ACCESS GUIDES

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -3,4 +3,156 @@ title: Deploying Machine ID on Kubernetes
 description: How to install and configure Machine ID on Kubernetes
 ---
 
-TODO
+Kubernetes is a popular container workload orchestrator. This document covers
+deploying Machine ID as a Kubernetes workload in order to provide credentials
+to other workloads running in the same Kubernetes namespace.
+
+## Background
+
+There are typically two deployment styles when it comes to workloads such as
+`tbot` which provide a service to other workloads in your cluster.
+
+**Standalone Deployment**: `tbot` runs as a Kubernetes deployment, writing the
+output credentials to a Kubernetes secret, which can then be mounted in the pods
+that need to use the credentials.
+
+**Sidecar**: `tbot` runs as a second container within the same pod as the
+service that needs to use the credentials. The credentials are written to a
+directory which is mounted within both the containers.
+
+Due to the current limited support in Kubernetes for sidecars, we recommend that
+the Standalone Deployment style is used. This style will be covered later in
+this guide.
+
+## Guide
+
+### Before you start
+
+###
+
+```yaml
+kind: token
+version: v2
+metadata:
+  name: kubernetes-bot
+spec:
+  roles: [Bot]
+  bot_name: docker-desktop
+  join_method: kubernetes
+  kubernetes:
+    type: static_jwks
+    static_jwks:
+      jwks: |
+        {"keys":[{"use":"sig","kty":"RSA","kid":"KCk4tlf5yXj7GJ20L9XcvviNIiCf1QaUhw1Cyzd5VjA","alg":"RS256","n":"vYiAKomeNl--3-HaQ24DhJLlgg05gWIKmYRUxPx5vg4NLTdezUHxl70mygFNSYQrSgRqGpUp1j3_fOQYVKhWOVMPLtIYz4pnH-3mUBhNhpfLZiyMUqtjhijekqGOhlbEwHDvCm0tAMESSJBNHneR2tqEugsnDOpPmi3Z220MPJFO9FotFNd4vhmwEp9raWEIRSW3tRZiBoZ_1DAgR5LlO4q__sr125WL0n3s9exVrjQJxpkkUD4ECdO9020VtgPXL3sw__bE0UMuOWDvAY2sCb6rIN76rRLUbGc_IIP1ahLoFVDqdef-tsFM4pW_dbXu77YpfTfK_sTKOEVeGtKBJQ","e":"AQAB"}]}
+    allow:
+    - service_account: "default:tbot"
+```
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tbot
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tbot-secrets-admin
+subjects:
+  - kind: ServiceAccount
+    name: tbot
+roleRef:
+  kind: Role
+  name:  secrets-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: secrets-admin
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    verbs: ["*"]
+```
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tbot
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tbot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tbot
+    spec:
+      containers:
+        - name: tbot
+          image: public.ecr.aws/gravitational/teleport:14.0.0
+          command:
+            - tbot
+          args:
+            - start
+            - -c
+            - /config/tbot.yaml
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+      serviceAccountName: tbot
+      volumes:
+        - name: config
+          configMap:
+            name: tbot-config
+        - name: join-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: join-sa-token
+                  expirationSeconds: 600
+                  audience: leaf.tele.ottr.sh
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tbot-config
+data:
+  tbot.yaml: |
+    version: v2
+    onboarding:
+      join_method: kubernetes
+      token: bot-kubernetes
+    storage:
+      type: memory
+    auth_server: example.teleport.sh:443
+    outputs:
+      # Replace this output with the appropriate one determined in the access
+      # guide you follow after this guide. Retain the `destination` field to
+      # write to a secret.
+      - type: identity
+        destination:
+          type: kubernetes_secret
+          secret_name: output-secret
+```
+
+## Next steps
+
+TODO: Follow an access guide to configure access >:3

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -102,7 +102,9 @@ metadata:
   name: tbot
   namespace: default
 ---
-# This role grants the ability to manage secrets within the namespace.
+# This role grants the ability to manage secrets within the namespace - this is
+# necessary for the `kubernetes_secret` destination to work correctly.
+#
 # You may wish to add the `resourceNames` field to the role to further restrict
 # this access in sensitive environments.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -130,33 +130,7 @@ $ kubectl apply -f ./k8s-rbac.yaml
 
 ### Step 2/4. Create a join token, role and bot user
 
-TODO: Improve this description to make it clear this is the role the bot
-TODO: attaches to generated credentials and not the role the bot uses itself
-TODO: We need to do a better job at distinguishing this.
-TODO: As each guide will do this, let's pull this into a include
-
-First, a role must be created that the bot will use when outputting credentials.
-For now, an empty role will be created, but in the access guides, you will add
-privileges to this role.
-
-Create `bot-role.yaml`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: example-bot
-spec:
-  allow: {}
-  deny: {}
-  options: {}
-```
-
-Use `tctl` to apply this file:
-
-```code
-$ tctl create -f bot-role.yaml
-```
+(!docs/pages/includes/machine-id/blank-role.mdx!)
 
 Now the join token must be created. Before we can create it, we need to
 determine the JWKS of the Kubernetes Cluster.

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -96,6 +96,8 @@ will allow the `tbot` Pod to read and write credentials to a Secret.
 Create a file called `k8s-rbac.yaml`:
 
 ```yaml
+# This ServiceAccount will be used to give the `tbot` pods a discrete identity
+# which can be validated by the Teleport Auth Server.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -199,12 +201,12 @@ $ tctl bots add example --token example-bot --roles example-bot
 
 ### Step 3/4. Create a `tbot` deployment
 
-TODO: Explain these
+First, a ConfigMap will be created to contain the configuration file for `tbot`.
+This will then be mounted into the Pod.
 
-The configuration for `tbot` will be stored inside a Kubernetes ConfigMap.
-This can then be mapped into the pod.
-
-Create `k8s-deployment-config.yaml`:
+Create `k8s-deployment-config.yaml`, replacing the value of `token` with the
+name of the token you created earlier and the value of `auth_server` with the
+address of your Teleport Proxy or Auth Server:
 
 ```yaml
 apiVersion: v1
@@ -217,9 +219,14 @@ data:
     version: v2
     onboarding:
       join_method: kubernetes
+      # ensure token is set to the name of the join token you created earlier
       token: bot-kubernetes
     storage:
+      # a memory destination is used for the bots own state since the kubernetes
+      # join method does not require persistence.
       type: memory
+    # ensure this is configured to the address of your Teleport Proxy or
+    # Auth Server. Prefer the address of the Teleport Proxy.
     auth_server: example.teleport.sh:443
     # outputs will be filled in during the completion of an access guide.
     outputs: []
@@ -232,8 +239,10 @@ $ kubectl apply -f k8s-deployment-config.yaml
 ```
 
 With the ConfigMap created, you can now create the `tbot` deployment itself.
+For this
 
-Create `k8s-deployment.yaml`:
+Create `k8s-deployment.yaml`, replacing `example.teleport.sh` with the name
+of your Teleport cluster:
 
 ```yaml
 apiVersion: apps/v1
@@ -263,10 +272,16 @@ spec:
             - -c
             - /config/tbot.yaml
           env:
+            # POD_NAMESPACE is required for the kubernetes_secret` destination
+            # type to work correctly.
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # KUBERNETES_TOKEN_PATH specifies the path to the service account
+            # JWT to use for joining.
+            # This path is based on the configuration of the volume and
+            # volumeMount.
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
           volumeMounts:
@@ -284,7 +299,11 @@ spec:
             sources:
               - serviceAccountToken:
                   path: join-sa-token
+                  # 600 seconds is the minimum that Kubernetes supports. We
+                  # recommend this value is used.
                   expirationSeconds: 600
+                  # `example.teleport.sh` must be replaced with the name of
+                  # your Teleport cluster.
                   audience: example.teleport.sh
 ```
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -3,9 +3,8 @@ title: Deploying Machine ID on Kubernetes
 description: How to install and configure Machine ID on Kubernetes
 ---
 
-Kubernetes is a popular container workload orchestrator. This document covers
-deploying Machine ID as a Kubernetes workload in order to provide credentials
-to other workloads running in the same Kubernetes namespace.
+This page contains relevant background information and specific steps for
+deploying Machine ID on Kubernetes.
 
 ## Background
 
@@ -22,15 +21,14 @@ service that needs to use the credentials. The credentials are written to a
 directory which is mounted within both the containers.
 
 Due to the current limited support in Kubernetes for sidecars, we recommend that
-the Standalone Deployment style is used. This style will be covered later in
-this guide.
+the Standalone Deployment style is used. The guide will demonstrate this
+recommendation.
 
-### Join method
+### The `kubernetes` join method
 
-In order for `tbot` to join your Teleport cluster, a join token must be
-configured. A join token is configured with a join method that specifies how
-`tbot` can perform the initial authentication. These join methods are platform
-specific in order to leverage forms of identity available on that platform.
+TODO: Brief overview of how the join method works for this platform.
+
+### Using a non-`kubernetes` join method
 
 When deploying `tbot` to a Teleport cluster, it is generally recommended to use
 the `kubernetes` join method. This will work with most Kubernetes clusters.
@@ -70,6 +68,7 @@ Namespace you wish to use.
   default in Kubernetes 1.20).
 - `kubectl` authenticated with the ability to create resources in the cluster
   you wish to deploy `tbot` into.
+- TODO: Rest of prerequisites
 
 ### Step 1/4. Prepare Kubernetes RBAC
 
@@ -249,7 +248,7 @@ $ kubectl apply -f ./k8s-deployment-config.yaml
 $ kubectl apply -f ./k8s-deployment.yaml
 ```
 
-TODO: VERIFY IT WORKS!!
+TODO: How to check it's running happily
 
 ### Step 4/4. Configure Outputs
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -275,6 +275,8 @@ $ kubectl apply -f ./k8s-deployment-config.yaml
 $ kubectl apply -f ./k8s-deployment.yaml
 ```
 
+TODO: VERIFY IT WORKS!!
+
 ### Step 4/4. Configure Outputs
 
 Follow one of the [access guides](../access-guides.mdx) to configure an output

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -26,8 +26,16 @@ recommendation.
 
 ### The `kubernetes` join method
 
-TODO: Brief overview of how the join method works for this platform. Explain
-TODO: JWKS
+The `kubernetes` join method, used by `tbot` to prove its identity to the
+Teleport Auth Server, identifies the bot using the Kubernetes Service Account
+that is associated with the Pod that `tbot` is running within.
+
+The Pod receives a JWT signed by the Kubernetes API server. This JWT contains
+claims that identify the service account, the pod and the namespace.
+
+In order to validate a presented JWT is legitimate, the Teleport Auth Server
+checks the signature of the JWT against the Kubernetes cluster's public signing
+key.
 
 ### Using a non-`kubernetes` join method
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -26,18 +26,37 @@ this guide.
 
 ## Before you start
 
+This guide will deploy the resources to the `default` Kubernetes Namespace.
+Modify this value to deploy Machine ID into a Namespace of your choosing.
+
 ## Step 1/4. Prepare Kubernetes RBAC
+
+In order to prepare the Kubernetes cluster for Machine ID, several Kubernetes
+RBAC resources must be created.
+
+A ServiceAccount will be created and later assigned to the Pod that will run
+`tbot`. This creates a static identity that we can allow access to join the
+Teleport Cluster and also provides an identity to which we can assign Kubernetes
+privileges.
+
+A Role granting the ability to read and write to secrets in the Namespace will
+be created and then assigned to the ServiceAccount using a RoleBinding. This
+will allow the `tbot` Pod to read and write credentials to a Secret.
+
+Create a file called `k8s-rbac.yaml`:
 
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tbot
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tbot-secrets-admin
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: tbot
@@ -49,16 +68,26 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: default
   name: secrets-admin
+  namespace: default
 rules:
-  - apiGroups: [""] # "" indicates the core API group
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["*"]
 ```
 
+Apply this file to your Kubernetes Cluster:
+
+```code
+$ kubectl apply -f ./k8s-rbac.yaml
+```
 
 ## Step 2/4. Create a join token and bot user
+
+```code
+$ kubectl proxy -p 8080
+$ curl http://localhost:8080/openid/v1/jwks
+```
 
 ```yaml
 kind: token
@@ -73,9 +102,9 @@ spec:
     type: static_jwks
     static_jwks:
       jwks: |
-        {"keys":[{"use":"sig","kty":"RSA","kid":"KCk4tlf5yXj7GJ20L9XcvviNIiCf1QaUhw1Cyzd5VjA","alg":"RS256","n":"vYiAKomeNl--3-HaQ24DhJLlgg05gWIKmYRUxPx5vg4NLTdezUHxl70mygFNSYQrSgRqGpUp1j3_fOQYVKhWOVMPLtIYz4pnH-3mUBhNhpfLZiyMUqtjhijekqGOhlbEwHDvCm0tAMESSJBNHneR2tqEugsnDOpPmi3Z220MPJFO9FotFNd4vhmwEp9raWEIRSW3tRZiBoZ_1DAgR5LlO4q__sr125WL0n3s9exVrjQJxpkkUD4ECdO9020VtgPXL3sw__bE0UMuOWDvAY2sCb6rIN76rRLUbGc_IIP1ahLoFVDqdef-tsFM4pW_dbXu77YpfTfK_sTKOEVeGtKBJQ","e":"AQAB"}]}
+        # Place the data returned by the curl command here
     allow:
-    - service_account: "default:tbot"
+    - service_account: "default:tbot" # In the format of `namespace:service_account_name`
 ```
 
 ## Step 3/4. Create a `tbot` deployment
@@ -85,6 +114,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tbot-config
+  namespace: default
 data:
   tbot.yaml: |
     version: v2
@@ -102,6 +132,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tbot
+  namespace: default
 spec:
   replicas: 1
   strategy:
@@ -149,6 +180,11 @@ spec:
                   audience: example.teleport.sh
 ```
 
+```code
+$ kubectl apply -f ./k8s-deployment-config.yaml
+$ kubectl apply -f ./k8s-deployment.yaml
+```
+
 ## Step 4/4. Configure Outputs
 
 Follow one of the access guides to configure an output that produces the type
@@ -171,6 +207,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: tsh
+  namespace: default
 spec:
   containers:
     - name: tsh

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -94,6 +94,20 @@ metadata:
   name: tbot
   namespace: default
 ---
+# This role grants the ability to manage secrets within the namespace.
+# You may wish to add the `resourceNames` field to the role to further restrict
+# this access in sensitive environments.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secrets-admin
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+---
+# Bind the role to the service account created for tbot.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -106,16 +120,6 @@ roleRef:
   kind: Role
   name:  secrets-admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: secrets-admin
-  namespace: default
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["*"]
 ```
 
 Apply this file to your Kubernetes Cluster:

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -26,7 +26,8 @@ recommendation.
 
 ### The `kubernetes` join method
 
-TODO: Brief overview of how the join method works for this platform.
+TODO: Brief overview of how the join method works for this platform. Explain
+TODO: JWKS
 
 ### Using a non-`kubernetes` join method
 
@@ -131,13 +132,18 @@ $ kubectl apply -f ./k8s-rbac.yaml
 
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
-Now the join token must be created. Before we can create it, we need to
-determine the JWKS of the Kubernetes Cluster.
-TODO: Explain why we need to fetch the jwks
+Next, a join token needs to be configured. This will be used by `tbot` to join
+the cluster. As the `kubernetes` join method will be used, the JWKS of the
+Kubernetes Cluster must first be determined. This will allow the Teleport
+Auth Server to verify that the Service Account token presented by `tbot` is
+signed legitimately by the Kubernetes cluster.
+
+Run the following commands to determine the JWKS:
 
 ```code
 $ kubectl proxy -p 8080
 $ curl http://localhost:8080/openid/v1/jwks
+{"keys":[--snip--]}%
 ```
 
 Create `bot-token.yaml`, ensuring you insert the value from the JWKS endpoint
@@ -156,7 +162,7 @@ spec:
     type: static_jwks
     static_jwks:
       jwks: |
-        # Place the data returned by the curl command here
+        {"keys":[--snip--]} # Place the data returned by the curl command here
     allow:
     - service_account: "default:tbot" # In the format of `namespace:service_account_name`
 ```
@@ -170,6 +176,11 @@ $ tctl bots add example --token example-bot --roles example-bot
 ### Step 3/4. Create a `tbot` deployment
 
 TODO: Explain these
+
+The configuration for `tbot` will be stored inside a Kubernetes ConfigMap.
+This can then be mapped into the pod.
+
+Create `k8s-deployment-config.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -189,6 +200,16 @@ data:
     # outputs will be filled in during the completion of an access guide.
     outputs: []
 ```
+
+Apply this file to your Kubernetes Cluster:
+
+```code
+$ kubectl apply -f k8s-deployment-config.yaml
+```
+
+With the ConfigMap created, you can now create the `tbot` deployment itself.
+
+Create `k8s-deployment.yaml`:
 
 ```yaml
 apiVersion: apps/v1
@@ -243,12 +264,20 @@ spec:
                   audience: example.teleport.sh
 ```
 
+Apply this file to your Kubernetes Cluster:
+
 ```code
-$ kubectl apply -f ./k8s-deployment-config.yaml
 $ kubectl apply -f ./k8s-deployment.yaml
 ```
 
 TODO: How to check it's running happily
+
+```code
+$ kubectl describe deployment/tbot
+$ kubectl logs deployment/tbot
+```
+
+TODO: Explain at this point that its not doing much.
 
 ### Step 4/4. Configure Outputs
 

--- a/docs/pages/machine-id/platform-guides/kubernetes.mdx
+++ b/docs/pages/machine-id/platform-guides/kubernetes.mdx
@@ -25,7 +25,7 @@ Due to the current limited support in Kubernetes for sidecars, we recommend that
 the Standalone Deployment style is used. This style will be covered later in
 this guide.
 
-### Join Method
+### Join method
 
 In order for `tbot` to join your Teleport cluster, a join token must be
 configured. A join token is configured with a join method that specifies how
@@ -53,11 +53,23 @@ a single join token. These services are:
 
 ## Guide
 
+This guide will demonstrate installing `tbot` into a Kubernetes cluster as a
+Deployment. The `kubernetes` join method will be used to authenticate the bot
+to the Teleport cluster.
+
+<Admonition type="tip" title="Namespace">
+The examples in this guide will install a `tbot` deployment in the `default`
+Namespace of the Kubernetes cluster. Adjust references to `default` to the
+Namespace you wish to use.
+</Admonition>
+
 ### Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
-- `kubectl` configured to access the cluster you wish to deploy `tbot` into.
-- TODO: K8S version
+- A Kubernetes cluster with support for Token Volume Projection (enabled by
+  default in Kubernetes 1.20).
+- `kubectl` authenticated with the ability to create resources in the cluster
+  you wish to deploy `tbot` into.
 
 ### Step 1/4. Prepare Kubernetes RBAC
 
@@ -112,21 +124,56 @@ Apply this file to your Kubernetes Cluster:
 $ kubectl apply -f ./k8s-rbac.yaml
 ```
 
-### Step 2/4. Create a join token and bot user
+### Step 2/4. Create a join token, role and bot user
+
+TODO: Improve this description to make it clear this is the role the bot
+TODO: attaches to generated credentials and not the role the bot uses itself
+TODO: We need to do a better job at distinguishing this.
+TODO: As each guide will do this, let's pull this into a include
+
+First, a role must be created that the bot will use when outputting credentials.
+For now, an empty role will be created, but in the access guides, you will add
+privileges to this role.
+
+Create `bot-role.yaml`:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: example-bot
+spec:
+  allow: {}
+  deny: {}
+  options: {}
+```
+
+Use `tctl` to apply this file:
+
+```code
+$ tctl create -f bot-role.yaml
+```
+
+Now the join token must be created. Before we can create it, we need to
+determine the JWKS of the Kubernetes Cluster.
+TODO: Explain why we need to fetch the jwks
 
 ```code
 $ kubectl proxy -p 8080
 $ curl http://localhost:8080/openid/v1/jwks
 ```
 
+Create `bot-token.yaml`, ensuring you insert the value from the JWKS endpoint
+in `spec.kubernetes.static_jwks.jwks`:
+
 ```yaml
 kind: token
 version: v2
 metadata:
-  name: bot-kubernetes-demo
+  name: example-bot
 spec:
   roles: [Bot]
-  bot_name: docker-desktop
+  bot_name: example
   join_method: kubernetes
   kubernetes:
     type: static_jwks
@@ -137,11 +184,15 @@ spec:
     - service_account: "default:tbot" # In the format of `namespace:service_account_name`
 ```
 
+Create the bot, specifying the token and role that you have created:
+
 ```code
-$ tctl bots add kubernetes-demo --token bot-kubernetes-demo --roles TODO-THEYNEEDAROLEHEREBUTWEDONTKNOWWHATTHJEROLENEEDSUNTILACCESS
+$ tctl bots add example --token example-bot --roles example-bot
 ```
 
 ### Step 3/4. Create a `tbot` deployment
+
+TODO: Explain these
 
 ```yaml
 apiVersion: v1
@@ -158,7 +209,8 @@ data:
     storage:
       type: memory
     auth_server: example.teleport.sh:443
-    outputs: [] # This section will be filled later in the guide.
+    # outputs will be filled in during the completion of an access guide.
+    outputs: []
 ```
 
 ```yaml
@@ -224,7 +276,7 @@ $ kubectl apply -f ./k8s-deployment.yaml
 Follow one of the [access guides](../access-guides.mdx) to configure an output
 that meets your access needs.
 
-In order to adjust the access guide to work well with Kubernetes, use the
+In order to adjust the access guides to work well with Kubernetes, use the
 Kubernetes Secret destination type. This will write the generated artifacts
 to a specified Kubernetes Secret, for example:
 
@@ -267,5 +319,7 @@ spec:
 
 ## Next steps
 
-REFERENCE
-ACCESS GUIDES
+- Follow the [access guides](../access-guides.mdx) to finish configuring `tbot` for
+  your environment.
+- Read the [configuration reference](../reference/configuration.mdx) to explore
+  all the available configuration options.

--- a/docs/pages/machine-id/platform-guides/linux.mdx
+++ b/docs/pages/machine-id/platform-guides/linux.mdx
@@ -7,7 +7,13 @@ description: How to install and configure Machine ID on a Linux host
 
 ### Service vs Oneshot
 
+TODO: Explain when you'd want to  use a service and when you'd want to use
+oneshot. This guide will show service with systemd - explain choice of service
+supervisor
+
 ## Guide
+
+This guide will...
 
 ### Before you start
 

--- a/docs/pages/machine-id/platform-guides/linux.mdx
+++ b/docs/pages/machine-id/platform-guides/linux.mdx
@@ -3,4 +3,28 @@ title: Deploying Machine ID on Linux
 description: How to install and configure Machine ID on a Linux host
 ---
 
-TODO
+## Background
+
+### Service vs Oneshot
+
+## Guide
+
+### Before you start
+
+### Step 1/3. Create a join token
+
+### Step 2/3. Create a role and bot user
+
+### Step 3/3. Configure `tbot`
+
+### Step 4/4. Configure Outputs
+
+Follow one of the [access guides](../access-guides.mdx) to configure an output
+that meets your access needs.
+
+## Next steps
+
+- Follow the [access guides](../access-guides.mdx) to finish configuring `tbot` for
+  your environment.
+- Read the [configuration reference](../reference/configuration.mdx) to explore
+  all the available configuration options.

--- a/docs/pages/machine-id/platform-guides/linux.mdx
+++ b/docs/pages/machine-id/platform-guides/linux.mdx
@@ -3,9 +3,16 @@ title: Deploying Machine ID on Linux
 description: How to install and configure Machine ID on a Linux host
 ---
 
+This page contains relevant background information and specific steps for
+deploying Machine ID on a Linux host.
+
 ## Background
 
-### Service vs Oneshot
+### The `token` join method
+
+TODO: Brief overview of how the join method works for this platform.
+
+### Daemon vs Oneshot
 
 TODO: Explain when you'd want to  use a service and when you'd want to use
 oneshot. This guide will show service with systemd - explain choice of service
@@ -17,13 +24,13 @@ This guide will...
 
 ### Before you start
 
-### Step 1/3. Create a join token
+### Step 1/4. Create a join token
 
-### Step 2/3. Create a role and bot user
+### Step 2/4. Create a role and bot user
 
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
-### Step 3/3. Configure `tbot`
+### Step 3/4. Configure `tbot`
 
 ### Step 4/4. Configure Outputs
 

--- a/docs/pages/machine-id/platform-guides/linux.mdx
+++ b/docs/pages/machine-id/platform-guides/linux.mdx
@@ -24,15 +24,19 @@ This guide will...
 
 ### Before you start
 
-### Step 1/4. Create a join token
-
-### Step 2/4. Create a role and bot user
+### Step 1/3. Create a role and bot user
 
 (!docs/pages/includes/machine-id/blank-role.mdx!)
 
-### Step 3/4. Configure `tbot`
+Create the bot, specifying the role that you have created:
 
-### Step 4/4. Configure Outputs
+```code
+$ tctl bots add example --roles example-bot
+```
+
+### Step 2/3. Configure `tbot`
+
+### Step 3/3. Configure Outputs
 
 Follow one of the [access guides](../access-guides.mdx) to configure an output
 that meets your access needs.

--- a/docs/pages/machine-id/platform-guides/linux.mdx
+++ b/docs/pages/machine-id/platform-guides/linux.mdx
@@ -21,6 +21,8 @@ This guide will...
 
 ### Step 2/3. Create a role and bot user
 
+(!docs/pages/includes/machine-id/blank-role.mdx!)
+
 ### Step 3/3. Configure `tbot`
 
 ### Step 4/4. Configure Outputs


### PR DESCRIPTION
Mostly a focus on fleshing out, but not finishing, the Kubernetes guide. Largely, the headers/content are correct, but the internal copy may be a bit rough.

I went with the Kubernetes guide because:

- It needs to link out to the AWS/GCP guides when talking about EKS/GKE - and vice versa. I'm curious how the hierarchy of that looks.
- It needs to link out to the access guides & provide some additional advice about the `kubernetes_secret` destination at the same time.

I've also just filled out the headers/sections of the AWS, Linux and GCP guides - I wanted to see if the same shape in the Kubernetes platform guide would work for those.