### PR TITLE
Add UseAuth config for AccessGraph service

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -70,6 +70,7 @@ type AuthorizerOpts struct {
 
 type AccessGraphConfig struct {
 	Enabled  bool
+	UseAuth  bool
 	Endpoint string
 }
 
@@ -398,7 +399,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 // authorizeLocalUser returns authz context based on the username
 func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
 	var opt []services.AccessCheckerOption
-	if a.accessGraph.Enabled {
+	if a.accessGraph.Enabled && a.accessGraph.UseAuth {
 		opt = append(opt, services.WithTAG(a.accessGraph.Endpoint))
 	}
 	return ContextForLocalUser(u, a.accessPoint, a.clusterName, a.disableDeviceAuthorization, opt...)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1115,6 +1115,7 @@ type PluginService struct {
 // AccessGraph represents the configuration for the AccessGraph service.
 type AccessGraph struct {
 	Enabled  bool   `yaml:"enabled"`
+	UseAuth  bool   `yaml:"use_auth"`
 	Endpoint string `yaml:"endpoint"`
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1894,6 +1894,7 @@ func (process *TeleportProcess) initAuthService() error {
 		AccessGraph: authz.AccessGraphConfig{
 			Enabled:  cfg.AccessGraph.Enabled,
 			Endpoint: cfg.AccessGraph.Addr,
+			UseAuth:  cfg.AccessGraph.UseAuth,
 		},
 	})
 	if err != nil {
@@ -4045,7 +4046,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			OpenAIConfig:    cfg.OpenAIConfig,
 			NodeWatcher:     nodeWatcher,
 			AccessGraphAddr: accessGraphAddr,
-			TracerProvider: process.TracingProvider,
+			TracerProvider:  process.TracingProvider,
 		}
 		webHandler, err := web.NewHandler(webConfig)
 		if err != nil {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -291,10 +291,13 @@ type Config struct {
 
 // AccessGraphConfig represents TAG server config
 type AccessGraphConfig struct {
-	// Enabled predicate reporting enabled
+	// Enabled Access Graph reporting enabled
 	Enabled bool
 
-	// Addr predicate service addr
+	// When enabled, the TAG server will be used to evaluate access requests
+	UseAuth bool
+
+	// Addr of the Access Graph service addr
 	Addr string
 }
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -7432,6 +7432,10 @@ func (u mockCurrentUser) GetTraits() map[string][]string {
 	return u.traits
 }
 
+func (u mockCurrentUser) GetName() string {
+	return "mockCurrentUser"
+}
+
 func TestNewAccessCheckerForRemoteCluster(t *testing.T) {
 	user := mockCurrentUser{
 		roles: []string{"dev", "admin"},


### PR DESCRIPTION
Added a new configuration field `UseAuth` for the AccessGraph service to decide whether to use TAG for authentication or not. This provides better flexibility for different use cases where we want to use TAG for read-only view.