### PR TITLE
Web: Add new supported aws region (il-central-1) to selector

### DIFF
--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -147,6 +147,7 @@ export const awsRegionMap = {
   'eu-south-2': 'Europe (Spain)',
   'eu-north-1': 'Europe (Stockholm)',
   'eu-central-2': 'Europe (Zurich)',
+  'il-central-1': 'Israel (Tel Aviv)',
   'me-south-1': 'Middle East (Bahrain)',
   'me-central-1': 'Middle East (UAE)',
   'sa-east-1': 'South America (São Paulo)',


### PR DESCRIPTION
In response to adding support for `il-central-1` in backend: https://github.com/gravitational/teleport/pull/31533

Screenshot
<img width="410" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/234eed5c-ae6a-43b5-a6c6-8fc6067079fb">
