### PR TITLE
Discovery Config: move file configuration types to their own package

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -85,6 +85,18 @@ func ValidateJoinMethod(method JoinMethod) error {
 	return nil
 }
 
+// JoinParams configures the parameters for Simplified Node Joining.
+type JoinParams struct {
+	TokenName string          `yaml:"token_name"`
+	Method    JoinMethod      `yaml:"method"`
+	Azure     AzureJoinParams `yaml:"azure,omitempty"`
+}
+
+// AzureJoinParams configures the parameters specific to the Azure join method.
+type AzureJoinParams struct {
+	ClientID string `yaml:"client_id"`
+}
+
 type KubernetesJoinType string
 
 var (

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/discovery"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/pam"
@@ -1323,7 +1324,7 @@ func applySSHConfig(fc *FileConfig, cfg *servicecfg.Config) (err error) {
 
 // getInstallerProxyAddr determines the address of the proxy for discovered
 // nodes to connect to.
-func getInstallerProxyAddr(installParams *InstallParams, fc *FileConfig) string {
+func getInstallerProxyAddr(installParams *discovery.InstallParams, fc *FileConfig) string {
 	// Explicit proxy address.
 	if installParams != nil && installParams.PublicProxyAddr != "" {
 		return installParams.PublicProxyAddr
@@ -2518,7 +2519,7 @@ func splitRoles(roles string) []string {
 // applyTokenConfig applies the auth_token and join_params to the config
 func applyTokenConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.AuthToken != "" {
-		if fc.JoinParams != (JoinParams{}) {
+		if fc.JoinParams != (types.JoinParams{}) {
 			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
 
@@ -2528,7 +2529,7 @@ func applyTokenConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return nil
 	}
 
-	if fc.JoinParams != (JoinParams{}) {
+	if fc.JoinParams != (types.JoinParams{}) {
 		cfg.SetToken(fc.JoinParams.TokenName)
 
 		if err := types.ValidateJoinMethod(fc.JoinParams.Method); err != nil {
@@ -2537,7 +2538,7 @@ func applyTokenConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 
 		cfg.JoinMethod = fc.JoinParams.Method
 
-		if fc.JoinParams.Azure != (AzureJoinParams{}) {
+		if fc.JoinParams.Azure != (types.AzureJoinParams{}) {
 			cfg.JoinParams = servicecfg.JoinParams{
 				Azure: servicecfg.AzureJoinParams{
 					ClientID: fc.JoinParams.Azure.ClientID,

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types/installers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/discovery"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 )
@@ -910,7 +911,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				GCPMatchers: []GCPMatcher{
+				GCPMatchers: []discovery.GCPMatcher{
 					{
 						Types:     []string{"gke"},
 						Locations: []string{"*"},
@@ -940,7 +941,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				GCPMatchers: []GCPMatcher{
+				GCPMatchers: []discovery.GCPMatcher{
 					{
 						Types:     []string{"gke"},
 						Locations: []string{"eucentral1"},
@@ -971,7 +972,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				GCPMatchers: []GCPMatcher{
+				GCPMatchers: []discovery.GCPMatcher{
 					{
 						Types:     []string{"gke"},
 						Locations: []string{"eucentral1"},
@@ -980,8 +981,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						},
 						ProjectIDs:      []string{"p1", "p2"},
 						ServiceAccounts: []string{"a@example.com", "b@example.com"},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: defaults.GCPInviteTokenName,
 								Method:    types.JoinMethodGCP,
 							},
@@ -1004,7 +1005,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AzureMatchers: []AzureMatcher{
+				AzureMatchers: []discovery.AzureMatcher{
 					{
 						Types:   []string{"aks"},
 						Regions: []string{"*"},
@@ -1036,7 +1037,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AzureMatchers: []AzureMatcher{
+				AzureMatchers: []discovery.AzureMatcher{
 					{
 						Types:   []string{"aks"},
 						Regions: []string{"eucentral1"},
@@ -1066,22 +1067,22 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AWSMatchers: []AWSMatcher{
+				AWSMatchers: []discovery.AWSMatcher{
 					{
 						Types:   []string{"ec2"},
 						Regions: []string{"eu-central-1"},
 						Tags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: defaults.IAMInviteTokenName,
 								Method:    types.JoinMethodIAM,
 							},
 							SSHDConfig: "/etc/ssh/sshd_config",
 							ScriptName: installers.InstallerScriptName,
 						},
-						SSM: AWSSSM{DocumentName: defaults.AWSInstallerDocument},
+						SSM: discovery.AWSSSM{DocumentName: defaults.AWSInstallerDocument},
 					},
 				},
 			},
@@ -1115,22 +1116,22 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AWSMatchers: []AWSMatcher{
+				AWSMatchers: []discovery.AWSMatcher{
 					{
 						Types:   []string{"ec2"},
 						Regions: []string{"eu-central-1"},
 						Tags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: "hello-iam-a-token",
 								Method:    types.JoinMethodIAM,
 							},
 							SSHDConfig: "/etc/ssh/sshd_config",
 							ScriptName: "installer-custom",
 						},
-						SSM:           AWSSSM{DocumentName: "hello_document"},
+						SSM:           discovery.AWSSSM{DocumentName: "hello_document"},
 						AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
 						ExternalID:    "externalID123",
 					},
@@ -1213,22 +1214,22 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AWSMatchers: []AWSMatcher{
+				AWSMatchers: []discovery.AWSMatcher{
 					{
 						Types:   []string{"redshift-serverless"},
 						Regions: []string{"us-west-1"},
 						Tags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: "aws-discovery-iam-token",
 								Method:    types.JoinMethodIAM,
 							},
 							SSHDConfig: "/etc/ssh/sshd_config",
 							ScriptName: "default-installer",
 						},
-						SSM:           AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
+						SSM:           discovery.AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
 						AssumeRoleARN: "",
 						ExternalID:    "externalid123",
 					},
@@ -1291,15 +1292,15 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AWSMatchers: []AWSMatcher{
+				AWSMatchers: []discovery.AWSMatcher{
 					{
-						SSM: AWSSSM{
+						SSM: discovery.AWSSSM{
 							DocumentName: defaults.AWSInstallerDocument,
 						},
 						Regions: []string{"eu-west-1"},
 						Tags:    map[string]apiutils.Strings{"*": {"*"}},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: defaults.IAMInviteTokenName,
 								Method:    types.JoinMethodIAM,
 							},
@@ -1329,7 +1330,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AzureMatchers: []AzureMatcher{
+				AzureMatchers: []discovery.AzureMatcher{
 					{
 						Types:          []string{"vm"},
 						Regions:        []string{"westcentralus"},
@@ -1338,8 +1339,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						ResourceTags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: "azure-discovery-token",
 								Method:    "azure",
 							},
@@ -1375,7 +1376,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{
-				AzureMatchers: []AzureMatcher{
+				AzureMatchers: []discovery.AzureMatcher{
 					{
 						Types:          []string{"vm"},
 						Regions:        []string{"westcentralus"},
@@ -1384,8 +1385,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						ResourceTags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
-						InstallParams: &InstallParams{
-							JoinParams: JoinParams{
+						InstallParams: &discovery.InstallParams{
+							JoinParams: types.JoinParams{
 								TokenName: "custom-azure-token",
 								Method:    "azure",
 							},

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/configurators"
+	"github.com/gravitational/teleport/lib/discovery"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -79,7 +80,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -109,7 +110,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -173,7 +174,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -200,7 +201,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -258,7 +259,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherElastiCache}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -409,7 +410,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherMemoryDB}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -543,13 +544,13 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Discovery: config.Discovery{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{
 							Types:   []string{services.AWSMatcherEC2},
 							Regions: []string{"eu-central-1"},
 							Tags:    map[string]utils.Strings{"*": []string{"*"}},
-							InstallParams: &config.InstallParams{
-								JoinParams: config.JoinParams{
+							InstallParams: &discovery.InstallParams{
+								JoinParams: types.JoinParams{
 									TokenName: "token",
 									Method:    types.JoinMethodIAM,
 								},
@@ -585,7 +586,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -596,7 +597,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -656,7 +657,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRedshiftServerless}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -756,7 +757,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			fileConfig: &config.FileConfig{
 				Databases: config.Databases{
 					Service: config.Service{EnabledFlag: "true"},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherOpenSearch}, Regions: []string{"us-west-2"}},
 					},
 				},
@@ -830,7 +831,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 							},
 						},
 					},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}, AssumeRoleARN: role4},
 						{Types: []string{services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}, AssumeRoleARN: roleTarget.String(), ExternalID: "foo"},
 					},
@@ -879,7 +880,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 							},
 						},
 					},
-					AWSMatchers: []config.AWSMatcher{
+					AWSMatchers: []discovery.AWSMatcher{
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}, AssumeRoleARN: role4},
 						{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}, AssumeRoleARN: role5, ExternalID: "foo"},
 					},
@@ -932,7 +933,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -950,7 +951,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -968,7 +969,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -986,7 +987,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshiftServerless}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1004,7 +1005,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherElastiCache}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1022,7 +1023,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherMemoryDB}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1040,7 +1041,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherOpenSearch}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1058,7 +1059,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-1"}},
 							{Types: []string{services.AWSMatcherRedshift, services.AWSMatcherRDS, services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}},
 							{Types: []string{services.AWSMatcherElastiCache}, Regions: []string{"us-west-2"}, AssumeRoleARN: role1, ExternalID: "foo"},
@@ -1138,7 +1139,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRDS}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1172,7 +1173,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1206,7 +1207,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1240,7 +1241,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshiftServerless}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1264,7 +1265,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherElastiCache}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1318,7 +1319,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherMemoryDB}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1362,7 +1363,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherOpenSearch}, Regions: []string{"us-west-2"}},
 						},
 					},
@@ -1386,7 +1387,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				fileConfig: &config.FileConfig{
 					Discovery: config.Discovery{
 						Service: config.Service{EnabledFlag: "true"},
-						AWSMatchers: []config.AWSMatcher{
+						AWSMatchers: []discovery.AWSMatcher{
 							{Types: []string{services.AWSMatcherRedshift}, Regions: []string{"us-west-1"}},
 							{Types: []string{services.AWSMatcherRedshift, services.AWSMatcherRDS, services.AWSMatcherRDSProxy}, Regions: []string{"us-west-2"}},
 							{Types: []string{services.AWSMatcherElastiCache}, Regions: []string{"us-west-2"}, AssumeRoleARN: role1, ExternalID: "foo"},
@@ -1792,11 +1793,11 @@ func TestAWSDocumentConfigurator(t *testing.T) {
 			PublicAddr: []string{"proxy.example.org:443"},
 		},
 		Discovery: config.Discovery{
-			AWSMatchers: []config.AWSMatcher{
+			AWSMatchers: []discovery.AWSMatcher{
 				{
 					Types:   []string{"ec2"},
 					Regions: []string{"eu-central-1"},
-					SSM:     config.AWSSSM{DocumentName: "document"},
+					SSM:     discovery.AWSSSM{DocumentName: "document"},
 				},
 			},
 		},

--- a/lib/discovery/aws.go
+++ b/lib/discovery/aws.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/installers"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// AWSMatcher matches AWS EC2 instances and AWS Databases
+type AWSMatcher struct {
+	// Types are AWS database types to match, "ec2", "rds", "redshift", "elasticache",
+	// or "memorydb".
+	Types []string `yaml:"types,omitempty"`
+	// Regions are AWS regions to query for databases.
+	Regions []string `yaml:"regions,omitempty"`
+	// AssumeRoleARN is the AWS role to assume for database discovery.
+	AssumeRoleARN string `yaml:"assume_role_arn,omitempty"`
+	// ExternalID is the AWS external ID to use when assuming a role for
+	// database discovery in an external AWS account.
+	ExternalID string `yaml:"external_id,omitempty"`
+	// Tags are AWS tags to match.
+	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+	// InstallParams sets the join method when installing on
+	// discovered EC2 nodes
+	InstallParams *InstallParams `yaml:"install,omitempty"`
+	// SSM provides options to use when sending a document command to
+	// an EC2 node
+	SSM AWSSSM `yaml:"ssm,omitempty"`
+}
+
+// AWSSSM provides options to use when executing SSM documents
+type AWSSSM struct {
+	// DocumentName is the name of the document to use when executing an
+	// SSM command
+	DocumentName string `yaml:"document_name,omitempty"`
+}
+
+// CheckAndSetDefaultsForAWSMatchers sets the default values for discovery AWS matchers
+// and validates the provided types.
+func CheckAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
+	for i := range matcherInput {
+		matcher := &matcherInput[i]
+		for _, matcherType := range matcher.Types {
+			if !slices.Contains(services.SupportedAWSMatchers, matcherType) {
+				return trace.BadParameter("discovery service type does not support %q, supported resource types are: %v",
+					matcherType, services.SupportedAWSMatchers)
+			}
+		}
+
+		for _, region := range matcher.Regions {
+			if err := awsapiutils.IsValidRegion(region); err != nil {
+				return trace.BadParameter("discovery service does not support region %q; supported regions are: %v",
+					region, awsutils.GetKnownRegions())
+			}
+		}
+
+		if matcher.AssumeRoleARN != "" {
+			_, err := awsutils.ParseRoleARN(matcher.AssumeRoleARN)
+			if err != nil {
+				return trace.Wrap(err, "discovery service AWS matcher assume_role_arn is invalid")
+			}
+		} else if matcher.ExternalID != "" {
+			for _, t := range matcher.Types {
+				if !slices.Contains(services.RequireAWSIAMRolesAsUsersMatchers, t) {
+					return trace.BadParameter("discovery service AWS matcher assume_role_arn is empty, but has external_id %q",
+						matcher.ExternalID)
+				}
+			}
+		}
+
+		if matcher.Tags == nil || len(matcher.Tags) == 0 {
+			matcher.Tags = map[string]apiutils.Strings{types.Wildcard: {types.Wildcard}}
+		}
+
+		var installParams types.InstallerParams
+		var err error
+
+		if matcher.InstallParams == nil {
+			matcher.InstallParams = &InstallParams{
+				JoinParams: types.JoinParams{
+					TokenName: defaults.IAMInviteTokenName,
+					Method:    types.JoinMethodIAM,
+				},
+				ScriptName:      installers.InstallerScriptName,
+				InstallTeleport: "",
+				SSHDConfig:      defaults.SSHDConfigPath,
+			}
+			installParams, err = matcher.InstallParams.Parse()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		} else {
+			if method := matcher.InstallParams.JoinParams.Method; method == "" {
+				matcher.InstallParams.JoinParams.Method = types.JoinMethodIAM
+			} else if method != types.JoinMethodIAM {
+				return trace.BadParameter("only IAM joining is supported for EC2 auto-discovery")
+			}
+
+			if matcher.InstallParams.JoinParams.TokenName == "" {
+				matcher.InstallParams.JoinParams.TokenName = defaults.IAMInviteTokenName
+			}
+
+			if matcher.InstallParams.SSHDConfig == "" {
+				matcher.InstallParams.SSHDConfig = defaults.SSHDConfigPath
+			}
+
+			installParams, err = matcher.InstallParams.Parse()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if installer := matcher.InstallParams.ScriptName; installer == "" {
+				if installParams.InstallTeleport {
+					matcher.InstallParams.ScriptName = installers.InstallerScriptName
+				} else {
+					matcher.InstallParams.ScriptName = installers.InstallerScriptNameAgentless
+				}
+			}
+		}
+
+		if matcher.SSM.DocumentName == "" {
+			if installParams.InstallTeleport {
+				matcher.SSM.DocumentName = defaults.AWSInstallerDocument
+			} else {
+				matcher.SSM.DocumentName = defaults.AWSAgentlessInstallerDocument
+			}
+		}
+	}
+	return nil
+}

--- a/lib/discovery/azure.go
+++ b/lib/discovery/azure.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/installers"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// AzureMatcher matches Azure resources.
+type AzureMatcher struct {
+	// Subscriptions are Azure subscriptions to query for resources.
+	Subscriptions []string `yaml:"subscriptions,omitempty"`
+	// ResourceGroups are Azure resource groups to query for resources.
+	ResourceGroups []string `yaml:"resource_groups,omitempty"`
+	// Types are Azure types to match: "mysql", "postgres", "aks", "vm"
+	Types []string `yaml:"types,omitempty"`
+	// Regions are Azure locations to match for databases.
+	Regions []string `yaml:"regions,omitempty"`
+	// ResourceTags are Azure tags on resources to match.
+	ResourceTags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+	// InstallParams sets the join method when installing on
+	// discovered Azure nodes.
+	InstallParams *InstallParams `yaml:"install,omitempty"`
+}
+
+// CheckAndSetDefaultsForAzureMatchers sets the default values for discovery Azure matchers
+// and validates the provided types.
+func CheckAndSetDefaultsForAzureMatchers(matcherInput []AzureMatcher) error {
+	for i := range matcherInput {
+		matcher := &matcherInput[i]
+
+		if len(matcher.Types) == 0 {
+			return trace.BadParameter("At least one Azure discovery service type must be specified, the supported resource types are: %v",
+				services.SupportedAzureMatchers)
+		}
+
+		for _, matcherType := range matcher.Types {
+			if !slices.Contains(services.SupportedAzureMatchers, matcherType) {
+				return trace.BadParameter("Azure discovery service type does not support %q resource type; supported resource types are: %v",
+					matcherType, services.SupportedAzureMatchers)
+			}
+		}
+
+		if slices.Contains(matcher.Types, services.AzureMatcherVM) {
+			if err := checkAndSetDefaultsForAzureInstaller(matcher); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		if slices.Contains(matcher.Regions, types.Wildcard) || len(matcher.Regions) == 0 {
+			matcher.Regions = []string{types.Wildcard}
+		}
+
+		if slices.Contains(matcher.Subscriptions, types.Wildcard) || len(matcher.Subscriptions) == 0 {
+			matcher.Subscriptions = []string{types.Wildcard}
+		}
+
+		if slices.Contains(matcher.ResourceGroups, types.Wildcard) || len(matcher.ResourceGroups) == 0 {
+			matcher.ResourceGroups = []string{types.Wildcard}
+		}
+
+		if len(matcher.ResourceTags) == 0 {
+			matcher.ResourceTags = map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			}
+		}
+
+	}
+	return nil
+}
+
+func checkAndSetDefaultsForAzureInstaller(matcher *AzureMatcher) error {
+	if matcher.InstallParams == nil {
+		matcher.InstallParams = &InstallParams{
+			JoinParams: types.JoinParams{
+				TokenName: defaults.AzureInviteTokenName,
+				Method:    types.JoinMethodAzure,
+			},
+			ScriptName: installers.InstallerScriptName,
+		}
+		return nil
+	}
+
+	switch matcher.InstallParams.JoinParams.Method {
+	case types.JoinMethodAzure, "":
+		matcher.InstallParams.JoinParams.Method = types.JoinMethodAzure
+	default:
+		return trace.BadParameter("only Azure joining is supported for Azure auto-discovery")
+	}
+
+	if token := matcher.InstallParams.JoinParams.TokenName; token == "" {
+		matcher.InstallParams.JoinParams.TokenName = defaults.AzureInviteTokenName
+	}
+
+	if installer := matcher.InstallParams.ScriptName; installer == "" {
+		matcher.InstallParams.ScriptName = installers.InstallerScriptName
+	}
+	return nil
+}

--- a/lib/discovery/gcp.go
+++ b/lib/discovery/gcp.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/installers"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// GCPMatcher matches GCP resources.
+type GCPMatcher struct {
+	// Types are GKE resource types to match: "gke", "gce".
+	Types []string `yaml:"types,omitempty"`
+	// Locations are GKE locations to search resources for.
+	Locations []string `yaml:"locations,omitempty"`
+	// Tags are GCP labels to match.
+	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+	// ProjectIDs are the GCP project ID where the resources are deployed.
+	ProjectIDs []string `yaml:"project_ids,omitempty"`
+	// ServiceAccounts are the emails of service accounts attached to VMs.
+	ServiceAccounts []string `yaml:"service_accounts,omitempty"`
+	// InstallParams sets the join method when installing on
+	// discovered GCP VMs.
+	InstallParams *InstallParams `yaml:"install,omitempty"`
+}
+
+// CheckAndSetDefaultsForGCPMatchers sets the default values for GCP matchers
+// and validates the provided types.
+func CheckAndSetDefaultsForGCPMatchers(matcherInput []GCPMatcher) error {
+	for i := range matcherInput {
+		matcher := &matcherInput[i]
+
+		if len(matcher.Types) == 0 {
+			return trace.BadParameter("At least one GCP discovery service type must be specified, the supported resource types are: %v",
+				services.SupportedGCPMatchers)
+		}
+
+		for _, matcherType := range matcher.Types {
+			if !slices.Contains(services.SupportedGCPMatchers, matcherType) {
+				return trace.BadParameter("GCP discovery service type does not support %q resource type; supported resource types are: %v",
+					matcherType, services.SupportedGCPMatchers)
+			}
+		}
+
+		if slices.Contains(matcher.Types, services.GCPMatcherCompute) {
+			if err := checkAndSetDefaultsForGCPInstaller(matcher); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		if slices.Contains(matcher.Locations, types.Wildcard) || len(matcher.Locations) == 0 {
+			matcher.Locations = []string{types.Wildcard}
+		}
+
+		if slices.Contains(matcher.ProjectIDs, types.Wildcard) {
+			return trace.BadParameter("GCP discovery service project_ids does not support wildcards; please specify at least one value in project_ids.")
+		}
+		if len(matcher.ProjectIDs) == 0 {
+			return trace.BadParameter("GCP discovery service project_ids does cannot be empty; please specify at least one value in project_ids.")
+		}
+
+		if len(matcher.Tags) == 0 {
+			matcher.Tags = map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			}
+		}
+
+	}
+	return nil
+}
+
+func checkAndSetDefaultsForGCPInstaller(matcher *GCPMatcher) error {
+	if matcher.InstallParams == nil {
+		matcher.InstallParams = &InstallParams{
+			JoinParams: types.JoinParams{
+				TokenName: defaults.GCPInviteTokenName,
+				Method:    types.JoinMethodGCP,
+			},
+			ScriptName: installers.InstallerScriptName,
+		}
+		return nil
+	}
+
+	switch matcher.InstallParams.JoinParams.Method {
+	case types.JoinMethodGCP, "":
+		matcher.InstallParams.JoinParams.Method = types.JoinMethodGCP
+	default:
+		return trace.BadParameter("only GCP joining is supported for GCP auto-discovery")
+	}
+
+	if token := matcher.InstallParams.JoinParams.TokenName; token == "" {
+		matcher.InstallParams.JoinParams.TokenName = defaults.GCPInviteTokenName
+	}
+
+	if installer := matcher.InstallParams.ScriptName; installer == "" {
+		matcher.InstallParams.ScriptName = installers.InstallerScriptName
+	}
+	return nil
+}

--- a/lib/discovery/install_params.go
+++ b/lib/discovery/install_params.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+)
+
+// InstallParams sets join method to use on discovered nodes
+type InstallParams struct {
+	// JoinParams sets the token and method to use when generating
+	// config on cloud instances
+	JoinParams types.JoinParams `yaml:"join_params,omitempty"`
+	// ScriptName is the name of the teleport installer script
+	// resource for the cloud instance to execute
+	ScriptName string `yaml:"script_name,omitempty"`
+	// InstallTeleport disables agentless discovery
+	InstallTeleport string `yaml:"install_teleport,omitempty"`
+	// SSHDConfig provides the path to write sshd configuration changes
+	SSHDConfig string `yaml:"sshd_config,omitempty"`
+	// PublicProxyAddr is the address of the proxy the discovered node should use
+	// to connect to the cluster. Used ony in Azure.
+	PublicProxyAddr string `yaml:"public_proxy_addr,omitempty"`
+}
+
+func (ip *InstallParams) Parse() (types.InstallerParams, error) {
+	install := types.InstallerParams{
+		JoinMethod:      ip.JoinParams.Method,
+		JoinToken:       ip.JoinParams.TokenName,
+		ScriptName:      ip.ScriptName,
+		InstallTeleport: true,
+		SSHDConfig:      ip.SSHDConfig,
+	}
+
+	if ip.InstallTeleport == "" {
+		return install, nil
+	}
+
+	var err error
+	install.InstallTeleport, err = apiutils.ParseBool(ip.InstallTeleport)
+	if err != nil {
+		return types.InstallerParams{}, trace.Wrap(err)
+	}
+
+	return install, nil
+}

--- a/lib/discovery/kube.go
+++ b/lib/discovery/kube.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// KubernetesMatcher matches Kubernetes resources.
+type KubernetesMatcher struct {
+	// Types are Kubernetes services types to match. Currently only 'app' is supported.
+	Types []string `yaml:"types,omitempty"`
+	// Namespaces are Kubernetes namespaces in which to discover services
+	Namespaces []string `yaml:"namespaces,omitempty"`
+	// Labels are Kubernetes services labels to match.
+	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
+}
+
+// CheckAndSetDefaultsForKubeMatchers sets the default values for Kubernetes matchers
+// and validates the provided types.
+func CheckAndSetDefaultsForKubeMatchers(matchers []KubernetesMatcher) error {
+	for i := range matchers {
+		matcher := &matchers[i]
+
+		for _, t := range matcher.Types {
+			if !slices.Contains(services.SupportedKubernetesMatchers, t) {
+				return trace.BadParameter("Kubernetes discovery does not support %q resource type; supported resource types are: %v",
+					t, services.SupportedKubernetesMatchers)
+			}
+		}
+
+		if len(matcher.Types) == 0 {
+			matcher.Types = []string{services.KubernetesMatchersApp}
+		}
+
+		if len(matcher.Namespaces) == 0 {
+			matcher.Namespaces = []string{types.Wildcard}
+		}
+
+		if len(matcher.Labels) == 0 {
+			matcher.Labels = map[string]apiutils.Strings{types.Wildcard: {types.Wildcard}}
+		}
+	}
+
+	return nil
+}

--- a/lib/integrations/awsoidc/deployservice_config.go
+++ b/lib/integrations/awsoidc/deployservice_config.go
@@ -61,7 +61,7 @@ func generateTeleportConfigString(req DeployServiceRequest) (string, error) {
 			AWSARN:     "arn:aws:sts::<account-id>:assumed-role/<taskRoleARN>/*",
 		}
 	*/
-	teleportConfig.JoinParams = config.JoinParams{
+	teleportConfig.JoinParams = types.JoinParams{
 		TokenName: *req.TeleportIAMTokenName,
 		Method:    types.JoinMethodIAM,
 	}


### PR DESCRIPTION
Should be a no-op in terms of production code.

This PR moves all the Discovery Config Types that are used when loading the matchers from a `teleport.yaml` file (section `discovery_service.aws/azure/gcp/kube` ) to their own package.

To be used by the dynamic discovery config (link pr)

WIP