### PR TITLE
[v12] Validate unknown AWS regions from discovery matchers

### DIFF
--- a/api/utils/aws/identifiers_test.go
+++ b/api/utils/aws/identifiers_test.go
@@ -74,3 +74,55 @@ func TestIsValidAccountID(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidRegion(t *testing.T) {
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	for _, tt := range []struct {
+		name     string
+		region   string
+		errCheck require.ErrorAssertionFunc
+	}{
+		{
+			name:     "us region",
+			region:   "us-east-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "eu region",
+			region:   "eu-west-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "us gov",
+			region:   "us-gov-east-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "valid format",
+			region:   "xx-iso-somewhere-100",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "empty",
+			region:   "",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "symbols",
+			region:   "us@east-1",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "invalid country code",
+			region:   "xxx-east-1",
+			errCheck: isBadParamErrFn,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidRegion(tt.region))
+		})
+	}
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -58,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // CommandLineFlags stores command line flag values, it's a much simplified subset
@@ -1232,6 +1233,17 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *service.Config) error {
 		installParams, err := matcher.InstallParams.Parse()
 		if err != nil {
 			return trace.Wrap(err)
+		}
+
+		for _, region := range matcher.Regions {
+			if !awsutils.IsKnownRegion(region) {
+				log.Warnf("AWS matcher uses unknown region %q. "+
+					"There could be a typo in %q. "+
+					"Ignore this message if this is a new AWS region that is unknown to the AWS SDK used to compile this binary. "+
+					"Known regions are: %v.",
+					region, region, awsutils.GetKnownRegions(),
+				)
+			}
 		}
 
 		cfg.Discovery.AWSMatchers = append(cfg.Discovery.AWSMatchers,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -30,13 +30,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
@@ -45,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/bpf"
@@ -55,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // FileConfig structure represents the teleport configuration stored in a config file
@@ -477,21 +477,9 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// awsRegions returns the list of all regions available on every aws partition.
-// It is used to validate the AWSMatcher.Regions values.
-func awsRegions() []string {
-	var regions []string
-	partitions := endpoints.DefaultPartitions()
-	for _, partition := range partitions {
-		regions = append(regions, maps.Keys(partition.Regions())...)
-	}
-	return regions
-}
-
 // checkAndSetDefaultsForAWSMatchers sets the default values for discovery AWS matchers
 // and validates the provided types.
 func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
-	regions := awsRegions()
 	for i := range matcherInput {
 		matcher := &matcherInput[i]
 		for _, matcherType := range matcher.Types {
@@ -503,13 +491,13 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 
 		if len(matcher.Regions) == 0 {
 			return trace.BadParameter("discovery service requires at least one region; supported regions are: %v",
-				regions)
+				awsutils.GetKnownRegions())
 		}
 
 		for _, region := range matcher.Regions {
-			if !slices.Contains(regions, region) {
+			if err := awsapiutils.IsValidRegion(region); err != nil {
 				return trace.BadParameter("discovery service does not support region %q; supported regions are: %v",
-					region, regions)
+					region, awsutils.GetKnownRegions())
 			}
 		}
 

--- a/lib/utils/aws/region.go
+++ b/lib/utils/aws/region.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// IsKnownRegion returns true if provided region is one of the "well-known"
+// AWS regions.
+func IsKnownRegion(region string) bool {
+	return slices.Contains(GetKnownRegions(), region)
+}
+
+// GetKnownRegions returns a list of "well-known" AWS regions generated from
+// AWS SDK.
+func GetKnownRegions() []string {
+	knownRegionsOnce.Do(func() {
+		var regions []string
+		partitions := endpoints.DefaultPartitions()
+		for _, partition := range partitions {
+			regions = append(regions, maps.Keys(partition.Regions())...)
+		}
+		knownRegions = regions
+	})
+	return knownRegions
+}
+
+var (
+	knownRegions     []string
+	knownRegionsOnce sync.Once
+)

--- a/lib/utils/aws/region_test.go
+++ b/lib/utils/aws/region_test.go
@@ -30,7 +30,6 @@ func TestGetKnownRegions(t *testing.T) {
 	t.Run("hand picked", func(t *testing.T) {
 		for _, region := range []string{
 			"us-east-1",
-			"il-central-1",
 			"cn-north-1",
 			"us-gov-west-1",
 			"us-isob-east-1",

--- a/lib/utils/aws/region_test.go
+++ b/lib/utils/aws/region_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/aws"
+)
+
+func TestGetKnownRegions(t *testing.T) {
+	// Picked a few regions just to make sure GetKnownRegions is returning
+	// something that includes these.
+	t.Run("hand picked", func(t *testing.T) {
+		for _, region := range []string{
+			"us-east-1",
+			"il-central-1",
+			"cn-north-1",
+			"us-gov-west-1",
+			"us-isob-east-1",
+		} {
+			require.Contains(t, GetKnownRegions(), region)
+		}
+	})
+
+	// Ideally this should be tested in api/utils/aws but api has no access
+	// to AWS SDK. If this fails aws.IsValidRegion should be updated.
+	t.Run("IsValidRegion", func(t *testing.T) {
+		for _, region := range GetKnownRegions() {
+			require.NoError(t, aws.IsValidRegion(region))
+		}
+	})
+
+}
+func TestIsKnownRegion(t *testing.T) {
+	for _, region := range GetKnownRegions() {
+		require.True(t, IsKnownRegion(region))
+	}
+
+	for _, region := range []string{
+		"us-east-100",
+		"cn-north",
+	} {
+		require.False(t, IsKnownRegion(region))
+	}
+}


### PR DESCRIPTION
Changelog: Support discovery for new AWS region il-central-1

Backport #31533 to branch/v12