### PR TITLE
[v14] Validate unknown AWS regions from discovery matchers

### DIFF
--- a/api/utils/aws/identifiers_test.go
+++ b/api/utils/aws/identifiers_test.go
@@ -154,6 +154,11 @@ func TestIsValidRegion(t *testing.T) {
 			errCheck: require.NoError,
 		},
 		{
+			name:     "valid format",
+			region:   "xx-iso-somewhere-100",
+			errCheck: require.NoError,
+		},
+		{
 			name:     "empty",
 			region:   "",
 			errCheck: isBadParamErrFn,
@@ -161,6 +166,11 @@ func TestIsValidRegion(t *testing.T) {
 		{
 			name:     "symbols",
 			region:   "us@east-1",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "invalid country code",
+			region:   "xxx-east-1",
 			errCheck: isBadParamErrFn,
 		},
 	} {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // CommandLineFlags stores command line flag values, it's a much simplified subset
@@ -1330,6 +1331,17 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		installParams, err := matcher.InstallParams.Parse()
 		if err != nil {
 			return trace.Wrap(err)
+		}
+
+		for _, region := range matcher.Regions {
+			if !awsutils.IsKnownRegion(region) {
+				log.Warnf("AWS matcher uses unknown region %q. "+
+					"There could be a typo in %q. "+
+					"Ignore this message if this is a new AWS region that is unknown to the AWS SDK used to compile this binary. "+
+					"Known regions are: %v.",
+					region, region, awsutils.GetKnownRegions(),
+				)
+			}
 		}
 
 		cfg.Discovery.AWSMatchers = append(cfg.Discovery.AWSMatchers,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -30,13 +30,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
@@ -494,21 +492,9 @@ kubernetes matchers are present`)
 	return nil
 }
 
-// awsRegions returns the list of all regions available on every aws partition.
-// It is used to validate the AWSMatcher.Regions values.
-func awsRegions() []string {
-	var regions []string
-	partitions := endpoints.DefaultPartitions()
-	for _, partition := range partitions {
-		regions = append(regions, maps.Keys(partition.Regions())...)
-	}
-	return regions
-}
-
 // checkAndSetDefaultsForAWSMatchers sets the default values for discovery AWS matchers
 // and validates the provided types.
 func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
-	regions := awsRegions()
 	for i := range matcherInput {
 		matcher := &matcherInput[i]
 		for _, matcherType := range matcher.Types {
@@ -520,13 +506,13 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 
 		if len(matcher.Regions) == 0 {
 			return trace.BadParameter("discovery service requires at least one region; supported regions are: %v",
-				regions)
+				awsutils.GetKnownRegions())
 		}
 
 		for _, region := range matcher.Regions {
-			if !slices.Contains(regions, region) {
+			if !awsutils.IsValidRegion(region) {
 				return trace.BadParameter("discovery service does not support region %q; supported regions are: %v",
-					region, regions)
+					region, awsutils.GetKnownRegions())
 			}
 		}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
@@ -510,7 +511,7 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 		}
 
 		for _, region := range matcher.Regions {
-			if !awsutils.IsValidRegion(region) {
+			if err := awsapiutils.IsValidRegion(region); err != nil {
 				return trace.BadParameter("discovery service does not support region %q; supported regions are: %v",
 					region, awsutils.GetKnownRegions())
 			}

--- a/lib/utils/aws/region.go
+++ b/lib/utils/aws/region.go
@@ -17,7 +17,6 @@ limitations under the License.
 package aws
 
 import (
-	"regexp"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -29,11 +28,6 @@ import (
 // AWS regions.
 func IsKnownRegion(region string) bool {
 	return slices.Contains(GetKnownRegions(), region)
-}
-
-// IsValidRegion checks if the provided region is in valid format.
-func IsValidRegion(region string) bool {
-	return validRegionRegex.MatchString(region)
 }
 
 // GetKnownRegions returns a list of "well-known" AWS regions generated from
@@ -51,16 +45,6 @@ func GetKnownRegions() []string {
 }
 
 var (
-	// validRegionRegex is a regex that defines the format of AWS regions.
-	//
-	// The regex matches the following from left to right:
-	// - starts with 2 lower case letters that represents a geo region like a
-	//   country code
-	// - optional -gov, -iso, -isob for corresponding partitions
-	// - a geo direction like "east", "west", etc.
-	// - a single digit counter
-	validRegionRegex = regexp.MustCompile("^[a-z]{2}(-gov|-iso|-isob)?-(north|east|west|south|central|northeast|northwest|southeast|southwest)-[1-9]$")
-
 	knownRegions     []string
 	knownRegionsOnce sync.Once
 )

--- a/lib/utils/aws/region.go
+++ b/lib/utils/aws/region.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"regexp"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// IsKnownRegion returns true if provided region is one of the "well-known"
+// AWS regions.
+func IsKnownRegion(region string) bool {
+	return slices.Contains(GetKnownRegions(), region)
+}
+
+// IsValidRegion checks if the provided region is in valid format.
+func IsValidRegion(region string) bool {
+	return validRegionRegex.MatchString(region)
+}
+
+// GetKnownRegions returns a list of "well-known" AWS regions generated from
+// AWS SDK.
+func GetKnownRegions() []string {
+	knownRegionsOnce.Do(func() {
+		var regions []string
+		partitions := endpoints.DefaultPartitions()
+		for _, partition := range partitions {
+			regions = append(regions, maps.Keys(partition.Regions())...)
+		}
+		knownRegions = regions
+	})
+	return knownRegions
+}
+
+var (
+	// validRegionRegex is a regex that defines the format of AWS regions.
+	//
+	// The regex matches the following from left to right:
+	// - starts with 2 lower case letters that represents a geo region like a
+	//   country code
+	// - optional -gov, -iso, -isob for corresponding partitions
+	// - a geo direction like "east", "west", etc.
+	// - a single digit counter
+	validRegionRegex = regexp.MustCompile("^[a-z]{2}(-gov|-iso|-isob)?-(north|east|west|south|central|northeast|northwest|southeast|southwest)-[1-9]$")
+
+	knownRegions     []string
+	knownRegionsOnce sync.Once
+)

--- a/lib/utils/aws/region_test.go
+++ b/lib/utils/aws/region_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsKnownRegion(t *testing.T) {
+	for _, region := range []string{
+		"us-east-1",
+		"cn-north-1",
+		"us-gov-west-1",
+		"us-isob-east-1",
+	} {
+		require.True(t, IsKnownRegion(region))
+	}
+
+	for _, region := range []string{
+		"us-east-100",
+		"cn-north",
+	} {
+		require.False(t, IsKnownRegion(region))
+	}
+}
+
+func TestIsValidRegion(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputRegions []string
+		checkResult  require.BoolAssertionFunc
+	}{
+		{
+			// If this test fails, validRegionRegex must be updated.
+			name:         "known regions",
+			inputRegions: GetKnownRegions(),
+			checkResult:  require.True,
+		},
+		{
+			name: "valid regions",
+			inputRegions: []string{
+				"us-gov-central-1",
+				"xx-northwest-5",
+			},
+			checkResult: require.True,
+		},
+		{
+			name: "invalid regions",
+			inputRegions: []string{
+				"x-east-1",
+				"us-east-10",
+				"us-nowhere-1",
+				"us-xx-east-1",
+			},
+			checkResult: require.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, region := range test.inputRegions {
+				test.checkResult(t, IsValidRegion(region), region)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Changelog: Support discovery for new AWS region il-central-1

Backport #31533 to branch/v14