### PR TITLE
helm: fix deletion hook serviceAccount in the agent chart

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -40,7 +40,7 @@ roleRef:
   name: {{ .Release.Name }}-delete-hook
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-delete-hook
+  name: {{ template "teleport-kube-agent.deleteHookServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -74,7 +74,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
       name: RELEASE-NAME-delete-hook
     subjects:
     - kind: ServiceAccount
-      name: RELEASE-NAME-delete-hook
+      name: lint-serviceaccount
       namespace: NAMESPACE
   3: |
     apiVersion: batch/v1


### PR DESCRIPTION
Fixes an issue reported on Slack: the rolebinding does not grant the required rights to the deletion service account when the service account name value is set.