### PR TITLE
Improve error messaging when trying to use login rules in OSS

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
@@ -59,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/auth/assist/assistv1"
 	integrationService "github.com/gravitational/teleport/lib/auth/integration/integrationv1"
+	"github.com/gravitational/teleport/lib/auth/loginrule"
 	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/auth/trust/trustv1"
 	"github.com/gravitational/teleport/lib/auth/userloginstate"
@@ -69,6 +71,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/joinserver"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -5371,6 +5374,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	userloginstatev1.RegisterUserLoginStateServiceServer(server, userLoginStateServer)
+
+	// Only register the service if this is an open source build. Enterprise builds
+	// register the actual service via an auth plugin, if we register here then all
+	// Enterprise builds would fail with a duplicate service registered error.
+	if modules.GetModules().BuildType() == modules.BuildOSS {
+		loginrulepb.RegisterLoginRuleServiceServer(server, loginrule.NotImplementedService{})
+	}
 
 	return authServer, nil
 }

--- a/lib/auth/loginrule/service.go
+++ b/lib/auth/loginrule/service.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loginrule
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// NotImplementedService is a [loginrulepb.LoginRuleServiceServer] which
+// returns errors for all RPCs that indicate that enterprise
+// is required to use the service. Using a [loginrulepb.UnimplementedLoginRuleServiceServer]
+// would result in ambiguous not implemented errors being returned from open source.
+type NotImplementedService struct {
+	loginrulepb.UnimplementedLoginRuleServiceServer
+}
+
+func (NotImplementedService) CreateLoginRule(context.Context, *loginrulepb.CreateLoginRuleRequest) (*loginrulepb.LoginRule, error) {
+	return nil, services.ErrRequiresEnterprise
+}
+func (NotImplementedService) UpsertLoginRule(context.Context, *loginrulepb.UpsertLoginRuleRequest) (*loginrulepb.LoginRule, error) {
+	return nil, services.ErrRequiresEnterprise
+}
+func (NotImplementedService) GetLoginRule(context.Context, *loginrulepb.GetLoginRuleRequest) (*loginrulepb.LoginRule, error) {
+	return nil, services.ErrRequiresEnterprise
+}
+func (NotImplementedService) ListLoginRules(context.Context, *loginrulepb.ListLoginRulesRequest) (*loginrulepb.ListLoginRulesResponse, error) {
+	return nil, services.ErrRequiresEnterprise
+}
+func (NotImplementedService) DeleteLoginRule(context.Context, *loginrulepb.DeleteLoginRuleRequest) (*emptypb.Empty, error) {
+	return nil, services.ErrRequiresEnterprise
+}
+func (NotImplementedService) TestLoginRule(context.Context, *loginrulepb.TestLoginRuleRequest) (*loginrulepb.TestLoginRuleResponse, error) {
+	return nil, services.ErrRequiresEnterprise
+}


### PR DESCRIPTION
Registers a LoginRuleServiceServer that returns errors indicating that enterprise is required to use the feature. This should reduce confusion that may be caused when users attempt to use login rules on an OSS auth instance.


### Before
```bash
$ tctl create -f loginrule.yaml
ERROR: unknown service teleport.loginrule.v1.LoginRuleService
```

### After
```bash
$ tctl login_rule test --load-from-cluster traits.json
ERROR: this feature requires Teleport Enterprise

$ tctl create -f loginrule.yaml
ERROR: this feature requires Teleport Enterprise
```