### PR TITLE
Fixes Malformed GCP example script

### DIFF
--- a/docs/pages/server-access/guides/gcp-discovery.mdx
+++ b/docs/pages/server-access/guides/gcp-discovery.mdx
@@ -161,10 +161,8 @@ the host keys to the guest attributes below:
   Create a file named `add-host-keys.sh` and copy the following into it:
   ```sh
   #!/usr/bin/env bash
-  for file in /etc/ssh/ssh_host_*_key.pub
-    do
-    KEY_TYPE=$(awk '\''{print $1}'\'' $file)
-    KEY=$(awk '\''{print $2}'\''  $file)
+  for file in /etc/ssh/ssh_host_*_key.pub; do
+    read -r KEY_TYPE KEY _ <"$file"
     curl -X PUT --data "$KEY" "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/hostkeys/$KEY_TYPE" -H "Metadata-Flavor: Google"
   done
   ```


### PR DESCRIPTION
Addresses: #31382

Fixes a malformed script in our documentation that exposes a GCP VM's
public host keys as custom metadata. The original script was poorly
escaped and would not run as written.

This patch removes the issue by replacing the string tokenisation with
`read` rather than `awk`, also simplifying the script.

See-Also: #31382
Changelog: None
