### PR TITLE
[v14] Fix inconsistency with `kubectl auth can-i get pods/<pod> -n <ns>`

### DIFF
--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -298,7 +298,11 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 		if name == "" && namespace == "" {
 			return true, nil
 		}
-		if name != "" {
+		// If the resource name isn't empty but the resource kind is a namespace scope
+		// match - i.e. the resource.Kind==types.KindKubeNamespace and the desired
+		// resource kind is not a cluster-wide resource - we should skip the resource
+		// name validation.
+		if name != "" && !namespaceScopeMatch {
 			switch ok, err := utils.SliceMatchesRegex(name, []string{resource.Name}); {
 			case err != nil:
 				return false, trace.Wrap(err)

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -296,6 +296,22 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "user without access to clusterrole role2",
+			args: args{
+				name:     "role2",
+				kind:     "clusterroles",
+				apiGroup: "rbac.authorization.k8s.io",
+				resources: []types.KubernetesResource{
+					{
+						Kind:  types.KindKubeClusterRole,
+						Name:  "role",
+						Verbs: []string{types.Wildcard},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "user check clusterrole access with empty role name",
 			args: args{
 				name:     "",
@@ -326,6 +342,22 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			name: "user tries to check a specific pod when he holds a namespace resource",
+			args: args{
+				name:      "pod-1",
+				kind:      "pods",
+				namespace: "namespace-1",
+				resources: []types.KubernetesResource{
+					{
+						Kind:  types.KindKubeNamespace,
+						Name:  "namespace-1",
+						Verbs: []string{types.Wildcard},
+					},
+				},
+			},
+			want: true,
 		},
 	}
 


### PR DESCRIPTION
Backport #31862 to branch/v14