### PR TITLE
Add optimistic locking support to the memory backend

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -743,10 +743,6 @@ func (b *EtcdBackend) Put(ctx context.Context, item backend.Item) (*backend.Leas
 
 // KeepAlive updates TTL on the lease ID
 func (b *EtcdBackend) KeepAlive(ctx context.Context, lease backend.Lease, expires time.Time) error {
-	if lease.ID == 0 {
-		return trace.BadParameter("lease is not specified")
-	}
-
 	// instead of keep-alive on the old lease, set up a new lease
 	// because we would like the event to be generated
 	// which does not happen in case of lease keep-alive

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -169,6 +169,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 	if m.tree.Has(&btreeItem{Item: i}) {
 		return nil, trace.AlreadyExists("key %q already exists", string(i.Key))
 	}
+	i.Revision = backend.CreateRevision()
 	event := backend.Event{
 		Type: types.OpPut,
 		Item: i,
@@ -177,7 +178,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 	if !m.EventsOff {
 		m.buf.Emit(event)
 	}
-	return m.newLease(i), nil
+	return backend.NewLease(i), nil
 }
 
 // Get returns a single item or not found error
@@ -208,6 +209,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	if !m.Mirror {
 		i.ID = m.generateID()
+		i.Revision = backend.CreateRevision()
 	}
 	event := backend.Event{
 		Type: types.OpPut,
@@ -217,7 +219,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 	if !m.EventsOff {
 		m.buf.Emit(event)
 	}
-	return m.newLease(i), nil
+	return backend.NewLease(i), nil
 }
 
 // Put puts value into backend (creates if it does not
@@ -231,6 +233,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 	m.removeExpired()
 	if !m.Mirror {
 		i.ID = m.generateID()
+		i.Revision = backend.CreateRevision()
 	}
 	event := backend.Event{
 		Type: types.OpPut,
@@ -240,7 +243,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 	if !m.EventsOff {
 		m.buf.Emit(event)
 	}
-	return m.newLease(i), nil
+	return backend.NewLease(i), nil
 }
 
 // Delete deletes item by key, returns NotFound error
@@ -317,9 +320,10 @@ func (m *Memory) GetRange(ctx context.Context, startKey []byte, endKey []byte, l
 
 // KeepAlive updates TTL on the lease
 func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires time.Time) error {
-	if lease.IsEmpty() {
-		return trace.BadParameter("lease is empty")
+	if len(lease.Key) == 0 {
+		return trace.BadParameter("missing parameter key")
 	}
+
 	m.Lock()
 	defer m.Unlock()
 	m.removeExpired()
@@ -332,6 +336,7 @@ func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires tim
 	if !m.Mirror {
 		// ID is updated on keep alive for consistency with other backends
 		item.ID = m.generateID()
+		item.Revision = backend.CreateRevision()
 	}
 	event := backend.Event{
 		Type: types.OpPut,
@@ -366,6 +371,9 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 	if !bytes.Equal(existingItem.Value, expected.Value) {
 		return nil, trace.CompareFailed("current value does not match expected for %v", string(expected.Key))
 	}
+	if !m.Mirror {
+		replaceWith.Revision = backend.CreateRevision()
+	}
 	event := backend.Event{
 		Type: types.OpPut,
 		Item: replaceWith,
@@ -374,7 +382,61 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 	if !m.EventsOff {
 		m.buf.Emit(event)
 	}
-	return m.newLease(replaceWith), nil
+	return backend.NewLease(replaceWith), nil
+}
+
+func (m *Memory) ConditionalDelete(ctx context.Context, key []byte, rev string) error {
+	if len(key) == 0 {
+		return trace.BadParameter("missing parameter key")
+	}
+	m.Lock()
+	defer m.Unlock()
+	m.removeExpired()
+
+	item, found := m.tree.Get(&btreeItem{Item: backend.Item{Key: key}})
+	if !found || item.Item.Revision != rev {
+		return trace.Wrap(backend.ErrIncorrectRevision)
+	}
+
+	event := backend.Event{
+		Type: types.OpDelete,
+		Item: backend.Item{
+			Key: key,
+		},
+	}
+	m.processEvent(event)
+	if !m.EventsOff {
+		m.buf.Emit(event)
+	}
+	return nil
+}
+
+func (m *Memory) ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	if len(i.Key) == 0 {
+		return nil, trace.BadParameter("missing parameter key")
+	}
+	m.Lock()
+	defer m.Unlock()
+	m.removeExpired()
+
+	item, found := m.tree.Get(&btreeItem{Item: i})
+	if !found || item.Item.Revision != i.Revision {
+		return nil, trace.Wrap(backend.ErrIncorrectRevision)
+	}
+
+	if !m.Mirror {
+		i.ID = m.generateID()
+		i.Revision = backend.CreateRevision()
+	}
+	event := backend.Event{
+		Type: types.OpPut,
+		Item: i,
+	}
+	m.processEvent(event)
+	if !m.EventsOff {
+		m.buf.Emit(event)
+	}
+	return backend.NewLease(i), nil
 }
 
 // NewWatcher returns a new event watcher
@@ -399,15 +461,6 @@ func (m *Memory) getRange(ctx context.Context, startKey, endKey []byte, limit in
 		return true
 	})
 	return res
-}
-
-func (m *Memory) newLease(item backend.Item) *backend.Lease {
-	var lease backend.Lease
-	if item.Expires.IsZero() {
-		return &lease
-	}
-	lease.Key = item.Key
-	return &lease
 }
 
 // removeExpired makes a pass through map and removes expired elements

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -143,6 +143,7 @@ func (s *Reporter) Create(ctx context.Context, i Item) (*Lease, error) {
 		ctx,
 		"backend/Create",
 		oteltrace.WithAttributes(
+			attribute.String("revision", i.Revision),
 			attribute.String("key", string(i.Key)),
 		),
 	)
@@ -166,6 +167,7 @@ func (s *Reporter) Put(ctx context.Context, i Item) (*Lease, error) {
 		ctx,
 		"backend/Put",
 		oteltrace.WithAttributes(
+			attribute.String("revision", i.Revision),
 			attribute.String("key", string(i.Key)),
 		),
 	)
@@ -188,6 +190,7 @@ func (s *Reporter) Update(ctx context.Context, i Item) (*Lease, error) {
 		ctx,
 		"backend/Update",
 		oteltrace.WithAttributes(
+			attribute.String("revision", i.Revision),
 			attribute.String("key", string(i.Key)),
 		),
 	)
@@ -303,6 +306,7 @@ func (s *Reporter) KeepAlive(ctx context.Context, lease Lease, expires time.Time
 		ctx,
 		"backend/KeepAlive",
 		oteltrace.WithAttributes(
+			attribute.String("revision", lease.Revision),
 			attribute.Int64("lease", lease.ID),
 			attribute.String("key", string(lease.Key)),
 		),

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -179,6 +179,14 @@ func RunBackendComplianceSuite(t *testing.T, newBackend Constructor) {
 	t.Run("Limit", func(t *testing.T) {
 		testLimit(t, newBackend)
 	})
+
+	t.Run("ConditionalUpdate", func(t *testing.T) {
+		testConditionalUpdate(t, newBackend)
+	})
+
+	t.Run("ConditionalDelete", func(t *testing.T) {
+		testConditionalDelete(t, newBackend)
+	})
 }
 
 // RequireItems asserts that the supplied `actual` items collection matches
@@ -189,6 +197,7 @@ func RequireItems(t *testing.T, expected, actual []backend.Item) {
 	for i := range expected {
 		require.Equal(t, expected[i].Key, actual[i].Key)
 		require.Equal(t, expected[i].Value, actual[i].Value)
+		require.Equal(t, expected[i].Revision, actual[i].Revision)
 	}
 }
 
@@ -207,17 +216,20 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 	_, err = uut.Update(ctx, item)
 	require.True(t, trace.IsNotFound(err))
 
-	_, err = uut.Create(ctx, item)
+	lease, err := uut.Create(ctx, item)
 	require.NoError(t, err)
 
+	item.Revision = lease.Revision
+
 	// create will fail on existing item
-	_, err = uut.Create(context.Background(), item)
+	_, err = uut.Create(ctx, item)
 	require.True(t, trace.IsAlreadyExists(err))
 
 	// get succeeds
 	out, err := uut.Get(ctx, item.Key)
 	require.NoError(t, err)
 	require.Equal(t, item.Value, out.Value)
+	require.Equal(t, item.Revision, out.Revision)
 
 	// get range succeeds
 	res, err := uut.GetRange(ctx, item.Key, backend.RangeEnd(item.Key), backend.NoLimit)
@@ -227,12 +239,13 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 
 	// update succeeds
 	updated := backend.Item{Key: prefix("/hello"), Value: []byte("world 2")}
-	_, err = uut.Update(ctx, updated)
+	lease, err = uut.Update(ctx, updated)
 	require.NoError(t, err)
 
 	out, err = uut.Get(ctx, item.Key)
 	require.NoError(t, err)
 	require.Equal(t, updated.Value, out.Value)
+	require.Equal(t, lease.Revision, out.Revision)
 
 	// delete succeeds
 	require.NoError(t, uut.Delete(ctx, item.Key))
@@ -245,12 +258,13 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 
 	// put new item succeeds
 	item = backend.Item{Key: prefix("/put"), Value: []byte("world")}
-	_, err = uut.Put(ctx, item)
+	lease, err = uut.Put(ctx, item)
 	require.NoError(t, err)
 
 	out, err = uut.Get(ctx, item.Key)
 	require.NoError(t, err)
 	require.Equal(t, item.Value, out.Value)
+	require.Equal(t, lease.Revision, out.Revision)
 
 	// put with large key and binary value succeeds.
 	// NB: DynamoDB has a maximum overall key length of 1024 bytes, so
@@ -268,12 +282,13 @@ func testCRUD(t *testing.T, newBackend Constructor) {
 	_, err = rand.Read(data)
 	require.NoError(t, err)
 	item = backend.Item{Key: prefix(key), Value: data}
-	_, err = uut.Put(ctx, item)
+	lease, err = uut.Put(ctx, item)
 	require.NoError(t, err)
 
 	out, err = uut.Get(ctx, item.Key)
 	require.NoError(t, err)
 	require.Equal(t, item.Value, out.Value)
+	require.Equal(t, lease.Revision, out.Revision)
 }
 
 func testQueryRange(t *testing.T, newBackend Constructor) {
@@ -290,9 +305,11 @@ func testQueryRange(t *testing.T, newBackend Constructor) {
 	c1 := backend.Item{Key: prefix("/prefix/c/c1"), Value: []byte("val c1")}
 	c2 := backend.Item{Key: prefix("/prefix/c/c2"), Value: []byte("val c2")}
 
-	for _, item := range []backend.Item{outOfScope, a, b, c1, c2} {
-		_, err := uut.Create(ctx, item)
+	// create items and set the revisions received from the lease
+	for _, item := range []*backend.Item{&outOfScope, &a, &b, &c1, &c2} {
+		lease, err := uut.Create(ctx, *item)
 		require.NoError(t, err, "Failed creating value: %q => %q", item.Key, item.Value)
+		item.Revision = lease.Revision
 	}
 
 	// prefix range fetch
@@ -344,9 +361,10 @@ func testDeleteRange(t *testing.T, newBackend Constructor) {
 	c1 := backend.Item{Key: prefix("/prefix/c/c1"), Value: []byte("val c1")}
 	c2 := backend.Item{Key: prefix("/prefix/c/c2"), Value: []byte("val c2")}
 
-	for _, item := range []backend.Item{a, b, c1, c2} {
-		_, err := uut.Create(ctx, item)
+	for _, item := range []*backend.Item{&a, &b, &c1, &c2} {
+		lease, err := uut.Create(ctx, *item)
 		require.NoError(t, err, "Failed creating value: %q => %q", item.Key, item.Value)
+		item.Revision = lease.Revision
 	}
 
 	err = uut.DeleteRange(ctx, prefix("/prefix/c"), backend.RangeEnd(prefix("/prefix/c")))
@@ -360,33 +378,35 @@ func testDeleteRange(t *testing.T, newBackend Constructor) {
 
 // testCompareAndSwap tests compare and swap functionality
 func testCompareAndSwap(t *testing.T, newBackend Constructor) {
-	uut, _, err := newBackend()
+	uut, clock, err := newBackend()
 	require.NoError(t, err)
 	defer func() { require.NoError(t, uut.Close()) }()
 
 	prefix := MakePrefix()
 	ctx := context.Background()
+	expires := clock.Now().UTC().Add(time.Hour)
 
 	key := prefix("one")
 
-	// compare and swap on non existing value will fail
-	_, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1")}, backend.Item{Key: key, Value: []byte("2")})
+	// compare and swap on non-existing value will fail
+	_, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1"), Revision: "1"}, backend.Item{Key: prefix("one"), Value: []byte("2"), Revision: "1"})
 	require.True(t, trace.IsCompareFailed(err))
 
 	// create value and try again...
-	_, err = uut.Create(ctx, backend.Item{Key: key, Value: []byte("1")})
+	lease, err := uut.Create(ctx, backend.Item{Key: key, Value: []byte("1"), Expires: expires})
 	require.NoError(t, err)
 
 	// success CAS!
-	_, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1")}, backend.Item{Key: key, Value: []byte("2")})
+	lease, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1"), Revision: lease.Revision, Expires: expires}, backend.Item{Key: prefix("one"), Value: []byte("2"), Revision: lease.Revision, Expires: expires})
 	require.NoError(t, err)
 
 	out, err := uut.Get(ctx, key)
 	require.NoError(t, err)
 	require.Equal(t, []byte("2"), out.Value)
+	require.Equal(t, lease.Revision, out.Revision)
 
-	// value has been updated - not '1' any more
-	_, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1")}, backend.Item{Key: key, Value: []byte("3")})
+	// value has been updated - not '1' anymore
+	_, err = uut.CompareAndSwap(ctx, backend.Item{Key: key, Value: []byte("1"), Revision: lease.Revision}, backend.Item{Key: prefix("one"), Value: []byte("3"), Revision: lease.Revision})
 	require.True(t, trace.IsCompareFailed(err))
 
 	// existing value has not been changed by the failed CAS operation
@@ -441,11 +461,12 @@ func testExpiration(t *testing.T, newBackend Constructor) {
 	prefix := MakePrefix()
 	ctx := context.Background()
 
-	itemA := backend.Item{Key: prefix("a"), Value: []byte("val1")}
-	_, err = uut.Put(ctx, itemA)
+	itemA := backend.Item{Key: prefix("a"), Value: []byte("val1"), Expires: clock.Now().UTC().Add(time.Hour)}
+	leaseA, err := uut.Put(ctx, itemA)
 	require.NoError(t, err)
+	itemA.Revision = leaseA.Revision
 
-	itemB := backend.Item{Key: prefix("b"), Value: []byte("val1"), Expires: clock.Now().Add(1 * time.Second)}
+	itemB := backend.Item{Key: prefix("b"), Value: []byte("val1"), Expires: clock.Now().UTC().Add(time.Second)}
 	_, err = uut.Put(ctx, itemB)
 	require.NoError(t, err)
 
@@ -546,13 +567,14 @@ func testEvents(t *testing.T, newBackend Constructor) {
 	requireEvent(t, watcher, types.OpInit, nil, eventTimeout)
 
 	// Add item to backend.
-	item := &backend.Item{Key: prefix("b"), Value: []byte("val")}
-	_, err = uut.Put(ctx, *item)
+	item := &backend.Item{Key: prefix("b"), Value: []byte("val"), Expires: clock.Now().UTC().Add(time.Hour)}
+	lease, err := uut.Put(ctx, *item)
 	require.NoError(t, err)
 
 	// Make sure item was added into backend.
 	item, err = uut.Get(ctx, item.Key)
 	require.NoError(t, err)
+	require.Equal(t, lease.Revision, item.Revision)
 
 	// Make sure a PUT event is emitted.
 	e := requireEvent(t, watcher, types.OpPut, item.Key, eventTimeout)
@@ -573,14 +595,15 @@ func testEvents(t *testing.T, newBackend Constructor) {
 	item = &backend.Item{
 		Key:     prefix("c"),
 		Value:   []byte("val"),
-		Expires: clock.Now().Add(1 * time.Second),
+		Expires: clock.Now().UTC().Add(time.Second),
 	}
-	_, err = uut.Put(ctx, *item)
+	lease, err = uut.Put(ctx, *item)
 	require.NoError(t, err)
 
 	// Make sure item was added into backend.
 	item, err = uut.Get(ctx, item.Key)
 	require.NoError(t, err)
+	require.Equal(t, lease.Revision, item.Revision)
 
 	// Make sure a PUT event is emitted.
 	e = requireEvent(t, watcher, types.OpPut, item.Key, eventTimeout)
@@ -882,7 +905,7 @@ func testConcurrentOperations(t *testing.T, newBackend Constructor) {
 	defer func() { require.NoError(t, uutA.Close()) }()
 
 	uutB, _, err := newBackend(WithConcurrentBackend(uutA))
-	if err == ErrConcurrentAccessNotSupported {
+	if errors.Is(err, ErrConcurrentAccessNotSupported) {
 		t.Skip("Backend does not support concurrent access")
 	}
 	require.NoError(t, err)
@@ -975,7 +998,7 @@ func testMirror(t *testing.T, newBackend Constructor) {
 	const eventTimeout = 2 * time.Second
 
 	uut, _, err := newBackend(WithMirrorMode(true))
-	if err == ErrMirrorNotSupported {
+	if errors.Is(err, ErrMirrorNotSupported) {
 		t.Skip("Backend does not support mirror mode")
 	}
 	require.NoError(t, err)
@@ -1050,6 +1073,95 @@ func testMirror(t *testing.T, newBackend Constructor) {
 	// Make sure item was added into backend despite being expired.
 	_, err = uut.Get(ctx, item2.Key)
 	require.NoError(t, err)
+}
+
+// conditionalBackend is a placeholder interface that allows testing backends that
+// implement optimistic locking. Once all backends support optimistic locking the
+// [backend.Backend] will be extended and this interface will be deleted.
+type conditionalBackend interface {
+	// ConditionalUpdate updates value in the backend if the revision of the [backend.Item] matches
+	// the stored revision.
+	ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error)
+
+	// ConditionalDelete deletes item by key if the revision of the [backend.Item] matches
+	// the stored revision.
+	ConditionalDelete(ctx context.Context, key []byte, revision string) error
+}
+
+func testConditionalDelete(t *testing.T, newBackend Constructor) {
+	uut, _, err := newBackend()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, uut.Close()) }()
+
+	cbk, ok := uut.(conditionalBackend)
+	if !ok {
+		t.Skip("backend does not implement conditional interface")
+	}
+
+	ctx := context.Background()
+	prefix := MakePrefix()
+
+	item := backend.Item{Key: prefix("/hello"), Value: []byte("world")}
+	lease, err := uut.Create(ctx, item)
+	require.NoError(t, err)
+	require.NotEmpty(t, lease.Revision)
+
+	// delete fails when revisions don't match
+	err = cbk.ConditionalDelete(ctx, item.Key, "1")
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+
+	// delete succeeds when revisions match
+	require.NoError(t, cbk.ConditionalDelete(ctx, item.Key, lease.Revision))
+
+	// validate that the item was deleted
+	_, err = uut.Get(ctx, item.Key)
+	require.True(t, trace.IsNotFound(err))
+
+	// validate that deleting a non-existent item fails
+	err = cbk.ConditionalDelete(ctx, item.Key, lease.Revision)
+	require.True(t, trace.IsCompareFailed(err))
+}
+
+func testConditionalUpdate(t *testing.T, newBackend Constructor) {
+	uut, _, err := newBackend()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, uut.Close()) }()
+
+	cbk, ok := uut.(conditionalBackend)
+	if !ok {
+		t.Skip("backend does not implement conditional interface")
+	}
+
+	ctx := context.Background()
+	prefix := MakePrefix()
+
+	item := backend.Item{Key: prefix("/hello"), Value: []byte("world")}
+
+	// Updating a non-existent item should fail.
+	_, err = cbk.ConditionalUpdate(ctx, item)
+	require.True(t, trace.IsCompareFailed(err))
+
+	// Create the item.
+	lease, err := uut.Create(ctx, item)
+	require.NoError(t, err)
+	require.NotEmpty(t, lease.Revision)
+
+	item.Revision = "100"
+	// Update fails when revisions don't match.
+	_, err = cbk.ConditionalUpdate(ctx, item)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+
+	// Update succeeds when revisions match and a new revision
+	// is created. Try more than once to ensure the revision returned
+	// in the lease matches the value stored in the backend.
+	item.Revision = lease.Revision
+	for i := 0; i < 2; i++ {
+		lease, err = cbk.ConditionalUpdate(ctx, item)
+		require.NoError(t, err)
+		require.NotEmpty(t, lease.Revision)
+		require.NotEqual(t, item.Revision, lease.Revision)
+		item.Revision = lease.Revision
+	}
 }
 
 func AddItem(ctx context.Context, t *testing.T, uut backend.Backend, key []byte, value string, expires time.Time) (backend.Item, backend.Lease) {


### PR DESCRIPTION
Implements ConditionalUpdate and ConditionalDelete for the memory backend and extends existing backend methods to take the revision into account. The backend test suite has also been updated to run optimistic locking tests on any backends that support it.

Contributes to #30416