### PR TITLE
Ignore Vagrant folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ coverage
 # vite
 .swc
 web/certs/
+
+# Vagrant
+/.vagrant/


### PR DESCRIPTION
I'm using Vagrant for BPF work and the lack of this ignore keeps bugging me.

Adding as a separate PR so I can easily backport too.