### PR TITLE
CodeQL: Fix Go 1.21 build fix and update branch list

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'master', 'branch/v11', 'branch/v12', 'branch/v13' ]
+        branch: [ 'master', 'branch/v12', 'branch/v13', 'branch/v14' ]
         language: [ 'go', 'javascript' ]
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         cache: false
+        go-version-file: go.mod
       if: ${{ matrix.language == 'go' }}
 
     - name: Initialize the CodeQL tools for scanning


### PR DESCRIPTION
Fix CodeQL Build and update branch list to include the v14 branch.

This PR fixes https://github.com/gravitational/SecOps/issues/414

Test build and analysis can be seen in this run: https://github.com/gravitational/teleport/actions/runs/6188331568/job/16800106312?pr=31892