### PR TITLE
Only show copy button on hover

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -87,6 +87,8 @@ export function ResourceCard({ resource, onLabelClick }: Props) {
   const [numMoreLabels, setNumMoreLabels] = useState(0);
   const [isNameOverflowed, setIsNameOverflowed] = useState(false);
 
+  const [hovered, setHovered] = useState(false);
+
   const innerContainer = useRef<Element | null>(null);
   const labelsInnerContainer = useRef(null);
   const nameText = useRef<HTMLDivElement | null>(null);
@@ -172,7 +174,10 @@ export function ResourceCard({ resource, onLabelClick }: Props) {
   };
 
   return (
-    <CardContainer>
+    <CardContainer
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
       <CardInnerContainer
         ref={innerContainer}
         p={3}
@@ -197,7 +202,7 @@ export function ResourceCard({ resource, onLabelClick }: Props) {
                 </Text>
               )}
             </SingleLineBox>
-            <CopyButton name={name} />
+            {hovered && <CopyButton name={name} />}
             <ResourceActionButton resource={resource} />
           </Flex>
           <Flex flexDirection="row" alignItems="center">


### PR DESCRIPTION
This PR makes the "Copy" name button on unified resource cards only show when the card is hovered. Currently its always there on the cards. this will reduce visual clutter


https://github.com/gravitational/teleport/assets/5201977/8365ea27-5f00-4fee-a214-34c7cb51d2c7

