### PR TITLE
Remove unused backend.Batch interface

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -139,14 +139,6 @@ func StreamRange(ctx context.Context, bk Backend, startKey, endKey []byte, pageS
 	})
 }
 
-// Batch implements some batch methods
-// that are not mandatory for all interfaces,
-// only the ones used in bulk operations.
-type Batch interface {
-	// PutRange puts range of items in one transaction
-	PutRange(ctx context.Context, items []Item) error
-}
-
 // Lease represents a lease on the item that can be used
 // to extend item's TTL without updating its contents.
 //

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -100,7 +100,7 @@ type Config struct {
 	// Journal sets the journal_mode pragma
 	Journal string `json:"journal,omitempty"`
 	// Mirror turns on mirror mode for the backend,
-	// which will use record IDs for Put and PutRange passed from
+	// which will use record IDs for Put passed from
 	// the resources, not generate a new one
 	Mirror bool `json:"mirror"`
 }
@@ -576,23 +576,6 @@ func (l *Backend) Import(ctx context.Context, items []backend.Item) error {
 			return trace.Wrap(err)
 		}
 		return nil
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-// PutRange puts range of items into backend (creates if items doe not
-// exists, updates it otherwise)
-func (l *Backend) PutRange(ctx context.Context, items []backend.Item) error {
-	for i := range items {
-		if items[i].Key == nil {
-			return trace.BadParameter("missing parameter key in item %v", i)
-		}
-	}
-	err := l.inTransaction(ctx, func(tx *sql.Tx) error {
-		return l.putRangeInTransaction(ctx, tx, items, false)
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -141,10 +141,6 @@ func RunBackendComplianceSuite(t *testing.T, newBackend Constructor) {
 		testDeleteRange(t, newBackend)
 	})
 
-	t.Run("PutRange", func(t *testing.T) {
-		testPutRange(t, newBackend)
-	})
-
 	t.Run("CompareAndSwap", func(t *testing.T) {
 		testCompareAndSwap(t, newBackend)
 	})
@@ -357,32 +353,6 @@ func testDeleteRange(t *testing.T, newBackend Constructor) {
 	require.NoError(t, err)
 
 	// make sure items with "/prefix/c" are gone
-	result, err := uut.GetRange(ctx, prefix("/prefix"), backend.RangeEnd(prefix("/prefix")), backend.NoLimit)
-	require.NoError(t, err)
-	RequireItems(t, []backend.Item{a, b}, result.Items)
-}
-
-// testPutRange tests scenarios with put range
-func testPutRange(t *testing.T, newBackend Constructor) {
-	uut, _, err := newBackend()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, uut.Close()) }()
-
-	batchUut, ok := uut.(backend.Batch)
-	if !ok {
-		t.Skip("Backend should support Batch interface for this test")
-	}
-
-	ctx := context.Background()
-	prefix := MakePrefix()
-	a := backend.Item{Key: prefix("/prefix/a"), Value: []byte("val a")}
-	b := backend.Item{Key: prefix("/prefix/b"), Value: []byte("val b")}
-
-	// add one element that should not show up (i.e. a duplicate `a`)
-	err = batchUut.PutRange(ctx, []backend.Item{a, b, a})
-	require.NoError(t, err)
-
-	// prefix range fetch
 	result, err := uut.GetRange(ctx, prefix("/prefix"), backend.RangeEnd(prefix("/prefix")), backend.NoLimit)
 	require.NoError(t, err)
 	RequireItems(t, []backend.Item{a, b}, result.Items)


### PR DESCRIPTION
Only two backends implemented the interface and it was only being used by tests.