### PR TITLE
Partially revert #30248

### DIFF
--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -207,7 +207,7 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 	// wait for events received from upstream until the connection is terminated.
 	for {
 		eventType, obj, err := w.decodeStreamingMessage(streamingDecoder, objectDecoder)
-		if errors.Is(err, io.EOF) {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
 			return nil
 		} else if err != nil {
 			return trace.Wrap(err)

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -336,7 +336,8 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		Log: log,
 	})
 	require.NoError(t, err)
-
+	require.Equal(t, testCtx.KubeServer.Server.ReadTimeout, time.Duration(0), "kube server write timeout must be 0")
+	require.Equal(t, testCtx.KubeServer.Server.WriteTimeout, time.Duration(0), "kube server write timeout must be 0")
 	// Waits for len(clusters) heartbeats to start
 	waitForHeartbeats := len(cfg.Clusters)
 


### PR DESCRIPTION
This PR removes the `ReadTimeout` and `WriteTimeout` settings from `kube/proxy.Server`.

The revert is required because both settings were terminating watch streams earlier and causing several issues when parsing the long-lived data stream.