### PR TITLE
Leave access intact if access list has not been reviewed by review date.

### DIFF
--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -208,8 +208,8 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 	}
 
 	expires := member.Spec.Expires
-	if expires.IsZero() || accessList.Spec.Audit.NextAuditDate.Before(expires) {
-		expires = accessList.Spec.Audit.NextAuditDate
+	if expires.IsZero() {
+		return nil
 	}
 
 	if !clock.Now().Before(expires) {


### PR DESCRIPTION
Access lists will now leave access intact for members even if the access list hasn't been reviewed by the next audit date. Revoking access on a missed audit review may be too disruptive. This may be restored at a later date by adding in options to access lists to control behavior.