### PR TITLE
Respect MongoDB max message size

### DIFF
--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -175,6 +175,11 @@ func (e *Engine) processHandshakeResponse(ctx context.Context, respMessage proto
 	switch resp := respMessage.(type) {
 	// OP_REPLY is used on legacy handshake messages (deprecated on MongoDB 5.0)
 	case *protocol.MessageOpReply:
+		if len(resp.Documents) == 0 {
+			e.Log.Warn("Empty MongoDB handshake response.")
+			return
+		}
+
 		// Handshake messages are always the first document on a reply.
 		rawMessage = bson.Raw(resp.Documents[0])
 	// OP_MSG is used on modern handshake messages.

--- a/lib/srv/db/mongodb/protocol/fuzz_test.go
+++ b/lib/srv/db/mongodb/protocol/fuzz_test.go
@@ -160,7 +160,7 @@ func FuzzMongoRead(f *testing.F) {
 		msg := bytes.NewReader(msgBytes)
 
 		require.NotPanics(t, func() {
-			_, _ = ReadMessage(msg)
+			_, _ = ReadMessage(msg, DefaultMaxMessageSizeBytes)
 		})
 	})
 }

--- a/lib/srv/db/mongodb/protocol/message.go
+++ b/lib/srv/db/mongodb/protocol/message.go
@@ -162,5 +162,5 @@ func IsHandshake(m Message) bool {
 	}
 
 	// Servers must accept alternative casing for IsMasterCommand.
-	return strings.ToLower(cmd) == strings.ToLower(IsMasterCommand) || cmd == HelloCommand
+	return strings.EqualFold(cmd, IsMasterCommand) || cmd == HelloCommand
 }

--- a/lib/srv/db/mongodb/protocol/message.go
+++ b/lib/srv/db/mongodb/protocol/message.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -47,8 +48,8 @@ type Message interface {
 }
 
 // ReadMessage reads the next MongoDB wire protocol message from the reader.
-func ReadMessage(reader io.Reader) (Message, error) {
-	header, payload, err := readHeaderAndPayload(reader)
+func ReadMessage(reader io.Reader, maxMessageSize uint32) (Message, error) {
+	header, payload, err := readHeaderAndPayload(reader, maxMessageSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -66,7 +67,7 @@ func ReadMessage(reader io.Reader) (Message, error) {
 	case wiremessage.OpDelete:
 		return readOpDelete(*header, payload)
 	case wiremessage.OpCompressed:
-		return readOpCompressed(*header, payload)
+		return readOpCompressed(*header, payload, maxMessageSize)
 	case wiremessage.OpReply:
 		return readOpReply(*header, payload)
 	case wiremessage.OpKillCursors:
@@ -77,15 +78,15 @@ func ReadMessage(reader io.Reader) (Message, error) {
 }
 
 // ReadServerMessage reads wire protocol message from the MongoDB server connection.
-func ReadServerMessage(ctx context.Context, conn driver.Connection) (Message, error) {
+func ReadServerMessage(ctx context.Context, conn driver.Connection, maxMessageSize uint32) (Message, error) {
 	wm, err := conn.ReadWireMessage(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return ReadMessage(bytes.NewReader(wm))
+	return ReadMessage(bytes.NewReader(wm), maxMessageSize)
 }
 
-func readHeaderAndPayload(reader io.Reader) (*MessageHeader, []byte, error) {
+func readHeaderAndPayload(reader io.Reader, maxMessageSize uint32) (*MessageHeader, []byte, error) {
 	// First read message header which is 16 bytes.
 	var header [headerSizeBytes]byte
 	if _, err := io.ReadFull(reader, header[:]); err != nil {
@@ -101,8 +102,8 @@ func readHeaderAndPayload(reader io.Reader) (*MessageHeader, []byte, error) {
 		return nil, nil, trace.BadParameter("invalid header size %v", header)
 	}
 
-	payloadLength := int64(length - headerSizeBytes)
-	if payloadLength >= defaultMaxMessageSizeBytes {
+	payloadLength := uint32(length - headerSizeBytes)
+	if payloadLength >= maxMessageSize {
 		return nil, nil, trace.BadParameter("exceeded the maximum message size, got length: %d", length)
 	}
 
@@ -111,8 +112,8 @@ func readHeaderAndPayload(reader io.Reader) (*MessageHeader, []byte, error) {
 	}
 
 	// Then read the entire message body.
-	payloadBuff := bytes.NewBuffer(make([]byte, 0, buffAllocCapacity(payloadLength)))
-	if _, err := io.CopyN(payloadBuff, reader, payloadLength); err != nil {
+	payloadBuff := bytes.NewBuffer(make([]byte, 0, min(payloadLength, maxMessageSize)))
+	if _, err := io.CopyN(payloadBuff, reader, int64(payloadLength)); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -125,22 +126,10 @@ func readHeaderAndPayload(reader io.Reader) (*MessageHeader, []byte, error) {
 	}, payloadBuff.Bytes(), nil
 }
 
-// defaultMaxMessageSizeBytes is the default max size of mongoDB message.
-// It can be obtained by following command:
-// db.isMaster().maxMessageSizeBytes    48000000 (default)
-// TODO(jent): get the max limit from Mongo handshake
-// https://github.com/gravitational/teleport/issues/21286
-// For now allow 2x default mongoDB limit.
-const defaultMaxMessageSizeBytes = int64(48000000) * 2
-
-// buffCapacity returns the capacity for the payload buffer.
-// If payloadLength is greater than defaultMaxMessageSizeBytes the defaultMaxMessageSizeBytes is returned.
-func buffAllocCapacity(payloadLength int64) int64 {
-	if payloadLength >= defaultMaxMessageSizeBytes {
-		return defaultMaxMessageSizeBytes
-	}
-	return payloadLength
-}
+// DefaultMaxMessageSizeBytes is the default max size of mongoDB message. This
+// value is only used if the MongoDB doesn't impose any value. Defaults to
+// double size of MongoDB default.
+const DefaultMaxMessageSizeBytes = uint32(48000000) * 2
 
 // MessageHeader represents parsed MongoDB wire protocol message header.
 //
@@ -157,3 +146,21 @@ type MessageHeader struct {
 const (
 	headerSizeBytes = 16
 )
+
+const (
+	// IsMasterCommand is legacy handshake command name.
+	IsMasterCommand = "isMaster"
+	// HelloCommand is the handshake command name.
+	HelloCommand = "hello"
+)
+
+// IsHandshake returns true if the message is a handshake request.
+func IsHandshake(m Message) bool {
+	cmd, err := m.GetCommand()
+	if err != nil {
+		return false
+	}
+
+	// Servers must accept alternative casing for IsMasterCommand.
+	return strings.ToLower(cmd) == strings.ToLower(IsMasterCommand) || cmd == HelloCommand
+}

--- a/lib/srv/db/mongodb/protocol/message_test.go
+++ b/lib/srv/db/mongodb/protocol/message_test.go
@@ -35,7 +35,7 @@ func TestOpMsgSingleBody(t *testing.T) {
 	message := makeTestOpMsg(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -98,7 +98,7 @@ func TestMalformedOpMsg(t *testing.T) {
 			require.NoError(t, err)
 
 			message := makeTestOpMsgWithBody(t, document)
-			parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+			parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 			require.NoError(t, err)
 
 			_, err = parsed.GetDatabase()
@@ -130,7 +130,7 @@ func TestOpMsgDocumentSequence(t *testing.T) {
 	message.bytes = message.ToWire(0)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 
 	// Make sure we got the same message back.
@@ -146,7 +146,7 @@ func TestOpReply(t *testing.T) {
 	message := makeTestOpReply(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 }
@@ -159,7 +159,7 @@ func TestOpQuery(t *testing.T) {
 	message := makeTestOpQuery(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -182,7 +182,7 @@ func TestOpGetMore(t *testing.T) {
 	message := makeTestOpGetMore(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -200,7 +200,7 @@ func TestOpInsert(t *testing.T) {
 	message := makeTestOpInsert(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -218,7 +218,7 @@ func TestOpUpdate(t *testing.T) {
 	message := makeTestOpUpdate(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -236,7 +236,7 @@ func TestOpDelete(t *testing.T) {
 	message := makeTestOpDelete(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 
@@ -254,7 +254,7 @@ func TestOpKillCursors(t *testing.T) {
 	message := makeTestOpKillCursors(t)
 
 	// Read it back.
-	parsed, err := ReadMessage(bytes.NewReader(message.bytes))
+	parsed, err := ReadMessage(bytes.NewReader(message.bytes), DefaultMaxMessageSizeBytes)
 	require.NoError(t, err)
 	require.Equal(t, message, parsed)
 }
@@ -305,7 +305,7 @@ func TestOpCompressed(t *testing.T) {
 			compressedMessage := makeTestOpCompressed(t, test.message)
 
 			// Read it back.
-			parsed, err := ReadMessage(bytes.NewReader(compressedMessage.bytes))
+			parsed, err := ReadMessage(bytes.NewReader(compressedMessage.bytes), DefaultMaxMessageSizeBytes)
 			require.NoError(t, err)
 			require.Equal(t, compressedMessage, parsed)
 
@@ -331,7 +331,7 @@ func TestInvalidPayloadSize(t *testing.T) {
 		},
 		{
 			name:        "exceeded payload size",
-			payloadSize: int32(2*defaultMaxMessageSizeBytes + 1024),
+			payloadSize: int32(2*DefaultMaxMessageSizeBytes + 1024),
 			errMsg:      "exceeded the maximum message size",
 		},
 	}
@@ -357,7 +357,7 @@ func TestInvalidPayloadSize(t *testing.T) {
 			buf.Write(bytes.Repeat([]byte{0x1}, int(size)))
 			msg := bytes.NewReader(buf.Bytes())
 
-			_, err := ReadMessage(msg)
+			_, err := ReadMessage(msg, DefaultMaxMessageSizeBytes)
 			require.ErrorContains(t, err, errMsg)
 		})
 	}
@@ -375,7 +375,7 @@ func TestInvalidDecompressPayloadSize(t *testing.T) {
 	}
 	msg := bytes.NewReader(msgBytes)
 
-	_, err := ReadMessage(msg)
+	_, err := ReadMessage(msg, DefaultMaxMessageSizeBytes)
 	require.ErrorContains(t, err, "uncompressed size exceeded max")
 }
 

--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -80,6 +80,7 @@ type TestServer struct {
 
 	wireVersion      int
 	activeConnection int32
+	maxMessageSize   uint32
 
 	// conversationIdx conversion ID control number. It is increased every time
 	// a SASL conversation is started.
@@ -97,6 +98,13 @@ type TestServerOption func(*TestServer)
 func TestServerWireVersion(wireVersion int) TestServerOption {
 	return func(ts *TestServer) {
 		ts.wireVersion = wireVersion
+	}
+}
+
+// TestServerMaxMessageSize sets the test MongoDB server max message size.
+func TestServerMaxMessageSize(maxMessageSize uint32) TestServerOption {
+	return func(ts *TestServer) {
+		ts.maxMessageSize = maxMessageSize
 	}
 }
 
@@ -168,7 +176,7 @@ func (s *TestServer) handleConnection(conn net.Conn) error {
 	// Read client messages and reply to them - test server supports a very
 	// basic set of commands: "isMaster", "authenticate", "ping" and "find".
 	for {
-		message, err := protocol.ReadMessage(conn)
+		message, err := protocol.ReadMessage(conn, s.getMaxMessageSize())
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -235,7 +243,7 @@ func (s *TestServer) handleAuth(message protocol.Message) (protocol.Message, err
 // isMaster command is used as a handshake by the client to determine the
 // cluster topology.
 func (s *TestServer) handleIsMaster(message protocol.Message) (protocol.Message, error) {
-	isMasterReply, err := makeIsMasterReply(s.getWireVersion())
+	isMasterReply, err := makeIsMasterReply(s.getWireVersion(), s.getMaxMessageSize())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -381,6 +389,14 @@ func (s *TestServer) getWireVersion() int {
 	return 9 // Latest MongoDB server sends maxWireVersion=9.
 }
 
+// getMaxMessageSize returns the server's max message size.
+func (s *TestServer) getMaxMessageSize() uint32 {
+	if s.maxMessageSize != 0 {
+		return s.maxMessageSize
+	}
+	return protocol.DefaultMaxMessageSizeBytes
+}
+
 // Port returns the port server is listening on.
 func (s *TestServer) Port() string {
 	return s.port
@@ -416,12 +432,13 @@ func makeOKReply() ([]byte, error) {
 }
 
 // makeIsMasterReply builds a document used as a "isMaster" command reply.
-func makeIsMasterReply(wireVersion int) ([]byte, error) {
+func makeIsMasterReply(wireVersion int, maxMessageSize uint32) ([]byte, error) {
 	return bson.Marshal(bson.M{
-		"ok":             1,
-		"maxWireVersion": wireVersion,
-		"compression":    []string{"zlib"},
-		"serviceId":      primitive.NewObjectID(),
+		"ok":              1,
+		"maxWireVersion":  wireVersion,
+		"maxMessageBytes": maxMessageSize,
+		"compression":     []string{"zlib"},
+		"serviceId":       primitive.NewObjectID(),
 	})
 }
 


### PR DESCRIPTION
Closes #21286.

Read the `maxMessageBytes` value from the MongoDB server (through handshake response) and use it as a maximum size when reading protocol messages.

We're "intercepting" handshake response because Teleport uses a no-op handshake when connecting to the server. This means we cannot access the handshake information using `serverConn.Description().MaxMessageSize`.