### PR TITLE
Add error to Attempt in useAsync

### DIFF
--- a/web/packages/shared/hooks/useAsync.test.ts
+++ b/web/packages/shared/hooks/useAsync.test.ts
@@ -171,3 +171,26 @@ test('run does not update state after being re-run when the callback returns a r
     await secondRunPromise;
   });
 });
+
+test('error and statusText are set when the callback returns a rejected promise', async () => {
+  const expectedError = new Error('whoops');
+
+  const { result, waitFor } = renderHook(() =>
+    useAsync(() => Promise.reject(expectedError))
+  );
+
+  let runPromise: Promise<any>;
+  let [, run] = result.current;
+
+  act(() => {
+    runPromise = run();
+  });
+  await waitFor(() => result.current[0].status === 'error');
+
+  const attempt = result.current[0];
+  expect(attempt['error']).toEqual(expectedError);
+  expect(attempt['statusText']).toEqual(expectedError.message);
+
+  // The promise returned from run always succeeds, but any errors are captured as the second arg.
+  await expect(runPromise).resolves.toEqual([null, expectedError]);
+});

--- a/web/packages/shared/hooks/useAsync.test.ts
+++ b/web/packages/shared/hooks/useAsync.test.ts
@@ -188,7 +188,7 @@ test('error and statusText are set when the callback returns a rejected promise'
   await waitFor(() => result.current[0].status === 'error');
 
   const attempt = result.current[0];
-  expect(attempt['error']).toEqual(expectedError);
+  expect(attempt['error']).toBe(expectedError);
   expect(attempt['statusText']).toEqual(expectedError.message);
 
   // The promise returned from run always succeeds, but any errors are captured as the second arg.

--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -129,7 +129,7 @@ export function useAsync<Args extends unknown[], AttemptData>(
           setState(() => ({
             status: 'error',
             error: err,
-            statusText: err && err['message'],
+            statusText: err?.message,
             data: null,
           }));
 
@@ -230,12 +230,12 @@ export function makeProcessingAttempt<T>(): Attempt<T> {
   };
 }
 
-export function makeErrorAttempt<T>(error: any): Attempt<T> {
+export function makeErrorAttempt<T>(error: Error): Attempt<T> {
   return {
     data: null,
     status: 'error',
     error: error,
-    statusText: error['message'],
+    statusText: error.message,
   };
 }
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 
 import { Box } from 'design';
-import { Attempt } from 'shared/hooks/useAsync';
+import { Attempt, makeErrorAttempt } from 'shared/hooks/useAsync';
 
 import * as types from 'teleterm/ui/services/clusters/types';
 import {
@@ -70,12 +70,9 @@ function makeProps(): ClusterLoginPresentationProps {
   };
 }
 
-export const Error = () => {
+export const Err = () => {
   const props = makeProps();
-  props.initAttempt = {
-    status: 'error',
-    statusText: 'some error message',
-  };
+  props.initAttempt = makeErrorAttempt(new Error('some error message'));
 
   return (
     <TestContainer>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -192,7 +192,7 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
           return;
         }
 
-        if (joinClusterAttempt.statusText !== AgentProcessError.name) {
+        if (!(joinClusterAttempt.error instanceof AgentProcessError)) {
           return <StandardError error={joinClusterAttempt.statusText} />;
         }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -272,7 +272,7 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           };
         }
         case 'error': {
-          if (currentAction.attempt.statusText !== AgentProcessError.name) {
+          if (!(currentAction.attempt.error instanceof AgentProcessError)) {
             return {
               Icon: StyledWarning,
               title: 'Failed to start agent',

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -258,7 +258,7 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           return noop; // noop, not used, at this point it should be start processing.
         }
         default: {
-          return assertUnreachable(currentAction.attempt.status);
+          return assertUnreachable(currentAction.attempt);
         }
       }
     }
@@ -306,7 +306,7 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           return noop; // noop, not used, at this point it should be observe-process running.
         }
         default: {
-          return assertUnreachable(currentAction.attempt.status);
+          return assertUnreachable(currentAction.attempt);
         }
       }
       break;
@@ -377,7 +377,7 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           return noop; // noop, not used, at this point it should be observe-process exited.
         }
         default: {
-          return assertUnreachable(currentAction.attempt.status);
+          return assertUnreachable(currentAction.attempt);
         }
       }
     }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -117,7 +117,7 @@ test('startAgent re-throws errors that are thrown while spawning the process', a
   expect(error).toBeInstanceOf(AgentProcessError);
   expect(result.current.currentAction).toStrictEqual({
     kind: 'start',
-    attempt: makeErrorAttempt(AgentProcessError.name),
+    attempt: makeErrorAttempt(new AgentProcessError()),
     agentProcessState: {
       status: 'error',
       message: 'ENOENT',

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import {
   makeEmptyAttempt,
   makeProcessingAttempt,
-  makeErrorAttempt,
+  makeErrorAttemptWithStatusText,
   makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
 
@@ -91,7 +91,7 @@ export function OnlineWithFailedDbNameAttempt() {
   return (
     <DocumentGateway
       {...onlineDocumentGatewayProps}
-      changeDbNameAttempt={makeErrorAttempt<void>(
+      changeDbNameAttempt={makeErrorAttemptWithStatusText<void>(
         'Something went wrong with setting database name.'
       )}
     />
@@ -102,7 +102,7 @@ export function OnlineWithFailedPortAttempt() {
   return (
     <DocumentGateway
       {...onlineDocumentGatewayProps}
-      changePortAttempt={makeErrorAttempt<void>(
+      changePortAttempt={makeErrorAttemptWithStatusText<void>(
         'Something went wrong with setting port.'
       )}
     />
@@ -113,10 +113,10 @@ export function OnlineWithFailedDbNameAndPortAttempts() {
   return (
     <DocumentGateway
       {...onlineDocumentGatewayProps}
-      changeDbNameAttempt={makeErrorAttempt<void>(
+      changeDbNameAttempt={makeErrorAttemptWithStatusText<void>(
         'Something went wrong with setting database name.'
       )}
-      changePortAttempt={makeErrorAttempt<void>(
+      changePortAttempt={makeErrorAttemptWithStatusText<void>(
         'Something went wrong with setting port.'
       )}
     />
@@ -142,7 +142,7 @@ export function OfflineWithFailedConnectAttempt() {
       gateway={undefined}
       defaultPort="62414"
       connected={false}
-      connectAttempt={makeErrorAttempt<void>(
+      connectAttempt={makeErrorAttemptWithStatusText<void>(
         'listen tcp 127.0.0.1:62414: bind: address already in use'
       )}
     />

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -21,7 +21,7 @@ import { debounce } from 'shared/utils/highbar';
 import {
   Attempt,
   makeEmptyAttempt,
-  makeErrorAttempt,
+  makeErrorAttemptWithStatusText,
   makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
 
@@ -59,7 +59,7 @@ export function Terminal(props: TerminalProps) {
   useEffect(() => {
     const removeOnStartErrorListener = props.ptyProcess.onStartError(
       message => {
-        setStartPtyProcessAttempt(makeErrorAttempt(message));
+        setStartPtyProcessAttempt(makeErrorAttemptWithStatusText(message));
       }
     );
 


### PR DESCRIPTION
## Motivation

The master version of useAsync preserves only the message property (`statusText`) of any error thrown during the action. It is good enough for 90% of use cases where you only want to show the error in the UI and do nothing else.

However, sometimes you want to show different UI [depending on what kind of error was thrown](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#handling_a_specific_error_type). The best way to do this is to use [a custom error class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types), rather than depending on the error message. But since `useAsync` preserves only the message property through `statusText`, this is not possible. This leads to workarounds which make the code more complicated than it could be, see https://github.com/gravitational/teleport/pull/30910#discussion_r1304229057.

Another benefit of this approach, and actually the main reason I implemented this, is that custom errors can carry custom fields, acting almost like enum variants with extra data. Here's [an example](https://github.com/gravitational/teleport/pull/30910/commits/dee0ca4d54649bf4d2bcd906f3f343af75c35a0b).

Hence this PR. It adds `error` property to the `error` variant of `Attempt`. It keeps `statusText` on other variants for compatibility purposes. There's about 15 instances, mostly in tests, where `statusText` is read without inspecting `status` first.

Otherwise I tried to keep the behavior of `useAsync` the same to guarantee that everything else keeps working as usual.

## Alternatives

There's not much else we could do instead. In other languages such as Elm, our `Attempt<T>` is represented as `Attempt<Data, Error>` where `Error` is an enum describing possible errors that the given function can return (see [RemoteData](https://package.elm-lang.org/packages/krisajenkins/remotedata/latest/RemoteData#RemoteData)). In JS that is not possible, because any function can throw anything at any point, it doesn't even have to be an instance of `Error`. This is also why `Promise` has the signature of `Promise<T>` and not `Promise<T, Err>`, because it's impossible to define what `Err` is (other than `any`).

## Concerns

When the idea first came to my mind, [I was concerned with storing non-serializable data in React state](https://github.com/gravitational/teleport/pull/30910#discussion_r1303971238). It turns out that it's not really a concern, it's a totally feasible thing to do, as the comment explains.

The only caveat would be if we wanted to store the state of `useAsync` on disk, as we do with some other pieces of data in Connect. However, as I also explained in that comment, `useAsync` usually represents the result of a transient operation (fetching someone from somewhere). Typically there's no need to store the result of such operation on disk and so far we don't have any instances of this in the codebase.