### PR TITLE
[v13] Remove unused bot_token.create event

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -230,8 +230,6 @@ const (
 	RecoveryTokenCreateEvent = "recovery_token.create"
 	// ResetPasswordTokenCreateEvent is emitted when a new reset password token is created.
 	ResetPasswordTokenCreateEvent = "reset_password_token.create"
-	// BotTokenCreateEvent is emitted when a new bot join user token is created
-	BotTokenCreateEvent = "bot_token.create"
 	// ResetPasswordTokenTTL is TTL of reset password token.
 	ResetPasswordTokenTTL = "ttl"
 	// PrivilegeTokenCreateEvent is emitted when a new user privilege token is created.


### PR DESCRIPTION
Some of the plumbing was there, but Teleport never actually emitted this event. The new join_token.create event is already emitted when a bot join token is created, so no additional work is necessary here.

Closes #31901
Backports #31944 