### PR TITLE
Rename the guide link in access-lists.mdx.

### DIFF
--- a/docs/pages/access-controls/access-lists.mdx
+++ b/docs/pages/access-controls/access-lists.mdx
@@ -9,6 +9,6 @@ managed within Teleport. With Access Lists, administrators and access list
 owners can regularly audit and control membership to specific roles and
 traits, which then tie easily back into Teleport's existing RBAC system.
 
-[A Simple Access List Example](./access-lists/guide.mdx)
+[Getting Started with Access Lists](./access-lists/guide.mdx)
 
 [Access List Reference](./access-lists/reference.mdx)


### PR DESCRIPTION
The link to the Access Lists guide in access-lists.mdx still had its old name. It's been renamed so that it matches the entry in the nav.