### PR TITLE
Enforce use of IMDSv2 for AMI builds

### DIFF
--- a/assets/aws/single-ami.json
+++ b/assets/aws/single-ami.json
@@ -31,6 +31,12 @@
     "instance_type": "{{user `instance_type`}}",
     "ssh_username": "ec2-user",
     "ami_name": "{{user `ami_name` | clean_resource_name}}",
+    "imds_support": "v2.0",
+    "metadata_options": {
+      "http_endpoint": "enabled",
+      "http_tokens": "required",
+      "http_put_response_hop_limit": 2
+    },
     "ssh_pty" : true,
     "associate_public_ip_address": true,
     "vpc_id": "{{user `vpc`}}",
@@ -68,6 +74,12 @@
     "instance_type": "{{user `instance_type`}}",
     "ssh_username": "ec2-user",
     "ami_name": "{{user `fips_ami_name` | clean_resource_name}}",
+    "imds_support": "v2.0",
+    "metadata_options": {
+      "http_endpoint": "enabled",
+      "http_tokens": "required",
+      "http_put_response_hop_limit": 2
+    },
     "ssh_pty" : true,
     "associate_public_ip_address": true,
     "vpc_id": "{{user `vpc`}}",

--- a/assets/aws/single-ami.pkr.hcl
+++ b/assets/aws/single-ami.pkr.hcl
@@ -134,6 +134,12 @@ source "amazon-ebs" "teleport-aws-linux" {
   instance_type                             = var.aws_instance_type
   region                                    = var.aws_region
   encrypt_boot                              = false
+  imds_support                              = "v2.0"
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
   run_tags = {
     Name    = local.ami_name
     purpose = local.resource_purpose_tag_value


### PR DESCRIPTION
Packer was not creating AMIs with IMDSv2 enforced. Make IMDSv2 required for the instances launched by Packer, as well as enforce that the AMIs build utilize only IMDSv2.

See also "Metadata Settings" and `imds_support` sections on: https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs