### PR TITLE
Add PROXY header getter to the proxy gRPC client

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -70,6 +70,9 @@ type ClientConfig struct {
 	// ViaJumpHost indicates if the connection to the cluster is direct
 	// or via another cluster.
 	ViaJumpHost bool
+	// PROXYHeaderGetter is used if present to get signed PROXY headers to propagate client's IP.
+	// Used by proxy's web server to make calls on behalf of connected clients.
+	PROXYHeaderGetter client.PROXYHeaderGetter
 
 	// The below items are intended to be used by tests to connect without mTLS.
 	// The gRPC transport credentials to use when establishing the connection to proxy.
@@ -315,6 +318,7 @@ func newDialerForGRPCClient(ctx context.Context, cfg *ClientConfig) func(context
 		client.WithInsecureSkipVerify(cfg.InsecureSkipVerify),
 		client.WithALPNConnUpgrade(cfg.ALPNConnUpgradeRequired),
 		client.WithALPNConnUpgradePing(true), // Use Ping protocol for long-lived connections.
+		client.WithPROXYHeaderGetter(cfg.PROXYHeaderGetter),
 	))
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2837,6 +2837,7 @@ func (tc *TeleportClient) ConnectToCluster(ctx context.Context) (*ClusterClient,
 		ALPNConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
 		InsecureSkipVerify:      tc.InsecureSkipVerify,
 		ViaJumpHost:             len(tc.JumpHosts) > 0,
+		PROXYHeaderGetter:       CreatePROXYHeaderGetter(ctx, tc.PROXYSigner),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR adds missing PROXY header getter to the Proxy grpc client, so it can send signed PROXY header when `ProxySigner` is present in teleport client - in cases when Proxy does calls on behalf of the user, like with downloading/uploading files in web UI.

Fixes #31845