### PR TITLE
oss-fuzz-build.sh: Remove FuzzParseWebLinks

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -69,9 +69,6 @@ build_teleport_fuzzers() {
     FuzzParseProxyJump fuzz_parse_proxy_jump
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/utils \
-    FuzzParseWebLinks fuzz_parse_web_links
-
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/utils \
     FuzzReadYAML fuzz_read_yaml
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \


### PR DESCRIPTION
This test has had two failures (timeouts) on oss-fuzz that are false positives (5894581923479552 & 5112269123747840).  Both are very large and when run in go fuzz are not reproducible (local execution ~2 seconds)

Disabling due to these false positives