### PR TITLE
Fix discovering Azure VMs with wildcard regions

### DIFF
--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -151,8 +152,11 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Inst
 		return nil, trace.Wrap(err)
 	}
 	instancesByRegion := make(map[string][]*armcompute.VirtualMachine)
-	for _, region := range f.Regions {
-		instancesByRegion[region] = []*armcompute.VirtualMachine{}
+	allowAllRegions := slices.Contains(f.Regions, types.Wildcard)
+	if !allowAllRegions {
+		for _, region := range f.Regions {
+			instancesByRegion[region] = []*armcompute.VirtualMachine{}
+		}
 	}
 
 	vms, err := client.ListVirtualMachines(ctx, f.ResourceGroup)
@@ -162,7 +166,7 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Inst
 
 	for _, vm := range vms {
 		location := aws.StringValue(vm.Location)
-		if _, ok := instancesByRegion[location]; !ok {
+		if _, ok := instancesByRegion[location]; !ok && !allowAllRegions {
 			continue
 		}
 		vmTags := make(map[string]string, len(vm.Tags))

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -118,6 +118,15 @@ func TestAzureWatcher(t *testing.T) {
 			},
 			wantVMs: []string{"vm2", "vm4"},
 		},
+		{
+			name: "location wildcard",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"rg1", "rg2"},
+				Regions:        []string{types.Wildcard},
+				ResourceTags:   types.Labels{"*": []string{"*"}},
+			},
+			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This PR fixes a bug where the discovery service would not discover Azure VMs if not given explicit regions, where it should have accepted an empty or wildcard list of regions.