### PR TITLE
Add interactive tonal primary colors

### DIFF
--- a/web/packages/design/src/theme/themeColors.story.js
+++ b/web/packages/design/src/theme/themeColors.story.js
@@ -154,7 +154,7 @@ const ColorsComponent = () => {
         <Text mb="2" typography="h4">
           Text Colors
         </Text>
-        <Flex width="fit-content" flexDirection="row">
+        <Flex width="fit-content" flexDirection="row" mb={4}>
           <Flex
             flexDirection="column"
             border={`1px solid ${theme.colors.text.muted}`}
@@ -289,6 +289,29 @@ const ColorsComponent = () => {
             </Text>
           </Flex>
         </Flex>
+        <Text mb="2" typography="h3">
+          Interactive Colors
+        </Text>
+        <Text mb="2">
+          Interactive colors are used for hover states, indicators, etc. An
+          example of this in use currently would be unified resource cards in
+          the Pinned and Pinned(Hovered) states.
+        </Text>
+        <SingleColorBox
+          mb="2"
+          path="theme.colors.interactive.tonal.primary[0]"
+          color={theme.colors.interactive.tonal.primary[0]}
+        />
+        <SingleColorBox
+          mb="2"
+          path="theme.colors.interactive.tonal.primary[1]"
+          color={theme.colors.interactive.tonal.primary[1]}
+        />
+        <SingleColorBox
+          mb="2"
+          path="theme.colors.interactive.tonal.primary[2]"
+          color={theme.colors.interactive.tonal.primary[2]}
+        />
       </Flex>
     </Flex>
   );

--- a/web/packages/design/src/theme/themeColors.story.js
+++ b/web/packages/design/src/theme/themeColors.story.js
@@ -297,21 +297,23 @@ const ColorsComponent = () => {
           example of this in use currently would be unified resource cards in
           the Pinned and Pinned(Hovered) states.
         </Text>
-        <SingleColorBox
-          mb="2"
-          path="theme.colors.interactive.tonal.primary[0]"
-          color={theme.colors.interactive.tonal.primary[0]}
-        />
-        <SingleColorBox
-          mb="2"
-          path="theme.colors.interactive.tonal.primary[1]"
-          color={theme.colors.interactive.tonal.primary[1]}
-        />
-        <SingleColorBox
-          mb="2"
-          path="theme.colors.interactive.tonal.primary[2]"
-          color={theme.colors.interactive.tonal.primary[2]}
-        />
+        <Flex gap={4}>
+          <SingleColorBox
+            mb="2"
+            path="theme.colors.interactive.tonal.primary[0]"
+            color={theme.colors.interactive.tonal.primary[0]}
+          />
+          <SingleColorBox
+            mb="2"
+            path="theme.colors.interactive.tonal.primary[1]"
+            color={theme.colors.interactive.tonal.primary[1]}
+          />
+          <SingleColorBox
+            mb="2"
+            path="theme.colors.interactive.tonal.primary[2]"
+            color={theme.colors.interactive.tonal.primary[2]}
+          />
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -74,6 +74,16 @@ const colors: ThemeColors = {
 
   brand: '#FFA028',
 
+  interactive: {
+    tonal: {
+      primary: [
+        'rgba(255,160,40, 0.1)',
+        'rgba(255,160,40, 0.18)',
+        'rgba(255,160,40, 0.25)',
+      ],
+    },
+  },
+
   text: {
     main: '#FFFFFF',
     slightlyMuted: '#BEBEBE',

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -74,6 +74,16 @@ const colors: ThemeColors = {
 
   brand: '#9F85FF',
 
+  interactive: {
+    tonal: {
+      primary: [
+        'rgba(159,133,255, 0.1)',
+        'rgba(159,133,255, 0.18)',
+        'rgba(159,133,255, 0.25)',
+      ],
+    },
+  },
+
   text: {
     main: '#FFFFFF',
     slightlyMuted: 'rgba(255, 255, 255, 0.72)',

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -71,6 +71,16 @@ const colors: ThemeColors = {
 
   brand: '#512FC9',
 
+  interactive: {
+    tonal: {
+      primary: [
+        'rgba(81,47,201, 0.1)',
+        'rgba(81,47,201, 0.18)',
+        'rgba(81,47,201, 0.25)',
+      ],
+    },
+  },
+
   text: {
     main: '#000000',
     slightlyMuted: 'rgba(0,0,0,0.72)',

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -45,6 +45,13 @@ export type ThemeColors = {
 
   brand: string;
 
+  /**
+   * Interactive colors are used to highlight different actions or states
+   * based on intent.
+   *
+   * For example, primary would be used for as selected states,
+   * or hover over primary intent actions.
+   */
   interactive: {
     tonal: {
       primary: string[];

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -45,6 +45,12 @@ export type ThemeColors = {
 
   brand: string;
 
+  interactive: {
+    tonal: {
+      primary: string[];
+    };
+  };
+
   text: {
     /** The most important text. */
     main: string;


### PR DESCRIPTION
This PR adds the interactive tonal primary colors to our theme colors. It boils down to the 'brand' color with alpha. Another route would be to use a hexToRgb helper to pass the brand in and then append the alpha state but that seemed a bit much, especially considering our current util that does that only handles `rgb` and not `rgba`. 

If it becomes necessary, we can revisit the util and add any alpha property we need. For now, this is fine and explicit. 
This supports https://github.com/gravitational/teleport/issues/30418 by adding the colors needed for the pinned resource cards

<img width="548" alt="Screenshot 2023-09-16 at 11 46 33 AM" src="https://github.com/gravitational/teleport/assets/5201977/c32ee63e-f177-49fa-961f-c3d96f0a8e87">
