### PR TITLE
Append a portion of the GUID when naming discovered desktops

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -16,6 +16,7 @@ package desktop
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/netip"
@@ -271,10 +272,18 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *l
 		return nil, trace.Wrap(err)
 	}
 
+	// ensure no '.' in name, because we use SNI to route to the right
+	// desktop, and our cert is valid for *.desktop.teleport.cluster.local
+	name := strings.ReplaceAll(hostname, ".", "-")
+
+	// append portion of the object GUID to ensure that desktops from
+	// different domains that happen to have the same hostname don't conflict
+	if guid := entry.GetRawAttributeValue(windows.AttrObjectGUID); len(guid) >= 4 {
+		name += "-" + hex.EncodeToString(guid[:4])
+	}
+
 	desktop, err := types.NewWindowsDesktopV3(
-		// ensure no '.' in name, because we use SNI to route to the right
-		// desktop, and our cert is valid for *.desktop.teleport.cluster.local
-		strings.ReplaceAll(hostname, ".", "-"),
+		name,
 		labels,
 		types.WindowsDesktopSpecV3{
 			Addr:   addr.String(),


### PR DESCRIPTION
Some users have encountered cases where they connect multiple distinct AD domains to Teleport, but the name of the domain is the same and the name of some of the hosts within the domain are also the same.

As a result, Teleport incorrectly deduplicates these desktops in the UI (we can't distinguish them from identical desktops reported by multiple agents).

Fix this by appending a portion of the objectGUID to the desktop name. Even if mutiple domains have identical names and hostnames, the GUID will differ and both will be shown in the UI. For example, `EC2AMAZ-37TSM4L-zacexample-com` becomes `EC2AMAZ-37TSM4L-zacexample-com-073ed387`.

Note: after an upgrade, there will be a period of time where the desktop with the old name hasn't expired but new heartbeats are using the new name. This might be a little bit confusing, but won't impact connectivity (both copies will have the same addr).