### PR TITLE
Machine ID Docs Refactor: Add `tctl` and `terraform` access guides

### DIFF
--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -14,6 +14,7 @@ then use `tctl` to deploy Teleport roles defined in files.
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - (!docs/pages/includes/tctl.mdx!)
 - `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -54,7 +54,9 @@ credentials needed by `tctl`. As `tctl` will be accessing the Teleport API, the
 correct output type to use is `identity`.
 
 For this guide, the `directory` destination will be used. This will write these
-credentials to a specified directory on disk.
+credentials to a specified directory on disk. Ensure that this directory can
+be written to by the Linux user that `tbot` runs as, and that it can be read by
+the Linux user that `tctl` will run as.
 
 Modify your `tbot` configuration to add an `identity` output:
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -75,17 +75,44 @@ authenticate with the Teleport Auth Server.
 
 ## Step 3/3. Use `tctl` with the identity output
 
+As an example, `tctl` will be used to apply a directory of YAML files that
+define Teleport roles. If these were stored in version control (e.g git) and
+this was executed on change, this would form the basis for managing Teleport
+roles in a GitOps style.
+
+The example role will not be useful within the context of your Teleport cluster
+and should be modified once you have completed this guide.
+
+Create a directory called `roles/` and within it create `example.yaml`:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: example-role
+spec:
+  allow:
+    logins: ['root']
+    node_labels:
+      'key': 'value'
+```
+
 To configure `tctl` to use the identity file, the `-i` flag is used. As the
 identity file does not specify the address of Teleport, `--auth-server` must
 also be specified with the address of your Teleport Proxy or Teleport Auth
 Server.
 
-In this example, `tctl` is used to apply each role YAML file within a directory.
-This could be used as part of a CI/CD process to manage Teleport configuration
-in a GitOps manner:
+Run `tctl`, replacing `example.teleport.sh:443` with the address of your
+Teleport Proxy or Auth Server and `/opt/machine-id/identity` with the path to
+the generated identity file if you have modified this:
 
 ```code
 $ tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
 ```
 
+Check your Teleport cluster, ensuring the role has been created.
+
 ## Next steps
+
+- Explore the [`tctl` reference](../../reference/cli/tctl.mdx) to discover all
+  `tctl` can do.

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -11,10 +11,11 @@ of custom automations.
 In this guide, you will configure `tbot` to produce credentials for `tctl`, and
 then use `tctl` to create and update Teleport configuration.
 
-## Before you start
+## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
-- `tbot` must be configured and installed on your platform. Follow a
+- (!docs/pages/includes/tctl.mdx!)
+- `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
 
 ## Step 1/3. Configure RBAC

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -99,10 +99,8 @@ version: v6
 metadata:
   name: example-role
 spec:
-  allow:
-    logins: ['root']
-    node_labels:
-      'key': 'value'
+  # This role does nothing as it is an example role.
+  allow: {}
 ```
 
 To configure `tctl` to use the identity file, the `-i` flag is used. As the

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -6,7 +6,7 @@ description: How to use Machine ID with `tctl` to manage your Teleport configura
 `tctl` is the Teleport cluster management CLI tool. Whilst it usually uses the
 credentials from the locally logged in user, it is also possible to use
 Machine ID credentials. This allows `tctl` to be leveraged as part of a custom
-automation deployed in a non-interactive environment (e.g CI/CD).
+automation workflow deployed in a non-interactive environment (e.g CI/CD).
 
 In this guide, you will configure `tbot` to produce credentials for `tctl`, and
 then use `tctl` to deploy Teleport roles defined in files.

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -5,11 +5,11 @@ description: How to use Machine ID with `tctl` to manage your Teleport configura
 
 `tctl` is the Teleport cluster management CLI tool. Whilst it usually uses the
 credentials from the locally logged in user, it is also possible to use
-Machine ID credentials. This allows `tctl` to be leveraged in scripts as part
-of custom automations.
+Machine ID credentials. This allows `tctl` to be leveraged as part of a custom
+automation deployed in a non-interactive environment (e.g CI/CD).
 
 In this guide, you will configure `tbot` to produce credentials for `tctl`, and
-then use `tctl` to create and update Teleport configuration.
+then use `tctl` to deploy Teleport roles defined in files.
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ outputs:
   destination:
     type: directory
     # For this guide, /opt/machine-id is used as the destination directory.
-    # You may wish to customise this. Multiple outputs cannot share the same
+    # You may wish to customize this. Multiple outputs cannot share the same
     # destination.
     path: /opt/machine-id
 ```

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -16,6 +16,7 @@ then use `tctl` to deploy Teleport roles defined in files.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
+
 - `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -84,7 +84,7 @@ authenticate with the Teleport Auth Server.
 ## Step 3/3. Use `tctl` with the identity output
 
 As an example, `tctl` will be used to apply a directory of YAML files that
-define Teleport roles. If these were stored in version control (e.g git) and
+define Teleport roles. If these were stored in version control (e.g., `git`) and
 this were executed on change, this would form the basis for managing Teleport
 roles in a GitOps style.
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -8,8 +8,8 @@ credentials from the locally logged in user, it is also possible to use
 Machine ID credentials. This allows `tctl` to be leveraged in scripts as part
 of custom automations.
 
-In this guide, we will configure `tbot` to produce an output which can be used
-with `tctl` to manage Teleport roles programatically.
+In this guide, you will configure `tbot` to produce credentials for `tctl`, and
+then use `tctl` to create and update Teleport configuration.
 
 ## Before you start
 
@@ -19,16 +19,33 @@ with `tctl` to manage Teleport roles programatically.
 
 ## Step 1/3. Configure RBAC
 
-TODO: Modify the role assigned to your bot to grant it privileges to create/update roles.
+In this guide, the output credentials will be used to create and update roles,
+so we will grant only the privileges to do this.
+
+As a role was already created for the output credentials during the platform
+guide, we will modify this role to add these privileges.
+
+Use `tctl edit role/example-bot` to add the following rule to the role:
+
+```yaml
+spec:
+  allow:
+    rules:
+    - resources:
+      - role
+      verbs:
+      - create
+      - update
+```
 
 ## Step 2/3. Configure `tbot` output
 
 ```yaml
 outputs:
-  - type: identity
-    destination:
-      type: directory
-      path: ./tbot-output
+- type: identity
+  destination:
+    type: directory
+    path: ./tbot-output
 ```
 
 ## Step 3/3. Use `tctl` with the identity output

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -3,4 +3,47 @@ title: Machine ID with `tctl`
 description: How to use Machine ID with `tctl` to manage your Teleport configuration
 ---
 
-TODO
+`tctl` is the Teleport cluster management CLI tool. Whilst it usually uses the
+credentials from the locally logged in user, it is also possible to use
+Machine ID credentials. This allows `tctl` to be leveraged in scripts as part
+of custom automations.
+
+In this guide, we will configure `tbot` to produce an output which can be used
+with `tctl` to manage Teleport roles programatically.
+
+## Before you start
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+- `tbot` must be configured and installed on your platform. Follow a
+  [platform guide](../platform-guides.mdx) to do so.
+
+## Step 1/3. Configure RBAC
+
+TODO: Modify the role assigned to your bot to grant it privileges to create/update roles.
+
+## Step 2/3. Configure `tbot` output
+
+```yaml
+outputs:
+  - type: identity
+    destination:
+      type: directory
+      path: ./tbot-output
+```
+
+## Step 3/3. Use `tctl` with the identity output
+
+To configure `tctl` to use the identity file, the `-i` flag is used. As the
+identity file does not specify the address of Teleport, `--auth-server` must
+also be specified with the address of your Teleport Proxy or Teleport Auth
+Server.
+
+In this example, `tctl` is used to apply each role YAML file within a directory.
+This could be used as part of a CI/CD process to manage Teleport configuration
+in a GitOps manner:
+
+```code
+$ tctl --auth-server example.teleport.sh:443 -i ./tbot-output/identity create -f roles/*.yaml
+```
+
+## Next steps

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -16,7 +16,6 @@ then use `tctl` to deploy Teleport roles defined in files.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -27,7 +27,7 @@ to modify the Teleport configuration. It's important to grant as few
 privileges as possible in order to limit the blast radius of an attack, so in
 this example we grant only the ability to create and update roles.
 
-If you have followed an access guide, you will have created a role and granted
+If you have followed a platform guide, you will have created a role and granted
 the bot the ability to impersonate it already. This role just needs to have the
 additional privileges added to it.
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -1,6 +1,6 @@
 ---
-title: Machine ID with `tctl`
-description: How to use Machine ID with `tctl` to manage your Teleport configuration
+title: Machine ID with tctl
+description: How to use Machine ID with tctl to manage your Teleport configuration
 ---
 
 `tctl` is the Teleport cluster management CLI tool. Whilst it usually uses the

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -19,11 +19,14 @@ then use `tctl` to create and update Teleport configuration.
 
 ## Step 1/3. Configure RBAC
 
-In this guide, the output credentials will be used to create and update roles,
-so we will grant only the privileges to do this.
+First, Teleport must be configured to allow the credentials produced by the bot
+to modify the Teleport configuration. It's important to grant as few
+privileges as possible in order to limit the blast radius of an attack, so in
+this example we grant only the ability to create and update roles.
 
-As a role was already created for the output credentials during the platform
-guide, we will modify this role to add these privileges.
+If you have followed an access guide, you will have created a role and granted
+the bot the ability to impersonate it already. This role just needs to have the
+additional privileges added to it.
 
 Use `tctl edit role/example-bot` to add the following rule to the role:
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -32,21 +32,46 @@ spec:
   allow:
     rules:
     - resources:
+      # Specify the names of resources you wish to manage with tctl.
+      # For this guide, we will only manage roles.
       - role
       verbs:
       - create
+      - read
       - update
+      - delete
+      - list
 ```
 
 ## Step 2/3. Configure `tbot` output
+
+Now, `tbot` needs to be configured with an output that will produce the
+credentials needed by `tctl`. As `tctl` will be accessing the Teleport API, the
+correct output type to use is `identity`.
+
+For this guide, the `directory` destination will be used. This will write these
+credentials to a specified directory on disk.
+
+Modify your `tbot` configuration to add an `identity` output:
 
 ```yaml
 outputs:
 - type: identity
   destination:
     type: directory
-    path: ./tbot-output
+    # For this guide, /opt/machine-id is used as the destination directory.
+    # You may wish to customise this. Multiple outputs cannot share the same
+    # destination.
+    path: /opt/machine-id
 ```
+
+If operating `tbot` as a background service, restart it. If running `tbot` in
+one-shot mode, it must be executed before you attempt to execute the Terraform
+plan later.
+
+You should now see an `identity` file under `/opt/machine-id`. This contains
+the private key and signed certificates needed by `tctl` to
+authenticate with the Teleport Auth Server.
 
 ## Step 3/3. Use `tctl` with the identity output
 
@@ -60,7 +85,7 @@ This could be used as part of a CI/CD process to manage Teleport configuration
 in a GitOps manner:
 
 ```code
-$ tctl --auth-server example.teleport.sh:443 -i ./tbot-output/identity create -f roles/*.yaml
+$ tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
 ```
 
 ## Next steps

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -85,7 +85,7 @@ authenticate with the Teleport Auth Server.
 
 As an example, `tctl` will be used to apply a directory of YAML files that
 define Teleport roles. If these were stored in version control (e.g git) and
-this was executed on change, this would form the basis for managing Teleport
+this were executed on change, this would form the basis for managing Teleport
 roles in a GitOps style.
 
 The example role will not be useful within the context of your Teleport cluster

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -22,7 +22,7 @@ then use `tctl` to deploy Teleport roles defined in files.
 
 ## Step 1/3. Configure RBAC
 
-First, Teleport must be configured to allow the credentials produced by the bot
+First, Teleport must be configured to allow the credentials produced by `tbot`
 to modify the Teleport configuration. It's important to grant as few
 privileges as possible in order to limit the blast radius of an attack, so in
 this example we grant only the ability to create and update roles.

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -97,7 +97,7 @@ Create a directory called `roles/` and within it create `example.yaml`:
 kind: role
 version: v6
 metadata:
-  name: example-role
+  name: tctl-test
 spec:
   # This role does nothing as it is an example role.
   allow: {}
@@ -117,6 +117,10 @@ $ tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create 
 ```
 
 Check your Teleport cluster, ensuring the role has been created.
+
+```code
+$ tctl get role/tctl-test
+```
 
 ## Next steps
 

--- a/docs/pages/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-id/access-guides/tctl.mdx
@@ -16,8 +16,9 @@ then use `tctl` to deploy Teleport roles defined in files.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-- `tbot` must be configured for your platform. Follow a
-  [platform guide](../platform-guides.mdx) to do so.
+- `tbot` must already be installed and configured on the machine that will
+  use `tctl`. For more information, see the
+  [platform guides](../platform-guides.mdx).
 
 ## Step 1/3. Configure RBAC
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -29,7 +29,7 @@ Terraform Provider and use Terraform to configure a Teleport role.
 
 ## Step 1/3. Configure RBAC
 
-First, Teleport must be configured to allow the credentials produced by the bot
+First, Teleport must be configured to allow the credentials produced by `tbot`
 to modify the Teleport configuration.
 
 If you have followed a platform guide, you will have created a role and granted

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -11,6 +11,7 @@ Terraform Provider.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 - `tbot` must be configured and installed on your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
+- Terraform >= 1.0.0+
 
 ## Step 1/3. Configure RBAC
 
@@ -34,15 +35,39 @@ spec:
 
 ## Step 2/3. Configure `tbot` output
 
+Modify your `tbot` configuration to include an `identity` output:
+
 ```yaml
 outputs:
 - type: identity
   destination:
     type: directory
+    # For this guide, /opt/machine-id is used as the destination directory.
+    # You may wish to customise this. Multiple outputs cannot share the same
+    # destination.
     path: /opt/machine-id
 ```
 
 ## Step 3/3. Use Terraform with the identity output
+
+Start by creating a new Terraform working directory:
+
+```code
+$ mkdir ./my-terraform && cd ./my-terraform
+$ terraform init
+```
+
+In order to configure the Teleport Terraform provider to use the credentials
+output by Machine ID, we use the `identity_file_path` option. Whilst is is
+possible to configure the Terraform provider using the TLS certificate, the
+identity file provides support across more Teleport configurations.
+
+This example creates a simple role for demonstrative purposes, this role is
+unlikely to be useful within your Teleport Cluster. Therefore, once you have
+confirmed that you have configured Terraform correctly, this resource should be
+modified to suit your needs.
+
+In this directory, create `main.tf`:
 
 ```hcl
 terraform {
@@ -81,6 +106,18 @@ resource "teleport_role" "terraform-test" {
   }
 }
 ```
+
+Replace the address within the Teleport provider with that of your Teleport
+Proxy or Auth Server and if you have modified the identity output directory,
+adjust that here also.
+
+Now, execute Terraform to test the configuration:
+
+```code
+$ terraform apply
+```
+
+Check your Teleport cluster, ensuring the role has been created.
 
 ## Next steps
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -3,7 +3,7 @@ title: Machine ID with the Teleport Terraform Provider
 description: How to use Machine ID with the Teleport Terraform provider to manage your Teleport configuration as IaC
 ---
 
-Teleports Terraform provider can be used to configure your Teleport cluster
+The Teleport Terraform provider can be used to configure your Teleport cluster
 using Terraform. This Terraform provider requires a way to authenticate with
 Teleport and Machine ID credentials can be used for this purpose.
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -16,6 +16,7 @@ Terraform Provider and use Terraform to configure a Teleport role.
   $ terraform version
   # Terraform v(=terraform.version=)
   ```
+
 - `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -35,7 +35,14 @@ spec:
 
 ## Step 2/3. Configure `tbot` output
 
-Modify your `tbot` configuration to include an `identity` output:
+Now, `tbot` needs to be configured with an output that will produce the
+credentials needed by the Terraform provider. As the Terraform provider will be
+accessing the Teleport API, the correct output type to use is `identity`.
+
+For this guide, the `directory` destination will be used. This will write these
+credentials to a specified directory on disk.
+
+Modify your `tbot` configuration to add an `identity` output:
 
 ```yaml
 outputs:
@@ -47,6 +54,14 @@ outputs:
     # destination.
     path: /opt/machine-id
 ```
+
+If operating `tbot` as a background service, restart it. If running `tbot` in
+one-shot mode, it must be executed before you attempt to execute the Terraform
+plan later.
+
+You should now see an `identity` file under `/opt/machine-id`. This contains
+the private key and signed certificates needed by the Terraform provider to
+authenticate with the Teleport Auth Server.
 
 ## Step 3/3. Use Terraform with the identity output
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -68,7 +68,9 @@ credentials needed by the Terraform provider. As the Terraform provider will be
 accessing the Teleport API, the correct output type to use is `identity`.
 
 For this guide, the `directory` destination will be used. This will write these
-credentials to a specified directory on disk.
+credentials to a specified directory on disk. Ensure that this directory can
+be written to by the Linux user that `tbot` runs as, and that it can be read by
+the Linux user that Terraform will run as.
 
 Modify your `tbot` configuration to add an `identity` output:
 
@@ -150,9 +152,9 @@ resource "teleport_role" "terraform-test" {
 }
 ```
 
-Replace the address within the Teleport provider with that of your Teleport
-Proxy or Auth Server and if you have modified the identity output directory,
-adjust that here also.
+Replace `teleport.example.com:443` with the address of your Teleport Proxy or
+Auth Server. If you modified the destination directory from `/opt/machine-id`,
+then this should also be replaced.
 
 Now, execute Terraform to test the configuration:
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -15,6 +15,13 @@ Terraform Provider and use Terraform to configure a Teleport role.
 
 ## Step 1/3. Configure RBAC
 
+First, Teleport must be configured to allow the credentials produced by the bot
+to modify the Teleport configuration.
+
+If you have followed an access guide, you will have created a role and granted
+the bot the ability to impersonate it already. This role just needs to have the
+additional privileges added to it.
+
 Use `tctl edit role/example-bot` to add the following rule to the role:
 
 ```yaml
@@ -22,9 +29,24 @@ spec:
   allow:
     rules:
     - resources:
-      # Specify the names of resources you wish to manage with Terraform.
-      # For this guide, we will only manage roles.
+      # These currently represent all the resources that can be configured by
+      # Terraform. You may wish to remove resources that you do not intend to
+      # configure with Terraform from this list to reduce blast radius.
+      - app
+      - cluster_auth_preference
+      - cluster_networking_config
+      - db
+      - device
+      - github
+      - login_rule
+      - oidc
+      - okta_import_rule
       - role
+      - saml
+      - session_recording_config
+      - token
+      - trusted_cluster
+      - user
       verbs:
       - create
       - read

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -15,6 +15,7 @@ Terraform Provider and use Terraform to configure a Teleport role.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
+
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
   ```code

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -32,7 +32,7 @@ Terraform Provider and use Terraform to configure a Teleport role.
 First, Teleport must be configured to allow the credentials produced by the bot
 to modify the Teleport configuration.
 
-If you have followed an access guide, you will have created a role and granted
+If you have followed a platform guide, you will have created a role and granted
 the bot the ability to impersonate it already. This role just needs to have the
 additional privileges added to it.
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -4,7 +4,7 @@ description: How to use Machine ID with the Teleport Terraform provider to manag
 ---
 
 In this guide, you will configure `tbot` to produce credentials for the Teleport
-Terraform Provider.
+Terraform Provider and use Terraform to configure a Teleport role.
 
 ## Before you start
 
@@ -137,5 +137,5 @@ Check your Teleport cluster, ensuring the role has been created.
 ## Next steps
 
 - Explore the
-  [Terraform provider resource reference](https://goteleport.com/docs/reference/terraform-provider/)
-  to discover what can be configured with Terraform.
+  [Terraform provider resource reference](../../reference/terraform-provider.mdx)
+  to discover what can be configured with the Teleport Terraform provider.

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -3,12 +3,17 @@ title: Machine ID with the Teleport Terraform Provider
 description: How to use Machine ID with the Teleport Terraform provider to manage your Teleport configuration as IaC
 ---
 
+Teleports Terraform provider can be used to configure your Teleport cluster
+using Terraform. This Terraform provider requires a way to authenticate with
+Teleport and Machine ID credentials can be used for this purpose.
+
 In this guide, you will configure `tbot` to produce credentials for the Teleport
 Terraform Provider and use Terraform to configure a Teleport role.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - (!docs/pages/includes/tctl.mdx!)
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -6,12 +6,18 @@ description: How to use Machine ID with the Teleport Terraform provider to manag
 In this guide, you will configure `tbot` to produce credentials for the Teleport
 Terraform Provider and use Terraform to configure a Teleport role.
 
-## Before you start
+## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
-- `tbot` must be configured and installed on your platform. Follow a
+- (!docs/pages/includes/tctl.mdx!)
+- [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+  ```code
+  $ terraform version
+  # Terraform v(=terraform.version=)
+  ```
+- `tbot` must be configured for your platform. Follow a
   [platform guide](../platform-guides.mdx) to do so.
-- Terraform >= 1.0.0+
 
 ## Step 1/3. Configure RBAC
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -150,12 +150,8 @@ resource "teleport_role" "terraform-test" {
   }
 
   spec = {
-    allow = {
-      logins = ["root"]
-      node_labels = {
-        key    = ["value"]
-      }
-    }
+    # This role does nothing as it is an example role.
+    allow = {}
   }
 }
 ```

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -80,7 +80,7 @@ outputs:
   destination:
     type: directory
     # For this guide, /opt/machine-id is used as the destination directory.
-    # You may wish to customise this. Multiple outputs cannot share the same
+    # You may wish to customize this. Multiple outputs cannot share the same
     # destination.
     path: /opt/machine-id
 ```

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -23,8 +23,9 @@ Terraform Provider and use Terraform to configure a Teleport role.
   # Terraform v(=terraform.version=)
   ```
 
-- `tbot` must be configured for your platform. Follow a
-  [platform guide](../platform-guides.mdx) to do so.
+- `tbot` must already be installed and configured on the machine that will
+  run Terraform. For more information, see the
+  [platform guides](../platform-guides.mdx).
 
 ## Step 1/3. Configure RBAC
 

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -3,4 +3,87 @@ title: Machine ID with the Teleport Terraform Provider
 description: How to use Machine ID with the Teleport Terraform provider to manage your Teleport configuration as IaC
 ---
 
-TODO
+In this guide, you will configure `tbot` to produce credentials for the Teleport
+Terraform Provider.
+
+## Before you start
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+- `tbot` must be configured and installed on your platform. Follow a
+  [platform guide](../platform-guides.mdx) to do so.
+
+## Step 1/3. Configure RBAC
+
+Use `tctl edit role/example-bot` to add the following rule to the role:
+
+```yaml
+spec:
+  allow:
+    rules:
+    - resources:
+      # Specify the names of resources you wish to manage with Terraform.
+      # For this guide, we will only manage roles.
+      - role
+      verbs:
+      - create
+      - read
+      - update
+      - delete
+      - list
+```
+
+## Step 2/3. Configure `tbot` output
+
+```yaml
+outputs:
+- type: identity
+  destination:
+    type: directory
+    path: /opt/machine-id
+```
+
+## Step 3/3. Use Terraform with the identity output
+
+```hcl
+terraform {
+  required_providers {
+    teleport = {
+      version = "(=teleport.version=)"
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+    }
+  }
+}
+
+provider "teleport" {
+  # Replace with the address of your Teleport Proxy or Auth Server.
+  addr               = "teleport.example.com:443"
+  # Replace with the directory configured in the identity output in the
+  # previous step.
+  identity_file_path = "/opt/machine-id/identity"
+}
+
+# This is an example. Replace this with the resource you wish to be managed
+# with Terraform. See the following reference for supported options:
+# https://goteleport.com/docs/reference/terraform-provider/
+resource "teleport_role" "terraform-test" {
+  metadata = {
+    name        = "terraform-test"
+    description = "Example role created by Terraform"
+  }
+
+  spec = {
+    allow = {
+      logins = ["root"]
+      node_labels = {
+        key    = ["value"]
+      }
+    }
+  }
+}
+```
+
+## Next steps
+
+- Explore the
+  [Terraform provider resource reference](https://goteleport.com/docs/reference/terraform-provider/)
+  to discover what can be configured with Terraform.

--- a/docs/pages/machine-id/access-guides/terraform.mdx
+++ b/docs/pages/machine-id/access-guides/terraform.mdx
@@ -166,7 +166,11 @@ Now, execute Terraform to test the configuration:
 $ terraform apply
 ```
 
-Check your Teleport cluster, ensuring the role has been created.
+Check your Teleport cluster, ensuring the role has been created:
+
+```code
+$ tctl get role/terraform-test
+```
 
 ## Next steps
 


### PR DESCRIPTION
Adds content for the `tctl` and `terraform` access guides based on the new structure.