### PR TITLE
Reduce proxy already claimed log entry noise

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -268,7 +268,11 @@ func (p *AgentPool) run() error {
 
 		agent, err := p.connectAgent(p.ctx, p.events)
 		if err != nil {
-			p.log.WithError(err).Debugf("Failed to connect agent.")
+			if isProxyAlreadyClaimed(err) {
+				p.log.Debugf("Failed to connect agent: %v", err)
+			} else {
+				p.log.WithError(err).Debugf("Failed to connect agent.")
+			}
 		} else {
 			p.wg.Add(1)
 			p.active.add(agent)


### PR DESCRIPTION
## What 

Don't dump error stack trace for  the "proxy already claimed" well known error

#### Before:
```
Original Error: *errors.errorString ssh: handshake failed: proxy already claimed
Stack Trace:
        /Users/marek/go/src/github.com/gravitational/teleport/api/observability/tracing/ssh/ssh.go:164 github.com/gravitational/teleport/api/observability/tracing/ssh.NewClientConn
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agent_dialer.go:86 github.com/gravitational/teleport/lib/reversetunnel.(*agentDialer).DialContext
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agent.go:362 github.com/gravitational/teleport/lib/reversetunnel.(*agent).connect
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agent.go:317 github.com/gravitational/teleport/lib/reversetunnel.(*agent).Start
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agentpool.go:310 github.com/gravitational/teleport/lib/reversetunnel.(*AgentPool).connectAgent
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agentpool.go:269 github.com/gravitational/teleport/lib/reversetunnel.(*AgentPool).run
        /Users/marek/go/src/github.com/gravitational/teleport/lib/reversetunnel/agentpool.go:253 github.com/gravitational/teleport/lib/reversetunnel.(*AgentPool).Start.func1
        /Users/marek/go/go1.21.0/src/runtime/asm_amd64.s:1650 runtime.goexit
```

#### After: 
```
2023-09-18T17:01:17+02:00 DEBU [PROXY:AGE] Failed to connect agent: ssh: handshake failed: proxy already claimed localCluster: targetCluster:ice-berg.dev reversetunnel/agentpool.go:272
```