### PR TITLE
Fix variable in Azure AD docs

### DIFF
--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -64,9 +64,7 @@ Before you get started, you’ll need:
 
    ![Edit Basic SAML Configuration](../../../img/azuread/azuread-6-editbasicsaml.png)
 
-1. Enter the URL for your Teleport cluster or Teleport tenant in the **Entity ID** and **Reply URL**  fields. For example:
-   name="mytenant.teleport.sh:443" /> to the host and HTTPS port of your
-   Teleport Proxy Service (or Teleport Team/Enterprise Cloud tenant):
+1. Enter the URL for your Teleport Proxy Service host in the **Entity ID** and **Reply URL**  fields:
 
    ```code
    https://<Var name="mytenant.teleport.sh:443" />/v1/webapi/saml/acs/ad


### PR DESCRIPTION
Fixes #25090

An earlier change to this page clarified URL values to assign when setting up an Azure AD connector, but left a malformed `Var` component. This change fixes the `Var` component.