### PR TITLE
Prevent duplicate service registration

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -71,7 +71,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/joinserver"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -5378,7 +5377,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	// Only register the service if this is an open source build. Enterprise builds
 	// register the actual service via an auth plugin, if we register here then all
 	// Enterprise builds would fail with a duplicate service registered error.
-	if modules.GetModules().BuildType() == modules.BuildOSS {
+	if cfg.PluginRegistry == nil || !cfg.PluginRegistry.IsRegistered("auth.enterprise") {
 		loginrulepb.RegisterLoginRuleServiceServer(server, loginrule.NotImplementedService{})
 	}
 


### PR DESCRIPTION
Enterprise tests do not always set the enterprise build type which causes test failures due to duplicate service registration. To prevent every test from needing to update the modules the PluginRegistry was modified to expose a mechanism to detect if a plugin is registered or not. The old check that registered a not implemented LoginRuleService now makes use of this mechanism to verify that the enterprise auth plugin is not registered.