### PR TITLE
Omit WithError for "proxy already claimed"

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -369,7 +369,7 @@ func (a *agent) connect() error {
 		a.client.Close()
 		// the error message must end with [alreadyClaimedErrorMessage] to be
 		// recognized by [isAlreadyClaimed]
-		return trace.Errorf("failed to claim proxy %v: "+alreadyClaimedErrorMessage, a.client.Principals())
+		return trace.Errorf("failed to claim proxy %v: "+proxyAlreadyClaimedError, a.client.Principals())
 	}
 
 	startupCtx, cancel := context.WithCancel(a.ctx)

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -367,8 +367,8 @@ func (a *agent) connect() error {
 
 	if !a.lease.Claim(a.client.Principals()...) {
 		a.client.Close()
-		// the error message must end with [alreadyClaimedErrorMessage] to be
-		// recognized by [isAlreadyClaimed]
+		// the error message must end with [proxyAlreadyClaimedError] to be
+		// recognized by [isProxyAlreadyClaimed]
 		return trace.Errorf("failed to claim proxy %v: "+proxyAlreadyClaimedError, a.client.Principals())
 	}
 

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -367,7 +367,9 @@ func (a *agent) connect() error {
 
 	if !a.lease.Claim(a.client.Principals()...) {
 		a.client.Close()
-		return trace.Errorf("Failed to claim proxy: %v claimed by another agent", a.client.Principals())
+		// the error message must end with [alreadyClaimedErrorMessage] to be
+		// recognized by [isAlreadyClaimed]
+		return trace.Errorf("failed to claim proxy %v: "+alreadyClaimedErrorMessage, a.client.Principals())
 	}
 
 	startupCtx, cancel := context.WithCancel(a.ctx)

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -18,6 +18,7 @@ package reversetunnel
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -32,6 +33,18 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/proxy"
 )
+
+const alreadyClaimedErrorMessage = "proxy already claimed"
+
+// isAlreadyClaimed returns true if the error is non-nil and its message ends
+// with "proxy already claimed" (we can't extract a better sentinel out of a SSH
+// handshake, unfortunately).
+func isAlreadyClaimed(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.HasSuffix(err.Error(), alreadyClaimedErrorMessage)
+}
 
 // agentDialer dials an ssh server on behalf of an agent.
 type agentDialer struct {
@@ -61,7 +74,9 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 			OnCheckCert: func(c *ssh.Certificate) error {
 				if d.isClaimed != nil && d.isClaimed(c.ValidPrincipals...) {
 					d.log.Debugf("Aborting SSH handshake because the proxy %q is already claimed by some other agent.", c.ValidPrincipals[0])
-					return trace.Errorf("proxy already claimed")
+					// the error message must end with [alreadyClaimedErrorMessage] to be
+					// recognized by [isAlreadyClaimed]
+					return trace.Errorf(alreadyClaimedErrorMessage)
 				}
 
 				principals = c.ValidPrincipals
@@ -83,7 +98,11 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 		Timeout:         apidefaults.DefaultIOTimeout,
 	})
 	if err != nil {
-		d.log.WithError(err).Debugf("Failed to create client to %v.", addr.Addr)
+		if isAlreadyClaimed(err) {
+			d.log.Debugf("Failed to create client to %v: proxy already claimed.", addr.Addr)
+		} else {
+			d.log.WithError(err).Debugf("Failed to create client to %v.", addr.Addr)
+		}
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -248,7 +248,7 @@ func TestAgentFailedToClaimLease(t *testing.T) {
 
 	err := agent.Start(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Failed to claim proxy", "Expected failed to claim proxy error.")
+	require.Contains(t, err.Error(), proxyAlreadyClaimedError, "Expected failed to claim proxy error.")
 
 	callback.waitForCount(t, 2)
 	require.Contains(t, callback.states, AgentConnecting)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -268,7 +268,11 @@ func (p *AgentPool) run() error {
 
 		agent, err := p.connectAgent(p.ctx, p.events)
 		if err != nil {
-			p.log.WithError(err).Debugf("Failed to connect agent.")
+			if isAlreadyClaimed(err) {
+				p.log.Debugf("Failed to connect agent: proxy already claimed.")
+			} else {
+				p.log.WithError(err).Debugf("Failed to connect agent.")
+			}
 		} else {
 			p.wg.Add(1)
 			p.active.add(agent)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -268,8 +268,10 @@ func (p *AgentPool) run() error {
 
 		agent, err := p.connectAgent(p.ctx, p.events)
 		if err != nil {
-			if isAlreadyClaimed(err) {
-				p.log.Debugf("Failed to connect agent: proxy already claimed.")
+			// "proxy already claimed" is a fairly benign error, we should not
+			// spam the log with stack traces for it
+			if isProxyAlreadyClaimed(err) {
+				p.log.Debugf("Failed to connect agent: %v.", err)
 			} else {
 				p.log.WithError(err).Debugf("Failed to connect agent.")
 			}


### PR DESCRIPTION
This PR reduces the log spam from the stack traces (only displayed when the logs are in text mode rather than json) for errors stemming from an agent pool spawning a second agent and hitting a proxy that's already claimed.