### PR TITLE
[web] Add unifiedId to unified resources

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -54,6 +54,7 @@ import {
 import { Database } from 'teleport/services/databases';
 
 import { ResourceActionButton } from './ResourceActionButton';
+import { resourceName } from './Resources';
 
 // Since we do a lot of manual resizing and some absolute positioning, we have
 // to put some layout constants in place here.
@@ -321,13 +322,6 @@ function CopyButton({ name }: { name: string }) {
       </ButtonIcon>
     </HoverTooltip>
   );
-}
-
-export function resourceName(resource: UnifiedResource) {
-  if (resource.kind === 'app' && resource.friendlyName) {
-    return resource.friendlyName;
-  }
-  return resource.kind === 'node' ? resource.hostname : resource.name;
 }
 
 function resourceDescription(resource: UnifiedResource) {

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -38,10 +38,9 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 import { SearchResource } from 'teleport/Discover/SelectResource';
 import { useUrlFiltering, useInfiniteScroll } from 'teleport/components/hooks';
-
 import { UnifiedResource } from 'teleport/services/agents';
 
-import { ResourceCard, LoadingCard, resourceName } from './ResourceCard';
+import { ResourceCard, LoadingCard } from './ResourceCard';
 import SearchPanel from './SearchPanel';
 import { FilterPanel } from './FilterPanel';
 import './unifiedStyles.css';
@@ -182,8 +181,21 @@ export function Resources() {
   );
 }
 
-function resourceKey(resource: UnifiedResource) {
-  return `${resource.kind}/${resourceName(resource)}`;
+export function resourceKey(resource: UnifiedResource) {
+  if (resource.kind === 'node') {
+    return `${resource.hostname}/node`;
+  }
+  return `${resource.name}/${resource.kind}`;
+}
+
+export function resourceName(resource: UnifiedResource) {
+  if (resource.kind === 'app' && resource.friendlyName) {
+    return resource.friendlyName;
+  }
+  if (resource.kind === 'node') {
+    return resource.hostname;
+  }
+  return resource.name;
 }
 
 function NoResults({ query }: { query: string }) {


### PR DESCRIPTION
In support of https://github.com/gravitational/teleport/issues/30418
Fixes #30259 

This will help us dynamically create a "unified id" that matches how the resource is stored in our unified resources cache.

This will be the ID used when storing pinned resources in user preferences (upcoming PR)