### PR TITLE
[v14] Revert rejecting connection if PROXY header is signed with non-local cluster

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -500,6 +500,13 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 					}).Warnf("%s - could not get host CA", invalidProxySignatureError)
 					continue
 				}
+				if errors.Is(err, ErrNonLocalCluster) {
+					m.WithFields(log.Fields{
+						"src_addr": conn.RemoteAddr(),
+						"dst_addr": conn.LocalAddr(),
+					}).Debugf("%s - signed by non local cluster", invalidProxySignatureError)
+					continue
+				}
 				if err != nil {
 					return nil, trace.Wrap(err, "%s %s -> %s", invalidProxySignatureError, conn.RemoteAddr(), conn.LocalAddr())
 				}


### PR DESCRIPTION
This PR temporarily reverts rejecting connection if PROXY header is signed with non-local cluster for branch v14, because it leads to an issue when cluster's name is changed in the config ( https://github.com/gravitational/teleport/issues/32066 ). This is to make sure our v14 release is not affected by this issue while we're working on proper fix.