### PR TITLE
Add --quiet option to helm lint invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -710,7 +710,7 @@ test-go: test-go-prepare test-go-unit test-go-libfido2 test-go-touch-id test-go-
 
 #
 # Runs a test to ensure no environment variable leak into build binaries.
-# This is typically done as part of the bloat test in CI, but this 
+# This is typically done as part of the bloat test in CI, but this
 # target exists for local testing.
 #
 .PHONY: test-env-leakage
@@ -1075,13 +1075,13 @@ lint-helm:
 				export HELM_TEMP=$$(mktemp); \
 				echo -n "Using values from '$${VALUES}': "; \
 				yamllint -c examples/chart/.lint-config.yaml $${VALUES} || { cat -en $${VALUES}; exit 1; }; \
-				helm lint --strict $${CHART} -f $${VALUES} || exit 1; \
+				helm lint --quiet --strict $${CHART} -f $${VALUES} || exit 1; \
 				helm template test $${CHART} -f $${VALUES} 1>$${HELM_TEMP} || exit 1; \
 				yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -en $${HELM_TEMP}; exit 1; }; \
 			done \
 		else \
 			export HELM_TEMP=$$(mktemp); \
-			helm lint --strict $${CHART} || exit 1; \
+			helm lint --quiet --strict $${CHART} || exit 1; \
 			helm template test $${CHART} 1>$${HELM_TEMP} || exit 1; \
 			yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -en $${HELM_TEMP}; exit 1; }; \
 		fi; \


### PR DESCRIPTION
Without this, the helm lint prints hundreds of lines of messages that just tell you that everything was good. This makes it harder to spot real problems.