### PR TITLE
convert protobuf's zero time into go's zero time

### DIFF
--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -17,6 +17,8 @@ limitations under the License.
 package headerv1
 
 import (
+	"time"
+
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -46,11 +48,19 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 
 // FromMetadataProto converts v1 metadata into an internal metadata object.
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
+	// We map the Zero protobuf time to the zero go time.
+	// We have to do this because protobuf's zero is epoch and std's zero time
+	// is yeah 1 of the gregorian calendar.
+	expires := msg.Expires.AsTime()
+	if expires.Unix() == 0 {
+		expires = time.Time{}
+	}
+
 	return header.Metadata{
 		Name:        msg.Name,
 		Description: msg.Description,
 		Labels:      msg.Labels,
-		Expires:     msg.Expires.AsTime(),
+		Expires:     expires,
 		ID:          msg.Id,
 	}
 }

--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -50,7 +50,7 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
 	// We map the Zero protobuf time to the zero go time.
 	// We have to do this because protobuf's zero is epoch and std's zero time
-	// is yeah 1 of the gregorian calendar.
+	// is year 1 of the gregorian calendar.
 	expires := msg.Expires.AsTime()
 	if expires.Unix() == 0 {
 		expires = time.Time{}

--- a/api/types/header/convert/v1/header_test.go
+++ b/api/types/header/convert/v1/header_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types/header"
 )
 
@@ -57,4 +58,14 @@ func TestMetadataRoundtrip(t *testing.T) {
 	converted := FromMetadataProto(ToMetadataProto(metadata))
 
 	require.Empty(t, cmp.Diff(metadata, converted))
+}
+
+func TestMetadataZeroTime(t *testing.T) {
+	metadata := &headerv1.Metadata{
+		Expires: nil,
+	}
+
+	converted := FromMetadataProto(metadata)
+
+	require.True(t, converted.Expires.IsZero())
 }


### PR DESCRIPTION
This PR adds a particular case in the type conversion logic from protobuf time to go's time to maintain the zero time.

When creating a protobuf metadata struct without timestamp and converting it to a `header.Metadata`, it sets the Expiration time to epoch. Go's zero time is year 1 of the gregorian calendar, which means `time.IsZero()` evaluates to false. This means a non-expiring protobuf metadata is converted to an already expired metadata.