### PR TITLE
[v13] Fix `tsh kube login` when creds are expired or doesn't exist

### DIFF
--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -1233,8 +1233,13 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	// Check that this kube cluster exists.
-	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	var kubeStatus *kubernetesStatus
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		// Check that this kube cluster exists.
+		var err error
+		kubeStatus, err = fetchKubeStatus(cf.Context, tc)
+		return trace.Wrap(err)
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backports #31418 to branch/v13.

Stacked on #32092

Merge conflict while backporting was due to the fact that we do not want to backport the `retryWithAccessRequest` to v13.