### PR TITLE
Upgrade GitHub actions to node 20

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # v3.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.GHA_ASSUME_ROLE }}

--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
         uses: docker/login-action@v2
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build etcd image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ${{ github.workspace }}
           file: .github/services/Dockerfile.etcd

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "rust: ${RUST_VERSION}"
 
       - name: Install Node Toolchain
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           registry-type: public
       # Build and publish container image on ECR.
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: "examples/teleport-usage"
           tags: public.ecr.aws/gravitational/teleport-usage:${{ steps.version.outputs.version }}

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # v3.0.1
         with:
           role-to-assume: ${{ secrets.TELEPORT_USAGE_IAM_ROLE_ARN }}

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -16,7 +16,7 @@ jobs:
           echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # v3.0.1
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.TELEPORT_USAGE_IAM_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "node: ${NODE_VERSION}"
 
       - name: Setup Node Toolchain
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "node: ${NODE_VERSION}"
 
       - name: Setup Node Toolchain
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -40,7 +40,7 @@ jobs:
           ref: master
 
       - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # v3.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-region:  us-west-2
           role-to-assume: "arn:aws:iam::126027368216:role/tf-teleport-ami-gha-role"


### PR DESCRIPTION
This PR collapses the following  dependabot PRs into a single change.  The underlying reason for this simultaneous churn is NodeJS 16 reached EOL on 2023-09-11, and these are all updating to NodeJs 20, which drops support for older distros -- most notably CentOS:7.

* https://github.com/gravitational/teleport/pull/32063
* https://github.com/gravitational/teleport/pull/32061
* https://github.com/gravitational/teleport/pull/32060
* https://github.com/gravitational/teleport/pull/32059
* https://github.com/gravitational/teleport/pull/33153
* https://github.com/gravitational/teleport/pull/33823

### Notes
I'm bunching these for two reasons:

1. So that our regular github actions runs trigger on the PRs (many of these are disabled on dependabot PRs)
2. I have to run through a complete dev build including these changes and the `teleport.e` changes, since many of the actions are only exercised upon build/release.

Corresponding `e` PR: https://github.com/gravitational/teleport.e/pull/2243

### Testing
I've run a complete dev build and promote, since these updates touch a ton of different release codepaths:

* Build: https://drone.platform.teleport.sh/gravitational/teleport/30072
* Promote: https://drone.platform.teleport.sh/gravitational/teleport/30077

