### PR TITLE
Swap tibdex/github-app-token to actions/create-github-app-token 

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate GitHub Token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.REVIEWERS_APP_ID }}
           private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate GitHub Token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.REVIEWERS_APP_ID }}
           private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Generate GitHub Token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.REVIEWERS_APP_ID }}
           private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate GitHub Token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.REVIEWERS_APP_ID }}
           private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate Github token
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
This improves security for actions that have access to GitHub application private keys.  We now use a 2nd party action from GitHub (a large and well funded org whom we have a contractual relationship with) instead of the the action from `tibdex` who is an individual out on the internet.

As part of this change, I'm also comfortable dropping the SHA pinning -- since the `actions` org can be held to a higher level of trust for both security and backwards compatibility concerns.

Corresponding `e` PR: https://github.com/gravitational/teleport.e/pull/2244

### Testing
We've deployed this change to other repos (for instance [this SecOps change](https://github.com/gravitational/SecOps/commit/c75e7a0cf10b06c6ea0fb5d6c9b1e596013d52f7) or [this Cloud change](https://github.com/gravitational/cloud/pull/6244)).

Some of the other use cases will be tested by CI.  Some will not be tested (e.g. backport.yaml, or update-ami-ids.yaml, but they're similar to what we are testing so I'm not currently concerned about regressions if CI passes.