### PR TITLE
support discovered name match in tbot outputs

### DIFF
--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -66,11 +66,15 @@ func TestBot(t *testing.T) {
 		fakeHostname        = "test-host"
 		fakeHostID          = "uuid"
 		appName             = "test-app"
-		databaseServiceName = "test-database-service"
+		databaseServiceName = "test-database-service-rds-us-west-1-123456789012"
 		databaseUsername    = "test-database-username"
 		databaseName        = "test-database"
-		kubeClusterName     = "test-kube-cluster"
+		kubeClusterName     = "test-kube-cluster-eks-us-west-1-12345679012"
+		// fake some "auto-discovered" and renamed resources.
+		databaseServiceDiscoveredName = "test-database-service"
+		kubeClusterDiscoveredName     = "test-kube-cluster"
 	)
+
 	clusterName := string(fc.Auth.ClusterName)
 	_ = testhelpers.MakeAndRunTestAuthServer(t, log, fc, fds)
 	rootClient := testhelpers.MakeDefaultAuthClient(t, log, fc)
@@ -88,13 +92,7 @@ func TestBot(t *testing.T) {
 	_, err = rootClient.UpsertApplicationServer(ctx, appServer)
 	require.NoError(t, err)
 	// Register a database server so the bot can request certs for it.
-	db, err := types.NewDatabaseV3(types.Metadata{
-		Name: databaseServiceName,
-	}, types.DatabaseSpecV3{
-		Protocol: "mysql",
-		URI:      "example.com:1234",
-	})
-	require.NoError(t, err)
+	db := newMockDiscoveredDB(t, databaseServiceName, databaseServiceDiscoveredName)
 	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
 		Name: databaseServiceName,
 	}, types.DatabaseServerSpecV3{
@@ -106,13 +104,7 @@ func TestBot(t *testing.T) {
 	_, err = rootClient.UpsertDatabaseServer(ctx, dbServer)
 	require.NoError(t, err)
 	// Register a kubernetes server so the bot can request certs for it.
-	kubeCluster, err := types.NewKubernetesClusterV3(
-		types.Metadata{
-			Name: kubeClusterName,
-		},
-		types.KubernetesClusterSpecV3{},
-	)
-	require.NoError(t, err)
+	kubeCluster := newMockDiscoveredKubeCluster(t, kubeClusterName, kubeClusterDiscoveredName)
 	kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, fakeHostname, fakeHostID)
 	require.NoError(t, err)
 	_, err = rootClient.UpsertKubernetesServer(ctx, kubeServer)
@@ -198,12 +190,25 @@ func TestBot(t *testing.T) {
 		Database:    databaseName,
 		Username:    databaseUsername,
 	}
+	dbDiscoveredNameOutput := &config.DatabaseOutput{
+		Destination: &config.DestinationMemory{},
+		Service:     databaseServiceDiscoveredName,
+		Database:    databaseName,
+		Username:    databaseUsername,
+	}
 	kubeOutput := &config.KubernetesOutput{
 		// DestinationDirectory required or output will fail.
 		Destination: &config.DestinationDirectory{
 			Path: t.TempDir(),
 		},
 		KubernetesCluster: kubeClusterName,
+	}
+	kubeDiscoveredNameOutput := &config.KubernetesOutput{
+		// DestinationDirectory required or output will fail.
+		Destination: &config.DestinationDirectory{
+			Path: t.TempDir(),
+		},
+		KubernetesCluster: kubeClusterDiscoveredName,
 	}
 	sshHostOutput := &config.SSHHostOutput{
 		Destination: &config.DestinationMemory{},
@@ -215,8 +220,10 @@ func TestBot(t *testing.T) {
 			identityOutputWithRoles,
 			appOutput,
 			dbOutput,
+			dbDiscoveredNameOutput,
 			sshHostOutput,
 			kubeOutput,
+			kubeDiscoveredNameOutput,
 		},
 		testhelpers.DefaultBotConfigOpts{
 			UseAuthServer: true,
@@ -256,6 +263,14 @@ func TestBot(t *testing.T) {
 		require.Equal(t, kubeUsers, tlsIdent.KubernetesUsers)
 	})
 
+	t.Run("output: kubernetes discovered name", func(t *testing.T) {
+		tlsIdent := tlsIdentFromDest(ctx, t, kubeDiscoveredNameOutput.GetDestination())
+		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
+		require.Equal(t, kubeClusterName, tlsIdent.KubernetesCluster)
+		require.Equal(t, kubeGroups, tlsIdent.KubernetesGroups)
+		require.Equal(t, kubeUsers, tlsIdent.KubernetesUsers)
+	})
+
 	t.Run("output: application", func(t *testing.T) {
 		tlsIdent := tlsIdentFromDest(ctx, t, appOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
@@ -267,6 +282,16 @@ func TestBot(t *testing.T) {
 
 	t.Run("output: database", func(t *testing.T) {
 		tlsIdent := tlsIdentFromDest(ctx, t, dbOutput.GetDestination())
+		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
+		route := tlsIdent.RouteToDatabase
+		require.Equal(t, databaseServiceName, route.ServiceName)
+		require.Equal(t, databaseName, route.Database)
+		require.Equal(t, databaseUsername, route.Username)
+		require.Equal(t, "mysql", route.Protocol)
+	})
+
+	t.Run("output: database discovered name", func(t *testing.T) {
+		tlsIdent := tlsIdentFromDest(ctx, t, dbDiscoveredNameOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
 		route := tlsIdent.RouteToDatabase
 		require.Equal(t, databaseServiceName, route.ServiceName)
@@ -436,4 +461,141 @@ func TestBot_InsecureViaProxy(t *testing.T) {
 	// Run the bot a first time
 	firstBot := New(botConfig, log)
 	require.NoError(t, firstBot.Run(ctx))
+}
+
+func TestChooseOneResource(t *testing.T) {
+	t.Parallel()
+	t.Run("database", testChooseOneDatabase)
+	t.Run("kube cluster", testChooseOneKubeCluster)
+}
+
+func testChooseOneDatabase(t *testing.T) {
+	t.Parallel()
+	fooDB1 := newMockDiscoveredDB(t, "foo-rds-us-west-1-123456789012", "foo")
+	fooDB2 := newMockDiscoveredDB(t, "foo-rds-us-west-2-123456789012", "foo")
+	barDB := newMockDiscoveredDB(t, "bar-rds-us-west-1-123456789012", "bar")
+	tests := []struct {
+		desc      string
+		databases []types.Database
+		dbSvc     string
+		wantDB    types.Database
+		wantErr   string
+	}{
+		{
+			desc:      "by exact name match",
+			databases: []types.Database{fooDB1, fooDB2, barDB},
+			dbSvc:     "bar-rds-us-west-1-123456789012",
+			wantDB:    barDB,
+		},
+		{
+			desc:      "by unambiguous discovered name match",
+			databases: []types.Database{fooDB1, fooDB2, barDB},
+			dbSvc:     "bar",
+			wantDB:    barDB,
+		},
+		{
+			desc:      "ambiguous discovered name matches is an error",
+			databases: []types.Database{fooDB1, fooDB2, barDB},
+			dbSvc:     "foo",
+			wantErr:   `"foo" matches multiple auto-discovered databases`,
+		},
+		{
+			desc:      "no match is an error",
+			databases: []types.Database{fooDB1, fooDB2, barDB},
+			dbSvc:     "xxx",
+			wantErr:   `database "xxx" not found`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotDB, err := chooseOneDatabase(test.databases, test.dbSvc)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantDB, gotDB)
+		})
+	}
+}
+
+func testChooseOneKubeCluster(t *testing.T) {
+	fooKube1 := newMockDiscoveredKubeCluster(t, "foo-eks-us-west-1-123456789012", "foo")
+	fooKube2 := newMockDiscoveredKubeCluster(t, "foo-eks-us-west-2-123456789012", "foo")
+	barKube := newMockDiscoveredKubeCluster(t, "bar-eks-us-west-1-123456789012", "bar")
+	tests := []struct {
+		desc            string
+		clusters        []types.KubeCluster
+		kubeSvc         string
+		wantKubeCluster types.KubeCluster
+		wantErr         string
+	}{
+		{
+			desc:            "by exact name match",
+			clusters:        []types.KubeCluster{fooKube1, fooKube2, barKube},
+			kubeSvc:         "bar-eks-us-west-1-123456789012",
+			wantKubeCluster: barKube,
+		},
+		{
+			desc:            "by unambiguous discovered name match",
+			clusters:        []types.KubeCluster{fooKube1, fooKube2, barKube},
+			kubeSvc:         "bar",
+			wantKubeCluster: barKube,
+		},
+		{
+			desc:     "ambiguous discovered name matches is an error",
+			clusters: []types.KubeCluster{fooKube1, fooKube2, barKube},
+			kubeSvc:  "foo",
+			wantErr:  `"foo" matches multiple auto-discovered kubernetes clusters`,
+		},
+		{
+			desc:     "no match is an error",
+			clusters: []types.KubeCluster{fooKube1, fooKube2, barKube},
+			kubeSvc:  "xxx",
+			wantErr:  `kubernetes cluster "xxx" not found`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotKube, err := chooseOneKubeCluster(test.clusters, test.kubeSvc)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantKubeCluster, gotKube)
+		})
+	}
+}
+
+func newMockDiscoveredDB(t *testing.T, name, discoveredName string) *types.DatabaseV3 {
+	t.Helper()
+	db, err := types.NewDatabaseV3(types.Metadata{
+		Name: name,
+		Labels: map[string]string{
+			types.OriginLabel:         types.OriginCloud,
+			types.DiscoveredNameLabel: discoveredName,
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: "mysql",
+		URI:      "example.com:1234",
+	})
+	require.NoError(t, err)
+	return db
+}
+
+func newMockDiscoveredKubeCluster(t *testing.T, name, discoveredName string) *types.KubernetesClusterV3 {
+	t.Helper()
+	kubeCluster, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: name,
+			Labels: map[string]string{
+				types.OriginLabel:         types.OriginCloud,
+				types.DiscoveredNameLabel: discoveredName,
+			},
+		},
+		types.KubernetesClusterSpecV3{},
+	)
+	require.NoError(t, err)
+	return kubeCluster
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/31750

For backwards compatibility with v14 discovery service auto-renaming discovered resources, `tbot` should support outputs that match a resource by its original "discovered name"

This PR is for:
* databases
* kube clusters