### PR TITLE
athena: configure limits in examples

### DIFF
--- a/examples/athena/athena.tf
+++ b/examples/athena/athena.tf
@@ -122,6 +122,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "long_term_storage
       kms_master_key_id = aws_kms_key.audit_key.arn
       sse_algorithm     = "aws:kms"
     }
+    bucket_key_enabled = true
   }
 }
 
@@ -160,6 +161,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "transient_storage
       kms_master_key_id = aws_kms_key.audit_key.arn
       sse_algorithm     = "aws:kms"
     }
+    bucket_key_enabled = true
   }
 }
 
@@ -250,6 +252,7 @@ resource "aws_athena_workgroup" "workgroup" {
   name          = var.workgroup
   force_destroy = true
   configuration {
+    bytes_scanned_cutoff_per_query = var.workgroup_max_scanned_bytes_per_query
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }
@@ -275,6 +278,9 @@ output "athena_url" {
       format("workgroup=%s", aws_athena_workgroup.workgroup.name),
       format("queueURL=%s", aws_sqs_queue.audit_queue.url),
       format("queryResultsS3=s3://%s/query_results", aws_s3_bucket.transient_storage.bucket),
+      format("limiterBurst=%d", var.search_event_limiter_burst),
+      format("limiterRefillAmount=%s", var.search_event_limiter_amount),
+      format("limiterRefillTime=%s", var.search_event_limiter_time),
     ])
   )
 }

--- a/examples/athena/variables.tf
+++ b/examples/athena/variables.tf
@@ -43,3 +43,29 @@ variable "table_name" {
 variable "workgroup" {
   description = "Name of Athena workgroup"
 }
+
+variable "workgroup_max_scanned_bytes_per_query" {
+  description = "Limit per query of max scanned bytes"
+  default     = 1073741824 # 1GB
+}
+
+# search_event_limiter variables allows to configured rate limit on top of
+# search events API to prevent increasing costs in case of aggressive use of API.
+# In current version Athena Audit logger is not prepared for polling of API.
+# Burst=20, time=1m and amount=5, means that you can do 20 requests without any
+# throtling, next requests will be thottled, and tokens will be filled to
+# rate limit bucket at amount 5 every 1m.
+variable "search_event_limiter_burst" {
+  description = "Number of tokens available for rate limit used on top of search event API"
+  default     = 20
+}
+
+variable "search_event_limiter_time" {
+  description = "Duration between the addition of tokens to the bucket for rate limit used on top of search event API"
+  default     = "1m"
+}
+
+variable "search_event_limiter_amount" {
+  description = "Number of tokens added to the bucket during specific interval for rate limit used on top of search event API"
+  default     = 5
+}


### PR DESCRIPTION
This PR adds reasonable default to example athena infrastructure script. 
It also adds `bucket_key_enabled` setting on s3 buckets.

