### PR TITLE
Add access lists to editor role when upgrading Teleport.

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -521,6 +521,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindInstance, RO()),
 			types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
 			types.NewRule(types.KindNode, RW()),
+			types.NewRule(types.KindAccessList, RW()),
 		},
 		teleport.PresetAccessRoleName: {
 			types.NewRule(types.KindInstance, RO()),


### PR DESCRIPTION
When upgrading Teleport, we will now add permissions to manage Access Lists to the editor role. This role is already in the preset definition, but was not being added during upgrades.

Note: There is already a unit test that covers verifying that this role is added properly.