### PR TITLE
[v13] convert protobuf's zero time into go's zero time

### DIFF
--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -17,6 +17,8 @@ limitations under the License.
 package headerv1
 
 import (
+	"time"
+
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -46,11 +48,19 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 
 // FromMetadataProto converts v1 metadata into an internal metadata object.
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
+	// We map the Zero protobuf time to the zero go time.
+	// We have to do this because protobuf's zero is epoch and std's zero time
+	// is yeah 1 of the gregorian calendar.
+	expires := msg.Expires.AsTime()
+	if expires.Unix() == 0 {
+		expires = time.Time{}
+	}
+
 	return header.Metadata{
 		Name:        msg.Name,
 		Description: msg.Description,
 		Labels:      msg.Labels,
-		Expires:     msg.Expires.AsTime(),
+		Expires:     expires,
 		ID:          msg.Id,
 	}
 }

--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -48,12 +48,10 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 
 // FromMetadataProto converts v1 metadata into an internal metadata object.
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
-	// We map the Zero protobuf time to the zero go time.
-	// We have to do this because protobuf's zero is epoch and std's zero time
-	// is year 1 of the gregorian calendar.
-	expires := msg.Expires.AsTime()
-	if expires.Unix() == 0 {
-		expires = time.Time{}
+	// We map the zero protobuf time (nil) to the zero go time.
+	var expires time.Time
+	if msg.Expires != nil {
+		expires = msg.Expires.AsTime()
 	}
 
 	return header.Metadata{
@@ -67,11 +65,17 @@ func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
 
 // ToMetadataProto converts an internal metadata object into a v1 metadata protobuf message.
 func ToMetadataProto(metadata header.Metadata) *headerv1.Metadata {
+	// We map the zero go time to the zero protobuf time (nil).
+	var expires *timestamppb.Timestamp
+	if !metadata.Expires.IsZero() {
+		expires = timestamppb.New(metadata.Expires)
+	}
+
 	return &headerv1.Metadata{
 		Name:        metadata.Name,
 		Description: metadata.Description,
 		Labels:      metadata.Labels,
-		Expires:     timestamppb.New(metadata.Expires),
+		Expires:     expires,
 		Id:          metadata.ID,
 	}
 }

--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -50,7 +50,7 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
 	// We map the Zero protobuf time to the zero go time.
 	// We have to do this because protobuf's zero is epoch and std's zero time
-	// is yeah 1 of the gregorian calendar.
+	// is year 1 of the gregorian calendar.
 	expires := msg.Expires.AsTime()
 	if expires.Unix() == 0 {
 		expires = time.Time{}

--- a/api/types/header/convert/v1/header_test.go
+++ b/api/types/header/convert/v1/header_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types/header"
 )
 
@@ -57,4 +58,14 @@ func TestMetadataRoundtrip(t *testing.T) {
 	converted := FromMetadataProto(ToMetadataProto(metadata))
 
 	require.Empty(t, cmp.Diff(metadata, converted))
+}
+
+func TestMetadataZeroTime(t *testing.T) {
+	metadata := &headerv1.Metadata{
+		Expires: nil,
+	}
+
+	converted := FromMetadataProto(metadata)
+
+	require.True(t, converted.Expires.IsZero())
 }

--- a/api/types/header/convert/v1/header_test.go
+++ b/api/types/header/convert/v1/header_test.go
@@ -60,12 +60,21 @@ func TestMetadataRoundtrip(t *testing.T) {
 	require.Empty(t, cmp.Diff(metadata, converted))
 }
 
+// TestMetadataZeroTime checks that go's zero time is mapped to the protobuf's
+// zero time and vice-versa.
 func TestMetadataZeroTime(t *testing.T) {
+	// When a proto message without expiration is converted to metadata
 	metadata := &headerv1.Metadata{
 		Expires: nil,
 	}
-
 	converted := FromMetadataProto(metadata)
-
+	// IsZero() must be true (as this is how we check if the resource expires
+	// in most places).
 	require.True(t, converted.Expires.IsZero())
+
+	// When a metadata without an expiration is converted to protobuf
+	convertedTwice := ToMetadataProto(converted)
+
+	// The protobuf expiration field must be unset
+	require.Empty(t, cmp.Diff(metadata.Expires, convertedTwice.Expires))
 }


### PR DESCRIPTION
Backport #32081 and #32135 to branch/v13