### PR TITLE
Add documentation for `proxy_protocol` setting.

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -612,6 +612,14 @@
             {
               "title": "Reducing the Blast Radius of Attacks",
               "slug": "/management/security/reduce-blast-radius/"
+            },
+            {
+              "title": "PROXY Protocol",
+              "slug": "/management/security/proxy-protocol/",
+              "forScopes": [
+                "enterprise",
+                "oss"
+              ]
             }
           ]
         },

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -64,10 +64,9 @@ proxy_service:
   proxy_protocol: off
 ```
 
-You should make sure that Teleport is only accessible through load balancer, if you run it with `proxy_protocol: on`, so malicious 
-users can't spoof their IP address by connecting directly and sending custom PROXY header.
-Teleport only allows one PROXY protocol header for an incoming connection - that makes sure any client connecting through 
-PROXY enabled L4 load balancer will not be able to send their own PROXY header to the connection.
+You should make sure that Teleport is only accessible through the load balancer if you run it with `proxy_protocol: on`, so malicious 
+attackers can't spoof their IP address or bypass IP Pinning restrictions by connecting directly and sending a custom PROXY header.
+Teleport only allows one PROXY protocol header for an incoming connection - it will reject requests that include multiple PROXY lines to prevent attacks when `proxy_protocol: on`.
 
 PROXY protocol behavior is controlled separately for Auth service and Proxy service. So you should ensure both have the correct 
 setting. If there's a PROXY-enabled L4 load balancer between your Proxy and Auth services, you should set `proxy_protocol: on` on the Auth,

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -21,11 +21,18 @@ An example of the PROXYv1 protocol header:
 PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
 ```
 
+## Security
+
+Misconfiguration of the PROXY protocol behavior can lead to security problems. Since the PROXY protocol lacks built-in authentication, 
+a malicious attacker could send falsified custom PROXY protocol headers to spoof the their IP address. To prevent this, you must 
+explicitly configure PROXY protocol settings according to your network setup - if you don't run Teleport behind a L4 load balancer, that
+send PROXY headers, you **must** disable PROXY protocol support on Teleport.
+
 ## Configuring PROXY protocol for Teleport
 
-Teleport Proxy/Auth relies on PROXY protocol to get the client's real IP address when behind an L4 load balancer. 
-However, without proper configuration, there are security concerns. Since the PROXY protocol lacks built-in authentication, 
-a malicious entity could send falsified PROXY protocol headers to spoof the client's IP.
+Teleport Proxy/Auth relies on PROXY protocol to get the client's real IP address when behind a L4 load balancer. Having reliable
+client IP information is important from the security standpoint, because such features as audit logging and IP pinning depend on it and
+if PROXY protocol is not configured correctly, these features will be compromised.
 
 Usage of PROXY protocol in Teleport is controlled by `proxy_protocol` setting in the configuration for both 
 `proxy_service` and `auth_service` sections separately.
@@ -77,5 +84,5 @@ otherwise set it to `off`.
 You can also have Teleport Proxies have different PROXY protocol settings, if you run some of them behind a load balancer and some not, for
 example if you have dedicated Proxies for private and public networks.
 
-Running Teleport behind an L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
+Running Teleport behind a L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
 coming from the same IP address from Teleport's point of view, making the audit trail less useful and the IP pinning feature not helpful.

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -29,8 +29,7 @@ By default in a new installation of Teleport `proxy_protocol` is unspecified, us
 - `on`: PROXY protocol is enabled. If a PROXY protocol header is received, it
   will parse the header and extract the client's IP address and port. If the header
   isn't present, it will reject the connection with an error.
-- `off`: PROXY protocol is disabled. If a PROXY protocol header is received, it
-  will reject the connection with an error.
+- `off`: `off`: PROXY Protocol is disabled and forbidden. Any connection with a PROXY protocol header is automatically rejected.
 - `unspecified` - PROXY protocol is allowed, but not required. If a PROXY protocol header is received,
   it will replace the client's source IP address with the one from PROXY header, but source port will be set to `0`.
   If the header isn't present, it will assume the IP address and port are

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -1,0 +1,80 @@
+---
+title: PROXY protocol
+description: How to securely configure PROXY protocol usage with Teleport
+---
+<Admonition type="note" scope={["cloud", "team"]}>
+Users of Teleport Cloud don't need to manage PROXY protocol setting manually. It's set to `on` automatically 
+and can't be changed, since cloud Proxy/Auth services always run behind L4 load balancer with enabled PROXY protocol. 
+</Admonition>
+
+## What is PROXY protocol
+
+The PROXY protocol is a prefix added to the TCP connection containing information about the client IP. 
+It is most commonly used when networking setup includes a Layer 4 (L4) load balancer between the user and the endpoint service,
+like Teleport Proxy/Auth.
+L4 load balancers, by design, do not retain the original client's IP address and port when forwarding the connection and 
+PROXY protocol allows to overcome this problem by adding the client's original IP address and port before the actual TCP stream.
+
+## Configuring PROXY protocol for Teleport
+
+Teleport Proxy/Auth relies on PROXY protocol to get the client's real IP address when behind an L4 load balancer. 
+However, without proper configuration, there are security concerns. Since the PROXY protocol lacks built-in authentication, 
+a malicious entity could send falsified PROXY protocol headers to spoof the client's IP.
+
+Usage of PROXY protocol in Teleport is controlled by `proxy_protocol` setting in the configuration for both 
+`proxy_service` and `auth_service` sections separately.
+
+By default in a new installation of Teleport `proxy_protocol` is unspecified, users can manually set `proxy_protocol` to
+`on` or `off`:
+- `on`: PROXY protocol is enabled. If a PROXY protocol header is received, it
+  will parse the header and extract the client's IP address and port. If the header
+  isn't present, it will reject the connection with an error.
+- `off`: PROXY protocol is disabled. If a PROXY protocol header is received, it
+  will reject the connection with an error.
+- `unspecified` - PROXY protocol is allowed, but not required. If a PROXY protocol header is received,
+  it will replace the client' source IP address with the one from PROXY header, but source port will be set to `0`.
+  If the header isn't present, it will assume the IP address and port are
+  the same as the connection source IP address and port. **This is the default**
+
+Users are encouraged to explicitly set their `proxy_protocol` setting to `on` or `off` mode
+depending on the network setup. **Default unspecified value mode is not suitable for production**, it is only 
+suitable for test environments, in this mode Teleport doesn't not require PROXY prefix for the connection, but will 
+parse it if present. Incoming connections will also be marked by setting source port to `0` and this will be visible 
+in the audit events.
+
+<Admonition type="warning">
+
+IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in the config. Connections that are marked 
+with source port = 0 will be rejected during IP pinning checks.
+
+</Admonition>
+
+Main rule for configuring `proxy_protocol` setting - **If Teleport is running behind a L4 load balancer, that is set to 
+send PROXY protocol headers, you should set `proxy_protocol: on`**.
+
+```yaml
+proxy_service:
+  proxy_protocol: on
+```
+
+Otherwise you should set `proxy_protocol: off`
+
+```yaml
+proxy_service:
+  proxy_protocol: off
+```
+
+You should make sure that Teleport is only accessible through load balancer, if you run it with `proxy_protocol: on`, so malicious 
+users can't spoof their IP address by connecting directly and sending custom PROXY header.
+Teleport only allows one PROXY protocol header for an incoming connection - that makes sure any client connecting through 
+PROXY enabled L4 load balancer will not be able to send their own PROXY header to the connection.
+
+PROXY protocol behavior is controlled separately for Auth service and Proxy service. So you should make sure both have correct 
+setting. If there's PROXY-enabled L4 load balancer between your Proxy and Auth services, you should set `proxy_protocol: on` on the Auth,
+otherwise set it to `off`.
+
+You can also have Teleport Proxies to have different PROXY protocol settings, if you run some of them behind load balancer and some not, for
+example if you have dedicated Proxies for private and public networks.
+
+Running Teleport behind L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
+coming from the same IP address from Teleport's point of view, making audit trail less useful and IP pinning feature not helpful.

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -4,7 +4,7 @@ description: How to securely configure PROXY protocol usage with Teleport
 ---
 <Admonition type="note" scope={["cloud", "team"]}>
 Users of Teleport Cloud don't need to manage PROXY protocol setting manually. It's set to `on` automatically 
-and can't be changed, since cloud Proxy/Auth services always run behind L4 load balancer with enabled PROXY protocol. 
+and can't be changed, since cloud Proxy/Auth services managed by Teleport run behind a L4 load balancer with PROXY protocol configured. 
 </Admonition>
 
 ## What is PROXY protocol

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -15,6 +15,12 @@ like Teleport Proxy/Auth.
 L4 load balancers, by design, do not retain the original client's IP address and port when forwarding the connection and 
 PROXY protocol allows to overcome this problem by adding the client's original IP address and port before the actual TCP stream.
 
+An example of the PROXYv1 protocol header:
+
+```text
+PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
+```
+
 ## Configuring PROXY protocol for Teleport
 
 Teleport Proxy/Auth relies on PROXY protocol to get the client's real IP address when behind an L4 load balancer. 

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -26,9 +26,9 @@ Usage of PROXY protocol in Teleport is controlled by `proxy_protocol` setting in
 
 By default in a new installation of Teleport `proxy_protocol` is unspecified, users can manually set `proxy_protocol` to
 `on` or `off`:
-- `on`: PROXY protocol is enabled. If a PROXY protocol header is received, it
-  will parse the header and extract the client's IP address and port. If the header
-  isn't present, it will reject the connection with an error.
+- `on`: PROXY Protocol is enabled and mandatory. If a PROXY
+  protocol header is received, Teleport will parse the header and extract the client's IP
+  address and port. If the header isn't present, it will reject the connection with an error.
 - `off`: `off`: PROXY Protocol is disabled and forbidden. Any connection with a PROXY protocol header is automatically rejected.
 - `unspecified` - PROXY protocol is allowed, but not required. If a PROXY protocol header is received,
   it will replace the client's source IP address with the one from PROXY header, but source port will be set to `0`.

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -35,17 +35,14 @@ By default in a new installation of Teleport `proxy_protocol` is unspecified, us
 - `on`: PROXY Protocol is enabled and mandatory. If a PROXY
   protocol header is received, Teleport will parse the header and extract the client's IP
   address and port. If the header isn't present, it will reject the connection with an error.
-- `off`: `off`: PROXY Protocol is disabled and forbidden. Any connection with a PROXY protocol header is automatically rejected.
-- `unspecified` - PROXY protocol is allowed, but not required. If a PROXY protocol header is received,
-  it will replace the client's source IP address with the one from PROXY header, but source port will be set to `0`.
-  If the header isn't present, it will assume the IP address and port are
-  the same as the connection source IP address and port. **This is the default**
+- `off`: PROXY Protocol is disabled and forbidden. Any connection with a PROXY protocol header is automatically rejected.
 
 Users are encouraged to explicitly set their `proxy_protocol` setting to `on` or `off` mode
 depending on the network setup. **Default unspecified value mode is not suitable for production**, it is only 
-suitable for test environments, in this mode Teleport doesn't not require PROXY prefix for the connection, but will 
-parse it if present. Incoming connections will also be marked by setting source port to `0` and this will be visible 
-in the audit events.
+suitable for test environments. If `proxy_protocol` is unspecified Teleport does not require PROXY header for the connection, but will 
+parse it if present, client's source IP address will be replaced with the one from PROXY header and this address will appear in
+the audit events. Incoming connections with PROXY header will also be marked by setting source port to `0` and this will be visible 
+in the audit events as well.
 
 <Admonition type="warning">
 

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -32,7 +32,7 @@ By default in a new installation of Teleport `proxy_protocol` is unspecified, us
 - `off`: PROXY protocol is disabled. If a PROXY protocol header is received, it
   will reject the connection with an error.
 - `unspecified` - PROXY protocol is allowed, but not required. If a PROXY protocol header is received,
-  it will replace the client' source IP address with the one from PROXY header, but source port will be set to `0`.
+  it will replace the client's source IP address with the one from PROXY header, but source port will be set to `0`.
   If the header isn't present, it will assume the IP address and port are
   the same as the connection source IP address and port. **This is the default**
 

--- a/docs/pages/management/security/proxy-protocol.mdx
+++ b/docs/pages/management/security/proxy-protocol.mdx
@@ -69,12 +69,12 @@ users can't spoof their IP address by connecting directly and sending custom PRO
 Teleport only allows one PROXY protocol header for an incoming connection - that makes sure any client connecting through 
 PROXY enabled L4 load balancer will not be able to send their own PROXY header to the connection.
 
-PROXY protocol behavior is controlled separately for Auth service and Proxy service. So you should make sure both have correct 
-setting. If there's PROXY-enabled L4 load balancer between your Proxy and Auth services, you should set `proxy_protocol: on` on the Auth,
+PROXY protocol behavior is controlled separately for Auth service and Proxy service. So you should ensure both have the correct 
+setting. If there's a PROXY-enabled L4 load balancer between your Proxy and Auth services, you should set `proxy_protocol: on` on the Auth,
 otherwise set it to `off`.
 
-You can also have Teleport Proxies to have different PROXY protocol settings, if you run some of them behind load balancer and some not, for
+You can also have Teleport Proxies have different PROXY protocol settings, if you run some of them behind a load balancer and some not, for
 example if you have dedicated Proxies for private and public networks.
 
-Running Teleport behind L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
-coming from the same IP address from Teleport's point of view, making audit trail less useful and IP pinning feature not helpful.
+Running Teleport behind an L4 load balancer that doesn't send PROXY protocol headers will lead to all incoming connections seemingly
+coming from the same IP address from Teleport's point of view, making the audit trail less useful and the IP pinning feature not helpful.


### PR DESCRIPTION
This PR adds documentation for `proxy_prototol` setting, accounting for the changes we recently made for the `proxy_procotol` behavior.