### PR TITLE
convert go's zero time into protobuf zero's time

### DIFF
--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -48,12 +48,10 @@ func ToResourceHeaderProto(resourceHeader header.ResourceHeader) *headerv1.Resou
 
 // FromMetadataProto converts v1 metadata into an internal metadata object.
 func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
-	// We map the Zero protobuf time to the zero go time.
-	// We have to do this because protobuf's zero is epoch and std's zero time
-	// is year 1 of the gregorian calendar.
-	expires := msg.Expires.AsTime()
-	if expires.Unix() == 0 {
-		expires = time.Time{}
+	// We map the zero protobuf time (nil) to the zero go time.
+	var expires time.Time
+	if msg.Expires != nil {
+		expires = msg.Expires.AsTime()
 	}
 
 	return header.Metadata{
@@ -67,11 +65,19 @@ func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
 
 // ToMetadataProto converts an internal metadata object into a v1 metadata protobuf message.
 func ToMetadataProto(metadata header.Metadata) *headerv1.Metadata {
+	// We map the zero go time to the zero protobuf time (nil).
+	var expires *timestamppb.Timestamp
+	if metadata.Expires.IsZero() {
+		expires = nil
+	} else {
+		expires = timestamppb.New(metadata.Expires)
+	}
+
 	return &headerv1.Metadata{
 		Name:        metadata.Name,
 		Description: metadata.Description,
 		Labels:      metadata.Labels,
-		Expires:     timestamppb.New(metadata.Expires),
+		Expires:     expires,
 		Id:          metadata.ID,
 	}
 }

--- a/api/types/header/convert/v1/header.go
+++ b/api/types/header/convert/v1/header.go
@@ -67,9 +67,7 @@ func FromMetadataProto(msg *headerv1.Metadata) header.Metadata {
 func ToMetadataProto(metadata header.Metadata) *headerv1.Metadata {
 	// We map the zero go time to the zero protobuf time (nil).
 	var expires *timestamppb.Timestamp
-	if metadata.Expires.IsZero() {
-		expires = nil
-	} else {
+	if !metadata.Expires.IsZero() {
 		expires = timestamppb.New(metadata.Expires)
 	}
 

--- a/api/types/header/convert/v1/header_test.go
+++ b/api/types/header/convert/v1/header_test.go
@@ -60,12 +60,21 @@ func TestMetadataRoundtrip(t *testing.T) {
 	require.Empty(t, cmp.Diff(metadata, converted))
 }
 
+// TestMetadataZeroTime checks that go's zero time is mapped to the protobuf's
+// zero time and vice-versa.
 func TestMetadataZeroTime(t *testing.T) {
+	// When a proto message without expiration is converted to metadata
 	metadata := &headerv1.Metadata{
 		Expires: nil,
 	}
-
 	converted := FromMetadataProto(metadata)
-
+	// IsZero() must be true (as this is how we check if the resource expires
+	// in most places).
 	require.True(t, converted.Expires.IsZero())
+
+	// When a metadata without an expiration is converted to protobuf
+	convertedTwice := ToMetadataProto(converted)
+
+	// The protobuf expiration field must be unset
+	require.Empty(t, cmp.Diff(metadata.Expires, convertedTwice.Expires))
 }


### PR DESCRIPTION
Followup on PR https://github.com/gravitational/teleport/pull/32081, which I merged a bit too quickly. I realized the opposite mapping was also needed to have a stable conversion process (Terraform is really sensitive to those changes).

This PR makes the logic cleaner: instead of looking if the date is epoch, we check if the pointer is unset, this allows proper epoch representation.

This PR also introduces the opposite mapping: go's zero time will now be mapped to a nil proto Expiration (instead of a non-nil one representing 0001-01-01). This makes the proto -> api/type -> proto conversion also idempotent.

IMPORTANT: A client with the changes in this PR connecting to an older server without this commit will fail to create an expiry-less AccessList. I checked with @mdwn, and it should not be an issue to do this break today, as the AccessList is not officially supported yet.