### PR TITLE
Remove Cf-Access-Token header.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -870,9 +870,6 @@ const (
 	// internal application being proxied.
 	AppJWTHeader = "teleport-jwt-assertion"
 
-	// AppCFHeader is a compatibility header.
-	AppCFHeader = "cf-access-token"
-
 	// HostHeader is the name of the Host header.
 	HostHeader = "Host"
 )

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -403,7 +403,6 @@ func testRewriteHeadersRoot(p *Pack, t *testing.T) {
 
 	// verify these headers were not rewritten.
 	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
-	require.NotEqual(t, req.Header.Get(teleport.AppCFHeader), "rewritten-app-cf-header")
 	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
 	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")
 	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedHost), "rewritten-x-forwarded-host-header")
@@ -412,7 +411,7 @@ func testRewriteHeadersRoot(p *Pack, t *testing.T) {
 	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
 
 	// Verify JWT tokens.
-	for _, header := range []string{teleport.AppJWTHeader, teleport.AppCFHeader, "X-JWT"} {
+	for _, header := range []string{teleport.AppJWTHeader, "X-JWT"} {
 		verifyJWT(t, p, req.Header.Get(header), p.dumperAppURI)
 	}
 }
@@ -441,7 +440,6 @@ func testRewriteHeadersLeaf(p *Pack, t *testing.T) {
 
 	// verify these headers were not rewritten.
 	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
-	require.NotEqual(t, req.Header.Get(teleport.AppCFHeader), "rewritten-app-cf-header")
 	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
 	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
 	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -360,7 +360,6 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 
 var forwardedHeaderNames = []string{
 	teleport.AppJWTHeader,
-	teleport.AppCFHeader,
 	"X-Forwarded-Proto",
 	"X-Forwarded-Host",
 	"X-Forwarded-Server",

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -695,10 +695,6 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 							Value: "rewritten-app-jwt-header",
 						},
 						{
-							Name:  teleport.AppCFHeader,
-							Value: "rewritten-app-cf-header",
-						},
-						{
 							Name:  common.TeleportAPIErrorHeader,
 							Value: "rewritten-x-teleport-api-error",
 						},
@@ -836,10 +832,6 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 						{
 							Name:  teleport.AppJWTHeader,
 							Value: "rewritten-app-jwt-header",
-						},
-						{
-							Name:  teleport.AppCFHeader,
-							Value: "rewritten-app-cf-header",
 						},
 						{
 							Name:  common.TeleportAPIErrorHeader,

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -57,7 +57,6 @@ const (
 // ReservedHeaders is a list of headers injected by Teleport.
 var ReservedHeaders = append([]string{
 	teleport.AppJWTHeader,
-	teleport.AppCFHeader,
 	XForwardedSSL,
 	TeleportAPIErrorHeader,
 	TeleportAPIInfoHeader,

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -177,7 +177,6 @@ func (t *transport) rewriteRequest(r *http.Request) error {
 func rewriteHeaders(r *http.Request, c *transportConfig) {
 	// Add in JWT headers.
 	r.Header.Set(teleport.AppJWTHeader, c.jwt)
-	r.Header.Set(teleport.AppCFHeader, c.jwt)
 
 	if c.app.GetRewrite() == nil || len(c.app.GetRewrite().Headers) == 0 {
 		return


### PR DESCRIPTION
The Cf-Access-Token header seems to be a infrequently used header that can easily increase the size of the header by `len(roles) + len(traits)`, which can cause problems. Users are able to add this in on their own if they need it using header rewriting, so we'll remove this.

This has been tested locally and the header no longer appears.