### PR TITLE
[v13] chore: Bump OpenSSL to 3.0.11

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -38,9 +38,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.10 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.11 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '245cb0291e0db99d9ccf3692fa76f440b2b054c2' ] && \
+    [ "$(git rev-parse HEAD)" = '6ba3884c3235e1bb474b379026087f8216afacf4' ] && \
     ./config --release --libdir=/usr/local/lib && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -77,9 +77,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.10 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.11 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '245cb0291e0db99d9ccf3692fa76f440b2b054c2' ] && \
+    [ "$(git rev-parse HEAD)" = '6ba3884c3235e1bb474b379026087f8216afacf4' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -69,9 +69,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.10 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.11 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '245cb0291e0db99d9ccf3692fa76f440b2b054c2' ] && \
+    [ "$(git rev-parse HEAD)" = '6ba3884c3235e1bb474b379026087f8216afacf4' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -23,8 +23,8 @@ fi
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=openssl-3.0.10
-readonly CRYPTO_COMMIT=245cb0291e0db99d9ccf3692fa76f440b2b054c2
+readonly CRYPTO_VERSION=openssl-3.0.11
+readonly CRYPTO_COMMIT=6ba3884c3235e1bb474b379026087f8216afacf4
 readonly FIDO2_VERSION=1.13.0
 readonly FIDO2_COMMIT=486a8f8667e42f55cee2bba301b41433cacec830
 


### PR DESCRIPTION
Backport #32140 to branch/v13