### PR TITLE
Add `proxy_protocol` setting to `teleport-cluster` chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -117,6 +117,36 @@ auth:
   imagePullPolicy: Always
 ```
 
+### `proxyProtocol`
+
+| Component   | Type     | Default value  | Required? | `teleport.yaml` equivalent |
+|-------------|----------|----------------|-----------|----------------------------|
+| `proxy`     | `string` | `null`         | no        | `proxy_service.proxy_protocol`  |
+
+
+The `proxyProtocol` value controls whether the Proxy pods will
+accept PROXY lines with the client's IP address when they are
+behind a L4 load balancer (e.g. AWS ELB, GCP L4 LB, etc) with PROXY protocol
+enabled. Since L4 LBs do not preserve the client's IP address, PROXY protocol is
+required to ensure that Teleport can properly audit the client's IP address.
+
+When Teleport pods are not behind a L4 LB with PROXY protocol enabled, this
+value should be set to `off` to prevent Teleport from accepting PROXY headers
+from untrusted sources.
+
+Possible values are:
+- `on`: will enable the PROXY protocol for all connections and will require the
+  L4 LB to send a PROXY header.
+- `off` will disable the PROXY protocol for all connections and denies all
+  connections prefixed a PROXY header.
+
+If `proxyProtocol` is unspecified, Teleport does not require PROXY header for the
+connection, but will accept it if present. This mode is considered insecure
+and should only be used for testing purposes.
+
+See the [PROXY Protocol security section](../../management/security/proxy-protocol.mdx) for more details.
+
+
 ### `auth.teleportConfig`
 
 | Type     | Default value | Required? |

--- a/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
@@ -70,6 +70,9 @@ proxy_service:
     uri: {{ .Values.acmeURI }}
   {{- end }}
 {{- end }}
+{{- if .Values.proxyProtocol }}
+  proxy_protocol: {{ .Values.proxyProtocol | quote }}
+{{- end }}
 {{- if and .Values.ingress.enabled (semverCompare ">= 14.0.0-0" (include "teleport-cluster.version" .)) }}
   trust_x_forwarded_for: true
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
@@ -233,3 +233,26 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data.teleport\.yaml
+  - it: sets "proxy_protocol" to "on"
+    set:
+      proxyProtocol: "on"
+      clusterName: teleport.example.com
+    asserts:
+      - matchRegex:
+          path: data.teleport\.yaml
+          pattern: 'proxy_protocol: "on"'
+  - it: sets "proxy_protocol" to "off"
+    set:
+      proxyProtocol: "off"
+      clusterName: teleport.example.com
+    asserts:
+      - matchRegex:
+          path: data.teleport\.yaml
+          pattern: 'proxy_protocol: "off"'
+  - it: does not set "proxy_protocol"
+    set:
+      clusterName: teleport.example.com
+    asserts:
+      - notMatchRegex:
+          path: data.teleport\.yaml
+          pattern: 'proxy_protocol:'

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -33,6 +33,15 @@
             "type": "string",
             "default": ""
         },
+        "proxyProtocol": {
+            "$id": "#/properties/proxyProtocol",
+            "type": "string",
+            "default": "",
+            "enum": [
+                "off",
+                "on"
+            ]
+        },
         "auth": {
             "$id": "#/properties/auth",
             "type": "object"
@@ -49,7 +58,9 @@
         "podMonitor": {
             "$id": "#/properties/podMonitor",
             "type": "object",
-            "required": ["enabled"],
+            "required": [
+                "enabled"
+            ],
             "properties": {
                 "enabled": {
                     "$id": "#/properties/podMonitor/enabled",
@@ -59,8 +70,12 @@
                 "additionalLabels": {
                     "$id": "#/properties/podMonitor/additionalLabels",
                     "type": "object",
-                    "default": {"prometheus": "default"},
-                    "additionalProperties": {"type": "string"}
+                    "default": {
+                        "prometheus": "default"
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "interval": {
                     "$id": "#/properties/podMonitor/interval",
@@ -72,7 +87,10 @@
         "authentication": {
             "$id": "#/properties/authentication",
             "type": "object",
-            "required": ["type", "localAuth"],
+            "required": [
+                "type",
+                "localAuth"
+            ],
             "properties": {
                 "type": {
                     "$id": "#/properties/authentication/properties/type",
@@ -97,7 +115,13 @@
                 "secondFactor": {
                     "$id": "#/properties/authentication/properties/secondFactor",
                     "type": "string",
-                    "enum": ["off", "on", "otp", "optional", "webauthn"],
+                    "enum": [
+                        "off",
+                        "on",
+                        "otp",
+                        "optional",
+                        "webauthn"
+                    ],
                     "default": "otp"
                 },
                 "webauthn": {
@@ -131,7 +155,13 @@
                 "secondFactor": {
                     "$id": "#/properties/authenticationSecondFactor/properties/secondFactor",
                     "type": "string",
-                    "enum": ["off", "on", "otp", "optional", "webauthn"],
+                    "enum": [
+                        "off",
+                        "on",
+                        "otp",
+                        "optional",
+                        "webauthn"
+                    ],
                     "default": "otp"
                 },
                 "webauthn": {
@@ -261,7 +291,9 @@
         "operator": {
             "$id": "#/properties/operator",
             "type": "object",
-            "required": ["enabled"],
+            "required": [
+                "enabled"
+            ],
             "properties": {
                 "enabled": {
                     "$id": "#/properties/operator/properties/enabled",
@@ -700,7 +732,13 @@
                 "level": {
                     "$id": "#/properties/log/properties/level",
                     "type": "string",
-                    "enum": ["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
+                    "enum": [
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "WARNING",
+                        "ERROR"
+                    ],
                     "default": "INFO"
                 },
                 "deployment": {

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -30,6 +30,30 @@ kubeClusterName: ""
 # If you want to run Teleport version X, you should use `helm --version X` instead.
 teleportVersionOverride: ""
 
+# The `proxyProtocol` value controls whether the Proxy pods will
+# accept PROXY lines with the client's IP address when they are
+# behind a L4 load balancer (e.g. AWS ELB, GCP L4 LB, etc) with PROXY protocol
+# enabled. Since L4 LBs do not preserve the client's IP address, PROXY protocol is
+# required to ensure that Teleport can properly audit the client's IP address.
+#
+# When Teleport pods are not behind a L4 LB with PROXY protocol enabled, this
+# value should be set to "off" to prevent Teleport from accepting PROXY headers
+# from untrusted sources.
+# Possible values are "on" and "off".
+# - "on" will enable the PROXY protocol for all connections and will require the
+#   L4 LB to send a PROXY header.
+# - "off" will disable the PROXY protocol for all connections and denies all
+#   connections prefixed with a PROXY header.
+#
+# If proxyProtocol is unspecified, Teleport does not require PROXY header for the
+# connection, but will accept it if present. This mode is considered insecure
+# and should only be used for testing purposes.
+#
+# See https://goteleport.com/docs/ver/14.x/management/security/proxy-protocol/
+# for more information.
+#
+# proxyProtocol: on
+
 # The `teleport-cluster` charts deploys two sets of pods: auth and proxy.
 # `auth` contains values specific for the auth pods. You can use it to
 #  set specific values for auth pods, taking precedence over chart-scoped values.


### PR DESCRIPTION
This PR adds a configuration option that allows users to configure the `proxy_protocol` setting to improve security.

Docs: https://goteleport.com/docs/ver/14.x/management/security/proxy-protocol/