### PR TITLE
[v14] Execute time-bound graceful shutdowns on `SIGINT`/`SIGTERM`.

### DIFF
--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -82,7 +82,7 @@ func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
 				process.Shutdown(ctx)
 				process.log.Infof("All services stopped, exiting.")
 				return nil
-			case syscall.SIGTERM, syscall.SIGKILL, syscall.SIGINT:
+			case syscall.SIGTERM, syscall.SIGINT:
 				timeout := getShutdownTimeout(process.log)
 				cancelCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 				process.log.Infof("Got signal %q, exiting within %vs.", signal, timeout.Seconds())

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -87,8 +87,8 @@ func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
 				cancelCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 				process.log.Infof("Got signal %q, exiting within %vs.", signal, timeout.Seconds())
 				go func() {
+					defer cancelFunc()
 					process.Shutdown(cancelCtx)
-					cancelFunc()
 				}()
 				<-cancelCtx.Done()
 				process.log.Infof("All services stopped or timeout passed, exiting immediately.")

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -86,9 +86,12 @@ func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
 				timeout := time.Second * 3
 				cancelCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 				process.log.Infof("Got signal %q, exiting within %vs.", signal, timeout.Seconds())
-				process.Shutdown(cancelCtx)
+				go func() {
+					process.Shutdown(cancelCtx)
+					cancelFunc()
+				}()
+				<-cancelCtx.Done()
 				process.log.Infof("All services stopped or timeout passed, exiting immediately.")
-				cancelFunc()
 				return nil
 			case syscall.SIGUSR1:
 				// All programs placed diagnostics on the standard output.

--- a/lib/service/signals_test.go
+++ b/lib/service/signals_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getShutdownTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{
+			name:     "no override",
+			envValue: "",
+			want:     defaultShutdownTimeout,
+		},
+		{
+			name:     "accept valid override, one second",
+			envValue: "1s",
+			want:     time.Second * 1,
+		},
+		{
+			name:     "accept valid override, one minute",
+			envValue: "1m",
+			want:     time.Minute * 1,
+		},
+		{
+			name:     "ignore invalid override",
+			envValue: "one moment",
+			want:     defaultShutdownTimeout,
+		},
+		{
+			name:     "valid override above maximum, trim",
+			envValue: "3000h",
+			want:     maxShutdownTimeout,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TELEPORT_UNSTABLE_SHUTDOWN_TIMEOUT", tt.envValue)
+			require.Equal(t, tt.want, getShutdownTimeout(logrus.StandardLogger()))
+		})
+	}
+}


### PR DESCRIPTION
Backport #31869 to branch/v14