### PR TITLE
Allow including only traits when doing a JWT rewrite

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -373,7 +373,7 @@ func (a *AppV3) CheckAndSetDefaults() error {
 
 	if a.Spec.Rewrite != nil {
 		switch a.Spec.Rewrite.JWTClaims {
-		case "", JWTClaimsRewriteRolesAndTraits, JWTClaimsRewriteRoles, JWTClaimsRewriteNone:
+		case "", JWTClaimsRewriteRolesAndTraits, JWTClaimsRewriteRoles, JWTClaimsRewriteNone, JWTClaimsRewriteTraits:
 		default:
 			return trace.BadParameter("app %q has unexpected JWT rewrite value %q", a.GetName(), a.Spec.Rewrite.JWTClaims)
 

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1098,6 +1098,8 @@ const (
 	JWTClaimsRewriteRolesAndTraits = "roles-and-traits"
 	// JWTClaimsRewriteRoles includes only the roles in the JWT token.
 	JWTClaimsRewriteRoles = "roles"
+	// JWTClaimsRewriteTraits includes only the traits in the JWT token.
+	JWTClaimsRewriteTraits = "traits"
 	// JWTClaimsRewriteNone include neither traits nor roles in the JWT token.
 	JWTClaimsRewriteNone = "none"
 )

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -297,7 +297,8 @@ this information from the token.
     # Options:
     # - roles-and-traits: include both roles and traits
     # - roles: include only roles
-    # - none :exclude both roles and traits from the JWT token
+    # - traits: include only traits
+    # - none: exclude both roles and traits from the JWT token
     # Default: roles-and-traits
     jwt_claims: roles-and-traits
     headers:

--- a/docs/pages/includes/config-reference/app-service.yaml
+++ b/docs/pages/includes/config-reference/app-service.yaml
@@ -53,6 +53,7 @@ app_service:
         ## Can be one of three options:
         ## - roles-and-traits: include both roles and traits in the JWT token
         ## - roles: include only roles in the JWT token
+        ## - traits: include only traits in the JWT token
         ## - none: include neither roles nor traits in the JWT token
         ## Default: roles-and-traits
         # jwt_claims: roles-and-traits

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -754,6 +754,15 @@ func TestRewriteJWT(t *testing.T) {
 			expectedTraits: wrappers.Traits{},
 			jwtRewrite:     types.JWTClaimsRewriteRoles,
 		},
+
+		{
+			name:          "test traits behavior",
+			expectedRoles: nil,
+			expectedTraits: wrappers.Traits{
+				"logins": []string{login},
+			},
+			jwtRewrite: types.JWTClaimsRewriteTraits,
+		},
 		{
 			name:           "test none behavior",
 			expectedRoles:  nil,

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -161,6 +161,8 @@ func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, 
 			roles = nil
 		case types.JWTClaimsRewriteRoles:
 			traits = nil
+		case types.JWTClaimsRewriteTraits:
+			roles = nil
 		case "", types.JWTClaimsRewriteRolesAndTraits:
 		}
 	}


### PR DESCRIPTION
Adds an option to specify `traits` as the only entries included in the JWT claims header