### PR TITLE
pgbk: specify the schema name in wal2json's add-tables

### DIFF
--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -17,6 +17,7 @@ package pgbk
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -242,4 +243,16 @@ func (w *wal2jsonMessage) toastCol(name string) *wal2jsonColumn {
 		return c
 	}
 	return w.oldCol(name)
+}
+
+// wal2jsonEscape turns a schema or table name into a form suitable for use in
+// wal2json's filter-tables or add-tables option, by prepending a backslash to
+// each character.
+func wal2jsonEscape(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		b.WriteRune('\\')
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -98,8 +98,6 @@ func (c *wal2jsonColumn) UUID() (uuid.UUID, error) {
 
 type wal2jsonMessage struct {
 	Action string `json:"action"`
-	Schema string `json:"schema"`
-	Table  string `json:"table"`
 
 	Columns  []wal2jsonColumn `json:"columns"`
 	Identity []wal2jsonColumn `json:"identity"`
@@ -113,16 +111,9 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		return nil, trace.BadParameter("unexpected action %q", w.Action)
 
 	case "T":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
 		return nil, trace.BadParameter("received truncate for table kv")
 
 	case "I":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		key, err := w.newCol("key").Bytea()
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing key on insert")
@@ -152,10 +143,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		}}, nil
 
 	case "D":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		key, err := w.oldCol("key").Bytea()
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing key on delete")
@@ -168,10 +155,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		}}, nil
 
 	case "U":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		// on an UPDATE, an unmodified TOASTed column might be missing from
 		// "columns", but it should be present in "identity" (and this also
 		// applies to "key"), so we use the toastCol accessor function

--- a/lib/backend/pgbk/wal2json_test.go
+++ b/lib/backend/pgbk/wal2json_test.go
@@ -113,8 +113,6 @@ func TestMessage(t *testing.T) {
 
 	m := &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("")},
 			{Name: "expires", Type: "bytea", Value: s("")},
@@ -126,15 +124,8 @@ func TestMessage(t *testing.T) {
 	_, err := m.Events()
 	require.ErrorContains(t, err, "missing column")
 
-	m.Table = "notkv"
-	evs, err := m.Events()
-	require.NoError(t, err)
-	require.Empty(t, evs)
-
 	m = &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("")},
 			{Name: "value", Type: "bytea", Value: s("")},
@@ -148,8 +139,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},
@@ -158,7 +147,7 @@ func TestMessage(t *testing.T) {
 		},
 		Identity: []wal2jsonColumn{},
 	}
-	evs, err = m.Events()
+	evs, err := m.Events()
 	require.NoError(t, err)
 	require.Len(t, evs, 1)
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
@@ -171,15 +160,8 @@ func TestMessage(t *testing.T) {
 		},
 	}))
 
-	m.Table = "notkv"
-	evs, err = m.Events()
-	require.NoError(t, err)
-	require.Empty(t, evs)
-
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
 			{Name: "expires", Type: "timestamp with time zone", Value: nil},
@@ -205,8 +187,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f32")},
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
@@ -243,8 +223,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
 		},
@@ -260,8 +238,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "D",
-		Schema: "public",
-		Table:  "kv",
 		Identity: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},


### PR DESCRIPTION
We currently run queries on the `kv` table with no schema qualifier, which means that we will end up using the first existing schema in the database's `search_path`, both when creating or updating the tables, and when using them. This can be used by database administrators to have Teleport use a schema that's not the default `public` schema, but the wal2json change feed was working under the assumption that the schema was always `public`, leading to a confusing scenario where no error is signaled, but the change feed pulls no events because it's looking for changes in `public.kv` when the actual table is `some_other_schema.kv`.

With this PR we read the schema name for the (unqualified) `kv` table when we open the change feed connection, and pass it to `add-tables` later. The string quoting strategy for the wal2json option (prepending a backslash to every character) was inspired by https://github.com/supabase/walrus/blob/aa36cf9ac8667573bc109fd62d4a57f267131b42/sql/walrus--0.1.sql#L125 .

changelog: fix: the PostgreSQL backend now handles default database schemas other than `public`

