### PR TITLE
[v14] pgbk: specify the schema name in wal2json's add-tables

### DIFF
--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -98,8 +98,6 @@ func (c *wal2jsonColumn) UUID() (uuid.UUID, error) {
 
 type wal2jsonMessage struct {
 	Action string `json:"action"`
-	Schema string `json:"schema"`
-	Table  string `json:"table"`
 
 	Columns  []wal2jsonColumn `json:"columns"`
 	Identity []wal2jsonColumn `json:"identity"`
@@ -113,16 +111,9 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		return nil, trace.BadParameter("unexpected action %q", w.Action)
 
 	case "T":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
 		return nil, trace.BadParameter("received truncate for table kv")
 
 	case "I":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		key, err := w.newCol("key").Bytea()
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing key on insert")
@@ -151,10 +142,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		}}, nil
 
 	case "D":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		key, err := w.oldCol("key").Bytea()
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing key on delete")
@@ -167,10 +154,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		}}, nil
 
 	case "U":
-		if w.Schema != "public" || w.Table != "kv" {
-			return nil, nil
-		}
-
 		// on an UPDATE, an unmodified TOASTed column might be missing from
 		// "columns", but it should be present in "identity" (and this also
 		// applies to "key"), so we use the toastCol accessor function

--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -17,6 +17,7 @@ package pgbk
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -239,4 +240,16 @@ func (w *wal2jsonMessage) toastCol(name string) *wal2jsonColumn {
 		return c
 	}
 	return w.oldCol(name)
+}
+
+// wal2jsonEscape turns a schema or table name into a form suitable for use in
+// wal2json's filter-tables or add-tables option, by prepending a backslash to
+// each character.
+func wal2jsonEscape(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		b.WriteRune('\\')
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/lib/backend/pgbk/wal2json_test.go
+++ b/lib/backend/pgbk/wal2json_test.go
@@ -113,8 +113,6 @@ func TestMessage(t *testing.T) {
 
 	m := &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("")},
 			{Name: "expires", Type: "bytea", Value: s("")},
@@ -126,15 +124,8 @@ func TestMessage(t *testing.T) {
 	_, err := m.Events()
 	require.ErrorContains(t, err, "missing column")
 
-	m.Table = "notkv"
-	evs, err := m.Events()
-	require.NoError(t, err)
-	require.Empty(t, evs)
-
 	m = &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("")},
 			{Name: "value", Type: "bytea", Value: s("")},
@@ -148,8 +139,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "I",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},
@@ -158,7 +147,7 @@ func TestMessage(t *testing.T) {
 		},
 		Identity: []wal2jsonColumn{},
 	}
-	evs, err = m.Events()
+	evs, err := m.Events()
 	require.NoError(t, err)
 	require.Len(t, evs, 1)
 	require.Empty(t, cmp.Diff(evs[0], backend.Event{
@@ -170,15 +159,8 @@ func TestMessage(t *testing.T) {
 		},
 	}))
 
-	m.Table = "notkv"
-	evs, err = m.Events()
-	require.NoError(t, err)
-	require.Empty(t, evs)
-
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
 			{Name: "expires", Type: "timestamp with time zone", Value: nil},
@@ -203,8 +185,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f32")},
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
@@ -240,8 +220,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "U",
-		Schema: "public",
-		Table:  "kv",
 		Columns: []wal2jsonColumn{
 			{Name: "value", Type: "bytea", Value: s("666f6f32")},
 		},
@@ -257,8 +235,6 @@ func TestMessage(t *testing.T) {
 
 	m = &wal2jsonMessage{
 		Action: "D",
-		Schema: "public",
-		Table:  "kv",
 		Identity: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},


### PR DESCRIPTION
Backport of #32197 to branch/v14

changelog: fix: the PostgreSQL backend now handles default database schemas other than `public`