### PR TITLE
ci: clarify failure on `go mod tidy`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run `go mod tidy`
         run: rm go.sum api/go.sum && go mod tidy && (cd api && go mod tidy)
 
-      - name: Check for changes
+      - name: Check for no changes after `go mod tidy`
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
 


### PR DESCRIPTION
This PR updates the name of the step that checks that there's no changes to `go.mod` and `go.sum` after a `go mod tidy` to make it more obvious what the issue is.