### PR TITLE
Validate SAMLIdPServiceProviders ACS endpoints

### DIFF
--- a/lib/services/saml_idp_service_provider.go
+++ b/lib/services/saml_idp_service_provider.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/gravitational/trace"
 
@@ -25,12 +26,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// SAMLIdPServiceProviderGetter defines interface for fetching SAMLIdPServiceProvider resources.
+// SAMLIdpServiceProviderGetter defines interface for fetching SAMLIdPServiceProvider resources.
 type SAMLIdpServiceProviderGetter interface {
 	ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, nextKey string) ([]types.SAMLIdPServiceProvider, string, error)
 }
 
-// SAMLIdPServiceProvider defines an interface for managing SAML IdP service providers.
+// SAMLIdPServiceProviders defines an interface for managing SAML IdP service providers.
 type SAMLIdPServiceProviders interface {
 	SAMLIdpServiceProviderGetter
 	// GetSAMLIdPServiceProvider returns the specified SAML IdP service provider resources.
@@ -118,4 +119,18 @@ func GenerateIdPServiceProviderFromFields(name string, entityDescriptor string) 
 		return nil, trace.Wrap(err)
 	}
 	return &s, nil
+}
+
+// ValidateAssertionConsumerServicesEndpoint ensures that the Assertion Consumer Service location
+// is a valid HTTPS endpoint.
+func ValidateAssertionConsumerServicesEndpoint(acs string) error {
+	endpoint, err := url.Parse(acs)
+	switch {
+	case err != nil:
+		return trace.Wrap(err)
+	case endpoint.Scheme != "https":
+		return trace.BadParameter("the assertion consumer services location must be an https endpoint")
+	}
+
+	return nil
 }

--- a/lib/services/saml_idp_service_provider_test.go
+++ b/lib/services/saml_idp_service_provider_test.go
@@ -61,6 +61,32 @@ func TestSAMLIdPServiceProviderMarshal(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestValidateAssertionConsumerServicesEndpoint(t *testing.T) {
+	cases := []struct {
+		location  string
+		assertion require.ErrorAssertionFunc
+	}{
+		{
+			location:  "https://sptest.iamshowcase.com/acs",
+			assertion: require.NoError,
+		},
+		{
+			location:  "http://sptest.iamshowcase.com/acs",
+			assertion: require.Error,
+		},
+		{
+			location:  "javascript://sptest.iamshowcase.com/acs",
+			assertion: require.Error,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.location, func(t *testing.T) {
+			test.assertion(t, ValidateAssertionConsumerServicesEndpoint(test.location))
+		})
+	}
+}
+
 var samlIDPServiceProviderYAML = `---
 kind: saml_idp_service_provider
 version: v1


### PR DESCRIPTION
Enforces that all ACS endpoints are HTTPS to prevent any XSS attacks. To allow admins to interogate any existing resources which may be impacted validation only happens on create and update but not get. All usages of SAMLIdPServiceProviders within teleport follow all internal retrievals with a call to
services.ValidateAssertionConsumerServicesEndpoint in order to subvert invalid ACS endpoints.