### PR TITLE
Stop implicitly loading global tsh config on Windows

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -843,8 +843,8 @@ The `<alias>` can only be a top-level subcommand. In other words, you can define
 
 `tsh` loads two kinds of configuration files:
 
-- global: by default `/etc/tsh.yaml`, unless overridden by  the `$TELEPORT_GLOBAL_TSH_CONFIG` env var.
-- user-specific: `$TELEPORT_HOME/config/config.yaml`, which by defaults resolves to `~/.tsh/config/config.yaml`.
+- global: set via the `$TELEPORT_GLOBAL_TSH_CONFIG` env var if not provided it will default to `/etc/tsh.yaml` on non-Windows operating systems.
+- user-specific: `$TELEPORT_HOME/config/config.yaml`, which by default resolves to `~/.tsh/config/config.yaml`.
 
 `tsh` merges the user-specific config with the global config. In case of conflicts (i.e. same alias defined in both files), the user-specific config has higher priority.
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -397,8 +397,8 @@ type CLIConf struct {
 	// displayParticipantRequirements is set if verbose participant requirement information should be printed for moderated sessions.
 	displayParticipantRequirements bool
 
-	// TshConfig is the loaded tsh configuration file ~/.tsh/config/config.yaml.
-	TshConfig TshConfig
+	// TSHConfig is the loaded tsh configuration file ~/.tsh/config/config.yaml.
+	TSHConfig TSHConfig
 
 	// ListAll specifies if an ls command should return results from all clusters and proxies.
 	ListAll bool
@@ -1091,10 +1091,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	cf.TshConfig = *confOptions
+	cf.TSHConfig = *confOptions
 
 	// aliases
-	ar := newAliasRunner(cf.TshConfig.Aliases)
+	ar := newAliasRunner(cf.TSHConfig.Aliases)
 	aliasCommand, runtimeArgs := findAliasCommand(args)
 	if aliasDefinition, ok := ar.getAliasDefinition(aliasCommand); ok {
 		return ar.runAlias(ctx, aliasCommand, aliasDefinition, cf.executablePath, runtimeArgs)
@@ -1104,7 +1104,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	utils.UpdateAppUsageTemplate(app, args)
 	command, err := app.Parse(args)
 	if errors.Is(err, kingpin.ErrExpectedCommand) {
-		if _, ok := cf.TshConfig.Aliases[aliasCommand]; ok {
+		if _, ok := cf.TSHConfig.Aliases[aliasCommand]; ok {
 			log.Debugf("Failing due to recursive alias %q. Aliases seen: %v", aliasCommand, ar.getSeenAliases())
 			return trace.BadParameter("recursive alias %q; correct alias definition and try again", aliasCommand)
 		}
@@ -3499,7 +3499,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	}
 
 	// Check if this host has a matching proxy template.
-	tProxy, tHost, tCluster, tMatched := cf.TshConfig.ProxyTemplates.Apply(fullHostName)
+	tProxy, tHost, tCluster, tMatched := cf.TSHConfig.ProxyTemplates.Apply(fullHostName)
 	if !tMatched && useProxyTemplate {
 		return nil, trace.BadParameter("proxy jump contains {{proxy}} variable but did not match any of the templates in tsh config")
 	} else if tMatched {
@@ -3596,7 +3596,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	if c.ExtraProxyHeaders == nil {
 		c.ExtraProxyHeaders = map[string]string{}
 	}
-	for _, proxyHeaders := range cf.TshConfig.ExtraHeaders {
+	for _, proxyHeaders := range cf.TSHConfig.ExtraHeaders {
 		proxyGlob := utils.GlobToRegexp(proxyHeaders.Proxy)
 		proxyRegexp, err := regexp.Compile(proxyGlob)
 		if err != nil {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -324,7 +324,7 @@ func TestAlias(t *testing.T) {
 			t.Setenv(tshBinMainTestEnv, "1")
 
 			// write config to use
-			config := &TshConfig{Aliases: tt.aliases}
+			config := &TSHConfig{Aliases: tt.aliases}
 			configBytes, err := yamlv2.Marshal(config)
 			require.NoError(t, err)
 			err = os.WriteFile(filepath.Join(tmpHomePath, "tsh_global.yaml"), configBytes, 0o777)
@@ -878,7 +878,7 @@ func TestMakeClient(t *testing.T) {
 	conf.NodePort = 46528
 	conf.LocalForwardPorts = []string{"80:remote:180"}
 	conf.DynamicForwardedPorts = []string{":8080"}
-	conf.TshConfig.ExtraHeaders = []ExtraProxyHeaders{
+	conf.TSHConfig.ExtraHeaders = []ExtraProxyHeaders{
 		{Proxy: "proxy:3080", Headers: map[string]string{"A": "B"}},
 		{Proxy: "*roxy:3080", Headers: map[string]string{"C": "D"}},
 		{Proxy: "*hello:3080", Headers: map[string]string{"E": "F"}}, // shouldn't get included

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -35,28 +35,27 @@ func TestLoadConfigNonExistingFile(t *testing.T) {
 	fullFilePath := "/tmp/doesntexist." + uuid.NewString()
 	gotConfig, gotErr := loadConfig(fullFilePath)
 	require.NoError(t, gotErr)
-	require.Equal(t, &TshConfig{}, gotConfig)
+	require.Equal(t, &TSHConfig{}, gotConfig)
 }
 
 func TestLoadConfigEmptyFile(t *testing.T) {
 	t.Parallel()
 
-	file, err := os.CreateTemp("", "test-telelport")
+	file, err := os.CreateTemp(t.TempDir(), "test-telelport")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
 
 	_, err = file.Write([]byte(" "))
 	require.NoError(t, err)
 
 	gotConfig, gotErr := loadConfig(file.Name())
 	require.NoError(t, gotErr)
-	require.Equal(t, &TshConfig{}, gotConfig)
+	require.Equal(t, &TSHConfig{}, gotConfig)
 }
 
 func TestLoadAllConfigs(t *testing.T) {
 	t.Parallel()
 
-	writeConf := func(fn string, config TshConfig) {
+	writeConf := func(fn string, config TSHConfig) {
 		dir, _ := path.Split(fn)
 		err := os.MkdirAll(dir, 0777)
 		require.NoError(t, err)
@@ -69,7 +68,7 @@ func TestLoadAllConfigs(t *testing.T) {
 	tmp := t.TempDir()
 
 	globalPath := path.Join(tmp, "etc", "tsh_global.yaml")
-	globalConf := TshConfig{
+	globalConf := TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy:   "global",
 			Headers: map[string]string{"bar": "123"},
@@ -78,7 +77,7 @@ func TestLoadAllConfigs(t *testing.T) {
 
 	homeDir := path.Join(tmp, "home", "myuser", ".tsh")
 	userPath := path.Join(homeDir, "config", "config.yaml")
-	userConf := TshConfig{
+	userConf := TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy:   "user",
 			Headers: map[string]string{"bar": "456"},
@@ -94,7 +93,7 @@ func TestLoadAllConfigs(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, &TshConfig{
+	require.Equal(t, &TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{
 			{
 				Proxy:   "user",
@@ -113,7 +112,7 @@ func TestLoadAllConfigs(t *testing.T) {
 func TestTshConfigMerge(t *testing.T) {
 	t.Parallel()
 
-	sampleConfig := TshConfig{
+	sampleConfig := TSHConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy: "foo",
 			Headers: map[string]string{
@@ -125,15 +124,15 @@ func TestTshConfigMerge(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		config1 *TshConfig
-		config2 *TshConfig
-		want    TshConfig
+		config1 *TSHConfig
+		config2 *TSHConfig
+		want    TSHConfig
 	}{
 		{
 			name:    "empty + empty = empty",
 			config1: nil,
 			config2: nil,
-			want:    TshConfig{Aliases: map[string]string{}},
+			want:    TSHConfig{Aliases: map[string]string{}},
 		},
 		{
 			name:    "empty + x = x",
@@ -149,14 +148,14 @@ func TestTshConfigMerge(t *testing.T) {
 		},
 		{
 			name: "headers combine different proxies",
-			config1: &TshConfig{
+			config1: &TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{{
 					Proxy: "foo",
 					Headers: map[string]string{
 						"bar": "123",
 					},
 				}}},
-			config2: &TshConfig{
+			config2: &TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{{
 					Proxy: "bar",
 					Headers: map[string]string{
@@ -164,7 +163,7 @@ func TestTshConfigMerge(t *testing.T) {
 					},
 				}},
 			},
-			want: TshConfig{
+			want: TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{
 					{
 						Proxy: "bar",
@@ -184,21 +183,21 @@ func TestTshConfigMerge(t *testing.T) {
 		},
 		{
 			name: "headers combine same proxy",
-			config1: &TshConfig{
+			config1: &TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{{
 					Proxy: "foo",
 					Headers: map[string]string{
 						"bar": "123",
 					},
 				}}},
-			config2: &TshConfig{
+			config2: &TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{{
 					Proxy: "foo",
 					Headers: map[string]string{
 						"bar": "456",
 					},
 				}}},
-			want: TshConfig{
+			want: TSHConfig{
 				ExtraHeaders: []ExtraProxyHeaders{
 					{
 						Proxy: "foo",
@@ -218,7 +217,7 @@ func TestTshConfigMerge(t *testing.T) {
 		},
 		{
 			name: "aliases combine",
-			config1: &TshConfig{
+			config1: &TSHConfig{
 				ExtraHeaders:   nil,
 				ProxyTemplates: nil,
 				Aliases: map[string]string{
@@ -226,7 +225,7 @@ func TestTshConfigMerge(t *testing.T) {
 					"bar": "bar1",
 				},
 			},
-			config2: &TshConfig{
+			config2: &TSHConfig{
 				ExtraHeaders:   nil,
 				ProxyTemplates: nil,
 				Aliases: map[string]string{
@@ -234,7 +233,7 @@ func TestTshConfigMerge(t *testing.T) {
 					"bar": "bar2",
 				},
 			},
-			want: TshConfig{
+			want: TSHConfig{
 				ExtraHeaders:   nil,
 				ProxyTemplates: nil,
 				Aliases: map[string]string{
@@ -258,7 +257,7 @@ func TestTshConfigMerge(t *testing.T) {
 func TestProxyTemplatesApply(t *testing.T) {
 	t.Parallel()
 
-	tshConfig := TshConfig{
+	tshConfig := TSHConfig{
 		ProxyTemplates: ProxyTemplates{
 			{
 				Template: `^(.+)\.(us.example.com):(.+)$`,
@@ -337,7 +336,7 @@ func TestProxyTemplatesApply(t *testing.T) {
 func TestProxyTemplatesMakeClient(t *testing.T) {
 	t.Parallel()
 
-	tshConfig := TshConfig{
+	tshConfig := TSHConfig{
 		ProxyTemplates: ProxyTemplates{
 			{
 				Template: `^(.+)\.(us.example.com):(.+)$`,
@@ -355,7 +354,7 @@ func TestProxyTemplatesMakeClient(t *testing.T) {
 			Proxy:     "proxy:3080",
 			UserHost:  "localhost",
 			HomePath:  t.TempDir(),
-			TshConfig: tshConfig,
+			TSHConfig: tshConfig,
 		}
 
 		// Create a empty profile so we don't ping proxy.


### PR DESCRIPTION
To avoid security issues caused by a possible lack of file system permissions on Windows tsh only loads global config if the path to the file is explicitly provided in the TELEPORT_GLOBAL_TSH_CONFIG environment variable.