### PR TITLE
Add access list to default allow editor preset role

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -521,6 +521,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindInstance, RO()),
 			types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
 			types.NewRule(types.KindNode, RW()),
+			types.NewRule(types.KindAccessList, RW()),
 		},
 		teleport.PresetAccessRoleName: {
 			types.NewRule(types.KindInstance, RO()),


### PR DESCRIPTION
update existing editor role to allow `access_list` read/write rules

how it will be tested, is being discussed here in mean time: https://github.com/gravitational/teleport/pull/32128