### PR TITLE
Upload one file per Vercel preview deployment

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         id: deploy
         run: |
-          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > deployment-url.txt
+          vercel deploy --archive=tgz --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > deployment-url.txt
           preview_url="$(cat deployment-url.txt)"
           echo "PREVIEW_URL=$preview_url" >> $GITHUB_OUTPUT
       - uses: actions/github-script@v6


### PR DESCRIPTION
Currently, the Vercel preview workflow uses the default `vercel deploy` behavior, which uploads every source file to Vercel. The result is often rate limiting by the Vercel API, which prevents some preview workflows from running.

This change adds the `--archive=tgz` flag to the `vercel deploy` command to upload a single tarball instead, as recommended by Vercel support.

The flag is undocumented, but you can consult the PR that added it to the `vercel` CLI (vercel/vercel#8356) for context.