### PR TITLE
Fix the userloginstate generator if the user has no traits.

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -146,6 +146,10 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 
 		state.Spec.Roles = append(state.Spec.Roles, accessList.Spec.Grants.Roles...)
 
+		if state.Spec.Traits == nil && len(accessList.Spec.Grants.Traits) > 0 {
+			state.Spec.Traits = map[string][]string{}
+		}
+
 		for k, values := range accessList.Spec.Grants.Traits {
 			state.Spec.Traits[k] = append(state.Spec.Traits[k], values...)
 		}


### PR DESCRIPTION
If the user has no traits and traits need to be assigned, the generator will create an empty map to put the traits into.