### PR TITLE
docs: include SLES install with zypper repo in ent install

### DIFF
--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -100,6 +100,30 @@ $ sudo dnf install teleport-ent-fips
 ```
 
 </TabItem>
+<TabItem label="SLES 12 SP5+ and 15 SP5+ (zypper)">
+
+```code
+# Source variables about OS version
+$ source /etc/os-release
+# Add the Teleport Zypper repository.
+# First, get the OS major version from $VERSION_ID so this fetches the correct
+# package version.
+$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+# Use Zypper to add the teleport RPM repo
+$ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport-zypper.repo")
+
+# Install teleport
+$ sudo zypper install teleport-ent
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ sudo zypper install teleport-ent-fips
+```
+
+</TabItem>
+
 <TabItem label="Tarball" >
 
 In the example commands below, update `$SYSTEM_ARCH` with the appropriate


### PR DESCRIPTION
This is included in cloud install. Relevant for self-hosted too.