### PR TITLE
Move Upcoming Releases to v14

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -1,117 +1,40 @@
 ---
 title: Teleport Upcoming Releases
 description: A timeline of upcoming Teleport releases.
-h1: Upcoming Teleport Releases
 ---
 
 The Teleport team delivers a new major release roughly every 3 months.
 
 ## Teleport
 
-### Teleport 12.3.0
+| Version | Date                 |
+|---------|----------------------|
+| 14.1.0  | October 16th, 2023   |
 
-####  Automatic user creation for Desktop Access
+### 14.1.0
 
-Teleport's passwordless access for local users will provide the ability to
-create Windows users on demand, similar to how host-user creation works for SSH
-servers.
+#### Access Reviews
 
-#### SFTP UX enhancements
+Access list owners will be able to perform regular periodic reviews of the list
+members.
 
-Will include fixes for wildcard patterns, excessive audit logging and PyCharm
-compatibility. [#22748](https://github.com/gravitational/teleport/issues/22748)
-[#21518](https://github.com/gravitational/teleport/issues/21518)
-[#22982](https://github.com/gravitational/teleport/issues/22982)
-[#22263](https://github.com/gravitational/teleport/issues/22263)
-[#20863](https://github.com/gravitational/teleport/issues/20863)
-[#23593](https://github.com/gravitational/teleport/issues/23593)
+#### Connect my Computer for Teleport Connect
 
-| Version | Date          |
-|---------|---------------|
-| 12.3.0  | May 1st, 2023 |
+Users on macOS and Linux will be able to seamlessly add their computer to a Teleport
+cluster with Teleport Connect.
 
-### Teleport 13.0.0
+#### EC2 agentless support for SSH
 
-| Version        | Date             |
-|----------------|------------------|
-| 13.0.0-alpha.1 | April 17th, 2023 |
-| 13.0.0         | May 8th, 2023    |
-
-####  Automatic upgrades
-
-Users will be able to configure Teleport agents to upgrade automatically.
-
-####  TLS routing through ALB for server access and Kubernetes access
-
-Teleport will support server access and Kubernetes access through load
-balancers in TLS routing mode.
-
-####  Ability to import applications and groups from Okta to Application Access
-
-Teleport will be able to imports Okta apps and groups and users will be able to
-use Access Requests with Okta apps and groups.
-
-####  AWS OpenSearch support for Database Access
-
-Database access will add support for connecting to AWS OpenSearch.
-
-#### Cross-Cluster Search for Teleport Connect
-
-Teleport Connect will include a new search experience, allowing you to search
-for and connect to resources across all logged-in clusters.
-
-#### Kubernetes access performance improvements
-
-Users will experience better performance when interacting with Kubernetes clusters.
-
-#### Universal binaries (including Apple Silicon) for macOS
-
-Teleport will run natively on ARM Macs, without the need for Rosetta emulation.
-
-#### Simplified RDS onboarding flow in Access Management UI
-
-Teleport Access Management UI will provide ability to connect to AWS account
-and select RDS databases for onboarding.
-
-#### Light theme for Web UI
-
-Teleport's web UI will ship with an optional light theme.
-
-#### Other
-
-In addition, the following improvements
-
-- Improved SQL Server PKINIT Auth support
-- Session recording video export support for Desktop Access
-- Add support for locking to Web UI
-- Device listing in Web UI
-
-### 13.1.0
-
-####  GCP Auto-Discovery for Server Access
-
-Teleport will be able to automatically enroll GCP VM for server access.
-
-####  OpsGenie Access Request Plugin
-
-Teleport will include OpsGenie access plugin.
-
-*Delayed from Teleport 13.0.0.*
-
-| Version | Date           |
-|---------|----------------|
-| 12.3.0  | June 1st, 2023 |
+Users will be able to connect to EC2 instances via AWS EC2 Instance Connect
+endpoints, without needing to install Teleport agents.
 
 ## Teleport Cloud
 
 The key deliverables for Teleport Cloud in the next quarter:
 
-| Week of          | Description                                          |
-|------------------|------------------------------------------------------|
-| April 10th, 2023 | Teleport 12.2 begins to roll out for Cloud customers |
-| May 8th, 2023    | Add support for hosted Access Request plugins        |
-| June 5th, 2023   | Teleport 13.1 begins to roll out for Cloud customers |
-| June 5th, 2023   | Advanced Audit Log rollout begins                    |
+| Week of          | Description                                           |
+|------------------|-------------------------------------------------------|
+| August 7th, 2023 | Teleport 13.3 will begin rollout                      |
 
 ## Production readiness
 


### PR DESCRIPTION
- Move the Upcoming Releases page from v13 to v14
- Remove upcoming release notes for v14 and before