### PR TITLE
Connect My Computer: Add progress bar to the setup screen

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+
+import { wait } from 'shared/utils/wait';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -45,6 +47,30 @@ export function Default() {
     addr: '127.0.0.1:3022',
     labelsList: [],
   });
+  return <ShowState cluster={cluster} appContext={appContext} />;
+}
+
+export function Errored() {
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext({ appVersion: cluster.proxyVersion });
+  appContext.connectMyComputerService.createAgentConfigFile = () => {
+    throw new Error('Failed to write file, no permissions.');
+  };
+  return <ShowState cluster={cluster} appContext={appContext} />;
+}
+
+export function InProgress() {
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext({ appVersion: cluster.proxyVersion });
+  const ref = useRef(new AbortController());
+
+  useEffect(() => {
+    return () => ref.current.abort();
+  }, []);
+
+  appContext.connectMyComputerService.downloadAgent = () =>
+    wait(24 * 3600 * 100, ref.current.signal);
+
   return <ShowState cluster={cluster} appContext={appContext} />;
 }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -22,7 +22,11 @@ import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspace
 
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 
-import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer';
+import { IAppContext } from 'teleterm/ui/types';
+
+import { Cluster } from 'teleterm/services/tshd/types';
+
+import { ConnectMyComputerContextProvider } from '../connectMyComputerContext';
 
 import { DocumentConnectMyComputerSetup } from './DocumentConnectMyComputerSetup';
 
@@ -33,56 +37,37 @@ export default {
 export function Default() {
   const cluster = makeRootCluster();
   const appContext = new MockAppContext({ appVersion: cluster.proxyVersion });
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
+  appContext.connectMyComputerService.waitForNodeToJoin = async () => ({
+    uri: '/clusters/teleport-local/servers/178ef081-259b-4aa5-a018-449b5ea7e694',
+    tunnel: false,
+    name: '178ef081-259b-4aa5-a018-449b5ea7e694',
+    hostname: 'foo',
+    addr: '127.0.0.1:3022',
+    labelsList: [],
   });
-
-  return (
-    <MockAppContextProvider appContext={appContext}>
-      <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-        <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
-          <DocumentConnectMyComputerSetup />
-        </ConnectMyComputerContextProvider>
-      </MockWorkspaceContextProvider>
-    </MockAppContextProvider>
-  );
+  return <ShowState cluster={cluster} appContext={appContext} />;
 }
 
 export function AgentVersionTooNew() {
   const cluster = makeRootCluster({ proxyVersion: '16.3.0' });
   const appContext = new MockAppContext({ appVersion: '17.0.0' });
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
 
-  return (
-    <MockAppContextProvider appContext={appContext}>
-      <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-        <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
-          <DocumentConnectMyComputerSetup />
-        </ConnectMyComputerContextProvider>
-      </MockWorkspaceContextProvider>
-    </MockAppContextProvider>
-  );
+  return <ShowState cluster={cluster} appContext={appContext} />;
 }
 
 export function AgentVersionTooOld() {
   const cluster = makeRootCluster({ proxyVersion: '16.3.0' });
   const appContext = new MockAppContext({ appVersion: '14.1.0' });
+  return <ShowState cluster={cluster} appContext={appContext} />;
+}
+
+function ShowState({
+  cluster,
+  appContext,
+}: {
+  cluster: Cluster;
+  appContext: IAppContext;
+}) {
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);
   appContext.workspacesService.setState(draftState => {
     draftState.rootClusterUri = cluster.uri;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -16,8 +16,6 @@
 
 import React, { useEffect, useRef, useLayoutEffect } from 'react';
 
-import { wait } from 'shared/utils/wait';
-
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
@@ -80,7 +78,9 @@ export function InProgress() {
   }, []);
 
   appContext.connectMyComputerService.downloadAgent = () =>
-    wait(24 * 3600 * 100, ref.current.signal);
+    new Promise(resolve => {
+      ref.current.signal.addEventListener('abort', () => resolve(undefined));
+    });
 
   return <ShowState cluster={cluster} appContext={appContext} />;
 }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -16,11 +16,10 @@ limitations under the License.
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Box, ButtonPrimary, Flex, Text } from 'design';
+import { Box, ButtonPrimary, Text } from 'design';
 import { makeEmptyAttempt, useAsync } from 'shared/hooks/useAsync';
 import { wait } from 'shared/utils/wait';
 import * as Alerts from 'design/Alert';
-import { CircleCheck, CircleCross, CirclePlay, Spinner } from 'design/Icon';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
@@ -38,6 +37,8 @@ import { isAccessDeniedError } from 'teleterm/services/tshd/errors';
 import { useAgentProperties } from '../useAgentProperties';
 import { Logs } from '../Logs';
 import { CompatibilityError } from '../CompatibilityPromise';
+
+import { ProgressBar } from './ProgressBar';
 
 const logger = new Logger('DocumentConnectMyComputerSetup');
 
@@ -333,58 +334,28 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
 
   return (
     <>
-      <ol
-        css={`
-          padding-left: 0;
-          list-style: inside decimal;
-        `}
-      >
-        {steps.map(step => (
-          <Flex
-            key={step.name}
-            alignItems="baseline"
-            gap={2}
-            data-testid={step.name}
-            data-teststatus={step.attempt.status}
-          >
-            {step.attempt.status === '' && <CirclePlay />}
-            {step.attempt.status === 'processing' && (
-              <Spinner
-                css={`
-                  animation: spin 1s linear infinite;
-                  @keyframes spin {
-                    from {
-                      transform: rotate(0deg);
-                    }
-                    to {
-                      transform: rotate(360deg);
-                    }
-                  }
-                `}
-              />
-            )}
-            {step.attempt.status === 'success' && (
-              <CircleCheck color="success" />
-            )}
-            {step.attempt.status === 'error' && (
-              <CircleCross color="error.main" />
-            )}
-            <li>
-              {step.name}
-              {step.attempt.status === 'error' && (
-                <>
-                  {step.customError?.() || (
-                    <StandardError error={step.attempt.statusText} />
-                  )}
-                </>
-              )}
-            </li>
-          </Flex>
-        ))}
-      </ol>
-
+      <ProgressBar
+        phases={steps.map(step => ({
+          status: step.attempt.status,
+          name: step.name,
+          Error: () =>
+            step.attempt.status === 'error' &&
+            (step.customError?.() || (
+              <StandardError error={step.attempt.statusText} />
+            )),
+        }))}
+      />
       {hasSetupFailed && (
-        <ButtonPrimary onClick={runSteps}>Retry</ButtonPrimary>
+        <ButtonPrimary
+          mt={3}
+          mx="auto"
+          css={`
+            display: block;
+          `}
+          onClick={runSteps}
+        >
+          Retry
+        </ButtonPrimary>
       )}
     </>
   );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -76,9 +76,7 @@ function Information(props: { onSetUpAgentClick(): void }) {
         </>
       )}
       <Text>
-        The setup process will download and launch the Teleport agent, making
-        your computer available in the <strong>{clusterName}</strong> cluster as{' '}
-        <strong>{hostname}</strong>.
+        <ClusterAndHostnameCopy clusterName={clusterName} hostname={hostname} />
         <br />
         <br />
         Cluster users with the role <strong>{roleName}</strong> will be able to
@@ -331,9 +329,13 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
   ]);
 
   const hasSetupFailed = steps.some(s => s.attempt.status === 'error');
+  const { clusterName, hostname } = useAgentProperties();
 
   return (
     <>
+      <Text mb={3}>
+        <ClusterAndHostnameCopy clusterName={clusterName} hostname={hostname} />
+      </Text>
       <ProgressBar
         phases={steps.map(step => ({
           status: step.attempt.status,
@@ -374,6 +376,19 @@ function StandardError(props: {
     >
       {props.error}
     </Alerts.Danger>
+  );
+}
+
+function ClusterAndHostnameCopy(props: {
+  clusterName: string;
+  hostname: string;
+}): JSX.Element {
+  return (
+    <>
+      The setup process will download and launch the Teleport agent, making your
+      computer available in the <strong>{props.clusterName}</strong> cluster as{' '}
+      <strong>{props.hostname}</strong>.
+    </>
   );
 }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -96,6 +96,7 @@ function Information(props: { onSetUpAgentClick(): void }) {
         `}
         disabled={!isAgentCompatible}
         onClick={props.onSetUpAgentClick}
+        data-testid="start-setup"
       >
         Connect
       </ButtonPrimary>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/ProgressBar.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/ProgressBar.tsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Flex, Box } from 'design';
+import { Check, Warning, Refresh } from 'design/Icon';
+import { decomposeColor, emphasize } from 'design/theme/utils/colorManipulator';
+import { AttemptStatus } from 'shared/hooks/useAsync';
+
+interface ProgressBarProps {
+  phases: {
+    status: AttemptStatus;
+    name: string;
+    Error: React.ElementType;
+  }[];
+}
+
+export function ProgressBar({ phases }: ProgressBarProps): JSX.Element {
+  return (
+    <Flex flexDirection="column">
+      {phases.map((phase, index) => (
+        <Flex
+          py="12px"
+          key={phase.name}
+          style={{ position: 'relative' }}
+          data-testid={phase.name}
+          data-teststatus={phase.status}
+        >
+          <Phase status={phase.status} isLast={index === phases.length - 1} />
+          <div>
+            {index + 1}. {phase.name}
+            <phase.Error />
+          </div>
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
+
+function Phase({
+  status,
+  isLast,
+}: {
+  status: AttemptStatus;
+  isLast: boolean;
+}): JSX.Element {
+  const theme = useTheme();
+  // we have to use a solid color here; otherwise
+  // <StyledLine> would be visible through the component
+  const phaseSolidColor = getPhaseSolidColor(theme);
+  let bg = phaseSolidColor;
+
+  if (status === 'success') {
+    bg = theme.colors.success;
+  }
+
+  if (status === 'error') {
+    bg = theme.colors.error.main;
+  }
+
+  return (
+    <>
+      <StyledPhase mr="3" bg={bg}>
+        <PhaseIcon status={status} />
+      </StyledPhase>
+      {!isLast && (
+        <StyledLine
+          color={status === 'success' ? theme.colors.success : phaseSolidColor}
+        />
+      )}
+    </>
+  );
+}
+
+const StyledPhase = styled(Box)`
+  display: flex;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  z-index: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledLine = styled(Box)`
+  width: 0;
+  position: absolute;
+  left: 11px;
+  bottom: -12px;
+  border: 1px solid;
+  height: 100%;
+`;
+
+function PhaseIcon({ status }: { status: AttemptStatus }): JSX.Element {
+  if (status === 'success') {
+    return <Check size="small" color="white" />;
+  }
+
+  if (status === 'error') {
+    return <Warning size="small" color="white" />;
+  }
+
+  if (status === 'processing') {
+    return (
+      <Refresh
+        size="extraLarge"
+        color="success"
+        css={`
+          animation: anim-rotate 1.5s infinite linear;
+          @keyframes anim-rotate {
+            0% {
+              transform: rotate(0);
+            }
+            100% {
+              transform: rotate(360deg);
+            }
+        `}
+      />
+    );
+  }
+
+  return (
+    <Box
+      borderRadius="50%"
+      css={`
+        background: ${props => props.theme.colors.spotBackground[1]};
+      `}
+      as="span"
+      height="14px"
+      width="14px"
+    />
+  );
+}
+
+function getPhaseSolidColor(theme: any): string {
+  const alpha = decomposeColor(theme.colors.spotBackground[1]).values[3] || 0;
+  return emphasize(theme.colors.levels.surface, alpha);
+}


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/27881

Adds `ProgressBar` component from cloud.
I had to do some modifications, the most important one is the 'progres icon'. We have switched to the new icon library, so we no longer have that old, simple progres icon. I tested using `<Indicator />`, but it didn't look good. Finally, I decided for `Refresh` icon.

-------

One thing I don't like about our setup page is that the content doesn't seem to be centered horizontally (this is because we need space to display errors, which are usually larger than the configuration items).
An idea that came to my mind is to add a sentence above the steps that would take the full width. Thanks to this, the content looks wider.

Before: 
<img width="1431" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/6ae48923-5306-46f9-a278-a85dd4727278">

After:
<img width="1246" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/bfc276a0-df44-4522-bb4d-2e775ecccd20">

Let me know what you think about it.