### PR TITLE
`compareSemVers` should return 0 if values are equal

### DIFF
--- a/web/packages/shared/utils/semVer.test.ts
+++ b/web/packages/shared/utils/semVer.test.ts
@@ -40,4 +40,6 @@ test('compareSemVers', () => {
     '10.1.0',
     '11.1.0',
   ]);
+
+  expect(compareSemVers('1.0.0', '1.0.0')).toBe(0);
 });

--- a/web/packages/shared/utils/semVer.ts
+++ b/web/packages/shared/utils/semVer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const compareSemVers = (a: string, b: string): -1 | 1 => {
+export const compareSemVers = (a: string, b: string): -1 | 1 | 0 => {
   const splitA = a.split('.');
   const splitB = b.split('.');
 
@@ -40,5 +40,5 @@ export const compareSemVers = (a: string, b: string): -1 | 1 => {
     return patchA > patchB ? 1 : -1;
   }
 
-  return 1;
+  return 0;
 };

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.test.tsx
@@ -51,6 +51,13 @@ describe('shouldShowAgentUpgradeSuggestion returns', () => {
       expected: false,
     },
     {
+      name: 'the agent is on the same version',
+      isLocalBuild: false,
+      appVersion: '14.1.0',
+      proxyVersion: '14.1.0',
+      expected: false,
+    },
+    {
       name: 'is a dev build',
       isLocalBuild: true,
       appVersion: '1.0.0-dev',


### PR DESCRIPTION
I noticed that `UpgradeAgentSuggestion` component is visible even when the cluster and the agent are on the same version.
This led me to the `compareSemVers` function, which seems to have a bug, because it returns 1 if elements are equal.
If any of the the conditions didn't return then it means that the versions are equal and 0 should be returned.