### PR TITLE
Bump UI Role version to `v7`

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -248,6 +248,9 @@ type Role interface {
 // NewRole constructs new standard V7 role.
 // This creates a V7 role with V4+ RBAC semantics.
 func NewRole(name string, spec RoleSpecV6) (Role, error) {
+	// When incrementing the role version, make sure to update the
+	// role version in the asset file used by the UI.
+	// See: web/packages/teleport/src/Roles/templates/role.yaml
 	role, err := NewRoleWithVersion(name, V7, spec)
 	return role, trace.Wrap(err)
 }
@@ -895,6 +898,9 @@ func (r *RoleV6) GetPrivateKeyPolicy() keys.PrivateKeyPolicy {
 func (r *RoleV6) setStaticFields() {
 	r.Kind = KindRole
 	if r.Version != V3 && r.Version != V4 && r.Version != V5 && r.Version != V6 {
+		// When incrementing the role version, make sure to update the
+		// role version in the asset file used by the UI.
+		// See: web/packages/teleport/src/Roles/templates/role.yaml
 		r.Version = V7
 	}
 }

--- a/web/packages/teleport/src/Roles/templates/role.yaml
+++ b/web/packages/teleport/src/Roles/templates/role.yaml
@@ -16,17 +16,26 @@ spec:
     kubernetes_users:
     - '{{internal.kubernetes_users}}'
     - 'dev'
+
+    # List of Kubernetes resources users can access with this role
+    # This example allows access to all resources in all namespaces
+    kubernetes_resources:
+    - kind: '*'
+      namespace: '*'
+      name: '*'
+      verbs: ['*']
+
     # List of allowed SSH logins
     logins: ['{{internal.logins}}', ubuntu, debian]
 
     # List of node labels that users can SSH into
     node_labels:
       '*': '*'
-      
+
     # List of application labels users can access
-    app_labels:    
+    app_labels:
       '*': '*'
-      
+
     # List of database labels users can access database servers
     db_labels:
       '*': '*'
@@ -38,7 +47,7 @@ spec:
     db_users:
     - '{{internal.db_users}}'
     - developer
-    
+
     # List of windows desktop access labels that users can open desktop sessions to
     windows_desktop_labels:
       '*': '*'
@@ -71,4 +80,4 @@ spec:
       # Limits user credentials to 8 hours. After the time to live (TTL) expires,
       # users must re-login
       max_session_ttl: 8h0m0s
-version: v5
+version: v7


### PR DESCRIPTION
This PR bumps the default Role version to `v7`.
The version is controlled by a fixed asset in web package as was never updated