### PR TITLE
docs: Application access header rewrites should be a list

### DIFF
--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -52,8 +52,8 @@ To fix CSRF or CORS issues:
        public_addr: <Var name="grafana.teleport.example.com"/>
        rewrite:
          headers:
-           Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
-           Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
+         - Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
+         - Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
    ```
 
 1. Save your changes and restart the Teleport service.
@@ -84,8 +84,8 @@ To fix CSRF or CORS issues if you deploy applications using Kubernetes and `tele
        public_addr: <Var name="grafana.teleport.example.com"/>
        rewrite:
          headers:
-           Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
-           Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
+         - Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
+         - Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
    ```
 
 ## Untrusted certificate errors


### PR DESCRIPTION
I realised when I sent @lsgunn-teleport the information on how to add the `Origin` and `Host` headers that I didn't make it obvious that they should be provided as a list.