### PR TITLE
Fix dynamic labels not being present on server access audit events

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -245,7 +245,7 @@ func (s *Server) TargetMetadata() apievents.ServerMetadata {
 		ServerNamespace: s.GetNamespace(),
 		ServerID:        s.ID(),
 		ServerAddr:      s.Addr(),
-		ServerLabels:    s.labels,
+		ServerLabels:    s.getAllLabels(),
 		ServerHostname:  s.hostname,
 	}
 }
@@ -1030,6 +1030,18 @@ func (s *Server) getDynamicLabels() map[string]types.CommandLabelV2 {
 		return make(map[string]types.CommandLabelV2)
 	}
 	return types.LabelsToV2(s.dynamicLabels.Get())
+}
+
+// getAllLabels return a combination of static and dynamic labels.
+func (s *Server) getAllLabels() map[string]string {
+	lmap := make(map[string]string)
+	for key, value := range s.getStaticLabels() {
+		lmap[key] = value
+	}
+	for key, cmd := range s.getDynamicLabels() {
+		lmap[key] = cmd.Result
+	}
+	return lmap
 }
 
 // GetInfo returns a services.Server that represents this server.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -185,26 +185,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testServer.Shutdown(ctx)) })
 
-	priv, pub, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err)
-
-	tlsPub, err := auth.PrivateKeyToPublicKeyTLS(priv)
-	require.NoError(t, err)
-
-	certs, err := testServer.Auth().GenerateHostCerts(ctx,
-		&proto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     testServer.ClusterName(),
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		})
-	require.NoError(t, err)
-
-	// set up user CA and set up a user that has access to the server
-	signer, err := sshutils.NewSigner(priv, certs.SSH)
-	require.NoError(t, err)
-
+	signer := newSigner(t, ctx, testServer)
 	nodeID := uuid.New().String()
 	nodeClient, err := testServer.NewClient(auth.TestIdentity{
 		I: authz.BuiltinRole{
@@ -2482,6 +2463,84 @@ func TestHandlePuTTYWinadj(t *testing.T) {
 	require.Equal(t, "hello once more\n", string(out))
 }
 
+func TestTargetMetadata(t *testing.T) {
+	ctx := context.Background()
+	testServer, err := auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			ClusterName: "localhost",
+			Dir:         t.TempDir(),
+			Clock:       clockwork.NewFakeClock(),
+		},
+	})
+	require.NoError(t, err)
+
+	nodeID := uuid.New().String()
+	nodeClient, err := testServer.NewClient(auth.TestIdentity{
+		I: authz.BuiltinRole{
+			Role:     types.RoleNode,
+			Username: nodeID,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, nodeClient.Close()) })
+
+	lockWatcher := newLockWatcher(ctx, t, nodeClient)
+
+	sessionController, err := srv.NewSessionController(srv.SessionControllerConfig{
+		Semaphores:   nodeClient,
+		AccessPoint:  nodeClient,
+		LockEnforcer: lockWatcher,
+		Emitter:      nodeClient,
+		Component:    teleport.ComponentNode,
+		ServerID:     nodeID,
+	})
+	require.NoError(t, err)
+
+	nodeDir := t.TempDir()
+	serverOptions := []ServerOption{
+		SetUUID(nodeID),
+		SetNamespace(apidefaults.Namespace),
+		SetEmitter(nodeClient),
+		SetPAMConfig(&servicecfg.PAMConfig{Enabled: false}),
+		SetLabels(
+			map[string]string{"foo": "bar"},
+			services.CommandLabels{
+				"baz": &types.CommandLabelV2{
+					Period:  types.NewDuration(time.Second),
+					Command: []string{"expr", "1", "+", "3"},
+				},
+			}, nil,
+		),
+		SetBPF(&bpf.NOP{}),
+		SetRestrictedSessionManager(&restricted.NOP{}),
+		SetLockWatcher(lockWatcher),
+		SetX11ForwardingConfig(&x11.ServerConfig{}),
+		SetSessionController(sessionController),
+	}
+
+	sshSrv, err := New(
+		ctx,
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		testServer.ClusterName(),
+		[]ssh.Signer{newSigner(t, ctx, testServer)},
+		nodeClient,
+		nodeDir,
+		"",
+		utils.NetAddr{},
+		nodeClient,
+		serverOptions...)
+	require.NoError(t, err)
+
+	metadata := sshSrv.TargetMetadata()
+	require.Equal(t, nodeID, metadata.ServerID)
+	require.Equal(t, apidefaults.Namespace, metadata.ServerNamespace)
+	require.Equal(t, "", metadata.ServerAddr)
+	require.Equal(t, "localhost", metadata.ServerHostname)
+
+	require.Contains(t, metadata.ServerLabels, "foo")
+	require.Contains(t, metadata.ServerLabels, "baz")
+}
+
 // upack holds all ssh signing artifacts needed for signing and checking user keys
 type upack struct {
 	// key is a raw private user key
@@ -2613,6 +2672,32 @@ func requireRoot(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("This test will be skipped because tests are not being run as root.")
 	}
+}
+
+// newSigner creates a new SSH signer that can be used by the Server.
+func newSigner(t *testing.T, ctx context.Context, testServer *auth.TestServer) ssh.Signer {
+	t.Helper()
+
+	priv, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+
+	tlsPub, err := auth.PrivateKeyToPublicKeyTLS(priv)
+	require.NoError(t, err)
+
+	certs, err := testServer.Auth().GenerateHostCerts(ctx,
+		&proto.HostCertsRequest{
+			HostID:       hostID,
+			NodeName:     testServer.ClusterName(),
+			Role:         types.RoleNode,
+			PublicSSHKey: pub,
+			PublicTLSKey: tlsPub,
+		})
+	require.NoError(t, err)
+
+	// set up user CA and set up a user that has access to the server
+	signer, err := sshutils.NewSigner(priv, certs.SSH)
+	require.NoError(t, err)
+	return signer
 }
 
 // maxPipeSize is one larger than the maximum pipe size for most operating


### PR DESCRIPTION
The SSH session uses the [`TargetMetadata` function](https://github.com/gravitational/teleport/blob/743d137b62bc5f1f46efeb6de52549625a08bccd/lib/srv/sess.go#L707) to grab server metadata which is then [used on audit logging](https://github.com/gravitational/teleport/blob/743d137b62bc5f1f46efeb6de52549625a08bccd/lib/srv/sess.go#L878). The issue was that this function only used the labels available at [`SetLabels`](https://github.com/gravitational/teleport/blob/743d137b62bc5f1f46efeb6de52549625a08bccd/lib/srv/regular/sshserver.go#L487) (as it relied on the `s.labels` attribute).

This PR updates it to use a combination of static and dynamic labels (similar to the `GetAllLabels` function from resources).


<details>
<summary>Audit logs example</summary>

SSH service configuration:
```yaml
ssh_service:
  enabled: "yes"
  commands:
  - name: OS
    command: [uname]
    period: 1h
```

Before:
```
{
  "addr.local": "127.0.0.1:4443",
  "addr.remote": "127.0.0.1:49840",
  "cluster_name": "root.teleport.dev",
  "code": "T2000I",
  "ei": 0,
  "event": "session.start",
  "initial_command": [
    ""
  ],
  "login": "gabrielcorado",
  "namespace": "default",
  "proto": "ssh",
  "server_addr": "[::]:3022",
  "server_hostname": "root.teleport.dev",
  "server_id": "b51ef330-73dd-4719-b8aa-8fb0c1c2dd65",
  "session_recording": "node",
  "sid": "f885497e-b847-4436-b12c-218c6cd3f04f",
  "size": "141:22",
  "time": "2023-09-21T15:44:20.543Z",
  "uid": "0b76a567-7a52-4a02-9c8f-5d546f8429d6",
  "user": "alice"
}
```

After:
```diff
{
  "addr.local": "127.0.0.1:4443",
  "addr.remote": "127.0.0.1:50162",
  "cluster_name": "root.teleport.dev",
  "code": "T2000I",
  "ei": 0,
  "event": "session.start",
  "initial_command": [
    ""
  ],
  "login": "gabrielcorado",
  "namespace": "default",
  "proto": "ssh",
  "server_addr": "[::]:3022",
  "server_hostname": "root.teleport.dev",
  "server_id": "b51ef330-73dd-4719-b8aa-8fb0c1c2dd65",
+ "server_labels": {
+   "OS": "Darwin"
+ },
  "session_recording": "node",
  "sid": "46f82471-b834-41a9-a50b-6ee326a692af",
  "size": "141:22",
  "time": "2023-09-21T15:50:32.784Z",
  "uid": "5827ab06-f793-4fae-b680-b067aa02f1f0",
  "user": "alice"
}
```

</details>