### PR TITLE
Fix repeated ServiceAccount in `teleport-kube-agent` chart

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -22,7 +22,11 @@ Create the name of the service account to use for the post-delete hook
 if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name-delete-hook
 */}}
 {{- define "teleport-kube-agent.deleteHookServiceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
 {{- printf "%s-delete-hook" (include "teleport-kube-agent.serviceAccountName" . ) -}}
+{{- else -}}
+{{- (include "teleport-kube-agent.serviceAccountName" . ) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "teleport-kube-agent.version" -}}

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -22,7 +22,7 @@ Create the name of the service account to use for the post-delete hook
 if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name-delete-hook
 */}}
 {{- define "teleport-kube-agent.deleteHookServiceAccountName" -}}
-{{- coalesce .Values.serviceAccount.name .Values.serviceAccountName (printf "%s-delete-hook" .Release.Name) -}}
+{{- printf "%s-delete-hook" (include "teleport-kube-agent.serviceAccountName" . ) -}}
 {{- end -}}
 
 {{- define "teleport-kube-agent.version" -}}

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -96,7 +96,7 @@ tests:
           apiVersion: v1
       - equal:
           path: metadata.name
-          value: lint-serviceaccount
+          value: lint-serviceaccount-delete-hook
 
   - it: should create Role for post-delete hook by default
     template: delete_hook.yaml


### PR DESCRIPTION
This PR fixes a repeated ServiceAccount object when installing the chart