### PR TITLE
[v12] Bump UI Role version to `v6`

### DIFF
--- a/web/packages/teleport/src/Roles/templates/role.yaml
+++ b/web/packages/teleport/src/Roles/templates/role.yaml
@@ -16,17 +16,25 @@ spec:
     kubernetes_users:
     - '{{internal.kubernetes_users}}'
     - 'dev'
+
+    # List of Kubernetes pods users can access with this role
+    # This example allows access to all pods in all namespaces
+    kubernetes_resources:
+    - kind: 'pod'
+      namespace: '*'
+      name: '*'
+
     # List of allowed SSH logins
     logins: ['{{internal.logins}}', ubuntu, debian]
 
     # List of node labels that users can SSH into
     node_labels:
       '*': '*'
-      
+
     # List of application labels users can access
-    app_labels:    
+    app_labels:
       '*': '*'
-      
+
     # List of database labels users can access database servers
     db_labels:
       '*': '*'
@@ -38,7 +46,7 @@ spec:
     db_users:
     - '{{internal.db_users}}'
     - developer
-    
+
     # List of windows desktop access labels that users can open desktop sessions to
     windows_desktop_labels:
       '*': '*'
@@ -71,4 +79,4 @@ spec:
       # Limits user credentials to 8 hours. After the time to live (TTL) expires,
       # users must re-login
       max_session_ttl: 8h0m0s
-version: v5
+version: v6


### PR DESCRIPTION
This PR bumps the default Role version to `v6`.
The version is controlled by a fixed asset in web package as was never updated