### PR TITLE
integrations/operator: join via Kubernetes

### DIFF
--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -334,12 +334,6 @@ func getTeleportBotUser(ctx context.Context, opts Options, authClient auth.Clien
 
 }
 
-// botExists checks if the bot described in the Options exists
-func botExists(ctx context.Context, opts Options, authClient auth.ClientI) (bool, error) {
-	botUser, err := getTeleportBotUser(ctx, opts, authClient)
-	return botUser != nil, trace.Wrap(err)
-}
-
 // getCAPins uses the local auth client to get the cluster CAs and compute their pins
 func getCAPins(ctx context.Context, authClient auth.ClientI) ([]string, error) {
 	// Getting the cluster CA Pins to be able to join regardless of the cert SANs.


### PR DESCRIPTION
This PR makes the operator use the Kubernetes join method.

This PR only changes the join method, it doesn't do the other changes we need to improve stability:
- start tbot on container start (versus start on leader election) so we fail on rollout and don't do cascade failures
- create the bot, role and token without the local auth client, prior to the container start, so we know if somehting goes wrong before (--apply-on-startup)
- adds tests (we also have an in-flight test PR, but the changes in this one are not testable without a full Kubernetes setup and a virtualized fs)
