### PR TITLE
Fix `tsh logout` with broken key dir

### DIFF
--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -223,6 +223,9 @@ func (k *Key) authorizedHostKeys(hostnames ...string) ([]ssh.PublicKey, error) {
 // TeleportClientTLSConfig returns client TLS configuration used
 // to authenticate against API servers.
 func (k *Key) TeleportClientTLSConfig(cipherSuites []uint16, clusters []string) (*tls.Config, error) {
+	if len(k.TLSCert) == 0 {
+		return nil, trace.NotFound("TLS certificate not found")
+	}
 	return k.clientTLSConfig(cipherSuites, k.TLSCert, clusters)
 }
 
@@ -399,6 +402,9 @@ func canAddToSystemAgent(agentKey agent.AddedKey) bool {
 // TeleportTLSCertificate returns the parsed x509 certificate for
 // authentication against Teleport APIs.
 func (k *Key) TeleportTLSCertificate() (*x509.Certificate, error) {
+	if len(k.TLSCert) == 0 {
+		return nil, trace.NotFound("TLS certificate not found")
+	}
 	return tlsca.ParseCertificatePEM(k.TLSCert)
 }
 
@@ -491,7 +497,7 @@ func (k *Key) SSHSigner() (ssh.Signer, error) {
 // SSHCert returns parsed SSH certificate
 func (k *Key) SSHCert() (*ssh.Certificate, error) {
 	if k.Cert == nil {
-		return nil, trace.NotFound("SSH cert not available")
+		return nil, trace.NotFound("SSH cert not found")
 	}
 	return sshutils.ParseCertificate(k.Cert)
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2030,7 +2030,7 @@ func onLogin(cf *CLIConf) error {
 func onLogout(cf *CLIConf) error {
 	// Extract all clusters the user is currently logged into.
 	active, available, err := cf.FullProfileStatus()
-	if err != nil {
+	if err != nil && !trace.IsCompareFailed(err) {
 		if trace.IsNotFound(err) {
 			fmt.Printf("All users logged out.\n")
 			return nil
@@ -2061,7 +2061,7 @@ func onLogout(cf *CLIConf) error {
 
 		// Load profile for the requested proxy/user.
 		profile, err := tc.ProfileStatus()
-		if err != nil && !trace.IsNotFound(err) {
+		if err != nil && !trace.IsNotFound(err) && !trace.IsCompareFailed(err) {
 			return trace.Wrap(err)
 		}
 
@@ -3389,7 +3389,7 @@ func makeClientForProxy(cf *CLIConf, proxy string) (*client.TeleportClient, erro
 	profile, profileError := c.GetProfile(c.ClientStore, proxy)
 	if profileError == nil {
 		if err := tc.LoadKeyForCluster(ctx, profile.SiteName); err != nil {
-			if !trace.IsNotFound(err) && !trace.IsConnectionProblem(err) {
+			if !trace.IsNotFound(err) && !trace.IsConnectionProblem(err) && !trace.IsCompareFailed(err) {
 				return nil, trace.Wrap(err)
 			}
 			log.WithError(err).Infof("Could not load key for %s into the local agent.", cf.SiteName)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -21,6 +21,9 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -44,6 +47,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otlp "go.opentelemetry.io/proto/otlp/trace/v1"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
 	yamlv2 "gopkg.in/yaml.v2"
 
@@ -5055,6 +5059,85 @@ func TestBenchmarkMySQL(t *testing.T) {
 			}
 			require.NotEmpty(t, errorLine, "expected benchmark to fail")
 			require.Contains(t, errorLine, tc.expectedErrContains)
+		})
+	}
+}
+
+func TestLogout(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	privPEM, err := keys.MarshalPrivateKey(key)
+	require.NoError(t, err)
+	privateKey, err := keys.NewPrivateKey(key, privPEM)
+	require.NoError(t, err)
+	clientKey := &client.Key{
+		KeyIndex: client.KeyIndex{
+			ProxyHost:   "proxy",
+			Username:    "user",
+			ClusterName: "cluster",
+		},
+		PrivateKey: privateKey,
+	}
+	profile := &profile.Profile{
+		WebProxyAddr: clientKey.ProxyHost,
+		Username:     clientKey.Username,
+		SiteName:     clientKey.ClusterName,
+	}
+
+	for _, tt := range []struct {
+		name         string
+		modifyKeyDir func(t *testing.T, homePath string)
+	}{
+		{
+			name:         "normal home dir",
+			modifyKeyDir: func(t *testing.T, homePath string) {},
+		}, {
+			name: "public key missing",
+			modifyKeyDir: func(t *testing.T, homePath string) {
+				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				require.NoError(t, os.Remove(pubKeyPath))
+			},
+		}, {
+			name: "private key missing",
+			modifyKeyDir: func(t *testing.T, homePath string) {
+				privKeyPath := keypaths.UserKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				require.NoError(t, os.Remove(privKeyPath))
+			},
+		}, {
+			name: "public key mismatch",
+			modifyKeyDir: func(t *testing.T, homePath string) {
+				newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				require.NoError(t, err)
+				sshPub, err := ssh.NewPublicKey(newKey.Public())
+				require.NoError(t, err)
+
+				pubKeyPath := keypaths.PublicKeyPath(homePath, clientKey.ProxyHost, clientKey.Username)
+				err = os.WriteFile(pubKeyPath, ssh.MarshalAuthorizedKey(sshPub), 0600)
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpHomePath := t.TempDir()
+
+			store := client.NewFSClientStore(tmpHomePath)
+			err = store.AddKey(clientKey)
+			require.NoError(t, err)
+			store.SaveProfile(profile, true)
+
+			tt.modifyKeyDir(t, tmpHomePath)
+
+			_, err := os.Lstat(tmpHomePath)
+			require.NoError(t, err)
+
+			err = Run(context.Background(), []string{"logout"}, setHomePath(tmpHomePath))
+			require.NoError(t, err)
+
+			// direcory should be empty.
+			f, err := os.Open(tmpHomePath)
+			require.NoError(t, err)
+			_, err = f.Readdir(1)
+			require.ErrorIs(t, err, io.EOF)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes `tsh logout` when there are issues with the user's key dir, such as:
* mismatched public/private key
* missing public/private key

This fixes logout behavior with Hardware Key support, which prevents users from logging out if they edit their PIV keys with things like `ykman piv reset` or `ykman piv keys generate`. With users having the option to customize their slots with https://github.com/gravitational/teleport/pull/31732, this UX fix is more important.