### PR TITLE
[v14] Use cluster name from ServerIdentity for Auth multiplexer

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -500,13 +500,6 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 					}).Warnf("%s - could not get host CA", invalidProxySignatureError)
 					continue
 				}
-				if errors.Is(err, ErrNonLocalCluster) {
-					m.WithFields(log.Fields{
-						"src_addr": conn.RemoteAddr(),
-						"dst_addr": conn.LocalAddr(),
-					}).Debugf("%s - signed by non local cluster", invalidProxySignatureError)
-					continue
-				}
 				if err != nil {
 					return nil, trace.Wrap(err, "%s %s -> %s", invalidProxySignatureError, conn.RemoteAddr(), conn.LocalAddr())
 				}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1950,7 +1950,7 @@ func (process *TeleportProcess) initAuthService() error {
 		Listener:            listener,
 		ID:                  teleport.Component(process.id),
 		CertAuthorityGetter: muxCAGetter,
-		LocalClusterName:    clusterName,
+		LocalClusterName:    connector.ServerIdentity.ClusterName,
 	})
 	if err != nil {
 		listener.Close()


### PR DESCRIPTION
This PR makes sure cluster name on Auth listener is always correct from signed PROXY headers point of view (all other multiplexer listeners already use cluster name from ServerIdentity) and removes skipping ErrNonLocalCluster error in multiplexer. Proxy sends signed PROXY headers using cluster name from ServerIdentity. If cluster name in file config was changed it didn't match with original cluster name and auth service couldn't verify Proxy's signed headers.

This is follow up for https://github.com/gravitational/teleport/pull/32068

Fixes https://github.com/gravitational/teleport/issues/32066