### PR TITLE
Fix repeated installation for Azure and GCP VM auto-discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -592,23 +592,23 @@ const (
 	// SubscriptionIDLabel is used to identify virtual machines by Azure
 	// subscription ID found via automatic discovery, to avoid re-running
 	// installation commands on the node.
-	SubscriptionIDLabel = TeleportNamespace + "/subscription-id"
+	SubscriptionIDLabel = TeleportInternalLabelPrefix + "subscription-id"
 	// VMIDLabel is used to identify virtual machines by ID found
 	// via automatic discovery, to avoid re-running installation commands
 	// on the node.
-	VMIDLabel = TeleportNamespace + "/vm-id"
+	VMIDLabel = TeleportInternalLabelPrefix + "vm-id"
 	// ProjectIDLabel is used to identify virtual machines by GCP project
 	// id found via automatic discovery, to avoid re-running
 	// installation commands on the node.
-	ProjectIDLabel = TeleportNamespace + "/project-id"
+	ProjectIDLabel = TeleportInternalLabelPrefix + "project-id"
 	// ZoneLabek is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
-	ZoneLabel = TeleportNamespace + "/zone"
+	ZoneLabel = TeleportInternalLabelPrefix + "zone"
 	// NameLabel is used to identify virtual machines by GCP VM name
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
-	NameLabel = TeleportNamespace + "/name"
+	NameLabel = TeleportInternalLabelPrefix + "name"
 
 	// CloudLabel is used to identify the cloud where the resource was discovered.
 	CloudLabel = TeleportNamespace + "/cloud"

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1657,8 +1657,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "name",
 						Labels: map[string]string{
-							types.SubscriptionIDLabel: "testsub",
-							types.VMIDLabel:           "test-vmid",
+							"teleport.internal/subscription-id": "testsub",
+							"teleport.internal/vm-id":           "test-vmid",
 						},
 						Namespace: defaults.Namespace,
 					},
@@ -1689,8 +1689,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "name",
 						Labels: map[string]string{
-							types.SubscriptionIDLabel: "testsub",
-							types.VMIDLabel:           "alternate-vmid",
+							"teleport.internal/subscription-id": "testsub",
+							"teleport.internal/vm-id":           "alternate-vmid",
 						},
 						Namespace: defaults.Namespace,
 					},
@@ -1878,9 +1878,9 @@ func TestGCPVMDiscovery(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "name",
 						Labels: map[string]string{
-							types.ProjectIDLabel: "myproject",
-							types.ZoneLabel:      "myzone",
-							types.NameLabel:      "myinstance",
+							"teleport.internal/project-id": "myproject",
+							"teleport.internal/zone":       "myzone",
+							"teleport.internal/name":       "myinstance",
 						},
 						Namespace: defaults.Namespace,
 					},
@@ -1905,9 +1905,9 @@ func TestGCPVMDiscovery(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "name",
 						Labels: map[string]string{
-							types.ProjectIDLabel: "myproject",
-							types.ZoneLabel:      "myzone",
-							types.NameLabel:      "myotherinstance",
+							"teleport.internal/project-id": "myproject",
+							"teleport.internal/zone":       "myzone",
+							"teleport.internal/name":       "myotherinstance",
 						},
 						Namespace: defaults.Namespace,
 					},


### PR DESCRIPTION
This PR fixes a bug where the keys of labels applied to discovered Azure and GCP VMs did not match the labels the Discovery Service expected, causing the Discovery Service to try to install them again.

This PR also adds a workaround for an Azure quirk where Azure would not run the same command more than once.

Fixes #28879.