### PR TITLE
Refresh resources after Connect My Computer setup

### DIFF
--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -47,9 +47,9 @@ export type ResourceLabel = {
 };
 
 export type ResourceFilter = {
-  // query is query expression using the predicate language.
+  /** query is query expression using the predicate language. */
   query?: string;
-  // search contains search words/phrases separated by space.
+  /** search contains search words/phrases separated by space. */
   search?: string;
   sort?: SortType;
   limit?: number;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.test.tsx
@@ -27,6 +27,7 @@ import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvi
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import Logger, { NullService } from 'teleterm/logger';
+import * as useResourcesContext from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 import * as connectMyComputerContext from '../connectMyComputerContext';
 
@@ -40,7 +41,7 @@ beforeEach(() => {
   jest.restoreAllMocks();
 });
 
-describe('connectMyComputerSetup', () => {
+describe('setup of DocumentConnectMyComputer', () => {
   const tests: Array<{
     name: string;
     expectedStatus: AttemptStatus;
@@ -69,63 +70,10 @@ describe('connectMyComputerSetup', () => {
     },
   ];
   test.each(tests)('$name', async ({ expectedStatus, mockAppContext }) => {
-    const cluster = makeRootCluster({
-      loggedInUser: makeLoggedInUser({
-        acl: {
-          tokens: {
-            create: true,
-            list: true,
-            read: true,
-            edit: true,
-            pb_delete: true,
-            use: true,
-          },
-        },
-      }),
-    });
-    const appContext = new MockAppContext({
-      appVersion: cluster.proxyVersion,
-    });
-    appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-    appContext.workspacesService.setState(draftState => {
-      draftState.rootClusterUri = cluster.uri;
-      draftState.workspaces[cluster.uri] = {
-        localClusterUri: cluster.uri,
-        documents: [],
-        location: undefined,
-        accessRequests: undefined,
-      };
-    });
-
-    jest
-      .spyOn(appContext.mainProcessClient, 'isAgentConfigFileCreated')
-      .mockResolvedValue(false);
-    jest
-      .spyOn(appContext.connectMyComputerService, 'createRole')
-      .mockResolvedValue({ certsReloaded: false });
-    jest
-      .spyOn(appContext.connectMyComputerService, 'createAgentConfigFile')
-      .mockResolvedValue({ token: '1234' });
-    jest
-      .spyOn(appContext.connectMyComputerService, 'runAgent')
-      .mockResolvedValue();
-    jest
-      .spyOn(appContext.connectMyComputerService, 'waitForNodeToJoin')
-      .mockResolvedValue(makeServer());
-
+    const { appContext, elementToRender } = setupAppContext();
     mockAppContext?.(appContext);
 
-    render(
-      <MockAppContextProvider appContext={appContext}>
-        <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-          <connectMyComputerContext.ConnectMyComputerContextProvider
-            rootClusterUri={cluster.uri}
-          >
-            <DocumentConnectMyComputerSetup />
-          </connectMyComputerContext.ConnectMyComputerContextProvider>
-        </MockWorkspaceContextProvider>
-      </MockAppContextProvider>
-    );
+    render(elementToRender);
 
     screen.getByText('Connect').click();
 
@@ -137,4 +85,97 @@ describe('connectMyComputerSetup', () => {
       { container: step }
     );
   });
+
+  it('calls requestResourcesRefresh after setup is done', async () => {
+    const mockResourcesContext = {
+      requestResourcesRefresh: jest.fn(),
+      onResourcesRefreshRequest: jest.fn(),
+    };
+    jest
+      .spyOn(useResourcesContext, 'useResourcesContext')
+      .mockImplementation(() => mockResourcesContext);
+
+    const { elementToRender } = setupAppContext();
+
+    render(elementToRender);
+
+    // Start the setup.
+    screen.getByText('Connect').click();
+
+    // Wait for the setup to finish.
+    const step = await screen.findByTestId('Joining the cluster');
+    await waitFor(
+      () => expect(step).toHaveAttribute('data-teststatus', 'success'),
+      { container: step }
+    );
+
+    expect(mockResourcesContext.requestResourcesRefresh).toHaveBeenCalledTimes(
+      1
+    );
+  });
 });
+
+function setupAppContext(): {
+  elementToRender: React.ReactElement;
+  appContext: MockAppContext;
+} {
+  const cluster = makeRootCluster({
+    loggedInUser: makeLoggedInUser({
+      acl: {
+        tokens: {
+          create: true,
+          list: true,
+          read: true,
+          edit: true,
+          pb_delete: true,
+          use: true,
+        },
+      },
+    }),
+  });
+  const appContext = new MockAppContext({
+    appVersion: cluster.proxyVersion,
+  });
+  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = cluster.uri;
+    draftState.workspaces[cluster.uri] = {
+      localClusterUri: cluster.uri,
+      documents: [],
+      location: undefined,
+      accessRequests: undefined,
+    };
+  });
+
+  jest
+    .spyOn(appContext.mainProcessClient, 'isAgentConfigFileCreated')
+    .mockResolvedValue(false);
+  jest
+    .spyOn(appContext.connectMyComputerService, 'createRole')
+    .mockResolvedValue({ certsReloaded: false });
+  jest
+    .spyOn(appContext.connectMyComputerService, 'createAgentConfigFile')
+    .mockResolvedValue({ token: '1234' });
+  jest
+    .spyOn(appContext.connectMyComputerService, 'runAgent')
+    .mockResolvedValue();
+  jest
+    .spyOn(appContext.connectMyComputerService, 'waitForNodeToJoin')
+    .mockResolvedValue(makeServer());
+
+  const elementToRender = (
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
+        <useResourcesContext.ResourcesContextProvider>
+          <connectMyComputerContext.ConnectMyComputerContextProvider
+            rootClusterUri={cluster.uri}
+          >
+            <DocumentConnectMyComputerSetup />
+          </connectMyComputerContext.ConnectMyComputerContextProvider>
+        </useResourcesContext.ResourcesContextProvider>
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  return { elementToRender, appContext };
+}

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -34,6 +34,7 @@ import Logger from 'teleterm/logger';
 import { codeOrSignal } from 'teleterm/ui/utils/process';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import { isAccessDeniedError } from 'teleterm/services/tshd/errors';
+import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 import { useAgentProperties } from '../useAgentProperties';
 import { Logs } from '../Logs';
@@ -114,6 +115,7 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
     setDownloadAgentAttempt,
     agentProcessState,
   } = useConnectMyComputerContext();
+  const { requestResourcesRefresh } = useResourcesContext();
   const cluster = ctx.clustersService.findCluster(rootClusterUri);
   const nodeToken = useRef<string>();
 
@@ -169,6 +171,11 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
         if (error) {
           throw error;
         }
+
+        // Now that the node has joined the server, let's refresh all open DocumentCluster instances
+        // to show the new node.
+        requestResourcesRefresh();
+
         try {
           await ctx.connectMyComputerService.deleteToken(
             cluster.uri,
@@ -182,7 +189,12 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
           }
           throw error;
         }
-      }, [startAgent, ctx.connectMyComputerService, cluster.uri])
+      }, [
+        startAgent,
+        ctx.connectMyComputerService,
+        cluster.uri,
+        requestResourcesRefresh,
+      ])
     );
 
   const steps = [

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -402,7 +402,7 @@ export const useConnectMyComputerContext = () => {
 
   if (!context) {
     throw new Error(
-      'ConnectMyComputerContext requires ConnectMyComputerContextProvider context.'
+      'useConnectMyComputerContext must be used within a ConnectMyComputerContextProvider'
     );
   }
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.test.tsx
@@ -76,20 +76,31 @@ it('adds a listener for resource refresh', async () => {
   );
 
   expect(result.error).toBeFalsy();
+  act(() => {
+    result.current.updateSearch('foo');
+  });
 
   // Wait for the initial fetch to finish.
   await waitFor(() => result.current.fetchAttempt.status === 'success');
-  expect(fetchFunction).toHaveBeenCalledTimes(1);
+  // Called twice, first for the initial call and then another after search update.
+  expect(fetchFunction).toHaveBeenCalledTimes(2);
+  expect(fetchFunction).toHaveBeenCalledWith(
+    expect.objectContaining({ search: 'foo' })
+  );
 
   // Verify that the listener is added.
   act(() => {
     requestResourcesRefresh();
   });
   await waitFor(() => result.current.fetchAttempt.status === 'success');
-  expect(fetchFunction).toHaveBeenCalledTimes(2);
+  expect(fetchFunction).toHaveBeenCalledTimes(3);
+  // Verify that the hook uses the same args to fetch the list of resources after
+  // requestResourcesRefresh is called.
+  expect(fetchFunction.mock.calls[2]).toEqual(fetchFunction.mock.calls[1]);
 
-  // Verify that the cleanup function gets called.
+  // Verify that the cleanup function gets called by requesting a refresh again and verifying that
+  // the fetch function has not been called.
   unmount();
   requestResourcesRefresh();
-  expect(fetchFunction).toHaveBeenCalledTimes(2);
+  expect(fetchFunction).toHaveBeenCalledTimes(3);
 });

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+
+import {
+  ResourcesContextProvider,
+  useResourcesContext,
+} from '../resourcesContext';
+import ClusterContext, { ClusterContextProvider } from '../clusterContext';
+
+import { useServerSideResources } from './useServerSideResources';
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('adds a listener for resource refresh', async () => {
+  let requestResourcesRefresh: () => void;
+  const fetchFunction = jest.fn(() =>
+    Promise.resolve({
+      agentsList: [],
+      totalCount: 0,
+      startKey: '',
+    })
+  );
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster();
+
+  // We must somehow trigger a request for resources refresh. Since we don't mock anything, we have
+  // to use capture requestResourcesRefresh somehow.
+  const RefreshRequester = () => {
+    requestResourcesRefresh = useResourcesContext().requestResourcesRefresh;
+
+    return null;
+  };
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <ClusterContextProvider
+        value={new ClusterContext(appContext, cluster.uri, '/docs/123')}
+      >
+        <ResourcesContextProvider>
+          {children}
+
+          <RefreshRequester />
+        </ResourcesContextProvider>
+      </ClusterContextProvider>
+    </MockAppContextProvider>
+  );
+
+  const { result, waitFor, unmount } = renderHook(
+    () =>
+      useServerSideResources<any>(
+        { fieldName: 'hostname', dir: 'ASC' },
+        fetchFunction
+      ),
+    { wrapper }
+  );
+
+  expect(result.error).toBeFalsy();
+
+  // Wait for the initial fetch to finish.
+  await waitFor(() => result.current.fetchAttempt.status === 'success');
+  expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+  // Verify that the listener is added.
+  act(() => {
+    requestResourcesRefresh();
+  });
+  await waitFor(() => result.current.fetchAttempt.status === 'success');
+  expect(fetchFunction).toHaveBeenCalledTimes(2);
+
+  // Verify that the cleanup function gets called.
+  unmount();
+  requestResourcesRefresh();
+  expect(fetchFunction).toHaveBeenCalledTimes(2);
+});

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
@@ -27,6 +27,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
 import { useClusterContext } from '../clusterContext';
+import { useResourcesContext } from '../resourcesContext';
 
 type AgentFilter = WeakAgentFilter & { sort: SortType };
 
@@ -58,6 +59,7 @@ export function useServerSideResources<Agent>(
 ) {
   const ctx = useAppContext();
   const { clusterUri } = useClusterContext();
+  const { onResourcesRefreshRequest } = useResourcesContext();
   const [pageIndex, setPageIndex] = useState(0);
   const [keys, setKeys] = useState<string[]>([]);
   const [agentFilter, setAgentFilter] = useState<AgentFilter>({
@@ -118,7 +120,11 @@ export function useServerSideResources<Agent>(
       newKeys[pageIndex] = response.startKey;
       setKeys(newKeys);
     };
+
     fetchAndUpdateKeys();
+
+    const { cleanup } = onResourcesRefreshRequest(fetchAndUpdateKeys);
+    return cleanup;
   }, [agentFilter, pageIndex]);
 
   function updateAgentFilter(filter: AgentFilter) {
@@ -172,7 +178,6 @@ export function useServerSideResources<Agent>(
 
   return {
     fetchAttempt,
-    fetch,
     updateSearch,
     updateSort,
     updateQuery,

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import {
+  ResourcesContextProvider,
+  useResourcesContext,
+} from './resourcesContext';
+
+describe('requestResourcesRefresh', () => {
+  it('calls listener registered with onResourcesRefreshRequest', () => {
+    const wrapper = ({ children }) => (
+      <ResourcesContextProvider>{children}</ResourcesContextProvider>
+    );
+    const { result } = renderHook(() => useResourcesContext(), { wrapper });
+
+    const listener = jest.fn();
+    result.current.onResourcesRefreshRequest(listener);
+    result.current.requestResourcesRefresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('onResourcesRefreshRequest cleanup function', () => {
+  it('removes the listener', () => {
+    const wrapper = ({ children }) => (
+      <ResourcesContextProvider>{children}</ResourcesContextProvider>
+    );
+    const { result } = renderHook(() => useResourcesContext(), { wrapper });
+
+    const listener = jest.fn();
+    const { cleanup } = result.current.onResourcesRefreshRequest(listener);
+
+    cleanup();
+    result.current.requestResourcesRefresh();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EventEmitter } from 'events';
+
+import React, {
+  createContext,
+  FC,
+  useCallback,
+  useContext,
+  useRef,
+} from 'react';
+
+export interface ResourcesContext {
+  /**
+   * requestResourcesRefresh makes all DocumentCluster instances within the workspace refresh the
+   * resource list with current filters.
+   *
+   * Its main purpose is to refresh the resource list in existing DocumentCluster tabs after a
+   * Connect My Computer node is set up.
+   */
+  requestResourcesRefresh: () => void;
+  /**
+   * onResourcesRefreshRequest registers a listener that will be called any time a refresh is
+   * requested. Typically called from useEffect, for this purpose it returns a cleanup function.
+   */
+  onResourcesRefreshRequest: (listener: () => void) => { cleanup: () => void };
+}
+
+const ResourcesContext = createContext<ResourcesContext>(null);
+
+export const ResourcesContextProvider: FC = props => {
+  const emitterRef = useRef<EventEmitter>();
+  if (!emitterRef.current) {
+    emitterRef.current = new EventEmitter();
+  }
+
+  // This function could be expanded to emit a cluster URI so that a request refresh for a root
+  // cluster doesn't trigger refreshes of leaf DocumentCluster instances and vice versa.
+  // However, the implementation should be good enough for now since it's used only in Connect My
+  // Computer setup anyway.
+  const requestResourcesRefresh = useCallback(
+    () => emitterRef.current.emit('refresh'),
+    []
+  );
+
+  const onResourcesRefreshRequest = useCallback(listener => {
+    emitterRef.current.addListener('refresh', listener);
+
+    return {
+      cleanup: () => {
+        emitterRef.current.removeListener('refresh', listener);
+      },
+    };
+  }, []);
+
+  return (
+    <ResourcesContext.Provider
+      value={{ requestResourcesRefresh, onResourcesRefreshRequest }}
+      children={props.children}
+    />
+  );
+};
+
+export const useResourcesContext = () => {
+  const context = useContext(ResourcesContext);
+
+  if (!context) {
+    throw new Error(
+      'useResourcesContext must be used within a ResourcesContextProvider'
+    );
+  }
+
+  return context;
+};

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -43,6 +43,8 @@ import { DocumentGatewayKube } from 'teleterm/ui/DocumentGatewayKube';
 import Document from 'teleterm/ui/Document';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
+import { ResourcesContextProvider } from '../DocumentCluster/resourcesContext';
+
 import { WorkspaceContextProvider } from './workspaceContext';
 import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel';
 
@@ -83,21 +85,23 @@ export function DocumentsRenderer(props: {
           key={workspace.rootClusterUri}
         >
           <WorkspaceContextProvider value={workspace}>
-            <ConnectMyComputerContextProvider
-              rootClusterUri={workspace.rootClusterUri}
-            >
-              {workspace.documentsService.getDocuments().length ? (
-                renderDocuments(workspace.documentsService)
-              ) : (
-                <KeyboardShortcutsPanel />
-              )}
-              {workspace.rootClusterUri ===
-                workspacesService.getRootClusterUri() &&
-                createPortal(
-                  <ConnectMyComputerNavigationMenu />,
-                  props.topBarContainerRef?.current
+            <ResourcesContextProvider>
+              <ConnectMyComputerContextProvider
+                rootClusterUri={workspace.rootClusterUri}
+              >
+                {workspace.documentsService.getDocuments().length ? (
+                  renderDocuments(workspace.documentsService)
+                ) : (
+                  <KeyboardShortcutsPanel />
                 )}
-            </ConnectMyComputerContextProvider>
+                {workspace.rootClusterUri ===
+                  workspacesService.getRootClusterUri() &&
+                  createPortal(
+                    <ConnectMyComputerNavigationMenu />,
+                    props.topBarContainerRef?.current
+                  )}
+              </ConnectMyComputerContextProvider>
+            </ResourcesContextProvider>
           </WorkspaceContextProvider>
         </DocumentsContainer>
       ))}

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -237,7 +237,9 @@ export const useSearchContext = () => {
   const context = useContext(SearchContext);
 
   if (!context) {
-    throw new Error('SearchContext requires SearchContextProvider context.');
+    throw new Error(
+      'useSearchContext must be used within a SearchContextProvider'
+    );
   }
 
   return context;


### PR DESCRIPTION
At the moment, after the CMC setup is done, the user will typically have two tabs open: a tab with cluster resources showing old list of servers and a tab with Connect My Computer. The cluster resources tab shows an old list because the list was fetched before the node joined the server. There's no obvious way to refresh the list of resources, so really the best thing a user could do is to simply open a new tab with resources. That's assuming that they're familiar with the fact that the new tab button opens a new cluster resources tab. If they just downloaded Connect, they're probably not aware of that.

While writing docs for Connect My Computer, I started adding a new subsection under Connect My Computer > Troubleshooting called "The Connect My Computer tab says that the agent is running, but the computer is not visible in the cluster resources". I realized that the behavior described above is going to cause so much confusion that not addressing it would be hugely detrimental to the success of the feature. Grzegorz and I talked about this a month or two ago, but at the time I disregarded the issue.

This PR makes it so that after a successful setup, all DocumentCluster instances within the workspace will have their resource lists refreshed. This could of course be optimized to not refresh lists in leaf clusters or if the list currently doesn't display any servers. However, since it's going to be used only in CMC for now and we're soon going to add unified resources view, I wanted to keep it simple.

<details>
<summary>Before and after vids</summary>

Before:

The new resources shows up only after I press re-execute the search by focusing the input and pressing enter.

https://github.com/gravitational/teleport/assets/27113/13c83624-36e8-4820-8613-cd4a729f2e5f

After:

https://github.com/gravitational/teleport/assets/27113/5d783e6b-7c51-4e2c-80e5-8ae21ff00a76
</details>