### PR TITLE
Fix overflow in dropdown menu

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -408,7 +408,7 @@ chart.
 ## macOS
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
-<TabItem label="Teleport Team/Community Edition" scope={["oss","team"]}>
+<TabItem label="Community/Team" scope={["oss","team"]}>
   <Tabs>
   <TabItem label="Teleport package" >
   You can download one of the following .pkg installers for macOS:


### PR DESCRIPTION
Closes gravitational/docs#353

One dropdown menu item within the Installation page has a label that overflows. This change shortens the label to fix the overflow.

While another route would have been to change the CSS of the dropdown menu, widening it would start to approach the maximum width of some mobile devices.

In general, the Installation page is filled with interactive boxes that make for a somewhat convoluted reading experience. A later change will reconsider the information architecture of this page.