### PR TITLE
Use Proxy gRPC API during login

### DIFF
--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -38,12 +38,41 @@ type ClusterClient struct {
 	AuthClient  auth.ClientI
 	Tracer      oteltrace.Tracer
 	cluster     string
+	root        string
 }
 
 // ClusterName returns the name of the cluster that the client
 // is connected to.
 func (c *ClusterClient) ClusterName() string {
 	return c.cluster
+}
+
+// CurrentCluster returns an authenticated auth server client for the local cluster.
+// The returned auth server client does not need to be closed, it will be closed
+// when the ClusterClient is closed.
+func (c *ClusterClient) CurrentCluster() auth.ClientI {
+	// The auth.ClientI is wrapped in an sharedAuthClient to prevent callers from
+	// being able to close the client. The auth.ClientI is only to be closed
+	// when the ClusterClient is closed.
+	return sharedAuthClient{ClientI: c.AuthClient}
+}
+
+// ConnectToRootCluster connects to the auth server of the root cluster
+// via proxy. It returns connected and authenticated auth server client.
+func (c *ClusterClient) ConnectToRootCluster(ctx context.Context) (auth.ClientI, error) {
+	root, err := c.ConnectToCluster(ctx, c.root)
+	return root, trace.Wrap(err)
+}
+
+// ConnectToCluster connects to the auth server of the given cluster via proxy. It returns connected and authenticated auth server client
+func (c *ClusterClient) ConnectToCluster(ctx context.Context, clusterName string) (auth.ClientI, error) {
+	if c.cluster == clusterName {
+		return c.CurrentCluster(), nil
+	}
+
+	clientConfig := c.ProxyClient.ClientConfig(ctx, clusterName)
+	authClient, err := auth.NewClient(clientConfig)
+	return authClient, trace.Wrap(err)
 }
 
 // Close terminates the connections to Auth and Proxy.
@@ -97,6 +126,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 			AuthClient:  authClient,
 			Tracer:      c.Tracer,
 			cluster:     rootClusterName,
+			root:        rootClusterName,
 		}
 		// only close the new auth client and not the copied cluster client.
 		defer authClient.Close()

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1903,13 +1903,13 @@ func onLogin(cf *CLIConf) error {
 	// "authoritative" source.
 	cf.Username = tc.Username
 
-	proxyClient, rootAuthClient, err := tc.ConnectToRootCluster(cf.Context, key)
+	clusterClient, rootAuthClient, err := tc.ConnectToRootCluster(cf.Context, key)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer func() {
 		rootAuthClient.Close()
-		proxyClient.Close()
+		clusterClient.Close()
 	}()
 
 	// TODO(fspmarshall): Refactor access request & cert reissue logic to allow
@@ -2017,7 +2017,7 @@ func onLogin(cf *CLIConf) error {
 	// don't use the alert API very heavily. If we start to make more use of it, we
 	// could probably add a separate `tsh alerts ls` command, and truncate the list
 	// with a message like "run 'tsh alerts ls' to view N additional alerts".
-	if err := common.ShowClusterAlerts(cf.Context, proxyClient.CurrentCluster(), os.Stderr, map[string]string{
+	if err := common.ShowClusterAlerts(cf.Context, clusterClient.CurrentCluster(), os.Stderr, map[string]string{
 		types.AlertOnLogin: "yes",
 	}, types.AlertSeverity_LOW); err != nil {
 		log.WithError(err).Warn("Failed to display cluster alerts.")


### PR DESCRIPTION
Reduce login latency by using the Proxy gRPC API instead of the legacy Proxy SSH API when connecting to the root cluster