### PR TITLE
Stop emitting trusted_cluster_token.create

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2366,20 +2366,6 @@ func emitTokenEvent(
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit join token create event.")
 	}
-	for _, role := range roles {
-		if role == types.RoleTrustedCluster {
-			//nolint:staticcheck // Emit a deprecated event.
-			if err := e.EmitAuditEvent(ctx, &apievents.TrustedClusterTokenCreate{
-				Metadata: apievents.Metadata{
-					Type: events.TrustedClusterTokenCreateEvent,
-					Code: events.TrustedClusterTokenCreateCode,
-				},
-				UserMetadata: userMetadata,
-			}); err != nil {
-				log.WithError(err).Warn("Failed to emit trusted cluster token create event.")
-			}
-		}
-	}
 }
 
 func (a *ServerWithRoles) UpsertToken(ctx context.Context, token types.ProvisionToken) error {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4037,16 +4037,6 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 					Roles:      types.SystemRoles{types.RoleTrustedCluster},
 					JoinMethod: types.JoinMethodToken,
 				},
-				//nolint:staticcheck // Emit a deprecated event.
-				&eventtypes.TrustedClusterTokenCreate{
-					Metadata: eventtypes.Metadata{
-						Type: events.TrustedClusterTokenCreateEvent,
-						Code: events.TrustedClusterTokenCreateCode,
-					},
-					UserMetadata: eventtypes.UserMetadata{
-						User: "token-creator",
-					},
-				},
 			},
 		},
 		{
@@ -4195,16 +4185,6 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 					},
 					Roles:      types.SystemRoles{types.RoleTrustedCluster},
 					JoinMethod: types.JoinMethodToken,
-				},
-				//nolint:staticcheck // Emit a deprecated event.
-				&eventtypes.TrustedClusterTokenCreate{
-					Metadata: eventtypes.Metadata{
-						Type: events.TrustedClusterTokenCreateEvent,
-						Code: events.TrustedClusterTokenCreateCode,
-					},
-					UserMetadata: eventtypes.UserMetadata{
-						User: "token-upserter",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
This was deprecated in v14 and will no longer be emitted in v15. The event code and conversion remains so that we can still render audit logs properly when this old event is present.

Closes #29392