### PR TITLE
Fix install-linux.mdx

### DIFF
--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,11 +1,17 @@
 Select an edition, then follow the instructions for that edition to install Teleport.
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
-  <TabItem label="Teleport Team" scope="team">
+  <TabItem label="Teleport Community Edition">
 
   ```code
-  $ curl https://goteleport.com/static/install.sh | bash -s (=cloud.version=)
+  $ curl https://goteleport.com/static/install.sh | bash -s (=teleport.version=)
   ```
+
+  </TabItem>
+  <TabItem label="Teleport Team">
+  (!docs/pages/includes/cloud/install-linux-cloud.mdx!)
+
+  (!docs/pages/includes/repo-channels.mdx!)
 
   <Details title="Is my Teleport instance compatible with Teleport Team?">
 
@@ -18,19 +24,12 @@ Select an edition, then follow the instructions for that edition to install Tele
   </Details>
 
   </TabItem>
-  <TabItem label="Open Source" scope="oss">
-
-  ```code
-  $ curl https://goteleport.com/static/install.sh | bash -s (=teleport.version=)
-  ```
-
-  </TabItem>
-  <TabItem label="Enterprise" scope="enterprise">
+  <TabItem label="Teleport Enterprise">
   (!docs/pages/includes/install-linux-ent-self-hosted.mdx!)
 
   (!docs/pages/includes/repo-channels.mdx!)
   </TabItem>
-  <TabItem label="Enterprise Cloud" scope="cloud">
+  <TabItem label="Teleport Enterprise Cloud">
   (!docs/pages/includes/cloud/install-linux-cloud.mdx!)
 
   (!docs/pages/includes/repo-channels.mdx!)


### PR DESCRIPTION
Closes #32195

Correct some issues that were confusing or wrong:

- Move "Community Edition" to the first, default tab. Since we removed scopes from the docs, and "Teleport Team" was the first tab in this partial, it looked like Teleport Team was the intended default installation.  This is incorrect.
- Change the Teleport Team installation instructions to show the Cloud installation steps.