### PR TITLE
[v12] docs: remove guidance on version warning older than v11

### DIFF
--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -25,16 +25,6 @@ available in Teleport Enterprise.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-<Admonition type="warning">
-All `teleport` instances in the cluster must be running Teleport `v10.0.0` or
-greater in order for Resource Access Requests to be properly enforced.
-Older versions of `teleport` will only do RBAC checks based on roles and will
-not respect resource restrictions.
-It is not recommended to enable Resource Access Requests by setting any
-`search_as_roles` until all `teleport` instances in your cluster have been
-upgraded to version 10.
-</Admonition>
-
 ## Step 1/8. Create the requester role
 
 This role allows the requester to search for resources accessible by the

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -3,16 +3,6 @@ title: Database Access with Elasticsearch
 description: How to configure Teleport database access with Elasticsearch.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="10.3"
->
-  Database access for Elasticsearch is available starting from Teleport `10.3`.
-</Details>
-
 This guide will help you to configure secured access to an Elasticsearch database using the Teleport Database Service.
 
 ## Prerequisites
@@ -21,9 +11,7 @@ This guide will help you to configure secured access to an Elasticsearch databas
 
 - A self-hosted Elasticsearch database. Elastic Cloud [does not support client certificates](https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security), which are required for setting up the Database Service.
 
-- A host where you will run the Teleport Database Service. If you are already
-  running the Teleport Database Service, you must ensure that it uses Teleport
-  version 10.3 or newer in order to connect to Elasticsearch.
+- A host where you will run the Teleport Database Service.
 
   See [Installation](../../installation.mdx) for details.
 

--- a/docs/pages/database-access/guides/snowflake.mdx
+++ b/docs/pages/database-access/guides/snowflake.mdx
@@ -3,16 +3,6 @@ title: Database Access with Snowflake
 description: How to configure Teleport database access with Snowflake.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="10.0"
->
-  Database access for Snowflake is available starting from Teleport `10.0`.
-</Details>
-
 This guide will help you to:
 
 - Install and configure Teleport.
@@ -37,7 +27,7 @@ This guide will help you to:
 
 - `snowsql` installed and added to your system's `PATH` environment variable.
 
-- A host where you will run the Teleport Database Service. Teleport version 10.0 or newer must be installed.
+- A host where you will run the Teleport Database Service.
 
   See [Installation](../../installation.mdx) for details.
 


### PR DESCRIPTION
backport #32364 to branch/v12