### PR TITLE
[v12] Improve AWS CLI Access performance by caching AWS session credentials

### DIFF
--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -471,10 +471,6 @@ var staticAWSCredentialsForAssumedRole = credentials.NewStaticCredentials(assume
 var staticAWSCredentials = credentials.NewStaticCredentials("AKIDl", "SECRET", "SESSION")
 var staticAWSCredentialsForClient = credentials.NewStaticCredentials("fakeClientKeyID", "fakeClientSecret", "")
 
-func getStaticAWSCredentials(client.ConfigProvider, time.Time, string, string, string) *credentials.Credentials {
-	return staticAWSCredentials
-}
-
 type suite struct {
 	*httptest.Server
 	identity *tlsca.Identity
@@ -499,8 +495,8 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, app types.Applic
 	})
 
 	svc, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
-		GetSigningCredentials: getStaticAWSCredentials,
-		Clock:                 clock,
+		CredentialsGetter: awsutils.NewStaticCredentialsGetter(staticAWSCredentials),
+		Clock:             clock,
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -269,7 +269,9 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{})
+	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
+		Clock: c.Clock,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -69,9 +69,8 @@ type Engine struct {
 	// RoundTrippers is a cache of RoundTrippers, mapped by service endpoint.
 	// It is not guarded by a mutex, since requests are processed serially.
 	RoundTrippers map[string]http.RoundTripper
-	// GetSigningCredsFn allows to set the function responsible for obtaining STS credentials.
-	// Used in tests to set static AWS credentials and skip API call.
-	GetSigningCredsFn libaws.GetSigningCredentialsFunc
+	// CredentialsGetter is used to obtain STS credentials.
+	CredentialsGetter libaws.CredentialsGetter
 }
 
 var _ common.Engine = (*Engine)(nil)
@@ -84,9 +83,9 @@ func (e *Engine) InitializeConnection(clientConn net.Conn, sessionCtx *common.Se
 		return trace.Wrap(err)
 	}
 	svc, err := libaws.NewSigningService(libaws.SigningServiceConfig{
-		Clock:                 e.Clock,
-		Session:               awsSession,
-		GetSigningCredentials: e.GetSigningCredsFn,
+		Clock:             e.Clock,
+		Session:           awsSession,
+		CredentialsGetter: e.CredentialsGetter,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/db/dynamodb_test.go
+++ b/lib/srv/db/dynamodb_test.go
@@ -22,10 +22,8 @@ import (
 	"net"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	awsdynamodb "github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/stretchr/testify/require"
@@ -35,6 +33,7 @@ import (
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/dynamodb"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 func registerTestDynamoDBEngine() {
@@ -48,12 +47,10 @@ func newTestDynamoDBEngine(ec common.EngineConfig) common.Engine {
 		EngineConfig:  ec,
 		RoundTrippers: make(map[string]http.RoundTripper),
 		// inject mock AWS credentials.
-		GetSigningCredsFn: staticAWSCredentials,
+		CredentialsGetter: awsutils.NewStaticCredentialsGetter(
+			credentials.NewStaticCredentials("AKIDl", "SECRET", "SESSION"),
+		),
 	}
-}
-
-func staticAWSCredentials(client.ConfigProvider, time.Time, string, string, string) *credentials.Credentials {
-	return credentials.NewStaticCredentials("AKIDl", "SECRET", "SESSION")
 }
 
 func TestAccessDynamoDB(t *testing.T) {

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2023 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// GetCredentialsRequest is the request for obtaining STS credentials.
+type GetCredentialsRequest struct {
+	// Provider is the user session used to create the STS client.
+	Provider client.ConfigProvider
+	// Expiry is session expiry to be requested.
+	Expiry time.Time
+	// SessionName is the session name to be requested.
+	SessionName string
+	// RoleARN is the role ARN to be requested.
+	RoleARN string
+	// ExternalID is the external ID to be requested, if not empty.
+	ExternalID string
+}
+
+// CredentialsGetter defines an interface for obtaining STS credentials.
+type CredentialsGetter interface {
+	// Get obtains STS credentials.
+	Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error)
+}
+
+type credentialsGetter struct {
+}
+
+// NewCredentialsGetter returns a new CredentialsGetter.
+func NewCredentialsGetter() CredentialsGetter {
+	return &credentialsGetter{}
+}
+
+// Get obtains STS credentials.
+func (g *credentialsGetter) Get(_ context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	logrus.Debugf("Creating STS session %q for %q.", request.SessionName, request.RoleARN)
+	return stscreds.NewCredentials(request.Provider, request.RoleARN,
+		func(cred *stscreds.AssumeRoleProvider) {
+			cred.RoleSessionName = request.SessionName
+			cred.Expiry.SetExpiration(request.Expiry, 0)
+
+			if request.ExternalID != "" {
+				cred.ExternalID = aws.String(request.ExternalID)
+			}
+		},
+	), nil
+}
+
+// CachedCredentialsGetterConfig is the config for creating a CredentialsGetter that caches credentials.
+type CachedCredentialsGetterConfig struct {
+	// Getter is the CredentialsGetter for obtaining the STS credentials.
+	Getter CredentialsGetter
+	// CacheTTL is the cache TTL.
+	CacheTTL time.Duration
+	// Clock is used to control time.
+	Clock clockwork.Clock
+}
+
+// SetDefaults sets default values for CachedCredentialsGetterConfig.
+func (c *CachedCredentialsGetterConfig) SetDefaults() {
+	if c.Getter == nil {
+		c.Getter = NewCredentialsGetter()
+	}
+	if c.CacheTTL <= 0 {
+		c.CacheTTL = time.Minute
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+}
+
+type cachedCredentialsGetter struct {
+	config CachedCredentialsGetterConfig
+	cache  *utils.FnCache
+}
+
+// NewCachedCredentialsGetter returns a CredentialsGetter that caches credentials.
+func NewCachedCredentialsGetter(config CachedCredentialsGetterConfig) (CredentialsGetter, error) {
+	config.SetDefaults()
+
+	cache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL:   config.CacheTTL,
+		Clock: config.Clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &cachedCredentialsGetter{
+		config: config,
+		cache:  cache,
+	}, nil
+}
+
+// Get returns cached credentials if found, or fetch it from the configured
+// getter.
+func (g *cachedCredentialsGetter) Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	credentials, err := utils.FnCacheGet(ctx, g.cache, request, func(ctx context.Context) (*credentials.Credentials, error) {
+		credentials, err := g.config.Getter.Get(ctx, request)
+		return credentials, trace.Wrap(err)
+	})
+	return credentials, trace.Wrap(err)
+}
+
+type staticCredentialsGetter struct {
+	credentials *credentials.Credentials
+}
+
+// NewStaticCredentialsGetter returns a CredentialsGetter that always returns
+// the same provided credentials.
+//
+// Used in testing to mock CredentialsGetter.
+func NewStaticCredentialsGetter(credentials *credentials.Credentials) CredentialsGetter {
+	return &staticCredentialsGetter{
+		credentials: credentials,
+	}
+}
+
+// Get returns the credentials provided to NewStaticCredentialsGetter.
+func (g *staticCredentialsGetter) Get(_ context.Context, _ GetCredentialsRequest) (*credentials.Credentials, error) {
+	if g.credentials == nil {
+		return nil, trace.NotFound("no credentials found")
+	}
+	return g.credentials, nil
+}

--- a/lib/utils/aws/credentials_test.go
+++ b/lib/utils/aws/credentials_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCredentialsGetter struct {
+}
+
+func (f *fakeCredentialsGetter) Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	return credentials.NewStaticCredentials(
+		fmt.Sprintf("%s-%s-%s", request.SessionName, request.RoleARN, request.ExternalID),
+		uuid.NewString(),
+		uuid.NewString(),
+	), nil
+}
+
+func TestCachedCredentialsGetter(t *testing.T) {
+	t.Parallel()
+
+	hostSession := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.AnonymousCredentials,
+		Region:      aws.String("us-west-2"),
+	}))
+	fakeClock := clockwork.NewFakeClock()
+
+	getter, err := NewCachedCredentialsGetter(CachedCredentialsGetterConfig{
+		Getter:   &fakeCredentialsGetter{},
+		CacheTTL: time.Minute,
+		Clock:    fakeClock,
+	})
+	require.NoError(t, err)
+
+	cred1, err := getter.Get(context.Background(), GetCredentialsRequest{
+		Provider:    hostSession,
+		Expiry:      fakeClock.Now().Add(time.Hour),
+		SessionName: "test-session",
+		RoleARN:     "test-role",
+	})
+	require.NoError(t, err)
+	checkCredentialsAccessKeyID(t, cred1, "test-session-test-role-")
+
+	tests := []struct {
+		name         string
+		sessionName  string
+		roleARN      string
+		externalID   string
+		advanceClock time.Duration
+		compareCred1 require.ComparisonAssertionFunc
+	}{
+		{
+			name:         "cached",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			compareCred1: require.Same,
+		},
+		{
+			name:         "different session name",
+			sessionName:  "test-session-2",
+			roleARN:      "test-role",
+			compareCred1: require.NotSame,
+		},
+		{
+			name:         "different role ARN",
+			sessionName:  "test-session",
+			roleARN:      "test-role-2",
+			compareCred1: require.NotSame,
+		},
+		{
+			name:         "different external ID",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			externalID:   "test-id",
+			compareCred1: require.NotSame,
+		},
+		{
+			name:         "cache expired",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			advanceClock: time.Hour,
+			compareCred1: require.NotSame,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClock.Advance(test.advanceClock)
+
+			cred, err := getter.Get(context.Background(), GetCredentialsRequest{
+				Provider:    hostSession,
+				Expiry:      fakeClock.Now().Add(time.Hour),
+				SessionName: test.sessionName,
+				RoleARN:     test.roleARN,
+				ExternalID:  test.externalID,
+			})
+			require.NoError(t, err)
+			checkCredentialsAccessKeyID(t, cred, fmt.Sprintf("%s-%s-%s", test.sessionName, test.roleARN, test.externalID))
+			test.compareCred1(t, cred1, cred)
+		})
+	}
+}
+
+func checkCredentialsAccessKeyID(t *testing.T, cred *credentials.Credentials, wantAccessKeyID string) {
+	t.Helper()
+	value, err := cred.Get()
+	require.NoError(t, err)
+	require.Equal(t, wantAccessKeyID, value.AccessKeyID)
+}

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -23,10 +23,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -57,9 +53,8 @@ type SigningServiceConfig struct {
 	Session *awssession.Session
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
-	// GetSigningCredentials allows to set the function responsible for obtaining STS credentials.
-	// Used in tests to set static AWS credentials and skip API call.
-	GetSigningCredentials GetSigningCredentialsFunc
+	// CredentialsGetter is used to obtain STS credentials.
+	CredentialsGetter CredentialsGetter
 }
 
 // CheckAndSetDefaults validates the SigningServiceConfig config.
@@ -76,8 +71,17 @@ func (s *SigningServiceConfig) CheckAndSetDefaults() error {
 		}
 		s.Session = ses
 	}
-	if s.GetSigningCredentials == nil {
-		s.GetSigningCredentials = GetAWSCredentialsFromSTSAPI
+	if s.CredentialsGetter == nil {
+		// Use cachedCredentialsGetter by default. cachedCredentialsGetter
+		// caches the credentials for one minute.
+		cachedGetter, err := NewCachedCredentialsGetter(CachedCredentialsGetterConfig{
+			Clock: s.Clock,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		s.CredentialsGetter = cachedGetter
 	}
 	return nil
 }
@@ -157,7 +161,16 @@ func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, sig
 	// 100-continue" headers without being signed, otherwise the Athena service
 	// would reject the requests.
 	unsignedHeaders := removeUnsignedHeaders(reqCopy)
-	credentials := s.GetSigningCredentials(s.Session, signCtx.Expiry, signCtx.SessionName, signCtx.AWSRoleArn, signCtx.AWSExternalID)
+	credentials, err := s.CredentialsGetter.Get(ctx, GetCredentialsRequest{
+		Provider:    s.Session,
+		Expiry:      signCtx.Expiry,
+		SessionName: signCtx.SessionName,
+		RoleARN:     signCtx.AWSRoleArn,
+		ExternalID:  signCtx.AWSExternalID,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	signer := NewSigner(credentials, signCtx.SigningName)
 	_, err = signer.Sign(reqCopy, bytes.NewReader(payload), signCtx.SigningName, signCtx.SigningRegion, s.Clock.Now())
 	if err != nil {
@@ -167,24 +180,6 @@ func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, sig
 	// copy removed headers back to the request after signing it, but don't copy the old Authorization header.
 	copyHeaders(reqCopy, req, utils.RemoveFromSlice(unsignedHeaders, "Authorization"))
 	return reqCopy, nil
-}
-
-// GetSigningCredentialsFunc allows to set the function responsible for obtaining STS credentials.
-// Used in tests to set static AWS credentials and skip API call.
-type GetSigningCredentialsFunc func(provider client.ConfigProvider, expiry time.Time, sessName, roleARN, externalID string) *credentials.Credentials
-
-// GetAWSCredentialsFromSTSAPI obtains STS credentials.
-func GetAWSCredentialsFromSTSAPI(provider client.ConfigProvider, expiry time.Time, sessName, roleARN, externalID string) *credentials.Credentials {
-	return stscreds.NewCredentials(provider, roleARN,
-		func(cred *stscreds.AssumeRoleProvider) {
-			cred.RoleSessionName = sessName
-			cred.Expiry.SetExpiration(expiry, 0)
-
-			if externalID != "" {
-				cred.ExternalID = aws.String(externalID)
-			}
-		},
-	)
 }
 
 // removeUnsignedHeaders removes and returns header keys that are not included in SigV4 SignedHeaders.


### PR DESCRIPTION
Changelog: none

Backport #30922 to branch/v12

Minor conflicts
- removed opensearch related changes
- minor fix to dynamodb.