### PR TITLE
Prevent duplicate Access List owners.

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -170,18 +170,18 @@ func (a *AccessList) CheckAndSetDefaults() error {
 	// Deduplicate owners. The backend will currently prevent this, but it's possible that access lists
 	// were created with duplicated owners before the backend checked for duplicate owners. In order to
 	// ensure that these access lists are backwards compatible, we'll deduplicate them here.
-	ownerMap := map[string]bool{}
+	ownerMap := make(map[string]struct{}, len(a.Spec.Owners))
 	deduplicatedOwners := []Owner{}
 	for _, owner := range a.Spec.Owners {
 		if owner.Name == "" {
 			return trace.BadParameter("owner name is missing")
 		}
 
-		if ownerMap[owner.Name] {
+		if _, ok := ownerMap[owner.Name]; ok {
 			continue
 		}
 
-		ownerMap[owner.Name] = true
+		ownerMap[owner.Name] = struct{}{}
 		deduplicatedOwners = append(deduplicatedOwners, owner)
 	}
 	a.Spec.Owners = deduplicatedOwners

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/types/header"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/header"
 )
 
 func TestDeduplicateOwners(t *testing.T) {

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -21,8 +21,66 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDeduplicateOwners(t *testing.T) {
+	accessList, err := NewAccessList(
+		header.Metadata{
+			Name: "duplicate test",
+		},
+		Spec{
+			Title:       "title",
+			Description: "test access list",
+			Owners: []Owner{
+				{
+					Name:        "test-user1",
+					Description: "test user 1",
+				},
+				{
+					Name:        "test-user2",
+					Description: "test user 2",
+				},
+				{
+					Name:        "test-user2",
+					Description: "duplicate",
+				},
+			},
+			Audit: Audit{
+				Frequency: time.Hour,
+			},
+			MembershipRequires: Requires{
+				Roles: []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			OwnershipRequires: Requires{
+				Roles: []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
+			},
+			Grants: Grants{
+				Roles: []string{"grole1", "grole2"},
+				Traits: map[string][]string{
+					"gtrait1": {"gvalue1", "gvalue2"},
+					"gtrait2": {"gvalue3", "gvalue4"},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, accessList.Spec.Owners, 2)
+	require.Equal(t, "test-user1", accessList.Spec.Owners[0].Name)
+	require.Equal(t, "test user 1", accessList.Spec.Owners[0].Description)
+	require.Equal(t, "test-user2", accessList.Spec.Owners[1].Name)
+	require.Equal(t, "test user 2", accessList.Spec.Owners[1].Description)
+}
 
 func TestAuditMarshaling(t *testing.T) {
 	audit := Audit{

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -112,6 +112,13 @@ func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*ac
 // UpsertAccessList creates or updates an access list resource.
 func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *accesslist.AccessList) (*accesslist.AccessList, error) {
 	err := a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		ownerMap := map[string]bool{}
+		for _, owner := range accessList.Spec.Owners {
+			if ownerMap[owner.Name] {
+				return trace.AlreadyExists("owner %s already exists in the owner list", owner.Name)
+			}
+			ownerMap[owner.Name] = true
+		}
 		return trace.Wrap(a.service.UpsertResource(ctx, accessList))
 	})
 	if err != nil {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -112,12 +112,12 @@ func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*ac
 // UpsertAccessList creates or updates an access list resource.
 func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *accesslist.AccessList) (*accesslist.AccessList, error) {
 	err := a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		ownerMap := map[string]bool{}
+		ownerMap := make(map[string]struct{}, len(accessList.Spec.Owners))
 		for _, owner := range accessList.Spec.Owners {
-			if ownerMap[owner.Name] {
+			if _, ok := ownerMap[owner.Name]; ok {
 				return trace.AlreadyExists("owner %s already exists in the owner list", owner.Name)
 			}
-			ownerMap[owner.Name] = true
+			ownerMap[owner.Name] = struct{}{}
 		}
 		return trace.Wrap(a.service.UpsertResource(ctx, accessList))
 	})


### PR DESCRIPTION
Duplicate access list owners are now prevented. In the event that duplicate access list owners are currently in the backend, this commit will deduplicate them and choose the first owner with the same name when getting the access list to maintain backwards compatibility.