### PR TITLE
Add small delay to display shimmer boxes

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -261,9 +261,34 @@ export function ResourceCard({ resource, onLabelClick }: Props) {
   );
 }
 
-export function LoadingCard() {
-  function randomNum(min: number, max: number) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+type LoadingCardProps = {
+  delay?: 'none' | 'short' | 'long';
+};
+
+const DelayValueMap = {
+  none: 0,
+  short: 400, // 0.4s;
+  long: 600, // 0.6s;
+};
+
+function randomNum(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
+  const [canDisplay, setCanDisplay] = useState(false);
+
+  useEffect(() => {
+    const displayTimeout = setTimeout(() => {
+      setCanDisplay(true);
+    }, DelayValueMap[delay]);
+    return () => {
+      clearTimeout(displayTimeout);
+    };
+  }, []);
+
+  if (!canDisplay) {
+    return null;
   }
 
   return (

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -159,7 +159,7 @@ export function Resources() {
         ))}
         {/* Using index as key here is ok because these elements never change order */}
         {attempt.status === 'processing' &&
-          loadingCardArray.map((_, i) => <LoadingCard key={i} />)}
+          loadingCardArray.map((_, i) => <LoadingCard delay="short" key={i} />)}
       </ResourcesContainer>
       <div ref={setScrollDetector} />
       <ListFooter>


### PR DESCRIPTION
This adds an optional prop to delay the loading card in the unified resources view. This prevents any 'flicker' while items are loading. Example before and after.
I thought of adding this to the shimmer box component itself, but decided against it. The shimmer box isn't the loader, its a component we use to build the loaders, for example this LoadingCard component. If we added the delay to the shimmer box component, we'd have to add the optional prop to every shimmerbox component in our LoadingCard and that seemed irrational.

https://github.com/gravitational/teleport/assets/5201977/f625c947-1e56-4221-ac07-79e6e2415b59


https://github.com/gravitational/teleport/assets/5201977/3dbcdee4-b8e1-4d3e-8ce8-72528be31939

