### PR TITLE
fix: Let users without a useable device issue register challenges

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5420,16 +5420,30 @@ func (a *Server) validateMFAAuthResponseForRegister(
 	ctx context.Context,
 	resp *proto.MFAAuthenticateResponse, username string, passwordless bool,
 ) (hasDevices bool, err error) {
+	// Let users without a useable device go through registration.
 	if resp == nil || (resp.GetTOTP() == nil && resp.GetWebauthn() == nil) {
 		devices, err := a.Services.GetMFADevices(ctx, username, false /* withSecrets */)
-		switch {
-		case err != nil:
+		if err != nil {
 			return false, trace.Wrap(err)
-		case len(devices) > 0:
+		}
+		if len(devices) == 0 {
+			// Allowed, no devices registered.
+			return false, nil
+		}
+
+		authPref, err := a.GetAuthPreference(ctx)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		totpEnabled := authPref.IsSecondFactorTOTPAllowed()
+		webauthnEnabled := authPref.IsSecondFactorWebauthnAllowed()
+
+		devsByType := groupByDeviceType(devices, webauthnEnabled)
+		if (totpEnabled && devsByType.TOTP) || (webauthnEnabled && len(devsByType.Webauthn) > 0) {
 			return false, trace.BadParameter("second factor authentication required")
 		}
 
-		// Allowed, but no devices registered.
+		// Allowed, no useable devices registered.
 		return false, nil
 	}
 


### PR DESCRIPTION
Count devices according to the cluster settings, so users without a useable device can still register new MFA devices.

Fixes bug brought to light by #32271 (and subsequent PRs). This is a long-standing corner case of privilege tokens. `tsh` registrations in current release branches not affected (including v14).

#20343

Changelog: Fix a corner case of privilege tokens where MFA devices disabled by cluster settings were still counted against the user.