### PR TITLE
[v14] fix: Let users without a useable device issue register challenges

### DIFF
--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -463,27 +463,12 @@ func (s *Server) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePriv
 
 	tokenKind := UserTokenTypePrivilege
 
-	switch {
-	case req.GetExistingMFAResponse() == nil:
-		// Allows users with no devices to bypass second factor re-auth.
-		devices, err := s.Services.GetMFADevices(ctx, username, false /* withSecrets */)
-		switch {
-		case err != nil:
-			return nil, trace.Wrap(err)
-		case len(devices) > 0:
-			return nil, trace.BadParameter("second factor authentication required")
-		}
-
+	switch hasDevices, err := s.validateMFAAuthResponseForRegister(
+		ctx, req.GetExistingMFAResponse(), username, false /* passwordless */); {
+	case err != nil:
+		return nil, trace.Wrap(err)
+	case !hasDevices:
 		tokenKind = UserTokenTypePrivilegeException
-
-	default:
-		if err := s.WithUserLock(username, func() error {
-			_, _, err := s.validateMFAAuthResponse(
-				ctx, req.GetExistingMFAResponse(), username, false /* passwordless */)
-			return err
-		}); err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	// Delete any existing user tokens for user before creating.


### PR DESCRIPTION
Cherry-pick of parts of #32271 (validateMFAAuthResponseForRegister function) and #32428, with a couple of manual changes due to branch drift.

Count devices according to the cluster settings, so users without a useable device can still register new MFA devices (via privilege tokens).

This is a long-standing corner case of privilege tokens. tsh registrations not affected.

Changelog: Fix a corner case of privilege tokens where MFA devices disabled by cluster settings were still counted against the user.