### PR TITLE
docs: helm install agent updates

### DIFF
--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -349,7 +349,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \
   --create-namespace \
-  --namespace=teleport \
+  --namespace=teleport-agent \
   --set labels.environment=demo \
   --version (=teleport.version=)
 ```
@@ -358,7 +358,7 @@ After a few seconds, verify that you have deployed the Teleport Kubernetes
 Service by running the following command:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 ```
 
 This should show that the Kubernetes Service is running:

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -187,7 +187,7 @@ Make sure that the Teleport agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 NAME                    READY   STATUS    RESTARTS   AGE
 teleport-kube-agent-0   1/1     Running   0          32s
 ```

--- a/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
@@ -135,7 +135,7 @@ Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 $ teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> \
+   --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/>:443 \
    --name=example-clickhouse \
    --protocol=clickhouse-http \
    --uri=clickhouse.example.com:8443 \
@@ -149,7 +149,7 @@ $ teleport db configure create \
 $ teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> \
+   --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/>:443 \
    --name=example-clickhouse \
    --protocol=clickhouse \
    --uri=clickhouse.example.com:9440 \
@@ -178,7 +178,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --create-namespace \
   --namespace teleport-agent \
   --set roles=db \
-  --set proxyAddr=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> \
+  --set proxyAddr=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/>:443 \
   --set authToken=${JOIN_TOKEN?} \
   --set "databases[0].name=example-clickhouse" \
   --set "databases[0].uri=clickhouse.example.com:8443" \
@@ -196,7 +196,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --create-namespace \
   --namespace teleport-agent \
   --set roles=db \
-  --set proxyAddr=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> \
+  --set proxyAddr=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/>:443 \
   --set authToken=${JOIN_TOKEN?} \
   --set "databases[0].name=example-clickhouse" \
   --set "databases[0].uri=clickhouse.example.com:9440" \
@@ -227,7 +227,7 @@ Log in to Teleport and list the databases you can connect to. You should see the
 ClickHouse database you enrolled earlier:
 
 ```code
-$ tsh login --proxy=<Var name="proxy-address" /> --user=alice
+$ tsh login --proxy=<Var name="teleport.example.com" /> --user=alice
 $ tsh db ls
 # Name                      Description Allowed Users Labels  Connect
 # ------------------------- ----------- ------------- ------- -------
@@ -269,7 +269,7 @@ Log in to Teleport and list the databases you can connect to. You should see the
 ClickHouse database you enrolled earlier:
 
 ```code
-$ tsh login --proxy=<Var name="proxy-address" /> --user=alice
+$ tsh login --proxy=<Var name="teleport.example.com" /> --user=alice
 $ tsh db ls
 # Name                    Description Allowed Users Labels  Connect
 # ----------------------- ----------- ------------- ------- -------

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -127,61 +127,12 @@ Install and configure Teleport where you will run the Teleport Database Service:
 
   (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
-  <Tabs>
-  <TabItem label="Teleport Enterprise" scope={["enterprise"]}>
-  Install the Teleport Kube Agent into your Kubernetes Cluster
-  with the Teleport Database Service configuration.
-  
-  ```code
-  $ JOIN_TOKEN=$(cat /tmp/token)
-  $ helm install teleport-kube-agent teleport/teleport-kube-agent \
-    --create-namespace \
-    --namespace teleport-agent \
-    --set roles=db \
-    --set proxyAddr=teleport.example.com:443 \
-    --set authToken=${JOIN_TOKEN?} \
-    --set "databases[0].name=oracle" \
-    --set "databases[0].uri=oracle.example.com:2484" \
-    --set "databases[0].protocol=oracle" \
-    --set "labels.env=dev" \
-    --version (=teleport.version=)
-  ```
-  
-  </TabItem>
-  <TabItem label="Teleport Enterprise Cloud" scope={["cloud"]}>
-  Install the Teleport Kube Agent into your Kubernetes Cluster
-  with the Teleport Database Service configuration.
-  
-  ```code
-  $ JOIN_TOKEN=$(cat /tmp/token)
-  $ helm install teleport-kube-agent teleport/teleport-kube-agent \
-    --create-namespace \
-    --namespace teleport-agent \
-    --set roles=db \
-    --set proxyAddr=mytenant.teleport.sh:443 \
-    --set authToken=${JOIN_TOKEN?} \
-    --set "databases[0].name=oracle" \
-    --set "databases[0].uri=oracle.example.com:2484" \
-    --set "databases[0].protocol=oracle" \
-    --set "labels.env=dev" \
-    --version (=cloud.version=)
-  ```
-  
-  </TabItem>
-  </Tabs>
+  (!docs/pages/includes/database-access/db-helm-install.mdx dbName="oracle" dbProtocol="oracle" databaseAddress="oracle.example.com:2484" !)
+
 </TabItem>
 </Tabs>
 
 (!docs/pages/includes/database-access/multiple-instances-tip.mdx !)
-
-Make sure that the Teleport agent pod is running. You should see one Teleport
-agent pod pod with a single ready container:
-
-```code
-$ kubectl -n teleport get pods
-NAME                    READY   STATUS    RESTARTS   AGE
-teleport-kube-agent-0   1/1     Running   0          32s
-```
 
 ## Step 5/6. (Optional) Configure Teleport to pull audit logs from Oracle Audit Trail
 

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -112,7 +112,7 @@ Save the token in a file called `/tmp/token` on the host that will run the
 Database Service.
 
 </TabItem>
-<TabItem label="Kubernetes">
+<TabItem label="Kubernetes Cluster">
 
 Later in this guide, you will use this join token when configuring the Teleport
 Database Service.

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -308,7 +308,7 @@ annotations:
 Install the Helm chart for Teleport agent services, `teleport-kube-agent`:
 
 ```code
-$ helm -n teleport install teleport-kube-agent teleport/teleport-kube-agent \
+$ helm -n teleport-agent install teleport-kube-agent teleport/teleport-kube-agent \
   --values values.yaml --create-namespace
 ```
 
@@ -316,7 +316,7 @@ Make sure that the Teleport agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 NAME                    READY   STATUS    RESTARTS   AGE
 teleport-kube-agent-0   1/1     Running   0          32s
 ```

--- a/docs/pages/includes/database-access/db-helm-install.mdx
+++ b/docs/pages/includes/database-access/db-helm-install.mdx
@@ -46,7 +46,7 @@ Make sure that the Teleport agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 NAME                    READY   STATUS    RESTARTS   AGE
 teleport-kube-agent-0   1/1     Running   0          32s
 ```

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -170,7 +170,7 @@ Make sure that the Teleport agent pod is running. You should see one Teleport
 agent pod pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 NAME               READY   STATUS    RESTARTS   AGE
 teleport-agent-0   1/1     Running   0          32s
 ```

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -231,7 +231,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --set authToken=<Var name="token" /> \
   --set labels.region=local --set labels.platform=minikube \
   --create-namespace \
-  --namespace=teleport \
+  --namespace=teleport-agent \
   --version (=teleport.version=)
 ```
 
@@ -242,7 +242,7 @@ these to configure access controls for the cluster later in this guide.
 Verify that the `teleport` pod is running in your cluster:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 ```
 
 You can check that the Teleport Kubernetes Service registered itself with your

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -263,7 +263,7 @@ Make sure that the Teleport agent pod is running. You should see one Teleport
 agent pod pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n <Var name="teleport-agent"/> get pods
 NAME               READY   STATUS    RESTARTS   AGE
 teleport-agent-0   1/1     Running   0          32s
 ```

--- a/docs/pages/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/kubernetes-access/troubleshooting.mdx
@@ -190,7 +190,7 @@ Make sure that the Teleport agent pod is running. You should see one Teleport
 agent pod pod with a single ready container:
 
 ```code
-$ kubectl -n teleport get pods
+$ kubectl -n teleport-agent get pods
 NAME               READY   STATUS    RESTARTS   AGE
 teleport-agent-0   1/1     Running   0          32s
 ```


### PR DESCRIPTION
- update clickhouse to include port number for proxy
- use common include for oracle kubernetes helm install
- fix to common helm kubectl namespace call
- rds update to use same tab name for navigation
- fix namespace reference in kube and app getting started