### PR TITLE
Use important alert for Connect dev setup

### DIFF
--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -39,7 +39,8 @@ process](#build-process) section.
 
 ## Development
 
-**Make sure to run `yarn build-native-deps-for-term` first** before attempting to launch the app in
+> [!IMPORTANT]
+> **Make sure to run `yarn build-native-deps-for-term` first** before attempting to launch the app in
 development mode. That's because Electron is running its own version of Node. That command will
 fetch or build native packages that were made for that specific version of Node.
 


### PR DESCRIPTION
This was typically the main struggle for people setting up Connect. I saw that webapps uses those [fancy alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), so I figured adding one here might help as well.