### PR TITLE
[v12] `compareSemVers` should return 0 if values are equal

### DIFF
--- a/web/packages/teleport/src/lib/util.test.ts
+++ b/web/packages/teleport/src/lib/util.test.ts
@@ -100,6 +100,8 @@ test('compareSemVers', () => {
     '10.1.0',
     '11.1.0',
   ]);
+
+  expect(compareSemVers('1.0.0', '1.0.0')).toBe(0);
 });
 
 test('sortByString with simple string array', () => {

--- a/web/packages/teleport/src/lib/util.ts
+++ b/web/packages/teleport/src/lib/util.ts
@@ -86,7 +86,7 @@ export function arrayStrDiff(stringsA: string[], stringsB: string[]) {
   return stringsA.filter(l => !stringsB.includes(l));
 }
 
-export const compareSemVers = (a: string, b: string): -1 | 1 => {
+export const compareSemVers = (a: string, b: string): -1 | 1 | 0 => {
   const splitA = a.split('.');
   const splitB = b.split('.');
 
@@ -112,7 +112,7 @@ export const compareSemVers = (a: string, b: string): -1 | 1 => {
     return patchA > patchB ? 1 : -1;
   }
 
-  return 1;
+  return 0;
 };
 
 // compareByString is a sort compare function that


### PR DESCRIPTION
Backport #32315

This fix is needed only for Connect My Computer which we doesn't have in v12. 
However, having a difference in implementation between master and other branches can cause some bugs in the future.