### PR TITLE
pgbk: remove CREATE PUBLICATION

### DIFF
--- a/lib/backend/pgbk/pgbk.go
+++ b/lib/backend/pgbk/pgbk.go
@@ -249,8 +249,10 @@ var schemas = []string{
 		CONSTRAINT kv_pkey PRIMARY KEY (key)
 	);
 	CREATE INDEX kv_expires_idx ON kv (expires) WHERE expires IS NOT NULL;`,
-	`ALTER TABLE kv REPLICA IDENTITY FULL;
-	CREATE PUBLICATION kv_pub FOR TABLE kv;`,
+
+	// v14.0.0 also had `CREATE PUBLICATION kv_pub FOR TABLE kv` in schema
+	// version 2
+	"ALTER TABLE kv REPLICA IDENTITY FULL;",
 }
 
 var _ backend.Backend = (*Backend)(nil)


### PR DESCRIPTION
Doing `CREATE PUBLICATION` actually requires create permissions over the database rather than just the schema that contains the `kv` table, so it's technically a breaking change if the database user only has privileges over a schema (see #32197, which was prompted by a customer that restricts the database user to a specific schema).

It's harmless to remove the line, as the `kv_pub` publication is not currently used anywhere and it was only added to more easily support the use of `pgoutput` in the future. A note was left in its stead, so we don't accidentally try to blindly create the publication again.