### PR TITLE
[v12] docs: remove v10 references

### DIFF
--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -201,7 +201,7 @@ $ tsh login --proxy=example.teleport.sh
 
 ## U2F
 
-Starting with Teleport v10, WebAuthn replaces U2F. If you haven't configured U2F
+WebAuthn has replaced U2F in Teleport from previous versions. If you haven't configured U2F
 before, no further action is necessary—any U2F devices are automatically
 supported.
 

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -22,8 +22,8 @@ Machine ID supports the following Teleport features:
 
 - [Server Access](./getting-started.mdx)
 - [Database Access](./guides/databases.mdx)
-- [Kubernetes Access](./guides/kubernetes.mdx) (*in Teleport v10.1*)
-- [Application Access](./guides/applications.mdx) (*in Teleport v10.1*)
+- [Kubernetes Access](./guides/kubernetes.mdx)
+- [Application Access](./guides/applications.mdx)
   - Note: [AWS Console](../application-access/cloud-apis/aws-console.mdx) and API access are currently unsupported.
 - [Teleport API Access](../api/introduction.mdx)
 

--- a/docs/pages/management/operations/proxy-peering.mdx
+++ b/docs/pages/management/operations/proxy-peering.mdx
@@ -13,9 +13,6 @@ and Teleport services like the Database Service and Application Service.
 
 An existing Teleport Enterprise cluster. See [introduction to Teleport Enterprise](../../choose-an-edition/teleport-enterprise/introduction.mdx) to get started.
 
-All components in the cluster should be running Teleport `10.0` or later. See our
-[upgrade procedure](./upgrading.mdx) for help upgrading a Teleport cluster.
-
 Teleport Proxy Service instances must be able to reach each other over the network on port
 `3021` by default. Ensure there are no firewall policies that would block communication
 between instances.


### PR DESCRIPTION
Backport #32444 to branch/v12