### PR TITLE
docs: Flip Github connector examples for OSS vs Commercial

### DIFF
--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -91,11 +91,11 @@ kind: github
 metadata:
   name: github
 spec:
-  api_endpoint_url: https://api.github.com
+  api_endpoint_url: ""
   client_id: <client-id>
   client_secret: <client-secret>
   display: GitHub
-  endpoint_url: https://github.com
+  endpoint_url: ""
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   teams_to_logins: null
   teams_to_roles:
@@ -114,11 +114,11 @@ kind: github
 metadata:
   name: github
 spec:
-  api_endpoint_url: ""
+  api_endpoint_url: https://api.github.com
   client_id: <client-id>
   client_secret: <client-secret>
   display: GitHub
-  endpoint_url: ""
+  endpoint_url: https://github.com
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   teams_to_logins: null
   teams_to_roles:


### PR DESCRIPTION
The Github connector examples in the docs were switched around.

Trying to create a Github connector with `api_endpoint_url` or `endpoint_url` set when using Teleport Community Edition results in an error:

```
[ec2-user@teleport ~]$ sudo /usr/local/bin/tctl create -f github.yaml
ERROR: this feature requires Teleport Enterprise
```

Setting both these values to empty strings causes creation to succeed.

Reported on Slack.