### PR TITLE
Update getting started

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -5,8 +5,14 @@ videoBanner: BJWbSqiDLeU
 tocDepth: 3
 ---
 
-Teleport is an identity-aware, multi-protocol access proxy. Teleport understands
-the SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire
+Teleport provides connectivity, authentication, access controls 
+and audit for infrastructure.
+
+It includes an identity-aware access proxy, a CA that issues short-lived certificates, 
+a unified access control system and a tunneling system to access resources 
+behind the firewall.
+
+Teleport understands the SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire
 protocols, plus many others. It can integrate with Single Sign-On providers and
 enables you to apply access policies using infrastructure-as-code and GitOps
 tools.


### PR DESCRIPTION
Do not refer of teleport as IAP, update messaging to be more accurate.

Many customers see Teleport only as a proxy because in many places we refer to it as IAP. Teleport has grown into a larger system, and we should mention that it includes IAP, CA and other components.

