### PR TITLE
Drain unused SSH channels

### DIFF
--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -45,13 +45,13 @@ func ConnectProxyTransport(sconn ssh.Conn, req *DialReq, exclusive bool) (conn *
 		return nil, false, trace.Wrap(err)
 	}
 
-	channel, discard, err := sconn.OpenChannel(constants.ChanTransport, nil)
+	channel, reqC, err := sconn.OpenChannel(constants.ChanTransport, nil)
 	if err != nil {
 		return nil, true, trace.Wrap(err)
 	}
 
 	// DiscardRequests will return when the channel or underlying connection is closed.
-	go ssh.DiscardRequests(discard)
+	go ssh.DiscardRequests(reqC)
 
 	// Send a special SSH out-of-band request called "teleport-transport"
 	// the agent on the other side will create a new TCP/IP connection to

--- a/api/utils/sshutils/ssh.go
+++ b/api/utils/sshutils/ssh.go
@@ -300,3 +300,19 @@ func RunSSH(ctx context.Context, addr, command string, cfg *ssh.ClientConfig, op
 	err = session.Run(command)
 	return b.Bytes(), trace.Wrap(err)
 }
+
+// ChannelReadWriter represents the data streams of an ssh.Channel-like object.
+type ChannelReadWriter interface {
+	io.ReadWriter
+	Stderr() io.ReadWriter
+}
+
+// DiscardChannelData discards all data received from an ssh channel in the
+// background.
+func DiscardChannelData(ch ChannelReadWriter) {
+	if ch == nil {
+		return
+	}
+	go io.Copy(io.Discard, ch)
+	go io.Copy(io.Discard, ch.Stderr())
+}

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -404,6 +404,7 @@ func (a *agent) sendFirstHeartbeat(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	sshutils.DiscardChannelData(channel)
 
 	a.hbChannel = channel
 	a.hbRequests = requests
@@ -624,6 +625,7 @@ func (a *agent) handleChannels() error {
 // reqC : request payload
 func (a *agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 	a.log.Debugf("handleDiscovery requests channel.")
+	sshutils.DiscardChannelData(ch)
 	defer func() {
 		if err := ch.Close(); err != nil {
 			a.log.Warnf("Failed to close discovery channel: %v", err)

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -104,16 +104,19 @@ func (m *mockSSHClient) GlobalRequests() <-chan *ssh.Request {
 	return m.MockGlobalRequests
 }
 
+type fakeReaderWriter struct{}
+
+func (n fakeReaderWriter) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (n fakeReaderWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
 type mockSSHChannel struct {
+	fakeReaderWriter
 	MockSendRequest func(name string, wantReply bool, payload []byte) (bool, error)
-}
-
-func (m *mockSSHChannel) Read(data []byte) (int, error) {
-	return 0, trace.NotImplemented("")
-}
-
-func (m *mockSSHChannel) Write(data []byte) (int, error) {
-	return 0, trace.NotImplemented("")
 }
 
 func (m *mockSSHChannel) Close() error { return nil }
@@ -129,7 +132,7 @@ func (m *mockSSHChannel) SendRequest(name string, wantReply bool, payload []byte
 }
 
 func (m *mockSSHChannel) Stderr() io.ReadWriter {
-	return nil
+	return fakeReaderWriter{}
 }
 
 // mockAgentInjection implements several interfaces for injecting into an agent.

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -146,10 +146,11 @@ func (c *remoteConn) Close() error {
 
 // OpenChannel will open a SSH channel to the remote side.
 func (c *remoteConn) OpenChannel(name string, data []byte) (ssh.Channel, error) {
-	channel, _, err := c.sconn.OpenChannel(name, data)
+	channel, reqC, err := c.sconn.OpenChannel(name, data)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	go ssh.DiscardRequests(reqC)
 
 	return channel, nil
 }
@@ -233,11 +234,13 @@ func (c *remoteConn) openDiscoveryChannel() (ssh.Channel, error) {
 		return c.discoveryCh, nil
 	}
 
-	c.discoveryCh, _, err = c.sconn.OpenChannel(chanDiscovery, nil)
+	discoveryCh, reqC, err := c.sconn.OpenChannel(chanDiscovery, nil)
 	if err != nil {
 		c.markInvalid(err)
 		return nil, trace.Wrap(err)
 	}
+	go ssh.DiscardRequests(reqC)
+	c.discoveryCh = discoveryCh
 	return c.discoveryCh, nil
 }
 

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -698,6 +698,15 @@ func (s *localSite) fanOutProxies(proxies []types.Server) {
 // if the agent has missed several heartbeats in a row, Proxy marks
 // the connection as invalid.
 func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-chan *ssh.Request) {
+	sshutils.DiscardChannelData(ch)
+	if ch != nil {
+		defer func() {
+			if err := ch.Close(); err != nil {
+				s.log.Warnf("Failed to close heartbeat channel: %v", err)
+			}
+		}()
+	}
+
 	logger := s.log.WithFields(log.Fields{
 		"serverID": rconn.nodeID,
 		"addr":     rconn.conn.RemoteAddr().String(),

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -383,6 +383,15 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 		"addr":     conn.conn.RemoteAddr().String(),
 	})
 
+	sshutils.DiscardChannelData(ch)
+	if ch != nil {
+		defer func() {
+			if err := ch.Close(); err != nil {
+				logger.Warnf("Failed to close heartbeat channel: %v", err)
+			}
+		}()
+	}
+
 	firstHeartbeat := true
 	proxyResyncTicker := s.clock.NewTicker(s.proxySyncInterval)
 	defer func() {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -933,7 +933,7 @@ func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
 			}
 			return
 		}
-		ch, _, err := nch.Accept()
+		ch, reqC, err := nch.Accept()
 		if err != nil {
 			s.log.Warnf("Unable to accept channel: %v", err)
 			if err := nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err)); err != nil {
@@ -941,6 +941,7 @@ func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
 			}
 			return
 		}
+		go ssh.DiscardRequests(reqC)
 		go s.handleDirectTCPIPRequest(ctx, ch, req)
 	default:
 		if err := nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType)); err != nil {

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -135,10 +135,11 @@ func (c *ConnectionContext) StartAgentChannel() (teleagent.Agent, error) {
 		return nil, trace.AccessDenied("agent forwarding has not been requested")
 	}
 	// open a agent channel to client
-	ch, _, err := c.ServerConn.OpenChannel(AuthAgentRequest, nil)
+	ch, reqC, err := c.ServerConn.OpenChannel(AuthAgentRequest, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	go ssh.DiscardRequests(reqC)
 	return &agentChannel{
 		ExtendedAgent: agent.NewClient(ch),
 		ch:            ch,

--- a/lib/sshutils/ctx_test.go
+++ b/lib/sshutils/ctx_test.go
@@ -30,14 +30,18 @@ var (
 	errClose      = errors.New("channel closed")
 )
 
-type mockChannel struct{}
+type fakeReaderWriter struct{}
 
-func (mc *mockChannel) Read(data []byte) (int, error) {
-	return 0, nil
+func (n fakeReaderWriter) Read(_ []byte) (int, error) {
+	return 0, io.EOF
 }
 
-func (mc *mockChannel) Write(data []byte) (int, error) {
-	return 0, nil
+func (n fakeReaderWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+type mockChannel struct {
+	fakeReaderWriter
 }
 
 func (mc *mockChannel) Close() error {
@@ -53,7 +57,7 @@ func (mc *mockChannel) SendRequest(name string, wantReply bool, payload []byte) 
 }
 
 func (mc *mockChannel) Stderr() io.ReadWriter {
-	return nil
+	return fakeReaderWriter{}
 }
 
 func TestAgentChannelClose(t *testing.T) {


### PR DESCRIPTION
This change drains unused SSH channels and requests to prevent a situation where an attacker could repeatedly open channels and send data that won't be read, causing Teleport to eventually run out of memory.