### PR TITLE
[v14] docs: Flip Github connector examples for OSS vs Commercial

### DIFF
--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -91,11 +91,11 @@ kind: github
 metadata:
   name: github
 spec:
-  api_endpoint_url: https://api.github.com
+  api_endpoint_url: ""
   client_id: <client-id>
   client_secret: <client-secret>
   display: GitHub
-  endpoint_url: https://github.com
+  endpoint_url: ""
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   teams_to_logins: null
   teams_to_roles:
@@ -114,11 +114,11 @@ kind: github
 metadata:
   name: github
 spec:
-  api_endpoint_url: ""
+  api_endpoint_url: https://api.github.com
   client_id: <client-id>
   client_secret: <client-secret>
   display: GitHub
-  endpoint_url: ""
+  endpoint_url: https://github.com
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   teams_to_logins: null
   teams_to_roles:


### PR DESCRIPTION
Backport #32501 to branch/v14