### PR TITLE
[v12] docs: add faq answer for using oss or ent release for agents

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -254,6 +254,9 @@ Yes. We recommend Teleport's [event handler plugin](../../management/export-audi
 
 If you plan on connecting more than 10,000 nodes or agents, please contact your account executive or customer support to ensure your tenant is properly scaled.
 
+## Should we use Enterprise or Open Source Teleport for connecting resources to our Teleport cluster?
+(!docs/pages/includes/ent-vs-community-faq.mdx!)
+
 ## Are internal connections encrypted / authenticated?
 
 Teleport components communicate with themselves using mTLS, with a separate certificate authority for each tenant. Connections to AWS services, such as DynamoDB and

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -48,6 +48,9 @@ Yes, Teleport supports reverse SSH tunnels out of the box. To configure
 behind-firewall clusters refer to our
 [Trusted Clusters](./management/admin/trustedclusters.mdx) guide.
 
+## Should we use Enterprise or Open Source Teleport for connecting resources to our Teleport cluster?
+(!docs/pages/includes/ent-vs-community-faq.mdx!)
+
 ## Can individual agents create reverse tunnels to the Proxy Service without creating a new cluster?
 
 Yes. When running a Teleport agent, use the `--auth-server` flag to point to the

--- a/docs/pages/includes/ent-vs-community-faq.mdx
+++ b/docs/pages/includes/ent-vs-community-faq.mdx
@@ -1,0 +1,22 @@
+Teleport Team, Enterprise, and Enterprise Cloud customers should use the Enterprise release of the 
+`teleport` binary for agents. Running the Community Edition binary could result in
+incompatibility to these cluster editions for certain features.
+
+To verify you have a Teleport Enterprise release installed run the `teleport version`
+command and Enterprise will be in the output.
+
+```code
+$ teleport version
+# Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+```
+
+Teleport Community Edition clusters should use the Teleport Community Edition releases. The `teleport version`
+command will only include Teleport in its output for those releases.
+
+```code
+$ teleport version
+# Teleport v(=teleport.version=) go(=teleport.golang=)
+```
+
+See the [Installation](../installation.mdx) guide for details on installing to specific platforms
+with Enterprise or OSS releases. 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/32442 to branch/v13