### PR TITLE
Updated Packer versions to fix tag builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5680,7 +5680,7 @@ steps:
         path: /root/.aws
 
   - name: Build OSS AMIs
-    image: hashicorp/packer:1.7.6
+    image: hashicorp/packer:1.9.4
     volumes:
       - name: dockersock
         path: /var/run
@@ -5688,6 +5688,7 @@ steps:
         path: /root/.aws
     commands:
       - apk add --no-cache aws-cli jq make
+      - packer plugins install github.com/hashicorp/amazon
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - export TELEPORT_VERSION=$(cat /go/.version.txt)
       - export PUBLIC_AMI_NAME=gravitational-teleport-ami-oss-$TELEPORT_VERSION
@@ -16894,6 +16895,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 313f7224af1b5aaaba377740d80b35ad8ffb8f9be21c48793df3c473b81f4818
+hmac: a502ad4f850ee688b8ba1370d3fa7cf1dd8b9a71e78985db0c8e749e5b272f30
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -5856,7 +5856,7 @@ steps:
         path: /root/.aws
 
   - name: Build Enterprise AMIs
-    image: hashicorp/packer:1.7.6
+    image: hashicorp/packer:1.9.4
     volumes:
       - name: dockersock
         path: /var/run
@@ -5864,6 +5864,7 @@ steps:
         path: /root/.aws
     commands:
       - apk add --no-cache aws-cli jq make
+      - packer plugins install github.com/hashicorp/amazon
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - export TELEPORT_VERSION=$(cat /go/.version.txt)
       - export PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-$TELEPORT_VERSION
@@ -16895,6 +16896,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: a502ad4f850ee688b8ba1370d3fa7cf1dd8b9a71e78985db0c8e749e5b272f30
+hmac: 26860e1b07cd9776b845bea867e4a97db26a25c72c3a5210414d384c812b5405
 
 ...


### PR DESCRIPTION
Tag builds are currently broken due to [this change](https://github.com/gravitational/teleport/pull/31983) and subsequent backports. The version of Packer that we are currently running in the Drone release pipeline is several years out of date and does not include the an AWS plugin version that supports the `imds_support` field. This PR fixes the issue by by bumping both the Packer version, and Packer AWS plugin version.

This change needs to be backported through v12 to unblock releases.