### PR TITLE
remove db name checkers for protocols

### DIFF
--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -103,6 +103,10 @@ func databaseNameMatcher(dbProtocol, database string) *services.DatabaseNameMatc
 		defaults.ProtocolOpenSearch,
 		// DynamoDB integration doesn't support schema access control.
 		defaults.ProtocolDynamoDB,
+		// Snowflake integration doesn't support schema access control.
+		defaults.ProtocolSnowflake,
+		// Oracle integration doesn't support schema access control.
+		defaults.ProtocolOracle,
 		// Clickhouse Database Access doesn't support schema access control
 		defaults.ProtocolClickHouse,
 		defaults.ProtocolClickHouseHTTP:

--- a/lib/srv/db/snowflake_test.go
+++ b/lib/srv/db/snowflake_test.go
@@ -112,14 +112,13 @@ func TestAccessSnowflake(t *testing.T) {
 			err:          "HTTP: 401",
 		},
 		{
-			desc:         "no access to databases",
+			desc:         "database name access is not enforced",
 			user:         "alice",
 			role:         "admin",
 			allowDbNames: []string{},
 			allowDbUsers: []string{types.Wildcard},
 			dbName:       "snowflake",
 			dbUser:       "snowflake",
-			err:          "HTTP: 401",
 		},
 		{
 			desc:         "no access to users",

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -1461,8 +1461,8 @@ func formatDatabaseConnectCommand(clusterFlag string, active tlsca.RouteToDataba
 // formatDatabaseConnectArgs generates the arguments for "tsh db connect" command.
 func formatDatabaseConnectArgs(clusterFlag string, active tlsca.RouteToDatabase) (flags []string) {
 	// figure out if we need --db-user and --db-name
-	needUser := role.RequireDatabaseUserMatcher(active.Protocol)
-	needDatabase := role.RequireDatabaseNameMatcher(active.Protocol)
+	needUser := isDatabaseUserRequired(active.Protocol)
+	needDatabase := isDatabaseNameRequired(active.Protocol)
 
 	if clusterFlag != "" {
 		flags = append(flags, fmt.Sprintf("--cluster=%s", clusterFlag))

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -860,8 +860,8 @@ func (d *databaseInfo) checkAndSetDefaults(cf *CLIConf, tc *client.TeleportClien
 	// ensure the route protocol matches the db.
 	d.Protocol = db.GetProtocol()
 
-	needDBUser := d.Username == "" && role.RequireDatabaseUserMatcher(d.Protocol)
-	needDBName := d.Database == "" && role.RequireDatabaseNameMatcher(d.Protocol)
+	needDBUser := d.Username == "" && isDatabaseUserRequired(d.Protocol)
+	needDBName := d.Database == "" && isDatabaseNameRequired(d.Protocol)
 	if !needDBUser && !needDBName {
 		return nil
 	}
@@ -1146,6 +1146,26 @@ func getDefaultDBUser(db types.Database, checker services.AccessChecker) (string
 		}
 	}
 	return "", trace.BadParameter(errMsg)
+}
+
+// isDatabaseUserRequired returns whether the --db-user flag is required for
+// the db protocol.
+func isDatabaseUserRequired(protocol string) bool {
+	return role.RequireDatabaseUserMatcher(protocol)
+}
+
+// isDatabaseNameRequired returns whether the --db-name flag is required for
+// the db protocol.
+func isDatabaseNameRequired(protocol string) bool {
+	if role.RequireDatabaseNameMatcher(protocol) {
+		return true
+	}
+	switch protocol {
+	case defaults.ProtocolOracle:
+		// Always require database name for the Oracle protocol.
+		return true
+	}
+	return false
 }
 
 // getDefaultDBName enumerates the allowed database names for a given database


### PR DESCRIPTION
This PR removes db name checkers for snowflake and Oracle.

## Why

We do not intend to enforce db name RBAC for these protocols, and we do not document it.
Our docs state:
> Database names are only enforced for PostgreSQL and MongoDB databases.

Currently, we enforce RBAC checks for Snowflake and Oracle at connection time.
However we do not enforce RBAC if an already connected user switches db name.

If a user tries e.g. `tsh db connect snowflakedb --db-user=alice --db-name=prod` and they get an access denied error message about connecting to the "prod" db name, this may give a user the false impression that our docs are simply out of date; they may think they can rely on Teleport RBAC to enforce db name access control.

Snowflake: `--db-name` is the snowflake db warehouse. A user can issue `USE WAREHOUSE <some-warehouse>` command after connecting. They could, for example, do `tsh db connect snowflakedb --db-user=alice --db-name=dev`, pass RBAC checks for `dev` warehouse, and then switch to the `prod` warehouse.

Oracle: Same idea, except `--db-name` corresponds to an "Oracle RAC database":
https://github.com/gravitational/teleport/blob/f1ab6cc8a27984c6ffb0e9b123fd01844c23f8ee/lib/client/db/dbcmd/dbcmd.go#L696-L698

(oracle docs): https://docs.oracle.com/middleware/12211/bip/BIPAD/GUID-FB2AEC3B-2178-48DF-8B9F-76ED2D6B5194.htm#BIPAD289

> Oracle RAC database
> 
> To connect to an Oracle RAC database, use the following format:
> 
> jdbc:oracle:thin:@//<host>[:<port>]/<service_name>
> 
> For example: jdbc:oracle:thin:@//myhost.example.com:1521/my_service

@smallinsky I have found mixed results while investigating whether it is possible to switch services during an Oracle connection, and I'm not familiar with Oracle. Could you take a look at that to make sure? If we decide to keep the Oracle DB name matcher, then we'll need to update this PR and update our docs to say:
> Database names are only enforced for PostgreSQL, MongoDB, and Oracle databases.

~Leaving this PR in draft so we can decide on the oracle question.~