### PR TITLE
Convert `examples/teleport-usage` to use distroless image

### DIFF
--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -1,12 +1,24 @@
-FROM golang:1.21-bullseye
-WORKDIR /app
-COPY go.mod go.sum main.go /app/
-RUN go build -o teleport_usage
-FROM debian:stable-slim
-RUN apt-get -y update && \
-   apt-get install -y ca-certificates && \
-   apt-get -y clean && \
-   rm -rf /var/lib/apt/lists/*
-WORKDIR /app
-COPY --from=0 /app/teleport_usage /app/
-ENTRYPOINT ["./teleport_usage"]
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12
+
+FROM golang:1.21-bookworm as builder
+
+WORKDIR /go/src/github.com/gravitational/teleport/examples/teleport-usage
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Download and Cache dependencies before building and copying source
+# This will prevent re-downloading dependencies if they have not changed, as this
+# `run` layer will be cached
+RUN go mod download
+
+COPY main.go main.go
+
+RUN CGO_ENABLED=0 go build -o /go/bin/teleport_usage
+
+FROM $BASE_IMAGE
+WORKDIR /
+COPY --from=builder /go/bin/teleport_usage .
+
+ENTRYPOINT ["/teleport_usage"]


### PR DESCRIPTION
Standardize `examples/teleport-usage` to use the same base image and other (general) build commands as `integrations/kube-agent-updater` and `integrations/operator`.

The main change is moving from `debian:stable-slim` to `distroless/static-debian12`.