### PR TITLE
Update copy of Connect My Computer setup & misc improvements

### DIFF
--- a/web/packages/design/src/Button/Button.jsx
+++ b/web/packages/design/src/Button/Button.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { bool, string } from 'prop-types';
 
-import { space, width, height } from 'design/system';
+import { space, width, height, alignSelf } from 'design/system';
 
 const Button = ({ children, setRef, ...props }) => {
   return (
@@ -85,6 +85,7 @@ const themedStyles = props => {
     ...block(props),
     ...height(props),
     ...textTransform(props),
+    ...alignSelf(props),
   };
 };
 
@@ -217,6 +218,7 @@ Button.propTypes = {
    */
   ...space.propTypes,
   ...height.propTypes,
+  ...alignSelf.propTypes,
 };
 
 Button.defaultProps = {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -19,15 +19,13 @@ import React, { useEffect, useRef, useLayoutEffect } from 'react';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
-
 import {
   makeRootCluster,
   makeServer,
 } from 'teleterm/services/tshd/testHelpers';
-
 import { IAppContext } from 'teleterm/ui/types';
-
 import { Cluster } from 'teleterm/services/tshd/types';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 import { ConnectMyComputerContextProvider } from '../connectMyComputerContext';
 
@@ -141,9 +139,11 @@ function ShowState({
   return (
     <MockAppContextProvider appContext={appContext}>
       <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-        <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
-          <DocumentConnectMyComputerSetup />
-        </ConnectMyComputerContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
+            <DocumentConnectMyComputerSetup />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
       </MockWorkspaceContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -117,16 +117,18 @@ function ShowState({
   appContext: IAppContext;
   clickStartSetup?: boolean;
 }) {
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  if (!appContext.clustersService.state.clusters.get(cluster.uri)) {
+    appContext.clustersService.state.clusters.set(cluster.uri, cluster);
+    appContext.workspacesService.setState(draftState => {
+      draftState.rootClusterUri = cluster.uri;
+      draftState.workspaces[cluster.uri] = {
+        localClusterUri: cluster.uri,
+        documents: [],
+        location: undefined,
+        accessRequests: undefined,
+      };
+    });
+  }
 
   useLayoutEffect(() => {
     if (clickStartSetup) {
@@ -134,7 +136,7 @@ function ShowState({
         document.querySelector('[data-testid=start-setup]') as HTMLButtonElement
       )?.click();
     }
-  }, []);
+  }, [clickStartSetup]);
 
   return (
     <MockAppContextProvider appContext={appContext}>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Box, ButtonPrimary, Text } from 'design';
+import { Box, ButtonPrimary, Flex, Text } from 'design';
 import { makeEmptyAttempt, useAsync } from 'shared/hooks/useAsync';
 import { wait } from 'shared/utils/wait';
 import * as Alerts from 'design/Alert';
@@ -347,8 +347,8 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
   const { clusterName, hostname } = useAgentProperties();
 
   return (
-    <>
-      <Text mb={3}>
+    <Flex flexDirection="column" alignItems="flex-start" gap={3}>
+      <Text>
         <ClusterAndHostnameCopy clusterName={clusterName} hostname={hostname} />
       </Text>
       <ProgressBar
@@ -363,18 +363,11 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
         }))}
       />
       {hasSetupFailed && (
-        <ButtonPrimary
-          mt={3}
-          mx="auto"
-          css={`
-            display: block;
-          `}
-          onClick={runSteps}
-        >
+        <ButtonPrimary alignSelf="center" onClick={runSteps}>
           Retry
         </ButtonPrimary>
       )}
-    </>
+    </Flex>
   );
 }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -77,6 +77,8 @@ function Information(props: { onSetUpAgentClick(): void }) {
         </>
       )}
       <Text>
+        Connect My Computer allows you to add this device to the Teleport
+        cluster with just a few clicks.{' '}
         <ClusterAndHostnameCopy clusterName={clusterName} hostname={hostname} />
         <br />
         <br />
@@ -398,7 +400,7 @@ function ClusterAndHostnameCopy(props: {
 }): JSX.Element {
   return (
     <>
-      The setup process will download and launch the Teleport agent, making your
+      The setup process will download and launch a Teleport agent, making your
       computer available in the <strong>{props.clusterName}</strong> cluster as{' '}
       <strong>{props.hostname}</strong>.
     </>


### PR DESCRIPTION
While working on the docs, I realized that the setup page lacked a direct explanation of what Connect My Computer is for, so this PR adds this.

The commit that adds `alignSelf` to `Button` will be submitted as a separate PR (#32545) and backported to all supported branches. Otherwise someone could add some new UI, then backport it to v13 without realizing that `alignSelf` on buttons doesn't work there.
