### PR TITLE
provide more user friendly error when circuit breaker tripped

### DIFF
--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(nil, "breaker is tripped")
+var ErrStateTripped = trace.ConnectionProblem(nil, "Circuit Breaker is tripped. Unable to connect to Teleport Auth service.")
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(nil, "circuit breaker is tripped. unable to connect to Teleport auth service.")
+var ErrStateTripped = trace.ConnectionProblem(nil, "circuit breaker is tripped. unable to connect to api service")
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(nil, "Circuit Breaker is tripped. Unable to connect to Teleport Auth service.")
+var ErrStateTripped = trace.ConnectionProblem(nil, "circuit breaker is tripped. unable to connect to Teleport auth service.")
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(nil, "circuit breaker is tripped. unable to connect to api service")
+var ErrStateTripped = trace.ConnectionProblem(fmt.Errorf("circuit breaker is tripped. unable to connect to api service"), "Unable to reach Teleport API on Auth Service. Number of attempts has tripped circuit breaker.")
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {
@@ -329,7 +329,12 @@ func (c *CircuitBreaker) beforeExecution() (uint64, error) {
 
 	generation, state := c.currentState(now)
 
+	//temp
+
 	switch {
+	case state == StateStandby:
+		return generation, ErrStateTripped
+
 	case state == StateTripped:
 		return generation, ErrStateTripped
 	}

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(fmt.Errorf("circuit breaker is tripped. unable to connect to api service"), "Unable to reach Teleport API on Auth Service. Number of attempts has tripped circuit breaker.")
+var ErrStateTripped = trace.ConnectionProblem(fmt.Errorf("circuit breaker is tripped. unable to connect to api service"), "Unable to reach API service. Number of attempts has tripped circuit breaker.")
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -329,12 +329,7 @@ func (c *CircuitBreaker) beforeExecution() (uint64, error) {
 
 	generation, state := c.currentState(now)
 
-	//temp
-
 	switch {
-	case state == StateStandby:
-		return generation, ErrStateTripped
-
 	case state == StateTripped:
 		return generation, ErrStateTripped
 	}


### PR DESCRIPTION
A user could see this error if a Circuit Breaker is tripped. Providing a more user friendly error.

![image](https://github.com/gravitational/teleport/assets/60704961/4bb3a5fe-45fc-43d1-9a8a-ea23e704b66d)
