### PR TITLE
Add cost optimized pagination search for athena

### DIFF
--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -76,14 +76,15 @@ func TestConfig_SetFromURL(t *testing.T) {
 		},
 		{
 			name: "params to querier - part 2",
-			url:  "athena://db.tbl/?getQueryResultsInterval=200ms&limiterRefillAmount=2&&limiterRefillTime=2s&limiterBurst=3",
+			url:  "athena://db.tbl/?getQueryResultsInterval=200ms&limiterRefillAmount=2&&limiterRefillTime=2s&limiterBurst=3&disableSearchCostOptimization=true",
 			want: Config{
-				TableName:               "tbl",
-				Database:                "db",
-				GetQueryResultsInterval: 200 * time.Millisecond,
-				LimiterRefillAmount:     2,
-				LimiterRefillTime:       2 * time.Second,
-				LimiterBurst:            3,
+				TableName:                     "tbl",
+				Database:                      "db",
+				GetQueryResultsInterval:       200 * time.Millisecond,
+				LimiterRefillAmount:           2,
+				LimiterRefillTime:             2 * time.Second,
+				LimiterBurst:                  3,
+				DisableSearchCostOptimization: true,
 			},
 		},
 		{

--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -17,6 +17,7 @@ package athena
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -38,189 +39,323 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func Test_querier_prepareQuery(t *testing.T) {
+func TestSearchEvents(t *testing.T) {
+	toDateParam := func(in time.Time) string {
+		return fmt.Sprintf("'%s'", in.Format(time.DateOnly))
+	}
+
+	toAthenaTimestampParam := func(in time.Time) string {
+		return fmt.Sprintf("timestamp '%s'", in.Format(athenaTimestampFormat))
+	}
+
 	const (
 		tablename        = "test_table"
 		selectFromPrefix = `SELECT DISTINCT uid, event_time, event_data FROM test_table`
 		whereTimeRange   = ` WHERE event_date BETWEEN date(?) AND date(?) AND event_time BETWEEN ? and ?`
 	)
-	fromTimeUTC := time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC)
-	toTimeUTC := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
-	fromDateParam := "'2023-02-01'"
-	fromTimestampParam := "timestamp '2023-02-01 00:00:00'"
-	toDateParam := "'2023-06-01'"
-	toTimestampParam := "timestamp '2023-06-01 00:00:00'"
-	timeRangeParams := []string{fromDateParam, toDateParam, fromTimestampParam, toTimestampParam}
 
-	keysetTimeUTC := time.Date(2023, 2, 15, 0, 0, 0, 0, time.UTC)
-	keysetDateParam := "'2023-02-15'"
-	keysetTimestampParam := "timestamp '2023-02-15 00:00:00'"
+	fromUTC := time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC)
+	toUTC := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
 
-	keySetFrom9762a4fe := &keyset{
-		t:   keysetTimeUTC,
-		uid: uuid.MustParse("9762a4fe-ac4b-47b5-ba4f-5f70d065849a"),
+	uuidUsedInKeyset := "9762a4fe-ac4b-47b5-ba4f-5f70d065849a"
+	keysetNearTo := &keyset{
+		t:   toUTC.Add(-15 * time.Minute),
+		uid: uuid.MustParse(uuidUsedInKeyset),
+	}
+	keysetNearFrom := &keyset{
+		t:   fromUTC.Add(15 * time.Minute),
+		uid: uuid.MustParse(uuidUsedInKeyset),
 	}
 
+	dynamoKeysetTimestamp := time.Date(2023, 4, 27, 8, 22, 58, 0, time.UTC)
+
+	timeRangeParams := []string{toDateParam(fromUTC), toDateParam(toUTC), toAthenaTimestampParam(fromUTC), toAthenaTimestampParam(toUTC)}
+
+	sliceOfDummyEvents := func(noOfEvents int) []apievents.AuditEvent {
+		out := make([]apievents.AuditEvent, 0, noOfEvents)
+		for i := 0; i < noOfEvents; i++ {
+			out = append(out, &apievents.AppCreate{
+				Metadata: apievents.Metadata{
+					ID:   uuid.NewString(),
+					Time: time.Now().UTC(),
+					Type: events.AppCreateEvent,
+				},
+				AppMetadata: apievents.AppMetadata{
+					AppName: "app-1",
+				},
+			})
+		}
+		return out
+	}
+
+	singleCallResults := func(noOfEvents int) [][]apievents.AuditEvent {
+		return [][]apievents.AuditEvent{sliceOfDummyEvents(noOfEvents)}
+	}
+
+	wantCallsToAthena := func(t *testing.T, mock *mockAthenaExecutor, want int) {
+		require.Equal(t, want, len(mock.startQueryReqs))
+	}
+	wantSingleCallToAthena := func(t *testing.T, mock *mockAthenaExecutor) {
+		wantCallsToAthena(t, mock, 1)
+	}
+	wantQuery := func(t *testing.T, mock *mockAthenaExecutor, want string) {
+		require.Empty(t, cmp.Diff(want, aws.ToString(mock.startQueryReqs[0].QueryString)), "query")
+	}
+	wantQueryParamsInCallNo := func(t *testing.T, mock *mockAthenaExecutor, call int, want ...string) {
+		require.Empty(t, cmp.Diff(want, mock.startQueryReqs[call].ExecutionParameters), "params")
+	}
+	wantQueryParams := func(t *testing.T, mock *mockAthenaExecutor, want ...string) {
+		wantQueryParamsInCallNo(t, mock, 0, want...)
+	}
 	tests := []struct {
-		name         string
-		searchParams searchParams
-		wantQuery    string
-		wantParams   []string
-		wantErr      string
+		name                string
+		searchParams        *events.SearchEventsRequest
+		searchSessionParams *events.SearchSessionEventsRequest
+		queryResultsResps   [][]apievents.AuditEvent
+		wantErr             string
+		check               func(t *testing.T, m *mockAthenaExecutor, paginationKey string)
 	}{
 		{
 			name: "query on time range",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				limit:     100,
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:  fromUTC,
+				To:    toUTC,
+				Limit: 100,
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` ORDER BY event_time ASC, uid ASC LIMIT 100;`,
-			wantParams: timeRangeParams,
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock, timeRangeParams...)
+			},
 		},
 		{
 			name: "query on time range order DESC",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				limit:     100,
-				order:     types.EventOrderDescending,
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:  fromUTC,
+				To:    toUTC,
+				Limit: 100,
+				Order: types.EventOrderDescending,
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` ORDER BY event_time DESC, uid DESC LIMIT 100;`,
-			wantParams: timeRangeParams,
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` ORDER BY event_time DESC, uid DESC LIMIT 100;`)
+				wantQueryParams(t, mock, timeRangeParams...)
+			},
 		},
 		{
 			name: "query with event types",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				filter:    searchEventsFilter{eventTypes: []string{"app.create", "app.delete"}},
-				limit:     100,
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:       fromUTC,
+				To:         toUTC,
+				Limit:      100,
+				EventTypes: []string{"app.create", "app.delete"},
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND event_type IN (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`,
-			wantParams: append(timeRangeParams, "'app.create'", "'app.delete'"),
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND event_type IN (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock, append(timeRangeParams, "'app.create'", "'app.delete'")...)
+			},
 		},
 		{
 			name: "session id",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				sessionID: "9762a4fe-ac4b-47b5-ba4f-5f70d065849a",
-				limit:     100,
-				tablename: tablename,
+			searchSessionParams: &events.SearchSessionEventsRequest{
+				From:      fromUTC,
+				To:        toUTC,
+				SessionID: "9762a4fe-ac4b-47b5-ba4f-5f70d065849a",
+				Limit:     100,
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND session_id = ? ORDER BY event_time ASC, uid ASC LIMIT 100;`,
-			wantParams: append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'"),
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND session_id = ? AND event_type IN (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock, append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", "'session.end'", "'windows.desktop.session.end'")...)
+			},
 		},
 		{
 			name: "query on time range with keyset",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				limit:     100,
-				startKey:  keySetFrom9762a4fe.ToKey(),
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:  fromUTC,
+				To:    toUTC,
+				Limit: 100,
+				// keyset with timestamp near original 'To' value is used to
+				// test case when we are close to end of time range (no cost optimiation).
+				StartKey: keysetNearTo.ToKey(),
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND (event_time, uid) > (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`,
-			wantParams: []string{
-				// in ASC order and valid value in keyset, instead of from, use value from ketset.
-				keysetDateParam, toDateParam, // event_date BETWEEN date(?) AND date(?)
-				keysetTimestampParam, toTimestampParam, // event_time BETWEEN ? and ?`
-				keysetTimestampParam, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", //  AND (event_time, uid) > (?,?)
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND (event_time, uid) > (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock,
+					// in ASC order and valid value in keyset, instead of from, use value from keyset.
+					toDateParam(keysetNearTo.t), toDateParam(toUTC), // event_date BETWEEN date(?) AND date(?)
+					toAthenaTimestampParam(keysetNearTo.t), toAthenaTimestampParam(toUTC), // event_time BETWEEN ? and ?`
+					toAthenaTimestampParam(keysetNearTo.t), "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", //  AND (event_time, uid) > (?,?))
+				)
 			},
 		},
 		{
 			name: "query on time range DESC with keyset",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				limit:     100,
-				order:     types.EventOrderDescending,
-				startKey:  keySetFrom9762a4fe.ToKey(),
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:  fromUTC,
+				To:    toUTC,
+				Limit: 100,
+				Order: types.EventOrderDescending,
+				// keyset with timestamp near original 'From' value is used to
+				// test case when we are close to end of time range (no cost optimiation).
+				StartKey: keysetNearFrom.ToKey(),
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND (event_time, uid) < (?,?) ORDER BY event_time DESC, uid DESC LIMIT 100;`,
-			wantParams: []string{
-				// in DESC order and valid value in keyset, instead of from, use value from ketset.
-				fromDateParam, keysetDateParam, // event_date BETWEEN date(?) AND date(?)
-				fromTimestampParam, keysetTimestampParam, // event_time BETWEEN ? and ?`
-				keysetTimestampParam, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", // AND (event_time, uid) < (?,?)
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND (event_time, uid) < (?,?) ORDER BY event_time DESC, uid DESC LIMIT 100;`)
+				wantQueryParams(t, mock,
+					// in DESC order and valid value in keyset, instead of from, use value from keyset.
+					toDateParam(fromUTC), toDateParam(keysetNearFrom.t), // event_date BETWEEN date(?) AND date(?)
+					toAthenaTimestampParam(fromUTC), toAthenaTimestampParam(keysetNearFrom.t), // event_time BETWEEN ? and ?`
+					toAthenaTimestampParam(keysetNearFrom.t), "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", // AND (event_time, uid) < (?,?)
+				)
 			},
 		},
 		{
 			name: "query on time range with keyset from dynamo",
-			searchParams: searchParams{
-				fromUTC: fromTimeUTC,
-				toUTC:   toTimeUTC,
-				limit:   100,
-				order:   types.EventOrderAscending,
+			searchParams: &events.SearchEventsRequest{
+				From: fromUTC,
+				// To is set here as value from keyset +5h to test case
+				// when cost optimized search should not be used.
+				To:    dynamoKeysetTimestamp.Add(5 * time.Hour),
+				Limit: 100,
+				Order: types.EventOrderAscending,
 				// startKey generated by dynamo which points to Apr 27 2023 08:22:58 UTC
-				startKey:  `{"date":"2023-04-27","iterator":{"CreatedAt":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"1682583778","NS":null,"NULL":null,"S":null,"SS":null},"CreatedAtDate":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"2023-04-27","SS":null},"EventIndex":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"0","NS":null,"NULL":null,"S":null,"SS":null},"SessionID":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"4bc51fd7-4f0c-47ee-b9a5-da621fbdbabb","SS":null}}}`,
-				tablename: tablename,
+				StartKey: `{"date":"2023-04-27","iterator":{"CreatedAt":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"1682583778","NS":null,"NULL":null,"S":null,"SS":null},"CreatedAtDate":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"2023-04-27","SS":null},"EventIndex":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"0","NS":null,"NULL":null,"S":null,"SS":null},"SessionID":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"4bc51fd7-4f0c-47ee-b9a5-da621fbdbabb","SS":null}}}`,
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND (event_time, uid) > (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`,
-			wantParams: []string{
-				// in ASC order and valid value in keyset, instead of from, use value from ketset.
-				"'2023-04-27'", toDateParam, // event_date BETWEEN date(?) AND date(?)
-				`timestamp '2023-04-27 08:22:58'`, toTimestampParam, // event_time BETWEEN ? and ?`
-				`timestamp '2023-04-27 08:22:58'`, "'00000000-0000-0000-0000-000000000000'", // AND (event_time, uid) > (?,?)
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				dynamoKeysetTimestamp := time.Date(2023, 4, 27, 8, 22, 58, 0, time.UTC)
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND (event_time, uid) > (?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock,
+					// in ASC order and valid value in keyset, instead of from, use value from ketset.
+					toDateParam(dynamoKeysetTimestamp), toDateParam(dynamoKeysetTimestamp.Add(5*time.Hour)), // event_date BETWEEN date(?) AND date(?)
+					toAthenaTimestampParam(dynamoKeysetTimestamp), toAthenaTimestampParam(dynamoKeysetTimestamp.Add(5*time.Hour)), // event_time BETWEEN ? and ?`
+					toAthenaTimestampParam(dynamoKeysetTimestamp), "'00000000-0000-0000-0000-000000000000'", // AND (event_time, uid) > (?,?)
+				)
 			},
 		},
 		{
 			name: "query on time range with keyset from dynamo and desc order",
-			searchParams: searchParams{
-				fromUTC: fromTimeUTC,
-				toUTC:   toTimeUTC,
-				limit:   100,
-				order:   types.EventOrderDescending,
+			searchParams: &events.SearchEventsRequest{
+				// To is set here as value from keyset -5h to test case
+				// when cost optimized search should not be used.
+				From:  dynamoKeysetTimestamp.Add(-5 * time.Hour),
+				To:    toUTC,
+				Limit: 100,
+				Order: types.EventOrderDescending,
 				// startKey generated by dynamo which points to Apr 27 2023 08:22:58 UTC
-				startKey:  `{"date":"2023-04-27","iterator":{"CreatedAt":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"1682583778","NS":null,"NULL":null,"S":null,"SS":null},"CreatedAtDate":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"2023-04-27","SS":null},"EventIndex":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"0","NS":null,"NULL":null,"S":null,"SS":null},"SessionID":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"4bc51fd7-4f0c-47ee-b9a5-da621fbdbabb","SS":null}}}`,
-				tablename: tablename,
+				StartKey: `{"date":"2023-04-27","iterator":{"CreatedAt":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"1682583778","NS":null,"NULL":null,"S":null,"SS":null},"CreatedAtDate":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"2023-04-27","SS":null},"EventIndex":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":"0","NS":null,"NULL":null,"S":null,"SS":null},"SessionID":{"B":null,"BOOL":null,"BS":null,"L":null,"M":null,"N":null,"NS":null,"NULL":null,"S":"4bc51fd7-4f0c-47ee-b9a5-da621fbdbabb","SS":null}}}`,
 			},
-			wantQuery: selectFromPrefix + whereTimeRange +
-				` AND (event_time, uid) < (?,?) ORDER BY event_time DESC, uid DESC LIMIT 100;`,
-			wantParams: []string{
-				// in DESC order and valid value in keyset, instead of from, use value from ketset.
-				fromDateParam, "'2023-04-27'", // event_date BETWEEN date(?) AND date(?)
-				fromTimestampParam, `timestamp '2023-04-27 08:22:58'`, // event_time BETWEEN ? and ?`
-				`timestamp '2023-04-27 08:22:58'`, "'ffffffff-ffff-ffff-ffff-ffffffffffff'", // AND (event_time, uid) < (?,?)
+			queryResultsResps: singleCallResults(100),
+			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
+				dynamoKeysetTimestamp := time.Date(2023, 4, 27, 8, 22, 58, 0, time.UTC)
+				wantSingleCallToAthena(t, mock)
+				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
+					` AND (event_time, uid) < (?,?) ORDER BY event_time DESC, uid DESC LIMIT 100;`)
+				wantQueryParams(t, mock,
+					// in DESC order and valid value in keyset, instead of from, use value from ketset.
+					toDateParam(dynamoKeysetTimestamp.Add(-5*time.Hour)), toDateParam(dynamoKeysetTimestamp), // event_date BETWEEN date(?) AND date(?)
+					toAthenaTimestampParam(dynamoKeysetTimestamp.Add(-5*time.Hour)), toAthenaTimestampParam(dynamoKeysetTimestamp), // event_time BETWEEN ? and ?`
+					toAthenaTimestampParam(dynamoKeysetTimestamp), "'ffffffff-ffff-ffff-ffff-ffffffffffff'", // AND (event_time, uid) < (?,?)
+				)
 			},
 		},
 		{
 			name: "invalid keyset",
-			searchParams: searchParams{
-				fromUTC:   fromTimeUTC,
-				toUTC:     toTimeUTC,
-				limit:     100,
-				order:     types.EventOrderDescending,
-				startKey:  "invalid-keyset",
-				tablename: tablename,
+			searchParams: &events.SearchEventsRequest{
+				From:     fromUTC,
+				To:       toUTC,
+				Limit:    100,
+				Order:    types.EventOrderDescending,
+				StartKey: "invalid-keyset",
 			},
 			wantErr: "unsupported keyset format",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotQuery, gotParams, err := prepareQuery(tt.searchParams)
+			mock := &mockAthenaExecutor{
+				getQueryResults: tt.queryResultsResps,
+			}
+			q := querier{
+				athenaClient: mock,
+				querierConfig: querierConfig{
+					tablename: tablename,
+					clock:     clockwork.NewRealClock(),
+					logger:    utils.NewLoggerForTests(),
+					tracer:    tracing.NoopTracer(teleport.ComponentAthena),
+					// Use something > 0, to avoid default 600ms delay.
+					getQueryResultsInitialDelay: 1 * time.Microsecond,
+				},
+			}
+			var err error
+			var paginationKey string
+			if tt.searchParams != nil {
+				_, paginationKey, err = q.SearchEvents(context.Background(), *tt.searchParams)
+			} else {
+				_, paginationKey, err = q.SearchSessionEvents(context.Background(), *tt.searchSessionParams)
+			}
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(gotQuery, tt.wantQuery), "query")
-				require.Empty(t, cmp.Diff(gotParams, tt.wantParams), "params")
+			}
+			if tt.check != nil {
+				tt.check(t, mock, paginationKey)
 			}
 		})
 	}
+}
+
+type mockAthenaExecutor struct {
+	startQueryReqs []*athena.StartQueryExecutionInput
+
+	// getQueryResults defines slice of responses returned in each consecutive call.
+	getQueryResults [][]apievents.AuditEvent
+	getQueryCall    int
+}
+
+func (m *mockAthenaExecutor) StartQueryExecution(ctx context.Context, params *athena.StartQueryExecutionInput, optFns ...func(*athena.Options)) (*athena.StartQueryExecutionOutput, error) {
+	m.startQueryReqs = append(m.startQueryReqs, params)
+	return &athena.StartQueryExecutionOutput{QueryExecutionId: aws.String(uuid.NewString())}, nil
+}
+
+func (m *mockAthenaExecutor) GetQueryExecution(ctx context.Context, params *athena.GetQueryExecutionInput, optFns ...func(*athena.Options)) (*athena.GetQueryExecutionOutput, error) {
+	return &athena.GetQueryExecutionOutput{QueryExecution: &athenaTypes.QueryExecution{Status: &athenaTypes.QueryExecutionStatus{State: athenaTypes.QueryExecutionStateSucceeded}}}, nil
+}
+
+func (m *mockAthenaExecutor) GetQueryResults(ctx context.Context, params *athena.GetQueryResultsInput, optFns ...func(*athena.Options)) (*athena.GetQueryResultsOutput, error) {
+	callNo := m.getQueryCall
+	m.getQueryCall++
+	if len(m.getQueryResults) > callNo {
+		out := []athenaTypes.Row{}
+		for _, event := range m.getQueryResults[callNo] {
+			row, err := apiEventToAthenaRow(event)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, row)
+		}
+		return &athena.GetQueryResultsOutput{ResultSet: &athenaTypes.ResultSet{Rows: out}}, nil
+	}
+	return nil, errors.New("not defined mock response")
 }
 
 func Test_keyset(t *testing.T) {
@@ -397,6 +532,26 @@ type eventsWithToken struct {
 	returnToken string
 }
 
+func apiEventToAthenaRow(event apievents.AuditEvent) (athenaTypes.Row, error) {
+	fields, err := events.ToEventFields(event)
+	if err != nil {
+		return athenaTypes.Row{}, err
+	}
+	marshaled, err := utils.FastMarshal(fields)
+	if err != nil {
+		return athenaTypes.Row{}, err
+	}
+	return athenaTypes.Row{
+		Data: []athenaTypes.Datum{
+			// The first 2 fields are ignored in our code, they are returned only because Athena requires
+			// to return parameters used in ordering.
+			{VarCharValue: aws.String("ignored")},
+			{VarCharValue: aws.String("ignored")},
+			{VarCharValue: aws.String(string(marshaled))},
+		},
+	}, nil
+}
+
 func (f *fakeAthenaResultsGetter) GetQueryResults(ctx context.Context, params *athena.GetQueryResultsInput, optFns ...func(*athena.Options)) (*athena.GetQueryResultsOutput, error) {
 	if f.resp == nil {
 		return &athena.GetQueryResultsOutput{}, nil
@@ -416,23 +571,11 @@ func (f *fakeAthenaResultsGetter) GetQueryResults(ctx context.Context, params *a
 	}
 
 	for _, event := range eventsWithToken.events {
-		fields, err := events.ToEventFields(event)
+		row, err := apiEventToAthenaRow(event)
 		if err != nil {
 			return nil, err
 		}
-		marshaled, err := utils.FastMarshal(fields)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, athenaTypes.Row{
-			Data: []athenaTypes.Datum{
-				// The first 2 fields are ignored in our code, they are returned only because Athena requires
-				// to return parameters used in ordering.
-				{VarCharValue: aws.String("ignored")},
-				{VarCharValue: aws.String("ignored")},
-				{VarCharValue: aws.String(string(marshaled))},
-			},
-		})
+		rows = append(rows, row)
 	}
 
 	f.iteration++


### PR DESCRIPTION
It's recommended to do review commit by commit:
- https://github.com/gravitational/teleport/commit/c2395a5b936afca0c2ef00e696927b271b2e539d - small refactor
- https://github.com/gravitational/teleport/commit/065ca6310903668a5345c6c35365d4a44b7c70b4 - actual implementation

This PR adds cost optimized search for athena queries when pagination key is used.

https://github.com/gravitational/teleport/pull/31810 addressed part of the main issue, it reduces the range when pagination key is close to end of range. However when we are at the begging of big time range, it still results in big scans.

This PR tries to optimize for cost, rather then execution time. 
It is implemented by manually reducing range, and if there are not enough results, range is extending up to max range.

Ex. For timerange (2023-04-01 12:00, 2023-08-01 12:00) we will do following calls:
1. (2023-04-01 12:00, 2023-04-01 13:00) - 1h increase
2. (2023-04-01 12:00, 2023-04-02 12:00) - 24h increase
3. (2023-04-01 12:00, 2023-04-08 12:00) - 24*7h increase
4. (2023-04-01 12:00, 2023-05-01 12:00) - 24*30h increase
5. (2023-04-01 12:00, 2023-08-01 12:00) - original range.
If any of steps returns enough data based on limit, we return immediately.

Event exporter if often run with limit 20 or 200, it means that it should be mostly covered by 1h increase. 

This is temporary workaround around huge scans that can be triggered by events exporter doing polling of search events API. Long term fix for it, is to build new [export API over queue](https://github.com/gravitational/cloud/blob/master/rfd/0059-new-datastore-auditlogs.md#export-flow). 
