### PR TITLE
Make hardcoded UUIDs used in test helpers less random

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -17,9 +17,9 @@
 import * as tsh from './types';
 
 export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
-  uri: '/clusters/teleport-local/servers/178ef081-259b-4aa5-a018-449b5ea7e694',
+  uri: '/clusters/teleport-local/servers/1234abcd-1234-abcd-1234-abcd1234abcd',
   tunnel: false,
-  name: '178ef081-259b-4aa5-a018-449b5ea7e694',
+  name: '1234abcd-1234-abcd-1234-abcd1234abcd',
   hostname: 'foo',
   addr: '127.0.0.1:3022',
   labelsList: [],
@@ -61,7 +61,7 @@ export const makeRootCluster = (
   connected: true,
   leaf: false,
   proxyHost: 'teleport-local:3080',
-  authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
+  authClusterId: 'fefe3434-fefe-3434-fefe-3434fefe3434',
   loggedInUser: makeLoggedInUser(),
   proxyVersion: '1.0.0',
   ...props,


### PR DESCRIPTION
Connect My Computer in Connect 14.0.0 is hidden behind a feature flag. It doesn't have all feature working yet, but you can generally enable the feature flag and test some of them.

While testing compatibility warnings, which are visible only in a packaged version of the app, I'd enable the flag and then wonder why the Connect button isn't working. It'd fail with:

```
ERROR: failed connecting to host 178ef081-259b-4aa5-a018-449b5ea7e694:0: failed to receive cluster details response
failed to dial target host
unable to locate node matching UUID-like target 178ef081-259b-4aa5-a018-449b5ea7e694
```

That's because that version of Connect My Computer [hardcodes the node that is returned from `waitForNodeToJoin`](
https://github.com/gravitational/teleport/blob/v14.0.0/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts#L84-L93) – this RPC simply wasn't implemented back then. However, the UUID for that node looks just like a regular UUID, so I'd already investigate this problem twice only to realize what's wrong a couple of minutes later.

This PR changes the UUIDs in the test helpers to be less random so that if we ever do something like this in the future, it'll be more clear that some hardcoded test data ended up in the wrong place.
