### PR TITLE
Simplify `LockTarget.IsEmpty` implementation

### DIFF
--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -218,11 +218,6 @@ func (c *LockV2) CheckAndSetDefaults() error {
 	return nil
 }
 
-// IsEmpty returns true if none of the target's fields is set.
-func (t LockTarget) IsEmpty() bool {
-	return protoKnownFieldsEqual(&t, &LockTarget{})
-}
-
 // IntoMap returns the target attributes in the form of a map.
 func (t LockTarget) IntoMap() (map[string]string, error) {
 	m := map[string]string{}
@@ -235,6 +230,19 @@ func (t LockTarget) IntoMap() (map[string]string, error) {
 // FromMap copies values from a map into this LockTarget.
 func (t *LockTarget) FromMap(m map[string]string) error {
 	return trace.Wrap(utils.ObjectToStruct(m, t))
+}
+
+// IsEmpty returns true if none of the target's fields is set.
+func (t LockTarget) IsEmpty() bool {
+	return t.User == "" &&
+		t.Role == "" &&
+		t.Login == "" &&
+		t.Node == "" &&
+		t.MFADevice == "" &&
+		t.WindowsDesktop == "" &&
+		t.AccessRequest == "" &&
+		t.Device == "" &&
+		t.ServerID == ""
 }
 
 // Match returns true if the lock's target is matched by this target.


### PR DESCRIPTION
```go
func BenchmarkAccessRequestLockTarget(b *testing.B) {
	for n := 0; n < b.N; n++ {
		lt := LockTarget{
			AccessRequest: "12345678-1234-1234-1234-123456789012",
		}
		require.False(b, lt.IsEmpty())
	}
}
```

```
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/api/types
BenchmarkAccessRequestLockTarget-10                    5452818               206.5 ns/op             0 B/op          0 allocs/op
BenchmarkAccessRequestLockTargetCmpEqual-10             440600              2591 ns/op            2256 B/op         43 allocs/op
```