### PR TITLE
Enforce optimistic locking for user resources 

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -651,6 +651,11 @@ func testRoleRefreshWithBogusRequestID(t *testing.T, testPack *accessRequestTest
 	err = auth.UpsertUser(user)
 	require.NoError(t, err)
 
+	// Get user to obtain the revision since the user isn't returned
+	// from the create call above.
+	user, err = auth.GetUser(user.GetName(), false)
+	require.NoError(t, err)
+
 	// Create a client with the old set of roles.
 	clt, err := testPack.tlsServer.NewClient(TestUser(username))
 	require.NoError(t, err)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -802,6 +802,8 @@ func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
 	require.Nil(t, s.mockEmitter.LastEvent())
 
 	// test update user
+	user, err = s.a.GetUser(user.GetName(), false)
+	require.NoError(t, err)
 	err = s.a.UpdateUser(ctx, user)
 	require.NoError(t, err)
 	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserUpdatedEvent)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -274,6 +274,11 @@ func TestSSOUserCanReissueCert(t *testing.T) {
 	user.SetCreatedBy(types.CreatedBy{
 		Connector: &types.ConnectorRef{Type: "oidc", ID: "google"},
 	})
+
+	// Get the user to retrieve the revision.
+	user, err = srv.Auth().GetUser(user.GetName(), false)
+	require.NoError(t, err)
+
 	err = srv.Auth().UpdateUser(ctx, user)
 	require.NoError(t, err)
 

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -826,6 +826,7 @@ func (a *Server) createGithubUser(ctx context.Context, p *CreateUserParams, dryR
 				existingUser.GetName())
 		}
 
+		user.SetRevision(existingUser.GetRevision())
 		if err := a.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1791,6 +1791,10 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update some traits and roles.
+
+	newUser, err = clt.GetUser(newUser.GetName(), false)
+	require.NoError(t, err)
+
 	newRoleName := "new-role"
 	newUser.SetLogins([]string{"apple", "banana"})
 	newUser.SetDatabaseUsers([]string{"llama", "alpaca"})

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -822,7 +822,7 @@ func (l *Backend) ConditionalUpdate(ctx context.Context, i backend.Item) (*backe
 			}
 			defer stmt.Close()
 
-			if _, err := stmt.ExecContext(ctx, types.OpPut, now, string(i.Key), id(now), expires(i.Expires), i.Value, i.Revision); err != nil {
+			if _, err := stmt.ExecContext(ctx, types.OpPut, now, string(i.Key), id(now), expires(i.Expires), i.Value, rev); err != nil {
 				return trace.Wrap(err)
 			}
 		}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -463,7 +463,7 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client auth.ClientI, 
 		// Unmarshalling user sets createdBy to zero values which will overwrite existing data.
 		// This field should not be allowed to be overwritten.
 		user.SetCreatedBy(existingUser.GetCreatedBy())
-
+		user.SetRevision(existingUser.GetRevision())
 		if err := client.UpdateUser(ctx, user); err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
This also ensures that SSO users created by the GitHub connector are setting the revision if the user already existed.

Contributes to https://github.com/gravitational/teleport/issues/30416
Depends on https://github.com/gravitational/teleport.e/pull/2304