### PR TITLE
Cleanup and simplify MFA test helpers

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2423,7 +2423,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	authServer.emitter = mockEmitter
+	authServer.SetEmitter(mockEmitter)
 	clock := authServer.GetClock()
 	ctx := context.Background()
 

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -250,27 +250,29 @@ func TestServer_ChangePassword(t *testing.T) {
 func TestChangeUserAuthentication(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestTLSServer(t)
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+	clock := testServer.Clock()
 	ctx := context.Background()
 
 	tests := []struct {
 		name              string
-		setAuthPreference func()
-		getReq            func(string) *proto.ChangeUserAuthenticationRequest
-		getInvalidReq     func(string) *proto.ChangeUserAuthenticationRequest
+		setAuthPreference func(t *testing.T)
+		getReq            func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest
+		getInvalidReq     func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest
 	}{
 		{
 			name: "with second factor off and password only",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorOff,
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
 					NewPassword: []byte("password1"),
@@ -279,47 +281,47 @@ func TestChangeUserAuthentication(t *testing.T) {
 		},
 		{
 			name: "with second factor otp",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorOTP,
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
-				res, err := srv.Auth().CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+				registerChal, err := authServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
 					TokenID:    resetTokenID,
 					DeviceType: proto.DeviceType_DEVICE_TYPE_TOTP,
 				})
-				require.NoError(t, err)
+				require.NoError(t, err, "CreateRegisterChallenge")
 
-				otpToken, err := totp.GenerateCode(res.GetTOTP().GetSecret(), srv.Clock().Now())
-				require.NoError(t, err)
+				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal, WithTestDeviceClock(clock))
+				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.ChangeUserAuthenticationRequest{
-					TokenID:     resetTokenID,
-					NewPassword: []byte("password2"),
-					NewMFARegisterResponse: &proto.MFARegisterResponse{Response: &proto.MFARegisterResponse_TOTP{
-						TOTP: &proto.TOTPRegisterResponse{Code: otpToken},
-					}},
+					TokenID:                resetTokenID,
+					NewPassword:            []byte("password2"),
+					NewMFARegisterResponse: registerSolved,
 				}
 			},
 			// Invalid MFA fields when auth settings set to only otp.
-			getInvalidReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
 					NewPassword: []byte("password2"),
-					NewMFARegisterResponse: &proto.MFARegisterResponse{Response: &proto.MFARegisterResponse_Webauthn{
-						Webauthn: &wanpb.CredentialCreationResponse{},
-					}},
+					NewMFARegisterResponse: &proto.MFARegisterResponse{
+						Response: &proto.MFARegisterResponse_Webauthn{
+							Webauthn: &wanpb.CredentialCreationResponse{},
+						},
+					},
 				}
 			},
 		},
 		{
 			name: "with second factor webauthn",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorWebauthn,
@@ -328,31 +330,40 @@ func TestChangeUserAuthentication(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
-				_, webauthnRegRes, err := getMockedWebauthnAndRegisterRes(srv.Auth(), resetTokenID, proto.DeviceUsage_DEVICE_USAGE_MFA)
-				require.NoError(t, err)
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+				registerChal, err := authServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+					TokenID:     resetTokenID,
+					DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
+				})
+				require.NoError(t, err, "CreateRegisterChallenge")
+
+				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
 					NewPassword:            []byte("password3"),
-					NewMFARegisterResponse: webauthnRegRes,
+					NewMFARegisterResponse: registerSolved,
 				}
 			},
 			// Invalid totp fields when auth settings set to only webauthn.
-			getInvalidReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
-					TokenID:                resetTokenID,
-					NewPassword:            []byte("password3"),
-					NewMFARegisterResponse: &proto.MFARegisterResponse{Response: &proto.MFARegisterResponse_TOTP{}},
+					TokenID:     resetTokenID,
+					NewPassword: []byte("password3"),
+					NewMFARegisterResponse: &proto.MFARegisterResponse{
+						Response: &proto.MFARegisterResponse_TOTP{},
+					},
 				}
 			},
 		},
 		{
 			name: "with passwordless",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorWebauthn,
@@ -361,29 +372,38 @@ func TestChangeUserAuthentication(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
-				_, webauthnRes, err := getMockedWebauthnAndRegisterRes(srv.Auth(), resetTokenID, proto.DeviceUsage_DEVICE_USAGE_PASSWORDLESS)
-				require.NoError(t, err)
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+				registerChal, err := authServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+					TokenID:     resetTokenID,
+					DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_PASSWORDLESS,
+				})
+				require.NoError(t, err, "CreateRegisterChallenge")
+
+				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal, WithPasswordless())
+				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
-					NewMFARegisterResponse: webauthnRes,
+					NewMFARegisterResponse: registerSolved,
 				}
 			},
 			// Missing webauthn for passwordless.
-			getInvalidReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
-					TokenID:                resetTokenID,
-					NewMFARegisterResponse: &proto.MFARegisterResponse{Response: &proto.MFARegisterResponse_TOTP{}},
+					TokenID: resetTokenID,
+					NewMFARegisterResponse: &proto.MFARegisterResponse{
+						Response: &proto.MFARegisterResponse_TOTP{},
+					},
 				}
 			},
 		},
 		{
 			name: "with second factor on",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorOn,
@@ -392,22 +412,29 @@ func TestChangeUserAuthentication(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
-				_, mfaResp, err := getMockedWebauthnAndRegisterRes(srv.Auth(), resetTokenID, proto.DeviceUsage_DEVICE_USAGE_MFA)
-				require.NoError(t, err)
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+				registerChal, err := authServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+					TokenID:     resetTokenID,
+					DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
+				})
+				require.NoError(t, err, "CreateRegisterChallenge")
+
+				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
 					NewPassword:            []byte("password4"),
-					NewMFARegisterResponse: mfaResp,
+					NewMFARegisterResponse: registerSolved,
 					NewDeviceName:          "new-device",
 				}
 			},
 			// Empty register response, when auth settings requires second factors.
-			getInvalidReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
 					NewPassword: []byte("password4"),
@@ -416,7 +443,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 		},
 		{
 			name: "with second factor optional and no second factor",
-			setAuthPreference: func() {
+			setAuthPreference: func(t *testing.T) {
 				authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorOptional,
@@ -425,10 +452,10 @@ func TestChangeUserAuthentication(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				err = srv.Auth().SetAuthPreference(ctx, authPreference)
+				err = authServer.SetAuthPreference(ctx, authPreference)
 				require.NoError(t, err)
 			},
-			getReq: func(resetTokenID string) *proto.ChangeUserAuthenticationRequest {
+			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
 					NewPassword: []byte("password5"),
@@ -436,39 +463,39 @@ func TestChangeUserAuthentication(t *testing.T) {
 			},
 		},
 	}
-
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
 			username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
-			_, _, err := CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+			_, _, err := CreateUserAndRole(authServer, username, []string{username}, nil)
 			require.NoError(t, err)
 
-			c.setAuthPreference()
+			c.setAuthPreference(t)
 
-			token, err := srv.Auth().CreateResetPasswordToken(ctx, CreateUserTokenRequest{
+			resetToken, err := authServer.CreateResetPasswordToken(ctx, CreateUserTokenRequest{
 				Name: username,
 			})
 			require.NoError(t, err)
+			token := resetToken.GetName()
 
 			if c.getInvalidReq != nil {
-				invalidReq := c.getInvalidReq(token.GetName())
-				_, err := srv.Auth().changeUserAuthentication(ctx, invalidReq)
+				invalidReq := c.getInvalidReq(t, token)
+				_, err := authServer.changeUserAuthentication(ctx, invalidReq)
 				require.True(t, trace.IsBadParameter(err))
 			}
 
-			validReq := c.getReq(token.GetName())
-			_, err = srv.Auth().changeUserAuthentication(ctx, validReq)
+			validReq := c.getReq(t, token)
+			_, err = authServer.changeUserAuthentication(ctx, validReq)
 			require.NoError(t, err)
 
 			// Test password is updated.
 			if len(validReq.NewPassword) != 0 {
-				err := srv.Auth().checkPasswordWOToken(username, validReq.NewPassword)
+				err := authServer.checkPasswordWOToken(username, validReq.NewPassword)
 				require.NoError(t, err)
 			}
 
 			// Test device was registered.
 			if validReq.NewMFARegisterResponse != nil {
-				devs, err := srv.Auth().Services.GetMFADevices(ctx, username, false /* without secrets*/)
+				devs, err := authServer.Services.GetMFADevices(ctx, username, false /* without secrets*/)
 				require.NoError(t, err)
 				require.Len(t, devs, 1)
 


### PR DESCRIPTION
Do the following changes:

1. Tests that care about particular MFA registration flows do so explicitly (for example, by creating privilege tokens)
2. Test that don't care about the MFA registration path use a high-level helper
3. Drop getMockedWebauthnAndRegisterRes
4. Rewrite helpers like createUserWithSecondFactors and addOneOfEachMFADevice to take advantage of TestDevice

TestDevice is the preferred mechanism to handle MFA ceremonies for testing.

This is far from ideal, but hopefully should make tests more resilient, easier to navigate and easier to "update" in large scale.

#20343