### PR TITLE
docs: Remove reference to use a load balancer

### DIFF
--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -19,8 +19,7 @@ windows_desktop_service:
     # Address of the LDAP server for secure LDAP connections.
     # Usually, this address will use port 636, like: ldap.example.com:636.
     # For best results, this address should point to a highly-available
-    # endpoint (a load balancer, VIP, or round-robin DNS) rather than
-    # a single domain controller.
+    # endpoint rather than a single domain controller.
     addr: '$LDAP_SERVER_ADDRESS'
     # Optional: the server name to use when validating the LDAP server's
     # certificate. Useful in cases where addr is an IP but the server


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/19525

> In the desktop access docs, we recommend the following:
>    ```
>    For best results, this address should point to a highly-available
>    endpoint (a load balancer, VIP, or round-robin DNS) rather than
>    a single domain controller
>  ```
> While the idea of not using the endpoint of a single DC is sound, we should probably avoid mentioning load balancers.
> 
> AWS Managed AD explicitly [recommends against](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_best_practices.html#) using LBs as they can direct traffic to a DC that is not yet ready.
> MSFT has a page on [load balancers](https://social.technet.microsoft.com/wiki/contents/articles/33547.load-balancers-and-active-directory.aspx) and generally recommends client-side load balancing