### PR TITLE
Change --auth-server to --proxy where the port is 443 or where text s…

### DIFF
--- a/docs/pages/agents/join-services-to-your-cluster/join-token.mdx
+++ b/docs/pages/agents/join-services-to-your-cluster/join-token.mdx
@@ -80,7 +80,7 @@ Run this on the new node to join the cluster:
    --roles=node \
    --token=(=presets.tokens.first=) \
    --ca-pin=(=presets.ca_pin=) \
-   --auth-server=192.0.2.0:3025
+   --proxy=192.0.2.0:3025
 
 Please note:
 
@@ -293,7 +293,7 @@ $ tctl nodes add --ttl=5m --roles=proxy
 #    --roles=proxy \
 #    --token=(=presets.tokens.first=) \
 #    --ca-pin=(=presets.ca_pin=) \
-#    --auth-server=123.123.123.123:443
+#    --proxy=123.123.123.123:443
 # 
 # Please note:
 # 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -42,12 +42,12 @@ Next, start the Database Service.
 <TabItem label="Teleport CLI">
 
 On the node where you will run the Database Service, start Teleport, pointing
-the `--auth-server` flag at the address of your Teleport Proxy Service:
+the `--proxy` flag at the address of your Teleport Proxy Service:
 
 ```code
 $ sudo teleport db start \
   --token=/tmp/token \
-  --auth-server=teleport.example.com:443 \
+  --proxy=teleport.example.com:443 \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \
@@ -56,7 +56,7 @@ $ sudo teleport db start \
 ```
 
 <Admonition type="note">
-  The `--auth-server` flag must point to the Teleport cluster's Proxy Service endpoint
+  The `--proxy` flag must point to the Teleport cluster's Proxy Service endpoint
   because the Database Service always connects back to the cluster over a reverse
   tunnel.
 </Admonition>
@@ -104,13 +104,13 @@ See the full [YAML reference](../reference/configuration.mdx) for details.
 <TabItem label="Teleport CLI">
 
 On the node where you will run the Database Service, start Teleport, pointing the
-`--auth-server` flag at the address of your Teleport Cloud tenant, e.g.,
+`--proxy` flag at the address of your Teleport Cloud tenant, e.g.,
 `mytenant.teleport.sh`.
 
 ```code
 $ sudo teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh:443 \
+  --proxy=mytenant.teleport.sh:443 \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -39,7 +39,7 @@ $ teleport db start \
 ```code
 $ teleport db start \
     --token=/path/to/token \
-    --auth-server=mytenant.teleport.sh:443 \
+    --proxy=mytenant.teleport.sh:443 \
     --name=example \
     --protocol=postgres \
     --uri=postgres.mytenant.teleport.sh:5432
@@ -53,7 +53,7 @@ $ teleport db start \
 | - | - |
 | `-d/--debug` | Enable verbose logging to stderr. |
 | `--pid-file` | Full path to the PID file. By default no PID file will be created. |
-| `--auth-server` | Address of the Teleport Proxy Service. |
+| `--proxy` | Address of the Teleport Proxy Service. |
 | `--token` | Invitation token to register with the Auth Service. |
 | `--ca-pin` | CA pin to validate the Auth Service. |
 | `-c/--config` | Path to a configuration file (default `/etc/teleport.yaml`). |

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -42,11 +42,10 @@ behind-firewall clusters refer to our
 
 ## Can individual agents create reverse tunnels to the Proxy Service without creating a new cluster?
 
-Yes. When running a Teleport agent, use the `--auth-server` flag to point to the
-Proxy Service address (this would be `public_addr` and `web_listen_addr` in your
-file configuration). For more information, see
-[Adding Nodes to the
-Cluster](./agents/join-services-to-your-cluster/join-token.mdx).
+Yes. When running a Teleport agent, use the `--proxy` flag to point to the
+Teleport Proxy Service address specified in the `public_addr` and `web_listen_addr` 
+fields in the Teleport configuratin file. For more information, see
+[Join Services with a Secure Token](./agents/join-services-to-your-cluster/join-token.mdx).
 
 ## Can Nodes use a single port for reverse tunnels?
 

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -144,7 +144,7 @@ the foreground to better understand how it works.
      --destination-dir=/opt/machine-id \
      --token=(=presets.tokens.first=) \
      --join-method=token \
-     --auth-server=example.teleport.sh:443
+     --proxy=example.teleport.sh:443
   ```
 
   </TabItem>
@@ -157,7 +157,7 @@ the foreground to better understand how it works.
      --destination-dir=/opt/machine-id \
      --token=iam-token \
      --join-method=iam \
-     --auth-server=example.teleport.sh:443
+     --proxy=example.teleport.sh:443
   ```
 
   </TabItem>

--- a/docs/pages/machine-id/guides/circleci.mdx
+++ b/docs/pages/machine-id/guides/circleci.mdx
@@ -181,7 +181,7 @@ jobs:
           command: |
             export TELEPORT_ANONYMOUS_TELEMETRY=1
             tbot start \
-              --auth-server=tele.example.com:443 \
+              --proxy=tele.example.com:443 \
               --join-method=circleci --token=circleci-demo \
               --oneshot \
               --destination-dir=./certs \

--- a/docs/pages/machine-id/guides/gitlab.mdx
+++ b/docs/pages/machine-id/guides/gitlab.mdx
@@ -140,7 +140,7 @@ deploy-job:
     - 'curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz'
     - tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     - sudo ./teleport/install
-    - 'tbot start --token=gitlab-demo --destination-dir=/tmp/tbot-user --data-dir=/tmp/tbot-data --auth-server=teleport.example.com:443 --join-method=gitlab --oneshot'
+    - 'tbot start --token=gitlab-demo --destination-dir=/tmp/tbot-user --data-dir=/tmp/tbot-data --proxy=teleport.example.com:443 --join-method=gitlab --oneshot'
     - 'tsh -i /tmp/tbot-user/identity --proxy teleport.example.com:443 ssh ci-user@my-node "echo $CI_JOB_ID >> ~/gitlab_run_log"'
 ```
 

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -175,7 +175,7 @@ First, create a basic configuration file using the following parameters:
      --join-method=token \
      --certificate-ttl=1h0m0s \
      --ca-pin=(=presets.ca_pin=) \
-     --auth-server=example.teleport.sh:443
+     --=example.teleport.sh:443
   ```
   </TabItem>
   <TabItem label="IAM method">
@@ -186,7 +186,7 @@ First, create a basic configuration file using the following parameters:
      --join-method=iam \
      --certificate-ttl=1h0m0s \
      --ca-pin=(=presets.ca_pin=) \
-     --auth-server=example.teleport.sh:443
+     --proxy=example.teleport.sh:443
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -87,9 +87,9 @@ Proxy Service TLS certificate. This is the case when:
 - The Teleport config file `proxy_server` setting is set to the Proxy Service endpoint:
   - `proxy_server: "tele.example.com:443"` or
   - `proxy_server: "tele.example.com:3080"`
-- Teleport is started with the `--auth-server` flag pointing to the Proxy Service endpoint:
-  - `teleport [app | db] start --auth-server=tele.example.com:443` or
-  - `teleport [app | db] start --auth-server=tele.example.com:3080`
+- Teleport is started with the `--proxy` flag pointing to the Proxy Service endpoint:
+  - `teleport [app | db] start --proxy=tele.example.com:443` or
+  - `teleport [app | db] start --proxy=tele.example.com:3080`
 
 Instructions for disabling TLS certificate verification depend on how you are
 running Teleport: via the `teleport` CLI, using a Helm chart, or via systemd:
@@ -178,9 +178,9 @@ To disable certificate verification use the `--insecure` flag when running `tctl
 `tctl` will determine how to connect to the Auth Service in a few ways:
 - loading configuration from a local profile after logging in with `tsh`
 - loading from a config file passed as an argument: `tctl -c /etc/teleport.yaml`
-- passing the `--auth-server` flag directly, as in:
-  - `tctl --auth-server=tele.example.com:443` or
-  - `tctl --auth-server=tele.example.com:3080`
+- passing the `--proxy` flag directly, as in:
+  - `tctl --proxy=tele.example.com:443` or
+  - `tctl --proxy=tele.example.com:3080`
 
 If any of these methods tries to connect via the Teleport Proxy Service, and the Proxy Service is using 
 self-signed certificates, then `tctl` will not trust the certificate from the Proxy Service and you will get an


### PR DESCRIPTION
…uggests the connection is to the Teleport Proxy Service.

Related to https://github.com/gravitational/teleport/issues/17845