### PR TITLE
Use cluster name from ServerIdentity for Auth multiplexer

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1950,7 +1950,7 @@ func (process *TeleportProcess) initAuthService() error {
 		Listener:            listener,
 		ID:                  teleport.Component(process.id),
 		CertAuthorityGetter: muxCAGetter,
-		LocalClusterName:    clusterName,
+		LocalClusterName:    connector.ServerIdentity.ClusterName,
 	})
 	if err != nil {
 		listener.Close()


### PR DESCRIPTION
Apply fix from https://github.com/gravitational/teleport/pull/32352 to master branch (forward port?). We don't need to remove skipping of an `ErrNonLocalCluster` error here, because it was already done before.