### PR TITLE
Start migrating `tctl edit` away from force creating resources

### DIFF
--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -59,14 +60,19 @@ func (e *EditCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	$ tctl edit rc/remote`).SetValue(&e.ref)
 }
 
-func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (bool, error) {
 	if cmd != e.cmd.FullCommand() {
 		return false, nil
 	}
 
+	err := e.editResource(ctx, client)
+	return true, trace.Wrap(err)
+}
+
+func (e *EditCommand) editResource(ctx context.Context, client auth.ClientI) error {
 	f, err := os.CreateTemp("", "teleport-resource*.yaml")
 	if err != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	defer func() {
@@ -87,20 +93,20 @@ func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 	err = rc.Get(ctx, client)
 	if closeErr := f.Close(); closeErr != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	if err != nil {
-		return true, trace.Wrap(err, "could not get resource %v: %v", rc.ref.String(), err)
+		return trace.Wrap(err, "could not get resource %v: %v", rc.ref.String(), err)
 	}
 
 	originalSum, err := checksum(f.Name())
 	if err != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	originalName, err := resourceName(f.Name())
 	if err != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	args := strings.Fields(editor())
@@ -109,37 +115,64 @@ func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr
 	if err := editorCmd.Start(); err != nil {
-		return true, trace.BadParameter("could not start editor %v: %v", editor(), err)
+		return trace.BadParameter("could not start editor %v: %v", editor(), err)
 	}
 	if err := editorCmd.Wait(); err != nil {
-		return true, trace.BadParameter("skipping resource update, editor did not complete successfully: %v", err)
+		return trace.BadParameter("skipping resource update, editor did not complete successfully: %v", err)
 	}
 
 	newSum, err := checksum(f.Name())
 	if err != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// nothing to do if the resource was not modified
 	if newSum == originalSum {
 		fmt.Println("edit canceled, no changes made")
-		return true, nil
+		return nil
 	}
 
 	newName, err := resourceName(f.Name())
 	if err != nil {
-		return true, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	if originalName != newName {
-		return true, trace.NotImplemented("renaming resources is not supported with tctl edit")
+		return trace.NotImplemented("renaming resources is not supported with tctl edit")
 	}
 
-	if err := rc.Create(ctx, client); err != nil {
-		return true, trace.Wrap(err)
+	f, err = utils.OpenFileAllowingUnsafeLinks(rc.filename)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer f.Close()
+
+	decoder := kyaml.NewYAMLOrJSONDecoder(f, defaults.LookaheadBufSize)
+	var raw services.UnknownResource
+	if err := decoder.Decode(&raw); err != nil {
+		if errors.Is(err, io.EOF) {
+			return trace.BadParameter("no resources found, empty input?")
+		}
+		return trace.Wrap(err)
 	}
 
-	return true, nil
+	// Use the UpdateHandler if the resource has one, otherwise fallback to using
+	// the CreateHandler. UpdateHandlers are preferred over CreateHandler because an update
+	// will not forcibly overwrite a resource unlike with create which requires the force
+	// flag to be set to update an existing resource.
+	updator, found := rc.UpdateHandlers[ResourceKind(raw.Kind)]
+	if found {
+		return trace.Wrap(updator(ctx, client, raw))
+	}
+
+	// TODO(tross) remove the fallback to CreateHandlers once all the resources
+	// have been updated to implement an UpdateHandler.
+	if creator, found := rc.CreateHandlers[ResourceKind(raw.Kind)]; found {
+		return trace.Wrap(creator(ctx, client, raw))
+	}
+
+	return trace.BadParameter("updating resources of type %q is not supported", raw.Kind)
+
 }
 
 // editor gets the text editor to be used for editing the resource


### PR DESCRIPTION
`tctl edit` was always performing a forceful update in the same way that `tctl create -f` was. This prevents optimistic from being enforced during the update step of the edit command and thus nullifies some of the usefulness of the feature(preventing concurrent updates to a resource).

Since not all resources support Update operations, some only support Upsert, and optimistic locking will slowly be added one resource at at time the new behavior was only implemented for user resources. The UpdateHandlers will be updated in follow up PRs when the resource has support for optimistic locking added.