### PR TITLE
[v14] Fix issue Teleport Connect Kube terminal throws internal server error

### DIFF
--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -98,6 +98,11 @@ func (k *kube) makeALPNLocalProxyForKube(cas map[string]tls.Certificate) error {
 		return trace.NewAggregate(err, listener.Close())
 	}
 
+	webProxyHost, err := utils.Host(k.cfg.WebProxyAddr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	k.localProxy, err = alpnproxy.NewLocalProxy(alpnproxy.LocalProxyConfig{
 		InsecureSkipVerify:      k.cfg.Insecure,
 		RemoteProxyAddr:         k.cfg.WebProxyAddr,
@@ -107,7 +112,7 @@ func (k *kube) makeALPNLocalProxyForKube(cas map[string]tls.Certificate) error {
 		ALPNConnUpgradeRequired: k.cfg.TLSRoutingConnUpgradeRequired,
 	},
 		alpnproxy.WithHTTPMiddleware(middleware),
-		alpnproxy.WithSNI(client.GetKubeTLSServerName(k.cfg.WebProxyAddr)),
+		alpnproxy.WithSNI(client.GetKubeTLSServerName(webProxyHost)),
 		alpnproxy.WithClusterCAs(k.closeContext, k.cfg.RootClusterCACertPoolFunc),
 	)
 	if err != nil {

--- a/lib/teleterm/gateway/kube_test.go
+++ b/lib/teleterm/gateway/kube_test.go
@@ -223,16 +223,20 @@ func mustStartMockProxyWithKubeAPI(t *testing.T, identity tlsca.Identity) *mockP
 	return m
 }
 
-func mustGenCAForProxyKubeAddr(t *testing.T, key *keys.PrivateKey, host string) (tls.Certificate, *tlsca.CertAuthority) {
+func mustGenCAForProxyKubeAddr(t *testing.T, key *keys.PrivateKey, hostAddr string) (tls.Certificate, *tlsca.CertAuthority) {
 	t.Helper()
+
+	addr, err := utils.ParseAddr(hostAddr)
+	require.NoError(t, err)
 
 	certPem, err := tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
 		Entity: pkix.Name{
 			CommonName:   "localhost",
 			Organization: []string{"Teleport"},
 		},
-		Signer:   key,
-		DNSNames: []string{client.GetKubeTLSServerName(host)}, // Use special kube SNI.
+		Signer: key,
+		// Use special kube SNI. Make sure only host (no port) is used.
+		DNSNames: []string{client.GetKubeTLSServerName(addr.Host())},
 		TTL:      defaults.CATTL,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Backport #32595 to branch/v14

Changelog: Fixed issue where Teleport Connect Kube terminal throws an internal server error