### PR TITLE
docs: remove multi level claim reference

### DIFF
--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -207,7 +207,7 @@ email: "alice@example.com"
 # Alice is a member of groups admins and devs
 groups: ["admins", "devs"]
 # She can access prod and staging environments
-access: {"env": ["prod", "staging"]}
+env: ["prod", "staging"]}
 ```
 
 Let's create a role template called `sso-users` that expects external attribute
@@ -319,7 +319,7 @@ email: "alice@example.com"
 # Alice is a member of groups admins and devs
 groups: ["admins", "devs"]
 # She can access prod and staging environments
-access: {"env": ["prod", "staging"]}
+env: ["prod", "staging"]}
 ```
 
 Let's see how these variables are used with role template `interpolation`:
@@ -343,11 +343,11 @@ spec:
     # Functions transform variables.
     database_users: ['{{email.local(external.email)}}']
     db_labels:
-      'env': '{{regexp.replace(external.access["env"], "^(staging)$", "$1")}}'
+      'env': '{{regexp.replace(external.env, "^(staging)$", "$1")}}'
 
     # Labels can mix template and hard-coded values.
     node_labels:
-      'env': '{{external.access["env"]}}'
+      'env': '{{external.env}}'
       'region': 'us-west-2'
 
     kubernetes_labels:

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -207,7 +207,7 @@ email: "alice@example.com"
 # Alice is a member of groups admins and devs
 groups: ["admins", "devs"]
 # She can access prod and staging environments
-env: ["prod", "staging"]}
+env: ["prod", "staging"]
 ```
 
 Let's create a role template called `sso-users` that expects external attribute
@@ -319,7 +319,7 @@ email: "alice@example.com"
 # Alice is a member of groups admins and devs
 groups: ["admins", "devs"]
 # She can access prod and staging environments
-env: ["prod", "staging"]}
+env: ["prod", "staging"]
 ```
 
 Let's see how these variables are used with role template `interpolation`:

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -218,7 +218,7 @@ spec:
     db_names: ['{{external.db_names}}']
     db_roles: ['{{external.db_roles}}']
     db_labels:
-      'env': '{{regexp.replace(external.access["env"], "^(staging)$", "$1")}}'
+      'env': '{{regexp.replace(external.env, "^(staging)$", "$1")}}'
 
     # app_labels: a user with this role will be allowed to connect to
     # applications with labels matching below.


### PR DESCRIPTION
Teleport currently supports only one level of traits reference.