### PR TITLE
Fix Access List Members cache and eventing.

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -615,7 +615,7 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 				return nil, trace.BadParameter("missing parameter AccessLists")
 			}
 			collections.accessListMembers = &genericCollection[*accesslist.AccessListMember, services.AccessListMembersGetter, accessListMembersExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessLists
+			collections.byKind[resourceKind] = collections.accessListMembers
 		default:
 			return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 		}

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -91,7 +91,7 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var accessList *accesslist.AccessList
+	var accessList accesslist.AccessList
 	if err := utils.FastUnmarshal(data, &accessList); err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
@@ -107,7 +107,7 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	if !cfg.Expires.IsZero() {
 		accessList.SetExpiry(cfg.Expires)
 	}
-	return accessList, nil
+	return &accessList, nil
 }
 
 // AccessListMembersGetter defines an interface for reading access list members.
@@ -161,7 +161,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var member *accesslist.AccessListMember
+	var member accesslist.AccessListMember
 	if err := utils.FastUnmarshal(data, &member); err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
@@ -177,7 +177,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	if !cfg.Expires.IsZero() {
 		member.SetExpiry(cfg.Expires)
 	}
-	return member, nil
+	return &member, nil
 }
 
 // IsAccessListOwner will return true if the user is an owner for the current list.

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1637,7 +1637,7 @@ func (p *headlessAuthenticationParser) parse(event backend.Event) (types.Resourc
 
 func newAccessListParser() *accessListParser {
 	return &accessListParser{
-		baseParser: newBaseParser(backend.Key(accessListPrefix, "")),
+		baseParser: newBaseParser(backend.ExactKey(accessListPrefix)),
 	}
 }
 
@@ -1687,7 +1687,7 @@ func (p *userLoginStateParser) parse(event backend.Event) (types.Resource, error
 
 func newAccessListMemberParser() *accessListMemberParser {
 	return &accessListMemberParser{
-		baseParser: newBaseParser(backend.Key(accessListMemberPrefix)),
+		baseParser: newBaseParser(backend.ExactKey(accessListMemberPrefix)),
 	}
 }
 

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1637,7 +1637,7 @@ func (p *headlessAuthenticationParser) parse(event backend.Event) (types.Resourc
 
 func newAccessListParser() *accessListParser {
 	return &accessListParser{
-		baseParser: newBaseParser(backend.Key(accessListPrefix)),
+		baseParser: newBaseParser(backend.Key(accessListPrefix, "")),
 	}
 }
 


### PR DESCRIPTION
Two things were happening that were shadowing the Access List members cache and eventing.

1. In the cache collections, the wrong reader was being assigned to the lookup map. The correct reader was being used elsewhere, however, so the caching tests appear to have still been working.
2. The watcher in lib/services/local/events.go apparently collapses prefixes if they overlap. Prefix `access_list_members` is encompassed by `access_list`, so the access list members prefix was eliminated from the watcher. As a result, access list member events were being processed by the access list parser, which resulted in non-critical warnings.

Local testing and dogfooding has yielded that this has had no apparent impact, at least in situations without cache propagation. However, I've got a feeling that this could affect situations with multiple auth servers.

Thanks to @jakule for finding this, as it was hidden in the debug logs and had no apparent impact on tests.