### PR TITLE
Enable FIPS mode at the OS level for AWS AMIs

### DIFF
--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -3,12 +3,12 @@
 # Update packages
 dnf -y update
 
-# Install 
+# Install
 #  - uuid used for random token generation,
 #  - python for certbot
 dnf install -y uuid python3
 
-# Install certbot 
+# Install certbot
 python3 -m venv /opt/certbot
 /opt/certbot/bin/pip install --upgrade pip
 /opt/certbot/bin/pip install certbot certbot-dns-route53
@@ -33,6 +33,8 @@ rm -rf /tmp/teleport /tmp/teleport.tar.gz
 if [[ "${TELEPORT_FIPS}" == 1 ]]; then
     # add --fips to 'teleport start' commands in FIPS mode
     sed -i -E 's_^(ExecStart=/usr/local/bin/teleport start)_\1 --fips_' /etc/systemd/system/teleport*.service
+    # https://docs.aws.amazon.com/linux/al2023/ug/fips-mode.html
+    fips-mode-setup --enable
 fi
 
 # Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)

--- a/assets/aws/files/install.sh
+++ b/assets/aws/files/install.sh
@@ -71,6 +71,10 @@ if [ -f /tmp/teleport-fips ]; then
     rm -rf /tmp/teleport.tar.gz /tmp/teleport-ent
     # add --fips to 'teleport start' commands in FIPS mode
     sed -i -E "s_ExecStart=/usr/local/bin/teleport start(.*)_ExecStart=/usr/local/bin/teleport start --fips\1_g" /etc/systemd/system/teleport*.service
+    # https://aws.amazon.com/blogs/publicsector/enabling-fips-mode-amazon-linux-2/
+    yum install -y dracut-fips
+    dracut -f
+    /sbin/grubby --update-kernel=ALL --args="fips=1"
 else
     if [[ "${TELEPORT_TYPE}" == "oss" ]]; then
         TARBALL_FILENAME="/tmp/files/teleport-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"

--- a/assets/aws/single-ami.json
+++ b/assets/aws/single-ami.json
@@ -16,7 +16,7 @@
   },
   "builders": [{
     "name": "teleport-aws-linux",
-    "ami_description": "Gravitational Teleport using AWS Linux AMI",
+    "ami_description": "Gravitational Teleport using Amazon Linux 2 AMI",
     "type": "amazon-ebs",
     "region": "{{user `aws_region`}}",
     "source_ami_filter": {
@@ -59,7 +59,7 @@
     }
   },{
     "name": "teleport-aws-linux-fips",
-    "ami_description": "Gravitational Teleport with FIPS support using AWS Linux AMI",
+    "ami_description": "Gravitational Teleport with FIPS support using Amazon Linux 2 AMI",
     "type": "amazon-ebs",
     "region": "{{user `aws_region`}}",
     "source_ami_filter": {

--- a/assets/aws/single-ami.pkr.hcl
+++ b/assets/aws/single-ami.pkr.hcl
@@ -69,7 +69,7 @@ variable "teleport_fips" {
 
 variable "teleport_tarball" {
   description = "Path to teleport tarball"
-  type = string  
+  type = string
 }
 
 variable "teleport_uid" {
@@ -103,10 +103,10 @@ data "amazon-ami" "teleport-hardened-base" {
 }
 
 locals {
-  # apply a default AMI name if no name was specified on the command line. 
+  # apply a default AMI name if no name was specified on the command line.
   unsafe_ami_name = var.ami_name != "" ? var.ami_name : "teleport-debug-ami-${var.teleport_type}-${var.teleport_version}"
 
-  # sanitise the AMI name so that its safe for use with AWS 
+  # sanitise the AMI name so that its safe for use with AWS
   ami_name = regex_replace(local.unsafe_ami_name, "[^a-zA-Z0-9\\- \\(\\).\\'[\\]@]", "-")
 
   # split the comma-separated region list out into a proper array
@@ -115,11 +115,11 @@ locals {
   ami_description = "Teleport${var.teleport_fips ? " with FIPS support" : ""} using Hardened Amazon Linux 2023 AMI"
   build_type      = "production${var.teleport_fips ? "-fips" : ""}"
 
-  # Used in AWS access policies. Do not change without consulting the teleport-prod 
+  # Used in AWS access policies. Do not change without consulting the teleport-prod
   # terraform.
   resource_purpose_tag_value = "release-ami-builder"
 
-  # We can't execute from /tmp due to CIS hardenning guidelines, so we have to 
+  # We can't execute from /tmp due to CIS hardening guidelines, so we have to
   # specify a place to run provisioning scripts
   remote_folder = "/home/ec2-user"
 }


### PR DESCRIPTION
While Teleport uses Go in FIPS mode (via boringcrypto), the underlying OS was not configured to use its own FIPS mode.

AL2: https://aws.amazon.com/blogs/publicsector/enabling-fips-mode-amazon-linux-2/
AL2023: https://docs.aws.amazon.com/linux/al2023/ug/fips-mode.html

changelog: Enable FIPS mode at the OS level for AWS AMIs