### PR TITLE
Connect: Add --debug flag, don't pass --insecure flag in dev mode by default

### DIFF
--- a/docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx
+++ b/docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx
@@ -1,0 +1,7 @@
+```code
+# Using macOS open utility:
+$ open -a "Teleport Connect" --args {{ flags }}
+
+# Running the executable directly:
+$ /Applications/Teleport\ Connect.app/Contents/MacOS/Teleport\ Connect {{ flags }}
+```

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -296,15 +296,32 @@ and follow the *Submit a Bug* link.
 <TabItem label="macOS">
 Be sure to attach logs, which can be found under `~/Library/Application Support/Teleport Connect/logs`.
 The version of the app can be found in the app menu under the About Teleport Connect menu item.
+
+To get more detailed logs, run Teleport Connect with the `--debug` flag:
+
+(!docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx flags="--debug"!)
 </TabItem>
 <TabItem label="Linux">
 Be sure to attach logs, which can be found under `~/.config/Teleport Connect/logs`. The app version
 can be found by pressing `Alt` to access the app menu, then -> Help -> About Teleport Connect.
+
+To get more detailed logs, run Teleport Connect with the `--debug` flag:
+
+```code
+$ teleport-connect --debug
+````
 </TabItem>
 <TabItem label="Windows">
 Be sure to attach logs, which can be found under `C:\Users\%UserName%\AppData\Roaming\Teleport Connect\logs`.
 You may need to adjust File Explorer to [view hidden files and folders](https://support.microsoft.com/en-us/search?query=how%20to%20view%20hidden%20files%20in%20windows%2010).
 The app version can be found by pressing `Alt` to access the app menu -> Help -> About Teleport Connect.
+
+
+To get more detailed logs, open Teleport Connect from the Command Prompt with the `--debug` flag:
+
+```code
+$ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --debug
+````
 </TabItem>
 </Tabs>
 
@@ -326,13 +343,8 @@ using this mode in production.
 To launch the app in insecure mode, open a terminal first. From there you can launch the app in one
 of two ways:
 
-```code
-# Using macOS open utility:
-$ open -a "Teleport Connect" --args --insecure
+(!docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx flags="--insecure"!)
 
-# Passing the flag to the executable directly:
-$ /Applications/Teleport\ Connect.app/Contents/MacOS/Teleport\ Connect --insecure
-```
 </TabItem>
 <TabItem label="Linux">
 From a terminal, open Teleport Connect with the `--insecure` flag:

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -46,7 +46,7 @@ const TSH_BIN_DEFAULT_PATH_FOR_DEV = path.resolve(
 const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
 
 // Allows running tsh in insecure mode (development)
-const isInsecure = dev || argv.includes('--insecure');
+const isInsecure = argv.includes('--insecure');
 
 export function getRuntimeSettings(): RuntimeSettings {
   const userDataDir = app.getPath('userData');

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -47,6 +47,7 @@ const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
 
 // Allows running tsh in insecure mode (development)
 const isInsecure = argv.includes('--insecure');
+const isDebug = argv.includes('--debug');
 
 export function getRuntimeSettings(): RuntimeSettings {
   const userDataDir = app.getPath('userData');
@@ -102,8 +103,10 @@ export function getRuntimeSettings(): RuntimeSettings {
   const appVersion = dev ? process.env.npm_package_version : app.getVersion();
 
   if (isInsecure) {
-    tshd.flags.unshift('--debug');
     tshd.flags.unshift('--insecure');
+  }
+  if (dev || isDebug) {
+    tshd.flags.unshift('--debug');
   }
 
   return {


### PR DESCRIPTION
We ran into a bug related to certs in tshd (#32595) that wasn't uncovered during development because of the --insecure flag being passed by default (see [the slack thread](https://gravitational.slack.com/archives/C03FJA391M3/p1695754002746159?thread_ts=1695743532.072489&cid=C03FJA391M3)).

Passing `--debug` used to be tied to passing `--insecure`. I added `--debug` as a separate flag because we need a way to pass --debug to tshd from a packaged app.