### PR TITLE
Fix data race in Postgres engine on connection close

### DIFF
--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgconn"
@@ -419,12 +418,11 @@ func (e *Engine) receiveFromServer(serverConn *pgconn.PgConn, serverErrCh chan<-
 	copyReader, copyWriter := io.Pipe()
 	defer copyWriter.Close()
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	closeChan := make(chan struct{})
 
 	go func() {
 		defer copyReader.Close()
-		defer wg.Done()
+		defer close(closeChan)
 
 		// server will never be used to write to server,
 		// which is why we pass io.Discard instead of e.rawServerConn
@@ -460,7 +458,7 @@ func (e *Engine) receiveFromServer(serverConn *pgconn.PgConn, serverErrCh chan<-
 		log.WithError(err).Warn("Server -> Client copy finished with unexpected error.")
 	}
 
-	wg.Wait()
+	<-closeChan
 
 	serverErrCh <- trace.Wrap(err)
 	log.Debugf("Stopped receiving from server. Transferred %v bytes.", total)


### PR DESCRIPTION
This fixes the data race noticed by a new test in another PR: https://github.com/gravitational/teleport/pull/32485. The test has since changed enough not to trigger the data race anymore, but the original formulation still triggers it often enough.
 

```
WARNING: DATA RACE
Read at 0x00c005f72880 by goroutine 7359:
  github.com/jackc/pgconn.(*PgConn).IsClosed()
      /go/pkg/mod/github.com/jackc/pgconn@v1.14.1/pgconn.go:695 +0x49d
  github.com/gravitational/teleport/lib/srv/db/postgres.(*Engine).receiveFromServer.func1()
      /__w/teleport/teleport/lib/srv/db/postgres/engine.go:436 +0x4aa

Previous write at 0x00c005f72880 by goroutine 7325:
  github.com/jackc/pgconn.(*PgConn).Close()
      /go/pkg/mod/github.com/jackc/pgconn@v1.14.1/pgconn.go:627 +0x92
  github.com/gravitational/teleport/lib/srv/db/postgres.(*Engine).HandleConnection.func2()
      /__w/teleport/teleport/lib/srv/db/postgres/engine.go:167 +0x64
  runtime.deferreturn()
      /opt/go/src/runtime/panic.go:477 +0x30
  github.com/gravitational/teleport/lib/srv/db/common.(*reportingEngine).HandleConnection()
      /__w/teleport/teleport/lib/srv/db/common/reporting.go:87 +0x21a
  github.com/gravitational/teleport/lib/srv/db.(*Server).handleConnection()
      /__w/teleport/teleport/lib/srv/db/server.go:1021 +0x764
  github.com/gravitational/teleport/lib/srv/db.(*Server).HandleConnection()
      /__w/teleport/teleport/lib/srv/db/server.go:945 +0x95a
  github.com/gravitational/teleport/lib/srv/db.(*testContext).startHandlingConnections.func1()
      /__w/teleport/teleport/lib/srv/db/access_test.go:1488 +0x4f

Goroutine 7359 (running) created at:
  github.com/gravitational/teleport/lib/srv/db/postgres.(*Engine).receiveFromServer()
      /__w/teleport/teleport/lib/srv/db/postgres/engine.go:[421](https://github.com/gravitational/teleport/actions/runs/6313772578/job/17142603054?pr=32485#step:10:425) +0x4cf
  github.com/gravitational/teleport/lib/srv/db/postgres.(*Engine).HandleConnection.func6()
      /__w/teleport/teleport/lib/srv/db/postgres/engine.go:180 +0x5d

Goroutine 7325 (running) created at:
  github.com/gravitational/teleport/lib/srv/db.(*testContext).startHandlingConnections()
      /__w/teleport/teleport/lib/srv/db/access_test.go:1488 +0x84
  github.com/gravitational/teleport/lib/srv/db.TestDatabaseServerAutoDisconnect.func4()
      /__w/teleport/teleport/lib/srv/db/server_test.go:201 +0x33
```