### PR TITLE
[v13] Fix Access List Members cache and eventing.

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -615,7 +615,7 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 				return nil, trace.BadParameter("missing parameter AccessLists")
 			}
 			collections.accessListMembers = &genericCollection[*accesslist.AccessListMember, services.AccessListMembersGetter, accessListMembersExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessLists
+			collections.byKind[resourceKind] = collections.accessListMembers
 		default:
 			return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 		}

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -86,7 +86,7 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var accessList *accesslist.AccessList
+	var accessList accesslist.AccessList
 	if err := utils.FastUnmarshal(data, &accessList); err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
@@ -99,7 +99,7 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	if !cfg.Expires.IsZero() {
 		accessList.SetExpiry(cfg.Expires)
 	}
-	return accessList, nil
+	return &accessList, nil
 }
 
 // AccessListMembersGetter defines an interface for reading access list members.
@@ -152,7 +152,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var member *accesslist.AccessListMember
+	var member accesslist.AccessListMember
 	if err := utils.FastUnmarshal(data, &member); err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
@@ -165,7 +165,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	if !cfg.Expires.IsZero() {
 		member.SetExpiry(cfg.Expires)
 	}
-	return member, nil
+	return &member, nil
 }
 
 // IsAccessListOwner will return true if the user is an owner for the current list.

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1568,7 +1568,7 @@ func (p *integrationParser) parse(event backend.Event) (types.Resource, error) {
 
 func newAccessListParser() *accessListParser {
 	return &accessListParser{
-		baseParser: newBaseParser(backend.Key(accessListPrefix)),
+		baseParser: newBaseParser(backend.ExactKey(accessListPrefix)),
 	}
 }
 
@@ -1651,7 +1651,7 @@ func (p *userLoginStateParser) parse(event backend.Event) (types.Resource, error
 
 func newAccessListMemberParser() *accessListMemberParser {
 	return &accessListMemberParser{
-		baseParser: newBaseParser(backend.Key(accessListMemberPrefix)),
+		baseParser: newBaseParser(backend.ExactKey(accessListMemberPrefix)),
 	}
 }
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/32619 to branch/v13.

Note: This backport is manual because the order of the parsers in `lib/services/local/events.go` changed due to the order in which things were backported to v13. Nothing else was changed.