### PR TITLE
Error when redundant prefixes are detected in events.

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -202,6 +202,9 @@ type Watcher interface {
 	// Close closes the watcher and releases
 	// all associated resources
 	Close() error
+
+	// Prefixes returns the prefixes that the watcher is monitoring.
+	Prefixes() [][]byte
 }
 
 // GetResult provides the result of GetRange request

--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -305,7 +305,7 @@ type BufferWatcher struct {
 // String returns user-friendly representation
 // of the buffer watcher
 func (w *BufferWatcher) String() string {
-	return fmt.Sprintf("Watcher(name=%v, prefixes=%v, capacity=%v, size=%v)", w.Name, string(bytes.Join(w.Prefixes, []byte(", "))), w.capacity, len(w.eventsC))
+	return fmt.Sprintf("Watcher(name=%v, prefixes=%v, capacity=%v, size=%v)", w.Name, string(bytes.Join(w.Watch.Prefixes, []byte(", "))), w.capacity, len(w.eventsC))
 }
 
 // Events returns events channel.  This method performs internal work and should be re-called after each event
@@ -324,6 +324,13 @@ func (w *BufferWatcher) Events() <-chan Event {
 // Done channel is closed when watcher is closed
 func (w *BufferWatcher) Done() <-chan struct{} {
 	return w.ctx.Done()
+}
+
+// Prefixes returns the prefixes that the watcher is monitoring.
+func (w *BufferWatcher) Prefixes() [][]byte {
+	prefixes := make([][]byte, len(w.Watch.Prefixes))
+	copy(prefixes, w.Watch.Prefixes)
+	return prefixes
 }
 
 // flushBacklog attempts to push any backlogged events into the
@@ -431,7 +438,7 @@ type watcherTree struct {
 
 // add adds buffer watcher to the tree
 func (t *watcherTree) add(w *BufferWatcher) {
-	for _, p := range w.Prefixes {
+	for _, p := range w.Watch.Prefixes {
 		prefix := string(p)
 		val, ok := t.Tree.Get(prefix)
 		var watchers []*BufferWatcher
@@ -449,7 +456,7 @@ func (t *watcherTree) rm(w *BufferWatcher) bool {
 		return false
 	}
 	var found bool
-	for _, p := range w.Prefixes {
+	for _, p := range w.Watch.Prefixes {
 		prefix := string(p)
 		val, ok := t.Tree.Get(prefix)
 		if !ok {

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -201,6 +201,13 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if len(prefixes) != len(w.Prefixes()) {
+		// If you've hit this error, the prefixes in two or more of your parsers probably overlap, meaning
+		// one prefix will also contain another as a subset. Look into using backend.ExactKey instead of
+		// backend.Key in your parser.
+		return nil, trace.BadParameter("redundant prefixes detected in events, which will result in event parsers not aligning with their intended prefix")
+	}
 	return newWatcher(w, e.Entry, parsers, validKinds), nil
 }
 

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
 func TestVerifyEventWatcherPrefxies(t *testing.T) {

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyEventWatcherPrefxies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		expectedPrefixes [][]byte
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name: "no overlap",
+			expectedPrefixes: [][]byte{
+				backend.Key("one"),
+				backend.Key("two"),
+				backend.Key("three"),
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "overlap",
+			expectedPrefixes: [][]byte{
+				backend.Key("one"),
+				backend.Key("oneoverlap"),
+				backend.Key("two"),
+				backend.Key("three"),
+			},
+			assertErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			mem, err := memory.New(memory.Config{})
+			require.NoError(t, err)
+
+			w, err := mem.NewWatcher(ctx, backend.Watch{
+				Name:            "test-watcher",
+				Prefixes:        test.expectedPrefixes,
+				QueueSize:       10,
+				MetricComponent: "component",
+			})
+			require.NoError(t, err)
+
+			test.assertErr(t, verifyEventWatcherPrefixes(test.expectedPrefixes, w))
+		})
+	}
+}


### PR DESCRIPTION
When creating a new events watcher, redundant prefixes will be detected and produce an error. This should prevent developer mistakes where watched prefixes overlap, causing subsets of events not to be parsed. This has been verified manually.