### PR TITLE
[v14] remove docs for deprecated `tsh proxy db` flags

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -436,9 +436,7 @@ $ tsh proxy db [<flags>] <db>
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--cert-file` | none | string | Path to the certificate file for configuring TLS on the local proxy.|
 | `--cluster` | none | string | The name of the Teleport cluster to connect to. |
-| `--key-file` | none | string | Path to the private key file for configuring TLS on the local proxy.|
 | `--db-name` | none | string | Optional database name to log in to. |
 | `--db-user` | none | string | Optional database user to log in as. |
 | `--port` | none | string | Source port used by the local proxy.|


### PR DESCRIPTION
Backport #32525 to branch/v14