### PR TITLE
App idle web handler

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -103,6 +103,12 @@ func (s *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	netCfg, err := s.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	session, err := types.NewWebSession(sessionID, types.KindAppSession, types.WebSessionSpecV2{
 		User:        req.Username,
 		Priv:        privateKey,
@@ -110,6 +116,7 @@ func (s *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 		TLSCert:     certs.TLS,
 		Expires:     s.clock.Now().Add(ttl),
 		BearerToken: bearer,
+		IdleTimeout: types.Duration(netCfg.GetWebIdleTimeout()),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"crypto/subtle"
+	"fmt"
 	"net/http"
 
 	"github.com/gravitational/trace"
@@ -91,6 +92,15 @@ func (h *Handler) handleAuth(w http.ResponseWriter, r *http.Request, p httproute
 	http.SetCookie(w, &http.Cookie{
 		Name:     SubjectCookieName,
 		Value:    subjectCookieValue,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+	})
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "__Host-grv_app_last_active",
+		Value:    fmt.Sprintf("%v", h.c.Clock.Now().UnixMilli()),
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -856,9 +856,9 @@ func (s *sessionCache) invalidateSession(ctx context.Context, sctx *SessionConte
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	if err := clt.DeleteUserAppSessions(ctx, &proto.DeleteUserAppSessionsRequest{Username: sctx.GetUser()}); err != nil {
-		return trace.Wrap(err)
-	}
+	// if err := clt.DeleteUserAppSessions(ctx, &proto.DeleteUserAppSessionsRequest{Username: sctx.GetUser()}); err != nil {
+	// 	return trace.Wrap(err)
+	// }
 	if err := s.releaseResources(sctx.GetUser(), sctx.GetSessionID()); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION

rough poc

When user authenticates, set a `third` cookie that stores the last active. With every app request, during authn, check last active. If not idle, re-set cookie with a new last active, else delete app session and clear cookies

this doesn't handle "auto logout", lets stay a user timed out, it's when user clicks around sending a request and failed that will redirect user to login.