### PR TITLE
MySQL auto-user provisioning support for Aurora and version check

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -319,7 +319,7 @@ func checkMySQLSupportedVersion(serverVersion string) error {
 	// Reference:
 	// https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-0.html#mysqld-8-0-0-account-management
 	case ver.Major < 8:
-		return trace.BadParameter("role management is not supproted for MySQL servers older than 8.0")
+		return trace.BadParameter("role management is not supported for MySQL servers older than 8.0")
 
 	default:
 		return nil

--- a/lib/srv/db/mysql/autousers_test.go
+++ b/lib/srv/db/mysql/autousers_test.go
@@ -151,3 +151,32 @@ func Test_convertActivateError(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkMySQLSupportedVersion(t *testing.T) {
+	tests := []struct {
+		input      string
+		checkError require.ErrorAssertionFunc
+	}{
+		{
+			input:      "invalid-server-version",
+			checkError: require.NoError,
+		},
+		{
+			input:      "8.0.28",
+			checkError: require.NoError,
+		},
+		{
+			input:      "9.0.0",
+			checkError: require.NoError,
+		},
+		{
+			input:      "5.7.42",
+			checkError: require.Error,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			test.checkError(t, checkMySQLSupportedVersion(test.input))
+		})
+	}
+}


### PR DESCRIPTION
Related:
- #31902

Changes:
- Added supported version check
- Changed `defaultSchema` to `teleport` to support Aurora (Unlike RDS instance, Aurora doesn't allow procedure on built-in `mysql` database)

To create admin-user `teleport-admin`:
```
CREATE DATABASE IF NOT EXISTS teleport;
CREATE USER 'teleport-admin' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
GRANT SELECT ON mysql.role_edges TO 'teleport-admin' ;
GRANT PROCESS, ROLE_ADMIN, CREATE USER ON *.* TO 'teleport-admin' ;
GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON teleport.* TO 'teleport-admin' ;
```