### PR TITLE
docs: update Teleport Team prereqs

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -16,7 +16,7 @@ up to begin your [free trial](https://goteleport.com/signup/).
 
 - The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=cloud.version=).
   
-  You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
+  You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
 
 </TabItem>
 
@@ -42,7 +42,7 @@ up to begin your [free trial](https://goteleport.com/signup/).
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
 
-  You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
+  You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,15 +1,4 @@
 <Tabs>
-<TabItem scope="team" label="Teleport Team">
-
-- A Teleport Team account. If you don't have an account, sign 
-up to begin your [free trial](https://goteleport.com/signup/).
-
-- The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=teleport.version=).
-  
-  You can download these tools by visiting your [Teleport
-  account workspace](https://teleport.sh).
-
-</TabItem>
 <TabItem scope={["oss"]} label="Teleport Community Edition">
 
 - A running Teleport cluster. For details on how to set this up, see the
@@ -19,7 +8,18 @@ up to begin your [free trial](https://goteleport.com/signup/).
 
   See [Installation](../installation.mdx) for details.
 
+</TabItem>  
+<TabItem scope="team" label="Teleport Team">
+
+- A Teleport Team account. If you don't have an account, sign 
+up to begin your [free trial](https://goteleport.com/signup/).
+
+- The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=cloud.version=).
+  
+  You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
+
 </TabItem>
+
 <TabItem
   scope={["enterprise"]} label="Teleport Enterprise">
 
@@ -41,6 +41,8 @@ up to begin your [free trial](https://goteleport.com/signup/).
   and upgrade to Teleport Enterprise Cloud. 
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
+
+  You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/no-oss-prereqs-tabs.mdx
+++ b/docs/pages/includes/no-oss-prereqs-tabs.mdx
@@ -7,7 +7,7 @@
 - The Enterprise `tctl` admin tool and `tsh` client tool version >=
   (=cloud.version=).
 
-    You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
+    You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
 
   ```code
   $ tctl version

--- a/docs/pages/includes/no-oss-prereqs-tabs.mdx
+++ b/docs/pages/includes/no-oss-prereqs-tabs.mdx
@@ -5,8 +5,9 @@
   page](https://goteleport.com/signup/) to begin your free trial.
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >=
-  (=teleport.version=), which you can download by visiting your [Teleport
-  account](https://teleport.sh).
+  (=cloud.version=).
+
+    You can download these tools from the [Cloud Downloads page](../../choose-an-edition/teleport-cloud/downloads.mdx).
 
   ```code
   $ tctl version


### PR DESCRIPTION
Teleport team should use the cloud version and downloads page.  This matches to the installation page approach.