### PR TITLE
[v14] Sort cloud label names to the back in Unified Resource cards

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -779,6 +779,10 @@ const (
 	DiscoveryLabelLDAPPrefix = "ldap/"
 )
 
+// CloudLabelPrefixes are prefixes used by cloud labels, generally added when
+// using automatic discovery
+var CloudLabelPrefixes = []string{CloudAWS, CloudAzure, CloudGCP, DiscoveryLabelLDAPPrefix}
+
 const (
 	// TeleportInternalLabelPrefix is the prefix used by all Teleport internal labels. Those labels
 	// are automatically populated by Teleport and are expected to be used by Teleport internal

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -79,7 +79,24 @@ func (s sortedLabels) Len() int {
 }
 
 func (s sortedLabels) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	labelA := strings.ToLower(s[i].Name)
+	labelB := strings.ToLower(s[j].Name)
+
+	// types.CloudLabelPrefixes are label names that we want to always be at the end of
+	// the sorted labels list to reduce visual clutter. This will generally be automatically
+	// discovered cloud provider labels such as azure/aks-managed-createOperationID=123123123123
+	for _, sortName := range types.CloudLabelPrefixes {
+		name := strings.ToLower(sortName)
+		if strings.Contains(labelA, name) && !strings.Contains(labelB, name) {
+			return false // labelA should be at the end
+		}
+		if !strings.Contains(labelA, name) && strings.Contains(labelB, name) {
+			return true // labelB should be at the end
+		}
+	}
+
+	// If neither label contains any of the sendToBackOfSortNames, sort them as usual
+	return labelA < labelB
 }
 
 func (s sortedLabels) Swap(i, j int) {


### PR DESCRIPTION
Backport #32589 to branch/v14