### PR TITLE
Expand the Access Controls reference

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -474,7 +474,7 @@ guide for a more in depth explanation of the language.
 
 Teleport provides several template variables and functions to enable more robust access control:
 
-<Details title="Internal Variables and Functions">
+### Internal Variables and Functions
 
 #### `{{email.local(variable)}}`
 
@@ -554,10 +554,8 @@ Teleport provides several template variables and functions to enable more robust
 - **Description**: List of allowed Windows logins.
 - **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
 
-</Details>
+### External Variables
 
-<Details title="External Variables"
->
 These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
 
 #### `{{external.logins}}`
@@ -624,8 +622,6 @@ These variables provide context from an Identity Provider or other external data
 - **Provider**: OIDC/SAML
 
 Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
-
-</Details>
 
 [(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
 [(2)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -480,45 +480,60 @@ Teleport provides several template variables and functions to enable more robust
 
 - **Type**: Function
 - **Description**: Extracts the local part of an email address.
-- **Example**: `{{email.local(alice@example.com)}}` -> alice
+- **Example**: `{{email.local(alice@example.com)}}` -> `alice`
+
+This function is often paired with an external variable, for example:
+`{{email.local(external.username)}}` for IdPs using email addresses as the username.
 
 #### `{{regexp.match(expression, variable)}}`
 
 - **Type**: Function
-- **Description**: Returns true if the provided string matches the specified pattern.
-- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> true for matching input
+- **Description**: Returns true if the provided string matches the specified
+  pattern.
+- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> `true`
+  for matching input.
 
 #### `{{regexp.not_match(expression, variable)}}`
 
 - **Type**: Function
-- **Description**: Returns true if the provided string does not match the specified pattern.
-- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` -> true for non-matching input
+- **Description**: Returns true if the provided string does not match the
+  specified pattern.
+- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` ->
+  `true` for non-matching input.
 
 #### `{{regexp.replace(variable, expression, replacement)}}`
 
 - **Type**: Function
-- **Description**: Finds all matches of the expression and replaces them with the replacement. Supports expansion.
-- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}` -> alice (when input is alice@example.com)
+- **Description**: Finds all matches of the expression and replaces them with
+  the replacement. Supports expansion.
+- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}`
+  -> `alice` (when input is `alice@example.com`)
 
 #### `{{internal.azure_identities}}`
 
 - **Type**: Variable
+- **Description**: Returns the Azure identities defined in Teleport available to
+  the user. Azure identities can set for a specific user or defined in a role [(1)].
+- **Example**: `{{internal.azure_identities}}` -> `"/subscriptions/0000.../.../id1"`
 
 #### `{{internal.db_names}}`
 
 - **Type**: Variable
 - **Description**: List of all allowed database names.
-- **Example**: `{{internal.db_names}}` -> ["db_name_1", "db_name_2"]
+- **Example**: `{{internal.db_names}}` -> `["db_name_1", "db_name_2"]`
 
 #### `{{internal.db_users}}`
 
 - **Type**: Variable
 - **Description**: List of all allowed database users.
-- **Example**: `{{internal.db_users}}` -> ["db_user_1", "db_user_2"]
+- **Example**: `{{internal.db_users}}` -> `["db_user_1", "db_user_2"]`
 
 #### `{{internal.gcp_service_accounts}}`
 
 - **Type**: Variable
+- **Description**: List of GCP service accounts defined in Teleport available
+  to the user.
+- **Example**: `internal.gcp_service_accounts}}` -> `"user@google-cloud-project.iam.gserviceaccount.com"`
 
 #### `{{internal.jwt}}`
 
@@ -526,33 +541,38 @@ Teleport provides several template variables and functions to enable more robust
 - **Description**: A JWT token signed by Teleport that contains user identity information.
 - **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
 
+**Note**: This variable is used when defining application access, and is not
+available when defining roles.
+
 #### `{{internal.kube_username}}`
 
 - **Type**: Variable
+- **Description**: Kubernetes usernames available to the user.
+- **Example**: `{{internal.kube_username}}` -> `["myuser", "kube-admin"]`.
 
 #### `{{internal.kubernetes_groups}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Kubernetes groups.
-- **Example**: `{{internal.kubernetes_groups}}` -> ["group1", "group2"]
+- **Example**: `{{internal.kubernetes_groups}}` -> `["group1", "group2"]`
 
 #### `{{internal.kubernetes_users}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Kubernetes users.
-- **Example**: `{{internal.kubernetes_users}}` -> ["user1", "user2"]
+- **Example**: `{{internal.kubernetes_users}}` -> `["user1", "user2"]`
 
 #### `{{internal.logins}}`
 
 - **Type**: Variable
 - **Description**: List of allowed SSH logins.
-- **Example**: `{{internal.logins}}` -> ["user1", "user2"]
+- **Example**: `{{internal.logins}}` -> `["user1", "user2"]`
 
 #### `{{internal.windows_logins}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Windows logins.
-- **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
+- **Example**: `{{internal.windows_logins}}` -> `["user1", "user2"]`
 
 ### External Variables
 
@@ -561,18 +581,22 @@ These variables provide context from an Identity Provider or other external data
 #### `{{external.logins}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.username}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.access["label"]}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.env}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.first_name}}`
 
@@ -581,12 +605,16 @@ These variables provide context from an Identity Provider or other external data
 - **Example**: `{{external.first_name}}` -> `"Alice"`
 - **Provider**: OIDC/SAML
 
+**Note**: Per OIDC specifications this value may be given as `given_name`.
+
 #### `{{external.last_name}}`
 
 - **Type**: Variable
 - **Description**: Fetches the user's last name from the SSO provider.
 - **Example**: `{{external.last_name}}` -> `"Smith"`
 - **Provider**: OIDC/SAML
+
+**Note**: Per OIDC specifications this value may be given as `family_name`.
 
 #### `{{external.email}}`
 
@@ -605,14 +633,14 @@ These variables provide context from an Identity Provider or other external data
 #### `{{external.azure_identities}}`
 
 - **Type**: Variable
-- **Description**: Fetches the user's Azure identities from the SSO provider [(1)].
+- **Description**: Fetches the user's Azure identities from the SSO provider [(2)].
 - **Example**: `{{external.azure_identities}}` -> `["identity1"]`
 - **Provider**: OIDC/SAML
 
 #### `{{external.databases}}`
 
 - **Type**: Variable
-- **Description**: Fetches the user's allowed database names from the SSO provider [(2)].
+- **Description**: Fetches the user's allowed database names from the SSO provider [(3)].
 - **Example**: `{{external.databases}}` -> `["db1", "db2"]`
 - **Provider**: OIDC/SAML
 
@@ -623,5 +651,6 @@ These variables provide context from an Identity Provider or other external data
 
 Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
 
-[(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
-[(2)]: ../../database-access/rbac/#template-variables
+[(1)]: ../../application-access/controls/#enabling-a-user-to-access-azure-managed-identities
+[(2)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
+[(3)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -13,11 +13,16 @@ A Teleport role manages access by having two lists of rules: `allow` rules and
 - Nothing is allowed by default.
 - Deny rules get evaluated first and take priority.
 
-To manage cluster roles, as well as other dynamic resources, a Teleport
-administrator can use the Web UI or a [Teleport client
-tool](../management/dynamic-resources.mdx) like `tctl`, the Teleport Terraform
-provider, or the Teleport Kubernetes operator, as well as [custom API
-clients](../api/rbac.mdx).
+You can use any of the following to manage Teleport roles and other dynamic
+resources:
+- Teleport Web UI
+- The `tctl` client tool
+- Teleport Terraform provider
+- Teleport Kubernetes operator
+- [Custom API clients](../api/rbac.mdx)
+
+To read more about managing dynamic resources, see the [Dynamic
+Resources](../management/dynamic-resources.mdx) guide.
 
 You can view all roles in your cluster on your local workstation by running the
 following commands:
@@ -396,10 +401,10 @@ Teleport does not perform variable expansion on the values of the fields above.
 ### Label expressions
 
 <Admonition type="warning">
-Label expressions are available starting in Teleport version `13.1.1`.
-All components of your Teleport cluster must be upgraded to version `13.1.1`
-or newer before you will be able to use label expressions.
-This includes the Auth Service and **all** Teleport agents.
+Label expressions are available starting in Teleport version `13.1.1`. All
+components of your Teleport cluster must be upgraded to version `13.1.1` or
+newer before you can use label expressions. This includes the Auth Service and
+**all** Teleport agents.
 </Admonition>
 
 Teleport roles support matching resource labels with predicate expressions when
@@ -425,13 +430,13 @@ spec:
       contains(user.spec.traits["teams"], labels["team"])
 ```
 
-Typically you will only want to use one of `<kind>_labels` or
+Typically, you would only use either `<kind>_labels` or
 `<kind>_labels_expression` in a single role, but you are allowed to specify
 both.
-If you have both in a deny rule, the matching is greedy, if either one matches
-access will be denied.
-In an allow rule, the matching is not greedy, if both are set they both have to
-match for access to be allowed.
+
+If you have both in a deny rule, the matching is greedy. If either expression
+matches, access is denied. In an allow rule, the matching is not greedy. If both
+expressions are set, both expressions must be matched for access to be allowed.
 
 #### Fields
 
@@ -493,7 +498,7 @@ Labels for resources enrolled with Teleport:
 - `node_labels`
 - `windows_desktop_labels`
 
-Principals a user can assume on third-party systems:
+Principals a user can assume on infrastructure resources:
 - `aws_role_arns`
 - `azure_identities`
 - `db_names`
@@ -508,15 +513,14 @@ Principals a user can assume on third-party systems:
 - `logins`
 - `windows_desktop_logins`
 
-Teleport principals that user can impersonate:
+Teleport principals that a user can impersonate:
 - `impersonate.rules`
 - `impersonate.users`
 
 #### Functions
 
 You can use the following functions in role fields that govern access to
-principals on external systems. Both functions can take a template variable
-named above as an argument:
+principals on infrastructure resources:
 
 |Function|Description|
 |---|---|
@@ -533,7 +537,7 @@ sign-on provider.
 | Variable | Description |
 | - | - |
 | `{{internal.logins}}` | Substituted with a value stored in Teleport's local user database and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the "allowed logins" parameter used in the `tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [trusted cluster](../management/admin/trustedclusters.mdx), Teleport will substitute the logins from the root cluster whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root cluster, then `ubuntu` will be substituted in the leaf cluster with this variable. |
-|`{{internal.azure_identities}}`| Returns the Azure identities defined in Teleport available to the user. Azure identities can set for a specific user or defined in a role.|
+|`{{internal.azure_identities}}`| Returns the Azure identities defined in Teleport available to the user. Azure identities can be set for a specific user or defined in a role.|
 |`{{internal.db_names}}`|List of all allowed database names for the user.|
 |`{{internal.db_users}}`|List of all allowed database users for the user.|
 |`{{internal.gcp_service_accounts}}`|List of GCP service accounts for the user.|
@@ -542,7 +546,7 @@ sign-on provider.
 |`{{internal.kubernetes_users}}`|List of allowed Kubernetes users for the user.|
 |`{{internal.logins}}`|List of allowed SSH logins for the user.|
 |`{{internal.windows_logins}}`|List of allowed Windows logins for the user.|
-| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. See the next section for more information on referring to the `external` variable in Teleport roles. |
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, the variable is expanded to the value of the "xyz" claim. See the next section for more information on referring to the `external` variable in Teleport roles. |
 
 #### Accessing external traits in Teleport roles
 
@@ -573,7 +577,7 @@ formats, where `trait` is the name of the trait:
 - **Dot syntax:** `{{external.trait}}`
 - **Bracket syntax:** `{{external["trait"]}}`
 
-Teleport will expand the template variables above with the value of the SAML
+Teleport expands the template variables above with the value of the SAML
 attribute or OIDC claim called `trait`.
 
 You can specify an external trait in dot syntax if it begins with a letter and

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -1,102 +1,46 @@
 ---
-title: Access Controls Reference Documentation
-description: This reference shows you the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
-h1: Teleport Access Controls Reference
+title: Teleport Access Controls Reference
+description: Explains the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
 tocDepth: 3
 ---
 
 This guide shows you how to use Teleport roles to manage role-based access
 controls (RBAC) in your Teleport cluster.
 
-## Roles
-
-A Teleport `role` works by having two lists of rules: `allow` rules and `deny` rules.
-When declaring access rules, keep in mind the following:
+A Teleport role manages access by having two lists of rules: `allow` rules and
+`deny` rules.  When declaring access rules, keep in mind the following:
 
 - Nothing is allowed by default.
 - Deny rules get evaluated first and take priority.
 
-A rule consists of two parts: the resources and verbs. Here's an example of an
-`allow` rule describing a `list` verb applied to the SSH `sessions` resource.  It means "allow
-users of this role to see a list of active SSH sessions".
+To manage cluster roles, as well as other dynamic resources, a Teleport
+administrator can use the Web UI or a [Teleport client
+tool](../management/dynamic-resources.mdx) like `tctl`, the Teleport Terraform
+provider, or the Teleport Kubernetes operator, as well as [custom API
+clients](../api/rbac.mdx).
 
-```yaml
-allow:
-  - resources: [session]
-    verbs: [list]
-```
-
-If this rule was declared in the `deny` section of a role definition, it would
-prohibit users from getting a list of active sessions. You can see all of the
-available resources and verbs under the `allow` section in the example role
-configuration below.
-
-To manage cluster roles, a Teleport administrator can use the Web UI or the
-command line using [tctl resource commands](../reference/resources.mdx).
-To see the list of roles in a Teleport cluster, an administrator can execute:
-
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+You can view all roles in your cluster on your local workstation by running the
+following commands:
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
-# You can also run tctl on your Auth Service host without running "tsh login"
-# first.
-$ tsh login --user=myuser --proxy=teleport.example.com
+$ tsh login --user=myuser --proxy=<Var name="mytenant.teleport.sh" />
 $ tctl get roles
 ```
-
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-
-```code
-# Log in to your cluster with tsh so you can use tctl.
-$ tsh login --user=myuser --proxy=mytenant.teleport.sh
-$ tctl get roles
-```
-
-</TabItem>
-
-</Tabs>
 
 (!docs/pages/includes/backup-warning.mdx!)
+
+## Example role specification
 
 Here is a full role specification:
 
 (!docs/pages/includes/role-spec.mdx!)
 
-The following variables can be used with `logins` and `windows_desktop_logins` fields:
+## Role options
 
-| Variable | Description |
-| - | - |
-| `{{internal.logins}}` | Substituted with a value stored in Teleport's local user database<br/>and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the<br/>"allowed logins" parameter used in the<br/>`tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [trusted cluster](../management/admin/trustedclusters.mdx),<br/>Teleport will substitute the logins from the root cluster<br/>whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root<br/>cluster, then `ubuntu` will be substituted in the leaf<br/>cluster with this variable. |
-| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on).<br/>If using SAML, this will be expanded with "xyz" assertion value.<br/>For OIDC, this will be expanded a value of "xyz" claim. |
-
-Both variables above are there to deliver the same benefit: they allow Teleport
-administrators to define allowed OS logins via the user database, be it the
-local DB, or an identity manager behind a SAML or OIDC endpoint.
-
-### An example of a SAML assertion
-
-Assuming you have the following SAML assertion attribute in your response:
-
-```
-<Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname">
-        <AttributeValue>firstname.lastname</AttributeValue>
-</Attribute>
-```
-
-... you can use the following format in your role:
-
-```
-logins:
-   - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
-```
-
-### Role options
-
-As shown above, a role can define certain restrictions on sessions initiated by users.
-The table below documents the behavior of each option if multiple roles are assigned to a user.
+A role can define certain restrictions on sessions initiated by users. The table
+below documents the behavior of each option if multiple roles are assigned to a
+user:
 
 | Option | Description | Multi-role behavior |
 | - | - | - |
@@ -158,7 +102,7 @@ Version              |  `kubernetes_resources`
 `v6` Default |  `[]`
 `v7` Default |  `[{"kind":"*", "name":"*", "namespace":"*", "verbs": ["*"]}]`
 
-## RBAC for resources
+## RBAC for infrastructure resources
 
 A Teleport role defines which resources (e.g., applications, servers, and
 databases) a user can access.
@@ -240,70 +184,27 @@ spec:
       'environment': '^test|staging$'
 ```
 
-### Label expressions
+## RBAC for dynamic Teleport resources
 
-<Admonition type="warning">
-Label expressions are available starting in Teleport version `13.1.1`.
-All components of your Teleport cluster must be upgraded to version `13.1.1`
-or newer before you will be able to use label expressions.
-This includes the Auth Service and **all** Teleport agents.
-</Admonition>
+RBAC lets teams limit what resources are available to Teleport users. This can
+be helpful if, for example, you don't want regular users editing SSO
+(`auth_connector`) or creating and editing new roles (`role`).
 
-Teleport roles also support matching resource labels with predicate expressions
-when you need to:
-
-- combine logic with OR and AND operators
-- perform matching on label keys
-- implement negative matches
-
-The following example role would allow access to any nodes labeled `env=staging`
-or labeled `team=<team>`, where `<team>` is one of the values of the user's
-`teams` trait:
+A rule for modifying RBAC resources consists of two parts: the resources and
+verbs. Here's an example of an `allow` rule describing a `list` verb applied to
+the SSH `sessions` resource.  It means "allow users of this role to see a list
+of active SSH sessions".
 
 ```yaml
-kind: role
-version: v7
-metadata:
-  name: example-role
-spec:
-  allow:
-    node_labels_expression: |
-      labels["env"] == "staging" ||
-      contains(user.spec.traits["teams"], labels["team"])
+allow:
+  - resources: [session]
+    verbs: [list]
 ```
 
-The `<kind>_labels_expression` fields have the same purpose of the
-matching `<kind>_labels` fields, but support predicate expressions instead
-of label matchers.
-They can be used in the following fields of role `spec.allow` and `spec.deny`
-conditions:
-
-- `node_labels_expression`
-- `app_labels_expression`
-- `cluster_labels_expression`
-- `kubernetes_labels_expression`
-- `db_labels_expression`
-- `db_service_labels_expression`
-- `windows_desktop_labels_expression`
-- `group_labels_expression`
-
-Check out our
-[predicate language](../reference/predicate-language.mdx#label-expressions)
-guide for a more in depth explanation of the language.
-
-Typically you will only want to use one of `<kind>_labels` or
-`<kind>_labels_expression` in a single role, but you are allowed to specify
-both.
-If you have both in a deny rule, the matching is greedy, if either one matches
-access will be denied.
-In an allow rule, the matching is not greedy, if both are set they both have to
-match for access to be allowed.
-
-## Teleport resources
-
-RBAC lets teams limit what resources are available to Teleport users. This can be helpful if, for example,
-you don't want regular users editing SSO (`auth_connector`) or creating and editing new roles
-(`role`).
+If this rule was declared in the `deny` section of a role definition, it would
+prohibit users from getting a list of active sessions. You can see all of the
+available resources and verbs under the `allow` section in the example role
+configuration below.
 
 Below is an example `allow` section that illustrates commonly used `rules`.
 Each rule includes a list of Teleport resources and the CRUD
@@ -451,14 +352,253 @@ spec:
       where: '!contains(session_tracker.participants, user.metadata.name)'
 ```
 
-## Second Factor - U2F
+## Role predicates
 
-Refer to the [Second Factor - WebAuthn](./guides/webauthn.mdx#u2f) guide if you
-have a cluster using the legacy U2F support.
+In a Teleport role resource, certain fields allow you to use functions and
+variables to configure a user's access. The functions and variables available
+for a field depend on the access controls that the field configures.
+
+### Access Request predicate functions
+
+The following variables and functions allow more fine-grained control over a
+user's permissions to submit and review Access Requests.
+
+#### Fields
+
+You can use Access Request predicate functions in the following fields. You can
+include these fields within either `allow` rules or `deny` rules:
+
+- `request.search_as_roles`
+- `request.roles`
+- `review_requests.preview_as_roles`
+- `review_requests.roles`
+- `review_requests.where`
+
+#### Functions
+
+Access Requests support the following role predicate functions:
+
+|Function|Description|
+|---|---|
+|`{{regexp.match(regexp)}}`|Returns `true` if the regular expression matches a user's role.|
+|`{{regexp.not_match(regexp)}}`|Returns `true` if the regular expression does not match a user's role.|
+
+Regular expressions support both wildcards (the `*` character) and [Go-style
+regular expressions](https://pkg.go.dev/regexp). If an expression begins with
+the `^` character and ends with the `$` character, Teleport will evaluate it as
+a regular expression. Otherwise, it will evaluate it as a wildcard expression.
+Wildcards match a sequence of one or more characters.
+
+#### Variables
+
+Teleport does not perform variable expansion on the values of the fields above.
+
+### Label expressions
+
+<Admonition type="warning">
+Label expressions are available starting in Teleport version `13.1.1`.
+All components of your Teleport cluster must be upgraded to version `13.1.1`
+or newer before you will be able to use label expressions.
+This includes the Auth Service and **all** Teleport agents.
+</Admonition>
+
+Teleport roles support matching resource labels with predicate expressions when
+you need to:
+
+- combine logic with OR and AND operators
+- perform matching on label keys
+- implement negative matches
+
+The following example role would allow access to any nodes labeled `env=staging`
+or labeled `team=<team>`, where `<team>` is one of the values of the user's
+`teams` trait:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: example-role
+spec:
+  allow:
+    node_labels_expression: |
+      labels["env"] == "staging" ||
+      contains(user.spec.traits["teams"], labels["team"])
+```
+
+Typically you will only want to use one of `<kind>_labels` or
+`<kind>_labels_expression` in a single role, but you are allowed to specify
+both.
+If you have both in a deny rule, the matching is greedy, if either one matches
+access will be denied.
+In an allow rule, the matching is not greedy, if both are set they both have to
+match for access to be allowed.
+
+#### Fields
+
+The `<kind>_labels_expression` fields have the same purpose as the matching
+`<kind>_labels` fields, but support predicate expressions instead of label
+matchers.  They can be used in the following fields of role `spec.allow` and
+`spec.deny` conditions:
+
+- `node_labels_expression`
+- `app_labels_expression`
+- `cluster_labels_expression`
+- `kubernetes_labels_expression`
+- `db_labels_expression`
+- `db_service_labels_expression`
+- `windows_desktop_labels_expression`
+- `group_labels_expression`
+
+#### Variables
+
+You can use the following template variables in label expression fields:
+
+|Variable|Type|Description|
+|---|---|---|
+|`{{user.spec.traits}}`|`map[string][]string`|All of the user's traits. Use `{{user.spec.traits<key>}}` to get a list of trait values for the specified key.|
+|`{{labels}}`|`map[string]string`|All of the user's labels. Use `{{labels.<key>}}` to get the value for the specified key.|
+
+#### Functions
+
+You can use the following functions in label expression fields:
+
+|Function|Description|
+|---|---|
+|`{{contains(list,item)}}`|Returns `true` if the list of strings in `list` contains the specified `item` and `false` otherwise.|
+|`{{regexp.match(list,regexp)}}`|Returns `true` if the regular expression in `regexp` matches any of the strings in list of strings `list`. Returns `false` otherwise.|
+|`{{regexp.replace(list,regexp,replacement)}}`|Checks the list of strings `list`, returning a new list where each item that matches `regexp` is replaced with `replacement`. You can use `$n` in the replacement string to indicate a submatch group, e.g., `$1` to indicate the first submatch.|
+|`{{strings.upper(list)}}`|Returns the new list of strings that results from uppercasing each item in `list`, a list of strings.|
+|`{{strings.lower(list)}}`|Returns the new list of strings that results from lowercasing each item in `list`, a list of strings.|
+
+### Predicates for access to infrastructure resources
+
+When a user attempts to authenticate to an infrastructure resource
+proxied by Teleport, such as a database or Kubernetes cluster, Teleport determines from the user's roles:
+- Which infrastructure resources the user is authorized to authenticate to. 
+- Which principals the user can assume when they authenticate (for example,
+  Linux server logins and Kubernetes groups).
+
+#### Fields
+
+The following role fields control a user's access to infrastructure resources.
+All of these are fields within the `allow` and `deny` sections of a Teleport
+role resource.
+
+Labels for resources enrolled with Teleport:
+- `app_labels`
+- `cluster_labels`
+- `db_labels`
+- `db_service_labels`
+- `kubernetes_labels`
+- `node_labels`
+- `windows_desktop_labels`
+
+Principals a user can assume on third-party systems:
+- `aws_role_arns`
+- `azure_identities`
+- `db_names`
+- `db_roles`
+- `db_users`
+- `desktop_groups`
+- `gcp_service_accounts`
+- `host_groups`
+- `host_sudoers`
+- `kubernetes_groups`
+- `kubernetes_users`
+- `logins`
+- `windows_desktop_logins`
+
+Teleport principals that user can impersonate:
+- `impersonate.rules`
+- `impersonate.users`
+
+#### Functions
+
+You can use the following functions in role fields that govern access to
+principals on external systems. Both functions can take a template variable
+named above as an argument:
+
+|Function|Description|
+|---|---|
+|`{{email.local(variable)}}`|Extracts the local part of an email address.|
+|`{{regexp.replace(variable, expression, replacement)}}`|Finds all matches of the expression within the variable and replaces them with the replacement.|
+
+#### Variables
+
+For fields that configure access to infrastructure resources, Teleport
+substitutes the following variables with data from the authenticating user,
+drawing from the local user database as well as the user's external single
+sign-on provider.
+
+| Variable | Description |
+| - | - |
+| `{{internal.logins}}` | Substituted with a value stored in Teleport's local user database and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the "allowed logins" parameter used in the `tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [trusted cluster](../management/admin/trustedclusters.mdx), Teleport will substitute the logins from the root cluster whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root cluster, then `ubuntu` will be substituted in the leaf cluster with this variable. |
+|`{{internal.azure_identities}}`| Returns the Azure identities defined in Teleport available to the user. Azure identities can set for a specific user or defined in a role.|
+|`{{internal.db_names}}`|List of all allowed database names for the user.|
+|`{{internal.db_users}}`|List of all allowed database users for the user.|
+|`{{internal.gcp_service_accounts}}`|List of GCP service accounts for the user.|
+|`{{internal.kube_username}}`|Kubernetes usernames available to the user.|
+|`{{internal.kubernetes_groups}}`|List of allowed Kubernetes groups for the user.|
+|`{{internal.kubernetes_users}}`|List of allowed Kubernetes users for the user.|
+|`{{internal.logins}}`|List of allowed SSH logins for the user.|
+|`{{internal.windows_logins}}`|List of allowed Windows logins for the user.|
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. See the next section for more information on referring to the `external` variable in Teleport roles. |
+
+#### Accessing external traits in Teleport roles
+
+When a user authenticates to Teleport through a single sign-on identity provider
+(IdP), Teleport populates external variables using traits it receives from the
+IdP.
+
+For example, assuming you have the following SAML assertion attribute in your
+response:
+
+```
+<Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname">
+        <AttributeValue>firstname.lastname</AttributeValue>
+</Attribute>
+```
+
+... you can use the following format in your role:
+
+```
+logins:
+   - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
+```
+
+
+In role templates, you can refer to these variables using the following two
+formats, where `trait` is the name of the trait:
+
+- **Dot syntax:** `{{external.trait}}`
+- **Bracket syntax:** `{{external["trait"]}}`
+
+Teleport will expand the template variables above with the value of the SAML
+attribute or OIDC claim called `trait`.
+
+You can specify an external trait in dot syntax if it begins with a letter and
+contains only letters, numbers, and underscores. Otherwise, you must use bracket
+syntax to specify a trait.
+
+Common examples of external traits available through an identity provider
+include the following:
+
+- `{{external.logins}}`
+- `{{external.username}}`
+- `{{external.env}}`
+
+Teleport can only expand an `external` variable to a string or a list of
+strings. If you are using an OIDC-based SSO solution, ensure that you have
+configured your identity provider to include claims with values that have a
+supported data type.
+
+Refer to your identity provider's documentation for the complete list of
+available claims and attributes.
 
 ## Filter fields
 
-Here is an explanation of the fields used in the `where` and `filter` conditions within this guide.
+Here is an explanation of the fields used in the `where` and `filter` conditions
+within this guide:
 
 | Field                      | Description                                       |
 | -------------------------- | ------------------------------------------------- |
@@ -467,190 +607,13 @@ Here is an explanation of the fields used in the `where` and `filter` conditions
 | `session_tracker.participants` | The list of participants from an SSH session      |
 | `user.metadata.name`       | The user's name                                   |
 
-Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
+Read the [predicate
+language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
 
-## Template variables and functions
+## Second Factor - U2F
 
-Teleport provides several template variables and functions to enable more robust access control:
+Refer to the [Second Factor - WebAuthn](./guides/webauthn.mdx#u2f) guide if you
+have a cluster using the legacy U2F support.
 
-### Internal Variables and Functions
 
-#### `{{email.local(variable)}}`
-
-- **Type**: Function
-- **Description**: Extracts the local part of an email address.
-- **Example**: `{{email.local(alice@example.com)}}` -> `alice`
-
-This function is often paired with an external variable, for example:
-`{{email.local(external.username)}}` for IdPs using email addresses as the username.
-
-#### `{{regexp.match(expression, variable)}}`
-
-- **Type**: Function
-- **Description**: Returns true if the provided string matches the specified
-  pattern.
-- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> `true`
-  for matching input.
-
-#### `{{regexp.not_match(expression, variable)}}`
-
-- **Type**: Function
-- **Description**: Returns true if the provided string does not match the
-  specified pattern.
-- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` ->
-  `true` for non-matching input.
-
-#### `{{regexp.replace(variable, expression, replacement)}}`
-
-- **Type**: Function
-- **Description**: Finds all matches of the expression and replaces them with
-  the replacement. Supports expansion.
-- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}`
-  -> `alice` (when input is `alice@example.com`)
-
-#### `{{internal.azure_identities}}`
-
-- **Type**: Variable
-- **Description**: Returns the Azure identities defined in Teleport available to
-  the user. Azure identities can set for a specific user or defined in a role [(1)].
-- **Example**: `{{internal.azure_identities}}` -> `"/subscriptions/0000.../.../id1"`
-
-#### `{{internal.db_names}}`
-
-- **Type**: Variable
-- **Description**: List of all allowed database names.
-- **Example**: `{{internal.db_names}}` -> `["db_name_1", "db_name_2"]`
-
-#### `{{internal.db_users}}`
-
-- **Type**: Variable
-- **Description**: List of all allowed database users.
-- **Example**: `{{internal.db_users}}` -> `["db_user_1", "db_user_2"]`
-
-#### `{{internal.gcp_service_accounts}}`
-
-- **Type**: Variable
-- **Description**: List of GCP service accounts defined in Teleport available
-  to the user.
-- **Example**: `internal.gcp_service_accounts}}` -> `"user@google-cloud-project.iam.gserviceaccount.com"`
-
-#### `{{internal.jwt}}`
-
-- **Type**: Variable
-- **Description**: A JWT token signed by Teleport that contains user identity information.
-- **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
-
-**Note**: This variable is used when defining application access, and is not
-available when defining roles.
-
-#### `{{internal.kube_username}}`
-
-- **Type**: Variable
-- **Description**: Kubernetes usernames available to the user.
-- **Example**: `{{internal.kube_username}}` -> `["myuser", "kube-admin"]`.
-
-#### `{{internal.kubernetes_groups}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Kubernetes groups.
-- **Example**: `{{internal.kubernetes_groups}}` -> `["group1", "group2"]`
-
-#### `{{internal.kubernetes_users}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Kubernetes users.
-- **Example**: `{{internal.kubernetes_users}}` -> `["user1", "user2"]`
-
-#### `{{internal.logins}}`
-
-- **Type**: Variable
-- **Description**: List of allowed SSH logins.
-- **Example**: `{{internal.logins}}` -> `["user1", "user2"]`
-
-#### `{{internal.windows_logins}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Windows logins.
-- **Example**: `{{internal.windows_logins}}` -> `["user1", "user2"]`
-
-### External Variables
-
-These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
-
-#### `{{external.logins}}`
-
-- **Type**: Variable
-- **Provider**: Common across several IdPs
-
-#### `{{external.username}}`
-
-- **Type**: Variable
-- **Provider**: Common across several IdPs
-
-#### `{{external.access["label"]}}`
-
-- **Type**: Variable
-- **Provider**: Common across several IdPs
-
-#### `{{external.env}}`
-
-- **Type**: Variable
-- **Provider**: Common across several IdPs
-
-#### `{{external.first_name}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's first name from the SSO provider.
-- **Example**: `{{external.first_name}}` -> `"Alice"`
-- **Provider**: OIDC/SAML
-
-**Note**: Per OIDC specifications this value may be given as `given_name`.
-
-#### `{{external.last_name}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's last name from the SSO provider.
-- **Example**: `{{external.last_name}}` -> `"Smith"`
-- **Provider**: OIDC/SAML
-
-**Note**: Per OIDC specifications this value may be given as `family_name`.
-
-#### `{{external.email}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's email address from the SSO provider.
-- **Example**: `{{external.email}}` -> `"alice@example.com"`
-- **Provider**: OIDC/SAML
-
-#### `{{external.groups}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's group membership from the SSO provider.
-- **Example**: `{{external.groups}}` -> `["group1", "group2"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external.azure_identities}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's Azure identities from the SSO provider [(2)].
-- **Example**: `{{external.azure_identities}}` -> `["identity1"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external.databases}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's allowed database names from the SSO provider [(3)].
-- **Example**: `{{external.databases}}` -> `["db1", "db2"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external["custom_attribute"]}}`
-
-- **Type**: Variable
-- **Provider**: OIDC/SAML
-
-Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
-
-[(1)]: ../../application-access/controls/#enabling-a-user-to-access-azure-managed-identities
-[(2)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
-[(3)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -357,129 +357,18 @@ spec:
       where: '!contains(session_tracker.participants, user.metadata.name)'
 ```
 
-## Role predicates
+## Role templates
 
 In a Teleport role resource, certain fields allow you to use functions and
 variables to configure a user's access. The functions and variables available
 for a field depend on the access controls that the field configures.
 
-### Access Request predicate functions
+### Template expressions for access to infrastructure resources
 
-The following variables and functions allow more fine-grained control over a
-user's permissions to submit and review Access Requests.
-
-#### Fields
-
-You can use Access Request predicate functions in the following fields. You can
-include these fields within either `allow` rules or `deny` rules:
-
-- `request.search_as_roles`
-- `request.roles`
-- `review_requests.preview_as_roles`
-- `review_requests.roles`
-- `review_requests.where`
-
-#### Functions
-
-Access Requests support the following role predicate functions:
-
-|Function|Description|
-|---|---|
-|`{{regexp.match(regexp)}}`|Returns `true` if the regular expression matches a user's role.|
-|`{{regexp.not_match(regexp)}}`|Returns `true` if the regular expression does not match a user's role.|
-
-Regular expressions support both wildcards (the `*` character) and [Go-style
-regular expressions](https://pkg.go.dev/regexp). If an expression begins with
-the `^` character and ends with the `$` character, Teleport will evaluate it as
-a regular expression. Otherwise, it will evaluate it as a wildcard expression.
-Wildcards match a sequence of one or more characters.
-
-#### Variables
-
-Teleport does not perform variable expansion on the values of the fields above.
-
-### Label expressions
-
-<Admonition type="warning">
-Label expressions are available starting in Teleport version `13.1.1`. All
-components of your Teleport cluster must be upgraded to version `13.1.1` or
-newer before you can use label expressions. This includes the Auth Service and
-**all** Teleport agents.
-</Admonition>
-
-Teleport roles support matching resource labels with predicate expressions when
-you need to:
-
-- combine logic with OR and AND operators
-- perform matching on label keys
-- implement negative matches
-
-The following example role would allow access to any nodes labeled `env=staging`
-or labeled `team=<team>`, where `<team>` is one of the values of the user's
-`teams` trait:
-
-```yaml
-kind: role
-version: v7
-metadata:
-  name: example-role
-spec:
-  allow:
-    node_labels_expression: |
-      labels["env"] == "staging" ||
-      contains(user.spec.traits["teams"], labels["team"])
-```
-
-Typically, you would only use either `<kind>_labels` or
-`<kind>_labels_expression` in a single role, but you are allowed to specify
-both.
-
-If you have both in a deny rule, the matching is greedy. If either expression
-matches, access is denied. In an allow rule, the matching is not greedy. If both
-expressions are set, both expressions must be matched for access to be allowed.
-
-#### Fields
-
-The `<kind>_labels_expression` fields have the same purpose as the matching
-`<kind>_labels` fields, but support predicate expressions instead of label
-matchers.  They can be used in the following fields of role `spec.allow` and
-`spec.deny` conditions:
-
-- `node_labels_expression`
-- `app_labels_expression`
-- `cluster_labels_expression`
-- `kubernetes_labels_expression`
-- `db_labels_expression`
-- `db_service_labels_expression`
-- `windows_desktop_labels_expression`
-- `group_labels_expression`
-
-#### Variables
-
-You can use the following template variables in label expression fields:
-
-|Variable|Type|Description|
-|---|---|---|
-|`{{user.spec.traits}}`|`map[string][]string`|All of the user's traits. Use `{{user.spec.traits<key>}}` to get a list of trait values for the specified key.|
-|`{{labels}}`|`map[string]string`|All of the user's labels. Use `{{labels.<key>}}` to get the value for the specified key.|
-
-#### Functions
-
-You can use the following functions in label expression fields:
-
-|Function|Description|
-|---|---|
-|`{{contains(list,item)}}`|Returns `true` if the list of strings in `list` contains the specified `item` and `false` otherwise.|
-|`{{regexp.match(list,regexp)}}`|Returns `true` if the regular expression in `regexp` matches any of the strings in list of strings `list`. Returns `false` otherwise.|
-|`{{regexp.replace(list,regexp,replacement)}}`|Checks the list of strings `list`, returning a new list where each item that matches `regexp` is replaced with `replacement`. You can use `$n` in the replacement string to indicate a submatch group, e.g., `$1` to indicate the first submatch.|
-|`{{strings.upper(list)}}`|Returns the new list of strings that results from uppercasing each item in `list`, a list of strings.|
-|`{{strings.lower(list)}}`|Returns the new list of strings that results from lowercasing each item in `list`, a list of strings.|
-
-### Predicates for access to infrastructure resources
-
-When a user attempts to authenticate to an infrastructure resource
-proxied by Teleport, such as a database or Kubernetes cluster, Teleport determines from the user's roles:
-- Which infrastructure resources the user is authorized to authenticate to. 
+When a user attempts to authenticate to an infrastructure resource proxied by
+Teleport, such as a database or Kubernetes cluster, Teleport determines from the
+user's roles:
+- Whether the user is authorized to connect to the resource.
 - Which principals the user can assume when they authenticate (for example,
   Linux server logins and Kubernetes groups).
 
@@ -527,10 +416,10 @@ principals on infrastructure resources:
 |`{{email.local(variable)}}`|Extracts the local part of an email address.|
 |`{{regexp.replace(variable, expression, replacement)}}`|Finds all matches of the expression within the variable and replaces them with the replacement.|
 
-#### Variables
+#### Traits
 
 For fields that configure access to infrastructure resources, Teleport
-substitutes the following variables with data from the authenticating user,
+substitutes the following **traits** with data from the authenticating user,
 drawing from the local user database as well as the user's external single
 sign-on provider.
 
@@ -598,6 +487,118 @@ supported data type.
 
 Refer to your identity provider's documentation for the complete list of
 available claims and attributes.
+
+### Access Request template functions
+
+The following variables and functions allow more fine-grained control over a
+user's permissions to submit and review Access Requests.
+
+#### Fields
+
+You can use Access Request template functions in the following fields. You can
+include these fields within either `allow` rules or `deny` rules:
+
+- `request.search_as_roles`
+- `request.roles`
+- `review_requests.preview_as_roles`
+- `review_requests.roles`
+- `review_requests.where`
+
+#### Functions
+
+Access Requests support the following role template functions:
+
+|Function|Description|
+|---|---|
+|`{{regexp.match(regexp)}}`|Returns `true` if the regular expression matches a user's role.|
+|`{{regexp.not_match(regexp)}}`|Returns `true` if the regular expression does not match a user's role.|
+
+Regular expressions support both glob-style wildcards (the `*` character) and
+[Go-style regular expressions](https://pkg.go.dev/regexp). If an expression
+begins with the `^` character and ends with the `$` character, Teleport will
+evaluate it as a regular expression. Otherwise, it will evaluate it as a
+wildcard expression.  Wildcards match a sequence of one or more characters.
+
+#### Variables
+
+Teleport does not perform variable expansion on the values of the fields above.
+
+### Label expressions
+
+<Admonition type="warning">
+Label expressions are available starting in Teleport version `13.1.1`. All
+components of your Teleport cluster must be upgraded to version `13.1.1` or
+newer before you can use label expressions. This includes the Auth Service and
+**all** Teleport agents.
+</Admonition>
+
+Teleport roles support matching resource labels with template expressions when
+you need to:
+
+- combine logic with OR and AND operators
+- perform matching on label keys
+- implement negative matches
+
+The following example role would allow access to any nodes labeled `env=staging`
+or labeled `team=<team>`, where `<team>` is one of the values of the user's
+`teams` trait:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: example-role
+spec:
+  allow:
+    node_labels_expression: |
+      labels["env"] == "staging" ||
+      contains(user.spec.traits["teams"], labels["team"])
+```
+
+Typically, you would only use either `<kind>_labels` or
+`<kind>_labels_expression` in a single role, but you are allowed to specify
+both.
+
+If you have both in a deny rule, the matching is greedy. If either expression
+matches, access is denied. In an allow rule, the matching is not greedy. If both
+expressions are set, both expressions must be matched for access to be allowed.
+
+#### Fields
+
+The `<kind>_labels_expression` fields have the same purpose as the matching
+`<kind>_labels` fields, but support label expressions instead of label matchers.
+They can be used in the following fields of role `spec.allow` and `spec.deny`
+conditions:
+
+- `node_labels_expression`
+- `app_labels_expression`
+- `cluster_labels_expression`
+- `kubernetes_labels_expression`
+- `db_labels_expression`
+- `db_service_labels_expression`
+- `windows_desktop_labels_expression`
+- `group_labels_expression`
+
+#### Variables
+
+You can use the following template variables in label expression fields:
+
+|Variable|Type|Description|
+|---|---|---|
+|`{{user.spec.traits}}`|`map[string][]string`|All of the user's traits. Use `{{user.spec.traits<key>}}` to get a list of trait values for the specified key.|
+|`{{labels}}`|`map[string]string`|All of the user's labels. Use `{{labels.<key>}}` to get the value for the specified key.|
+
+#### Functions
+
+You can use the following functions in label expression fields:
+
+|Function|Description|
+|---|---|
+|`{{contains(list,item)}}`|Returns `true` if the list of strings in `list` contains the specified `item` and `false` otherwise.|
+|`{{regexp.match(list,regexp)}}`|Returns `true` if the regular expression in `regexp` matches any of the strings in list of strings `list`. Returns `false` otherwise.|
+|`{{regexp.replace(list,regexp,replacement)}}`|Checks the list of strings `list`, returning a new list where each item that matches `regexp` is replaced with `replacement`. You can use `$n` in the replacement string to indicate a submatch group, e.g., `$1` to indicate the first submatch.|
+|`{{strings.upper(list)}}`|Returns the new list of strings that results from uppercasing each item in `list`, a list of strings.|
+|`{{strings.lower(list)}}`|Returns the new list of strings that results from lowercasing each item in `list`, a list of strings.|
 
 ## Filter fields
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -189,6 +189,65 @@ spec:
       'environment': '^test|staging$'
 ```
 
+### Label expressions
+
+<Admonition type="warning">
+Label expressions are available starting in Teleport version `13.1.1`.
+All components of your Teleport cluster must be upgraded to version `13.1.1`
+or newer before you will be able to use label expressions.
+This includes the Auth Service and **all** Teleport agents.
+</Admonition>
+
+Teleport roles also support matching resource labels with predicate expressions
+when you need to:
+
+- combine logic with OR and AND operators
+- perform matching on label keys
+- implement negative matches
+
+The following example role would allow access to any nodes labeled `env=staging`
+or labeled `team=<team>`, where `<team>` is one of the values of the user's
+`teams` trait:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: example-role
+spec:
+  allow:
+    node_labels_expression: |
+      labels["env"] == "staging" ||
+      contains(user.spec.traits["teams"], labels["team"])
+```
+
+The `<kind>_labels_expression` fields have the same purpose of the
+matching `<kind>_labels` fields, but support predicate expressions instead
+of label matchers.
+They can be used in the following fields of role `spec.allow` and `spec.deny`
+conditions:
+
+- `node_labels_expression`
+- `app_labels_expression`
+- `cluster_labels_expression`
+- `kubernetes_labels_expression`
+- `db_labels_expression`
+- `db_service_labels_expression`
+- `windows_desktop_labels_expression`
+- `group_labels_expression`
+
+Check out our
+[predicate language](../reference/predicate-language.mdx#label-expressions)
+guide for a more in depth explanation of the language.
+
+Typically you will only want to use one of `<kind>_labels` or
+`<kind>_labels_expression` in a single role, but you are allowed to specify
+both.
+If you have both in a deny rule, the matching is greedy, if either one matches
+access will be denied.
+In an allow rule, the matching is not greedy, if both are set they both have to
+match for access to be allowed.
+
 ## RBAC for dynamic Teleport resources
 
 RBAC lets teams limit what resources are available to Teleport users. This can
@@ -522,83 +581,6 @@ wildcard expression.  Wildcards match a sequence of one or more characters.
 #### Variables
 
 Teleport does not perform variable expansion on the values of the fields above.
-
-### Label expressions
-
-<Admonition type="warning">
-Label expressions are available starting in Teleport version `13.1.1`. All
-components of your Teleport cluster must be upgraded to version `13.1.1` or
-newer before you can use label expressions. This includes the Auth Service and
-**all** Teleport agents.
-</Admonition>
-
-Teleport roles support matching resource labels with template expressions when
-you need to:
-
-- combine logic with OR and AND operators
-- perform matching on label keys
-- implement negative matches
-
-The following example role would allow access to any nodes labeled `env=staging`
-or labeled `team=<team>`, where `<team>` is one of the values of the user's
-`teams` trait:
-
-```yaml
-kind: role
-version: v7
-metadata:
-  name: example-role
-spec:
-  allow:
-    node_labels_expression: |
-      labels["env"] == "staging" ||
-      contains(user.spec.traits["teams"], labels["team"])
-```
-
-Typically, you would only use either `<kind>_labels` or
-`<kind>_labels_expression` in a single role, but you are allowed to specify
-both.
-
-If you have both in a deny rule, the matching is greedy. If either expression
-matches, access is denied. In an allow rule, the matching is not greedy. If both
-expressions are set, both expressions must be matched for access to be allowed.
-
-#### Fields
-
-The `<kind>_labels_expression` fields have the same purpose as the matching
-`<kind>_labels` fields, but support label expressions instead of label matchers.
-They can be used in the following fields of role `spec.allow` and `spec.deny`
-conditions:
-
-- `node_labels_expression`
-- `app_labels_expression`
-- `cluster_labels_expression`
-- `kubernetes_labels_expression`
-- `db_labels_expression`
-- `db_service_labels_expression`
-- `windows_desktop_labels_expression`
-- `group_labels_expression`
-
-#### Variables
-
-You can use the following template variables in label expression fields:
-
-|Variable|Type|Description|
-|---|---|---|
-|`{{user.spec.traits}}`|`map[string][]string`|All of the user's traits. Use `{{user.spec.traits<key>}}` to get a list of trait values for the specified key.|
-|`{{labels}}`|`map[string]string`|All of the user's labels. Use `{{labels.<key>}}` to get the value for the specified key.|
-
-#### Functions
-
-You can use the following functions in label expression fields:
-
-|Function|Description|
-|---|---|
-|`{{contains(list,item)}}`|Returns `true` if the list of strings in `list` contains the specified `item` and `false` otherwise.|
-|`{{regexp.match(list,regexp)}}`|Returns `true` if the regular expression in `regexp` matches any of the strings in list of strings `list`. Returns `false` otherwise.|
-|`{{regexp.replace(list,regexp,replacement)}}`|Checks the list of strings `list`, returning a new list where each item that matches `regexp` is replaced with `replacement`. You can use `$n` in the replacement string to indicate a submatch group, e.g., `$1` to indicate the first submatch.|
-|`{{strings.upper(list)}}`|Returns the new list of strings that results from uppercasing each item in `list`, a list of strings.|
-|`{{strings.lower(list)}}`|Returns the new list of strings that results from lowercasing each item in `list`, a list of strings.|
 
 ## Filter fields
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -558,7 +558,7 @@ Teleport provides several template variables and functions to enable more robust
 
 <Details title="External Variables"
 >
-These variables provide context from an Identity Provider or other external data source.
+These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
 
 #### `{{external.logins}}`
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -2,6 +2,7 @@
 title: Access Controls Reference Documentation
 description: This reference shows you the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
 h1: Teleport Access Controls Reference
+tocDepth: 3
 ---
 
 This guide shows you how to use Teleport roles to manage role-based access
@@ -469,3 +470,162 @@ Here is an explanation of the fields used in the `where` and `filter` conditions
 Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
 
+## Template variables and functions
+
+Teleport provides several template variables and functions to enable more robust access control:
+
+<Details title="Internal Variables and Functions">
+
+#### `{{email.local(variable)}}`
+
+- **Type**: Function
+- **Description**: Extracts the local part of an email address.
+- **Example**: `{{email.local(alice@example.com)}}` -> alice
+
+#### `{{regexp.match(expression, variable)}}`
+
+- **Type**: Function
+- **Description**: Returns true if the provided string matches the specified pattern.
+- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> true for matching input
+
+#### `{{regexp.not_match(expression, variable)}}`
+
+- **Type**: Function
+- **Description**: Returns true if the provided string does not match the specified pattern.
+- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` -> true for non-matching input
+
+#### `{{regexp.replace(variable, expression, replacement)}}`
+
+- **Type**: Function
+- **Description**: Finds all matches of the expression and replaces them with the replacement. Supports expansion.
+- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}` -> alice (when input is alice@example.com)
+
+#### `{{internal.azure_identities}}`
+
+- **Type**: Variable
+
+#### `{{internal.db_names}}`
+
+- **Type**: Variable
+- **Description**: List of all allowed database names.
+- **Example**: `{{internal.db_names}}` -> ["db_name_1", "db_name_2"]
+
+#### `{{internal.db_users}}`
+
+- **Type**: Variable
+- **Description**: List of all allowed database users.
+- **Example**: `{{internal.db_users}}` -> ["db_user_1", "db_user_2"]
+
+#### `{{internal.gcp_service_accounts}}`
+
+- **Type**: Variable
+
+#### `{{internal.jwt}}`
+
+- **Type**: Variable
+- **Description**: A JWT token signed by Teleport that contains user identity information.
+- **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
+
+#### `{{internal.kube_username}}`
+
+- **Type**: Variable
+
+#### `{{internal.kubernetes_groups}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Kubernetes groups.
+- **Example**: `{{internal.kubernetes_groups}}` -> ["group1", "group2"]
+
+#### `{{internal.kubernetes_users}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Kubernetes users.
+- **Example**: `{{internal.kubernetes_users}}` -> ["user1", "user2"]
+
+#### `{{internal.logins}}`
+
+- **Type**: Variable
+- **Description**: List of allowed SSH logins.
+- **Example**: `{{internal.logins}}` -> ["user1", "user2"]
+
+#### `{{internal.windows_logins}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Windows logins.
+- **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
+
+</Details>
+
+<Details title="External Variables"
+>
+These variables provide context from an Identity Provider or other external data source.
+
+#### `{{external.logins}}`
+
+- **Type**: Variable
+
+#### `{{external.username}}`
+
+- **Type**: Variable
+
+#### `{{external.access["label"]}}`
+
+- **Type**: Variable
+
+#### `{{external.env}}`
+
+- **Type**: Variable
+
+#### `{{external.first_name}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's first name from the SSO provider.
+- **Example**: `{{external.first_name}}` -> `"Alice"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.last_name}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's last name from the SSO provider.
+- **Example**: `{{external.last_name}}` -> `"Smith"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.email}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's email address from the SSO provider.
+- **Example**: `{{external.email}}` -> `"alice@example.com"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.groups}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's group membership from the SSO provider.
+- **Example**: `{{external.groups}}` -> `["group1", "group2"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external.azure_identities}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's Azure identities from the SSO provider [(1)].
+- **Example**: `{{external.azure_identities}}` -> `["identity1"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external.databases}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's allowed database names from the SSO provider [(2)].
+- **Example**: `{{external.databases}}` -> `["db1", "db2"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external["custom_attribute"]}}`
+
+- **Type**: Variable
+- **Provider**: OIDC/SAML
+
+Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
+
+</Details>
+
+[(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
+[(2)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/api/architecture.mdx
+++ b/docs/pages/api/architecture.mdx
@@ -44,7 +44,7 @@ tctl create -f api-role.yaml
 tctl users add api-user --roles=api-role
 ```
 
-See our [roles](../access-controls/reference.mdx#roles) documentation for more details
+See our [roles](../access-controls/reference.mdx) documentation for more details
 on role based access control.
 
 ## Credentials

--- a/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
+++ b/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
@@ -3,4 +3,4 @@
   Service version. See [version compatibility](../../faq.mdx#version-compatibility).
 - A local Teleport user: you must authenticate using credentials or passwordless login, and not with
   SSO.
-- Permissions to create join tokens (verb `create` for [the `token` resource](../../access-controls/reference.mdx#teleport-resources)).
+- Permissions to create join tokens (verb `create` for [the `token` resource](../../access-controls/reference.mdx#rbac-for-dynamic-teleport-resources)).

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -82,7 +82,7 @@ the lifecycle of the agent.
 {/* The permission to read and update users is needed during setup but not for regular usage,
 that's why it's not listed in the partial. */}
 - Permissions to read and update user objects in the backend (verbs `read` and `update` for [the
-  `user` resource](../access-controls/reference.mdx#teleport-resources)).
+  `user` resource](../access-controls/reference.mdx#rbac-for-dynamic-teleport-resources)).
 
 The agent runs as the current system user, not as root. Some features are thus not available, such
 as logging in as other system users or [host user creation](../server-access/guides/host-user-creation.mdx).
@@ -216,7 +216,7 @@ the agent was successfully configured.
 If you wish to prevent cluster users from using Connect My Computer, make sure they don't have
 permissions to create new join tokens. This is controlled by the `create` verb for the `token`
 resource. Either deny this permission explicitly or do not grant it in the first place. See [Access
-Controls Reference Documentation](../access-controls/reference.mdx#teleport-resources) for more
+Controls Reference Documentation](../access-controls/reference.mdx#rbac-for-dynamic-teleport-resources) for more
 details. Denying this permission will hide the icon in the top bar.
 
 Users who already set up agents will still be able to manage those agents, even after the denying

--- a/docs/pages/machine-id/access-guides/applications.mdx
+++ b/docs/pages/machine-id/access-guides/applications.mdx
@@ -170,7 +170,7 @@ has been configured to use both the client certificate and key.
 
 ## Next steps
 
-- Review the [Access Controls Reference](../../access-controls/reference.mdx#roles)
+- Review the [Access Controls Reference](../../access-controls/reference.mdx)
   to learn about restricting which Applications and other Teleport resources
   your bot may access.
 - Configure [JWTs](../../application-access/jwt/introduction.mdx) for your


### PR DESCRIPTION
Closes #11263

Teleport roles make use of separate but similar predicate languages.
Clarify these languages by giving each one a section within the Access
Controls reference.

This also clarifies other aspects of predicates in Teleport roles:

- Explain the dot vs. bracket syntax in `external` variables
- Add a note re: OIDC claim data types

To make room for the new organization, this also changes other aspects
of the page's structure:
- Some paragraphs in the introductory section were more appropriate in
  the section re: managing access to Teleport RBAC resources.
- Make the intro and title more readable.
- Move an out-of-place H3 regarding SAML to the `external` trait
  section.