### PR TITLE
Fix self-signed cert validity on macOS systems

### DIFF
--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -99,7 +99,7 @@ func createClientTLSConfig(clientKeyPair tls.Certificate, serverCertPath string)
 	}, nil
 }
 
-func generateAndSaveCert(targetPath string) (tls.Certificate, error) {
+func generateAndSaveCert(targetPath string, eku ...x509.ExtKeyUsage) (tls.Certificate, error) {
 	// The cert is first saved under a temp path and then renamed to targetPath. This prevents other
 	// processes from reading a half-written file.
 	tempFile, err := os.CreateTemp(filepath.Dir(targetPath), filepath.Base(targetPath))
@@ -108,7 +108,7 @@ func generateAndSaveCert(targetPath string) (tls.Certificate, error) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
+	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, eku...)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "failed to generate the certificate")
 	}

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -17,6 +17,7 @@ package teleterm
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -209,7 +210,7 @@ func createValidClientTLSConfig(t *testing.T, certsDir string) *tls.Config {
 	// reach the tsh gRPC server, so we need to use the renderer cert as the client cert.
 	clientCertPath := filepath.Join(certsDir, rendererCertFileName)
 	serverCertPath := filepath.Join(certsDir, tshdCertFileName)
-	clientCert, err := generateAndSaveCert(clientCertPath)
+	clientCert, err := generateAndSaveCert(clientCertPath, x509.ExtKeyUsageClientAuth)
 	require.NoError(t, err)
 
 	tlsConfig, err := createClientTLSConfig(clientCert, serverCertPath)


### PR DESCRIPTION
As per https://support.apple.com/en-in/HT210176:

> TLS server certificates must contain an ExtendedKeyUsage (EKU)
  extension containing the id-kp-serverAuth OID.

We were not specifying this EKU.

Validated by checking with the old self-signed certs:

    $ security verify-cert -c webproxy_cert.pem -p ssl -r webproxy_cert.pem
    Cert Verify Result: Invalid Extended Key Usage for policy

And then repeating the process after this change:

    $ security verify-cert -c webproxy_cert.pem -p ssl -r webproxy_cert.pem
    ...certificate verification successful.

Closes #32531