### PR TITLE
Cut CI unit test runtime in half

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -69,5 +69,5 @@ jobs:
         run: mount -t debugfs none /sys/kernel/debug/
 
       - name: Run tests
-        timeout-minutes: 40
-        run: make test-go test-sh test-api
+        timeout-minutes: 20
+        run: make -j"$(nproc)" test-go test-sh test-api


### PR DESCRIPTION
Set the number of Makefile jobs to run during unit testing to the number of cores of the machine that the tests run on. In testing this seems to cut the unit testing runtime in half without adverse side-effects.

Unfortunately this won't cut down on our merge time (limited by CI integration tests), but should provide much faster feedback for developers, as well as reduce our GHA costs.

We've ran almost [7000 runs of this workflow over the past month](https://github.com/gravitational/teleport/actions/workflows/unit-tests-code.yaml?query=created%3A%3E2023-08-13). At a 9 minute reduction in runtime (approximate), this will shave off at least 44 days of runtime every month (and more as we add tests). This workflow runs on a 32 core machine, which costs us [$0.128 per runtime minute](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates). This change should save almost $8000/month in GHA spend, before accounting for any cost reductions in our Github contract. Note that this math does not account for runs that end early (mostly due to test failures), however these account for a relatively small portion of our unit test runs.

Example runs:
* https://github.com/gravitational/teleport/actions/runs/6319351234/job/17160120550
* https://github.com/gravitational/teleport/actions/runs/6332348092/job/17198665394