### PR TITLE
Fix git installation path on CentOS 7 docker image

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -25,12 +25,12 @@ RUN yum groupinstall -y 'Development Tools' && \
     ${DEVTOOLSET}-make && \
     yum clean all
 
-RUN wget https://github.com/git/git/archive/refs/tags/v2.39.1.tar.gz && \
-    tar xf v2.39.1.tar.gz && \
-    cd git-2.39.1/ && \
+RUN wget https://github.com/git/git/archive/refs/tags/v2.42.0.tar.gz && \
+    tar xf v2.42.0.tar.gz && \
+    cd git-2.42.0/ && \
     scl enable ${DEVTOOLSET} "make configure && \
     ./configure --prefix=/usr/local && \
-    make -j6 all && \
+    make -j"$(nproc)" all && \
     DESTDIR=/opt/git make install"
 
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
@@ -199,8 +199,8 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum clean all && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8
 
-# Override the old git installed by yum. We need git 2+ on GitHub Actions.
-COPY --from=git2 /opt/git /usr/local
+# Override the old git in /usr/local installed by yum. We need git 2+ on GitHub Actions.
+COPY --from=git2 /opt/git /
 
 ARG BUILDARCH
 


### PR DESCRIPTION
When checking GHA logs of OS Compatibility build, I noticed info log
```
The repository will be downloaded using the GitHub REST API
To create a local Git repository instead, add Git 2.18 or higher to the PATH
```
Suggesting that our self-compiled git is not being used. For some reason our git binary was installed in /usr/local/usr/local/bin/git. I removed the additional /usr/local prefix to install the binary in the correct directory. I also updated git to the latest version.

To reviewers. If the newer git was not working and GHA was not complaining about it too much, we could also remove the self-compiled binary, but in the long run I'm not sure what else may stop working.