### PR TITLE
Make spacing of Connect My Computer status more consistent

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.tsx
@@ -15,8 +15,7 @@
  */
 
 import React from 'react';
-import { Text, ButtonPrimary, Alert } from 'design';
-
+import { Text, ButtonPrimary, Alert, Flex } from 'design';
 import Link from 'design/Link';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
@@ -92,9 +91,9 @@ export function CompatibilityError(props: {
   }
 
   return (
-    <>
+    <Flex flexDirection="column" gap={2}>
       {!props.hideAlert && (
-        <Alert>
+        <Alert mb={0}>
           The agent version is not compatible with the cluster version
         </Alert>
       )}
@@ -110,7 +109,6 @@ export function CompatibilityError(props: {
         {$content}
       </Text>
       <ButtonPrimary
-        mt={3}
         mx="auto"
         type="button"
         as="a"
@@ -120,7 +118,7 @@ export function CompatibilityError(props: {
       >
         Visit the downloads page
       </ButtonPrimary>
-    </>
+    </Flex>
   );
 }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
@@ -82,7 +82,7 @@ export function Running() {
     <ShowState
       appContext={appContext}
       agentProcessState={{ status: 'not-started' }}
-      proxyVersion="17.0.0."
+      proxyVersion="17.0.0"
     />
   );
 }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 
-import { wait } from 'shared/utils/wait';
-
-import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeRootCluster,
+  makeServer,
+  makeLabelsList,
+} from 'teleterm/services/tshd/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import AppContext from 'teleterm/ui/appContext';
 
@@ -30,6 +32,7 @@ import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
 import {
   AgentCompatibilityError,
   ConnectMyComputerContextProvider,
+  NodeWaitJoinTimeout,
 } from '../connectMyComputerContext';
 
 import { DocumentConnectMyComputerStatus } from './DocumentConnectMyComputerStatus';
@@ -43,7 +46,45 @@ export function NotStarted() {
 }
 
 export function Running() {
-  return <ShowState agentProcessState={{ status: 'running' }} />;
+  const appContext = new MockAppContext({ appVersion: '17.0.0' });
+
+  let agentUpdateListener: (state: AgentProcessState) => void;
+  appContext.mainProcessClient.subscribeToAgentUpdate = (
+    rootClusterUri,
+    listener
+  ) => {
+    agentUpdateListener = listener;
+    return { cleanup: () => undefined };
+  };
+  appContext.connectMyComputerService.isAgentConfigFileCreated = () =>
+    Promise.resolve(true);
+  appContext.connectMyComputerService.runAgent = async () => {
+    agentUpdateListener({ status: 'running' });
+  };
+  appContext.connectMyComputerService.waitForNodeToJoin = () =>
+    Promise.resolve(
+      makeServer({
+        hostname: 'staging-mac-mini',
+        labelsList: makeLabelsList({
+          hostname: 'staging-mac-mini',
+          'teleport.dev/connect-my-computer/owner': 'testuser@goteleport.com',
+        }),
+      })
+    );
+
+  useLayoutEffect(() => {
+    (
+      document.querySelector('[data-testid=start-agent]') as HTMLButtonElement
+    )?.click();
+  });
+
+  return (
+    <ShowState
+      appContext={appContext}
+      agentProcessState={{ status: 'not-started' }}
+      proxyVersion="17.0.0."
+    />
+  );
 }
 
 export function Errored() {
@@ -80,6 +121,30 @@ export function ExitedUnsuccessfully() {
         logs: 'teleport: error: unknown short flag -non-existing-flag',
         signal: null,
       }}
+    />
+  );
+}
+
+export function ErrorWithAlertAndLogs() {
+  const appContext = new MockAppContext({ appVersion: '17.0.0' });
+
+  appContext.connectMyComputerService.isAgentConfigFileCreated = () =>
+    Promise.resolve(true);
+  appContext.connectMyComputerService.waitForNodeToJoin = () =>
+    Promise.reject(
+      new NodeWaitJoinTimeout(
+        'teleport: error: unknown short flag -non-existing-flag'
+      )
+    );
+
+  return (
+    <ShowState
+      appContext={appContext}
+      agentProcessState={{
+        status: 'not-started',
+      }}
+      autoStart={true}
+      proxyVersion="17.0.0"
     />
   );
 }
@@ -182,40 +247,6 @@ function ShowState(props: {
     new MockAppContext({ appVersion: cluster.proxyVersion });
 
   appContext.mainProcessClient.getAgentState = () => props.agentProcessState;
-  appContext.mainProcessClient.subscribeToAgentUpdate = (
-    rootClusterUri,
-    listener
-  ) => {
-    listener(props.agentProcessState);
-    return { cleanup: () => undefined };
-  };
-  appContext.connectMyComputerService.runAgent = async () => {
-    await wait(1_000);
-  };
-  appContext.connectMyComputerService.waitForNodeToJoin = async () => {
-    if (props.agentProcessState.status === 'running') {
-      await wait(2_000);
-      return {
-        uri: `${cluster.uri}/servers/178ef081-259b-4aa5-a018-449b5ea7e694`,
-        tunnel: false,
-        name: '178ef081-259b-4aa5-a018-449b5ea7e694',
-        hostname: 'staging-mac-mini',
-        addr: '127.0.0.1:3022',
-        labelsList: [
-          {
-            name: 'hostname',
-            value: 'staging-mac-mini',
-          },
-          {
-            name: 'teleport.dev/connect-my-computer',
-            value: 'testuser@goteleport.com',
-          },
-        ],
-      };
-    }
-    await wait(3_000);
-    throw new Error('TIMEOUT. Cannot find node.');
-  };
   appContext.configService.set('feature.connectMyComputer', true);
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);
   appContext.workspacesService.setState(draftState => {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -175,119 +175,133 @@ export function DocumentConnectMyComputerStatus(
           again.
         </Alert>
       )}
-      <Flex justifyContent="space-between" mb={3}>
-        <Text
-          typography="h3"
-          css={`
-            display: flex;
-          `}
-        >
-          <Laptop mr={2} />
-          {/** The node name can be changed, so it might be different from the system hostname. */}
-          {agentNode?.hostname || hostname}
-        </Text>
-        <MenuIcon
-          buttonIconProps={{
-            css: css`
-              border-radius: ${props => props.theme.space[1]}px;
-              background: ${props => props.theme.colors.spotBackground[0]};
-            `,
-          }}
-          menuProps={{
-            anchorOrigin: {
-              vertical: 'bottom',
-              horizontal: 'right',
-            },
-            transformOrigin: {
-              vertical: 'top',
-              horizontal: 'right',
-            },
-          }}
-        >
-          <MenuItem onClick={openAgentLogs}>Open agent logs directory</MenuItem>
-          <MenuItem onClick={removeAgentAndClose}>Remove agent</MenuItem>
-        </MenuIcon>
-      </Flex>
 
-      <Transition in={!!agentNode} timeout={1_800} mountOnEnter unmountOnExit>
-        {state => (
-          <LabelsContainer gap={1} className={state}>
-            {renderLabels(agentNode.labelsList)}
-          </LabelsContainer>
-        )}
-      </Transition>
-      <Flex
-        mt={3}
-        mb={2}
-        gap={1}
-        display="flex"
-        alignItems="center"
-        minHeight="32px"
-      >
-        {prettyCurrentAction.Icon && <prettyCurrentAction.Icon size="medium" />}
-        {prettyCurrentAction.title}
-        {showConnectAndStopAgentButtons && (
-          <ButtonSecondary
-            onClick={killAgent}
-            disabled={disableConnectAndStopAgentButtons}
-            ml={3}
+      <Flex flexDirection="column" gap={3}>
+        <Flex flexDirection="column" gap={1}>
+          <Flex justifyContent="space-between">
+            <Text
+              typography="h3"
+              css={`
+                display: flex;
+              `}
+            >
+              <Laptop mr={2} />
+              {/** The node name can be changed, so it might be different from the system hostname. */}
+              {agentNode?.hostname || hostname}
+            </Text>
+            <MenuIcon
+              buttonIconProps={{
+                css: css`
+                  border-radius: ${props => props.theme.space[1]}px;
+                  background: ${props => props.theme.colors.spotBackground[0]};
+                `,
+              }}
+              menuProps={{
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'right',
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'right',
+                },
+              }}
+            >
+              <MenuItem onClick={openAgentLogs}>
+                Open agent logs directory
+              </MenuItem>
+              <MenuItem onClick={removeAgentAndClose}>Remove agent</MenuItem>
+            </MenuIcon>
+          </Flex>
+
+          <Transition
+            in={!!agentNode}
+            timeout={1_800}
+            mountOnEnter
+            unmountOnExit
           >
-            Stop Agent
-          </ButtonSecondary>
-        )}
-      </Flex>
-      {prettyCurrentAction.error && (
-        <Alert
-          css={`
-            white-space: pre-wrap;
-          `}
-        >
-          {prettyCurrentAction.error}
-        </Alert>
-      )}
-      {prettyCurrentAction.logs && <Logs logs={prettyCurrentAction.logs} />}
+            {state => (
+              <LabelsContainer gap={1} className={state}>
+                {renderLabels(agentNode.labelsList)}
+              </LabelsContainer>
+            )}
+          </Transition>
+        </Flex>
 
-      {isAgentIncompatible ? (
-        <CompatibilityError
-          // Hide the alert if the current action has failed. downloadAgent and startAgent already
-          // return an error message related to compatibility.
-          //
-          // Basically, we have to cover two use cases:
-          //
-          // * Auto start has failed due to compatibility promise, so the downloadAgent failed with
-          // an error.
-          // * Auto start wasn't enabled, so the current action has no errors, but the user should
-          // not be able to start the agent due to compatibility issues.
-          hideAlert={!!prettyCurrentAction.error}
-        />
-      ) : (
-        <>
-          <Text mb={4} mt={1}>
-            Connecting your computer will allow any cluster user with the role{' '}
-            <strong>{roleName}</strong> to access it as an SSH resource with the
-            user <strong>{systemUsername}</strong>.
-          </Text>
-          {showConnectAndStopAgentButtons ? (
-            <ButtonPrimary
-              block
-              disabled={disableConnectAndStopAgentButtons}
-              onClick={startSshSession}
-              size="large"
+        <Flex flexDirection="column" gap={2}>
+          <Flex gap={1} display="flex" alignItems="center" minHeight="32px">
+            {prettyCurrentAction.Icon && (
+              <prettyCurrentAction.Icon size="medium" />
+            )}
+            {prettyCurrentAction.title}
+            {showConnectAndStopAgentButtons && (
+              <ButtonSecondary
+                onClick={killAgent}
+                disabled={disableConnectAndStopAgentButtons}
+                ml={3}
+              >
+                Stop Agent
+              </ButtonSecondary>
+            )}
+          </Flex>
+          {prettyCurrentAction.error && (
+            <Alert
+              mb={0}
+              css={`
+                white-space: pre-wrap;
+              `}
             >
-              Connect
-            </ButtonPrimary>
-          ) : (
-            <ButtonPrimary
-              block
-              disabled={disableStartAgentButton}
-              onClick={downloadAndStartAgent}
-              size="large"
-            >
-              Start Agent
-            </ButtonPrimary>
+              {prettyCurrentAction.error}
+            </Alert>
           )}
-        </>
-      )}
+          {prettyCurrentAction.logs && <Logs logs={prettyCurrentAction.logs} />}
+        </Flex>
+
+        <Flex flexDirection="column" gap={2}>
+          {isAgentIncompatible ? (
+            <CompatibilityError
+              // Hide the alert if the current action has failed. downloadAgent and startAgent already
+              // return an error message related to compatibility.
+              //
+              // Basically, we have to cover two use cases:
+              //
+              // * Auto start has failed due to compatibility promise, so the downloadAgent failed with
+              // an error.
+              // * Auto start wasn't enabled, so the current action has no errors, but the user should
+              // not be able to start the agent due to compatibility issues.
+              hideAlert={!!prettyCurrentAction.error}
+            />
+          ) : (
+            <>
+              <Text>
+                Connecting your computer will allow any cluster user with the
+                role <strong>{roleName}</strong> to access it as an SSH resource
+                with the user <strong>{systemUsername}</strong>.
+              </Text>
+              {showConnectAndStopAgentButtons ? (
+                <ButtonPrimary
+                  block
+                  disabled={disableConnectAndStopAgentButtons}
+                  onClick={startSshSession}
+                  size="large"
+                >
+                  Connect
+                </ButtonPrimary>
+              ) : (
+                <ButtonPrimary
+                  block
+                  disabled={disableStartAgentButton}
+                  onClick={downloadAndStartAgent}
+                  size="large"
+                  data-testid="start-agent"
+                >
+                  Start Agent
+                </ButtonPrimary>
+              )}
+            </>
+          )}
+        </Flex>
+      </Flex>
     </Box>
   );
 }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -273,11 +273,18 @@ export function DocumentConnectMyComputerStatus(
             />
           ) : (
             <>
-              <Text>
-                Connecting your computer will allow any cluster user with the
-                role <strong>{roleName}</strong> to access it as an SSH resource
-                with the user <strong>{systemUsername}</strong>.
-              </Text>
+              {isRunning ? (
+                <Text>
+                  Any cluster user with the role <strong>{roleName}</strong> can
+                  now access your computer as <strong>{systemUsername}</strong>.
+                </Text>
+              ) : (
+                <Text>
+                  Connecting your computer will allow any cluster user with the
+                  role <strong>{roleName}</strong> to access it as an SSH
+                  resource with the user <strong>{systemUsername}</strong>.
+                </Text>
+              )}
               {showConnectAndStopAgentButtons ? (
                 <ButtonPrimary
                   block

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/Logs.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/Logs.tsx
@@ -23,8 +23,8 @@ interface LogsProps {
 
 export function Logs(props: LogsProps): JSX.Element {
   return (
-    <>
-      <Text mb={2}>Last 10 lines of logs:</Text>
+    <Flex flexDirection="column" gap={1}>
+      <Text>Last 10 lines of logs:</Text>
       <Flex
         width="100%"
         color="light"
@@ -44,6 +44,6 @@ export function Logs(props: LogsProps): JSX.Element {
           {props.logs}
         </span>
       </Flex>
-    </>
+    </Flex>
   );
 }


### PR DESCRIPTION
The previous version set spacing on each element individually. The new version splits elements into three separate groups. There's gap of 16px between each group, gap of 8px within each group and gap of 4px between closely related elements. For example, the line "Last 10 lines of logs:" now sticks closely to the logs with a gap of 4px.

This is inspired by [the stack layout primitive from Every Layout](https://every-layout.dev/layouts/stack/).

The only inconsistency now is a situation where autostart fails due to incompatibility issues as the alert about incompatibility is shown outside of `<CompatibilityError>`, but I think we can live with such a small difference in positioning.

I also changed the copy above the Connect button when the agent is running.

| Before | After |
| --- | --- |
| ![running before](https://github.com/gravitational/teleport/assets/27113/f739560f-93b2-44d6-b51d-2e94a4afb8a6) | ![running after](https://github.com/gravitational/teleport/assets/27113/fdefb2ab-5afd-4b5b-b00b-5f5eaccdaf30) |
| ![exited before](https://github.com/gravitational/teleport/assets/27113/b3d598e3-0daf-463a-881f-332043d7fde7) | ![exited after](https://github.com/gravitational/teleport/assets/27113/8c6d12b0-f746-483c-afa9-67c5545ff12f) |

| Regular incompatibility alert | Incompatibility alert on failed autostart |
| --- | --- |
| ![regular](https://github.com/gravitational/teleport/assets/27113/1a728c7e-f881-4e85-badf-0cd7ef3c9b9d) | ![failed autostart](https://github.com/gravitational/teleport/assets/27113/0ae7dd8d-6133-4bfa-9c1e-210b2375d852) |



