### PR TITLE
Machine ID Docs Refactor: SSH Access guide

### DIFF
--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -138,11 +138,14 @@ my-host
   Teleport's port multiplexing.
 </Notice>
 
-### Other tools
+### Connecting using other tools
 
 To integrate with other SSH tools, first determine whether the `ssh_config`
 is compatible with them. This is the case for many tools such as Ansible and the
 guidance provided under "Connecting using OpenSSH" should be sufficient.
+
+If you wish to integrate with Ansible, check out the
+[Ansible specific guide](./ansible.mdx).
 
 If your tool is not compatible with `ssh_config`, it may still be possible to
 configure it to use the credentials produced by Machine ID. It must support

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -3,4 +3,24 @@ title: Machine ID with Server Access
 description: How to use Machine ID to access servers via SSH
 ---
 
-TODO
+(!docs/pages/includes/machine-id/v2-config-warning.mdx!)
+
+Teleport Server Access protects and controls SSH access to servers. Machine ID
+can be used to grant machines secure, short-lived access to these servers.
+
+In this guide, you will configure `tbot` to produce credentials that can be
+used to access a Linux server enrolled in Teleport Server Access. The guide
+will cover access using Teleports CLI `tsh` as well as the OpenSSH SSH client.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- If you have not already connected your server to Teleport, follow
+  the [Server Access Getting Started Guide](../../application-access/getting-started.mdx).
+
+- (!docs/pages/includes/tctl.mdx!)
+
+- `tbot` must already be installed and configured on the machine that will
+  connect to Linux hosts with SSH. For more information, see the
+  [platform guides](../platform-guides.mdx).

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -145,12 +145,8 @@ is compatible with them. This is the case for many tools such as Ansible and the
 guidance provided under "Connecting using OpenSSH" should be sufficient.
 
 If your tool is not compatible with `ssh_config`, it may still be possible to
-configure it to use the credentials produced by Machine ID.
-
-It must support:
-
-- ProxyCommand or ProxyJump functionality
-- SSH Client Certificates
+configure it to use the credentials produced by Machine ID. It must support
+SSH client certificates and either ProxyCommand or ProxyJump functionality.
 
 ## Next steps
 

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -24,3 +24,100 @@ will cover access using Teleports CLI `tsh` as well as the OpenSSH SSH client.
 - `tbot` must already be installed and configured on the machine that will
   connect to Linux hosts with SSH. For more information, see the
   [platform guides](../platform-guides.mdx).
+
+## Step 1/3. Configure RBAC
+
+First, Teleport must be configured to allow the credentials produced by the bot
+to connect to the SSH servers. In this example, access will be granted to all
+SSH hosts for the username `root`.
+
+For production use, you should use labels to restrict this access to only the
+hosts that the bot will need to access. This is known as the principal of
+least privilege and limits the damage that exfiltrated credentials can do.
+
+If you have followed an access guide, you will have created a role and granted
+the bot the ability to impersonate it already. This role just needs to have the
+additional privileges added to it.
+
+Use `tctl edit role/example-bot` to add the following to the role:
+
+```yaml
+spec:
+  allow:
+    # Allow login to the user 'root'.
+    logins: ['root']
+    # Allow connection to any node. Adjust these labels to match only nodes
+    # that ansible needs to access.
+    node_labels:
+      '*': '*'
+```
+
+## Step 2/3. Configure the `tbot` output
+
+Now, `tbot` needs to be configured with an output that will produce the
+SSH certificate and OpenSSH configuration. For this we use the `identity` output
+type.
+
+Outputs must be configured with a destination. In this example, the `directory`
+destination will be used. This will write these credentials to a specified
+directory on disk. Ensure that this directory can be written to by the Linux
+user that `tbot` runs as, and that it can be read by the Linux user that needs
+to use SSH.
+
+Modify your `tbot` configuration to add an `identity` output:
+
+```yaml
+outputs:
+- type: identity
+  destination:
+    type: directory
+    # For this guide, /opt/machine-id is used as the destination directory.
+    # You may wish to customize this. Multiple outputs cannot share the same
+    # destination.
+    path: /opt/machine-id
+```
+
+If operating `tbot` as a background service, restart it. If running `tbot` in
+one-shot mode, it must be executed before you attempt to execute the Ansible
+playbook.
+
+## Step 3/3. Using the output credentials
+
+Once `tbot` has been run or restarted, you should now see several files under
+`/opt/machine-id`:
+
+- `identity`: this is a bundle of credentials that can be used by `tsh` to
+ authenticate.
+- `ssh_config`: this can be used with OpenSSH and other tools to configure them
+to use the Teleport Proxy with the correct credentials when making connections.
+- `known_hosts`: this contains the Teleport SSH host CAs and allows the SSH
+client to validate a hosts certificate.
+- `key-cert.pub`: this is an SSH certificate signed by the Teleport SSH user
+CA.
+- `key`: this is the private key needed to use the SSH certificate.
+
+These credentials can be used with Teleport's CLI `tsh` or with tools based on
+OpenSSHs SSH client.
+
+### Configuring `tsh`
+
+```code
+$ tsh -i /opt/machine-id/identity --proxy example.teleport.sh:443 root@my-host hostname
+```
+
+### Configuring OpenSSH
+
+```code
+$ ssh -F /opt/machine-id/ssh_config root@node-name.example.com
+```
+
+<Notice type="warning">
+  The `ssh_config` for OpenSSH still requires that `tsh` is installed on the
+  system that will use the `ssh_config`. This is necessary as `tsh` is used to
+  handle Teleport's port multiplexing.
+</Notice>
+
+## Next steps
+
+- Read the [configuration reference](../reference/configuration.mdx) to explore
+  all the available configuration options.

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -29,11 +29,14 @@ will cover access using Teleports CLI `tsh` as well as the OpenSSH SSH client.
 
 First, Teleport must be configured to allow the credentials produced by the bot
 to connect to the SSH servers. In this example, access will be granted to all
-SSH hosts for the username `root`.
+SSH nodes for the username `root`.
 
 For production use, you should use labels to restrict this access to only the
 hosts that the bot will need to access. This is known as the principal of
 least privilege and limits the damage that exfiltrated credentials can do.
+
+You may also wish to adjust this to grant access to a user other than `root`
+depending on what commands will need to be executed with the credentials.
 
 If you have followed an access guide, you will have created a role and granted
 the bot the ability to impersonate it already. This role just needs to have the
@@ -44,7 +47,7 @@ Use `tctl edit role/example-bot` to add the following to the role:
 ```yaml
 spec:
   allow:
-    # Allow login to the user 'root'.
+    # Allow login to the Linux user 'root'.
     logins: ['root']
     # Allow connection to any node. Adjust these labels to match only nodes
     # that ansible needs to access.
@@ -99,22 +102,40 @@ CA.
 These credentials can be used with Teleport's CLI `tsh` or with tools based on
 OpenSSHs SSH client.
 
-### Configuring `tsh`
+### Connecting using `tsh`
+
+To use `tsh` with a `tbot` identity output, the path to the `identity` file
+must be specified using the `-i` flag. In addition, `--proxy` must be used to
+specify the address of the Teleport Proxy that should be used when making
+connections.
+
+In this example, `tsh` is used to connect to a node called `my-host` via the
+proxy `example.teleport.sh:443` and to execute the command `hostname`:
 
 ```code
 $ tsh -i /opt/machine-id/identity --proxy example.teleport.sh:443 root@my-host hostname
+my-host
 ```
 
-### Configuring OpenSSH
+### Connecting using OpenSSH
+
+To use OpenSSH with the identity output, the path to the `ssh_config` should be
+provided to `ssh` with the `-F` flag.
+
+With the generated `ssh_config` you must append the name of the Teleport cluster
+to the name of the node - in this example, the command `hostname` is
+executed as `root` on the node `my-host` belonging to the cluster
+`example.teleport.sh`.
 
 ```code
-$ ssh -F /opt/machine-id/ssh_config root@node-name.example.com
+$ ssh -F /opt/machine-id/ssh_config root@my-host.example.teleport.sh hostname
+my-host
 ```
 
 <Notice type="warning">
-  The `ssh_config` for OpenSSH still requires that `tsh` is installed on the
-  system that will use the `ssh_config`. This is necessary as `tsh` is used to
-  handle Teleport's port multiplexing.
+  The `ssh_config` for OpenSSH requires that `tsh` is installed. This is
+  necessary as `tsh` is used to make the OpenSSH client compatible with
+  Teleport's port multiplexing.
 </Notice>
 
 ## Next steps

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -138,6 +138,20 @@ my-host
   Teleport's port multiplexing.
 </Notice>
 
+### Other tools
+
+To integrate with other SSH tools, first determine whether the `ssh_config`
+is compatible with them. This is the case for many tools such as Ansible and the
+guidance provided under "Connecting using OpenSSH" should be sufficient.
+
+If your tool is not compatible with `ssh_config`, it may still be possible to
+configure it to use the credentials produced by Machine ID.
+
+It must support:
+
+- ProxyCommand or ProxyJump functionality
+- SSH Client Certificates
+
 ## Next steps
 
 - Read the [configuration reference](../reference/configuration.mdx) to explore

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -81,8 +81,8 @@ outputs:
 ```
 
 If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to execute the Ansible
-playbook.
+one-shot mode, it must be executed before you attempt to use the credentials
+produced by `tbot` to connect to nodes via SSH.
 
 ## Step 3/3. Using the output credentials
 
@@ -90,16 +90,18 @@ Once `tbot` has been run or restarted, you should now see several files under
 `/opt/machine-id`:
 
 - `identity`: this is a bundle of credentials that can be used by `tsh` to
- authenticate.
+  authenticate.
 - `ssh_config`: this can be used with OpenSSH and other tools to configure them
-to use the Teleport Proxy Service with the correct credentials when making connections.
+  to use the Teleport Proxy Service with the correct credentials when making
+  connections.
 - `known_hosts`: this contains the Teleport SSH host CAs and allows the SSH
-client to validate a host's certificate.
+  client to validate a host's certificate.
 - `key-cert.pub`: this is an SSH certificate signed by the Teleport SSH user
-CA.
+  CA.
 - `key`: this is the private key needed to use the SSH certificate.
 
-These credentials can be used with Teleport's CLI `tsh` or with OpenSSH client tools like `ssh` and `sftp`.
+These credentials can be used with Teleport's CLI `tsh` or with OpenSSH client
+tools like `ssh` and `sftp`.
 
 ### Connecting using `tsh`
 

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -5,12 +5,12 @@ description: How to use Machine ID to access servers via SSH
 
 (!docs/pages/includes/machine-id/v2-config-warning.mdx!)
 
-Teleport Server Access protects and controls SSH access to servers. Machine ID
+Teleport protects and controls SSH access to servers. Machine ID
 can be used to grant machines secure, short-lived access to these servers.
 
 In this guide, you will configure `tbot` to produce credentials that can be
-used to access a Linux server enrolled in Teleport Server Access. The guide
-will cover access using Teleports CLI `tsh` as well as the OpenSSH SSH client.
+used to access a Linux server enrolled in Teleport. The guide
+will cover access using the Teleport CLI `tsh` as well as the OpenSSH client.
 
 ## Prerequisites
 
@@ -28,11 +28,11 @@ will cover access using Teleports CLI `tsh` as well as the OpenSSH SSH client.
 ## Step 1/3. Configure RBAC
 
 First, Teleport must be configured to allow the credentials produced by the bot
-to connect to the SSH servers. In this example, access will be granted to all
+to connect to SSH servers in your infrastructure. In this example, access will be granted to all
 SSH nodes for the username `root`.
 
 For production use, you should use labels to restrict this access to only the
-hosts that the bot will need to access. This is known as the principal of
+hosts that the bot will need to access. This is known as the principle of
 least privilege and limits the damage that exfiltrated credentials can do.
 
 You may also wish to adjust this to grant access to a user other than `root`
@@ -57,7 +57,7 @@ spec:
 
 ## Step 2/3. Configure the `tbot` output
 
-Now, `tbot` needs to be configured with an output that will produce the
+Now, `tbot` needs to be configured with an output that will produce an
 SSH certificate and OpenSSH configuration. For this we use the `identity` output
 type.
 
@@ -92,21 +92,20 @@ Once `tbot` has been run or restarted, you should now see several files under
 - `identity`: this is a bundle of credentials that can be used by `tsh` to
  authenticate.
 - `ssh_config`: this can be used with OpenSSH and other tools to configure them
-to use the Teleport Proxy with the correct credentials when making connections.
+to use the Teleport Proxy Service with the correct credentials when making connections.
 - `known_hosts`: this contains the Teleport SSH host CAs and allows the SSH
-client to validate a hosts certificate.
+client to validate a host's certificate.
 - `key-cert.pub`: this is an SSH certificate signed by the Teleport SSH user
 CA.
 - `key`: this is the private key needed to use the SSH certificate.
 
-These credentials can be used with Teleport's CLI `tsh` or with tools based on
-OpenSSHs SSH client.
+These credentials can be used with Teleport's CLI `tsh` or with OpenSSH client tools like `ssh` and `sftp`.
 
 ### Connecting using `tsh`
 
 To use `tsh` with a `tbot` identity output, the path to the `identity` file
 must be specified using the `-i` flag. In addition, `--proxy` must be used to
-specify the address of the Teleport Proxy that should be used when making
+specify the address of the Teleport Proxy Service that should be used when making
 connections.
 
 In this example, `tsh` is used to connect to a node called `my-host` via the
@@ -145,7 +144,7 @@ is compatible with them. This is the case for many tools such as Ansible and the
 guidance provided under "Connecting using OpenSSH" should be sufficient.
 
 If you wish to integrate with Ansible, check out the
-[Ansible specific guide](./ansible.mdx).
+[Ansible-specific guide](./ansible.mdx).
 
 If your tool is not compatible with `ssh_config`, it may still be possible to
 configure it to use the credentials produced by Machine ID. It must support

--- a/docs/pages/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-id/access-guides/ssh.mdx
@@ -28,15 +28,8 @@ will cover access using the Teleport CLI `tsh` as well as the OpenSSH client.
 ## Step 1/3. Configure RBAC
 
 First, Teleport must be configured to allow the credentials produced by the bot
-to connect to SSH servers in your infrastructure. In this example, access will be granted to all
-SSH nodes for the username `root`.
-
-For production use, you should use labels to restrict this access to only the
-hosts that the bot will need to access. This is known as the principle of
-least privilege and limits the damage that exfiltrated credentials can do.
-
-You may also wish to adjust this to grant access to a user other than `root`
-depending on what commands will need to be executed with the credentials.
+to connect to SSH servers in your infrastructure. In this example, access will
+be granted to all SSH nodes for the username `root`.
 
 If you have followed an access guide, you will have created a role and granted
 the bot the ability to impersonate it already. This role just needs to have the
@@ -54,6 +47,13 @@ spec:
     node_labels:
       '*': '*'
 ```
+
+You may also wish to adjust this to grant access to a user other than `root`
+depending on what commands will need to be executed with the credentials.
+
+For production use, you should adjust `node_labels` to restrict this access to
+only the hosts that the bot will need to access. This is known as the principle
+of least privilege and limits the damage that exfiltrated credentials can do.
 
 ## Step 2/3. Configure the `tbot` output
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/pull/31259

Adds a brand new Server Access guide as there's no existing standalone guide that currently exists for that.