### PR TITLE
Explain template variables wherever they appear

### DIFF
--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -350,6 +350,10 @@ To restrict access to a particular resource using a role similar to the ones
 below, edit one of the user's roles so the `search_as_roles` field includes the
 role you have created.
 
+For full details on how to use Teleport roles to configure RBAC, see the
+[Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 #### `node`
 
 You can restrict access to searching `node` resources by assigning values to the

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -352,7 +352,7 @@ role you have created.
 
 For full details on how to use Teleport roles to configure RBAC, see the
 [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 
 #### `node`
 

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -206,6 +206,6 @@ Device Trust enforcement.
 - The role we illustrated in this guide uses the `internal.logins` trait,
   which Teleport replaces with values from the Teleport local user
   database. For full details on how traits work in Teleport roles,
-  see the  [Teleport Access Controls
+  see the [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -207,5 +207,5 @@ Device Trust enforcement.
   which Teleport replaces with values from the Teleport local user
   database. For full details on how traits work in Teleport roles,
   see the [Teleport Access Controls
-  Reference](docs/pages/access-controls/reference.mdx#roles).
+  Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -203,9 +203,9 @@ Device Trust enforcement.
 - [Device Management](./device-management.mdx)
 - [Enforcing Device Trust](./enforcing-device-trust.mdx)
 - [Jamf Pro Integration](./jamf-integration.mdx)
-- The role we illustrated in this guide uses the `{{internal.logins}}` template
-  variable, which Teleport replaces with values from the Teleport local user
-  database. For full details on how variable expansion works in Teleport roles,
+- The role we illustrated in this guide uses the `internal.logins` trait,
+  which Teleport replaces with values from the Teleport local user
+  database. For full details on how traits work in Teleport roles,
   see the  [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -203,3 +203,9 @@ Device Trust enforcement.
 - [Device Management](./device-management.mdx)
 - [Enforcing Device Trust](./enforcing-device-trust.mdx)
 - [Jamf Pro Integration](./jamf-integration.mdx)
+- The role we illustrated in this guide uses the `{{internal.logins}}` template
+  variable, which Teleport replaces with values from the Teleport local user
+  database. For full details on how variable expansion works in Teleport roles,
+  see the  [Teleport Access Controls
+  Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -604,5 +604,5 @@ The roles we illustrated in this guide use `external` traits,
 which Teleport replaces with values from the single sign-on provider that the
 user used to authenticate with Teleport. For full details on how variable
 expansion works in Teleport roles, see the  [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -598,3 +598,11 @@ spec:
 version: v5
 ```
 
+## Next steps
+
+The roles we illustrated in this guide use the `external` template variable,
+which Teleport replaces with values from the single sign-on provider that the
+user used to authenticate with Teleport. For full details on how variable
+expansion works in Teleport roles, see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -600,7 +600,7 @@ version: v5
 
 ## Next steps
 
-The roles we illustrated in this guide use the `external` template variable,
+The roles we illustrated in this guide use `external` traits,
 which Teleport replaces with values from the single sign-on provider that the
 user used to authenticate with Teleport. For full details on how variable
 expansion works in Teleport roles, see the  [Teleport Access Controls

--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -208,5 +208,5 @@ In the Teleport role we illustrated in this guide, `external` traits
 are replaced with values from the single sign-on provider that the user
 used to authenticate to Teleport. For full details on how traits
 work in Teleport roles, see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -204,9 +204,9 @@ automatically in a browser.
 
 ## Next steps
 
-In the Teleport role we illustrated in this guide, the `external` template
-variable is replaced with values from the single sign-on provider that the user
-used to authenticate to Teleport. For full details on how variable expansion
-works in Teleport roles, see the  [Teleport Access Controls
+In the Teleport role we illustrated in this guide, `external` traits
+ are replaced with values from the single sign-on provider that the user
+used to authenticate to Teleport. For full details on how traits
+work in Teleport roles, see the  [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -201,3 +201,12 @@ automatically in a browser.
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+## Next steps
+
+In the Teleport role we illustrated in this guide, the `external` template
+variable is replaced with values from the single sign-on provider that the user
+used to authenticate to Teleport. For full details on how variable expansion
+works in Teleport roles, see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -205,8 +205,8 @@ automatically in a browser.
 ## Next steps
 
 In the Teleport role we illustrated in this guide, `external` traits
- are replaced with values from the single sign-on provider that the user
+are replaced with values from the single sign-on provider that the user
 used to authenticate to Teleport. For full details on how traits
-work in Teleport roles, see the  [Teleport Access Controls
+work in Teleport roles, see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -393,9 +393,9 @@ Change the Name ID format to use email instead:
 ## Further reading
 
 - [Teleport Configuration Resources Reference](../../reference/resources.mdx)
-- In the Teleport role we illustrated in this guide, the `external` template
-  variable is replaced with values from the single sign-on provider that the
-  user used to authenticate to Teleport. For full details on how variable
-  expansion works in Teleport roles, see the  [Teleport Access Controls
+- In the Teleport role we illustrated in this guide, `external` traits
+  are replaced with values from the single sign-on provider that the
+  user used to authenticate to Teleport. For full details on how traits
+  work in Teleport roles, see the  [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -397,5 +397,5 @@ Change the Name ID format to use email instead:
   are replaced with values from the single sign-on provider that the
   user used to authenticate to Teleport. For full details on how traits
   work in Teleport roles, see the [Teleport Access Controls
-  Reference](docs/pages/access-controls/reference.mdx#roles).
+  Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -396,6 +396,6 @@ Change the Name ID format to use email instead:
 - In the Teleport role we illustrated in this guide, `external` traits
   are replaced with values from the single sign-on provider that the
   user used to authenticate to Teleport. For full details on how traits
-  work in Teleport roles, see the  [Teleport Access Controls
+  work in Teleport roles, see the [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -393,3 +393,9 @@ Change the Name ID format to use email instead:
 ## Further reading
 
 - [Teleport Configuration Resources Reference](../../reference/resources.mdx)
+- In the Teleport role we illustrated in this guide, the `external` template
+  variable is replaced with values from the single sign-on provider that the
+  user used to authenticate to Teleport. For full details on how variable
+  expansion works in Teleport roles, see the  [Teleport Access Controls
+  Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -447,3 +447,11 @@ shows the slug is `my-team`. Update the teams to roles mapping.
       team: my-team
 ```
 
+## Next steps
+
+The role we illustrated in this guide uses the `{{internal.logins}}` template
+variable, which Teleport replaces with values from the Teleport local user
+database. For full details on how variable expansion works in Teleport roles,
+see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -449,9 +449,10 @@ shows the slug is `my-team`. Update the teams to roles mapping.
 
 ## Next steps
 
-The role we illustrated in this guide uses the `{{internal.logins}}` template
-variable, which Teleport replaces with values from the Teleport local user
-database. For full details on how variable expansion works in Teleport roles,
+
+The role we illustrated in this guide uses the `internal.logins` trait,
+ which Teleport replaces with values from the Teleport local user
+database. For full details on how traits work in Teleport roles,
 see the  [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -454,5 +454,5 @@ The role we illustrated in this guide uses the `internal.logins` trait,
 which Teleport replaces with values from the Teleport local user
 database. For full details on how traits work in Teleport roles,
 see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -451,8 +451,8 @@ shows the slug is `my-team`. Update the teams to roles mapping.
 
 
 The role we illustrated in this guide uses the `internal.logins` trait,
- which Teleport replaces with values from the Teleport local user
+which Teleport replaces with values from the Teleport local user
 database. For full details on how traits work in Teleport roles,
-see the  [Teleport Access Controls
+see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/gitlab.mdx
+++ b/docs/pages/access-controls/sso/gitlab.mdx
@@ -174,8 +174,12 @@ spec:
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice `{{external.email}}` login. It configures Teleport to look at
-  *"email"* GitLab claim and use that field as an allowed login for each user.  The `email.local(external.trait)` function will remove the `@domain` and just have the username prefix.
+- Notice the `{{external.email}}` login. It configures Teleport to look at
+  *"email"* GitLab claim and use that field as an allowed login for each user.
+  The `email.local(external.trait)` function removes the `@domain` and preserves
+  the username prefix. For full details on how variable expansion works in
+  Teleport roles, see the  [Teleport Access Controls
+  Reference](docs/pages/access-controls/reference.mdx#roles).
 - Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/pages/access-controls/sso/gitlab.mdx
+++ b/docs/pages/access-controls/sso/gitlab.mdx
@@ -179,7 +179,7 @@ spec:
   The `email.local(external.trait)` function removes the `@domain` and preserves
   the username prefix. For full details on how variable expansion works in
   Teleport roles, see the [Teleport Access Controls
-  Reference](docs/pages/access-controls/reference.mdx#roles).
+  Reference](../../access-controls/reference.mdx).
 - Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/pages/access-controls/sso/gitlab.mdx
+++ b/docs/pages/access-controls/sso/gitlab.mdx
@@ -174,11 +174,11 @@ spec:
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice the `{{external.email}}` login. It configures Teleport to look at
+- Notice the `{{external.email}}` login. It configures Teleport to look at the
   *"email"* GitLab claim and use that field as an allowed login for each user.
   The `email.local(external.trait)` function removes the `@domain` and preserves
   the username prefix. For full details on how variable expansion works in
-  Teleport roles, see the  [Teleport Access Controls
+  Teleport roles, see the [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 - Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -272,7 +272,7 @@ This example uses email as the username format.  The
 `email.local(external.username)` function call will remove the `@domain` and
 leave the username prefix. For full details on how variable expansion works in
 Teleport roles, see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 
 Use tctl to create this role in the Teleport Auth Service:
 

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -271,7 +271,7 @@ Notice the `{{external.username}}` login. It configures Teleport to look at the
 This example uses email as the username format.  The
 `email.local(external.username)` function call will remove the `@domain` and
 leave the username prefix. For full details on how variable expansion works in
-Teleport roles, see the  [Teleport Access Controls
+Teleport roles, see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 
 Use tctl to create this role in the Teleport Auth Service:

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -267,9 +267,12 @@ Members of this role have are assigned several attributes:
   see/replay past sessions or re-configure the Teleport cluster.
 
 Notice the `{{external.username}}` login. It configures Teleport to look at the
-*"username"* Okta claim and use that field as an allowed login for each user. This
-example uses email as the username format.  The `email.local(external.username)`
-function call will remove the `@domain` and leave the username prefix.
+*"username"* Okta claim and use that field as an allowed login for each user.
+This example uses email as the username format.  The
+`email.local(external.username)` function call will remove the `@domain` and
+leave the username prefix. For full details on how variable expansion works in
+Teleport roles, see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
 
 Use tctl to create this role in the Teleport Auth Service:
 

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -154,9 +154,9 @@ $ tctl create -f dev.yaml
 
 ## Next steps
 
-In the Teleport role we illustrated in this guide, the `external` template
-variable is replaced with values from the single sign-on provider that the user
-used to authenticate to Teleport. For full details on how variable expansion
-works in Teleport roles, see the  [Teleport Access Controls
+In the Teleport role we illustrated in this guide, `external` traits
+ are replaced with values from the single sign-on provider that the user
+used to authenticate to Teleport. For full details on how traits
+work in Teleport roles, see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -155,7 +155,7 @@ $ tctl create -f dev.yaml
 ## Next steps
 
 In the Teleport role we illustrated in this guide, `external` traits
- are replaced with values from the single sign-on provider that the user
+are replaced with values from the single sign-on provider that the user
 used to authenticate to Teleport. For full details on how traits
 work in Teleport roles, see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -158,5 +158,5 @@ In the Teleport role we illustrated in this guide, `external` traits
 are replaced with values from the single sign-on provider that the user
 used to authenticate to Teleport. For full details on how traits
 work in Teleport roles, see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -151,3 +151,12 @@ $ tctl create -f dev.yaml
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+## Next steps
+
+In the Teleport role we illustrated in this guide, the `external` template
+variable is replaced with values from the single sign-on provider that the user
+used to authenticate to Teleport. For full details on how variable expansion
+works in Teleport roles, see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -546,8 +546,8 @@ background and uses it to execute the command.
 - See the [Azure
   documentation](https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest)
   for the full list of `az` CLI commands.
-- For full details on how Teleport expands the `internal` and `external`
-  template variables we illustrated in the Teleport roles within this guide, see
+- For full details on how Teleport populates the `internal` and `external`
+  traits we illustrated in the Teleport roles within this guide, see
   the [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -549,5 +549,5 @@ background and uses it to execute the command.
 - For full details on how Teleport populates the `internal` and `external`
   traits we illustrated in the Teleport roles within this guide, see
   the [Teleport Access Controls
-  Reference](docs/pages/access-controls/reference.mdx#roles).
+  Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -546,3 +546,8 @@ background and uses it to execute the command.
 - See the [Azure
   documentation](https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest)
   for the full list of `az` CLI commands.
+- For full details on how Teleport expands the `internal` and `external`
+  template variables we illustrated in the Teleport roles within this guide, see
+  the [Teleport Access Controls
+  Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -645,3 +645,8 @@ command.
   reference of commands, view the Google Cloud documentation for
   [`gcloud`](https://cloud.google.com/sdk/gcloud/reference) and
   [`gsutil`](https://cloud.google.com/storage/docs/gsutil).
+- For full details on how Teleport expands the `internal` and `external`
+  template variables we illustrated in the Teleport roles within this guide, see
+  the [Teleport Access Controls
+  Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -648,5 +648,5 @@ command.
 - For full details on how Teleport populates the `internal` and `external`
   traits we illustrated in the Teleport roles within this guide, see
   the [Teleport Access Controls
-  Reference](docs/pages/access-controls/reference.mdx#roles).
+  Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -645,8 +645,8 @@ command.
   reference of commands, view the Google Cloud documentation for
   [`gcloud`](https://cloud.google.com/sdk/gcloud/reference) and
   [`gsutil`](https://cloud.google.com/storage/docs/gsutil).
-- For full details on how Teleport expands the `internal` and `external`
-  template variables we illustrated in the Teleport roles within this guide, see
+- For full details on how Teleport populates the `internal` and `external`
+  traits we illustrated in the Teleport roles within this guide, see
   the [Teleport Access Controls
   Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -132,10 +132,13 @@ for more information on enabling access to Azure managed identities.
 
 ## Next steps
 
+- For full details on how Teleport expands the `internal` and `external`
+  template variables we illustrated in this guide, see the [Teleport Access
+  Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 - View access controls [Getting Started](../access-controls/getting-started.mdx)
   and other available [guides](../access-controls/guides.mdx).
-- Learn about using [JWT tokens](./jwt/introduction.mdx) to implement access controls
-  in your application.
+- Learn about using [JWT tokens](./jwt/introduction.mdx) to implement access
+  controls in your application.
 - Integrate with your identity provider:
   - [OIDC](../access-controls/sso/oidc.mdx)
   - [ADFS](../access-controls/sso/adfs.mdx)

--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -132,8 +132,10 @@ for more information on enabling access to Azure managed identities.
 
 ## Next steps
 
-- For full details on how Teleport expands the `internal` and `external`
-  template variables we illustrated in this guide, see the [Teleport Access
+- View access controls [Getting Started](../access-controls/getting-started.mdx)
+  and other available [guides](../access-controls/guides.mdx).
+- For full details on how Teleport populates the `internal` and `external`
+  traits we illustrated in this guide, see the [Teleport Access
   Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 - View access controls [Getting Started](../access-controls/getting-started.mdx)
   and other available [guides](../access-controls/guides.mdx).

--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -136,7 +136,7 @@ for more information on enabling access to Azure managed identities.
   and other available [guides](../access-controls/guides.mdx).
 - For full details on how Teleport populates the `internal` and `external`
   traits we illustrated in this guide, see the [Teleport Access
-  Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+  Controls Reference](../access-controls/reference.mdx).
 - View access controls [Getting Started](../access-controls/getting-started.mdx)
   and other available [guides](../access-controls/guides.mdx).
 - Learn about using [JWT tokens](./jwt/introduction.mdx) to implement access

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -281,6 +281,10 @@ Additionally, the `{{internal.jwt}}` template variable will be replaced with
 a JWT token signed by Teleport that contains user identity information. See
 [Integrating with JWTs](../jwt/introduction.mdx) for more details.
 
+For full details on configuring Teleport roles, including how Teleport expands
+the `external` and `internal` template variables, see the [Teleport Access
+Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ### Configuring the JWT token
 
 By default, Teleport includes a user's roles and traits in the JWT

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -281,8 +281,8 @@ Additionally, the `{{internal.jwt}}` template variable will be replaced with
 a JWT token signed by Teleport that contains user identity information. See
 [Integrating with JWTs](../jwt/introduction.mdx) for more details.
 
-For full details on configuring Teleport roles, including how Teleport expands
-the `external` and `internal` template variables, see the [Teleport Access
+For full details on configuring Teleport roles, including how Teleport
+populates the `external` and `internal` traits, see the [Teleport Access
 Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 ### Configuring the JWT token

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -283,7 +283,7 @@ a JWT token signed by Teleport that contains user identity information. See
 
 For full details on configuring Teleport roles, including how Teleport
 populates the `external` and `internal` traits, see the [Teleport Access
-Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+Controls Reference](../../access-controls/reference.mdx).
 
 ### Configuring the JWT token
 

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -63,8 +63,8 @@ app_service:
     cloud: "Azure"
 ```
 
-For full details on configuring Teleport roles, including how Teleport expands
-the `external` template variable, see the [Teleport Access Controls
+For full details on configuring Teleport roles, including how Teleport
+populates the `external` traits, see the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 
 ## Application resource

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -63,6 +63,10 @@ app_service:
     cloud: "Azure"
 ```
 
+For full details on configuring Teleport roles, including how Teleport expands
+the `external` template variable, see the [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ## Application resource
 
 Full YAML spec of application resources managed by `tctl` resource commands:

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -65,7 +65,7 @@ app_service:
 
 For full details on configuring Teleport roles, including how Teleport
 populates the `external` traits, see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 
 ## Application resource
 

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -250,7 +250,7 @@ You can use predicate language function calls in templates, e.g. `{{email.local(
 
 For full details on how variable expansion works in Teleport roles, see the
 [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 
 **How role templates are evaluated**
 

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -248,6 +248,10 @@ You can use predicate language function calls in templates, e.g. `{{email.local(
 - Invalid values will be omitted, for example `-foo` is not a valid Unix login, so if variable `external.foo` equals
 `"-foo"`, it will be omitted in `logins: ["{{external.foo}}"]`.
 
+For full details on how variable expansion works in Teleport roles, see the
+[Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 **How role templates are evaluated**
 
 Role templates are evaluated at the time of access to any resource either by proxy or node.

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -98,7 +98,7 @@ Users created within the database will:
   templating](../../access-controls/guides/role-templates.mdx#interpolation-rules).
 - Read automatic user provisioning
   [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
-- The `{{internal.db_roles}}` template variables we illustrated in this guide
+- The `internal.db_roles` traits we illustrated in this guide
   are replaced with values from the Teleport local user database. For full
   details on how variable expansion works in Teleport roles, see the  [Teleport
   Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -92,6 +92,14 @@ Users created within the database will:
 
 ## Next steps
 
-- Connect using your [GUI database client](../../connect-your-client/gui-clients.mdx).
-- Learn about [role templating](../../access-controls/guides/role-templates.mdx#interpolation-rules).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Connect using your [GUI database
+  client](../../connect-your-client/gui-clients.mdx).
+- Learn about [role
+  templating](../../access-controls/guides/role-templates.mdx#interpolation-rules).
+- Read automatic user provisioning
+  [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- The `{{internal.db_roles}}` template variables we illustrated in this guide
+  are replaced with values from the Teleport local user database. For full
+  details on how variable expansion works in Teleport roles, see the  [Teleport
+  Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -101,5 +101,5 @@ Users created within the database will:
 - The `internal.db_roles` traits we illustrated in this guide
   are replaced with values from the Teleport local user database. For full
   details on how variable expansion works in Teleport roles, see the [Teleport
-  Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+  Access Controls Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -100,6 +100,6 @@ Users created within the database will:
   [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
 - The `internal.db_roles` traits we illustrated in this guide
   are replaced with values from the Teleport local user database. For full
-  details on how variable expansion works in Teleport roles, see the  [Teleport
+  details on how variable expansion works in Teleport roles, see the [Teleport
   Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 

--- a/docs/pages/database-access/rbac/configuring-access.mdx
+++ b/docs/pages/database-access/rbac/configuring-access.mdx
@@ -100,8 +100,8 @@ Similar to other role fields, `db_*` fields support templating variables.
 
 The `external.xyz` traits are replaced with values from external [single
 sign-on](../../access-controls/sso.mdx) providers. For OIDC, they will be
-replaced with a value of an "xyz" claim. For SAML, they are replaced 
- with an "xyz" assertion value. 
+replaced with the value of an "xyz" claim. For SAML, they are replaced 
+with an "xyz" assertion value. 
 
 For full details on how traits work in Teleport roles, see
 the [Teleport Access Controls

--- a/docs/pages/database-access/rbac/configuring-access.mdx
+++ b/docs/pages/database-access/rbac/configuring-access.mdx
@@ -98,9 +98,12 @@ is not currently enforced on MySQL connection attempts.
 
 Similar to other role fields, `db_*` fields support templating variables.
 
-The `{{external.xyz}}` variables are replaced with values from external [SSO](../../access-controls/sso.mdx)
-providers. For OIDC, they will be expanded with a value of an "xyz" claim; for
-SAML — with an "xyz" assertion value.
+The `{{external.xyz}}` variables are replaced with values from external [single
+sign-on](../../access-controls/sso.mdx) providers. For OIDC, they will be
+expanded with a value of an "xyz" claim; for SAML — with an "xyz" assertion
+value. For full details on how variable expansion works in Teleport roles, see
+the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
 
 For example, here is what a role may look like if you want to assign allowed
 database names from the user's Okta `databases` assertion:

--- a/docs/pages/database-access/rbac/configuring-access.mdx
+++ b/docs/pages/database-access/rbac/configuring-access.mdx
@@ -98,11 +98,13 @@ is not currently enforced on MySQL connection attempts.
 
 Similar to other role fields, `db_*` fields support templating variables.
 
-The `{{external.xyz}}` variables are replaced with values from external [single
+The `external.xyz` traits are replaced with values from external [single
 sign-on](../../access-controls/sso.mdx) providers. For OIDC, they will be
-expanded with a value of an "xyz" claim; for SAML — with an "xyz" assertion
-value. For full details on how variable expansion works in Teleport roles, see
-the  [Teleport Access Controls
+replaced with a value of an "xyz" claim. For SAML, they are replaced 
+ with an "xyz" assertion value. 
+
+For full details on how traits work in Teleport roles, see
+the [Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 
 For example, here is what a role may look like if you want to assign allowed

--- a/docs/pages/database-access/rbac/configuring-access.mdx
+++ b/docs/pages/database-access/rbac/configuring-access.mdx
@@ -105,7 +105,7 @@ with an "xyz" assertion value.
 
 For full details on how traits work in Teleport roles, see
 the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 
 For example, here is what a role may look like if you want to assign allowed
 database names from the user's Okta `databases` assertion:

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -100,16 +100,15 @@ spec:
     db_names: ["*"]
 ```
 
-The `{{internal.db_users}}` and `{{internal.db_names}}` template variables are
+The `internal.db_users` and `internal.db_names` traits are
 replaced with values from the Teleport local user database. For full details on
-how variable expansion works in Teleport roles, see the  [Teleport Access
+how traits work in Teleport roles, see the  [Teleport Access
 Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 Now suppose we want to grant Alice more permissive access.
 To keep this example simple, let's just assign Alice a different role.
 Update Alice's roles to include just the default Teleport role `access`, which allows access to all resources.
 We can update a user's roles from the command-line by using either `tctl users update` or `tctl create`:
-
 <Tabs>
   <TabItem label="tctl users update">
   ```sh

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -100,10 +100,16 @@ spec:
     db_names: ["*"]
 ```
 
+The `{{internal.db_users}}` and `{{internal.db_names}}` template variables are
+replaced with values from the Teleport local user database. For full details on
+how variable expansion works in Teleport roles, see the  [Teleport Access
+Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+
 Now suppose we want to grant Alice more permissive access.
 To keep this example simple, let's just assign Alice a different role.
 Update Alice's roles to include just the default Teleport role `access`, which allows access to all resources.
 We can update a user's roles from the command-line by using either `tctl users update` or `tctl create`:
+
 <Tabs>
   <TabItem label="tctl users update">
   ```sh

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -102,7 +102,7 @@ spec:
 
 The `internal.db_users` and `internal.db_names` traits are
 replaced with values from the Teleport local user database. For full details on
-how traits work in Teleport roles, see the  [Teleport Access
+how traits work in Teleport roles, see the [Teleport Access
 Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 Now suppose we want to grant Alice more permissive access.

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -103,7 +103,7 @@ spec:
 The `internal.db_users` and `internal.db_names` traits are
 replaced with values from the Teleport local user database. For full details on
 how traits work in Teleport roles, see the [Teleport Access
-Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+Controls Reference](../access-controls/reference.mdx).
 
 Now suppose we want to grant Alice more permissive access.
 To keep this example simple, let's just assign Alice a different role.

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -55,7 +55,7 @@ spec:
 
 For a full Teleport role reference, including information on how Teleport
 expands the `internal` and `external` traits, see the [Teleport
-Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+Access Controls Reference](../access-controls/reference.mdx).
 
 ## Labeling
 

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -54,7 +54,7 @@ spec:
 </Admonition>
 
 For a full Teleport role reference, including information on how Teleport
-expands the `internal` and `external` template variables, see the  [Teleport
+expands the `internal` and `external` traits, see the  [Teleport
 Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 ## Labeling

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -53,6 +53,10 @@ spec:
   Windows logins, and that these Windows users are properly secured.
 </Admonition>
 
+For a full Teleport role reference, including information on how Teleport
+expands the `internal` and `external` template variables, see the  [Teleport
+Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ## Labeling
 
 Both `allow` and `deny` rules support `windows_desktop_labels` selectors. These

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -54,7 +54,7 @@ spec:
 </Admonition>
 
 For a full Teleport role reference, including information on how Teleport
-expands the `internal` and `external` traits, see the  [Teleport
+expands the `internal` and `external` traits, see the [Teleport
 Access Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 ## Labeling

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -395,7 +395,7 @@ will populate them with information from each authenticating user.
 
 For more information on how template variable expansion works in Teleport roles,
 see the [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 
 ##### Single Sign-On provider traits
 

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -393,6 +393,10 @@ rather than hardcoding this information into your Teleport roles. To do so, you
 can add template variables to Teleport your roles, and the Teleport Auth Service
 will populate them with information from each authenticating user.
 
+For more information on how template variable expansion works in Teleport roles,
+see the [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ##### Single Sign-On provider traits
 
 Teleport's roles map OIDC claims or SAML attributes using template variables.

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -77,9 +77,9 @@ auditor no-login-6566121f-b602-47f1-a118-c9c618ee5aec             session:list,r
 editor                                                            user:list,create,read,update,delete,...
 ```
 
-The `{{internal.logins}}` template variable is replaced with values from the
-Teleport local user database. For full details on how variable expansion works
-in Teleport roles, see the  [Teleport Access Controls
+The `internal.logins` trait is replaced with values from the Teleport local user
+database. For full details on how traits work in Teleport roles, see the
+[Teleport Access Controls
 Reference](docs/pages/access-controls/reference.mdx#roles).
 
 Machine ID can join with a token or the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -77,6 +77,11 @@ auditor no-login-6566121f-b602-47f1-a118-c9c618ee5aec             session:list,r
 editor                                                            user:list,create,read,update,delete,...
 ```
 
+The `{{internal.logins}}` template variable is replaced with values from the
+Teleport local user database. For full details on how variable expansion works
+in Teleport roles, see the  [Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 Machine ID can join with a token or the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
 
 Assuming that you are using the default `access` role, ensure that you use the 

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -80,7 +80,7 @@ editor                                                            user:list,crea
 The `internal.logins` trait is replaced with values from the Teleport local user
 database. For full details on how traits work in Teleport roles, see the
 [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 
 Machine ID can join with a token or the [IAM Method](../agents/join-services-to-your-cluster/aws-iam.mdx) on AWS.
 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -686,6 +686,10 @@ node_labels:
   env: "{{external.env_from_okta}}"
 ```
 
+For full details on how variable expansion works in Teleport roles, see the
+[Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ### Update role mappings
 
 You can update role mappings for a trusted cluster resource by modifying the `role_map` 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -688,7 +688,7 @@ node_labels:
 
 For full details on how variable expansion works in Teleport roles, see the
 [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../../access-controls/reference.mdx).
 
 ### Update role mappings
 

--- a/docs/pages/management/dynamic-resources.mdx
+++ b/docs/pages/management/dynamic-resources.mdx
@@ -83,8 +83,8 @@ to manipulate cluster resources stored on the Auth Service backend. The design
 of Teleport's configuration interface makes it well suited for
 infrastructure-as-code and GitOps approaches.
 
-For more information on Teleport roles, including the `{{internal.logins}}`
-template variable we use in these example roles, see the [Teleport Access
+For more information on Teleport roles, including the `internal.logins`
+trait we use in these example roles, see the [Teleport Access
 Controls Reference](docs/pages/access-controls/reference.mdx#roles).
 
 ### YAML documents with `tctl`

--- a/docs/pages/management/dynamic-resources.mdx
+++ b/docs/pages/management/dynamic-resources.mdx
@@ -85,7 +85,7 @@ infrastructure-as-code and GitOps approaches.
 
 For more information on Teleport roles, including the `internal.logins`
 trait we use in these example roles, see the [Teleport Access
-Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+Controls Reference](../access-controls/reference.mdx).
 
 ### YAML documents with `tctl`
 

--- a/docs/pages/management/dynamic-resources.mdx
+++ b/docs/pages/management/dynamic-resources.mdx
@@ -83,6 +83,10 @@ to manipulate cluster resources stored on the Auth Service backend. The design
 of Teleport's configuration interface makes it well suited for
 infrastructure-as-code and GitOps approaches.
 
+For more information on Teleport roles, including the `{{internal.logins}}`
+template variable we use in these example roles, see the [Teleport Access
+Controls Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ### YAML documents with `tctl`
 
 You can define resources as YAML documents and apply them using the `tctl`

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -283,18 +283,16 @@ Two `user`s can grant elevated privileges to another `user` temporarily without 
 ## Next steps
 
 ### Guides
-
 - [Per-session MFA](../../access-controls/guides/per-session-mfa.mdx)
 - [Dual authorization](../../access-controls/guides/dual-authz.mdx)
 - [Role templates, allow/deny rules, and traits](../../access-controls/guides/role-templates.mdx)
 - [Access Requests](../../access-controls/access-requests.mdx)
 
 ### Background reading
-
 - [Authentication connectors](../../reference/authentication.mdx)
 - [Proxy Service](../../architecture/proxy.mdx)
 - [Auth Service](../../architecture/authentication.mdx)
--  The roles we illustrated in this guide use the `internal` template variable,
+-  The roles we illustrated in this guide use `internal` traits,
    which Teleport replaces with values from the Teleport local user database.
    For full details on how variable expansion works in Teleport roles, see the
    [Teleport Access Controls

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -292,9 +292,8 @@ Two `user`s can grant elevated privileges to another `user` temporarily without 
 - [Authentication connectors](../../reference/authentication.mdx)
 - [Proxy Service](../../architecture/proxy.mdx)
 - [Auth Service](../../architecture/authentication.mdx)
--  The roles we illustrated in this guide use `internal` traits,
-   which Teleport replaces with values from the Teleport local user database.
-   For full details on how variable expansion works in Teleport roles, see the
-   [Teleport Access Controls
-   Reference](docs/pages/access-controls/reference.mdx#roles).
+- The roles we illustrated in this guide use `internal` traits, which Teleport
+  replaces with values from the Teleport local user database.  For full details
+  on how variable expansion works in Teleport roles, see the [Teleport Access
+  Controls Reference](../../access-controls/reference.mdx).
 

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -283,12 +283,20 @@ Two `user`s can grant elevated privileges to another `user` temporarily without 
 ## Next steps
 
 ### Guides
+
 - [Per-session MFA](../../access-controls/guides/per-session-mfa.mdx)
 - [Dual authorization](../../access-controls/guides/dual-authz.mdx)
 - [Role templates, allow/deny rules, and traits](../../access-controls/guides/role-templates.mdx)
 - [Access Requests](../../access-controls/access-requests.mdx)
 
 ### Background reading
+
 - [Authentication connectors](../../reference/authentication.mdx)
 - [Proxy Service](../../architecture/proxy.mdx)
 - [Auth Service](../../architecture/authentication.mdx)
+-  The roles we illustrated in this guide use the `internal` template variable,
+   which Teleport replaces with values from the Teleport local user database.
+   For full details on how variable expansion works in Teleport roles, see the
+   [Teleport Access Controls
+   Reference](docs/pages/access-controls/reference.mdx#roles).
+

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -120,6 +120,10 @@ spec:
     logins: ["{{internal.logins}}"]
 ```
 
+For full details on how variable expansion works in Teleport roles, see the
+[Teleport Access Controls
+Reference](docs/pages/access-controls/reference.mdx#roles).
+
 ## Server role options
 
 The `allow` and `deny` sections described above are used for controlling

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -122,7 +122,7 @@ spec:
 
 For full details on how variable expansion works in Teleport roles, see the
 [Teleport Access Controls
-Reference](docs/pages/access-controls/reference.mdx#roles).
+Reference](../access-controls/reference.mdx).
 
 ## Server role options
 


### PR DESCRIPTION
Closes #13377

Wherever a page in the docs mentions the `internal` or `external` template variables as they apply to Teleport roles, link to the Teleport Access Controls Reference
(docs/pages/access-controls/reference.mdx#roles).

A separate change (#32696) will expand the Access Controls Reference to include more information on the `external` and `internal` template variables.