### PR TITLE
docs: Caveat for token permissions not scoped to any resource context

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -357,8 +357,29 @@ allow:
     - resources:
         - token
       verbs: [list, create, read, update, delete]
-
 ```
+
+### Allowing access to token resources
+
+You should note that if you configure a role that allows tokens to be created, a user assigned to the 
+role can create any type of token. 
+For example, assume you create a role with the following configuration:
+
+```yaml
+allow:
+  rules:
+    - resources:
+        - token
+      verbs: [list, create, read, update, delete]
+```
+
+With these permissions, usesr assigned this role can generate any type of tokens, including a token to join 
+a server to a cluster, establish a trust relationship between a root cluster and a new Teleport Poxy Service 
+or leaf cluster, or configure a device trust relationship for a managed device.
+Because the token resource isn't scoped to a specific context, such as a node or trusted cluster, you should 
+consider any role that provides token permissions to be an administrative role. In particular, you should 
+avoid configuring `allow` rules that grant `create` and `update` permissions on `token` resources to prevent 
+unexpected changes to the configuration or state of your cluster.
 
 ## RBAC for sessions
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -363,19 +363,27 @@ allow:
 
 You should note that if you configure a role that allows tokens to be created, a user assigned to the 
 role can create any type of token. 
-For example, assume you create a role with the following configuration:
+For example, you might create a role with the following configuration to enable assigned
+users to enroll servers:
 
 ```yaml
-allow:
-  rules:
-    - resources:
-        - token
-      verbs: [list, create, read, update, delete]
+kind: role
+version: v7
+metadata:
+  name: enroll-servers
+spec:
+  allow:
+    node_labels:
+      'env': 'us-lab'
+    rules:
+      - resources: [token]
+        verbs: [list, create, read, update, delete]
+  deny: {}
 ```
 
-With these permissions, usesr assigned this role can generate any type of tokens, including a token to join 
-a server to a cluster, establish a trust relationship between a root cluster and a new Teleport Poxy Service 
-or leaf cluster, or configure a device trust relationship for a managed device.
+With these permissions, users assigned this role can generate any type of token, including a token to enroll 
+a server, application, or database, establish a trust relationship between a root cluster and a new Teleport 
+Proxy Service or leaf cluster, or configure a device trust relationship for a managed device.
 Because the token resource isn't scoped to a specific context, such as a node or trusted cluster, you should 
 consider any role that provides token permissions to be an administrative role. In particular, you should 
 avoid configuring `allow` rules that grant `create` and `update` permissions on `token` resources to prevent 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -381,7 +381,7 @@ spec:
   deny: {}
 ```
 
-With these permissions, users assigned to the role cant generate tokens to enroll  
+With these permissions, users assigned to the role can generate tokens to enroll  
 a server, application, or database, establish a trust relationship between a root 
 cluster and a new Teleport Proxy Service or leaf cluster, or configure a device 
 trust relationship for a managed device.

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -361,8 +361,8 @@ allow:
 
 ### Allowing access to token resources
 
-You should note that if you configure a role that allows tokens to be created, a user assigned to the 
-role can create any type of token. 
+If you configure a role that allows tokens to be created, users assigned to the 
+role can create tokens to provision any type of Teleport resource. 
 For example, you might create a role with the following configuration to enable assigned
 users to enroll servers:
 
@@ -381,13 +381,15 @@ spec:
   deny: {}
 ```
 
-With these permissions, users assigned this role can generate any type of token, including a token to enroll 
-a server, application, or database, establish a trust relationship between a root cluster and a new Teleport 
-Proxy Service or leaf cluster, or configure a device trust relationship for a managed device.
+With these permissions, users assigned to the role cant generate tokens to enroll  
+a server, application, or database, establish a trust relationship between a root 
+cluster and a new Teleport Proxy Service or leaf cluster, or configure a device 
+trust relationship for a managed device.
 
-Because the token resource isn't scoped to a specific context, such as a node or trusted cluster, you should 
-consider any role that provides token permissions to be an administrative role. In particular, you should 
-avoid configuring `allow` rules that grant `create` and `update` permissions on `token` resources to prevent 
+Because the token resource isn't scoped to a specific context, such as a node or 
+trusted cluster, you should consider any role that provides token permissions to be 
+an administrative role. In particular, you should avoid configuring `allow` rules 
+that grant `create` and `update` permissions on `token` resources to prevent 
 unexpected changes to the configuration or state of your cluster.
 
 ## RBAC for sessions

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -384,6 +384,7 @@ spec:
 With these permissions, users assigned this role can generate any type of token, including a token to enroll 
 a server, application, or database, establish a trust relationship between a root cluster and a new Teleport 
 Proxy Service or leaf cluster, or configure a device trust relationship for a managed device.
+
 Because the token resource isn't scoped to a specific context, such as a node or trusted cluster, you should 
 consider any role that provides token permissions to be an administrative role. In particular, you should 
 avoid configuring `allow` rules that grant `create` and `update` permissions on `token` resources to prevent 


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport.e/issues/1359

One item in the Tracking issue.

> ### Join token security sensitivity
> (example improvement [gravitational/teleport-private#526](https://github.com/gravitational/teleport-private/issues/526))
> (Maybe summarize to just highlight that the role is not able to be scoped and that this role should be considered an administrative role)
> The ability to create a join token is a sensitive action within Teleport. Currently the role to create join tokens is not scoped, allowing the creation of any type of join token. This means that the same permissions that allow you to join a server also could establish an entire new proxy / leaf, or also establish a Device Trust relationship through MDM ([#1018 (comment)](https://github.com/gravitational/teleport.e/pull/1018#discussion_r1156604808)). The ability for the joining to influence the configuration and state of your cluster may result in unexpected security concerns, for that reason you should consider the ability to create join token's akin to an administrative role.