### PR TITLE
Enable hardware key support in the WebUI

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/utils/keys"
 )
 
 // WebSessionsGetter provides access to web sessions
@@ -649,6 +650,10 @@ type NewWebSessionRequest struct {
 	// This should only be set to true for web sessions that are purely in the purview of the Proxy
 	// and Auth services. Users should never have direct access to attested web sessions.
 	AttestWebSession bool
+	// PrivateKey is a specific private key to use when generating the web sessions' certificates.
+	// This should be provided when extending an attested web session in order to maintain the
+	// session attested status.
+	PrivateKey *keys.PrivateKey
 }
 
 // Check validates the request.

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -645,6 +645,10 @@ type NewWebSessionRequest struct {
 	AccessRequests []string
 	// RequestedResourceIDs optionally lists requested resources
 	RequestedResourceIDs []ResourceID
+	// AttestWebSession optionally attests the web session to meet private key policy requirements.
+	// This should only be set to true for web sessions that are purely in the purview of the Proxy
+	// and Auth services. Users should never have direct access to attested web sessions.
+	AttestWebSession bool
 }
 
 // Check validates the request.

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -65,7 +65,7 @@ func (requiredPolicy PrivateKeyPolicy) IsSatisfiedBy(keyPolicy PrivateKeyPolicy)
 	case PrivateKeyPolicyNone:
 		return true
 	case PrivateKeyPolicyHardwareKey:
-		return keyPolicy.isHardwareKeyVerified()
+		return keyPolicy.IsHardwareKeyPolicy()
 	case PrivateKeyPolicyHardwareKeyTouch:
 		return keyPolicy.isHardwareKeyTouchVerified()
 	case PrivateKeyPolicyHardwareKeyPIN:
@@ -74,17 +74,6 @@ func (requiredPolicy PrivateKeyPolicy) IsSatisfiedBy(keyPolicy PrivateKeyPolicy)
 		return keyPolicy.isHardwareKeyTouchVerified() && keyPolicy.isHardwareKeyPINVerified()
 	}
 
-	return false
-}
-
-func (p PrivateKeyPolicy) isHardwareKeyVerified() bool {
-	switch p {
-	case PrivateKeyPolicyHardwareKey,
-		PrivateKeyPolicyHardwareKeyTouch,
-		PrivateKeyPolicyHardwareKeyPIN,
-		PrivateKeyPolicyHardwareKeyTouchAndPIN:
-		return true
-	}
 	return false
 }
 

--- a/api/utils/keys/policy_test.go
+++ b/api/utils/keys/policy_test.go
@@ -34,23 +34,28 @@ var (
 		keys.PrivateKeyPolicyHardwareKeyTouch,
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+		keys.PrivateKeyPolicyWebSession,
 	}
 	hardwareKeyPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKey,
 		keys.PrivateKeyPolicyHardwareKeyTouch,
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+		keys.PrivateKeyPolicyWebSession,
 	}
 	hardwareKeyTouchPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyTouch,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+		keys.PrivateKeyPolicyWebSession,
 	}
 	hardwareKeyPINPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+		keys.PrivateKeyPolicyWebSession,
 	}
 	hardwareKeyTouchAndPINPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+		keys.PrivateKeyPolicyWebSession,
 	}
 )
 

--- a/api/utils/keys/policy_test.go
+++ b/api/utils/keys/policy_test.go
@@ -146,8 +146,14 @@ func TestGetPolicyFromSet(t *testing.T) {
 			},
 			wantPolicy: keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		}, {
-			name:       "touch and pin policy",
-			policySet:  privateKeyPolicies,
+			name: "touch and pin policy",
+			policySet: []keys.PrivateKeyPolicy{
+				keys.PrivateKeyPolicyNone,
+				keys.PrivateKeyPolicyHardwareKey,
+				keys.PrivateKeyPolicyHardwareKeyTouch,
+				keys.PrivateKeyPolicyHardwareKeyPIN,
+				keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+			},
 			wantPolicy: keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		},
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3493,6 +3493,14 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		accessRequests = nil
 	}
 
+	// Create a new web session with the same private key. This way, if the
+	// original session was an attested web session, the extended session will
+	// also be an attested web session.
+	prevKey, err := keys.ParsePrivateKey(prevSession.GetPriv())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	sessionTTL := utils.ToTTL(a.clock, expiresAt)
 	sess, err := a.NewWebSession(ctx, types.NewWebSessionRequest{
 		User:                 req.User,
@@ -3502,6 +3510,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		SessionTTL:           sessionTTL,
 		AccessRequests:       accessRequests,
 		RequestedResourceIDs: allowedResourceIDs,
+		PrivateKey:           prevKey,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -4128,9 +4137,11 @@ func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionReque
 		return nil, trace.Wrap(err)
 	}
 
-	priv, err := native.GeneratePrivateKey()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if req.PrivateKey == nil {
+		req.PrivateKey, err = native.GeneratePrivateKey()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	sessionTTL := req.SessionTTL
@@ -4141,21 +4152,20 @@ func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionReque
 	if req.AttestWebSession {
 		// Upsert web session attestation data so that this key's certs
 		// will be marked with the web session private key policy.
-		webAttData, err := services.NewWebSessionAttestationData(priv.Public())
+		webAttData, err := services.NewWebSessionAttestationData(req.PrivateKey.Public())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if err = a.UpsertKeyAttestationData(ctx, webAttData, sessionTTL); err != nil {
 			return nil, trace.Wrap(err)
 		}
-
 	}
 
 	certs, err := a.generateUserCert(certRequest{
 		user:           userState,
 		loginIP:        req.LoginIP,
 		ttl:            sessionTTL,
-		publicKey:      priv.MarshalSSHPublicKey(),
+		publicKey:      req.PrivateKey.MarshalSSHPublicKey(),
 		checker:        checker,
 		traits:         req.Traits,
 		activeRequests: services.RequestIDs{AccessRequests: req.AccessRequests},
@@ -4180,7 +4190,7 @@ func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionReque
 
 	sessionSpec := types.WebSessionSpecV2{
 		User:               req.User,
-		Priv:               priv.PrivateKeyPEM(),
+		Priv:               req.PrivateKey.PrivateKeyPEM(),
 		Pub:                certs.SSH,
 		TLSCert:            certs.TLS,
 		Expires:            startTime.UTC().Add(sessionTTL),

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2351,10 +2351,8 @@ func (a *ServerWithRoles) WebSessions() types.WebSessionInterface {
 
 // Get returns the web session specified with req.
 func (r *webSessionsWithRoles) Get(ctx context.Context, req types.GetWebSessionRequest) (types.WebSession, error) {
-	if err := r.c.currentUserAction(req.User); err != nil {
-		if err := r.c.action(apidefaults.Namespace, types.KindWebSession, types.VerbRead); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if err := r.c.action(apidefaults.Namespace, types.KindWebSession, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return r.ws.Get(ctx, req)
 }

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -500,7 +500,14 @@ func (s *Server) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRe
 		}
 	}
 
-	sess, err := s.createUserWebSession(ctx, user, loginIP)
+	sess, err := s.CreateWebSessionFromReq(ctx, types.NewWebSessionRequest{
+		User:             user.GetName(),
+		LoginIP:          loginIP,
+		Roles:            user.GetRoles(),
+		Traits:           user.GetTraits(),
+		LoginTime:        s.clock.Now().UTC(),
+		AttestWebSession: true,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/rfd/0080-hardware-key-support.md
+++ b/rfd/0080-hardware-key-support.md
@@ -99,7 +99,7 @@ Web sessions created by user-authorized endpoints like the auth http endpoint `P
 
 ##### Web Session Access
 
-Currently, the auth grpc endpoint `GetWebSession` can be used by a user to retrieve a specific web session, including secrets. This endpoint will be restricted to required `read` permissions for `KindWebSession`, similar to `GetWebSessions`. Users will still be able to retrieve non-secret web session info with the auth http endpoint `GET /:version/users/:user/web/sessions/:sid`.
+Currently, the auth grpc endpoint `GetWebSession` can be used by a user to retrieve a specific web session, including secrets. This endpoint will be restricted to require `read` permissions for `KindWebSession`, similar to `GetWebSessions`. Users will still be able to retrieve non-secret web session info with the auth http endpoint `GET /:version/users/:user/web/sessions/:sid`.
 
 ##### Web Session cookies
 


### PR DESCRIPTION
This PR enables hardware key support in the WebUI.

Changes:
- Update RFD
- Add the `web_session` private key policy
- Insert attestation data for web authenticated session -> web session certs and re-issued certs will be given the `web_session` private key policy.
- Update `grpc GetWebSession` to require `read` permissions for `KindWebSession` instead of allowing users to read their own web session secrets.

Depends on https://github.com/gravitational/teleport/pull/31743