### PR TITLE
Add param `extraContainers` to `teleport-cluster` and `teleport-kube-agent` Helm charts

### DIFF
--- a/examples/chart/teleport-cluster/.lint/extra-containers.yaml
+++ b/examples/chart/teleport-cluster/.lint/extra-containers.yaml
@@ -1,0 +1,12 @@
+clusterName: helm-lint.example.com
+extraContainers:
+  - name: nscenter
+    command:
+      - /bin/bash
+      - -c
+      - sleep infinity & wait
+    image: praqma/network-multitool
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+      runAsNonRoot: false

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -270,6 +270,9 @@ spec:
           readOnly: true
   {{- end }}
 {{ end }}
+{{- if $auth.extraContainers }}
+  {{- toYaml $auth.extraContainers | nindent 6 }}
+{{- end }}
 {{- if $projectedServiceAccountToken }}
       automountServiceAccountToken: false
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -255,6 +255,9 @@ spec:
 {{- if $proxy.extraVolumeMounts }}
   {{- toYaml $proxy.extraVolumeMounts | nindent 8 }}
 {{- end }}
+{{- if $proxy.extraContainers }}
+  {{- toYaml $proxy.extraContainers | nindent 6 }}
+{{- end }}
 {{- if $projectedServiceAccountToken }}
       automountServiceAccountToken: false
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -304,6 +304,7 @@ tests:
             name: my-mount
             secret:
               secretName: mySecret
+
   - it: should set imagePullPolicy when set in values
     template: auth/deployment.yaml
     set:
@@ -313,6 +314,35 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
+
+  - it: should have only one container when no `extraContainers` is set in values
+    template: auth/deployment.yaml
+    set:
+      extraContainers: []
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0]
+      - isNull:
+          path: spec.template.spec.containers[1]
+
+  - it: should add one more container when `extraContainers` is set in values
+    template: auth/deployment.yaml
+    values:
+      - ../.lint/extra-containers.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: nscenter
+            command:
+              - /bin/bash
+              - -c
+              - sleep infinity & wait
+            image: praqma/network-multitool
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              privileged: true
+              runAsNonRoot: false
 
   - it: should set environment when extraEnv set in values
     template: auth/deployment.yaml

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -332,6 +332,35 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
+  - it: should have only one container when no `extraContainers` is set in values
+    template: proxy/deployment.yaml
+    set:
+      extraContainers: []
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0]
+      - isNull:
+          path: spec.template.spec.containers[1]
+
+  - it: should add one more container when `extraContainers` is set in values
+    template: proxy/deployment.yaml
+    values:
+      - ../.lint/extra-containers.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: nscenter
+            command:
+              - /bin/bash
+              - -c
+              - sleep infinity & wait
+            image: praqma/network-multitool
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              privileged: true
+              runAsNonRoot: false
+
   - it: should set environment when extraEnv set in values
     template: proxy/deployment.yaml
     values:

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -19,6 +19,7 @@
         "affinity",
         "nodeSelector",
         "annotations",
+        "extraContainers",
         "extraVolumes",
         "extraVolumeMounts",
         "imagePullPolicy",
@@ -885,6 +886,11 @@
         },
         "extraEnv": {
             "$id": "#/properties/extraEnv",
+            "type": "array",
+            "default": []
+        },
+        "extraContainers": {
+            "$id": "#/properties/extraContainers",
             "type": "array",
             "default": []
         },

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -609,6 +609,19 @@ extraArgs: []
 # Extra environment to be configured on the Teleport pod
 extraEnv: []
 
+# Extra containers to be added to the Teleport pod
+extraContainers: []
+# - name: nscenter
+#   command:
+#     - /bin/bash
+#     - -c
+#     - sleep infinity & wait
+#   image: praqma/network-multitool
+#   imagePullPolicy: IfNotPresent
+#   securityContext:
+#     privileged: true
+#     runAsNonRoot: false
+
 # Extra volumes to mount into the Teleport pods
 # https://kubernetes.io/docs/concepts/storage/volumes/
 extraVolumes: []

--- a/examples/chart/teleport-kube-agent/.lint/extra-containers.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/extra-containers.yaml
@@ -1,0 +1,15 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+extraContainers:
+  - name: nscenter
+    command:
+      - /bin/bash
+      - -c
+      - sleep infinity & wait
+    image: praqma/network-multitool
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+      runAsNonRoot: false

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -190,6 +190,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
   {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
 {{- end }}
+{{- if .Values.extraContainers }}
+  {{- toYaml .Values.extraContainers | nindent 6 }}
+{{- end }}
       volumes:
       - name: "config"
         configMap:

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -207,6 +207,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
   {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
 {{- end }}
+{{- if .Values.extraContainers }}
+  {{- toYaml .Values.extraContainers | nindent 6 }}
+{{- end }}
       volumes:
       - name: "config"
         configMap:

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -8,7 +8,7 @@ tests:
   - it: creates a Deployment if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -22,7 +22,7 @@ tests:
   - it: sets Deployment labels when specified if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -40,7 +40,7 @@ tests:
   - it: sets Pod labels when specified if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -58,7 +58,7 @@ tests:
   - it: sets Deployment annotations when specified if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -75,7 +75,7 @@ tests:
   - it: sets Pod annotations when specified if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -93,7 +93,7 @@ tests:
   - it: should have one replica when replicaCount is not set if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -108,7 +108,7 @@ tests:
   - it: should have multiple replicas when replicaCount is set (using .replicaCount, deprecated) if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
        replicaCount: 3
@@ -141,7 +141,7 @@ tests:
   - it: should set affinity when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -157,7 +157,7 @@ tests:
     values:
       - ../.lint/backwards-compatibility.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -181,7 +181,7 @@ tests:
     values:
       - ../.lint/backwards-compatibility.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -202,7 +202,7 @@ tests:
   - it: should set tolerations when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -216,7 +216,7 @@ tests:
   - it: should set resources when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -240,7 +240,7 @@ tests:
   - it: should set SecurityContext if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -271,7 +271,7 @@ tests:
     values:
       - ../.lint/backwards-compatibility.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -283,10 +283,39 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should have only one container when no `extraContainers` is set in values
+    template: deployment.yaml
+    set:
+      extraContainers: []
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0]
+      - isNull:
+          path: spec.template.spec.containers[1]
+
+  - it: should add one more container when `extraContainers` is set in values
+    template: deployment.yaml
+    values:
+      - ../.lint/extra-containers.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: nscenter
+            command:
+              - /bin/bash
+              - -c
+              - sleep infinity & wait
+            image: praqma/network-multitool
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              privileged: true
+              runAsNonRoot: false
+
   - it: should mount extraVolumes and extraVolumeMounts if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -311,7 +340,7 @@ tests:
     values:
       - ../.lint/backwards-compatibility.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -326,7 +355,7 @@ tests:
   - it: should set environment when extraEnv set in values if action is Upgrade
     template: deployment.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -348,7 +377,7 @@ tests:
   - it: should provision initContainer correctly when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -383,7 +412,7 @@ tests:
     values:
       - ../.lint/backwards-compatibility.yaml
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -398,7 +427,7 @@ tests:
   - it: should expose diag port if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -416,7 +445,7 @@ tests:
   - it: should set nodeSelector if set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -432,7 +461,7 @@ tests:
   - it: should add emptyDir for data when existingDataVolume is not set if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -454,7 +483,7 @@ tests:
   - it: should correctly configure existingDataVolume when set if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -476,7 +505,7 @@ tests:
   - it: should mount tls.existingCASecretName and set environment when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -505,7 +534,7 @@ tests:
   - it: should mount tls.existingCASecretName and set extra environment when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -540,7 +569,7 @@ tests:
   - it: should set priorityClassName when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -555,7 +584,7 @@ tests:
   - it: should set not set priorityClassName when not set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -569,7 +598,7 @@ tests:
   - it: should set serviceAccountName when set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:
@@ -584,7 +613,7 @@ tests:
   - it: should set default serviceAccountName when not set in values if action is Upgrade
     template: deployment.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     values:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -217,6 +217,35 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should have only one container when no `extraContainers` is set in values
+    template: statefulset.yaml
+    set:
+      extraContainers: []
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0]
+      - isNull:
+          path: spec.template.spec.containers[1]
+
+  - it: should add one more container when `extraContainers` is set in values
+    template: statefulset.yaml
+    values:
+      - ../.lint/extra-containers.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: nscenter
+            command:
+              - /bin/bash
+              - -c
+              - sleep infinity & wait
+            image: praqma/network-multitool
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              privileged: true
+              runAsNonRoot: false
+
   - it: should mount extraVolumes and extraVolumeMounts
     template: statefulset.yaml
     values:
@@ -404,7 +433,7 @@ tests:
     values:
       - ../.lint/stateful.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     release:
@@ -420,7 +449,7 @@ tests:
     values:
       - ../.lint/stateful.yaml
     set:
-       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+       # unit test does not support lookup functions, so to test the behavior we use this undoc value
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     release:
@@ -437,7 +466,7 @@ tests:
     release:
       upgrade: true
     set:
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
@@ -459,7 +488,7 @@ tests:
     set:
       storage:
         requests: 256Mi
-      # unit test does not support lookup functions, so to test the behavior we use this undoc value 
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
     asserts:
@@ -594,7 +623,7 @@ tests:
     values:
       - ../.lint/stateful.yaml
     set:
-      storage: 
+      storage:
         enabled: false
     asserts:
       - contains:
@@ -629,7 +658,7 @@ tests:
       - ../.lint/stateful.yaml
     set:
       unitTestUpgrade: true
-      storage: 
+      storage:
         enabled: false
     asserts:
       - contains:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -29,6 +29,7 @@
         "log",
         "affinity",
         "annotations",
+        "extraContainers",
         "extraVolumes",
         "extraVolumeMounts",
         "imagePullPolicy",
@@ -595,6 +596,11 @@
         },
         "extraEnv": {
             "$id": "#/properties/extraEnv",
+            "type": "array",
+            "default": []
+        },
+        "extraContainers": {
+            "$id": "#/properties/extraContainers",
             "type": "array",
             "default": []
         },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -394,6 +394,19 @@ extraArgs: []
 # Extra environment to be configured on the Teleport pod
 extraEnv: []
 
+# Extra containers to be added to the Teleport pod
+extraContainers: []
+# - name: nscenter
+#   command:
+#     - /bin/bash
+#     - -c
+#     - sleep infinity & wait
+#   image: praqma/network-multitool
+#   imagePullPolicy: IfNotPresent
+#   securityContext:
+#     privileged: true
+#     runAsNonRoot: false
+
 # Extra volumes to mount into the Teleport pods
 # https://kubernetes.io/docs/concepts/storage/volumes/
 extraVolumes: []


### PR DESCRIPTION
https://github.com/gravitational/teleport/issues/6832

Add `extraContainers` to values.yaml for `teleport-cluster` and `teleport-kube-agent` Helm Charts.

This allows to add side containers to Teleport and Teleport-Agent pods.

P.S. original issue is closed, but I don't see these changes in master branch.