### PR TITLE
[v13] Use a context with a different scope for diagnostic trace upload

### DIFF
--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -1027,7 +1027,7 @@ func (s *Server) handleConnection(ctx context.Context, clientConn net.Conn) erro
 	if err != nil {
 		connectionDiagnosticID := sessionCtx.Identity.ConnectionDiagnosticID
 		if connectionDiagnosticID != "" && trace.IsAccessDenied(err) {
-			_, diagErr := s.cfg.AuthClient.AppendDiagnosticTrace(ctx,
+			_, diagErr := s.cfg.AuthClient.AppendDiagnosticTrace(cancelCtx,
 				connectionDiagnosticID,
 				&types.ConnectionDiagnosticTrace{
 					Type:    types.ConnectionDiagnosticTrace_RBAC_DATABASE_LOGIN,


### PR DESCRIPTION
Backport #32558 to branch/v13