### PR TITLE
Deflake `TestInteractiveSessionsNoAuth` test

### DIFF
--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -122,7 +122,8 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	testCtx.TLSServer, err = authServer.NewTestTLSServer()
+	testCtx.TLSServer, err = authServer.NewTestTLSServer(
+		auth.WithLimiterConfig(&limiter.Config{MaxConnections: 100000, MaxNumberOfUsers: 1000}))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.TLSServer.Close()) })
 

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -123,7 +123,20 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	testCtx.TLSServer, err = authServer.NewTestTLSServer(
-		auth.WithLimiterConfig(&limiter.Config{MaxConnections: 100000, MaxNumberOfUsers: 1000}))
+		// This test context is used by a test that stalls the LockWatcher to
+		// simulate the enforcement of the strict lock mode. When the test fakes
+		// the stall, the LockWatcher will enter a loop that constantly tries to
+		// pull locks from the backend to recover from the stall. This context causes
+		// the LockWatcher to hit the connection rate limit and fail with an error
+		// different from the expected one. We setup a custom rate limiter to avoid
+		// this issue.
+		auth.WithLimiterConfig(
+			&limiter.Config{
+				MaxConnections:   100000,
+				MaxNumberOfUsers: 1000,
+			},
+		),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.TLSServer.Close()) })
 


### PR DESCRIPTION
For this test, the LockWatcher is marked as stalled. When in stalled mode, the watcher bypasses cache and hits auth server directly. During the test, the auth rate limit is exceeded which causes the watcher to fail and report unexpected errors.

This PR bumps the auth server limits to prevent these cases.