### PR TITLE
[v14] Remove Connect My Computer feature flag

### DIFF
--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -110,10 +110,6 @@ export const createAppConfigSchema = (platform: Platform) => {
     'keymap.openSearchBar': shortcutSchema
       .default(defaultKeymap['openSearchBar'])
       .describe(getShortcutDesc('open the search bar')),
-    'feature.connectMyComputer': z
-      .boolean()
-      .default(false)
-      .describe('Enables sharing the computer.'),
     'headless.skipConfirm': z
       .boolean()
       .default(false)

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.story.tsx
@@ -247,7 +247,6 @@ function ShowState(props: {
     new MockAppContext({ appVersion: cluster.proxyVersion });
 
   appContext.mainProcessClient.getAgentState = () => props.agentProcessState;
-  appContext.configService.set('feature.connectMyComputer', true);
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);
   appContext.workspacesService.setState(draftState => {
     draftState.rootClusterUri = cluster.uri;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -21,8 +21,6 @@ import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
-import { createMockConfigService } from 'teleterm/services/config/fixtures/mocks';
-
 import { AgentProcessState } from 'teleterm/mainProcess/types';
 
 import { NavigationMenu } from './NavigationMenu';
@@ -163,9 +161,6 @@ function ShowState({
     proxyVersion: '17.0.0',
   });
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.configService = createMockConfigService({
-    'feature.connectMyComputer': true,
-  });
   appContext.workspacesService.setState(draftState => {
     draftState.rootClusterUri = cluster.uri;
     draftState.workspaces[cluster.uri] = {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -30,7 +30,6 @@ import {
   makeRootCluster,
   makeServer,
 } from 'teleterm/services/tshd/testHelpers';
-import { createMockConfigService } from 'teleterm/services/config/fixtures/mocks';
 
 import {
   AgentCompatibilityError,
@@ -42,7 +41,7 @@ import {
 import type { IAppContext } from 'teleterm/ui/types';
 import type { Cluster } from 'teleterm/services/tshd/types';
 
-function getMocksWithConnectMyComputerEnabled() {
+function getMocks() {
   const rootCluster = makeRootCluster({
     loggedInUser: makeLoggedInUser({
       acl: {
@@ -73,9 +72,6 @@ function getMocksWithConnectMyComputerEnabled() {
       accessRequests: undefined,
     };
   });
-  appContext.configService = createMockConfigService({
-    'feature.connectMyComputer': true,
-  });
 
   return { appContext, rootCluster };
 }
@@ -98,7 +94,7 @@ function renderUseConnectMyComputerContextHook(
 }
 
 test('startAgent re-throws errors that are thrown while spawning the process', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
   const eventEmitter = new EventEmitter();
   const errorStatus: AgentProcessState = {
     status: 'error',
@@ -150,7 +146,7 @@ test('startAgent re-throws errors that are thrown while spawning the process', a
 });
 
 test('starting the agent flips the workspace autoStart flag to true', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
 
   jest
     .spyOn(appContext.connectMyComputerService, 'waitForNodeToJoin')
@@ -172,7 +168,7 @@ test('starting the agent flips the workspace autoStart flag to true', async () =
 });
 
 test('killing the agent flips the workspace autoStart flag to false', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
 
   const { result } = renderUseConnectMyComputerContextHook(
     appContext,
@@ -187,7 +183,7 @@ test('killing the agent flips the workspace autoStart flag to false', async () =
 });
 
 test('failed autostart flips the workspace autoStart flag to false', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
 
   let currentAgentProcessState: AgentProcessState = {
     status: 'not-started',
@@ -224,7 +220,7 @@ test('failed autostart flips the workspace autoStart flag to false', async () =>
 });
 
 test('starts the agent automatically if the workspace autoStart flag is true', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
 
   const eventEmitter = new EventEmitter();
   let currentAgentProcessState: AgentProcessState = {
@@ -278,53 +274,34 @@ test('starts the agent automatically if the workspace autoStart flag is true', a
 describe('canUse', () => {
   const cases = [
     {
-      name: 'should be true when the user has permissions and the feature flag is enabled',
+      name: 'should be true when the user has permissions',
       hasPermissions: true,
-      isFeatureFlagEnabled: true,
       isAgentConfigured: false,
       expected: true,
     },
     {
-      name: 'should be true when the user does not have permissions, but the agent has been configured and the feature flag is enabled',
+      name: 'should be true when the user does not have permissions, but the agent has been configured',
       hasPermissions: false,
-      isFeatureFlagEnabled: true,
       isAgentConfigured: true,
       expected: true,
     },
     {
-      name: 'should be false when the user does not have permissions, the agent has not been configured and the feature flag is enabled',
+      name: 'should be false when the user does not have permissions and the agent has not been configured',
       hasPermissions: false,
       isAgentConfigured: false,
-      isFeatureFlagEnabled: true,
-      expected: false,
-    },
-    {
-      name: 'should be false when the user has permissions and the agent is configured but the feature flag is disabled',
-      hasPermissions: true,
-      isAgentConfigured: true,
-      isFeatureFlagEnabled: false,
       expected: false,
     },
   ];
 
   test.each(cases)(
     '$name',
-    async ({
-      hasPermissions,
-      isAgentConfigured,
-      isFeatureFlagEnabled,
-      expected,
-    }) => {
-      const { appContext, rootCluster } =
-        getMocksWithConnectMyComputerEnabled();
+    async ({ hasPermissions, isAgentConfigured, expected }) => {
+      const { appContext, rootCluster } = getMocks();
       // update Connect My Computer permissions
       appContext.clustersService.setState(draftState => {
         draftState.clusters.get(
           rootCluster.uri
         ).loggedInUser.acl.tokens.create = hasPermissions;
-      });
-      appContext.configService = createMockConfigService({
-        'feature.connectMyComputer': isFeatureFlagEnabled,
       });
       const isAgentConfigFileCreated = Promise.resolve(isAgentConfigured);
       jest
@@ -353,7 +330,7 @@ describe('canUse', () => {
 });
 
 test('removing the agent shows a notification', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
 
   const { result } = renderUseConnectMyComputerContextHook(
     appContext,
@@ -372,7 +349,7 @@ test('removing the agent shows a notification', async () => {
 });
 
 test('when the user does not have permissions to remove node a custom notification is shown', async () => {
-  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { appContext, rootCluster } = getMocks();
   jest
     .spyOn(appContext.connectMyComputerService, 'removeConnectMyComputerNode')
     .mockRejectedValue(new Error('access denied'));

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -104,7 +104,6 @@ export const ConnectMyComputerContextProvider: FC<{
     mainProcessClient,
     connectMyComputerService,
     clustersService,
-    configService,
     workspacesService,
     usageService,
   } = ctx;
@@ -125,10 +124,8 @@ export const ConnectMyComputerContextProvider: FC<{
     isAgentConfiguredAttempt.data;
 
   const rootCluster = clustersService.findCluster(rootClusterUri);
+
   const canUse = useMemo(() => {
-    const isFeatureFlagEnabled = configService.get(
-      'feature.connectMyComputer'
-    ).value;
     const hasPermissions = hasConnectMyComputerPermissions(
       rootCluster,
       mainProcessClient.getRuntimeSettings()
@@ -136,8 +133,9 @@ export const ConnectMyComputerContextProvider: FC<{
 
     // We check `isAgentConfigured`, because the user should always have access to the agent after configuring it.
     // https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#access-to-ui-and-autostart
-    return isFeatureFlagEnabled && (hasPermissions || isAgentConfigured);
-  }, [configService, isAgentConfigured, mainProcessClient, rootCluster]);
+    return hasPermissions || isAgentConfigured;
+  }, [isAgentConfigured, mainProcessClient, rootCluster]);
+
   const agentCompatibility = useMemo(
     () =>
       checkAgentCompatibility(


### PR DESCRIPTION
Backport #32835 to branch/v14

Slated for v14.1.

Changelog: [New feature] Teleport Connect 14.1 introduces Connect My Computer which makes it possible to add your personal machine to a Teleport cluster in just a couple of clicks. Whether you're exploring capabilities Teleport or want to make your computer available in your private cluster, Connect My Computer lets you do that without having to use the terminal to get the job done. Docs: https://goteleport.com/docs/connect-your-client/teleport-connect/#connect-my-computer

The docs won't work until #33149 is merged, which I'll do after v14.1 is released. For now, you can see docs working when viewing [the v15 version](https://goteleport.com/docs/ver/15.x/connect-your-client/teleport-connect/#connect-my-computer).