### PR TITLE
[v13] Cut CI unit test runtime in half

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -69,5 +69,5 @@ jobs:
         run: mount -t debugfs none /sys/kernel/debug/
 
       - name: Run tests
-        timeout-minutes: 40
-        run: make test-go test-sh test-api
+        timeout-minutes: 20
+        run: make -j"$(nproc)" test-go test-sh test-api


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/32706