### PR TITLE
[v12] Cut CI unit test runtime in half

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -71,7 +71,7 @@ jobs:
       # Run Teleport Unit tests.
       - name: Run tests
         timeout-minutes: 40
-        run: make test-go test-sh test-api
+        run: make -j"$(nproc)" test-go test-sh test-api
 
       # Run tests for the script located under "examples/teleport-usage".
       - name: Run teleport-usage tests


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/32706