### PR TITLE
Fixed integration test issue causing unnecessary runs

### DIFF
--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -36,7 +36,7 @@ jobs:
   test:
     name: Integration Tests (Non-root)
     needs: changes
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }} && needs.changes.outputs.changed == 'true' }}
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.changed == 'true' }}
     runs-on: ubuntu-22.04-16core
 
     permissions:


### PR DESCRIPTION
An extra `}}` is causing the `if` statement to not evaluate properly.