### PR TITLE
[v14] docs: update tctl tsh version location in prereqs

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -8,6 +8,19 @@
 
   See [Installation](../installation.mdx) for details.
 
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport v(=teleport.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=teleport.version=) go(=teleport.golang=)
+Proxy version: (=teleport.version=)
+Proxy: (=teleport.url=)
+```
+
 </TabItem>  
 <TabItem scope="team" label="Teleport Team">
 
@@ -17,6 +30,19 @@ up to begin your [free trial](https://goteleport.com/signup/).
 - The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=cloud.version=).
   
   You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
+
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=cloud.version=) go(=teleport.golang=)
+Proxy version: (=cloud.version=)
+Proxy: (=teleport.url=)
+```
 
 </TabItem>
 
@@ -32,6 +58,19 @@ up to begin your [free trial](https://goteleport.com/signup/).
   You can download these tools by visiting your [Teleport
   account workspace](https://teleport.sh).
 
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport Enterprise v(=teleport.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=teleport.version=) go(=teleport.golang=)
+Proxy version: (=teleport.version=)
+Proxy: (=teleport.url=)
+```
+
 </TabItem>
 <TabItem scope={["cloud"]}
   label="Teleport Enterprise Cloud">
@@ -43,20 +82,18 @@ up to begin your [free trial](https://goteleport.com/signup/).
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
 
   You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
+
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=cloud.version=) go(=teleport.golang=)
+Proxy version: (=cloud.version=)
+Proxy: (=teleport.url=)
+```
 </TabItem>
 </Tabs>
-
-  To check version information, run the `tctl version` and `tsh version` commands.
-  For example:
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
-  
-  $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
-  Proxy version: (=cloud.version=)
-  Proxy: (=teleport.url=)
-  ```
-
-

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -49,7 +49,7 @@ but filter and limit access to the servers based on their AWS region.
 
 1. Generate an invitation token for the host.
    
-   The invitation token is required for the local computer to join the Teleport cluster.   
+   The invitation token is required for the local computer to join the Teleport cluster.  
    The following example generates a new token that is valid for five minutes and can be used 
    to enroll a server:
    


### PR DESCRIPTION
Backport #32763 to branch/v14