### PR TITLE
[v13] docs: update tctl tsh version location in prereqs

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -16,6 +16,20 @@
 
   See [Installation](../installation.mdx) for details.
 
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport v(=teleport.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=teleport.version=) go(=teleport.golang=)
+Proxy version: (=teleport.version=)
+Proxy: (=teleport.url=)
+```
+
+
 </TabItem>
 <TabItem scope="team" label="Teleport Team">
 
@@ -25,6 +39,19 @@ up to begin your [free trial](https://goteleport.com/signup/).
 - The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=cloud.version=).
 
   You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
+
+To check version information, run the `tctl version` and `tsh version` commands.
+For example:
+
+```code
+$ tctl version
+# Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
+  
+$ tsh version
+# Teleport v(=cloud.version=) go(=teleport.golang=)
+Proxy version: (=cloud.version=)
+Proxy: (=teleport.url=)
+```
 
 </TabItem>
 <TabItem

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -21,12 +21,10 @@ For example:
 
 ```code
 $ tctl version
-# Teleport v(=teleport.version=) git:(=teleport.git=) go(=teleport.golang=)
+# Teleport v(=teleport.version=) go(=teleport.golang=)
   
 $ tsh version
 # Teleport v(=teleport.version=) go(=teleport.golang=)
-Proxy version: (=teleport.version=)
-Proxy: (=teleport.url=)
 ```
 
 
@@ -45,12 +43,10 @@ For example:
 
 ```code
 $ tctl version
-# Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
+# Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
   
 $ tsh version
 # Teleport v(=cloud.version=) go(=teleport.golang=)
-Proxy version: (=cloud.version=)
-Proxy: (=teleport.url=)
 ```
 
 </TabItem>

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -49,7 +49,7 @@ but filter and limit access to the servers based on their AWS region.
 
 1. Generate an invitation token for the host.
    
-   The invitation token is required for the local computer to join the Teleport cluster.   
+   The invitation token is required for the local computer to join the Teleport cluster.  
    The following example generates a new token that is valid for five minutes and can be used 
    to enroll a server:
    


### PR DESCRIPTION
backport #32763 to branch/v13