### PR TITLE
Allow breaker tripped error to be configurable

### DIFF
--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -103,7 +103,7 @@ func (s State) String() string {
 
 // ErrStateTripped will be returned from executions performed while the CircuitBreaker
 // is in StateTripped
-var ErrStateTripped = trace.ConnectionProblem(nil, "breaker is tripped")
+var ErrStateTripped = &trace.ConnectionProblemError{Message: "breaker is tripped"}
 
 // Config contains configuration of the CircuitBreaker
 type Config struct {
@@ -134,6 +134,9 @@ type Config struct {
 	IsSuccessful func(v interface{}, err error) bool
 	// Logger is the logger
 	Logger logrus.FieldLogger
+	// TrippedErrorMessage is an optional message to use as the error message when the CircuitBreaker
+	// is tripped. Defaults to ErrStateTripped if not provided.
+	TrippedErrorMessage string
 }
 
 // TripFn determines if the CircuitBreaker should be tripped based
@@ -331,7 +334,11 @@ func (c *CircuitBreaker) beforeExecution() (uint64, error) {
 
 	switch {
 	case state == StateTripped:
-		return generation, ErrStateTripped
+		if c.cfg.TrippedErrorMessage != "" {
+			return generation, trace.ConnectionProblem(nil, c.cfg.TrippedErrorMessage)
+		}
+
+		return generation, trace.Wrap(ErrStateTripped)
 	}
 
 	c.metrics.execute()

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -86,6 +86,8 @@ var _ ClientI = &Client{}
 func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*Client, error) {
 	cfg.DialInBackground = true
 
+	cfg.CircuitBreakerConfig.TrippedErrorMessage = "Unable to communicate with the Teleport Auth Service"
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Updates the clients created from `auth.NewClient` to set a more user friendly error message to be displayed when the auth service is unreachable than the default message. Screenshot of attempting to login when Auth is down below.

![272057404-5a6e93fa-1805-422a-bb3e-7adea9b869af](https://github.com/gravitational/teleport/assets/39066650/ed047038-c4de-4b9f-a7be-dbd335b5360c)
