### PR TITLE
Prevent blank revisions from being read from the backend

### DIFF
--- a/api/types/installer.go
+++ b/api/types/installer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// Installer is an installer script rseource
+// Installer is an installer script resource
 type Installer interface {
 	Resource
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/license"
 	"github.com/gravitational/trace"
@@ -233,7 +234,7 @@ func TestSessions(t *testing.T) {
 	out, err := s.a.GetWebSessionInfo(ctx, user, ws.GetName())
 	require.NoError(t, err)
 	ws.SetPriv(nil)
-	require.Equal(t, ws, out)
+	require.Empty(t, cmp.Diff(ws, out, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.a.WebSessions().Delete(ctx, types.DeleteWebSessionRequest{
 		User:      user,

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -433,6 +433,12 @@ func CreateRevision() string {
 	return uuid.NewString()
 }
 
+// BlankRevision is a placeholder revision to be used by backends when
+// the revision of the item in the backend is empty. This can happen
+// to any existing resources that were last written before support for
+// revisions was added.
+var BlankRevision = uuid.Nil.String()
+
 // NewLease creates a lease for the provided [Item].
 func NewLease(item Item) *Lease {
 	return &Lease{

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -318,10 +318,11 @@ func toEvent(rec *dynamodbstreams.Record) (*backend.Event, error) {
 		return &backend.Event{
 			Type: op,
 			Item: backend.Item{
-				Key:     trimPrefix(r.FullPath),
-				Value:   r.Value,
-				Expires: expires,
-				ID:      r.ID,
+				Key:      trimPrefix(r.FullPath),
+				Value:    r.Value,
+				Expires:  expires,
+				ID:       r.ID,
+				Revision: r.Revision,
 			},
 		}, nil
 	case types.OpDelete:

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -386,9 +386,10 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 }
 
 func (m *Memory) ConditionalDelete(ctx context.Context, key []byte, rev string) error {
-	if len(key) == 0 {
-		return trace.BadParameter("missing parameter key")
+	if len(key) == 0 || (rev == "" && !m.Mirror) {
+		return trace.Wrap(backend.ErrIncorrectRevision)
 	}
+
 	m.Lock()
 	defer m.Unlock()
 	m.removeExpired()
@@ -412,9 +413,10 @@ func (m *Memory) ConditionalDelete(ctx context.Context, key []byte, rev string) 
 }
 
 func (m *Memory) ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error) {
-	if len(i.Key) == 0 {
-		return nil, trace.BadParameter("missing parameter key")
+	if len(i.Key) == 0 || (i.Revision == "" && !m.Mirror) {
+		return nil, trace.Wrap(backend.ErrIncorrectRevision)
 	}
+
 	m.Lock()
 	defer m.Unlock()
 	m.removeExpired()

--- a/lib/services/discoveryconfig.go
+++ b/lib/services/discoveryconfig.go
@@ -64,6 +64,7 @@ func MarshalDiscoveryConfig(discoveryConfig *discoveryconfig.DiscoveryConfig, op
 	if !cfg.PreserveResourceID {
 		copy := *discoveryConfig
 		copy.SetResourceID(0)
+		copy.SetRevision("")
 		discoveryConfig = &copy
 	}
 	return utils.FastMarshal(discoveryConfig)
@@ -87,6 +88,9 @@ func UnmarshalDiscoveryConfig(data []byte, opts ...MarshalOption) (*discoverycon
 	}
 	if cfg.ID != 0 {
 		discoveryConfig.SetResourceID(cfg.ID)
+	}
+	if cfg.Revision != "" {
+		discoveryConfig.SetRevision(cfg.Revision)
 	}
 	if !cfg.Expires.IsZero() {
 		discoveryConfig.SetExpiry(cfg.Expires)

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -104,16 +104,18 @@ func (s *AccessService) UpsertRole(ctx context.Context, role types.Role) error {
 		return trace.Wrap(err)
 	}
 
+	rev := role.GetRevision()
 	value, err := services.MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
-		Value:   value,
-		Expires: role.Expiry(),
-		ID:      role.GetResourceID(),
+		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Value:    value,
+		Expires:  role.Expiry(),
+		ID:       role.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -203,15 +205,17 @@ func (s *AccessService) GetLocks(ctx context.Context, inForceOnly bool, targets 
 
 // UpsertLock upserts a lock.
 func (s *AccessService) UpsertLock(ctx context.Context, lock types.Lock) error {
+	rev := lock.GetRevision()
 	value, err := services.MarshalLock(lock)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(locksPrefix, lock.GetName()),
-		Value:   value,
-		Expires: lock.Expiry(),
-		ID:      lock.GetResourceID(),
+		Key:      backend.Key(locksPrefix, lock.GetName()),
+		Value:    value,
+		Expires:  lock.Expiry(),
+		ID:       lock.GetResourceID(),
+		Revision: rev,
 	}
 
 	if _, err = s.Put(ctx, item); err != nil {
@@ -260,15 +264,17 @@ func (s *AccessService) ReplaceRemoteLocks(ctx context.Context, clusterName stri
 			if !strings.HasPrefix(lock.GetName(), clusterName) {
 				lock.SetName(clusterName + "/" + lock.GetName())
 			}
+			rev := lock.GetRevision()
 			value, err := services.MarshalLock(lock)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 			item := backend.Item{
-				Key:     backend.Key(locksPrefix, lock.GetName()),
-				Value:   value,
-				Expires: lock.Expiry(),
-				ID:      lock.GetResourceID(),
+				Key:      backend.Key(locksPrefix, lock.GetName()),
+				Value:    value,
+				Expires:  lock.Expiry(),
+				ID:       lock.GetResourceID(),
+				Revision: rev,
 			}
 			newRemoteLocksToStore[string(item.Key)] = item
 		}

--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -99,15 +99,17 @@ func (s *AppService) UpdateApp(ctx context.Context, app types.Application) error
 	if err := app.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := app.GetRevision()
 	value, err := services.MarshalApp(app)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(appPrefix, app.GetName()),
-		Value:   value,
-		Expires: app.Expiry(),
-		ID:      app.GetResourceID(),
+		Key:      backend.Key(appPrefix, app.GetName()),
+		Value:    value,
+		Expires:  app.Expiry(),
+		ID:       app.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
 	if err != nil {

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -86,15 +86,17 @@ func (s *ClusterConfigurationService) DeleteClusterName() error {
 // SetClusterName sets the name of the cluster in the backend. SetClusterName
 // can only be called once on a cluster after which it will return trace.AlreadyExists.
 func (s *ClusterConfigurationService) SetClusterName(c types.ClusterName) error {
+	rev := c.GetRevision()
 	value, err := services.MarshalClusterName(c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.Create(context.TODO(), backend.Item{
-		Key:     backend.Key(clusterConfigPrefix, namePrefix),
-		Value:   value,
-		Expires: c.Expiry(),
+		Key:      backend.Key(clusterConfigPrefix, namePrefix),
+		Value:    value,
+		Expires:  c.Expiry(),
+		Revision: rev,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -105,16 +107,18 @@ func (s *ClusterConfigurationService) SetClusterName(c types.ClusterName) error 
 
 // UpsertClusterName sets the name of the cluster in the backend.
 func (s *ClusterConfigurationService) UpsertClusterName(c types.ClusterName) error {
+	rev := c.GetRevision()
 	value, err := services.MarshalClusterName(c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:     backend.Key(clusterConfigPrefix, namePrefix),
-		Value:   value,
-		Expires: c.Expiry(),
-		ID:      c.GetResourceID(),
+		Key:      backend.Key(clusterConfigPrefix, namePrefix),
+		Value:    value,
+		Expires:  c.Expiry(),
+		ID:       c.GetResourceID(),
+		Revision: rev,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -138,15 +142,17 @@ func (s *ClusterConfigurationService) GetStaticTokens() (types.StaticTokens, err
 
 // SetStaticTokens sets the list of static tokens used to provision nodes.
 func (s *ClusterConfigurationService) SetStaticTokens(c types.StaticTokens) error {
+	rev := c.GetRevision()
 	value, err := services.MarshalStaticTokens(c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	_, err = s.Put(context.TODO(), backend.Item{
-		Key:     backend.Key(clusterConfigPrefix, staticTokensPrefix),
-		Value:   value,
-		Expires: c.Expiry(),
-		ID:      c.GetResourceID(),
+		Key:      backend.Key(clusterConfigPrefix, staticTokensPrefix),
+		Value:    value,
+		Expires:  c.Expiry(),
+		ID:       c.GetResourceID(),
+		Revision: rev,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -185,6 +191,7 @@ func (s *ClusterConfigurationService) GetAuthPreference(ctx context.Context) (ty
 // on the backend.
 func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, preferences types.AuthPreference) error {
 	// Perform the modules-provided checks.
+	rev := preferences.GetRevision()
 	if err := modules.ValidateResource(preferences); err != nil {
 		return trace.Wrap(err)
 	}
@@ -195,9 +202,10 @@ func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, pre
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
-		Value: value,
-		ID:    preferences.GetResourceID(),
+		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value:    value,
+		ID:       preferences.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -234,15 +242,17 @@ func (s *ClusterConfigurationService) GetClusterAuditConfig(ctx context.Context,
 
 // SetClusterAuditConfig sets the cluster audit config on the backend.
 func (s *ClusterConfigurationService) SetClusterAuditConfig(ctx context.Context, auditConfig types.ClusterAuditConfig) error {
+	rev := auditConfig.GetRevision()
 	value, err := services.MarshalClusterAuditConfig(auditConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
-		Value: value,
-		ID:    auditConfig.GetResourceID(),
+		Key:      backend.Key(clusterConfigPrefix, auditPrefix),
+		Value:    value,
+		ID:       auditConfig.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -284,15 +294,17 @@ func (s *ClusterConfigurationService) SetClusterNetworkingConfig(ctx context.Con
 		return trace.Wrap(err)
 	}
 
+	rev := netConfig.GetRevision()
 	value, err := services.MarshalClusterNetworkingConfig(netConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
-		Value: value,
-		ID:    netConfig.GetResourceID(),
+		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value:    value,
+		ID:       netConfig.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -333,15 +345,17 @@ func (s *ClusterConfigurationService) SetSessionRecordingConfig(ctx context.Cont
 		return trace.Wrap(err)
 	}
 
+	rev := recConfig.GetRevision()
 	value, err := services.MarshalSessionRecordingConfig(recConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
-		Value: value,
-		ID:    recConfig.GetResourceID(),
+		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value:    value,
+		ID:       recConfig.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -391,14 +405,16 @@ func (s *ClusterConfigurationService) GetUIConfig(ctx context.Context) (types.UI
 }
 
 func (s *ClusterConfigurationService) SetUIConfig(ctx context.Context, uic types.UIConfig) error {
+	rev := uic.GetRevision()
 	value, err := services.MarshalUIConfig(uic)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.Put(ctx, backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, uiPrefix),
-		Value: value,
+		Key:      backend.Key(clusterConfigPrefix, uiPrefix),
+		Value:    value,
+		Revision: rev,
 	})
 	return trace.Wrap(err)
 }
@@ -413,20 +429,22 @@ func (s *ClusterConfigurationService) GetInstaller(ctx context.Context, name str
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return services.UnmarshalInstaller(item.Value)
+	return services.UnmarshalInstaller(item.Value, services.WithRevision(item.Revision))
 }
 
 // SetInstaller sets the script of the cluster in the backend
 func (s *ClusterConfigurationService) SetInstaller(ctx context.Context, ins types.Installer) error {
+	rev := ins.GetRevision()
 	value, err := services.MarshalInstaller(ins)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.Put(ctx, backend.Item{
-		Key:     backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, ins.GetName()),
-		Value:   value,
-		Expires: ins.Expiry(),
+		Key:      backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, ins.GetName()),
+		Value:    value,
+		Expires:  ins.Expiry(),
+		Revision: rev,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/services/local/connection_diagnostic.go
+++ b/lib/services/local/connection_diagnostic.go
@@ -67,15 +67,17 @@ func (s *ConnectionDiagnosticService) UpdateConnectionDiagnostic(ctx context.Con
 	if err := connectionDiagnostic.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := connectionDiagnostic.GetRevision()
 	value, err := services.MarshalConnectionDiagnostic(connectionDiagnostic)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
-		Value:   value,
-		Expires: connectionDiagnostic.Expiry(),
-		ID:      connectionDiagnostic.GetResourceID(),
+		Key:      backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
+		Value:    value,
+		Expires:  connectionDiagnostic.Expiry(),
+		ID:       connectionDiagnostic.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
 
@@ -107,10 +109,11 @@ func (s *ConnectionDiagnosticService) AppendDiagnosticTrace(ctx context.Context,
 	}
 
 	newItem := backend.Item{
-		Key:     backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
-		Value:   value,
-		Expires: connectionDiagnostic.Expiry(),
-		ID:      connectionDiagnostic.GetResourceID(),
+		Key:      backend.Key(connectionDiagnosticPrefix, connectionDiagnostic.GetName()),
+		Value:    value,
+		Expires:  connectionDiagnostic.Expiry(),
+		ID:       connectionDiagnostic.GetResourceID(),
+		Revision: existing.Revision,
 	}
 
 	_, err = s.CompareAndSwap(ctx, *existing, newItem)

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -99,15 +99,17 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, database types.Dat
 	if err := database.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := database.GetRevision()
 	value, err := services.MarshalDatabase(database)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(databasesPrefix, database.GetName()),
-		Value:   value,
-		Expires: database.Expiry(),
-		ID:      database.GetResourceID(),
+		Key:      backend.Key(databasesPrefix, database.GetName()),
+		Value:    value,
+		Expires:  database.Expiry(),
+		ID:       database.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
 	if err != nil {

--- a/lib/services/local/databaseservice.go
+++ b/lib/services/local/databaseservice.go
@@ -42,15 +42,17 @@ func (s *DatabaseServicesService) UpsertDatabaseService(ctx context.Context, ser
 	if err := service.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := service.GetRevision()
 	value, err := services.MarshalDatabaseService(service)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(databaseServicePrefix, service.GetName()),
-		Value:   value,
-		Expires: service.Expiry(),
-		ID:      service.GetResourceID(),
+		Key:      backend.Key(databaseServicePrefix, service.GetName()),
+		Value:    value,
+		Expires:  service.Expiry(),
+		ID:       service.GetResourceID(),
+		Revision: rev,
 	}
 	lease, err := s.Put(ctx, item)
 	if err != nil {

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -91,15 +91,17 @@ func (s *WindowsDesktopService) UpdateWindowsDesktop(ctx context.Context, deskto
 	if err := desktop.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := desktop.GetRevision()
 	value, err := services.MarshalWindowsDesktop(desktop)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
-		Value:   value,
-		Expires: desktop.Expiry(),
-		ID:      desktop.GetResourceID(),
+		Key:      backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
+		Value:    value,
+		Expires:  desktop.Expiry(),
+		ID:       desktop.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
 	if err != nil {
@@ -113,15 +115,17 @@ func (s *WindowsDesktopService) UpsertWindowsDesktop(ctx context.Context, deskto
 	if err := desktop.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := desktop.GetRevision()
 	value, err := services.MarshalWindowsDesktop(desktop)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
-		Value:   value,
-		Expires: desktop.Expiry(),
-		ID:      desktop.GetResourceID(),
+		Key:      backend.Key(windowsDesktopsPrefix, desktop.GetHostID(), desktop.GetName()),
+		Value:    value,
+		Expires:  desktop.Expiry(),
+		ID:       desktop.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Put(ctx, item)
 	if err != nil {

--- a/lib/services/local/discoveryconfig_test.go
+++ b/lib/services/local/discoveryconfig_test.go
@@ -58,7 +58,7 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+		cmpopts.IgnoreFields(header.Metadata{}, "ID", "Revision"),
 	}
 
 	// Create both discovery configs.

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -481,15 +481,17 @@ func (s *DynamicAccessService) updateAccessRequestPluginData(ctx context.Context
 }
 
 func itemFromAccessRequest(req types.AccessRequest) (backend.Item, error) {
+	rev := req.GetRevision()
 	value, err := services.MarshalAccessRequest(req)
 	if err != nil {
 		return backend.Item{}, trace.Wrap(err)
 	}
 	return backend.Item{
-		Key:     accessRequestKey(req.GetName()),
-		Value:   value,
-		Expires: req.Expiry(),
-		ID:      req.GetResourceID(),
+		Key:      accessRequestKey(req.GetName()),
+		Value:    value,
+		Expires:  req.Expiry(),
+		ID:       req.GetResourceID(),
+		Revision: rev,
 	}, nil
 }
 
@@ -499,10 +501,11 @@ func itemFromAccessListPromotions(req types.AccessRequest, suggestedItems *types
 		return backend.Item{}, trace.Wrap(err)
 	}
 	return backend.Item{
-		Key:     AccessRequestAllowedPromotionKey(req.GetName()),
-		Value:   value,
-		Expires: req.Expiry(), // expire the promotion at the same time as the access request
-		ID:      req.GetResourceID(),
+		Key:      AccessRequestAllowedPromotionKey(req.GetName()),
+		Value:    value,
+		Expires:  req.Expiry(), // expire the promotion at the same time as the access request
+		ID:       req.GetResourceID(),
+		Revision: req.GetRevision(),
 	}, nil
 }
 
@@ -524,6 +527,7 @@ func itemToAccessRequest(item backend.Item, opts ...services.MarshalOption) (typ
 }
 
 func itemFromPluginData(data types.PluginData) (backend.Item, error) {
+	rev := data.GetRevision()
 	value, err := services.MarshalPluginData(data)
 	if err != nil {
 		return backend.Item{}, trace.Wrap(err)
@@ -534,10 +538,11 @@ func itemFromPluginData(data types.PluginData) (backend.Item, error) {
 		return backend.Item{}, trace.BadParameter("plugin data size limit exceeded")
 	}
 	return backend.Item{
-		Key:     pluginDataKey(data.GetSubKind(), data.GetName()),
-		Value:   value,
-		Expires: data.Expiry(),
-		ID:      data.GetResourceID(),
+		Key:      pluginDataKey(data.GetSubKind(), data.GetName()),
+		Value:    value,
+		Expires:  data.Expiry(),
+		ID:       data.GetResourceID(),
+		Revision: rev,
 	}, nil
 }
 

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -126,7 +126,7 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 
 	out := make([]T, 0, len(result.Items))
 	for _, item := range result.Items {
-		resource, err := s.unmarshalFunc(item.Value)
+		resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -156,7 +156,7 @@ func (s *Service[T]) ListResources(ctx context.Context, pageSize int, pageToken 
 
 	out := make([]T, 0, len(result.Items))
 	for _, item := range result.Items {
-		resource, err := s.unmarshalFunc(item.Value)
+		resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision))
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -282,15 +282,17 @@ func (s *Service[T]) MakeBackendItem(resource T, name string) (backend.Item, err
 	if err := resource.CheckAndSetDefaults(); err != nil {
 		return backend.Item{}, trace.Wrap(err)
 	}
+	rev := resource.GetRevision()
 	value, err := s.marshalFunc(resource)
 	if err != nil {
 		return backend.Item{}, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     s.MakeKey(name),
-		Value:   value,
-		Expires: resource.Expiry(),
-		ID:      resource.GetResourceID(),
+		Key:      s.MakeKey(name),
+		Value:    value,
+		Expires:  resource.Expiry(),
+		ID:       resource.GetResourceID(),
+		Revision: rev,
 	}
 
 	return item, nil

--- a/lib/services/local/inventory.go
+++ b/lib/services/local/inventory.go
@@ -102,15 +102,17 @@ func (s *PresenceService) UpsertInstance(ctx context.Context, instance types.Ins
 		return trace.BadParameter("unexpected type %T, expected %T", instance, v1)
 	}
 
+	rev := instance.GetRevision()
 	value, err := utils.FastMarshal(v1)
 	if err != nil {
 		return trace.Errorf("failed to marshal Instance: %v", err)
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(instancePrefix, instance.GetName()),
-		Value:   value,
-		Expires: instance.Expiry(),
+		Key:      backend.Key(instancePrefix, instance.GetName()),
+		Value:    value,
+		Expires:  instance.Expiry(),
+		Revision: rev,
 	}
 
 	_, err = s.Backend.Put(ctx, item)

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -99,15 +99,17 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 	if err := cluster.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := cluster.GetRevision()
 	value, err := services.MarshalKubeCluster(cluster)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(kubernetesPrefix, cluster.GetName()),
-		Value:   value,
-		Expires: cluster.Expiry(),
-		ID:      cluster.GetResourceID(),
+		Key:      backend.Key(kubernetesPrefix, cluster.GetName()),
+		Value:    value,
+		Expires:  cluster.Expiry(),
+		ID:       cluster.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
 	if err != nil {

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -211,16 +211,18 @@ func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify 
 		return trace.Wrap(err)
 	}
 
+	rev := newPlugin.GetRevision()
 	value, err := services.MarshalPlugin(newPlugin)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.backend.CompareAndSwap(ctx, *item, backend.Item{
-		Key:     backend.Key(pluginsPrefix, plugin.GetName()),
-		Value:   value,
-		Expires: plugin.Expiry(),
-		ID:      plugin.GetResourceID(),
+		Key:      backend.Key(pluginsPrefix, plugin.GetName()),
+		Value:    value,
+		Expires:  plugin.Expiry(),
+		ID:       plugin.GetResourceID(),
+		Revision: rev,
 	})
 
 	return trace.Wrap(err)

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -69,15 +69,17 @@ func (s *ProvisioningService) tokenToItem(p types.ProvisionToken) (*backend.Item
 	if err := p.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := p.GetRevision()
 	data, err := services.MarshalProvisionToken(p)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(tokensPrefix, p.GetName()),
-		Value:   data,
-		Expires: p.Expiry(),
-		ID:      p.GetResourceID(),
+		Key:      backend.Key(tokensPrefix, p.GetName()),
+		Value:    data,
+		Expires:  p.Expiry(),
+		ID:       p.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -121,15 +121,17 @@ func itemFromUser(user types.User) (*backend.Item, error) {
 	if err := services.ValidateUser(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := user.GetRevision()
 	value, err := services.MarshalUser(user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
-		Value:   value,
-		Expires: user.Expiry(),
-		ID:      user.GetResourceID(),
+		Key:      backend.Key(webPrefix, usersPrefix, user.GetName(), paramsPrefix),
+		Value:    value,
+		Expires:  user.Expiry(),
+		ID:       user.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -158,15 +160,17 @@ func itemFromCertAuthority(ca types.CertAuthority) (*backend.Item, error) {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := ca.GetRevision()
 	value, err := services.MarshalCertAuthority(ca)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
-		Value:   value,
-		Expires: ca.Expiry(),
-		ID:      ca.GetResourceID(),
+		Key:      backend.Key(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
+		Value:    value,
+		Expires:  ca.Expiry(),
+		ID:       ca.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -177,15 +181,17 @@ func itemFromProvisionToken(p types.ProvisionToken) (*backend.Item, error) {
 	if err := p.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := p.GetRevision()
 	value, err := services.MarshalProvisionToken(p)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(tokensPrefix, p.GetName()),
-		Value:   value,
-		Expires: p.Expiry(),
-		ID:      p.GetResourceID(),
+		Key:      backend.Key(tokensPrefix, p.GetName()),
+		Value:    value,
+		Expires:  p.Expiry(),
+		ID:       p.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -196,15 +202,17 @@ func itemFromTrustedCluster(tc types.TrustedCluster) (*backend.Item, error) {
 	if err := tc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := tc.GetRevision()
 	value, err := services.MarshalTrustedCluster(tc)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(trustedClustersPrefix, tc.GetName()),
-		Value:   value,
-		Expires: tc.Expiry(),
-		ID:      tc.GetResourceID(),
+		Key:      backend.Key(trustedClustersPrefix, tc.GetName()),
+		Value:    value,
+		Expires:  tc.Expiry(),
+		ID:       tc.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -215,15 +223,17 @@ func itemFromGithubConnector(gc types.GithubConnector) (*backend.Item, error) {
 	if err := gc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := gc.GetRevision()
 	value, err := services.MarshalGithubConnector(gc)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, gc.GetName()),
-		Value:   value,
-		Expires: gc.Expiry(),
-		ID:      gc.GetResourceID(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, gc.GetName()),
+		Value:    value,
+		Expires:  gc.Expiry(),
+		ID:       gc.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -231,16 +241,18 @@ func itemFromGithubConnector(gc types.GithubConnector) (*backend.Item, error) {
 // itemFromRole attempts to encode the supplied role as an
 // instance of `backend.Item` suitable for storage.
 func itemFromRole(role types.Role) (*backend.Item, error) {
+	rev := role.GetRevision()
 	value, err := services.MarshalRole(role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	item := &backend.Item{
-		Key:     backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
-		Value:   value,
-		Expires: role.Expiry(),
-		ID:      role.GetResourceID(),
+		Key:      backend.Key(rolesPrefix, role.GetName(), paramsPrefix),
+		Value:    value,
+		Expires:  role.Expiry(),
+		ID:       role.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -248,15 +260,17 @@ func itemFromRole(role types.Role) (*backend.Item, error) {
 // itemFromOIDCConnector attempts to encode the supplied connector as an
 // instance of `backend.Item` suitable for storage.
 func itemFromOIDCConnector(connector types.OIDCConnector) (*backend.Item, error) {
+	rev := connector.GetRevision()
 	value, err := services.MarshalOIDCConnector(connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
-		Value:   value,
-		Expires: connector.Expiry(),
-		ID:      connector.GetResourceID(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Value:    value,
+		Expires:  connector.Expiry(),
+		ID:       connector.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -264,6 +278,7 @@ func itemFromOIDCConnector(connector types.OIDCConnector) (*backend.Item, error)
 // itemFromSAMLConnector attempts to encode the supplied connector as an
 // instance of `backend.Item` suitable for storage.
 func itemFromSAMLConnector(connector types.SAMLConnector) (*backend.Item, error) {
+	rev := connector.GetRevision()
 	if err := services.ValidateSAMLConnector(connector, nil); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -272,10 +287,11 @@ func itemFromSAMLConnector(connector types.SAMLConnector) (*backend.Item, error)
 		return nil, trace.Wrap(err)
 	}
 	item := &backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
-		Value:   value,
-		Expires: connector.Expiry(),
-		ID:      connector.GetResourceID(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Value:    value,
+		Expires:  connector.Expiry(),
+		ID:       connector.GetResourceID(),
+		Revision: rev,
 	}
 	return item, nil
 }
@@ -359,15 +375,17 @@ func itemFromLock(l types.Lock) (*backend.Item, error) {
 	if err := l.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := l.GetRevision()
 	value, err := services.MarshalLock(l)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &backend.Item{
-		Key:     backend.Key(locksPrefix, l.GetName()),
-		Value:   value,
-		Expires: l.Expiry(),
-		ID:      l.GetResourceID(),
+		Key:      backend.Key(locksPrefix, l.GetName()),
+		Value:    value,
+		Expires:  l.Expiry(),
+		ID:       l.GetResourceID(),
+		Revision: rev,
 	}, nil
 }
 

--- a/lib/services/local/restrictions.go
+++ b/lib/services/local/restrictions.go
@@ -41,16 +41,18 @@ func (s *RestrictionsService) SetNetworkRestrictions(ctx context.Context, nr typ
 	if err := nr.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := nr.GetRevision()
 	value, err := services.MarshalNetworkRestrictions(nr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:     backend.Key(restrictionsPrefix, network),
-		Value:   value,
-		Expires: nr.Expiry(),
-		ID:      nr.GetResourceID(),
+		Key:      backend.Key(restrictionsPrefix, network),
+		Value:    value,
+		Expires:  nr.Expiry(),
+		ID:       nr.GetResourceID(),
+		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)

--- a/lib/services/local/sessiontracker.go
+++ b/lib/services/local/sessiontracker.go
@@ -72,8 +72,7 @@ func (s *sessionTracker) UpdatePresence(ctx context.Context, sessionID, user str
 			return trace.Wrap(err)
 		}
 
-		err = session.UpdatePresence(user, s.bk.Clock().Now().UTC())
-		if err != nil {
+		if err := session.UpdatePresence(user, s.bk.Clock().Now().UTC()); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -83,9 +82,10 @@ func (s *sessionTracker) UpdatePresence(ctx context.Context, sessionID, user str
 		}
 
 		item := backend.Item{
-			Key:     backend.Key(sessionPrefix, sessionID),
-			Value:   sessionJSON,
-			Expires: session.Expiry(),
+			Key:      backend.Key(sessionPrefix, sessionID),
+			Value:    sessionJSON,
+			Expires:  session.Expiry(),
+			Revision: sessionItem.Revision,
 		}
 		_, err = s.bk.CompareAndSwap(ctx, *sessionItem, item)
 		if trace.IsCompareFailed(err) {
@@ -261,9 +261,10 @@ func (s *sessionTracker) UpdateSessionTracker(ctx context.Context, req *proto.Up
 		}
 
 		item := backend.Item{
-			Key:     backend.Key(sessionPrefix, req.SessionID),
-			Value:   sessionJSON,
-			Expires: expiry,
+			Key:      backend.Key(sessionPrefix, req.SessionID),
+			Value:    sessionJSON,
+			Expires:  expiry,
+			Revision: sessionItem.Revision,
 		}
 		_, err = s.bk.CompareAndSwap(ctx, *sessionItem, item)
 		if trace.IsCompareFailed(err) {

--- a/lib/services/local/status.go
+++ b/lib/services/local/status.go
@@ -126,15 +126,17 @@ func (s *StatusService) UpsertClusterAlert(ctx context.Context, alert types.Clus
 		alert.Metadata.SetExpiry(alert.Spec.Created.Add(time.Hour * 24))
 	}
 
+	rev := alert.GetRevision()
 	val, err := utils.FastMarshal(&alert)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	_, err = s.Backend.Put(ctx, backend.Item{
-		Key:     backend.Key(clusterAlertPrefix, alert.Metadata.Name),
-		Value:   val,
-		Expires: alert.Metadata.Expiry(),
+		Key:      backend.Key(clusterAlertPrefix, alert.Metadata.Name),
+		Value:    val,
+		Expires:  alert.Metadata.Expiry(),
+		Revision: rev,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -200,6 +200,7 @@ func (s *IdentityService) UpdateUserWithContext(ctx context.Context, user types.
 		return nil, trace.Wrap(err)
 	}
 
+	rev := user.GetRevision()
 	value, err := services.MarshalUser(user.WithoutSecrets().(types.User))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -209,7 +210,7 @@ func (s *IdentityService) UpdateUserWithContext(ctx context.Context, user types.
 		Value:    value,
 		Expires:  user.Expiry(),
 		ID:       user.GetResourceID(),
-		Revision: user.GetRevision(),
+		Revision: rev,
 	}
 	lease, err := s.Update(ctx, item)
 	if err != nil {
@@ -272,6 +273,7 @@ func (s *IdentityService) UpsertUserWithContext(ctx context.Context, user types.
 	if err := services.ValidateUser(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	rev := user.GetRevision()
 	value, err := services.MarshalUser(user.WithoutSecrets().(types.User))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -281,7 +283,7 @@ func (s *IdentityService) UpsertUserWithContext(ctx context.Context, user types.
 		Value:    value,
 		Expires:  user.Expiry(),
 		ID:       user.GetResourceID(),
-		Revision: user.GetRevision(),
+		Revision: rev,
 	}
 	lease, err := s.Put(ctx, item)
 	if err != nil {
@@ -308,6 +310,7 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 	if !ok {
 		return trace.BadParameter("Invalid user type %T", new)
 	}
+	rev := new.GetRevision()
 	newValue, err := services.MarshalUser(newRaw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -317,7 +320,7 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 		Value:    newValue,
 		Expires:  new.Expiry(),
 		ID:       new.GetResourceID(),
-		Revision: new.GetRevision(),
+		Revision: rev,
 	}
 
 	existingRaw, ok := existing.WithoutSecrets().(types.User)
@@ -937,13 +940,15 @@ func (s *IdentityService) UpsertMFADevice(ctx context.Context, user string, d *t
 		}
 	}
 
+	rev := d.GetRevision()
 	value, err := json.Marshal(d)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:   backend.Key(webPrefix, usersPrefix, user, mfaDevicePrefix, d.Id),
-		Value: value,
+		Key:      backend.Key(webPrefix, usersPrefix, user, mfaDevicePrefix, d.Id),
+		Value:    value,
+		Revision: rev,
 	}
 
 	if _, err := s.Put(ctx, item); err != nil {
@@ -1004,15 +1009,17 @@ func (s *IdentityService) GetMFADevices(ctx context.Context, user string, withSe
 
 // UpsertOIDCConnector upserts OIDC Connector
 func (s *IdentityService) UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) error {
+	rev := connector.GetRevision()
 	value, err := services.MarshalOIDCConnector(connector)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
-		Value:   value,
-		Expires: connector.Expiry(),
-		ID:      connector.GetResourceID(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, connector.GetName()),
+		Value:    value,
+		Expires:  connector.Expiry(),
+		ID:       connector.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Put(ctx, item)
 	if err != nil {
@@ -1119,14 +1126,16 @@ func (s *IdentityService) UpsertSAMLConnector(ctx context.Context, connector typ
 	if err := services.ValidateSAMLConnector(connector, nil); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := connector.GetRevision()
 	value, err := services.MarshalSAMLConnector(connector)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
-		Value:   value,
-		Expires: connector.Expiry(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
+		Value:    value,
+		Expires:  connector.Expiry(),
+		Revision: rev,
 	}
 	_, err = s.Put(ctx, item)
 	if err != nil {
@@ -1296,15 +1305,17 @@ func (s *IdentityService) UpsertGithubConnector(ctx context.Context, connector t
 	if err := connector.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	rev := connector.GetRevision()
 	value, err := services.MarshalGithubConnector(connector)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
-		Value:   value,
-		Expires: connector.Expiry(),
-		ID:      connector.GetResourceID(),
+		Key:      backend.Key(webPrefix, connectorsPrefix, githubPrefix, connectorsPrefix, connector.GetName()),
+		Value:    value,
+		Expires:  connector.Expiry(),
+		ID:       connector.GetResourceID(),
+		Revision: rev,
 	}
 	_, err = s.Put(ctx, item)
 	if err != nil {

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -41,6 +41,7 @@ func MarshalPluginData(pluginData types.PluginData, opts ...MarshalOption) ([]by
 			// to prevent unexpected data races
 			cp := *pluginData
 			cp.SetResourceID(0)
+			cp.SetRevision("")
 			pluginData = &cp
 		}
 		return utils.FastMarshal(pluginData)

--- a/lib/services/session.go
+++ b/lib/services/session.go
@@ -142,6 +142,9 @@ func UnmarshalWebToken(bytes []byte, opts ...MarshalOption) (types.WebToken, err
 		if config.ID != 0 {
 			token.SetResourceID(config.ID)
 		}
+		if config.Revision != "" {
+			token.SetRevision(config.Revision)
+		}
 		if !config.Expires.IsZero() {
 			token.Metadata.SetExpiry(config.Expires)
 		}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -559,7 +559,7 @@ func (s *ServicesTestSuite) WebSessionCRUD(t *testing.T) {
 
 	out, err := s.WebS.WebSessions().Get(ctx, req)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, ws))
+	require.Empty(t, cmp.Diff(out, ws, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	ws1, err := types.NewWebSession("sid1", types.KindWebSession,
 		types.WebSessionSpecV2{
@@ -575,7 +575,7 @@ func (s *ServicesTestSuite) WebSessionCRUD(t *testing.T) {
 
 	out2, err := s.WebS.WebSessions().Get(ctx, req)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out2, ws1))
+	require.Empty(t, cmp.Diff(out2, ws1, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	require.NoError(t, s.WebS.WebSessions().Delete(ctx, types.DeleteWebSessionRequest{
 		User:      req.User,

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -61,8 +61,13 @@ func MarshalUserLoginState(userLoginState *userloginstate.UserLoginState, opts .
 
 	if !cfg.PreserveResourceID {
 		prevID := userLoginState.GetResourceID()
-		defer func() { userLoginState.SetResourceID(prevID) }()
+		prevRev := userLoginState.GetRevision()
+		defer func() {
+			userLoginState.SetResourceID(prevID)
+			userLoginState.SetRevision(prevRev)
+		}()
 		userLoginState.SetResourceID(0)
+		userLoginState.SetRevision("")
 	}
 	return utils.FastMarshal(userLoginState)
 }


### PR DESCRIPTION
Overwrites any empty resource revisions with a placeholder value to prevent any blank revisions from being provided to users.