### PR TITLE
Set revisions on SSO users

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -826,6 +826,7 @@ func (a *Server) createGithubUser(ctx context.Context, p *CreateUserParams, dryR
 				existingUser.GetName())
 		}
 
+		user.SetRevision(existingUser.GetRevision())
 		if err := a.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -123,7 +123,7 @@ func TestCreateGithubUser(t *testing.T) {
 	tt := setupGithubContext(ctx, t)
 
 	// Dry-run creation of Github user.
-	user, err := tt.a.createGithubUser(context.Background(), &CreateUserParams{
+	user, err := tt.a.createGithubUser(ctx, &CreateUserParams{
 		ConnectorName: "github",
 		Username:      "foo@example.com",
 		Roles:         []string{"admin"},
@@ -137,7 +137,7 @@ func TestCreateGithubUser(t *testing.T) {
 	require.Error(t, err)
 
 	// Create GitHub user with 1 minute expiry.
-	_, err = tt.a.createGithubUser(context.Background(), &CreateUserParams{
+	_, err = tt.a.createGithubUser(ctx, &CreateUserParams{
 		ConnectorName: "github",
 		Username:      "foo",
 		Roles:         []string{"admin"},


### PR DESCRIPTION
Updates GitHub users to always have the correct revision set when updating the user. OIDC and SAML users were already updated and pulled in via the e ref update in #32932.