### PR TITLE
docs: Add Docker to partials and update the discord access request plugin

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -114,7 +114,7 @@ update.
 ### Create a config file
 
 <Tabs>
-<TabItem label="Executable">
+<TabItem label="Executable or Docker">
 The Teleport Discord plugin uses a config file in TOML format. Generate a
 boilerplate config by running the following command (the plugin will not run
 unless the config file is in `/etc/teleport-discord.toml`):
@@ -240,7 +240,7 @@ roleToRecipients:
 The final configuration file should resemble the following:
 
 <Tabs>
-<TabItem label="Executable">
+<TabItem label="Executable or Docker">
 ```toml
 (!examples/resources/plugins/teleport-discord.toml!)
 ```
@@ -269,7 +269,7 @@ If everything works fine, the log output should look like this:
 
 ```code
 $ teleport-discord start
-INFO   Starting Teleport Access Discord Plugin 7.2.1: discord/app.go:80
+INFO   Starting Teleport Access Discord Plugin (=teleport.version=): discord/app.go:80
 INFO   Plugin is ready discord/app.go:101
 ```
 </TabItem>
@@ -277,7 +277,7 @@ INFO   Plugin is ready discord/app.go:101
 Start the plugin:
 
 ```code
-$ docker run -v <path-to-config>:/etc/teleport-{{ name }}.toml public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=) start
+$ docker run -v <path-to-config>:/etc/teleport-discord.toml public.ecr.aws/gravitational/teleport-plugin-discord:(=teleport.version=) start
 ```
 </TabItem>
 <TabItem label="Helm Chart">

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -221,7 +221,7 @@ by adding the following to your `role_to_recipients` config (replace
 `YOUR-CHANNEL-ID` with a valid channel ID):
 
 <Tabs>
-<TabItem label="Executable">
+<TabItem label="Executable or Docker">
 ```toml
 [role_to_recipients]
 "*" = "YOUR-CHANNEL-ID"
@@ -271,6 +271,13 @@ If everything works fine, the log output should look like this:
 $ teleport-discord start
 INFO   Starting Teleport Access Discord Plugin 7.2.1: discord/app.go:80
 INFO   Plugin is ready discord/app.go:101
+```
+</TabItem>
+<TabItem label="Docker">
+Start the plugin:
+
+```code
+$ docker run -v <path-to-config>:/etc/teleport-{{ name }}.toml public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=) start
 ```
 </TabItem>
 <TabItem label="Helm Chart">

--- a/docs/pages/includes/plugins/config-toml-teleport.mdx
+++ b/docs/pages/includes/plugins/config-toml-teleport.mdx
@@ -1,5 +1,5 @@
 <Tabs>
-<TabItem label="Executable">
+<TabItem label="Executable or Docker">
 
 **`addr`**: Include the hostname and HTTPS port of your Teleport Proxy Service
 or Teleport Enterprise Cloud tenant (e.g., `teleport.example.com:443` or

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -6,8 +6,8 @@ plugins from source. You can run the plugin from a remote host or your local
 development machine.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-{{ name }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install
 ```
@@ -16,7 +16,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>
@@ -26,14 +26,14 @@ We currently only provide Docker images for `linux-amd64`.
 Pull the Docker image for the latest access request plugin by running the following command:
 
 ```code
-$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=)
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=)
 ```
 
 Make sure the plugin is installed by running the following command:
 
 ```code
-$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=) version
-teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-(=teleport.git=) (=teleport.golang=)
+$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=) version
+teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-(=teleport.git=) (=teleport.golang=)
 ```
 
 For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }})
@@ -55,7 +55,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -36,7 +36,7 @@ $ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.
 teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-(=teleport.git=) (=teleport.golang=)
 ```
 
-For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }})
+For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }}).
 
 </TabItem>
 <TabItem label="From Source">

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -6,8 +6,8 @@ plugins from source. You can run the plugin from a remote host or your local
 development machine.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-{{ name }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install
 ```
@@ -16,8 +16,27 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-fffffffff go(=teleport.golang=)
 ```
+
+</TabItem>
+<TabItem label="Docker Image">
+
+We currently only provide Docker images for `linux-amd64`. 
+Pull the Docker image for the latest access request plugin by running the following command:
+
+```code
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=)
+```
+
+Make sure the plugin is installed by running the following command:
+
+```code
+$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.version=) version
+teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-(=teleport.git=) (=teleport.golang=)
+```
+
+For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }})
 
 </TabItem>
 <TabItem label="From Source">
@@ -36,7 +55,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v(=teleport.version=) git:teleport-{{ name }}-v(=teleport.version=)-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>


### PR DESCRIPTION
~Changed the `teleport.plugin.version `variable to `teleport.version ` because it seems like the plugin versions align with the current teleport versions.~
Added Docker to the install-plugins partial.
Added Docker to tabs for Executables in the Discord-specific topic.
Added Docker to the tab in the plugin TOML configuration partial
