### PR TITLE
[v13] MenuIcon: Support arbitrary icon through Icon prop

### DIFF
--- a/web/packages/shared/components/MenuAction/MenuAction.story.tsx
+++ b/web/packages/shared/components/MenuAction/MenuAction.story.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { Flex } from 'design';
+import { Cog } from 'design/Icon';
 
 import { MenuIcon, MenuButton, MenuItem } from '.';
 
@@ -24,20 +25,40 @@ export default {
 };
 
 export const Menu = () => (
-  <Flex
-    mx="auto"
-    width="200px"
-    height="100px"
-    justifyContent="space-around"
-    alignItems="center"
-  >
-    <MenuIcon>
-      <MenuItem>Edit...</MenuItem>
-      <MenuItem>Delete...</MenuItem>
-    </MenuIcon>
-    <MenuButton>
-      <MenuItem>Edit...</MenuItem>
-      <MenuItem>Delete...</MenuItem>
-    </MenuButton>
+  <Flex gap={11} flexWrap="wrap">
+    <Flex flexDirection="column">
+      MenuIcon
+      <MenuIcon
+        menuProps={{
+          anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          transformOrigin: { vertical: 'top', horizontal: 'left' },
+        }}
+      >
+        <MenuItem>Edit…</MenuItem>
+        <MenuItem>Delete…</MenuItem>
+      </MenuIcon>
+    </Flex>
+
+    <Flex flexDirection="column">
+      MenuIcon with a custom icon
+      <MenuIcon
+        Icon={Cog}
+        menuProps={{
+          anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          transformOrigin: { vertical: 'top', horizontal: 'left' },
+        }}
+      >
+        <MenuItem>Edit…</MenuItem>
+        <MenuItem>Delete…</MenuItem>
+      </MenuIcon>
+    </Flex>
+
+    <Flex flexDirection="column">
+      MenuButton
+      <MenuButton>
+        <MenuItem>Edit…</MenuItem>
+        <MenuItem>Delete…</MenuItem>
+      </MenuButton>
+    </Flex>
   </Flex>
 );

--- a/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
@@ -22,6 +22,9 @@ import { Ellipsis } from 'design/Icon';
 import { MenuProps, AnchorProps } from './types';
 
 export default class MenuActionIcon extends React.Component<Props> {
+  static defaultProps = {
+    Icon: Ellipsis,
+  };
   anchorEl = null;
 
   state = {
@@ -44,7 +47,7 @@ export default class MenuActionIcon extends React.Component<Props> {
 
   render() {
     const { open } = this.state;
-    const { children, buttonIconProps, menuProps } = this.props;
+    const { children, buttonIconProps, menuProps, Icon } = this.props;
     return (
       <>
         <ButtonIcon
@@ -53,7 +56,7 @@ export default class MenuActionIcon extends React.Component<Props> {
           onClick={this.onOpen}
           data-testid="button"
         >
-          <Ellipsis />
+          <Icon />
         </ButtonIcon>
         <Menu
           menuListCss={menuListCss}
@@ -104,4 +107,5 @@ type Props = MenuProps & {
   defaultOpen?: boolean;
   buttonIconProps?: AnchorProps;
   menuProps?: MenuProps;
+  Icon?: React.ComponentType;
 };


### PR DESCRIPTION
Backport #32840.

v13 has a different default icon. It also doesn't have IconProps, so I had to relax the type of the prop a bit.