### PR TITLE
Fix Proxy Kube listener behavior regarding PROXY protocol usage

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -507,6 +508,164 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	require.NoError(t, err)
 
 	mustGetKubePod(t, k8Client)
+}
+
+// TestKubePROXYProtocol tests correct behavior of Proxy Kube listener regarding PROXY protocol usage.
+func TestKubePROXYProtocol(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	const (
+		kubeCluster = constants.KubeTeleportProxyALPNPrefix + "teleport.cluster.local"
+		k8User      = "alice@example.com"
+		k8RoleName  = "kubemaster"
+	)
+
+	testCases := []struct {
+		desc              string
+		proxyListenerMode types.ProxyListenerMode
+		proxyProtocolMode multiplexer.PROXYProtocolMode
+	}{
+		{
+			desc:              "PROXY protocol on, separate Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolOn,
+			proxyListenerMode: types.ProxyListenerMode_Separate,
+		},
+		{
+			desc:              "PROXY protocol off, separate Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolOff,
+			proxyListenerMode: types.ProxyListenerMode_Separate,
+		},
+		{
+			desc:              "PROXY protocol unspecified, separate Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolUnspecified,
+			proxyListenerMode: types.ProxyListenerMode_Separate,
+		},
+		{
+			desc:              "PROXY protocol on, multiplexed Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolOn,
+			proxyListenerMode: types.ProxyListenerMode_Multiplex,
+		},
+		{
+			desc:              "PROXY protocol off, multiplexed Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolOff,
+			proxyListenerMode: types.ProxyListenerMode_Multiplex,
+		},
+		{
+			desc:              "PROXY protocol unspecified, multiplexed Proxy listeners",
+			proxyProtocolMode: multiplexer.PROXYProtocolUnspecified,
+			proxyListenerMode: types.ProxyListenerMode_Multiplex,
+		},
+	}
+
+	username := helpers.MustGetCurrentUser(t).Username
+	kubeRoleSpec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:           []string{username},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubeGroups:       []string{kube.TestImpersonationGroup},
+			KubeUsers:        []string{k8User},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard},
+				},
+			},
+		},
+	}
+	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
+	require.NoError(t, err)
+
+	// Create mock kube server to test connection against
+	kubeAPIMockSvrRoot := startKubeAPIMock(t)
+	kubeConfigPathRoot := mustCreateKubeConfigFile(t, k8ClientConfig(kubeAPIMockSvrRoot.URL, kubeCluster))
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := helpers.InstanceConfig{
+				ClusterName: "root.example.com",
+				HostID:      uuid.New().String(),
+				NodeName:    helpers.Loopback,
+				Log:         utils.NewLoggerForTests(),
+			}
+			tconf := servicecfg.MakeDefaultConfig()
+			if tt.proxyListenerMode == types.ProxyListenerMode_Multiplex {
+				cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
+				tconf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			} else {
+				cfg.Listeners = helpers.StandardListenerSetup(t, &cfg.Fds)
+				tconf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
+				tconf.Proxy.DisableALPNSNIListener = true
+				tconf.Proxy.Kube.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyKube, &cfg.Fds))
+			}
+
+			testCluster := helpers.NewInstance(t, cfg)
+
+			tconf.Version = defaults.TeleportConfigVersionV3
+			tconf.DataDir = t.TempDir()
+			tconf.Auth.Enabled = true
+			tconf.Proxy.Enabled = true
+			tconf.Proxy.DisableWebInterface = true
+			tconf.SSH.Enabled = false
+			tconf.Proxy.Kube.Enabled = true
+
+			tconf.Proxy.PROXYProtocolMode = tt.proxyProtocolMode
+
+			tconf.Kube.Enabled = true
+			tconf.Kube.KubeconfigPath = kubeConfigPathRoot
+			tconf.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &tconf.FileDescriptors))
+
+			// Force multiplexer to check required PROXY lines on all connections
+			tconf.MultiplexerIgnoreSelfConnections = true
+
+			testCluster.AddUserWithRole(username, kubeRole)
+
+			require.NoError(t, testCluster.CreateEx(t, nil, tconf))
+			require.NoError(t, testCluster.Start())
+			t.Cleanup(func() {
+				require.NoError(t, testCluster.StopAll())
+			})
+
+			targetAddr := testCluster.Config.Proxy.WebAddr
+			if tt.proxyListenerMode == types.ProxyListenerMode_Separate {
+				targetAddr = testCluster.Config.Proxy.Kube.ListenAddr
+			}
+
+			// If PROXY protocol is required, create load balancer in front of Teleport cluster
+			if tt.proxyProtocolMode == multiplexer.PROXYProtocolOn {
+				frontend := *utils.MustParseAddr("127.0.0.1:0")
+				lb, err := utils.NewLoadBalancer(context.Background(), frontend)
+				require.NoError(t, err)
+				lb.PROXYHeader = []byte("PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n") // Send fake PROXY header
+				lb.AddBackend(targetAddr)
+				err = lb.Listen()
+				require.NoError(t, err)
+
+				go lb.Serve()
+				t.Cleanup(func() { require.NoError(t, lb.Close()) })
+				targetAddr = *utils.MustParseAddr(lb.Addr().String())
+			}
+
+			// Create kube client that we'll use to test that connection is working correctly.
+			k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
+				T:                   testCluster,
+				Username:            kubeRoleSpec.Allow.Logins[0],
+				KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
+				KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+				CustomTLSServerName: kubeCluster,
+				TargetAddress:       targetAddr,
+				RouteToCluster:      testCluster.Secrets.SiteName,
+			})
+			require.NoError(t, err)
+
+			resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
+		})
+	}
 }
 
 func TestKubeIPPinning(t *testing.T) {

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -572,8 +572,6 @@ func TestKubePROXYProtocol(t *testing.T) {
 			},
 		},
 	}
-	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
-	require.NoError(t, err)
 
 	// Create mock kube server to test connection against
 	kubeAPIMockSvrRoot := startKubeAPIMock(t)
@@ -618,8 +616,11 @@ func TestKubePROXYProtocol(t *testing.T) {
 			tconf.Kube.ListenAddr = utils.MustParseAddr(
 				helpers.NewListener(t, service.ListenerKube, &tconf.FileDescriptors))
 
-			// Force multiplexer to check required PROXY lines on all connections
-			tconf.MultiplexerIgnoreSelfConnections = true
+			// Force Proxy kube server multiplexer to check required PROXY lines on all connections
+			tconf.Options = []servicecfg.Option{servicecfg.NewKubeMultiplexerConfigOption(true)}
+
+			kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
+			require.NoError(t, err)
 
 			testCluster.AddUserWithRole(username, kubeRole)
 

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -617,7 +617,7 @@ func TestKubePROXYProtocol(t *testing.T) {
 				helpers.NewListener(t, service.ListenerKube, &tconf.FileDescriptors))
 
 			// Force Proxy kube server multiplexer to check required PROXY lines on all connections
-			tconf.Options = []servicecfg.Option{servicecfg.NewKubeMultiplexerConfigOption(true)}
+			tconf.Options = []servicecfg.Option{servicecfg.WithKubeMultiplexerIgnoreSelfConnectionsOption()}
 
 			kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
 			require.NoError(t, err)

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -269,10 +269,20 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	return server, nil
 }
 
-type MultiplexerConfigOption func(*multiplexer.Config) error
+// ServeOption is a functional option for the multiplexer.
+type ServeOption func(*multiplexer.Config)
+
+// WithMultiplexerIgnoreSelfConnections is used for tests, it makes multiplexer ignore the fact that it's self
+// connection (coming from same IP as the listening address) when deciding if it should drop connection with
+// missing required PROXY header. This is needed since all connections in tests are self connections.
+func WithMultiplexerIgnoreSelfConnections() ServeOption {
+	return func(cfg *multiplexer.Config) {
+		cfg.IgnoreSelfConnections = true
+	}
+}
 
 // Serve takes TCP listener, upgrades to TLS using config and starts serving
-func (t *TLSServer) Serve(listener net.Listener, options ...MultiplexerConfigOption) error {
+func (t *TLSServer) Serve(listener net.Listener, options ...ServeOption) error {
 	caGetter := func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 		return t.CachingAuthClient.GetCertAuthority(ctx, id, loadKeys)
 	}
@@ -291,10 +301,7 @@ func (t *TLSServer) Serve(listener net.Listener, options ...MultiplexerConfigOpt
 		ReadDeadline: 10 * time.Second,
 	}
 	for _, opt := range options {
-		err := opt(&muxConfig)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		opt(&muxConfig)
 	}
 
 	// Wrap listener with a multiplexer to get PROXY Protocol support.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -98,6 +98,11 @@ type TLSServerConfig struct {
 	KubernetesServersWatcher *services.KubeServerWatcher
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
+
+	// MultiplexerIgnoreSelfConnections is used for tests to control multiplexer's behavior regarding PROXY
+	// protocol for connections from same IP as the listener. This is required because in tests all connections
+	// are from the same IP.
+	MultiplexerIgnoreSelfConnections bool
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -288,6 +293,8 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 		// between the TCP being accepted and the time for the first byte is longer
 		// than the default value -  1s.
 		ReadDeadline: 10 * time.Second,
+
+		IgnoreSelfConnections: t.MultiplexerIgnoreSelfConnections,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4393,12 +4393,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		proxyProtocol := cfg.Proxy.PROXYProtocolMode
-		if clusterNetworkConfig.GetProxyListenerMode()== types.ProxyListenerMode_Multiplex {
-			// If ProxyListenerMode is MULTIPLEX it means that the ALPN listener handles the proxy line 
-			// and sends the connection to the Kubernetes listener. When it does, it shares the net.Conn
-			// and doesn't dial so the PROXY Protocol cannot be present. Under those circumstances, 
-			// ProxyProtocol must be off!
-			
+		if clusterNetworkConfig.GetProxyListenerMode() == types.ProxyListenerMode_Multiplex {
+			// If ProxyListenerMode is MULTIPLEX it means that the ALPN listener handles the PROXY line
+			// and sends the connection to the Proxy Kube listener. When it does, it uses the same net.Conn
+			// and doesn't dial so the PROXY Protocol cannot be present. Under those circumstances,
+			// ProxyProtocol for Proxy Kube listener must be off.
+
 			proxyProtocol = multiplexer.PROXYProtocolOff
 		}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4393,8 +4393,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		proxyProtocol := cfg.Proxy.PROXYProtocolMode
-		if _, ok := listeners.kube.(*alpnproxy.ListenerMuxWrapper); ok {
-			// If kube listener is multiplexed it means PROXY protocol was already handled upstream.
+		if clusterNetworkConfig.GetProxyListenerMode()== types.ProxyListenerMode_Multiplex {
+			// If ProxyListenerMode is MULTIPLEX it means that the ALPN listener handles the proxy line 
+			// and sends the connection to the Kubernetes listener. When it does, it shares the net.Conn
+			// and doesn't dial so the PROXY Protocol cannot be present. Under those circumstances, 
+			// ProxyProtocol must be off!
+			
 			proxyProtocol = multiplexer.PROXYProtocolOff
 		}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4453,12 +4453,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			}
 			log.Infof("Starting Kube proxy on %v.", kubeListenAddr)
 
-			var mopts []kubeproxy.MultiplexerConfigOption
+			var mopts []kubeproxy.ServeOption
 			for _, opt := range cfg.Options {
-				if muxOption, ok := opt.(servicecfg.KubeMultiplexerConfigOption); ok {
-					mopts = append(mopts, func(config *multiplexer.Config) error {
-						return muxOption(config)
-					})
+				if _, ok := opt.(servicecfg.KubeMultiplexerIgnoreSelfConnectionsOption); ok {
+					mopts = append(mopts, kubeproxy.WithMultiplexerIgnoreSelfConnections())
+					break
 				}
 			}
 

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -264,6 +264,11 @@ type Config struct {
 	// Note: When set, this overrides Auth and Proxy's AssistAPIKey settings.
 	OpenAIConfig *openai.ClientConfig
 
+	// MultiplexerIgnoreSelfConnections is used for tests to control multiplexer's behavior regarding PROXY
+	// protocol for connections from same IP as the listener. This is required because in tests all connections
+	// are from the same IP.
+	MultiplexerIgnoreSelfConnections bool
+
 	// token is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -290,26 +289,22 @@ type Config struct {
 	authServers []utils.NetAddr
 }
 
-// Option applies an option value for a Config.
+// Option allows to customize default behaviour of service initialization defined by Config
 type Option interface {
 	Apply(any) error
 }
 
-// KubeMultiplexerConfigOption allows to modify multiplexer config for Kube Proxy TLS server's listener
-type KubeMultiplexerConfigOption func(any) error
+// KubeMultiplexerIgnoreSelfConnectionsOption signals that Proxy TLS server's listener should
+// require PROXY header if 'proxyProtocolMode: true' even from self connections. Used in tests as all connections are self
+// connections there.
+type KubeMultiplexerIgnoreSelfConnectionsOption struct{}
 
-func (f KubeMultiplexerConfigOption) Apply(input any) error {
-	return f(input)
+func (k KubeMultiplexerIgnoreSelfConnectionsOption) Apply(input any) error {
+	return nil
 }
 
-func NewKubeMultiplexerConfigOption(val bool) KubeMultiplexerConfigOption {
-	return func(input any) error {
-		if cfg, ok := input.(*multiplexer.Config); ok {
-			cfg.IgnoreSelfConnections = val
-			return nil
-		}
-		return trace.BadParameter("unexpected option type - expected %T, got %T", &multiplexer.Config{}, input)
-	}
+func WithKubeMultiplexerIgnoreSelfConnectionsOption() KubeMultiplexerIgnoreSelfConnectionsOption {
+	return KubeMultiplexerIgnoreSelfConnectionsOption{}
 }
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -289,7 +289,7 @@ type Config struct {
 	authServers []utils.NetAddr
 }
 
-// Option allows to customize default behaviour of service initialization defined by Config
+// Option allows to customize default behavior of service initialization defined by Config
 type Option interface {
 	Apply(any) error
 }


### PR DESCRIPTION
This PR fixes an error in Proxy Kube listener setup - we always provided Proxy's `PROXYProtocolMode` setting to the Proxy's Kube listener, but it could be already behind an alpn multiplexed listener. So when `PROXYProtocolMode: on` Proxy Kube listener tried to check for presence of PROXY line that couldn't come, since alpn listener already consumed it.