### PR TITLE
Fix switch condition in Proxy listeners setup

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3604,8 +3604,8 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			}
 		}()
 		return &listeners, nil
-	case cfg.Proxy.PROXYProtocolMode != multiplexer.PROXYProtocolUnspecified && !cfg.Proxy.DisableWebService && !cfg.Proxy.DisableTLS:
-		process.log.Debugf("Setup Proxy: Proxy protocol is enabled for web service, multiplexing is on.")
+	case cfg.Proxy.PROXYProtocolMode != multiplexer.PROXYProtocolOff && !cfg.Proxy.DisableWebService && !cfg.Proxy.DisableTLS:
+		process.log.Debug("Setup Proxy: PROXY protocol is enabled for web service, multiplexing is on.")
 		listener, err := process.importOrCreateListener(ListenerProxyWeb, cfg.Proxy.WebAddr.Addr)
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR fixes switch condition in `setupProxyListeners()` - it was an error introduced by `proxy_protocol` changes (#31622). Original condition looked like `case cfg.Proxy.EnableProxyProtocol && !cfg.Proxy.DisableWebService && !cfg.Proxy.DisableTLS:` - so we used this branch if PROXY protocol was enabled, but now it's taken when PROXY protocol is switched off as well. It seems that mistake was not that damaging and in most cases we ended up with same listeners setup, since we still provided correct `PROXYProtocolMode` to multiplexer and it was off when required. Here we restore original default switch flow for unspecified `proxy_protocol` setting.