### PR TITLE
Split RDS Proxy guides per protocol

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1101,8 +1101,16 @@
               "slug": "/database-access/guides/rds/"
             },
             {
-              "title": "AWS RDS Proxy",
-              "slug": "/database-access/guides/rds-proxy/"
+              "title": "AWS RDS Proxy for MariaDB/MySQL",
+              "slug": "/database-access/guides/rds-proxy-mysql/"
+            },
+            {
+              "title": "AWS RDS Proxy for PostgreSQL",
+              "slug": "/database-access/guides/rds-proxy-postgres/"
+            },
+            {
+              "title": "AWS RDS Proxy for SQL Server",
+              "slug": "/database-access/guides/rds-proxy-sqlserver/"
             },
             {
               "title": "AWS Redshift",

--- a/docs/pages/database-access/guides/rds-proxy-mysql.mdx
+++ b/docs/pages/database-access/guides/rds-proxy-mysql.mdx
@@ -3,6 +3,6 @@ title: Database Access with AWS RDS Proxy for MariaDB/MySQL
 description: How to configure Teleport database access with AWS RDS Proxy for MariaDB/MySQL.
 ---
 
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for MariaDB/MySQL" dbConfigure="AWS RDS proxy for MariaDB/MySQL with IAM authentication" dbName="AWS RDS proxy for MariaDB/MySQL" !)
+(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for MariaDB or MySQL" dbConfigure="AWS RDS proxy for MariaDB or MySQL with IAM authentication" dbName="AWS RDS proxy for MariaDB or MySQL" !)
 
 (!docs/pages/includes/database-access/rds-proxy.mdx!)

--- a/docs/pages/database-access/guides/rds-proxy-mysql.mdx
+++ b/docs/pages/database-access/guides/rds-proxy-mysql.mdx
@@ -1,0 +1,8 @@
+---
+title: Database Access with AWS RDS Proxy for MariaDB/MySQL
+description: How to configure Teleport database access with AWS RDS Proxy for MariaDB/MySQL.
+---
+
+(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for MariaDB/MySQL" dbConfigure="AWS RDS proxy for MariaDB/MySQL with IAM authentication" dbName="AWS RDS proxy for MariaDB/MySQL" !)
+
+(!docs/pages/includes/database-access/rds-proxy.mdx!)

--- a/docs/pages/database-access/guides/rds-proxy-postgres.mdx
+++ b/docs/pages/database-access/guides/rds-proxy-postgres.mdx
@@ -1,0 +1,8 @@
+---
+title: Database Access with AWS RDS Proxy for PostgreSQL
+description: How to configure Teleport database access with AWS RDS Proxy for PostgreSQL
+---
+
+(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for PostgreSQL" dbConfigure="AWS RDS proxy for PostgreSQL with IAM authentication" dbName="AWS RDS proxy for PostgreSQL" !)
+
+(!docs/pages/includes/database-access/rds-proxy.mdx!)

--- a/docs/pages/database-access/guides/rds-proxy-sqlserver.mdx
+++ b/docs/pages/database-access/guides/rds-proxy-sqlserver.mdx
@@ -1,0 +1,8 @@
+---
+title: Database Access with AWS RDS Proxy for Microsoft SQL Server
+description: How to configure Teleport database access with AWS RDS Proxy for Microsoft SQL Server
+---
+
+(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy for Microsoft SQL Server" dbConfigure="AWS RDS proxy for Microsoft SQL Server with IAM authentication" dbName="AWS RDS proxy for Microsoft SQL Server" !)
+
+(!docs/pages/includes/database-access/rds-proxy.mdx!)

--- a/docs/pages/includes/database-access/guides.mdx
+++ b/docs/pages/includes/database-access/guides.mdx
@@ -7,8 +7,8 @@
 - [AWS ElastiCache & MemoryDB](../../database-access/guides/redis-aws.mdx): Connect AWS ElastiCache or AWS MemoryDB for Redis database.
 - [AWS RDS & Aurora](../../database-access/guides/rds.mdx): Connect AWS RDS or Aurora PostgreSQL, MariaDB or MySQL database.
 - [AWS RDS Proxy for MariaDB/MySQL](../../database-access/guides/rds-proxy-mysql.mdx): Connect AWS RDS Proxy instances to Teleport.
-- [AWS RDS Proxy for PostgreSQL](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
-- [AWS RDS Proxy for SQL Server](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
+- [AWS RDS Proxy for PostgreSQL](../../database-access/guides/rds-proxy-postgres.mdx): Connect AWS RDS Proxy instances to Teleport.
+- [AWS RDS Proxy for SQL Server](../../database-access/guides/rds-proxy-sqlserver.mdx): Connect AWS RDS Proxy instances to Teleport.
 - [AWS Redshift](../../database-access/guides/postgres-redshift.mdx): Connect AWS Redshift database.
 - [AWS Redshift Serverless](../../database-access/guides/redshift-serverless.mdx): Connect to AWS Redshift serverless.
 - [AWS Keyspaces (Apache Cassandra)](../../database-access/guides/aws-cassandra-keyspaces.mdx): Connect to an AWS Keyspaces database.

--- a/docs/pages/includes/database-access/guides.mdx
+++ b/docs/pages/includes/database-access/guides.mdx
@@ -6,7 +6,9 @@
 - [AWS OpenSearch](../../database-access/guides/aws-opensearch.mdx): Connect AWS OpenSearch.
 - [AWS ElastiCache & MemoryDB](../../database-access/guides/redis-aws.mdx): Connect AWS ElastiCache or AWS MemoryDB for Redis database.
 - [AWS RDS & Aurora](../../database-access/guides/rds.mdx): Connect AWS RDS or Aurora PostgreSQL, MariaDB or MySQL database.
-- [AWS RDS Proxy](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
+- [AWS RDS Proxy for MariaDB/MySQL](../../database-access/guides/rds-proxy-mysql.mdx): Connect AWS RDS Proxy instances to Teleport.
+- [AWS RDS Proxy for PostgreSQL](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
+- [AWS RDS Proxy for SQL Server](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
 - [AWS Redshift](../../database-access/guides/postgres-redshift.mdx): Connect AWS Redshift database.
 - [AWS Redshift Serverless](../../database-access/guides/redshift-serverless.mdx): Connect to AWS Redshift serverless.
 - [AWS Keyspaces (Apache Cassandra)](../../database-access/guides/aws-cassandra-keyspaces.mdx): Connect to an AWS Keyspaces database.

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -1,10 +1,3 @@
----
-title: Database Access with AWS RDS Proxy
-description: How to configure Teleport database access with AWS RDS Proxy.
----
-
-(!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy" dbConfigure="AWS RDS proxy with IAM authentication" dbName="AWS RDS proxy" !)
-
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Proxy Self-Hosted](../../../img/database-access/guides/rds-proxy_selfhosted.png)
@@ -17,7 +10,9 @@ description: How to configure Teleport database access with AWS RDS Proxy.
 
 <Admonition type="note" title="Supported Engine Family">
 Teleport currently supports RDS Proxy instances with engine family
-**PostgreSQL**, **MariaDB/MySQL** or **Microsoft SQL Server**.
+[PostgreSQL](../../database-access/guides/rds-proxy-postgres.mdx),
+[MariaDB/MySQL](../../database-access/guides/rds-proxy-postgres.mdx) or
+[Microsoft SQL Server](../../database-access/guides/rds-proxy-sqlserver.mdx).
 </Admonition>
 
 ## Prerequisites
@@ -155,11 +150,6 @@ To retrieve credentials for a database and connect to it:
 $ tsh db connect --db-user=alice --db-name=dev rds-proxy
 ```
 
-<Admonition type="note" title="Note">
-The appropriate database command-line client (`psql`, `mysql`, `mariadb`,
-`sqlcmd`) should be available in `PATH` in order to connect.
-</Admonition>
-
 To log out of the database and remove credentials:
 
 ```code
@@ -180,4 +170,3 @@ $ tsh db logout rds-proxy
   and [Setting up AWS Identity and Access Management (IAM)
   policies](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html)
   for RDS Proxy
-


### PR DESCRIPTION
Related to #32318.

Creates one page per protocol supported by RDS proxy integration. The pages have the same contents.

Note: One AWS console image relates to MySQL (the only difference is the authentication mechanism). I couldn't find a good way of changing this image depending on the protocol, so I'm leaving them as it is for now.