### PR TITLE
docs: set scopes for GitHub SSO

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -267,7 +267,8 @@
             },
             {
               "title": "GitHub",
-              "slug": "/access-controls/sso/github-sso/"
+              "slug": "/access-controls/sso/github-sso/",
+              "forScopes": ["oss", "team", "enterprise", "cloud"]
             },
             {
               "title": "GitLab",


### PR DESCRIPTION
Without the scopes the commercial tab is defaulted though community edition is defaulted at top.  If a Community Edition users trys that it will throw an error.

<img width="951" alt="image" src="https://github.com/gravitational/teleport/assets/60704961/ca798b97-791f-47c7-aefe-b6b94f0a8cf1">
