### PR TITLE
Reliability improvements for HSM tests

### DIFF
--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -236,6 +236,7 @@ func newAuthConfig(t *testing.T, log utils.Logger) *servicecfg.Config {
 	config.Log = log
 	config.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
 	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.PollingPeriod = 2 * time.Second
 
 	config.Auth.Enabled = true
 	config.Auth.NoAudit = true
@@ -278,6 +279,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, log utils.Logger) *ser
 	config.Log = log
 	config.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
 	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.PollingPeriod = 2 * time.Second
 
 	config.Proxy.Enabled = true
 	config.Proxy.DisableWebInterface = true

--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -191,6 +191,12 @@ func (t *teleportService) authAddr(testingT *testing.T) utils.NetAddr {
 	return *addr
 }
 
+func (t *teleportService) authAddrString(testingT *testing.T) string {
+	addr, err := t.process.AuthAddr()
+	require.NoError(testingT, err)
+	return addr.String()
+}
+
 type teleportServices []*teleportService
 
 func (s teleportServices) forEach(f func(t *teleportService) error) error {

--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -40,12 +40,13 @@ import (
 // up. Methods are not meant to be called concurrently on the same receiver and
 // are not generally thread safe.
 type teleportService struct {
-	name           string
-	log            utils.Logger
-	config         *servicecfg.Config
-	process        *service.TeleportProcess
-	serviceChannel chan *service.TeleportProcess
-	errorChannel   chan error
+	name              string
+	log               utils.Logger
+	config            *servicecfg.Config
+	process           *service.TeleportProcess
+	processGeneration int
+	serviceChannel    chan *service.TeleportProcess
+	errorChannel      chan error
 }
 
 func newTeleportService(t *testing.T, config *servicecfg.Config, name string) *teleportService {
@@ -77,73 +78,76 @@ func (t *teleportService) start(ctx context.Context) error {
 	// receive all new processes after restarts and write them to a goroutine.
 	go func() {
 		t.errorChannel <- service.Run(ctx, *t.config, func(cfg *servicecfg.Config) (service.Process, error) {
-			t.log.Debugf("(Re)starting %s", t.name)
+			t.log.Debugf("%s gen %d: starting next process generation (gen %d)", t.name, t.processGeneration, t.processGeneration+1)
 			svc, err := service.NewTeleport(cfg)
 			if err == nil {
-				t.log.Debugf("Started %s, writing to serviceChannel", t.name)
+				t.log.Debugf("%s gen %d: started, writing to serviceChannel", t.name, t.processGeneration+1)
 				t.serviceChannel <- svc
 			}
 			return svc, trace.Wrap(err)
 		})
 	}()
-	t.log.Debugf("Waiting for %s to start", t.name)
+	t.log.Debugf("%s gen 1: waiting for first start", t.name)
 	if err := t.waitForNewProcess(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	t.log.Debugf("%s started, waiting for it to be ready", t.name)
+	t.log.Debugf("%s gen 1: started, waiting for it to be ready", t.name)
 	return t.waitForReady(ctx)
 }
 
 func (t *teleportService) waitForNewProcess(ctx context.Context) error {
 	select {
 	case t.process = <-t.serviceChannel:
-		t.log.Debugf("received new process for %s from serviceChannel", t.name)
+		t.processGeneration += 1
+		t.log.Debugf("%s gen %d: received new process from serviceChannel", t.name, t.processGeneration)
 	case err := <-t.errorChannel:
 		return trace.Wrap(err)
 	case <-ctx.Done():
-		return trace.Wrap(ctx.Err(), "timed out waiting for %s to restart", t.name)
+		return trace.Wrap(ctx.Err(), "%s gen %d: timed out waiting for restart", t.name, t.processGeneration)
 	}
 	return nil
 }
 
 func (t *teleportService) waitForReady(ctx context.Context) error {
-	t.log.Debugf("Waiting for %s to be ready", t.name)
+	t.log.Debugf("%s gen %d: waiting for TeleportReadyEvent", t.name, t.processGeneration)
 	if _, err := t.process.WaitForEvent(ctx, service.TeleportReadyEvent); err != nil {
-		return trace.Wrap(err, "timed out waiting for %s to be ready", t.name)
+		return trace.Wrap(err, "timed out waiting for %s gen %d to be ready", t.name, t.processGeneration)
 	}
-	// If this is an Auth servier, also wait for AuthIdentityEvent so that we
+	t.log.Debugf("%s gen %d: got TeleportReadyEvent", t.name, t.processGeneration)
+	// If this is an Auth server, also wait for AuthIdentityEvent so that we
 	// can safely read the admin credentials and create a test client.
 	if t.process.GetAuthServer() != nil {
+		t.log.Debugf("%s gen %d: waiting for AuthIdentityEvent", t.name, t.processGeneration)
 		if _, err := t.process.WaitForEvent(ctx, service.AuthIdentityEvent); err != nil {
-			return trace.Wrap(err, "timed out waiting for %s auth identity event", t.name)
+			return trace.Wrap(err, "%s gen %d: timed out waiting AuthIdentityEvent", t.name, t.processGeneration)
 		}
-		t.log.Debugf("%s is ready", t.name)
+		t.log.Debugf("%s gen %d: got AuthIdentityEvent", t.name, t.processGeneration)
 	}
 	return nil
 }
 
 func (t *teleportService) waitForRestart(ctx context.Context) error {
-	t.log.Debugf("Waiting for %s to restart", t.name)
+	t.log.Debugf("%s gen %d: waiting for restart", t.name, t.processGeneration)
 	if err := t.waitForNewProcess(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	t.log.Debugf("%s restarted, waiting for new process to be ready", t.name)
+	t.log.Debugf("%s gen %d: restarted, waiting for new process (gen %d) to be ready", t.name, t.processGeneration-1, t.processGeneration)
 	return trace.Wrap(t.waitForReady(ctx))
 }
 
 func (t *teleportService) waitForShutdown(ctx context.Context) error {
-	t.log.Debugf("Waiting for %s to shut down", t.name)
+	t.log.Debugf("%s gen %d: waiting for shutdown", t.name, t.processGeneration)
 	select {
 	case err := <-t.errorChannel:
 		t.process = nil
 		return trace.Wrap(err)
 	case <-ctx.Done():
-		return trace.Wrap(ctx.Err(), "timed out waiting for %s to shut down", t.name)
+		return trace.Wrap(ctx.Err(), "%s gen %d: timed out waiting for shutdown", t.name, t.processGeneration)
 	}
 }
 
 func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error {
-	t.log.Debugf("Waiting for %s to have local additional keys", t.name)
+	t.log.Debugf("%s gen %d: waiting for local additional keys", t.name, t.processGeneration)
 	clusterName, err := t.process.GetAuthServer().GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -152,7 +156,7 @@ func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error 
 	for {
 		select {
 		case <-ctx.Done():
-			return trace.Wrap(ctx.Err(), "timed out waiting for %s to have local additional keys", t.name)
+			return trace.Wrap(ctx.Err(), "%s gen %d: timed out waiting for local additional keys", t.name, t.processGeneration)
 		case <-time.After(250 * time.Millisecond):
 		}
 		ca, err := t.process.GetAuthServer().GetCertAuthority(ctx, hostCAID, true)
@@ -167,16 +171,16 @@ func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error 
 			break
 		}
 	}
-	t.log.Debugf("%s has local additional keys", t.name)
+	t.log.Debugf("%s gen %d has local additional keys", t.name, t.processGeneration)
 	return nil
 }
 
 func (t *teleportService) waitForPhaseChange(ctx context.Context) error {
-	t.log.Debugf("Waiting for %s to change phase", t.name)
+	t.log.Debugf("%s gen %d: waiting for phase change", t.name, t.processGeneration)
 	if _, err := t.process.WaitForEvent(ctx, service.TeleportPhaseChangeEvent); err != nil {
-		return trace.Wrap(err, "timed out waiting for %s to change phase", t.name)
+		return trace.Wrap(err, "%s gen %d: timed out waiting for phase change", t.name, t.processGeneration)
 	}
-	t.log.Debugf("%s changed phase", t.name)
+	t.log.Debugf("%s gen %d: changed phase", t.name, t.processGeneration)
 	return nil
 }
 

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -186,10 +186,6 @@ func TestHSMRotation(t *testing.T) {
 
 // Tests multiple CA rotations and rollbacks with 2 HSM auth servers in an HA configuration
 func TestHSMDualAuthRotation(t *testing.T) {
-	// TODO(nklaassen): fix this test and re-enable it.
-	// https://github.com/gravitational/teleport/issues/20217
-	t.Skip("TestHSMDualAuthRotation is temporarily disabled due to flakiness")
-
 	requireHSMAvailable(t)
 	requireETCDAvailable(t)
 

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -84,7 +84,7 @@ func etcdBackendConfig(t *testing.T) *backend.Config {
 	t.Cleanup(func() {
 		bk, err := etcdbk.New(context.Background(), cfg.Params)
 		require.NoError(t, err)
-		require.NoError(t, bk.DeleteRange(context.Background(), []byte(prefix),
+		require.NoError(t, bk.DeleteRange(context.Background(), append([]byte("/"), []byte(prefix)...),
 			backend.RangeEnd([]byte(prefix))),
 			"failed to clean up etcd backend")
 	})

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -38,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 )
 
 func TestMain(m *testing.M) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1992,7 +1992,7 @@ func (process *TeleportProcess) initAuthService() error {
 		// the service has started
 		process.BroadcastEvent(Event{Name: AuthTLSReady, Payload: nil})
 		err := tlsServer.Serve()
-		if err != nil && err != http.ErrServerClosed {
+		if err != nil && errors.Is(err, http.ErrServerClosed) {
 			log.Warningf("TLS server exited with error: %v.", err)
 		}
 		return nil


### PR DESCRIPTION
This PR contains:
* log message improvements for HSM test helpers to help track down reload bugs more easily
* fixes the etcd backend cleanup to add a `/` prefix to the uuid key being deleted, it didn't work at all before
* re-enable TestHSMDualAuthRotation
* add retries to client connection tests with `require.Eventually`

I tried to run these tests repeatedly over the weekend but etcd ended up panicking during the 95th run for some reason. In the first 94 runs, I did not find any test failures. Before these improvements, I was seeing a ~7% failure rate with the same test setup, so this does appear to be a legitimate improvement.

^ Update: still seeing a ~5% failure rate at 5c79116ac908f2c4f35c3e3919d4a2e0c1ba8cf0, hoping for improvement with 0cf6e9d928772096d5ab8ef5f8e67931285c8b21

Fixes https://github.com/gravitational/teleport/issues/30893
Fixes https://github.com/gravitational/teleport/issues/20217
Fixes https://github.com/gravitational/teleport/issues/14172