### PR TITLE
[v13] Fix: Add access list field to web usercontext ACL

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -106,6 +106,8 @@ type userACL struct {
 	Assist access `json:"assist"`
 	// SAMLIdpServiceProvider defines access to `saml_idp_service_provider` objects.
 	SAMLIdpServiceProvider access `json:"samlIdpServiceProvider"`
+	// AccessList defines access to access list management.
+	AccessList access `json:"accessList"`
 }
 
 type authType string
@@ -227,6 +229,7 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	deviceTrust := newAccess(userRoles, ctx, types.KindDevice)
 	integrationsAccess := newAccess(userRoles, ctx, types.KindIntegration)
 	lockAccess := newAccess(userRoles, ctx, types.KindLock)
+	accessListAccess := newAccess(userRoles, ctx, types.KindAccessList)
 
 	acl := userACL{
 		AccessRequests:          requestAccess,
@@ -257,6 +260,7 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 		Locks:                   lockAccess,
 		Assist:                  assistAccess,
 		SAMLIdpServiceProvider:  samlIdpServiceProviderAccess,
+		AccessList:              accessListAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -71,6 +71,10 @@ func TestNewUserContext(t *testing.T) {
 			Verbs:     services.RW(),
 		},
 		{
+			Resources: []string{types.KindAccessList},
+			Verbs:     services.RW(),
+		},
+		{
 			Resources: []string{types.KindBilling},
 			Verbs:     services.RO(),
 		},
@@ -100,6 +104,7 @@ func TestNewUserContext(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.ACL.AccessRequests, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.ConnectionDiagnostic, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.Desktops, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.AccessList, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.AccessStrategy, accessStrategy{
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",

--- a/web/packages/design/src/SVGIcon/UserList.tsx
+++ b/web/packages/design/src/SVGIcon/UserList.tsx
@@ -44,7 +44,7 @@ import { SVGIcon } from './SVGIcon';
 
 import type { SVGIconProps } from './common';
 
-export function UserList({ size = 24, fill }: SVGIconProps) {
+export function UserList({ size = 18, fill }: SVGIconProps) {
   return (
     <SVGIcon
       size={size}


### PR DESCRIPTION
fixes: https://github.com/gravitational/teleport.e/issues/2343

`access_list` rules were not getting sent to the web UI because it was missing in the backend

manual backport gone wrong: https://github.com/gravitational/teleport/pull/30658, i somehow missed the `go` file changes

also snuck in a icon size change, the `access list` icon for the side nav was larger than the others

tested: 

<img width="981" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/2f2d1332-7fd4-4038-9645-fac0fc140fd1">

