### PR TITLE
Start migrating services.UserService to use context and return users

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -838,6 +838,18 @@ func (c *Client) CreateUser(ctx context.Context, user types.User) error {
 	return trace.Wrap(err)
 }
 
+// CreateUserWithContext creates a new user from the specified descriptor.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) CreateUserWithContext(ctx context.Context, user types.User) (types.User, error) {
+	err := c.CreateUser(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := c.GetUserWithContext(ctx, user.GetName(), false)
+	return created, trace.Wrap(err)
+}
+
 // UpdateUser updates an existing user in a backend.
 func (c *Client) UpdateUser(ctx context.Context, user types.User) error {
 	userV2, ok := user.(*types.UserV2)
@@ -847,6 +859,18 @@ func (c *Client) UpdateUser(ctx context.Context, user types.User) error {
 
 	_, err := c.grpc.UpdateUser(ctx, userV2)
 	return trace.Wrap(err)
+}
+
+// UpdateUserWithContext updates an existing user in a backend.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) UpdateUserWithContext(ctx context.Context, user types.User) (types.User, error) {
+	err := c.UpdateUser(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := c.GetUserWithContext(ctx, user.GetName(), false)
+	return updated, trace.Wrap(err)
 }
 
 // GetUser returns a list of usernames registered in the system.
@@ -863,6 +887,13 @@ func (c *Client) GetUser(name string, withSecrets bool) (types.User, error) {
 		return nil, trace.Wrap(err)
 	}
 	return user, nil
+}
+
+// GetUserWithContext returns a list of usernames registered in the system.
+// withSecrets controls whether authentication details are returned.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	return c.GetUser(name, withSecrets)
 }
 
 // GetCurrentUser returns current user as seen by the server.
@@ -908,6 +939,13 @@ func (c *Client) GetUsers(withSecrets bool) ([]types.User, error) {
 		users = append(users, user)
 	}
 	return users, nil
+}
+
+// GetUsersWithContext returns a list of users.
+// withSecrets controls whether authentication details are returned.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error) {
+	return c.GetUsers(withSecrets)
 }
 
 // DeleteUser deletes a user by name.

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -797,7 +797,7 @@ type ReadOktaAccessPoint interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
 
-	// GetOktaAssignment treturns the specified Okta assignment resources.
+	// GetOktaAssignment returns the specified Okta assignment resource.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 
 	// GetApplicationServers returns all registered application servers.

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -190,6 +190,9 @@ type ReadProxyAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
 
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
 	// GetNamespaces returns a list of namespaces
 	GetNamespaces() ([]types.Namespace, error)
 
@@ -429,6 +432,9 @@ type ReadKubernetesAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
 
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
@@ -494,6 +500,9 @@ type ReadAppsAccessPoint interface {
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
+
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
@@ -562,6 +571,9 @@ type ReadDatabaseAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
 
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
@@ -628,6 +640,9 @@ type ReadWindowsDesktopAccessPoint interface {
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
+
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
@@ -764,6 +779,9 @@ type ReadOktaAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
 
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
 	// ListUserGroups returns a paginated list of all user group resources.
 	ListUserGroups(context.Context, int, string) ([]types.UserGroup, string, error)
 
@@ -779,7 +797,7 @@ type ReadOktaAccessPoint interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
 
-	// GetOktaAssignmen treturns the specified Okta assignment resources.
+	// GetOktaAssignment treturns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 
 	// GetApplicationServers returns all registered application servers.
@@ -907,8 +925,14 @@ type Cache interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
 
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
 	// GetUsers returns a list of local users registered with this domain
 	GetUsers(withSecrets bool) ([]types.User, error)
+
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2637,6 +2637,17 @@ func (a *ServerWithRoles) GetUsers(withSecrets bool) ([]types.User, error) {
 	return a.authServer.GetUsers(withSecrets)
 }
 
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error) {
+	return a.GetUsers(withSecrets)
+}
+
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	user, err := a.GetUser(name, withSecrets)
+	return user, trace.Wrap(err)
+}
+
 func (a *ServerWithRoles) GetUser(name string, withSecrets bool) (types.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
@@ -2670,7 +2681,9 @@ func (a *ServerWithRoles) GetUser(name string, withSecrets bool) (types.User, er
 			}
 		}
 	}
-	return a.authServer.GetUser(name, withSecrets)
+
+	user, err := a.authServer.GetUser(name, withSecrets)
+	return user, trace.Wrap(err)
 }
 
 // GetCurrentUser returns current user as seen by the server.
@@ -3281,26 +3294,49 @@ func (a *ServerWithRoles) ChangeUserAuthentication(ctx context.Context, req *pro
 }
 
 // CreateUser inserts a new user entry in a backend.
-func (a *ServerWithRoles) CreateUser(ctx context.Context, user types.User) error {
+func (a *ServerWithRoles) CreateUser(ctx context.Context, u types.User) error {
+	_, err := a.CreateUserWithContext(context.TODO(), u)
+	return trace.Wrap(err)
+}
+
+// CreateUserWithContext inserts a new user entry in a backend.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) CreateUserWithContext(ctx context.Context, user types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return a.authServer.CreateUser(ctx, user)
+	user, err := a.authServer.CreateUserWithContext(ctx, user)
+	return user, trace.Wrap(err)
 }
 
 // UpdateUser updates an existing user in a backend.
 // Captures the auth user who modified the user record.
 func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) error {
+	_, err := a.UpdateUserWithContext(ctx, user)
+	return trace.Wrap(err)
+}
+
+// UpdateUserWithContext updates an existing user in a backend.
+// Captures the auth user who modified the user record.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) UpdateUserWithContext(ctx context.Context, user types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.UpdateUser(ctx, user)
+	updated, err := a.authServer.UpdateUserWithContext(ctx, user)
+	return updated, trace.Wrap(err)
 }
 
 func (a *ServerWithRoles) UpsertUser(u types.User) error {
+	_, err := a.UpsertUserWithContext(context.TODO(), u)
+	return trace.Wrap(err)
+}
+
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) UpsertUserWithContext(ctx context.Context, u types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	createdBy := u.GetCreatedBy()
@@ -3309,7 +3345,8 @@ func (a *ServerWithRoles) UpsertUser(u types.User) error {
 			User: types.UserRef{Name: a.context.User.GetName()},
 		})
 	}
-	return a.authServer.UpsertUser(u)
+	user, err := a.authServer.UpsertUserWithContext(ctx, u)
+	return user, trace.Wrap(err)
 }
 
 // UpdateAndSwapUser exists on [ServerWithRoles] only for compatibility with
@@ -4356,6 +4393,12 @@ func (a *ServerWithRoles) DeleteAllRoles() error {
 
 // DeleteAllUsers not implemented: can only be called locally.
 func (a *ServerWithRoles) DeleteAllUsers() error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
+// DeleteAllUsersWithContext not implemented: can only be called locally.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (a *ServerWithRoles) DeleteAllUsersWithContext(context.Context) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -330,6 +330,12 @@ func (c *Client) DeleteAllUsers() error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// DeleteAllUsersWithContext not implemented: can only be called locally.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) DeleteAllUsersWithContext(ctx context.Context) error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
 // CreateResetPasswordToken creates reset password token
 func (c *Client) CreateResetPasswordToken(ctx context.Context, req CreateUserTokenRequest) (types.UserToken, error) {
 	return c.APIClient.CreateResetPasswordToken(ctx, &proto.CreateResetPasswordTokenRequest{
@@ -447,6 +453,25 @@ func (c *Client) UserLoginStateClient() services.UserLoginStates {
 	return c.APIClient.UserLoginStateClient()
 }
 
+// UpsertUserWithContext UpsertUser user updates or inserts user entry.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) UpsertUserWithContext(ctx context.Context, user types.User) (types.User, error) {
+	if err := c.UpsertUser(user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user, err := c.GetUser(user.GetName(), false)
+	return user, trace.Wrap(err)
+}
+
+// GetUserWithContext returns the user matching the name as seen by the server.
+// withSecrets controls whether authentication details are returned.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Client) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	user, err := c.GetUser(name, withSecrets)
+	return user, trace.Wrap(err)
+}
+
 // WebService implements features used by Web UI clients
 type WebService interface {
 	// GetWebSessionInfo checks if a web session is valid, returns session id in case if
@@ -516,6 +541,9 @@ type IdentityService interface {
 
 	// GetUser returns user by name
 	GetUser(name string, withSecrets bool) (types.User, error)
+	// GetUserWithContext returns user by name.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
 	// GetCurrentUser returns current user as seen by the server.
 	// Useful especially in the context of remote clusters which perform role and trait mapping.
@@ -527,8 +555,16 @@ type IdentityService interface {
 	// CreateUser inserts a new entry in a backend.
 	CreateUser(ctx context.Context, user types.User) error
 
+	// CreateUser inserts a new entry in a backend.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	CreateUserWithContext(ctx context.Context, user types.User) (types.User, error)
+
 	// UpdateUser updates an existing user in a backend.
 	UpdateUser(ctx context.Context, user types.User) error
+
+	// UpdateUser updates an existing user in a backend.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	UpdateUserWithContext(ctx context.Context, user types.User) (types.User, error)
 
 	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
 	// the result to storage. Return `false` from `fn` to avoid storage changes.
@@ -539,6 +575,10 @@ type IdentityService interface {
 	// UpsertUser user updates or inserts user entry
 	UpsertUser(user types.User) error
 
+	// UpsertUserWithContext user updates or inserts user entry.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	UpsertUserWithContext(ctx context.Context, user types.User) (types.User, error)
+
 	// CompareAndSwapUser updates an existing user in a backend, but fails if
 	// the user in the backend does not match the expected value.
 	CompareAndSwapUser(ctx context.Context, new, expected types.User) error
@@ -548,6 +588,10 @@ type IdentityService interface {
 
 	// GetUsers returns a list of usernames registered in the system
 	GetUsers(withSecrets bool) ([]types.User, error)
+
+	// GetUsersWithContext returns a list of usernames registered in the system
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error)
 
 	// ChangePassword changes user password
 	ChangePassword(ctx context.Context, req *proto.ChangePasswordRequest) error
@@ -573,6 +617,10 @@ type IdentityService interface {
 
 	// DeleteAllUsers deletes all users
 	DeleteAllUsers() error
+
+	// DeleteAllUsers deletes all users
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	DeleteAllUsersWithContext(ctx context.Context) error
 
 	// CreateResetPasswordToken creates a new user reset token
 	CreateResetPasswordToken(ctx context.Context, req CreateUserTokenRequest) (types.UserToken, error)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -1158,16 +1158,21 @@ func CreateAccessPluginUser(ctx context.Context, clt clt, username string) (type
 	return user, nil
 }
 
+// CreateUserWithContext creates user and role and assigns role to a user, used in tests
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func CreateUserWithContext(ctx context.Context, clt clt, username string, roles ...types.Role) (types.User, error) {
+	return CreateUser(clt, username, roles...)
+}
+
 // CreateUser creates user and role and assigns role to a user, used in tests
 func CreateUser(clt clt, username string, roles ...types.Role) (types.User, error) {
-	ctx := context.TODO()
 	user, err := types.NewUser(username)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	for _, role := range roles {
-		err = clt.UpsertRole(ctx, role)
+		err = clt.UpsertRole(context.TODO(), role)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -113,8 +113,10 @@ type AuthorizerAccessPoint interface {
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
-	// GetUser returns a services.User for this cluster.
-	GetUser(name string, withSecrets bool) (types.User, error)
+	GetUser(user string, withSecrets bool) (types.User, error)
+
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
 	// GetCertAuthority returns cert authority by id
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1956,7 +1956,7 @@ func (c *Cache) GetRemoteCluster(clusterName string) (types.RemoteCluster, error
 }
 
 // GetUser is a part of auth.Cache implementation.
-func (c *Cache) GetUser(name string, withSecrets bool) (user types.User, err error) {
+func (c *Cache) GetUser(name string, withSecrets bool) (types.User, error) {
 	_, span := c.Tracer.Start(context.TODO(), "cache/GetUser")
 	defer span.End()
 
@@ -1969,7 +1969,7 @@ func (c *Cache) GetUser(name string, withSecrets bool) (user types.User, err err
 	}
 	defer rg.Release()
 
-	user, err = rg.reader.GetUser(name, withSecrets)
+	user, err := rg.reader.GetUser(name, withSecrets)
 	if trace.IsNotFound(err) && rg.IsCacheRead() {
 		// release read lock early
 		rg.Release()
@@ -1982,8 +1982,14 @@ func (c *Cache) GetUser(name string, withSecrets bool) (user types.User, err err
 	return user, trace.Wrap(err)
 }
 
+// GetUserWithContext is a part of auth.Cache implementation.
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Cache) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	return c.GetUser(name, withSecrets)
+}
+
 // GetUsers is a part of auth.Cache implementation
-func (c *Cache) GetUsers(withSecrets bool) (users []types.User, err error) {
+func (c *Cache) GetUsers(withSecrets bool) ([]types.User, error) {
 	_, span := c.Tracer.Start(context.TODO(), "cache/GetUsers")
 	defer span.End()
 
@@ -1996,6 +2002,12 @@ func (c *Cache) GetUsers(withSecrets bool) (users []types.User, err error) {
 	}
 	defer rg.Release()
 	return rg.reader.GetUsers(withSecrets)
+}
+
+// GetUsersWithContext is a part of auth.Cache implementation
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (c *Cache) GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error) {
+	return c.GetUsers(withSecrets)
 }
 
 // GetTunnelConnections is a part of auth.Cache implementation

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -142,6 +142,8 @@ type AccessResourcesGetter interface {
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
 
 	GetUser(userName string, withSecrets bool) (types.User, error)
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, userName string, withSecrets bool) (types.User, error)
 	GetRole(ctx context.Context, name string) (types.Role, error)
 }
 

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -69,6 +69,11 @@ func (m *mockGetter) GetUser(name string, withSecrets bool) (types.User, error) 
 	return user, nil
 }
 
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (m *mockGetter) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	return m.GetUser(name, withSecrets)
+}
+
 func (m *mockGetter) GetRole(ctx context.Context, name string) (types.Role, error) {
 	role, ok := m.roles[name]
 	if !ok {

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -38,6 +38,9 @@ import (
 type UserGetter interface {
 	// GetUser returns a user by name
 	GetUser(user string, withSecrets bool) (types.User, error)
+	// GetUserWithContext returns a user by name.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUserWithContext(ctx context.Context, user string, withSecrets bool) (types.User, error)
 }
 
 // UsersService is responsible for basic user management
@@ -45,6 +48,9 @@ type UsersService interface {
 	UserGetter
 	// UpdateUser updates an existing user.
 	UpdateUser(ctx context.Context, user types.User) error
+	// UpdateUserWithContext updates an existing user.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	UpdateUserWithContext(ctx context.Context, user types.User) (types.User, error)
 	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
 	// the result to storage. Return `false` from `fn` to avoid storage changes.
 	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
@@ -52,6 +58,9 @@ type UsersService interface {
 	UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 	// UpsertUser updates parameters about user
 	UpsertUser(user types.User) error
+	// UpsertUser updates parameters about user.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	UpsertUserWithContext(ctx context.Context, user types.User) (types.User, error)
 	// CompareAndSwapUser updates an existing user, but fails if the user does
 	// not match an expected backend value.
 	CompareAndSwapUser(ctx context.Context, new, existing types.User) error
@@ -59,14 +68,23 @@ type UsersService interface {
 	DeleteUser(ctx context.Context, user string) error
 	// GetUsers returns a list of users registered with the local auth server
 	GetUsers(withSecrets bool) ([]types.User, error)
+	// GetUsersWithContext returns a list of users registered with the local auth server.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	GetUsersWithContext(ctx context.Context, withSecrets bool) ([]types.User, error)
 	// DeleteAllUsers deletes all users
 	DeleteAllUsers() error
+	// DeleteAllUsersWithContext deletes all users.
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	DeleteAllUsersWithContext(ctx context.Context) error
 }
 
 // Identity is responsible for managing user entries and external identities
 type Identity interface {
 	// CreateUser creates user, only if the user entry does not exist
 	CreateUser(user types.User) error
+	// CreateUserWithContext creates user, only if the user entry does not exist
+	// TODO(tross) remove this once oss and e are converted to using the new signature.
+	CreateUserWithContext(ctx context.Context, user types.User) (types.User, error)
 
 	// UsersService implements most methods
 	UsersService

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -330,9 +330,6 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 	existingItem := backend.Item{
 		Key:      backend.Key(webPrefix, usersPrefix, existing.GetName(), paramsPrefix),
 		Value:    existingValue,
-		Expires:  existing.Expiry(),
-		ID:       existing.GetResourceID(),
-		Revision: existing.GetRevision(),
 	}
 
 	_, err = s.CompareAndSwap(ctx, existingItem, newItem)

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -221,6 +221,7 @@ func (s *IdentityService) UpdateUserWithContext(ctx context.Context, user types.
 		}
 	}
 	user.SetRevision(lease.Revision)
+	user.SetResourceID(lease.ID)
 	return user, nil
 }
 

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -328,8 +328,8 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 		return trace.Wrap(err)
 	}
 	existingItem := backend.Item{
-		Key:      backend.Key(webPrefix, usersPrefix, existing.GetName(), paramsPrefix),
-		Value:    existingValue,
+		Key:   backend.Key(webPrefix, usersPrefix, existing.GetName(), paramsPrefix),
+		Value: existingValue,
 	}
 
 	_, err = s.CompareAndSwap(ctx, existingItem, newItem)

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -6047,6 +6047,11 @@ func (f *userGetter) GetUser(name string, _ bool) (types.User, error) {
 	return user, nil
 }
 
+// TODO(tross) remove this once oss and e are converted to using the new signature.
+func (f *userGetter) GetUserWithContext(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	return f.GetUser(name, withSecrets)
+}
+
 func TestRoleSetLockingMode(t *testing.T) {
 	t.Parallel()
 	t.Run("empty RoleSet gives default LockingMode", func(t *testing.T) {


### PR DESCRIPTION
Adds new variants of existing methods that are going to be updated to support propagating context and return users from create, update and upsert. This is an unfortunate step required because e utilizes the interface for various functionality. In order to prevent breaking builds, the temporary methods were added so that e can be converted to them first, then oss can be updated to the new version of the interface. Once that is done e will be converted and then the temp methods will be removed.


Implements step 1 of https://github.com/gravitational/teleport/issues/32949