### PR TITLE
Fix desktop listener PROXY mode setting

### DIFF
--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -253,7 +253,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 		mux, err := multiplexer.New(multiplexer.Config{
 			Context:             process.ExitContext(),
 			Listener:            listener,
-			PROXYProtocolMode:   cfg.Proxy.PROXYProtocolMode,
+			PROXYProtocolMode:   multiplexer.PROXYProtocolOff, // Desktop service never should process unsigned PROXY headers.
 			ID:                  teleport.Component(teleport.ComponentWindowsDesktop),
 			CertAuthorityGetter: accessPoint.GetCertAuthority,
 			LocalClusterName:    clusterName,


### PR DESCRIPTION
PROXYProtocol mode setting was erroneously propagated from Proxy configuration into multiplexer listener of the desktop service. But desktop service should never actually process unsigned PROXY headers, since it's always contacted through the Proxy.