### PR TITLE
Better error handling

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -193,17 +193,13 @@ func (c *Client) Run(ctx context.Context) error {
 
 	select {
 	case err := <-rustRDPReturnCh:
-		{
-			// Ensure the startInputStreaming goroutine returns.
-			close(stopCh)
-			return err
-		}
+		// Ensure the startInputStreaming goroutine returns.
+		close(stopCh)
+		return err
 	case err := <-inputStreamingReturnCh:
-		{
-			// Ensure the startRustRDP goroutine returns.
-			stopErr := c.stopRustRdp()
-			return trace.NewAggregate(err, stopErr)
-		}
+		// Ensure the startRustRDP goroutine returns.
+		stopErr := c.stopRustRDP()
+		return trace.NewAggregate(err, stopErr)
 	}
 }
 
@@ -288,7 +284,6 @@ func (c *Client) startRustRDP(ctx context.Context) error {
 		return trace.BadParameter("user key was nil")
 	}
 
-	// TODO(isaiah): better error handling here
 	if res := C.client_run(
 		C.uintptr_t(c.handle),
 		C.CGOConnectParams{
@@ -317,7 +312,7 @@ func (c *Client) startRustRDP(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) stopRustRdp() error {
+func (c *Client) stopRustRDP() error {
 	if errCode := C.client_stop(C.uintptr_t(c.handle)); errCode != C.ErrCodeSuccess {
 		return trace.Errorf("client_stop failed: %v", errCode)
 	}

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -210,12 +210,7 @@ impl Client {
     ) -> tokio::task::JoinHandle<ClientResult<()>> {
         global::TOKIO_RT.spawn(async move {
             loop {
-                let res = read_stream.read_pdu().await;
-                if let Err(e) = res {
-                    trace!("res e {:?}", e);
-                    return Err(e.into());
-                }
-                let (action, mut frame) = res?;
+                let (action, mut frame) = read_stream.read_pdu().await?;
                 match action {
                     // Fast-path PDU, send to the browser for processing / rendering.
                     ironrdp_pdu::Action::FastPath => {

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -243,19 +243,11 @@ impl Client {
                                     })?
                                     .process(&frame)
                             })
+                            .await??;
+                        // Send response frames to write loop for writing to RDP server.
+                        write_requester
+                            .send(ClientFunction::WriteRawPdu(res))
                             .await?;
-                        match res {
-                            Ok(res) => {
-                                // Send response frames to write loop for writing to RDP server.
-                                write_requester
-                                    .send(ClientFunction::WriteRawPdu(res))
-                                    .await?;
-                            }
-                            Err(e) => {
-                                trace!("x224 {}", e);
-                                return Err(e.into());
-                            }
-                        }
                     }
                 }
             }

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -28,6 +28,7 @@ extern crate log;
 extern crate num_derive;
 
 use std::convert::TryFrom;
+use std::ffi::CString;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::os::raw::c_char;
@@ -60,6 +61,19 @@ pub extern "C" fn init() {
     env_logger::try_init().unwrap_or_else(|e| println!("failed to initialize Rust logger: {e}"));
 }
 
+/// free_string is used to free memory for strings that were passed back to Go side.
+///
+/// # Safety
+///
+/// The caller must ensure that the provided pointer was created by Rust using CString::into_raw
+/// method and that length of the string was not modified in the meantime.
+#[no_mangle]
+pub unsafe extern "C" fn free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(CString::from_raw(ptr));
+    }
+}
+
 /// client_run establishes an RDP connection with the provided `params`
 /// and executes the RDP session, hanging until the session ends.
 ///
@@ -67,12 +81,17 @@ pub extern "C" fn init() {
 /// manually by calling [`client_stop`]. Failure to end a session can
 /// result in a memory leak.
 ///
+/// Caller must free memory allocated for message returned (CGOResult.message)
+/// using free_string function.
+///
+/// Message returned by this function can be null.
+///
 /// # Safety
 ///
 /// The caller must ensure that cgo_handle is a valid handle and that
 /// go_addr, go_username, cert_der, key_der point to valid buffers.
 #[no_mangle]
-pub unsafe extern "C" fn client_run(cgo_handle: CgoHandle, params: CGOConnectParams) -> CGOErrCode {
+pub unsafe extern "C" fn client_run(cgo_handle: CgoHandle, params: CGOConnectParams) -> CGOResult {
     trace!("client_run");
     // Convert from C to Rust types.
     let addr = from_c_string(params.go_addr);
@@ -94,8 +113,16 @@ pub unsafe extern "C" fn client_run(cgo_handle: CgoHandle, params: CGOConnectPar
             show_desktop_wallpaper: params.show_desktop_wallpaper,
         },
     ) {
-        Ok(_) => CGOErrCode::ErrCodeSuccess,
-        Err(_) => CGOErrCode::ErrCodeFailure,
+        Ok(_) => CGOResult {
+            err_code: CGOErrCode::ErrCodeSuccess,
+            message: ptr::null_mut(),
+        },
+        Err(e) => CGOResult {
+            err_code: CGOErrCode::ErrCodeFailure,
+            message: CString::new(format!("{}", e))
+                .map(|c| c.into_raw())
+                .unwrap_or(ptr::null_mut()),
+        },
     }
 }
 
@@ -537,6 +564,12 @@ pub enum CGOErrCode {
     ErrCodeSuccess = 0,
     ErrCodeFailure = 1,
     ErrCodeClientPtr = 2,
+}
+
+#[repr(C)]
+pub struct CGOResult {
+    pub err_code: CGOErrCode,
+    pub message: *mut c_char,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This change removes couple of `unwrap` that could cause panics on the Rust side and prevents panics from invalid cgo handle on the Go side.
It also sends error message from IronRDP to UI and cleans up a little final sequence of closing various goroutines in case of error or sessions end.