### PR TITLE
[v14] chore: Address crypto/elliptic package deprecations

### DIFF
--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -156,11 +156,12 @@ func (muk *Key) signRegister(appIDHash, clientDataHash []byte) (*signRegisterRes
 	}
 	pubKey := ecdhPubKey.Bytes()
 
-	var dataToSign []byte
+	cap := 1 + len(appIDHash) + len(clientDataHash) + len(muk.KeyHandle) + len(pubKey)
+	dataToSign := make([]byte, 0, cap)
 	dataToSign = append(dataToSign, 0)
-	dataToSign = append(dataToSign, appIDHash[:]...)
-	dataToSign = append(dataToSign, clientDataHash[:]...)
-	dataToSign = append(dataToSign, muk.KeyHandle[:]...)
+	dataToSign = append(dataToSign, appIDHash...)
+	dataToSign = append(dataToSign, clientDataHash...)
+	dataToSign = append(dataToSign, muk.KeyHandle...)
 	dataToSign = append(dataToSign, pubKey...)
 
 	dataHash := sha256.Sum256(dataToSign)
@@ -177,13 +178,14 @@ func (muk *Key) signRegister(appIDHash, clientDataHash []byte) (*signRegisterRes
 		flags = uint8(protocol.FlagUserPresent | protocol.FlagUserVerified | protocol.FlagAttestedCredentialData)
 	}
 
-	var regData []byte
+	cap = 1 + len(pubKey) + 1 + len(muk.KeyHandle) + len(muk.Cert) + len(sig)
+	regData := make([]byte, 0, cap)
 	regData = append(regData, flags)
-	regData = append(regData, pubKey[:]...)
+	regData = append(regData, pubKey...)
 	regData = append(regData, byte(len(muk.KeyHandle)))
-	regData = append(regData, muk.KeyHandle[:]...)
-	regData = append(regData, muk.Cert[:]...)
-	regData = append(regData, sig[:]...)
+	regData = append(regData, muk.KeyHandle...)
+	regData = append(regData, muk.Cert...)
+	regData = append(regData, sig...)
 
 	return &signRegisterResult{
 		RawResp:   regData,

--- a/lib/auth/webauthncli/u2f_register.go
+++ b/lib/auth/webauthncli/u2f_register.go
@@ -17,6 +17,7 @@ package webauthncli
 import (
 	"bytes"
 	"context"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
@@ -26,6 +27,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/flynn/u2f/u2ftoken"
 	"github.com/fxamacker/cbor/v2"
@@ -180,21 +182,29 @@ func parseU2FRegistrationResponse(resp []byte) (*u2fRegistrationResponse, error)
 	}
 	buf = buf[1:]
 
-	// public key
-	//nolint:staticcheck // SA1019 requires Go 1.21 in go.mod and non-insignificant changes. TODO: fix.
-	x, y := elliptic.Unmarshal(elliptic.P256(), buf[:pubKeyLen])
-	if x == nil {
-		return nil, trace.BadParameter("failed to parse public key")
+	// public key, "4||X||Y" form.
+	pubKeyBytes := buf[:pubKeyLen]
+	// Validate pubKey points.
+	if _, err := ecdh.P256().NewPublicKey(pubKeyBytes); err != nil {
+		return nil, trace.Wrap(err, "unmarshal public key")
 	}
-	buf = buf[pubKeyLen:]
+	// There's no API to pry away X and Y from ecdh.PublicKey, so we do it
+	// manually, but only after the key is validated.
+	const uncompressedForm = 4
+	if pubKeyBytes[0] != uncompressedForm {
+		return nil, trace.BadParameter("public key not in uncompressed form")
+	}
+	pubKeyBytes = pubKeyBytes[1:] // holds X||Y
+	l := len(pubKeyBytes) / 2     // holds the size of a coordinate (X or Y)
 	pubKey := &ecdsa.PublicKey{
 		Curve: elliptic.P256(),
-		X:     x,
-		Y:     y,
+		X:     new(big.Int).SetBytes(pubKeyBytes[:l]),
+		Y:     new(big.Int).SetBytes(pubKeyBytes[l:]),
 	}
+	buf = buf[pubKeyLen:]
 
 	// key handle
-	l := int(buf[0])
+	l = int(buf[0]) // holds the keyHandle length.
 	buf = buf[1:]
 	// Size checking resumed from now on.
 	if len(buf) < l {


### PR DESCRIPTION
Backport #32806 to branch/v14

The elliptic.Marshal and elliptic.Unmarshal functions are deprecated, as of Go 1.21, in favor of crypto/ecdh. This does the necessary changes to move away from functions.

Sadly, in the case of elliptic.Unmarshal, there's not an equivalent that hands us the X and Y points of the curve, but the format is known so we parse it manually.