### PR TITLE
Revert "Upgrade etcd version used in integration tests to v3.5.9"

### DIFF
--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -9,11 +9,6 @@ HEALTHCHECK CMD etcdctl --insecure-discovery --endpoint=https://etcd0:2379 --key
 
 EXPOSE 2379 2380
 
-USER 0
-RUN mkdir teleportstorage.etcd
-RUN chown 1001 teleportstorage.etcd
-USER 1001
-
 ENTRYPOINT /opt/bitnami/etcd/bin/etcd --name teleportstorage \
     --initial-cluster-state new \
     --cert-file /certs/server-cert.pem \
@@ -22,4 +17,4 @@ ENTRYPOINT /opt/bitnami/etcd/bin/etcd --name teleportstorage \
     --advertise-client-urls=https://127.0.0.1:2379 \
     --listen-client-urls=https://0.0.0.0:2379 \
     --client-cert-auth \
-    --log-level debug
+    --debug

--- a/Makefile
+++ b/Makefile
@@ -909,7 +909,7 @@ test-e2e:
 
 .PHONY: run-etcd
 run-etcd:
-	docker build -f .github/services/Dockerfile.etcd -t etcdbox --build-arg=ETCD_VERSION=3.5.9 .
+	docker build -f .github/services/Dockerfile.etcd -t etcdbox --build-arg=ETCD_VERSION=3.3.9 .
 	docker run -it --rm -p'2379:2379' etcdbox
 
 #


### PR DESCRIPTION
Reverts gravitational/teleport#32936

Looks like this is causing problems https://github.com/gravitational/teleport/actions/runs/6400018211/job/17373013350?pr=32938