### PR TITLE
Fix broken etcd-ci image

### DIFF
--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -21,5 +21,4 @@ ENTRYPOINT /opt/bitnami/etcd/bin/etcd --name teleportstorage \
     --trusted-ca-file /certs/ca-cert.pem \
     --advertise-client-urls=https://127.0.0.1:2379 \
     --listen-client-urls=https://0.0.0.0:2379 \
-    --client-cert-auth \
-    --log-level debug
+    --client-cert-auth


### PR DESCRIPTION
This PR disables etcd debug logging. I'm hoping this makes the Dockerfile compatible with both etcd 3.3.9 and 3.5.9. The former uses a --debug flag while the latter uses --log-level debug, and neither supports both.

I'm considering this as a temporary fix for the fact that the Makefile builds the etcd container image with ETCD_VERSION=3.5.9 while .github/workflows//build-ci-service-images.yaml still uses 3.3.9, and any makefile changes trigger the currently broken Go unit tests.

I've tested and confirmed locally that this Dockerfile now works with both versions.

Some logs from the currently failing runs:
- https://github.com/gravitational/teleport/actions/runs/6400018211/job/17373013350?pr=32938
- https://github.com/gravitational/teleport/actions/runs/6400335064/job/17373806699?pr=32942