### PR TITLE
`removeSecure()` should close the file before removing it on Windows

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -324,11 +324,9 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 			}
 		}
 		// The file should be closed before removing it on Windows.
-		err := f.Close()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return trace.ConvertSystemError(os.Remove(filePath))
+		closeErr := trace.ConvertSystemError(f.Close())
+		removeErr := trace.ConvertSystemError(os.Remove(filePath))
+		return trace.NewAggregate(closeErr, removeErr)
 	} else {
 		removeErr := os.Remove(filePath)
 		if f != nil {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -323,6 +323,11 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 				}
 			}
 		}
+		// The file should be closed before removing it on Windows.
+		err := f.Close()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		return trace.ConvertSystemError(os.Remove(filePath))
 	} else {
 		removeErr := os.Remove(filePath)


### PR DESCRIPTION
After merging https://github.com/gravitational/teleport/pull/32260 removing keys on Windows is broken.

It affects logging out:
```
PS C:\Users\grzegorz> tsh logout --debug
2023-10-04T11:25:22+02:00 DEBU [KEYSTORE]  Reading certificates from path "C:\\Users\\grzegorz\\.tsh\\keys\\mercury.cloud.gravitational.io\\grzegorz.zdunek@goteleport.com-ssh\\mercury.cloud.gravitational.io-cert.pub". client\keystore.go:355
2023-10-04T11:25:22+02:00 DEBU [KEYSTORE]  Teleport TLS certificate valid until "2023-10-04 09:26:16 +0000 UTC". client\client_store.go:106
2023-10-04T11:25:22+02:00 INFO [CLIENT]    ALPN connection upgrade required for "mercury.cloud.gravitational.io:443": false. client\api.go:723
2023-10-04T11:25:22+02:00 INFO [CLIENT]    no host login given. defaulting to grzegorz client\api.go:1060
2023-10-04T11:25:22+02:00 ERRO [CLIENT]    [KEY AGENT] Unable to connect to SSH agent on socket: "". error:[
ERROR REPORT:
Original Error: *fs.PathError open \\.\pipe\openssh-ssh-agent: The system cannot find the file specified.
Stack Trace:
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/utils/agentconn/agent_windows.go:59 github.com/gravitational/teleport/lib/utils/agentconn.Dial
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/api.go:4556 github.com/gravitational/teleport/lib/client.connectToSSHAgent
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/keyagent.go:135 github.com/gravitational/teleport/lib/client.NewLocalAgent
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/api.go:1115 github.com/gravitational/teleport/lib/client.NewClient
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:3381 github.com/gravitational/teleport/tool/tsh/common.makeClientForProxy
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:3366 github.com/gravitational/teleport/tool/tsh/common.makeClient
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:2099 github.com/gravitational/teleport/tool/tsh/common.onLogout
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:1327 github.com/gravitational/teleport/tool/tsh/common.Run
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:544 github.com/gravitational/teleport/tool/tsh/common.Main
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/main.go:24 main.main
        C:/Drone/Workspace/build-native-windows-amd64/28944/toolchains/go/src/runtime/proc.go:267 runtime.main
        C:/Drone/Workspace/build-native-windows-amd64/28944/toolchains/go/src/runtime/asm_amd64.s:1650 runtime.goexit
User Message: open \\.\pipe\openssh-ssh-agent: The system cannot find the file specified.] client\api.go:4558
2023-10-04T11:25:22+02:00 DEBU [KEYSTORE]  Reading certificates from path "C:\\Users\\grzegorz\\.tsh\\keys\\mercury.cloud.gravitational.io\\grzegorz.zdunek@goteleport.com-ssh\\mercury.cloud.gravitational.io-cert.pub". client\keystore.go:355
2023-10-04T11:25:22+02:00 DEBU [KEYSTORE]  Teleport TLS certificate valid until "2023-10-04 09:26:16 +0000 UTC". client\client_store.go:106
2023-10-04T11:25:22+02:00 INFO [KEYAGENT]  Loading SSH key for user "grzegorz.zdunek@goteleport.com" and cluster "mercury.cloud.gravitational.io". client\keyagent.go:196
2023-10-04T11:25:22+02:00 DEBU [TSH]       Removing Teleport related entries with server '[https://mercury.cloud.gravitational.io:443](https://mercury.cloud.gravitational.io/)' from kubeconfig. common\tsh.go:2104
2023-10-04T11:25:22+02:00 DEBU [TSH]       Removing Teleport related entries for cluster 'mercury.cloud.gravitational.io' from kubeconfig. common\tsh.go:2111

ERROR REPORT:
Original Error: *trace.AccessDeniedError failed to execute command C:\Users\grzegorz\.tsh\current-profile error:  The process cannot access the file because it is being used by another process.
Stack Trace:
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/utils/fs.go:326 github.com/gravitational/teleport/lib/utils.removeSecure
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/utils/fs.go:265 github.com/gravitational/teleport/lib/utils.RemoveAllSecure
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/keystore.go:299 github.com/gravitational/teleport/lib/client.(*FSKeyStore).DeleteKeys
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/keyagent.go:589 github.com/gravitational/teleport/lib/client.(*LocalKeyAgent).DeleteKeys
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/lib/client/api.go:3262 github.com/gravitational/teleport/lib/client.(*TeleportClient).LogoutAll
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:2131 github.com/gravitational/teleport/tool/tsh/common.onLogout
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:1327 github.com/gravitational/teleport/tool/tsh/common.Run
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/common/tsh.go:544 github.com/gravitational/teleport/tool/tsh/common.Main
        C:/Drone/Workspace/build-native-windows-amd64/28944/go/src/github.com/gravitational/teleport/tool/tsh/main.go:24 main.main
        C:/Drone/Workspace/build-native-windows-amd64/28944/toolchains/go/src/runtime/proc.go:267 runtime.main
        C:/Drone/Workspace/build-native-windows-amd64/28944/toolchains/go/src/runtime/asm_amd64.s:1650 runtime.goexit
User Message: failed to execute command C:\Users\grzegorz\.tsh\current-profile error:  The process cannot access the file because it is being used by another process.
```
and probably some other things.

In the original PR, [Edoardo pointed out](https://github.com/gravitational/teleport/pull/32260#issuecomment-1729818078) that filling the original file with random data may cause problems. I was sure that this was a source of the issue. However, it turned out that removing the renamed file still resulted in the access denied error.

Finally, I found [this comment](https://stackoverflow.com/questions/63519526/should-i-close-os-file-before-calling-os-removeall/63520559#63520559) that explains that we should close the file before removing it on Windows.

Closes https://github.com/gravitational/teleport/issues/32788

Changelog: Fixed issue causing keys to be incorrectly removed in tsh and Teleport Connect on Windows.