### PR TITLE
Remove unused permissions from App role

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -734,8 +734,6 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindClusterAuthPreference, services.RO()),
 						types.NewRule(types.KindAppServer, services.RW()),
 						types.NewRule(types.KindApp, services.RO()),
-						types.NewRule(types.KindWebSession, services.RO()),
-						types.NewRule(types.KindWebToken, services.RO()),
 						types.NewRule(types.KindJWT, services.RW()),
 						types.NewRule(types.KindLock, services.RO()),
 					},


### PR DESCRIPTION
I have reviewed the code and found these permissions to go unused.

Tested manually:
- debug app access
- regular app access
- JWT assertion injection
- Header injection
- AWS access (`tsh aws s3 ls`)

See also: 
- https://github.com/gravitational/teleport-private/issues/977