### PR TITLE
[v14] `removeSecure()` should close the file before removing it on Windows

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -324,11 +324,9 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 			}
 		}
 		// The file should be closed before removing it on Windows.
-		err := f.Close()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return trace.ConvertSystemError(os.Remove(filePath))
+		closeErr := trace.ConvertSystemError(f.Close())
+		removeErr := trace.ConvertSystemError(os.Remove(filePath))
+		return trace.NewAggregate(closeErr, removeErr)
 	} else {
 		removeErr := os.Remove(filePath)
 		if f != nil {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -323,6 +323,11 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 				}
 			}
 		}
+		// The file should be closed before removing it on Windows.
+		err := f.Close()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		return trace.ConvertSystemError(os.Remove(filePath))
 	} else {
 		removeErr := os.Remove(filePath)


### PR DESCRIPTION
Backport #32948 to branch/v14

Changelog: Fixed issue causing keys to be incorrectly removed in tsh and Teleport Connect on Windows.