### PR TITLE
[v13] `removeSecure()` should close the file before removing it on Windows

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -284,6 +284,11 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 				}
 			}
 		}
+		// The file should be closed before removing it on Windows.
+		err := f.Close()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		return trace.ConvertSystemError(os.Remove(filePath))
 	} else {
 		removeErr := os.Remove(filePath)

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -285,11 +285,9 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 			}
 		}
 		// The file should be closed before removing it on Windows.
-		err := f.Close()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return trace.ConvertSystemError(os.Remove(filePath))
+		closeErr := trace.ConvertSystemError(f.Close())
+		removeErr := trace.ConvertSystemError(os.Remove(filePath))
+		return trace.NewAggregate(closeErr, removeErr)
 	} else {
 		removeErr := os.Remove(filePath)
 		if f != nil {


### PR DESCRIPTION
Backport #32948 to branch/v13

Changelog: Fixed issue causing keys to be incorrectly removed in tsh and Teleport Connect on Windows.