### PR TITLE
[v12] `removeSecure()` should close the file before removing it on Windows

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -303,11 +303,9 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 			}
 		}
 		// The file should be closed before removing it on Windows.
-		err := f.Close()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return trace.ConvertSystemError(os.Remove(filePath))
+		closeErr := trace.ConvertSystemError(f.Close())
+		removeErr := trace.ConvertSystemError(os.Remove(filePath))
+		return trace.NewAggregate(closeErr, removeErr)
 	} else {
 		removeErr := os.Remove(filePath)
 		if f != nil {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -302,6 +302,11 @@ func removeSecure(filePath string, fi os.FileInfo) error {
 				}
 			}
 		}
+		// The file should be closed before removing it on Windows.
+		err := f.Close()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		return trace.ConvertSystemError(os.Remove(filePath))
 	} else {
 		removeErr := os.Remove(filePath)


### PR DESCRIPTION
Backport #32948 to branch/v12

Changelog: Fixed issue causing keys to be incorrectly removed in tsh and Teleport Connect on Windows.