### PR TITLE
docs: join_sessions overrides the deny rule for sessions a user is allowed …

### DIFF
--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -148,6 +148,13 @@ spec:
         modes: ['moderator', 'observer']
 ```
 
+Users who are assigned a role with a `join_sessions` allow policy are
+implicitly allowed to list the sessions that the policy gives them permission 
+to join. If there's a `deny` rule that prevents listing sessions, the 
+`join_sessions` policy overrides the `deny` rule for the sessions the 
+policy allows the user to join. Outside of this exception for joining 
+sessions, `deny` statements take precedent. 
+
 #### Joining sessions example
 
 Here is an example of Jeff with role `prod-access` connecting to


### PR DESCRIPTION
…to join
Content change based on https://github.com/gravitational/teleport.e/issues/1359:

> Role configuration gotchas
> (possibly a note on this page: https://goteleport.com/docs/access-controls/reference/ or https://goteleport.com/docs/access-controls/guides/moderated-sessions/)
> join_sessions has a special condition within our RBAC. Although in general deny statements take precedent, when a user is provided the allow for join_sessions the account will be implicitly able to also list session. This is a nuanced exception where the allow will override an explicit denial for listing sessions.
> 

When this list / deny issue is resolved, https://github.com/gravitational/teleport/pull/32420 must also be updated.
Replaces https://github.com/gravitational/teleport/pull/32357