### PR TITLE
[v13] Web: fix passing in fill color into wrong field

### DIFF
--- a/web/packages/design/src/SVGIcon/ArrowFatLinesUp.tsx
+++ b/web/packages/design/src/SVGIcon/ArrowFatLinesUp.tsx
@@ -52,7 +52,7 @@ export function ArrowFatLinesUpIcon({
   return (
     <SVGIcon
       size={size}
-      color={fill}
+      fill={fill}
       viewBox="0 0 24 24"
       className="icon icon-arrowfatlinesup"
       {...otherProps}


### PR DESCRIPTION
this icon is used in a v13 backport https://github.com/gravitational/teleport.e/pull/2356, and the `fill` was getting passed in as color