### PR TITLE
Add helper for generating request TTL options

### DIFF
--- a/web/packages/teleport/src/AccessRequests/utils.test.ts
+++ b/web/packages/teleport/src/AccessRequests/utils.test.ts
@@ -18,6 +18,7 @@ import { Duration } from 'date-fns';
 
 import {
   middleValues,
+  requestTtlMiddleValues,
   roundToNearestTenMinutes,
 } from 'teleport/AccessRequests/utils';
 
@@ -226,6 +227,133 @@ describe('generate middle times', () => {
       expect(result).toEqual(generateResponse(new Date(created), expected));
     }
   );
+});
+
+describe('generate request TTL middle times', () => {
+  const cases: {
+    name: string;
+    created: string;
+    sessionTTL: string;
+    expected: Array<{
+      days: number;
+      hours: number;
+      minutes: number;
+    }>;
+  }[] = [
+    {
+      name: 'max session TTL',
+      created: '2021-09-01T00:00:00.000Z',
+      sessionTTL: '2021-09-02T06:00:00.000Z',
+      expected: [
+        {
+          days: 0,
+          hours: 1,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 2,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 3,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 4,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 6,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 8,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 12,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 18,
+          minutes: 0,
+        },
+        {
+          days: 1,
+          hours: 0,
+          minutes: 0,
+        },
+        {
+          days: 1,
+          hours: 6,
+          minutes: 0,
+        },
+      ],
+    },
+    {
+      name: 'shortest session TTL',
+      created: '2021-09-01T00:00:00.000Z',
+      sessionTTL: '2021-09-01T00:30:00.000Z',
+      expected: [
+        {
+          days: 0,
+          hours: 0,
+          minutes: 30,
+        },
+      ],
+    },
+    {
+      name: 'session TTL in middle',
+      created: '2021-09-01T00:00:00.000Z',
+      sessionTTL: '2021-09-01T08:30:00.000Z',
+      expected: [
+        {
+          days: 0,
+          hours: 1,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 2,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 3,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 4,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 6,
+          minutes: 0,
+        },
+        {
+          days: 0,
+          hours: 8,
+          minutes: 0,
+        },
+      ],
+    },
+  ];
+  test.each(cases)('$name', ({ sessionTTL, created, expected }) => {
+    const result = requestTtlMiddleValues(
+      new Date(created),
+      new Date(sessionTTL)
+    );
+    expect(result).toEqual(generateResponse(new Date(created), expected));
+  });
 });
 
 describe('round to nearest 10 minutes', () => {

--- a/web/packages/teleport/src/AccessRequests/utils.ts
+++ b/web/packages/teleport/src/AccessRequests/utils.ts
@@ -105,3 +105,43 @@ export function middleValues(
     duration: getInterval(d),
   }));
 }
+
+// Generate a list of middle values between now and the session TTL.
+export function requestTtlMiddleValues(
+  created: Date,
+  sessionTTL: Date
+): TimeDuration[] {
+  const getInterval = (d: Date) =>
+    roundToNearestTenMinutes(
+      intervalToDuration({
+        start: created,
+        end: d,
+      })
+    );
+
+  if (isAfter(addHours(created, 1), sessionTTL)) {
+    return [
+      {
+        timestamp: sessionTTL.getTime(),
+        duration: getInterval(sessionTTL),
+      },
+    ];
+  }
+
+  const points: Date[] = [];
+  // Staggered hour options, up to the maximum possible session TTL.
+  const hourOptions = [1, 2, 3, 4, 6, 8, 12, 18, 24, 30];
+
+  for (const h of hourOptions) {
+    const t = addHours(created, h);
+    if (isAfter(t, sessionTTL)) {
+      break;
+    }
+    points.push(t);
+  }
+
+  return points.map(d => ({
+    timestamp: d.getTime(),
+    duration: getInterval(d),
+  }));
+}


### PR DESCRIPTION
This change moves the `requestTtlMiddleValues` function from gravitational/teleport.e#2306 to OSS.