### PR TITLE
fix backend range keys

### DIFF
--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -42,12 +42,16 @@ func NewAccessService(backend backend.Backend) *AccessService {
 
 // DeleteAllRoles deletes all roles
 func (s *AccessService) DeleteAllRoles() error {
-	return s.DeleteRange(context.TODO(), backend.Key(rolesPrefix), backend.RangeEnd(backend.Key(rolesPrefix)))
+	startKey := backend.Key(rolesPrefix)
+	endKey := backend.RangeEnd(startKey)
+	return s.DeleteRange(context.TODO(), startKey, endKey)
 }
 
 // GetRoles returns a list of roles registered with the local auth server
 func (s *AccessService) GetRoles(ctx context.Context) ([]types.Role, error) {
-	result, err := s.GetRange(ctx, backend.Key(rolesPrefix), backend.RangeEnd(backend.Key(rolesPrefix)), backend.NoLimit)
+	startKey := backend.ExactKey(rolesPrefix)
+	endKey := backend.RangeEnd(startKey)
+	result, err := s.GetRange(ctx, startKey, endKey, backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -166,7 +170,7 @@ func (s *AccessService) GetLock(ctx context.Context, name string) (types.Lock, e
 
 // GetLocks gets all/in-force locks that match at least one of the targets when specified.
 func (s *AccessService) GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error) {
-	startKey := backend.Key(locksPrefix)
+	startKey := backend.ExactKey(locksPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -232,7 +236,7 @@ func (s *AccessService) DeleteLock(ctx context.Context, name string) error {
 
 // DeleteLock deletes all/in-force locks.
 func (s *AccessService) DeleteAllLocks(ctx context.Context) error {
-	startKey := backend.Key(locksPrefix)
+	startKey := backend.ExactKey(locksPrefix)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -245,7 +249,7 @@ func (s *AccessService) ReplaceRemoteLocks(ctx context.Context, clusterName stri
 			TTL:      time.Minute,
 		},
 	}, func(ctx context.Context) error {
-		remoteLocksKey := backend.Key(locksPrefix, clusterName)
+		remoteLocksKey := backend.ExactKey(locksPrefix, clusterName)
 		origRemoteLocks, err := s.GetRange(ctx, remoteLocksKey, backend.RangeEnd(remoteLocksKey), backend.NoLimit)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -38,7 +38,7 @@ func NewAppService(backend backend.Backend) *AppService {
 
 // GetApps returns all application resources.
 func (s *AppService) GetApps(ctx context.Context) ([]types.Application, error) {
-	startKey := backend.Key(appPrefix)
+	startKey := backend.ExactKey(appPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -130,7 +130,7 @@ func (s *AppService) DeleteApp(ctx context.Context, name string) error {
 
 // DeleteAllApps removes all application resources.
 func (s *AppService) DeleteAllApps(ctx context.Context) error {
-	startKey := backend.Key(appPrefix)
+	startKey := backend.ExactKey(appPrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/assistant.go
+++ b/lib/services/local/assistant.go
@@ -129,7 +129,7 @@ func (s *AssistService) DeleteAssistantConversation(ctx context.Context, req *as
 
 // deleteAllMessages deletes all messages in a conversation.
 func (s *AssistService) deleteAllMessages(ctx context.Context, username, conversationID string) error {
-	startKey := backend.Key(assistantMessagePrefix, username, conversationID)
+	startKey := backend.ExactKey(assistantMessagePrefix, username, conversationID)
 	if err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
@@ -179,7 +179,7 @@ func (s *AssistService) GetAssistantConversations(ctx context.Context, req *assi
 	if req.Username == "" {
 		return nil, trace.BadParameter("missing username")
 	}
-	startKey := backend.Key(assistantConversationPrefix, req.Username)
+	startKey := backend.ExactKey(assistantConversationPrefix, req.Username)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -218,7 +218,7 @@ func (s *AssistService) GetAssistantMessages(ctx context.Context, req *assist.Ge
 		return nil, trace.BadParameter("missing conversation ID")
 	}
 
-	startKey := backend.Key(assistantMessagePrefix, req.Username, req.ConversationId)
+	startKey := backend.ExactKey(assistantMessagePrefix, req.Username, req.ConversationId)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -365,7 +365,7 @@ func (s *ClusterConfigurationService) DeleteSessionRecordingConfig(ctx context.C
 
 // GetInstallers retrieves all the install scripts.
 func (s *ClusterConfigurationService) GetInstallers(ctx context.Context) ([]types.Installer, error) {
-	startKey := backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, "")
+	startKey := backend.ExactKey(clusterConfigPrefix, scriptsPrefix, installerPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -439,7 +439,7 @@ func (s *ClusterConfigurationService) DeleteInstaller(ctx context.Context, name 
 
 // DeleteAllInstallers removes all installer resources.
 func (s *ClusterConfigurationService) DeleteAllInstallers(ctx context.Context) error {
-	startKey := backend.Key(clusterConfigPrefix, scriptsPrefix, installerPrefix, "")
+	startKey := backend.ExactKey(clusterConfigPrefix, scriptsPrefix, installerPrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -38,7 +38,7 @@ func NewDatabasesService(backend backend.Backend) *DatabaseService {
 
 // GetDatabases returns all database resources.
 func (s *DatabaseService) GetDatabases(ctx context.Context) ([]types.Database, error) {
-	startKey := backend.Key(databasesPrefix)
+	startKey := backend.ExactKey(databasesPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -130,7 +130,7 @@ func (s *DatabaseService) DeleteDatabase(ctx context.Context, name string) error
 
 // DeleteAllDatabases removes all database resources.
 func (s *DatabaseService) DeleteAllDatabases(ctx context.Context) error {
-	startKey := backend.Key(databasesPrefix)
+	startKey := backend.ExactKey(databasesPrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/databaseservice.go
+++ b/lib/services/local/databaseservice.go
@@ -83,7 +83,7 @@ func (s *DatabaseServicesService) DeleteDatabaseService(ctx context.Context, nam
 
 // DeleteAllDatabaseServices removes all DatabaseService resources.
 func (s *DatabaseServicesService) DeleteAllDatabaseServices(ctx context.Context) error {
-	startKey := backend.Key(databaseServicePrefix)
+	startKey := backend.ExactKey(databaseServicePrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -38,7 +38,7 @@ func NewWindowsDesktopService(backend backend.Backend) *WindowsDesktopService {
 
 // GetWindowsDesktops returns all Windows desktops matching filter.
 func (s *WindowsDesktopService) GetWindowsDesktops(ctx context.Context, filter types.WindowsDesktopFilter) ([]types.WindowsDesktop, error) {
-	startKey := backend.Key(windowsDesktopsPrefix, "")
+	startKey := backend.ExactKey(windowsDesktopsPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -150,7 +150,7 @@ func (s *WindowsDesktopService) DeleteWindowsDesktop(ctx context.Context, hostID
 
 // DeleteAllWindowsDesktops removes all windows desktop resources.
 func (s *WindowsDesktopService) DeleteAllWindowsDesktops(ctx context.Context) error {
-	startKey := backend.Key(windowsDesktopsPrefix, "")
+	startKey := backend.ExactKey(windowsDesktopsPrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)
@@ -166,7 +166,7 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 	}
 
 	rangeStart := backend.Key(windowsDesktopsPrefix, req.StartKey)
-	rangeEnd := backend.RangeEnd(backend.Key(windowsDesktopsPrefix, ""))
+	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopsPrefix))
 	filter := services.MatchResourceFilter{
 		ResourceKind:        types.KindWindowsDesktop,
 		Labels:              req.Labels,
@@ -231,7 +231,7 @@ func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, 
 	}
 
 	rangeStart := backend.Key(windowsDesktopServicesPrefix, req.StartKey)
-	rangeEnd := backend.RangeEnd(backend.Key(windowsDesktopServicesPrefix, ""))
+	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopServicesPrefix))
 	filter := services.MatchResourceFilter{
 		ResourceKind:        types.KindWindowsDesktopService,
 		Labels:              req.Labels,

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -232,7 +232,9 @@ func (s *DynamicAccessService) GetAccessRequests(ctx context.Context, filter typ
 		}
 		return []types.AccessRequest{req}, nil
 	}
-	result, err := s.GetRange(ctx, backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix)), backend.NoLimit)
+	startKey := backend.ExactKey(accessRequestsPrefix)
+	endKey := backend.RangeEnd(startKey)
+	result, err := s.GetRange(ctx, startKey, endKey, backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -268,7 +270,9 @@ func (s *DynamicAccessService) DeleteAccessRequest(ctx context.Context, name str
 }
 
 func (s *DynamicAccessService) DeleteAllAccessRequests(ctx context.Context) error {
-	return trace.Wrap(s.DeleteRange(ctx, backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix))))
+	startKey := backend.ExactKey(accessRequestsPrefix)
+	endKey := backend.RangeEnd(startKey)
+	return trace.Wrap(s.DeleteRange(ctx, startKey, endKey))
 }
 
 func (s *DynamicAccessService) UpsertAccessRequest(ctx context.Context, req types.AccessRequest) error {
@@ -360,7 +364,7 @@ func (s *DynamicAccessService) getAccessRequestPluginData(ctx context.Context, f
 		}
 		return []types.PluginData{data}, nil
 	}
-	prefix := backend.Key(pluginDataPrefix, types.KindAccessRequest)
+	prefix := backend.ExactKey(pluginDataPrefix, types.KindAccessRequest)
 	result, err := s.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -115,7 +115,7 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 
 // GetResources returns a list of all resources.
 func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
-	rangeStart := backend.Key(s.backendPrefix, "")
+	rangeStart := backend.ExactKey(s.backendPrefix)
 	rangeEnd := backend.RangeEnd(rangeStart)
 
 	// no filter provided get the range directly
@@ -139,7 +139,7 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 // ListResources returns a paginated list of resources.
 func (s *Service[T]) ListResources(ctx context.Context, pageSize int, pageToken string) ([]T, string, error) {
 	rangeStart := backend.Key(s.backendPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.Key(s.backendPrefix, ""))
+	rangeEnd := backend.RangeEnd(backend.ExactKey(s.backendPrefix))
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > int(s.pageLimit) {
@@ -242,7 +242,7 @@ func (s *Service[T]) DeleteResource(ctx context.Context, name string) error {
 
 // DeleteAllResources removes all resources.
 func (s *Service[T]) DeleteAllResources(ctx context.Context) error {
-	startKey := backend.Key(s.backendPrefix, "")
+	startKey := backend.ExactKey(s.backendPrefix)
 	return trace.Wrap(s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 

--- a/lib/services/local/inventory.go
+++ b/lib/services/local/inventory.go
@@ -45,7 +45,7 @@ func (s *PresenceService) GetInstances(ctx context.Context, req types.InstanceFi
 		return stream.Once(instance)
 	}
 
-	startKey := backend.Key(instancePrefix, "")
+	startKey := backend.ExactKey(instancePrefix)
 	endKey := backend.RangeEnd(startKey)
 	items := backend.StreamRange(ctx, s, startKey, endKey, pageSize)
 	return stream.FilterMap(items, func(item backend.Item) (types.Instance, bool) {

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -38,7 +38,7 @@ func NewKubernetesService(backend backend.Backend) *KubernetesService {
 
 // GetKubernetesClusters returns all kubernetes cluster resources.
 func (s *KubernetesService) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster, error) {
-	startKey := backend.Key(kubernetesPrefix)
+	startKey := backend.ExactKey(kubernetesPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -130,7 +130,7 @@ func (s *KubernetesService) DeleteKubernetesCluster(ctx context.Context, name st
 
 // DeleteAllKubernetesClusters removes all kubernetes cluster resources.
 func (s *KubernetesService) DeleteAllKubernetesClusters(ctx context.Context) error {
-	startKey := backend.Key(kubernetesPrefix)
+	startKey := backend.ExactKey(kubernetesPrefix)
 	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -73,7 +73,7 @@ func (s *PluginsService) DeletePlugin(ctx context.Context, name string) error {
 
 // DeleteAllPlugins implements service.Plugins
 func (s *PluginsService) DeleteAllPlugins(ctx context.Context) error {
-	startKey := backend.Key(pluginsPrefix, "")
+	startKey := backend.ExactKey(pluginsPrefix)
 	err := s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)
@@ -131,7 +131,7 @@ func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey st
 	maxLimit := limit + 1
 
 	startKeyBytes := backend.Key(pluginsPrefix, startKey)
-	endKey := backend.RangeEnd(backend.Key(pluginsPrefix, ""))
+	endKey := backend.RangeEnd(backend.ExactKey(pluginsPrefix))
 	result, err := s.backend.GetRange(ctx, startKeyBytes, endKey, maxLimit)
 	if err != nil {
 		return nil, "", trace.Wrap(err)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -61,12 +61,16 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 
 // DeleteAllNamespaces deletes all namespaces
 func (s *PresenceService) DeleteAllNamespaces() error {
-	return s.DeleteRange(context.TODO(), backend.Key(namespacesPrefix), backend.RangeEnd(backend.Key(namespacesPrefix)))
+	startKey := backend.ExactKey(namespacesPrefix)
+	endKey := backend.RangeEnd(startKey)
+	return s.DeleteRange(context.TODO(), startKey, endKey)
 }
 
 // GetNamespaces returns a list of namespaces
 func (s *PresenceService) GetNamespaces() ([]types.Namespace, error) {
-	result, err := s.GetRange(context.TODO(), backend.Key(namespacesPrefix), backend.RangeEnd(backend.Key(namespacesPrefix)), backend.NoLimit)
+	startKey := backend.ExactKey(namespacesPrefix)
+	endKey := backend.RangeEnd(startKey)
+	result, err := s.GetRange(context.TODO(), startKey, endKey, backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -228,7 +232,9 @@ func serverInfoKey(subkind, name string) []byte {
 }
 
 func (s *PresenceService) getServers(ctx context.Context, kind, prefix string) ([]types.Server, error) {
-	result, err := s.GetRange(ctx, backend.Key(prefix), backend.RangeEnd(backend.Key(prefix)), backend.NoLimit)
+	startKey := backend.ExactKey(prefix)
+	endKey := backend.RangeEnd(startKey)
+	result, err := s.GetRange(ctx, startKey, endKey, backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -266,7 +272,7 @@ func (s *PresenceService) upsertServer(ctx context.Context, prefix string, serve
 
 // DeleteAllNodes deletes all nodes in a namespace
 func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) error {
-	startKey := backend.Key(nodesPrefix, namespace)
+	startKey := backend.ExactKey(nodesPrefix, namespace)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -304,7 +310,7 @@ func (s *PresenceService) GetNodes(ctx context.Context, namespace string) ([]typ
 	}
 
 	// Get all items in the bucket.
-	startKey := backend.Key(nodesPrefix, namespace)
+	startKey := backend.ExactKey(nodesPrefix, namespace)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -376,7 +382,7 @@ func (s *PresenceService) UpsertAuthServer(ctx context.Context, server types.Ser
 
 // DeleteAllAuthServers deletes all auth servers
 func (s *PresenceService) DeleteAllAuthServers() error {
-	startKey := backend.Key(authServersPrefix)
+	startKey := backend.ExactKey(authServersPrefix)
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
@@ -399,7 +405,7 @@ func (s *PresenceService) GetProxies() ([]types.Server, error) {
 
 // DeleteAllProxies deletes all proxies
 func (s *PresenceService) DeleteAllProxies() error {
-	startKey := backend.Key(proxiesPrefix)
+	startKey := backend.ExactKey(proxiesPrefix)
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
@@ -411,7 +417,7 @@ func (s *PresenceService) DeleteProxy(ctx context.Context, name string) error {
 
 // DeleteAllReverseTunnels deletes all reverse tunnels
 func (s *PresenceService) DeleteAllReverseTunnels() error {
-	startKey := backend.Key(reverseTunnelsPrefix)
+	startKey := backend.ExactKey(reverseTunnelsPrefix)
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
@@ -445,7 +451,7 @@ func (s *PresenceService) GetReverseTunnel(name string, opts ...services.Marshal
 
 // GetReverseTunnels returns a list of registered servers
 func (s *PresenceService) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
-	startKey := backend.Key(reverseTunnelsPrefix)
+	startKey := backend.ExactKey(reverseTunnelsPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -508,7 +514,7 @@ func (s *PresenceService) GetTrustedCluster(ctx context.Context, name string) (t
 
 // GetTrustedClusters returns all TrustedClusters in the backend.
 func (s *PresenceService) GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster, error) {
-	startKey := backend.Key(trustedClustersPrefix)
+	startKey := backend.ExactKey(trustedClustersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -585,7 +591,7 @@ func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...servi
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name")
 	}
-	startKey := backend.Key(tunnelConnectionsPrefix, clusterName)
+	startKey := backend.ExactKey(tunnelConnectionsPrefix, clusterName)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -605,7 +611,7 @@ func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...servi
 
 // GetAllTunnelConnections returns all tunnel connections
 func (s *PresenceService) GetAllTunnelConnections(opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
-	startKey := backend.Key(tunnelConnectionsPrefix)
+	startKey := backend.ExactKey(tunnelConnectionsPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -650,7 +656,7 @@ func (s *PresenceService) DeleteTunnelConnections(clusterName string) error {
 
 // DeleteAllTunnelConnections deletes all tunnel connections
 func (s *PresenceService) DeleteAllTunnelConnections() error {
-	startKey := backend.Key(tunnelConnectionsPrefix)
+	startKey := backend.ExactKey(tunnelConnectionsPrefix)
 	err := s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 	return trace.Wrap(err)
 }
@@ -710,7 +716,7 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 
 // GetRemoteClusters returns a list of remote clusters
 func (s *PresenceService) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	startKey := backend.Key(remoteClustersPrefix)
+	startKey := backend.ExactKey(remoteClustersPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -764,7 +770,7 @@ func (s *PresenceService) DeleteRemoteCluster(ctx context.Context, clusterName s
 
 // DeleteAllRemoteClusters deletes all remote clusters
 func (s *PresenceService) DeleteAllRemoteClusters() error {
-	startKey := backend.Key(remoteClustersPrefix)
+	startKey := backend.ExactKey(remoteClustersPrefix)
 	err := s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 	return trace.Wrap(err)
 }
@@ -1041,9 +1047,9 @@ func (s *PresenceService) GetSemaphores(ctx context.Context, filter types.Semaph
 	} else {
 		var startKey []byte
 		if filter.SemaphoreKind != "" {
-			startKey = backend.Key(semaphoresPrefix, filter.SemaphoreKind)
+			startKey = backend.ExactKey(semaphoresPrefix, filter.SemaphoreKind)
 		} else {
-			startKey = backend.Key(semaphoresPrefix)
+			startKey = backend.ExactKey(semaphoresPrefix)
 		}
 		result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 		if err != nil {
@@ -1129,7 +1135,7 @@ func (s *PresenceService) DeleteKubernetesServer(ctx context.Context, hostID, na
 
 // DeleteAllKubernetesServers removes all registered kubernetes servers.
 func (s *PresenceService) DeleteAllKubernetesServers(ctx context.Context) error {
-	startKey := backend.Key(kubeServersPrefix)
+	startKey := backend.ExactKey(kubeServersPrefix)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -1140,7 +1146,7 @@ func (s *PresenceService) GetKubernetesServers(ctx context.Context) ([]types.Kub
 }
 
 func (s *PresenceService) getKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	startKey := backend.Key(kubeServersPrefix)
+	startKey := backend.ExactKey(kubeServersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1165,7 +1171,7 @@ func (s *PresenceService) GetDatabaseServers(ctx context.Context, namespace stri
 	if namespace == "" {
 		return nil, trace.BadParameter("missing database server namespace")
 	}
-	startKey := backend.Key(dbServersPrefix, namespace)
+	startKey := backend.ExactKey(dbServersPrefix, namespace)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1243,7 +1249,7 @@ func (s *PresenceService) DeleteAllDatabaseServers(ctx context.Context, namespac
 	if namespace == "" {
 		return trace.BadParameter("missing database servers namespace")
 	}
-	startKey := backend.Key(dbServersPrefix, namespace)
+	startKey := backend.ExactKey(dbServersPrefix, namespace)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -1260,7 +1266,7 @@ func (s *PresenceService) GetApplicationServers(ctx context.Context, namespace s
 }
 
 func (s *PresenceService) getApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
-	startKey := backend.Key(appServersPrefix, namespace)
+	startKey := backend.ExactKey(appServersPrefix, namespace)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1326,7 +1332,7 @@ func (s *PresenceService) DeleteApplicationServer(ctx context.Context, namespace
 
 // DeleteAllApplicationServers removes all registered application servers.
 func (s *PresenceService) DeleteAllApplicationServers(ctx context.Context, namespace string) error {
-	startKey := backend.Key(appServersPrefix, namespace)
+	startKey := backend.ExactKey(appServersPrefix, namespace)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -1368,7 +1374,7 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 
 // GetWindowsDesktopServices returns all registered Windows desktop services.
 func (s *PresenceService) GetWindowsDesktopServices(ctx context.Context) ([]types.WindowsDesktopService, error) {
-	startKey := backend.Key(windowsDesktopServicesPrefix, "")
+	startKey := backend.ExactKey(windowsDesktopServicesPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1447,7 +1453,7 @@ func (s *PresenceService) DeleteWindowsDesktopService(ctx context.Context, name 
 
 // DeleteAllWindowsDesktopServices removes all registered Windows desktop services.
 func (s *PresenceService) DeleteAllWindowsDesktopServices(ctx context.Context) error {
-	startKey := backend.Key(windowsDesktopServicesPrefix, "")
+	startKey := backend.ExactKey(windowsDesktopServicesPrefix)
 	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 }
 
@@ -1479,7 +1485,7 @@ func (s *PresenceService) GetHostUserInteractionTime(ctx context.Context, name s
 
 // GetUserGroups returns all registered user groups.
 func (s *PresenceService) GetUserGroups(ctx context.Context, opts ...services.MarshalOption) ([]types.UserGroup, error) {
-	startKey := backend.Key(userGroupPrefix)
+	startKey := backend.ExactKey(userGroupPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1547,7 +1553,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	}
 
 	rangeStart := backend.Key(append(keyPrefix, req.StartKey)...)
-	rangeEnd := backend.RangeEnd(backend.Key(keyPrefix...))
+	rangeEnd := backend.RangeEnd(backend.ExactKey(keyPrefix...))
 	filter := services.MatchResourceFilter{
 		ResourceKind:        req.ResourceType,
 		Labels:              req.Labels,

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -117,7 +117,7 @@ func (s *ProvisioningService) DeleteToken(ctx context.Context, token string) err
 
 // GetTokens returns all active (non-expired) provisioning tokens
 func (s *ProvisioningService) GetTokens(ctx context.Context) ([]types.ProvisionToken, error) {
-	startKey := backend.Key(tokensPrefix)
+	startKey := backend.ExactKey(tokensPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -78,7 +78,7 @@ func (s *IdentityService) ListAppSessions(ctx context.Context, pageSize int, pag
 
 // GetSnowflakeSessions gets all Snowflake web sessions.
 func (s *IdentityService) GetSnowflakeSessions(ctx context.Context) ([]types.WebSession, error) {
-	startKey := backend.Key(snowflakePrefix, sessionsPrefix)
+	startKey := backend.ExactKey(snowflakePrefix, sessionsPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -103,7 +103,7 @@ func (s *IdentityService) ListSAMLIdPSessions(ctx context.Context, pageSize int,
 // listSessions gets a paginated list of sessions.
 func (s *IdentityService) listSessions(ctx context.Context, pageSize int, pageToken, user string, keyPrefix ...string) ([]types.WebSession, string, error) {
 	rangeStart := backend.Key(append(keyPrefix, pageToken)...)
-	rangeEnd := backend.RangeEnd(backend.Key(keyPrefix...))
+	rangeEnd := backend.RangeEnd(backend.ExactKey(keyPrefix...))
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > maxPageSize {
@@ -277,7 +277,7 @@ func (s *IdentityService) DeleteUserSAMLIdPSessions(ctx context.Context, user st
 
 // DeleteAllAppSessions removes all application web sessions.
 func (s *IdentityService) DeleteAllAppSessions(ctx context.Context) error {
-	startKey := backend.Key(appsPrefix, sessionsPrefix)
+	startKey := backend.ExactKey(appsPrefix, sessionsPrefix)
 	if err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
@@ -286,7 +286,7 @@ func (s *IdentityService) DeleteAllAppSessions(ctx context.Context) error {
 
 // DeleteAllSnowflakeSessions removes all Snowflake web sessions.
 func (s *IdentityService) DeleteAllSnowflakeSessions(ctx context.Context) error {
-	startKey := backend.Key(snowflakePrefix, sessionsPrefix)
+	startKey := backend.ExactKey(snowflakePrefix, sessionsPrefix)
 	if err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
@@ -295,7 +295,7 @@ func (s *IdentityService) DeleteAllSnowflakeSessions(ctx context.Context) error 
 
 // DeleteAllSAMLIdPSessions removes all SAML IdP sessions.
 func (s *IdentityService) DeleteAllSAMLIdPSessions(ctx context.Context) error {
-	startKey := backend.Key(samlIdPPrefix, sessionsPrefix)
+	startKey := backend.ExactKey(samlIdPPrefix, sessionsPrefix)
 	if err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
@@ -326,8 +326,8 @@ func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (
 
 // List gets all regular web sessions.
 func (r *webSessions) List(ctx context.Context) (out []types.WebSession, err error) {
-	key := backend.Key(webPrefix, sessionsPrefix)
-	result, err := r.backend.GetRange(ctx, key, backend.RangeEnd(key), backend.NoLimit)
+	startKey := backend.ExactKey(webPrefix, sessionsPrefix)
+	result, err := r.backend.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -376,14 +376,14 @@ func (r *webSessions) Delete(ctx context.Context, req types.DeleteWebSessionRequ
 
 // DeleteAll removes all regular web sessions.
 func (r *webSessions) DeleteAll(ctx context.Context) error {
-	startKey := backend.Key(webPrefix, sessionsPrefix)
+	startKey := backend.ExactKey(webPrefix, sessionsPrefix)
 	return trace.Wrap(r.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
 // DELETE IN 7.x.
 // listLegacySessions lists web sessions under a legacy path /web/users/<user>/sessions/<id>
 func (r *webSessions) listLegacySessions(ctx context.Context) ([]types.WebSession, error) {
-	startKey := backend.Key(webPrefix, usersPrefix)
+	startKey := backend.ExactKey(webPrefix, usersPrefix)
 	result, err := r.backend.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -434,8 +434,8 @@ func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (type
 
 // List gets all web tokens.
 func (r *webTokens) List(ctx context.Context) (out []types.WebToken, err error) {
-	key := backend.Key(webPrefix, tokensPrefix)
-	result, err := r.backend.GetRange(ctx, key, backend.RangeEnd(key), backend.NoLimit)
+	startKey := backend.ExactKey(webPrefix, tokensPrefix)
+	result, err := r.backend.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -478,7 +478,7 @@ func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest)
 
 // DeleteAll removes all web tokens.
 func (r *webTokens) DeleteAll(ctx context.Context) error {
-	startKey := backend.Key(webPrefix, tokensPrefix)
+	startKey := backend.ExactKey(webPrefix, tokensPrefix)
 	if err := r.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/sessiontracker.go
+++ b/lib/services/local/sessiontracker.go
@@ -114,7 +114,7 @@ func (s *sessionTracker) GetSessionTracker(ctx context.Context, sessionID string
 }
 
 func (s *sessionTracker) getActiveSessionTrackers(ctx context.Context, filter *types.SessionTrackerFilter) ([]types.SessionTracker, error) {
-	prefix := backend.Key(sessionPrefix)
+	prefix := backend.ExactKey(sessionPrefix)
 	result, err := s.bk.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/status.go
+++ b/lib/services/local/status.go
@@ -79,7 +79,7 @@ func (s *StatusService) GetClusterAlerts(ctx context.Context, query types.GetClu
 }
 
 func (s *StatusService) getAllClusterAlerts(ctx context.Context) ([]types.ClusterAlert, error) {
-	startKey := backend.Key(clusterAlertPrefix, "")
+	startKey := backend.ExactKey(clusterAlertPrefix)
 	result, err := s.Backend.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -171,7 +171,7 @@ func (s *StatusService) CreateAlertAck(ctx context.Context, ack types.AlertAckno
 
 // GetAlertAcks gets active alert ackowledgements.
 func (s *StatusService) GetAlertAcks(ctx context.Context) ([]types.AlertAcknowledgement, error) {
-	startKey := backend.Key(alertAckPrefix, "")
+	startKey := backend.ExactKey(alertAckPrefix)
 	result, err := s.Backend.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -196,7 +196,7 @@ func (s *StatusService) ClearAlertAcks(ctx context.Context, req proto.ClearAlert
 		return trace.BadParameter("missing alert id for ack clear")
 	}
 	if req.AlertID == types.Wildcard {
-		startKey := backend.Key(alertAckPrefix, "")
+		startKey := backend.ExactKey(alertAckPrefix)
 		return trace.Wrap(s.Backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 	}
 

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -39,7 +39,12 @@ func NewCAService(b backend.Backend) *CA {
 
 // DeleteAllCertAuthorities deletes all certificate authorities of a certain type
 func (s *CA) DeleteAllCertAuthorities(caType types.CertAuthType) error {
-	startKey := backend.Key(authoritiesPrefix, string(caType))
+	// The backend stores CAs like /authorities/<caType>/<name>, so caType is a
+	// prefix.
+	// If we do not use ExactKey here, then if a caType is a prefix of another
+	// caType, it will delete both, e.g.: DeleteAllCertAuthorities("foo") would
+	// also delete all authorities of caType "foo_some_suffix".
+	startKey := backend.ExactKey(authoritiesPrefix, string(caType))
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
@@ -266,7 +271,12 @@ func (s *CA) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, 
 	}
 
 	// Get all items in the bucket.
-	startKey := backend.Key(authoritiesPrefix, string(caType))
+	// The backend stores CAs like /authorities/<caType>/<name>, so caType is a
+	// prefix.
+	// If we do not use ExactKey here, then if a caType is a prefix of another
+	// caType, it will get both, e.g.: GetCertAuthorities("foo") would
+	// also get authorities of caType "foo_some_suffix".
+	startKey := backend.ExactKey(authoritiesPrefix, string(caType))
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/usertoken.go
+++ b/lib/services/local/usertoken.go
@@ -29,7 +29,7 @@ import (
 
 // GetUserTokens returns all user tokens.
 func (s *IdentityService) GetUserTokens(ctx context.Context) ([]types.UserToken, error) {
-	startKey := backend.Key(userTokenPrefix)
+	startKey := backend.ExactKey(userTokenPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR changes the starting key used for `GetRange` or `DeleteRange` to use `backend.ExactKey` instead of `backend.Key` where it makes sense.

I noticed when I added a new CertAuthType called `db_client` that deleting the `db` CA in tests was also deleting my new CA.This was because `DeleteAllCertAuthorities` was using `backend.Key(authoritiesPrefix, string(caType))`. Since `caType` is a prefix of cert authority backend item keys, `DeleteRange` deleted `db_client` authorities as well (it has "db" as a prefix).

`backend.ExactKey` is intended for this exact scenario. I then looked for all uses of `GetRange` and `DeleteRange` and updated the start key appropriately. For functions that use pagination, I kept the use of `backend.Key`.

I also changed everything that did `backend.Key(somePrefix, "")` to be `backend.ExactKey`, which is equivalent.