### PR TITLE
Fix --debug flag in Connect & enable devtools in debug mode

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -297,18 +297,18 @@ and follow the *Submit a Bug* link.
 Be sure to attach logs, which can be found under `~/Library/Application Support/Teleport Connect/logs`.
 The version of the app can be found in the app menu under the About Teleport Connect menu item.
 
-To get more detailed logs, run Teleport Connect with the `--debug` flag:
+To get more detailed logs, run Teleport Connect with the `--connect-debug` flag:
 
-(!docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx flags="--debug"!)
+(!docs/pages/connect-your-client/includes/launch-connect-with-flags-macos.mdx flags="--connect-debug"!)
 </TabItem>
 <TabItem label="Linux">
 Be sure to attach logs, which can be found under `~/.config/Teleport Connect/logs`. The app version
 can be found by pressing `Alt` to access the app menu, then -> Help -> About Teleport Connect.
 
-To get more detailed logs, run Teleport Connect with the `--debug` flag:
+To get more detailed logs, run Teleport Connect with the `--connect-debug` flag:
 
 ```code
-$ teleport-connect --debug
+$ teleport-connect --connect-debug
 ````
 </TabItem>
 <TabItem label="Windows">
@@ -317,10 +317,10 @@ You may need to adjust File Explorer to [view hidden files and folders](https://
 The app version can be found by pressing `Alt` to access the app menu -> Help -> About Teleport Connect.
 
 
-To get more detailed logs, open Teleport Connect from the Command Prompt with the `--debug` flag:
+To get more detailed logs, open Teleport Connect from the Command Prompt with the `--connect-debug` flag:
 
 ```code
-$ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --debug
+$ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --connect-debug
 ````
 </TabItem>
 </Tabs>

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
@@ -71,7 +71,7 @@ export class AgentRunner {
       'start',
       `--config=${configFile}`,
       this.settings.isLocalBuild && '--skip-version-check',
-      this.settings.tshd.insecure && '--insecure',
+      this.settings.insecure && '--insecure',
     ].filter(Boolean);
 
     this.logger.info(

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -130,6 +130,8 @@ export const makeRuntimeSettings = (
 ): RuntimeSettings => ({
   platform: 'darwin' as const,
   dev: true,
+  debug: true,
+  insecure: true,
   userDataDir: '',
   sessionDataDir: '',
   tempDataDir: '',
@@ -140,7 +142,6 @@ export const makeRuntimeSettings = (
   logsDir: '',
   defaultShell: '',
   tshd: {
-    insecure: true,
     requestedNetworkAddress: '',
     binaryPath: '',
     homeDir: '',

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -420,8 +420,8 @@ export default class MainProcess {
       },
     ];
 
-    // Enable actions like reload or toggle dev tools only in dev mode.
-    const viewMenuTemplate: MenuItemConstructorOptions = this.settings.dev
+    // Enable actions like reload or toggle dev tools only in debug mode.
+    const viewMenuTemplate: MenuItemConstructorOptions = this.settings.debug
       ? { role: 'viewMenu' }
       : {
           label: 'View',

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -43,12 +43,19 @@ const TSH_BIN_DEFAULT_PATH_FOR_DEV = path.resolve(
   'teleport', 'build', 'tsh',
 );
 
-const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
-
-// Allows running tsh in insecure mode (development)
-const isInsecure = argv.includes('--insecure');
+// Refer to the docs of RuntimeSettings type for an explanation behind dev, debug and insecure.
+const dev = env.NODE_ENV === 'development';
 // --debug is reserved by Node, so we have to use another flag.
-const isDebug = argv.includes('--connect-debug') || dev;
+const debug = argv.includes('--connect-debug') || dev;
+const insecure =
+  argv.includes('--insecure') ||
+  // --insecure is already in our docs, but let's add --connect-insecure too in case Node or
+  // Electron reserves it one day.
+  argv.includes('--connect-insecure') ||
+  // The flag is needed because it's not easy to pass a flag to the app in dev mode. `yarn
+  // start-term` causes a bunch of package scripts to be executed and each would have to pass the
+  // flag one level down.
+  (dev && !!env.CONNECT_INSECURE);
 
 export function getRuntimeSettings(): RuntimeSettings {
   const userDataDir = app.getPath('userData');
@@ -71,7 +78,6 @@ export function getRuntimeSettings(): RuntimeSettings {
   const agentsDir = getAgentsDir(userDataDir);
 
   const tshd = {
-    insecure: isInsecure,
     binaryPath: tshBinPath,
     homeDir: getTshHomeDir(),
     requestedNetworkAddress: tshAddress,
@@ -95,7 +101,7 @@ export function getRuntimeSettings(): RuntimeSettings {
   };
 
   // To start the app in dev mode, we run `electron path_to_main.js`. It means
-  //  that the app is run without package.json context, so it can not read the version
+  // that the app is run without package.json context, so it can not read the version
   // from it.
   // The way we run Electron can be changed (`electron .`), but it has one major
   // drawback - dev app and bundled app will use the same app data directory.
@@ -103,15 +109,17 @@ export function getRuntimeSettings(): RuntimeSettings {
   // A workaround is to read the version from `process.env.npm_package_version`.
   const appVersion = dev ? process.env.npm_package_version : app.getVersion();
 
-  if (isInsecure) {
+  if (insecure) {
     tshd.flags.unshift('--insecure');
   }
-  if (dev || isDebug) {
+  if (debug) {
     tshd.flags.unshift('--debug');
   }
 
   return {
     dev,
+    debug,
+    insecure,
     tshd,
     sharedProcess,
     tshdEvents,

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -47,7 +47,8 @@ const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
 
 // Allows running tsh in insecure mode (development)
 const isInsecure = argv.includes('--insecure');
-const isDebug = argv.includes('--debug');
+// --debug is reserved by Node, so we have to use another flag.
+const isDebug = argv.includes('--connect-debug') || dev;
 
 export function getRuntimeSettings(): RuntimeSettings {
   const userDataDir = app.getPath('userData');

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -23,7 +23,29 @@ import { FileStorage } from 'teleterm/services/fileStorage';
 import { ConfigService } from '../services/config';
 
 export type RuntimeSettings = {
+  /**
+   * dev controls whether the app runs in development mode. This mostly controls what kind of URL
+   * the Electron app opens after launching and affects the expectations of the app wrt the
+   * environment its being executed in.
+   */
   dev: boolean;
+  /**
+   * debug controls the level of logs emitted by tshd and gates access to devtools. In a packaged
+   * app it's false by default, but it can be enabled by executing the packaged app with the
+   * --connect-debug flag.
+   *
+   * dev implies debug.
+   */
+  debug: boolean;
+  /**
+   * insecure controls whether tsh invocations and Connect My Computer agents are run in insecure
+   * mode. This typically skips the cert checks when talking to the proxy.
+   *
+   * False by default in both packaged apps and in development mode. It can be turned on by:
+   * - Starting a packaged version of the app with the --insecure flag.
+   * - Starting the app in dev mode with the CONNECT_INSECURE env var.
+   */
+  insecure: boolean;
   userDataDir: string;
   sessionDataDir: string;
   tempDataDir: string;
@@ -39,7 +61,6 @@ export type RuntimeSettings = {
   platform: Platform;
   agentBinaryPath: string;
   tshd: {
-    insecure: boolean;
     requestedNetworkAddress: string;
     binaryPath: string;
     homeDir: string;

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -70,7 +70,7 @@ export class WindowsManager {
       autoHideMenuBar: true,
       title: 'Teleport Connect',
       webPreferences: {
-        devTools: this.settings.dev,
+        devTools: this.settings.debug,
         webgl: false,
         enableWebSQL: false,
         safeDialogs: true,

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -109,7 +109,7 @@ export function getPtyProcessOptions(
         escapedBinaryPath,
         `--proxy=${cmd.rootClusterId}`,
         `kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`,
-        settings.tshd.insecure && '--insecure',
+        settings.insecure && '--insecure',
       ]
         .filter(Boolean)
         .join(' ');


### PR DESCRIPTION
This fixes two small issues introduced in #32629:
* The only reason behind the docs changes is the `--debug` flag. That PR added `--debug`, but I didn't test it properly and I just assumed that we can pass it like `--insecure`. It turns out [`--debug` is reserved by Node.js](https://github.com/microsoft/vscode/issues/159011#issuecomment-1225292255) and has been deprecated, so the app just won't start with this flag. I changed it to `--connect-debug`.
* That PR turns off insecure mode in dev mode by default, requiring you to pass `--insecure`. I forgot though that passing a flag in dev mode is not straightforward due to the Matryoshka doll of processes that are started with `yarn start-term`. Instead, in dev mode one can now use the `CONNECT_INSECURE` env var.

This PR also enables devtools when `--connect-debug` is passed. gravitational/webapps#988 disabled devtools in non-dev mode to address an audit item from Doyensec – the devtools were enabled by default in the packaged app and this wasn't considered a good practice.

In theory, one could re-enable devtools by running a packaged app in dev mode by setting the `DEBUG_PROD` env var. However, this probably never worked properly as dev mode controls not only access to devtools, but also what URL the Electron window opens on start. In dev mode, it opens the local Webpack server address which is simply not available in a packaged app.

Instead, access to devtools is now gated by enabling debug mode.