### PR TITLE
Fix `tsh kube credentials` when root cluster roles don't allow Kube access

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -796,8 +796,10 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil && rootClusterName == c.teleportCluster {
-		return trace.Wrap(err)
+	if rootClusterName == c.teleportCluster {
+		if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	// Cache the new cert on disk for reuse.
 	if err := tc.LocalAgent().AddKubeKey(k); err != nil {

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -796,10 +796,11 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if rootClusterName == c.teleportCluster {
-		if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil {
-			return trace.Wrap(err)
-		}
+	if err := checkIfCertsAreAllowedToAccessCluster(k,
+		rootClusterName,
+		c.teleportCluster,
+		c.kubeCluster); err != nil {
+		return trace.Wrap(err)
 	}
 	// Cache the new cert on disk for reuse.
 	if err := tc.LocalAgent().AddKubeKey(k); err != nil {
@@ -829,7 +830,14 @@ func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Pro
 // defined. If not, it returns an error.
 // This is a safety check in order to print a better message to the user even
 // before hitting Teleport Kubernetes Proxy.
-func checkIfCertsAreAllowedToAccessCluster(k *client.Key, kubeCluster string) error {
+func checkIfCertsAreAllowedToAccessCluster(k *client.Key, rootCluster, teleportCluster, kubeCluster string) error {
+	// This is a safety check in order to print a better message to the user even
+	// before hitting Teleport Kubernetes Proxy.
+	// We only enforce this check for root clusters, since we don't have knowledge
+	// of the RBAC role mappings for remote clusters.
+	if rootCluster != teleportCluster {
+		return nil
+	}
 	for k8sCluster, cert := range k.KubeTLSCerts {
 		if k8sCluster != kubeCluster {
 			continue


### PR DESCRIPTION
This PR fixes an edge case where an error message is printed to the users without proper knowledge of the role mappings between root and leaf clusters.

The user certificates include the `kubernetes_users` and `kubernetes_groups` allowed in the root cluster. Still, nothing prevents the access from being successful if the leaf cluster roles after mapping introduce the Kubernetes principals.

This PR prevents tsh from failing when generating certificates for leaf Kubernetes clusters.