### PR TITLE
[v12] Track user connections across clusters

### DIFF
--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -750,7 +750,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 	return servers
 }
 
-func waitForAppServer(t *testing.T, tunnel reversetunnel.Server, name string, hostUUID string, apps []service.App) {
+func waitForAppServer(t *testing.T, tunnel reversetunnelclient.Server, name string, hostUUID string, apps []service.App) {
 	// Make sure that the app server is ready to accept connections.
 	// The remote site cache needs to be filled with new registered application services.
 	waitForAppRegInRemoteSiteCache(t, tunnel, name, apps, hostUUID)
@@ -888,7 +888,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 	return servers
 }
 
-func waitForAppRegInRemoteSiteCache(t *testing.T, tunnel reversetunnel.Server, clusterName string, cfgApps []service.App, hostUUID string) {
+func waitForAppRegInRemoteSiteCache(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, cfgApps []service.App, hostUUID string) {
 	require.Eventually(t, func() bool {
 		site, err := tunnel.GetSite(clusterName)
 		require.NoError(t, err)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
@@ -256,7 +257,7 @@ type TeleInstance struct {
 	// Internal stuff...
 	Process              *service.TeleportProcess
 	Config               *service.Config
-	Tunnel               reversetunnel.Server
+	Tunnel               reversetunnelclient.Server
 	RemoteClusterWatcher *reversetunnel.RemoteClusterTunnelManager
 
 	// Nodes is a list of additional nodes
@@ -1029,7 +1030,7 @@ type ProxyConfig struct {
 }
 
 // StartProxy starts another Proxy Server and connects it to the cluster.
-func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, *service.TeleportProcess, error) {
+func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnelclient.Server, *service.TeleportProcess, error) {
 	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName+"-"+cfg.Name)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -1098,12 +1099,12 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, *servi
 	log.Debugf("Teleport proxy (in instance %v) started: %v/%v events received.",
 		i.Secrets.SiteName, len(expectedEvents), len(receivedEvents))
 
-	// Extract and set reversetunnel.Server and reversetunnel.AgentPool upon
+	// Extract and set reversetunnelclient.Server and reversetunnel.AgentPool upon
 	// receipt of a ProxyReverseTunnelReady event
 	for _, re := range receivedEvents {
 		switch re.Name {
 		case service.ProxyReverseTunnelReady:
-			ts, ok := re.Payload.(reversetunnel.Server)
+			ts, ok := re.Payload.(reversetunnelclient.Server)
 			if ok {
 				return ts, process, nil
 			}
@@ -1199,12 +1200,12 @@ func (i *TeleInstance) Start() error {
 		return trace.Wrap(err)
 	}
 
-	// Extract and set reversetunnel.Server and reversetunnel.AgentPool upon
+	// Extract and set reversetunnelclient.Server and reversetunnel.AgentPool upon
 	// receipt of a ProxyReverseTunnelReady and ProxyAgentPoolReady respectively.
 	for _, re := range receivedEvents {
 		switch re.Name {
 		case service.ProxyReverseTunnelReady:
-			ts, ok := re.Payload.(reversetunnel.Server)
+			ts, ok := re.Payload.(reversetunnelclient.Server)
 			if ok {
 				i.Tunnel = ts
 			}

--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
 // WaitForTunnelConnections waits for remote tunnels connections
@@ -76,7 +76,7 @@ func TryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 	require.FailNow(t, "Timeout creating trusted cluster")
 }
 
-func WaitForClusters(tun reversetunnel.Server, expected int) func() bool {
+func WaitForClusters(tun reversetunnelclient.Server, expected int) func() bool {
 	return func() bool {
 		clusters, err := tun.GetSites()
 		if err != nil {
@@ -129,7 +129,7 @@ func WaitForNodeCount(ctx context.Context, t *TeleInstance, clusterName string, 
 }
 
 // WaitForActiveTunnelConnections waits for remote cluster to report a minimum number of active connections
-func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnel.Server, clusterName string, expectedCount int) {
+func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, expectedCount int) {
 	require.Eventually(t, func() bool {
 		cluster, err := tunnel.GetSite(clusterName)
 		if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -77,7 +77,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/pam"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
@@ -3520,7 +3520,7 @@ func testDiscoveryRecovers(t *testing.T, suite *integrationTestSuite) {
 	var reverseTunnelAddr string
 
 	// Helper function for adding a new proxy to "main".
-	addNewMainProxy := func(name string) (reversetunnel.Server, helpers.ProxyConfig) {
+	addNewMainProxy := func(name string) (reversetunnelclient.Server, helpers.ProxyConfig) {
 		t.Logf("adding main proxy %q...", name)
 		newConfig := helpers.ProxyConfig{
 			Name:              name,

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -587,7 +587,7 @@ func mustStartMockALBProxy(t *testing.T, proxyAddr string) *mockAWSALBProxy {
 }
 
 // waitForActivePeerProxyConnections waits for remote cluster to report a minimum number of active proxy peer connections
-func waitForActivePeerProxyConnections(t *testing.T, tunnel reversetunnel.Server, expectedCount int) { //nolint:unused // Only used by skipped test TestProxyTunnelStrategyProxyPeering
+func waitForActivePeerProxyConnections(t *testing.T, tunnel reversetunnelclient.Server, expectedCount int) { //nolint:unused // Only used by skipped test TestProxyTunnelStrategyProxyPeering
 	require.Eventually(t, func() bool {
 		return tunnel.GetProxyPeerClient().GetConnectionsCount() >= expectedCount
 	},

--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -31,7 +31,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -110,21 +110,21 @@ func connectViaProxyTunnel(ctx context.Context, cfg *Config) (auth.ClientI, erro
 	//
 	// TODO(nic): this logic should be implemented once and reused in IoT
 	// nodes.
-	resolver := reversetunnel.WebClientResolver(&webclient.Config{
+	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
 		Context:   ctx,
 		ProxyAddr: cfg.AuthServers[0].String(),
 		Insecure:  cfg.TLS.InsecureSkipVerify,
 		Timeout:   cfg.DialTimeout,
 	})
 
-	resolver, err := reversetunnel.CachingResolver(ctx, resolver, nil /* clock */)
+	resolver, err := reversetunnelclient.CachingResolver(ctx, resolver, nil /* clock */)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// reversetunnel.TunnelAuthDialer will take care of creating a net.Conn
+	// reversetunnelclient.TunnelAuthDialer will take care of creating a net.Conn
 	// within an SSH tunnel.
-	dialer, err := reversetunnel.NewTunnelAuthDialer(reversetunnel.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          cfg.SSH,
 		Log:                   cfg.Log,

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -53,7 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -148,7 +148,7 @@ func TestAuthenticate(t *testing.T) {
 	require.NoError(t, err)
 
 	tun := mockRevTunnel{
-		sites: map[string]reversetunnel.RemoteSite{
+		sites: map[string]reversetunnelclient.RemoteSite{
 			"remote": mockRemoteSite{name: "remote"},
 			"local":  mockRemoteSite{name: "local"},
 		},
@@ -185,7 +185,7 @@ func TestAuthenticate(t *testing.T) {
 		routeToCluster    string
 		kubernetesCluster string
 		haveKubeCreds     bool
-		tunnel            reversetunnel.Server
+		tunnel            reversetunnelclient.Server
 		kubeServers       []types.KubeServer
 		activeRequests    []string
 
@@ -1034,7 +1034,7 @@ func TestNewClusterSessionRemote(t *testing.T) {
 	// Succeed on remote cluster session
 	sess, err := f.newClusterSession(authCtx)
 	require.NoError(t, err)
-	require.Equal(t, []kubeClusterEndpoint{{addr: reversetunnel.LocalKubernetes}}, sess.kubeClusterEndpoints)
+	require.Equal(t, []kubeClusterEndpoint{{addr: reversetunnelclient.LocalKubernetes}}, sess.kubeClusterEndpoints)
 
 	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
@@ -1085,7 +1085,7 @@ func TestNewClusterSessionDirect(t *testing.T) {
 
 	// multiple kube services for kube cluster
 	publicKubeService, publicEndpoint := newKubeServer("public", "k8s.example.com", "kube-cluster")
-	tunnelKubeService, tunnelEndpoint := newKubeServer("tunnel", reversetunnel.LocalKubernetes, "kube-cluster")
+	tunnelKubeService, tunnelEndpoint := newKubeServer("tunnel", reversetunnelclient.LocalKubernetes, "kube-cluster")
 
 	f.cfg.CachingAuthClient = mockAccessPoint{
 		kubeServers: []types.KubeServer{publicKubeService, otherKubeService, tunnelKubeService, otherKubeService},
@@ -1300,11 +1300,11 @@ func (c *mockCSRClient) ProcessKubeCSR(csr auth.KubeCSR) (*auth.KubeCSRResponse,
 	}, nil
 }
 
-// mockRemoteSite is a reversetunnel.RemoteSite implementation with hardcoded
+// mockRemoteSite is a reversetunnelclient.RemoteSite implementation with hardcoded
 // name, because there's no easy way to construct a real
-// reversetunnel.RemoteSite.
+// reversetunnelclient.RemoteSite.
 type mockRemoteSite struct {
-	reversetunnel.RemoteSite
+	reversetunnelclient.RemoteSite
 	name string
 }
 
@@ -1349,12 +1349,12 @@ func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAut
 }
 
 type mockRevTunnel struct {
-	reversetunnel.Server
+	reversetunnelclient.Server
 
-	sites map[string]reversetunnel.RemoteSite
+	sites map[string]reversetunnelclient.RemoteSite
 }
 
-func (t mockRevTunnel) GetSite(name string) (reversetunnel.RemoteSite, error) {
+func (t mockRevTunnel) GetSite(name string) (reversetunnelclient.RemoteSite, error) {
 	s, ok := t.sites[name]
 	if !ok {
 		return nil, trace.NotFound("remote site %q not found", name)
@@ -1362,8 +1362,8 @@ func (t mockRevTunnel) GetSite(name string) (reversetunnel.RemoteSite, error) {
 	return s, nil
 }
 
-func (t mockRevTunnel) GetSites() ([]reversetunnel.RemoteSite, error) {
-	var sites []reversetunnel.RemoteSite
+func (t mockRevTunnel) GetSites() ([]reversetunnelclient.RemoteSite, error) {
+	var sites []reversetunnelclient.RemoteSite
 	for _, s := range t.sites {
 		sites = append(sites, s)
 	}

--- a/lib/proxy/clusterdial/dial.go
+++ b/lib/proxy/clusterdial/dial.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/proxy/peer"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
 // ClusterDialerFunc is a function that implements a peer.ClusterDialer.
@@ -32,14 +32,14 @@ func (f ClusterDialerFunc) Dial(clusterName string, request peer.DialParams) (ne
 }
 
 // NewClusterDialer implements proxy.ClusterDialer for a reverse tunnel server.
-func NewClusterDialer(server reversetunnel.Server) ClusterDialerFunc {
+func NewClusterDialer(server reversetunnelclient.Server) ClusterDialerFunc {
 	return func(clusterName string, request peer.DialParams) (net.Conn, error) {
 		site, err := server.GetSite(clusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		dialParams := reversetunnel.DialParams{
+		dialParams := reversetunnelclient.DialParams{
 			ServerID:      request.ServerID,
 			ConnType:      request.ConnType,
 			From:          request.From,

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/observability/tracing"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -293,27 +293,27 @@ func serverResolver(srv types.Server, err error) serverResolverFn {
 }
 
 type tunnel struct {
-	reversetunnel.Tunnel
+	reversetunnelclient.Tunnel
 
-	site reversetunnel.RemoteSite
+	site reversetunnelclient.RemoteSite
 	err  error
 }
 
-func (t tunnel) GetSite(cluster string) (reversetunnel.RemoteSite, error) {
+func (t tunnel) GetSite(cluster string) (reversetunnelclient.RemoteSite, error) {
 	return t.site, t.err
 }
 
 type testRemoteSite struct {
-	reversetunnel.RemoteSite
+	reversetunnelclient.RemoteSite
 	conn net.Conn
 	err  error
 }
 
-func (r testRemoteSite) Dial(reversetunnel.DialParams) (net.Conn, error) {
+func (r testRemoteSite) Dial(reversetunnelclient.DialParams) (net.Conn, error) {
 	return r.conn, r.err
 }
 
-func (r testRemoteSite) DialAuthServer(reversetunnel.DialParams) (net.Conn, error) {
+func (r testRemoteSite) DialAuthServer(reversetunnelclient.DialParams) (net.Conn, error) {
 	return r.conn, r.err
 }
 

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -668,21 +668,3 @@ const (
 	chanDiscoveryReq = "discovery"
 	reconnectRequest = "reconnect@goteleport.com"
 )
-
-const (
-	// LocalNode is a special non-resolvable address that indicates the request
-	// wants to connect to a dialed back node.
-	LocalNode = "@local-node"
-	// RemoteAuthServer is a special non-resolvable address that indicates client
-	// requests a connection to the remote auth server.
-	RemoteAuthServer = "@remote-auth-server"
-	// LocalKubernetes is a special non-resolvable address that indicates that clients
-	// requests a connection to the kubernetes endpoint of the local proxy.
-	// This has to be a valid domain name, so it lacks @
-	LocalKubernetes = "remote.kube.proxy." + constants.APIDomain
-	// LocalWindowsDesktop is a special non-resolvable address that indicates
-	// that clients requests a connection to the windows service endpoint of
-	// the local proxy.
-	// This has to be a valid domain name, so it lacks @
-	LocalWindowsDesktop = "remote.windows_desktop.proxy." + constants.APIDomain
-)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/proxy"
@@ -116,9 +117,9 @@ type AgentPoolConfig struct {
 	// either be proxy (trusted clusters) or node (dial back).
 	Component string
 	// ReverseTunnelServer holds all reverse tunnel connections.
-	ReverseTunnelServer Server
+	ReverseTunnelServer reversetunnelclient.Server
 	// Resolver retrieves the reverse tunnel address
-	Resolver Resolver
+	Resolver reversetunnelclient.Resolver
 	// Cluster is a cluster name of the proxy.
 	Cluster string
 	// FIPS indicates if Teleport was started in FIPS mode.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -563,7 +563,7 @@ func (p *AgentPool) getVersion(ctx context.Context) (string, error) {
 
 // transport creates a new transport instance.
 func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) *transport {
-	return &transport{
+	t := &transport{
 		closeContext:         ctx,
 		component:            p.Component,
 		localClusterName:     p.LocalCluster,
@@ -580,6 +580,17 @@ func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests
 		proxySigner:          p.PROXYSigner,
 		forwardClientAddress: true,
 	}
+
+	// If the AgentPool is being used for Proxy to Proxy communication between two clusters, then
+	// we check if the reverse tunnel server is capable of tracking user connections. This allows
+	// the leaf proxy to track sessions that are initiated via the root cluster. Without providing
+	// the user tracker the leaf cluster metrics will be incorrect and graceful shutdown will not
+	// wait for user sessions to be terminated prior to proceeding with the shutdown operation.
+	if p.IsRemoteCluster && p.ReverseTunnelServer != nil {
+		t.trackUserConnection = p.ReverseTunnelServer.TrackUserConnection
+	}
+
+	return t
 }
 
 // agentPoolRuntimeConfig contains configurations dynamically set and updated

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -1,177 +1,21 @@
-/*
-Copyright 2016 Gravitational, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package reversetunnel
 
-import (
-	"context"
-	"fmt"
-	"io"
-	"net"
-	"time"
+import "github.com/gravitational/teleport/lib/reversetunnelclient"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/proxy/peer"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/teleagent"
-)
-
-// DialParams is a list of parameters used to Dial to a node within a cluster.
-type DialParams struct {
-	// From is the source address.
-	From net.Addr
-
-	// To is the destination address.
-	To net.Addr
-
-	// GetUserAgent gets an SSH agent for use in connecting to the remote host. Used by the
-	// forwarding proxy.
-	GetUserAgent teleagent.Getter
-
-	// Address is used by the forwarding proxy to generate a host certificate for
-	// the target node. This is needed because while dialing occurs via IP
-	// address, tsh thinks it's connecting via DNS name and that's how it
-	// validates the host certificate.
-	Address string
-
-	// Principals are additional principals that need to be added to the host
-	// certificate. Used by the recording proxy to correctly generate a host
-	// certificate.
-	Principals []string
-
-	// ServerID the hostUUID.clusterName of a Teleport node. Used with nodes
-	// that are connected over a reverse tunnel.
-	ServerID string
-
-	// ProxyIDs is a list of proxy ids the node is connected to.
-	ProxyIDs []string
-
-	// ConnType is the type of connection requested, either node or application.
-	// Only used when connecting through a tunnel.
-	ConnType types.TunnelType
-
-	// FromPeerProxy indicates that the dial request is being tunneled from
-	// a peer proxy.
-	FromPeerProxy bool
-
-	// TeleportVersion shows version of the target node, if we know that it's teleport node.
-	TeleportVersion string
-
-	// OriginalClientDstAddr is used in PROXY headers to show where client originally contacted Teleport infrastructure
-	OriginalClientDstAddr net.Addr
-}
-
-func (params DialParams) String() string {
-	to := params.To.String()
-	if to == "" {
-		to = params.ServerID
-	}
-	return fmt.Sprintf("from: %q to: %q", params.From, to)
-}
-
-func stringOrEmpty(addr net.Addr) string {
-	if addr == nil {
-		return ""
-	}
-	return addr.String()
-}
-
-// RemoteSite represents remote teleport site that can be accessed via
-// teleport tunnel or directly by proxy
-//
-// There are two implementations of this interface: local and remote sites.
-type RemoteSite interface {
-	// DialAuthServer returns a net.Conn to the Auth Server of a site.
-	DialAuthServer(DialParams) (conn net.Conn, err error)
-	// Dial dials any address within the site network, in terminating
-	// mode it uses local instance of forwarding server to terminate
-	// and record the connection.
-	Dial(DialParams) (conn net.Conn, err error)
-	// DialTCP dials any address within the site network and
-	// ignores recording mode, used in components that need direct dialer.
-	DialTCP(DialParams) (conn net.Conn, err error)
-	// GetLastConnected returns last time the remote site was seen connected
-	GetLastConnected() time.Time
-	// GetName returns site name (identified by authority domain's name)
-	GetName() string
-	// GetStatus returns status of this site (either offline or connected)
-	GetStatus() string
-	// GetClient returns client connected to remote auth server
-	GetClient() (auth.ClientI, error)
-	// CachingAccessPoint returns access point that is lightweight
-	// but is resilient to auth server crashes
-	CachingAccessPoint() (auth.RemoteProxyAccessPoint, error)
-	// NodeWatcher returns the node watcher that maintains the node set for the site
-	NodeWatcher() (*services.NodeWatcher, error)
-	// GetTunnelsCount returns the amount of active inbound tunnels
-	// from the remote cluster
-	GetTunnelsCount() int
-	// IsClosed reports whether this RemoteSite has been closed and should no
-	// longer be used.
-	IsClosed() bool
-	// Closer allows the site to be closed
-	io.Closer
-}
-
-// Tunnel provides access to connected local or remote clusters
-// using unified interface.
-type Tunnel interface {
-	// GetSites returns a list of connected remote sites
-	GetSites() ([]RemoteSite, error)
-	// GetSite returns remote site this node belongs to
-	GetSite(domainName string) (RemoteSite, error)
-}
-
-// Server is a TCP/IP SSH server which listens on an SSH endpoint and remote/local
-// sites connect and register with it.
-type Server interface {
-	Tunnel
-	// Start starts server
-	Start() error
-	// Close closes server's operations immediately
-	Close() error
-	// DrainConnections closes listeners and begins draining connections without
-	// closing open connections.
-	DrainConnections(context.Context) error
-	// Shutdown performs graceful server shutdown closing open connections.
-	Shutdown(context.Context) error
-	// Wait waits for server to close all outstanding operations
-	Wait(ctx context.Context)
-	// GetProxyPeerClient returns the proxy peer client
-	GetProxyPeerClient() *peer.Client
-}
-
-const (
-	// NoApplicationTunnel is the error message returned when application
-	// reverse tunnel cannot be found.
-	//
-	// It usually happens when an app agent has shut down (or crashed) but
-	// hasn't expired from the backend yet.
-	NoApplicationTunnel = "could not find reverse tunnel, check that Application Service agent proxying this application is up and running"
-	// NoDatabaseTunnel is the error message returned when database reverse
-	// tunnel cannot be found.
-	//
-	// It usually happens when a database agent has shut down (or crashed) but
-	// hasn't expired from the backend yet.
-	NoDatabaseTunnel = "could not find reverse tunnel, check that Database Service agent proxying this database is up and running"
-	// NoOktaTunnel is the error message returned when an Okta
-	// reverse tunnel cannot be found.
-	//
-	// It usually happens when an Okta service has shut down (or crashed) but
-	// hasn't expired from the backend yet.
-	NoOktaTunnel = "could not find reverse tunnel, check that Okta Service agent proxying this application is up and running"
-)
+// RemoteSite is an alias used to prevent breaking e.
+// TODO(tross): remove once e has been updated to use reversetunnelclient
+type RemoteSite = reversetunnelclient.RemoteSite

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/forward"
 	"github.com/gravitational/teleport/lib/utils"
@@ -115,7 +116,7 @@ func newLocalSite(srv *server, domainName string, authServers []string, opts ...
 	if s.certificateCache == nil {
 		// instantiate a cache of host certificates for the forwarding server. the
 		// certificate cache is created in each site (instead of creating it in
-		// reversetunnel.server and passing it along) so that the host certificate
+		// reversetunnelclient.Server and passing it along) so that the host certificate
 		// is signed by the correct certificate authority.
 		certificateCache, err := newHostCertificateCache(srv.Config.KeyGen, srv.localAuthClient)
 		if err != nil {
@@ -218,7 +219,7 @@ func (s *localSite) GetLastConnected() time.Time {
 	return s.clock.Now()
 }
 
-func (s *localSite) DialAuthServer(params DialParams) (net.Conn, error) {
+func (s *localSite) DialAuthServer(params reversetunnelclient.DialParams) (net.Conn, error) {
 	if len(s.authServers) == 0 {
 		return nil, trace.ConnectionProblem(nil, "no auth servers available")
 	}
@@ -236,7 +237,7 @@ func (s *localSite) DialAuthServer(params DialParams) (net.Conn, error) {
 	return conn, nil
 }
 
-func (s *localSite) Dial(params DialParams) (net.Conn, error) {
+func (s *localSite) Dial(params reversetunnelclient.DialParams) (net.Conn, error) {
 	recConfig, err := s.accessPoint.GetSessionRecordingConfig(s.srv.Context)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -260,7 +261,7 @@ func shouldSendSignedPROXYHeader(signer multiplexer.PROXYHeaderSigner, version s
 		dstAddr == nil)
 }
 
-func (s *localSite) maybeSendSignedPROXYHeader(params DialParams, conn net.Conn, useTunnel, checkVersion bool) error {
+func (s *localSite) maybeSendSignedPROXYHeader(params reversetunnelclient.DialParams, conn net.Conn, useTunnel, checkVersion bool) error {
 	if !shouldSendSignedPROXYHeader(s.srv.proxySigner, params.TeleportVersion, useTunnel, checkVersion, params.From, params.OriginalClientDstAddr) {
 		return nil
 	}
@@ -278,7 +279,7 @@ func (s *localSite) maybeSendSignedPROXYHeader(params DialParams, conn net.Conn,
 }
 
 // TODO(awly): unit test this
-func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
+func (s *localSite) DialTCP(params reversetunnelclient.DialParams) (net.Conn, error) {
 	s.log.Debugf("Dialing %v.", params)
 
 	conn, useTunnel, err := s.getConn(params)
@@ -333,7 +334,7 @@ func (s *localSite) adviseReconnect(ctx context.Context) {
 	}
 }
 
-func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
+func (s *localSite) dialWithAgent(params reversetunnelclient.DialParams) (net.Conn, error) {
 	if params.GetUserAgent == nil {
 		return nil, trace.BadParameter("user agent getter missing")
 	}
@@ -421,7 +422,7 @@ func (s *localSite) dialTunnel(dreq *sshutils.DialReq) (net.Conn, error) {
 
 // tryProxyPeering determines whether the node should try to be reached over
 // a peer proxy.
-func (s *localSite) tryProxyPeering(params DialParams) bool {
+func (s *localSite) tryProxyPeering(params reversetunnelclient.DialParams) bool {
 	if s.peerClient == nil {
 		return false
 	}
@@ -436,7 +437,7 @@ func (s *localSite) tryProxyPeering(params DialParams) bool {
 }
 
 // skipDirectDial determines if a direct dial attempt should be made.
-func (s *localSite) skipDirectDial(params DialParams) (bool, error) {
+func (s *localSite) skipDirectDial(params reversetunnelclient.DialParams) (bool, error) {
 	// Connections to application and database servers should never occur
 	// over a direct dial.
 	switch params.ConnType {
@@ -455,14 +456,14 @@ func (s *localSite) skipDirectDial(params DialParams) (bool, error) {
 
 	// This node can only be reached over a tunnel, don't attempt to dial
 	// directly.
-	if params.To == nil || params.To.String() == "" || params.To.String() == LocalNode {
+	if params.To == nil || params.To.String() == "" || params.To.String() == reversetunnelclient.LocalNode {
 		return true, nil
 	}
 
 	return false, nil
 }
 
-func getTunnelErrorMessage(params DialParams, connStr string, err error) string {
+func getTunnelErrorMessage(params reversetunnelclient.DialParams, connStr string, err error) string {
 	errorMessageTemplate := `Teleport proxy failed to connect to %q agent %q over %s:
 
   %v
@@ -479,7 +480,14 @@ with the cluster.`
 	return fmt.Sprintf(errorMessageTemplate, params.ConnType, toAddr, connStr, err)
 }
 
-func (s *localSite) getConn(params DialParams) (conn net.Conn, useTunnel bool, err error) {
+func stringOrEmpty(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
+}
+
+func (s *localSite) getConn(params reversetunnelclient.DialParams) (conn net.Conn, useTunnel bool, err error) {
 	dreq := &sshutils.DialReq{
 		ServerID:        params.ServerID,
 		ConnType:        params.ConnType,

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -127,18 +128,18 @@ func (p *clusterPeers) GetLastConnected() time.Time {
 	return peer.GetLastConnected()
 }
 
-func (p *clusterPeers) DialAuthServer(DialParams) (net.Conn, error) {
+func (p *clusterPeers) DialAuthServer(reversetunnelclient.DialParams) (net.Conn, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial to auth server, this proxy has not been discovered yet, try again later")
 }
 
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (p *clusterPeers) Dial(params DialParams) (conn net.Conn, err error) {
+func (p *clusterPeers) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return p.DialTCP(params)
 }
 
-func (p *clusterPeers) DialTCP(params DialParams) (conn net.Conn, err error) {
+func (p *clusterPeers) DialTCP(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 
@@ -234,7 +235,7 @@ func (s *clusterPeer) GetLastConnected() time.Time {
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (s *clusterPeer) Dial(params DialParams) (conn net.Conn, err error) {
+func (s *clusterPeer) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy %v has not been discovered yet, try again later", s)
 }
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -71,7 +72,7 @@ type RemoteClusterTunnelManagerConfig struct {
 	LocalCluster string
 	// Local ReverseTunnelServer to reach other cluster members connecting to
 	// this proxy over a tunnel.
-	ReverseTunnelServer Server
+	ReverseTunnelServer reversetunnelclient.Server
 	// Clock is a mock-able clock.
 	Clock clockwork.Clock
 	// KubeDialAddr is an optional address of a local kubernetes proxy.
@@ -235,7 +236,7 @@ func realNewAgentPool(ctx context.Context, cfg RemoteClusterTunnelManagerConfig,
 
 		// Configs for remote cluster.
 		Cluster:         cluster,
-		Resolver:        StaticResolver(addr, apitypes.ProxyListenerMode_Separate),
+		Resolver:        reversetunnelclient.StaticResolver(addr, apitypes.ProxyListenerMode_Separate),
 		IsRemoteCluster: true,
 		PROXYSigner:     cfg.PROXYSigner,
 	})

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -32,7 +33,7 @@ import (
 func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 	t.Parallel()
 
-	resolverFn := func(addr string) Resolver {
+	resolverFn := func(addr string) reversetunnelclient.Resolver {
 		return func(context.Context) (*utils.NetAddr, types.ProxyListenerMode, error) {
 			return &utils.NetAddr{
 				Addr:        addr,

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/forward"
 	"github.com/gravitational/teleport/lib/utils"
@@ -66,7 +67,7 @@ type remoteSite struct {
 	certificateCache *certificateCache
 
 	// localClient provides access to the Auth Server API of the cluster
-	// within which reversetunnel.Server is running.
+	// within which reversetunnelclient.Server is running.
 	localClient auth.ClientI
 	// remoteClient provides access to the Auth Server API of the remote cluster that
 	// this site belongs to.
@@ -135,7 +136,7 @@ func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 }
 
 func (s *remoteSite) authServerContextDialer(ctx context.Context, network, address string) (net.Conn, error) {
-	conn, err := s.DialAuthServer(DialParams{})
+	conn, err := s.DialAuthServer(reversetunnelclient.DialParams{})
 	return conn, err
 }
 
@@ -786,7 +787,7 @@ func (s *remoteSite) watchLocks() error {
 	}
 }
 
-func (s *remoteSite) DialAuthServer(params DialParams) (net.Conn, error) {
+func (s *remoteSite) DialAuthServer(params reversetunnelclient.DialParams) (net.Conn, error) {
 	conn, err := s.connThroughTunnel(&sshutils.DialReq{
 		Address:       constants.RemoteAuthServer,
 		ClientSrcAddr: stringOrEmpty(params.From),
@@ -798,7 +799,7 @@ func (s *remoteSite) DialAuthServer(params DialParams) (net.Conn, error) {
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (s *remoteSite) Dial(params DialParams) (net.Conn, error) {
+func (s *remoteSite) Dial(params reversetunnelclient.DialParams) (net.Conn, error) {
 	recConfig, err := s.localAccessPoint.GetSessionRecordingConfig(s.ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -814,7 +815,7 @@ func (s *remoteSite) Dial(params DialParams) (net.Conn, error) {
 	return s.DialTCP(params)
 }
 
-func (s *remoteSite) DialTCP(params DialParams) (net.Conn, error) {
+func (s *remoteSite) DialTCP(params reversetunnelclient.DialParams) (net.Conn, error) {
 	s.logger.Debugf("Dialing from %v to %v.", params.From, params.To)
 
 	conn, err := s.connThroughTunnel(&sshutils.DialReq{
@@ -832,7 +833,7 @@ func (s *remoteSite) DialTCP(params DialParams) (net.Conn, error) {
 	return conn, nil
 }
 
-func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
+func (s *remoteSite) dialWithAgent(params reversetunnelclient.DialParams) (net.Conn, error) {
 	if params.GetUserAgent == nil {
 		return nil, trace.BadParameter("user agent getter missing")
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy/peer"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -281,7 +282,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 
 // NewServer creates and returns a reverse tunnel server which is fully
 // initialized but hasn't been started yet
-func NewServer(cfg Config) (Server, error) {
+func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -965,10 +966,10 @@ func (s *server) upsertRemoteCluster(conn net.Conn, sshConn *ssh.ServerConn) (*r
 	return site, remoteConn, nil
 }
 
-func (s *server) GetSites() ([]RemoteSite, error) {
+func (s *server) GetSites() ([]reversetunnelclient.RemoteSite, error) {
 	s.RLock()
 	defer s.RUnlock()
-	out := make([]RemoteSite, 0, len(s.remoteSites)+len(s.clusterPeers)+1)
+	out := make([]reversetunnelclient.RemoteSite, 0, len(s.remoteSites)+len(s.clusterPeers)+1)
 	out = append(out, s.localSite)
 
 	haveLocalConnection := make(map[string]bool)
@@ -1002,7 +1003,7 @@ func (s *server) getRemoteClusters() []*remoteSite {
 // with a cluster peer your best bet is to wait until the agent has discovered
 // all proxies behind a load balancer. Note, the cluster peer is a
 // services.TunnelConnection that was created by another proxy.
-func (s *server) GetSite(name string) (RemoteSite, error) {
+func (s *server) GetSite(name string) (reversetunnelclient.RemoteSite, error) {
 	s.RLock()
 	defer s.RUnlock()
 	if s.localSite.GetName() == name {
@@ -1029,7 +1030,7 @@ func (s *server) GetProxyPeerClient() *peer.Client {
 // alwaysClose forces onSiteTunnelClose to remove and close
 // the site by always returning false from HasValidConnections.
 type alwaysClose struct {
-	RemoteSite
+	reversetunnelclient.RemoteSite
 }
 
 func (a *alwaysClose) HasValidConnections() bool {
@@ -1122,7 +1123,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	}
 
 	// configure access to the full Auth Server API and the cached subset for
-	// the local cluster within which reversetunnel.Server is running.
+	// the local cluster within which reversetunnelclient.Server is running.
 	remoteSite.localClient = srv.localAuthClient
 	remoteSite.localAccessPoint = srv.localAccessPoint
 
@@ -1157,7 +1158,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	remoteSite.nodeWatcher = nodeWatcher
 	// instantiate a cache of host certificates for the forwarding server. the
 	// certificate cache is created in each site (instead of creating it in
-	// reversetunnel.server and passing it along) so that the host certificate
+	// reversetunnelclient.Server and passing it along) so that the host certificate
 	// is signed by the correct certificate authority.
 	certificateCache, err := newHostCertificateCache(srv.Config.KeyGen, srv.localAuthClient)
 	if err != nil {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1084,6 +1084,13 @@ func (s *server) rejectRequest(ch ssh.NewChannel, reason ssh.RejectionReason, ms
 	}
 }
 
+// TrackUserConnection tracks a user connection that should prevent
+// the server from being terminated if active. The returned function
+// should be called when the connection is terminated.
+func (s *server) TrackUserConnection() (release func()) {
+	return s.srv.TrackUserConnection()
+}
+
 // newRemoteSite helper creates and initializes 'remoteSite' instance
 func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite, error) {
 	connInfo, err := types.NewTunnelConnection(

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -400,6 +400,15 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 		}
 
 		p.log.Debugf("Returning direct dialed connection to %q.", addr)
+
+		// Requests to get a connection to the remote auth server do not provide a ConnType,
+		// and since an empty ConnType is converted to [types.NodeTunnel] in CheckAndSetDefaults,
+		// we need to check the address of the request to prevent auth connections from being
+		// counted as a proxied ssh session.
+		if r.ConnType == types.NodeTunnel && r.Address != reversetunnelclient.RemoteAuthServer {
+			return proxy.NewProxiedMetricConn(conn), false, nil
+		}
+
 		return conn, false, nil
 	}
 

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -93,6 +94,9 @@ type transport struct {
 	// preventing users connecting to the proxy tunnel listener spoofing their address; but we are still able to
 	// correctly propagate client address in reverse tunnel agents of nodes/services.
 	forwardClientAddress bool
+
+	// trackUserConnection is an optional mechanism used to count active user sessions.
+	trackUserConnection func() (release func())
 }
 
 // start will start the transporting data over the tunnel. This function will
@@ -246,6 +250,10 @@ func (p *transport) start() {
 		// tunnel from the SSH node by dreq.ServerID. We'll need to forward
 		// dreq.Address as well.
 		directAddress = dreq.Address
+
+		if p.trackUserConnection != nil {
+			defer p.trackUserConnection()()
+		}
 	default:
 		// Not a special address; could be empty.
 		directAddress = dreq.Address
@@ -396,6 +404,11 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 	}
 
 	p.log.Debugf("Returning connection dialed through tunnel with server ID %v.", r.ServerID)
+
+	if r.ConnType == types.NodeTunnel {
+		return proxy.NewProxiedMetricConn(conn), true, nil
+	}
+
 	return conn, true, nil
 }
 

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -18,7 +18,6 @@ package reversetunnel
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,88 +36,9 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/multiplexer"
-	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/proxy"
 )
-
-// NewTunnelAuthDialer creates a new instance of TunnelAuthDialer
-func NewTunnelAuthDialer(config TunnelAuthDialerConfig) (*TunnelAuthDialer, error) {
-	if err := config.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &TunnelAuthDialer{
-		TunnelAuthDialerConfig: config,
-	}, nil
-}
-
-// TunnelAuthDialerConfig specifies TunnelAuthDialer configuration.
-type TunnelAuthDialerConfig struct {
-	// Resolver retrieves the address of the proxy
-	Resolver Resolver
-	// ClientConfig is SSH tunnel client config
-	ClientConfig *ssh.ClientConfig
-	// Log is used for logging.
-	Log logrus.FieldLogger
-	// InsecureSkipTLSVerify is whether to skip certificate validation.
-	InsecureSkipTLSVerify bool
-}
-
-func (c *TunnelAuthDialerConfig) CheckAndSetDefaults() error {
-	if c.Resolver == nil {
-		return trace.BadParameter("missing tunnel address resolver")
-	}
-	return nil
-}
-
-// TunnelAuthDialer connects to the Auth Server through the reverse tunnel.
-type TunnelAuthDialer struct {
-	// TunnelAuthDialerConfig is the TunnelAuthDialer configuration.
-	TunnelAuthDialerConfig
-}
-
-// DialContext dials auth server via SSH tunnel
-func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
-	// Connect to the reverse tunnel server.
-	opts := []proxy.DialerOptionFunc{
-		proxy.WithInsecureSkipTLSVerify(t.InsecureSkipTLSVerify),
-	}
-
-	addr, mode, err := t.Resolver(ctx)
-	if err != nil {
-		t.Log.Errorf("Failed to resolve tunnel address: %v", err)
-		return nil, trace.Wrap(err)
-	}
-
-	if mode == types.ProxyListenerMode_Multiplex {
-		opts = append(opts, proxy.WithALPNDialer(&tls.Config{
-			NextProtos: []string{
-				string(alpncommon.ProtocolReverseTunnelV2),
-				string(alpncommon.ProtocolReverseTunnel),
-			},
-		}))
-	}
-
-	dialer := proxy.DialerFromEnvironment(addr.Addr, opts...)
-	sconn, err := dialer.Dial(ctx, addr.AddrNetwork, addr.Addr, t.ClientConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Build a net.Conn over the tunnel. Make this an exclusive connection:
-	// close the net.Conn as well as the channel upon close.
-	conn, _, err := sshutils.ConnectProxyTransport(
-		sconn.Conn,
-		&sshutils.DialReq{
-			Address: RemoteAuthServer,
-		},
-		true,
-	)
-	if err != nil {
-		return nil, trace.NewAggregate(err, sconn.Close())
-	}
-	return conn, nil
-}
 
 // parseDialReq parses the dial request. Is backward compatible with legacy
 // payload.
@@ -156,7 +76,7 @@ type transport struct {
 	sconn sshutils.Conn
 
 	// reverseTunnelServer holds all reverse tunnel connections.
-	reverseTunnelServer Server
+	reverseTunnelServer reversetunnelclient.Server
 
 	// server is either an SSH or application server. It can handle a connection
 	// (perform handshake and handle request).
@@ -237,7 +157,7 @@ func (p *transport) start() {
 	// Handle special non-resolvable addresses first.
 	switch dreq.Address {
 	// Connect to an Auth Server.
-	case RemoteAuthServer:
+	case reversetunnelclient.RemoteAuthServer:
 		if len(p.authServers) == 0 {
 			p.log.Errorf("connection rejected: no auth servers configured")
 			p.reply(req, false, []byte("no auth servers configured"))
@@ -247,7 +167,7 @@ func (p *transport) start() {
 
 		directAddress = utils.ChooseRandomString(p.authServers)
 	// Connect to the Kubernetes proxy.
-	case LocalKubernetes:
+	case reversetunnelclient.LocalKubernetes:
 		switch p.component {
 		case teleport.ComponentReverseTunnelServer:
 			p.reply(req, false, []byte("connection rejected: no remote kubernetes proxy"))
@@ -290,7 +210,7 @@ func (p *transport) start() {
 		}
 
 	// LocalNode requests are for the single server running in the agent pool.
-	case LocalNode, LocalWindowsDesktop:
+	case reversetunnelclient.LocalNode, reversetunnelclient.LocalWindowsDesktop:
 		// Transport is allocated with both teleport.ComponentReverseTunnelAgent
 		// and teleport.ComponentReverseTunnelServer. However, dialing to this address
 		// only makes sense when running within a teleport.ComponentReverseTunnelAgent.
@@ -352,7 +272,7 @@ func (p *transport) start() {
 		clientDst = dst
 	}
 	var signedHeader []byte
-	isKubeOrAuth := dreq.ConnType == types.KubeTunnel || dreq.Address == RemoteAuthServer
+	isKubeOrAuth := dreq.ConnType == types.KubeTunnel || dreq.Address == reversetunnelclient.RemoteAuthServer
 	if shouldSendSignedPROXYHeader(p.proxySigner, dreq.TeleportVersion, useTunnel, !isKubeOrAuth, clientSrc, clientDst) {
 		signedHeader, err = p.proxySigner.SignPROXYHeader(clientSrc, clientDst)
 		if err != nil {
@@ -457,11 +377,11 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 		// a direct dial, return right away.
 		switch r.ConnType {
 		case types.AppTunnel:
-			return nil, false, trace.ConnectionProblem(err, NoApplicationTunnel)
+			return nil, false, trace.ConnectionProblem(err, reversetunnelclient.NoApplicationTunnel)
 		case types.OktaTunnel:
-			return nil, false, trace.ConnectionProblem(err, NoOktaTunnel)
+			return nil, false, trace.ConnectionProblem(err, reversetunnelclient.NoOktaTunnel)
 		case types.DatabaseTunnel:
-			return nil, false, trace.ConnectionProblem(err, NoDatabaseTunnel)
+			return nil, false, trace.ConnectionProblem(err, reversetunnelclient.NoDatabaseTunnel)
 		}
 
 		errTun := err

--- a/lib/reversetunnelclient/agent.go
+++ b/lib/reversetunnelclient/agent.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reversetunnelclient
+
+import "github.com/gravitational/teleport/api/constants"
+
+const (
+	// LocalNode is a special non-resolvable address that indicates the request
+	// wants to connect to a dialed back node.
+	LocalNode = "@local-node"
+	// RemoteAuthServer is a special non-resolvable address that indicates client
+	// requests a connection to the remote auth server.
+	RemoteAuthServer = "@remote-auth-server"
+	// LocalKubernetes is a special non-resolvable address that indicates that clients
+	// requests a connection to the kubernetes endpoint of the local proxy.
+	// This has to be a valid domain name, so it lacks @
+	LocalKubernetes = "remote.kube.proxy." + constants.APIDomain
+	// LocalWindowsDesktop is a special non-resolvable address that indicates
+	// that clients requests a connection to the windows service endpoint of
+	// the local proxy.
+	// This has to be a valid domain name, so it lacks @
+	LocalWindowsDesktop = "remote.windows_desktop.proxy." + constants.APIDomain
+)

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -144,6 +144,10 @@ type Server interface {
 	Wait(ctx context.Context)
 	// GetProxyPeerClient returns the proxy peer client
 	GetProxyPeerClient() *peer.Client
+	// TrackUserConnection tracks a user connection that should prevent
+	// the server from being terminated if active. The returned function
+	// should be called when the connection is terminated.
+	TrackUserConnection() (release func())
 }
 
 const (

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -1,0 +1,168 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reversetunnelclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/proxy/peer"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/teleagent"
+)
+
+// DialParams is a list of parameters used to Dial to a node within a cluster.
+type DialParams struct {
+	// From is the source address.
+	From net.Addr
+
+	// To is the destination address.
+	To net.Addr
+
+	// GetUserAgent gets an SSH agent for use in connecting to the remote host. Used by the
+	// forwarding proxy.
+	GetUserAgent teleagent.Getter
+
+	// Address is used by the forwarding proxy to generate a host certificate for
+	// the target node. This is needed because while dialing occurs via IP
+	// address, tsh thinks it's connecting via DNS name and that's how it
+	// validates the host certificate.
+	Address string
+
+	// Principals are additional principals that need to be added to the host
+	// certificate. Used by the recording proxy to correctly generate a host
+	// certificate.
+	Principals []string
+
+	// ServerID the hostUUID.clusterName of a Teleport node. Used with nodes
+	// that are connected over a reverse tunnel.
+	ServerID string
+
+	// ProxyIDs is a list of proxy ids the node is connected to.
+	ProxyIDs []string
+
+	// ConnType is the type of connection requested, either node or application.
+	// Only used when connecting through a tunnel.
+	ConnType types.TunnelType
+
+	// FromPeerProxy indicates that the dial request is being tunneled from
+	// a peer proxy.
+	FromPeerProxy bool
+
+	// TeleportVersion shows version of the target node, if we know that it's teleport node.
+	TeleportVersion string
+
+	// OriginalClientDstAddr is used in PROXY headers to show where client originally contacted Teleport infrastructure
+	OriginalClientDstAddr net.Addr
+}
+
+func (params DialParams) String() string {
+	to := params.To.String()
+	if to == "" {
+		to = params.ServerID
+	}
+	return fmt.Sprintf("from: %q to: %q", params.From, to)
+}
+
+// RemoteSite represents remote teleport site that can be accessed via
+// teleport tunnel or directly by proxy
+//
+// There are two implementations of this interface: local and remote sites.
+type RemoteSite interface {
+	// DialAuthServer returns a net.Conn to the Auth Server of a site.
+	DialAuthServer(DialParams) (conn net.Conn, err error)
+	// Dial dials any address within the site network, in terminating
+	// mode it uses local instance of forwarding server to terminate
+	// and record the connection.
+	Dial(DialParams) (conn net.Conn, err error)
+	// DialTCP dials any address within the site network and
+	// ignores recording mode, used in components that need direct dialer.
+	DialTCP(DialParams) (conn net.Conn, err error)
+	// GetLastConnected returns last time the remote site was seen connected
+	GetLastConnected() time.Time
+	// GetName returns site name (identified by authority domain's name)
+	GetName() string
+	// GetStatus returns status of this site (either offline or connected)
+	GetStatus() string
+	// GetClient returns client connected to remote auth server
+	GetClient() (auth.ClientI, error)
+	// CachingAccessPoint returns access point that is lightweight
+	// but is resilient to auth server crashes
+	CachingAccessPoint() (auth.RemoteProxyAccessPoint, error)
+	// NodeWatcher returns the node watcher that maintains the node set for the site
+	NodeWatcher() (*services.NodeWatcher, error)
+	// GetTunnelsCount returns the amount of active inbound tunnels
+	// from the remote cluster
+	GetTunnelsCount() int
+	// IsClosed reports whether this RemoteSite has been closed and should no
+	// longer be used.
+	IsClosed() bool
+	// Closer allows the site to be closed
+	io.Closer
+}
+
+// Tunnel provides access to connected local or remote clusters
+// using unified interface.
+type Tunnel interface {
+	// GetSites returns a list of connected remote sites
+	GetSites() ([]RemoteSite, error)
+	// GetSite returns remote site this node belongs to
+	GetSite(domainName string) (RemoteSite, error)
+}
+
+// Server is a TCP/IP SSH server which listens on an SSH endpoint and remote/local
+// sites connect and register with it.
+type Server interface {
+	Tunnel
+	// Start starts server
+	Start() error
+	// Close closes server's operations immediately
+	Close() error
+	// DrainConnections closes listeners and begins draining connections without
+	// closing open connections.
+	DrainConnections(context.Context) error
+	// Shutdown performs graceful server shutdown closing open connections.
+	Shutdown(context.Context) error
+	// Wait waits for server to close all outstanding operations
+	Wait(ctx context.Context)
+	// GetProxyPeerClient returns the proxy peer client
+	GetProxyPeerClient() *peer.Client
+}
+
+const (
+	// NoApplicationTunnel is the error message returned when application
+	// reverse tunnel cannot be found.
+	//
+	// It usually happens when an app agent has shut down (or crashed) but
+	// hasn't expired from the backend yet.
+	NoApplicationTunnel = "could not find reverse tunnel, check that Application Service agent proxying this application is up and running"
+	// NoDatabaseTunnel is the error message returned when database reverse
+	// tunnel cannot be found.
+	//
+	// It usually happens when a database agent has shut down (or crashed) but
+	// hasn't expired from the backend yet.
+	NoDatabaseTunnel = "could not find reverse tunnel, check that Database Service agent proxying this database is up and running"
+	// NoOktaTunnel is the error message returned when an Okta
+	// reverse tunnel cannot be found.
+	//
+	// It usually happens when an Okta service has shut down (or crashed) but
+	// hasn't expired from the backend yet.
+	NoOktaTunnel = "could not find reverse tunnel, check that Okta Service agent proxying this application is up and running"
+)

--- a/lib/reversetunnelclient/api_with_roles.go
+++ b/lib/reversetunnelclient/api_with_roles.go
@@ -1,20 +1,18 @@
-/*
-Copyright 2020 Gravitational, Inc.
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package reversetunnel
+package reversetunnelclient
 
 import (
 	"github.com/gravitational/trace"
@@ -32,9 +30,10 @@ type ClusterGetter interface {
 }
 
 // NewTunnelWithRoles returns new authorizing tunnel
-func NewTunnelWithRoles(tunnel Tunnel, accessChecker services.AccessChecker, access ClusterGetter) *TunnelWithRoles {
+func NewTunnelWithRoles(tunnel Tunnel, localCluster string, accessChecker services.AccessChecker, access ClusterGetter) *TunnelWithRoles {
 	return &TunnelWithRoles{
 		tunnel:        tunnel,
+		localCluster:  localCluster,
 		accessChecker: accessChecker,
 		access:        access,
 	}
@@ -43,6 +42,8 @@ func NewTunnelWithRoles(tunnel Tunnel, accessChecker services.AccessChecker, acc
 // TunnelWithRoles authorizes requests
 type TunnelWithRoles struct {
 	tunnel Tunnel
+
+	localCluster string
 
 	// accessChecker is used to check RBAC permissions.
 	accessChecker services.AccessChecker
@@ -58,7 +59,7 @@ func (t *TunnelWithRoles) GetSites() ([]RemoteSite, error) {
 	}
 	out := make([]RemoteSite, 0, len(clusters))
 	for _, cluster := range clusters {
-		if _, ok := cluster.(*localSite); ok {
+		if t.localCluster == cluster.GetName() {
 			out = append(out, cluster)
 			continue
 		}
@@ -87,7 +88,7 @@ func (t *TunnelWithRoles) GetSite(clusterName string) (RemoteSite, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if _, ok := cluster.(*localSite); ok {
+	if t.localCluster == cluster.GetName() {
 		return cluster, nil
 	}
 	rc, err := t.access.GetRemoteCluster(clusterName)

--- a/lib/reversetunnelclient/fake.go
+++ b/lib/reversetunnelclient/fake.go
@@ -1,20 +1,18 @@
-/*
-Copyright 2020 Gravitational, Inc.
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package reversetunnel
+package reversetunnelclient
 
 import (
 	"net"
@@ -26,7 +24,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 )
 
-// FakeServer is a fake reversetunnel.Server implementation used in tests.
+// FakeServer is a fake reversetunnelclient.Server implementation used in tests.
 type FakeServer struct {
 	Server
 	// Sites is a list of sites registered via this fake reverse tunnel.
@@ -48,7 +46,7 @@ func (s *FakeServer) GetSite(name string) (RemoteSite, error) {
 	return nil, trace.NotFound("site %q not found", name)
 }
 
-// FakeRemoteSite is a fake reversetunnel.RemoteSite implementation used in tests.
+// FakeRemoteSite is a fake reversetunnelclient.RemoteSite implementation used in tests.
 type FakeRemoteSite struct {
 	RemoteSite
 	// Name is the remote site name.

--- a/lib/reversetunnelclient/resolver.go
+++ b/lib/reversetunnelclient/resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Gravitational, Inc
+// Copyright 2023 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reversetunnel
+package reversetunnelclient
 
 import (
 	"context"

--- a/lib/reversetunnelclient/resolver_test.go
+++ b/lib/reversetunnelclient/resolver_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reversetunnel
+package reversetunnelclient
 
 import (
 	"context"

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -1,0 +1,108 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reversetunnelclient
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
+	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/utils/proxy"
+)
+
+// NewTunnelAuthDialer creates a new instance of TunnelAuthDialer
+func NewTunnelAuthDialer(config TunnelAuthDialerConfig) (*TunnelAuthDialer, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TunnelAuthDialer{
+		TunnelAuthDialerConfig: config,
+	}, nil
+}
+
+// TunnelAuthDialerConfig specifies TunnelAuthDialer configuration.
+type TunnelAuthDialerConfig struct {
+	// Resolver retrieves the address of the proxy
+	Resolver Resolver
+	// ClientConfig is SSH tunnel client config
+	ClientConfig *ssh.ClientConfig
+	// Log is used for logging.
+	Log logrus.FieldLogger
+	// InsecureSkipTLSVerify is whether to skip certificate validation.
+	InsecureSkipTLSVerify bool
+}
+
+func (c *TunnelAuthDialerConfig) CheckAndSetDefaults() error {
+	if c.Resolver == nil {
+		return trace.BadParameter("missing tunnel address resolver")
+	}
+	return nil
+}
+
+// TunnelAuthDialer connects to the Auth Server through the reverse tunnel.
+type TunnelAuthDialer struct {
+	// TunnelAuthDialerConfig is the TunnelAuthDialer configuration.
+	TunnelAuthDialerConfig
+}
+
+// DialContext dials auth server via SSH tunnel
+func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	// Connect to the reverse tunnel server.
+	opts := []proxy.DialerOptionFunc{
+		proxy.WithInsecureSkipTLSVerify(t.InsecureSkipTLSVerify),
+	}
+
+	addr, mode, err := t.Resolver(ctx)
+	if err != nil {
+		t.Log.Errorf("Failed to resolve tunnel address: %v", err)
+		return nil, trace.Wrap(err)
+	}
+
+	if mode == types.ProxyListenerMode_Multiplex {
+		opts = append(opts, proxy.WithALPNDialer(&tls.Config{
+			NextProtos: []string{
+				string(alpncommon.ProtocolReverseTunnelV2),
+				string(alpncommon.ProtocolReverseTunnel),
+			},
+		}))
+	}
+
+	dialer := proxy.DialerFromEnvironment(addr.Addr, opts...)
+	sconn, err := dialer.Dial(ctx, addr.AddrNetwork, addr.Addr, t.ClientConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Build a net.Conn over the tunnel. Make this an exclusive connection:
+	// close the net.Conn as well as the channel upon close.
+	conn, _, err := sshutils.ConnectProxyTransport(
+		sconn.Conn,
+		&sshutils.DialReq{
+			Address: RemoteAuthServer,
+		},
+		true,
+	)
+	if err != nil {
+		return nil, trace.NewAggregate(err, sconn.Close())
+	}
+	return conn, nil
+}

--- a/lib/service/acme.go
+++ b/lib/service/acme.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
 
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/app"
 )
@@ -35,7 +35,7 @@ type hostPolicyCheckerConfig struct {
 	// clt is used to get the list of registered applications
 	clt app.Getter
 	// tun is a reverse tunnel
-	tun reversetunnel.Tunnel
+	tun reversetunnelclient.Tunnel
 	// clusterName is a name of this cluster
 	clusterName string
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/interval"
@@ -1155,19 +1155,19 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 }
 
 func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
-	resolver := reversetunnel.WebClientResolver(&webclient.Config{
+	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
 		Context:   process.ExitContext(),
 		ProxyAddr: addr,
 		Insecure:  lib.IsInsecureDevMode(),
 		Timeout:   process.Config.ClientTimeout,
 	})
 
-	resolver, err := reversetunnel.CachingResolver(process.ExitContext(), resolver, process.Clock)
+	resolver, err := reversetunnelclient.CachingResolver(process.ExitContext(), resolver, process.Clock)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	dialer, err := reversetunnel.NewTunnelAuthDialer(reversetunnel.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          sshConfig,
 		Log:                   process.log,

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/utils"
@@ -109,8 +110,8 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 
 	// Dialed out to a proxy, start servicing the reverse tunnel as a listener.
 	case useTunnel && cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		// create an adapter, from reversetunnel.ServerHandler to net.Listener.
-		shtl := reversetunnel.NewServerHandlerToListener(reversetunnel.LocalWindowsDesktop)
+		// create an adapter, from reversetunnelclient.ServerHandler to net.Listener.
+		shtl := reversetunnel.NewServerHandlerToListener(reversetunnelclient.LocalWindowsDesktop)
 		listener = shtl
 		agentPool, err = reversetunnel.NewAgentPool(
 			process.ExitContext(),

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -31,6 +31,7 @@ import (
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -112,8 +113,8 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 
 	// Dialed out to a proxy, start servicing the reverse tunnel as a listener.
 	case conn.UseTunnel() && cfg.Kube.ListenAddr.IsEmpty():
-		// create an adapter, from reversetunnel.ServerHandler to net.Listener.
-		shtl := reversetunnel.NewServerHandlerToListener(reversetunnel.LocalKubernetes)
+		// create an adapter, from reversetunnelclient.ServerHandler to net.Listener.
+		shtl := reversetunnel.NewServerHandlerToListener(reversetunnelclient.LocalKubernetes)
 		listener = shtl
 		agentPool, err = reversetunnel.NewAgentPool(
 			process.ExitContext(),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -104,6 +104,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	restricted "github.com/gravitational/teleport/lib/restrictedsession"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv"
@@ -275,13 +276,13 @@ type Connector struct {
 
 // TunnelProxyResolver if non-nil, indicates that the client is connected to the Auth Server
 // through the reverse SSH tunnel proxy
-func (c *Connector) TunnelProxyResolver() reversetunnel.Resolver {
+func (c *Connector) TunnelProxyResolver() reversetunnelclient.Resolver {
 	if c.Client == nil || c.Client.Dialer() == nil {
 		return nil
 	}
 
 	switch dialer := c.Client.Dialer().(type) {
-	case *reversetunnel.TunnelAuthDialer:
+	case *reversetunnelclient.TunnelAuthDialer:
 		return dialer.Resolver
 	default:
 		return nil
@@ -2925,7 +2926,7 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 			utils.NetAddr{Addr: string(teleport.PrincipalLocalhost)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV4)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV6)},
-			utils.NetAddr{Addr: reversetunnel.LocalKubernetes},
+			utils.NetAddr{Addr: reversetunnelclient.LocalKubernetes},
 		)
 		addrs = append(addrs, process.Config.Proxy.SSHPublicAddrs...)
 		addrs = append(addrs, process.Config.Proxy.TunnelPublicAddrs...)
@@ -2970,7 +2971,7 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 			utils.NetAddr{Addr: string(teleport.PrincipalLocalhost)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV4)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV6)},
-			utils.NetAddr{Addr: reversetunnel.LocalKubernetes},
+			utils.NetAddr{Addr: reversetunnelclient.LocalKubernetes},
 		)
 		addrs = append(addrs, process.Config.Kube.PublicAddrs...)
 	case types.RoleApp, types.RoleOkta:
@@ -2980,7 +2981,7 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 			utils.NetAddr{Addr: string(teleport.PrincipalLocalhost)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV4)},
 			utils.NetAddr{Addr: string(teleport.PrincipalLoopbackV6)},
-			utils.NetAddr{Addr: reversetunnel.LocalWindowsDesktop},
+			utils.NetAddr{Addr: reversetunnelclient.LocalWindowsDesktop},
 			utils.NetAddr{Addr: desktop.WildcardServiceDNS},
 		)
 		addrs = append(addrs, process.Config.WindowsDesktop.PublicAddrs...)
@@ -3539,7 +3540,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	// register SSH reverse tunnel server that accepts connections
 	// from remote teleport nodes
-	var tsrv reversetunnel.Server
+	var tsrv reversetunnelclient.Server
 	var peerClient *peer.Client
 
 	if !process.Config.Proxy.DisableReverseTunnel {
@@ -3594,7 +3595,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		process.RegisterCriticalFunc("proxy.reversetunnel.server", func() error {
+		process.RegisterCriticalFunc("proxy.reversetunnelclient.Server", func() error {
 			log.Infof("Starting %s:%s on %v using %v", teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr, process.Config.CachePolicy)
 			if err := tsrv.Start(); err != nil {
 				log.Error(err)
@@ -4375,7 +4376,7 @@ func kubeDialAddr(config ProxyConfig, mode types.ProxyListenerMode) utils.NetAdd
 	return config.Kube.ListenAddr
 }
 
-func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv reversetunnel.Server, accessPoint auth.ReadProxyAccessPoint, clusterName string) (*tls.Config, error) {
+func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv reversetunnelclient.Server, accessPoint auth.ReadProxyAccessPoint, clusterName string) (*tls.Config, error) {
 	cfg := process.Config
 	var tlsConfig *tls.Config
 	acmeCfg := process.Config.Proxy.ACME
@@ -5112,9 +5113,9 @@ func (process *TeleportProcess) initDebugApp() {
 	})
 }
 
-// SingleProcessModeResolver returns the reversetunnel.Resolver that should be used when running all components needed
+// SingleProcessModeResolver returns the reversetunnelclient.Resolver that should be used when running all components needed
 // within the same process. It's used for development and demo purposes.
-func (process *TeleportProcess) SingleProcessModeResolver(mode types.ProxyListenerMode) reversetunnel.Resolver {
+func (process *TeleportProcess) SingleProcessModeResolver(mode types.ProxyListenerMode) reversetunnelclient.Resolver {
 	return func(context.Context) (*utils.NetAddr, types.ProxyListenerMode, error) {
 		addr, ok := process.singleProcessMode(mode)
 		if !ok {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4197,12 +4197,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		// really guaranteed to be capable to serve new requests if we're
 		// halfway through a shutdown, and double closing a listener is fine.
 		listeners.Close()
-		rcWatcher.Close()
 		if payload == nil {
 			log.Infof("Shutting down immediately.")
 			if tsrv != nil {
 				warnOnErr(tsrv.Close(), log)
 			}
+			warnOnErr(rcWatcher.Close(), log)
 			if proxyServer != nil {
 				warnOnErr(proxyServer.Close(), log)
 			}
@@ -4246,6 +4246,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if tsrv != nil {
 				warnOnErr(tsrv.Shutdown(ctx), log)
 			}
+			warnOnErr(rcWatcher.Close(), log)
 			if proxyServer != nil {
 				warnOnErr(proxyServer.Shutdown(), log)
 			}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -54,7 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -433,7 +433,7 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 				string(teleport.PrincipalLocalhost),
 				string(teleport.PrincipalLoopbackV4),
 				string(teleport.PrincipalLoopbackV6),
-				reversetunnel.LocalKubernetes,
+				reversetunnelclient.LocalKubernetes,
 				"proxy-ssh-public-1",
 				"proxy-ssh-public-2",
 				"proxy-tunnel-public-1",
@@ -496,7 +496,7 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 				string(teleport.PrincipalLocalhost),
 				string(teleport.PrincipalLoopbackV4),
 				string(teleport.PrincipalLoopbackV6),
-				reversetunnel.LocalKubernetes,
+				reversetunnelclient.LocalKubernetes,
 				"kube-public-1",
 				"kube-public-2",
 			},
@@ -572,7 +572,7 @@ type mockAccessPoint struct {
 }
 
 type mockReverseTunnelServer struct {
-	reversetunnel.Server
+	reversetunnelclient.Server
 }
 
 func TestSetupProxyTLSConfig(t *testing.T) {

--- a/lib/srv/alpnproxy/auth/auth_proxy.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy.go
@@ -31,14 +31,14 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/multiplexer"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 type sitesGetter interface {
-	GetSites() ([]reversetunnel.RemoteSite, error)
+	GetSites() ([]reversetunnelclient.RemoteSite, error)
 }
 
 // NewAuthProxyDialerService create new instance of AuthProxyDialerService.
@@ -169,7 +169,7 @@ func (s *AuthProxyDialerService) dialRemoteAuthServer(ctx context.Context, clust
 		if site.GetName() != clusterName {
 			continue
 		}
-		conn, err := site.DialAuthServer(reversetunnel.DialParams{From: clientSrcAddr, OriginalClientDstAddr: clientDstAddr})
+		conn, err := site.DialAuthServer(reversetunnelclient.DialParams{From: clientSrcAddr, OriginalClientDstAddr: clientDstAddr})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -60,7 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -1338,7 +1338,7 @@ type testContext struct {
 	mux            *multiplexer.Mux
 	mysqlListener  net.Listener
 	webListener    *multiplexer.WebListener
-	fakeRemoteSite *reversetunnel.FakeRemoteSite
+	fakeRemoteSite *reversetunnelclient.FakeRemoteSite
 	server         *Server
 	emitter        *eventstest.ChannelEmitter
 	databaseCA     types.CertAuthority
@@ -2061,10 +2061,10 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 	}
 
 	// Establish fake reversetunnel b/w database proxy and database service.
-	testCtx.fakeRemoteSite = reversetunnel.NewFakeRemoteSite(testCtx.clusterName, proxyAuthClient)
+	testCtx.fakeRemoteSite = reversetunnelclient.NewFakeRemoteSite(testCtx.clusterName, proxyAuthClient)
 	t.Cleanup(func() { require.NoError(t, testCtx.fakeRemoteSite.Close()) })
-	tunnel := &reversetunnel.FakeServer{
-		Sites: []reversetunnel.RemoteSite{
+	tunnel := &reversetunnelclient.FakeServer{
+		Sites: []reversetunnelclient.RemoteSite{
 			testCtx.fakeRemoteSite,
 		},
 	}

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -59,7 +59,7 @@ type ProxyContext struct {
 	// Identity is the authorized client Identity.
 	Identity tlsca.Identity
 	// Cluster is the remote Cluster running the database server.
-	Cluster reversetunnel.RemoteSite
+	Cluster reversetunnelclient.RemoteSite
 	// Servers is a list of database Servers that proxy the requested database.
 	Servers []types.DatabaseServer
 	// AuthContext is a context of authenticated user.

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/enterprise"
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
@@ -83,7 +83,7 @@ type ProxyServerConfig struct {
 	// Authorizer is responsible for authorizing user identities.
 	Authorizer authz.Authorizer
 	// Tunnel is the reverse tunnel server.
-	Tunnel reversetunnel.Server
+	Tunnel reversetunnelclient.Server
 	// TLSConfig is the proxy server TLS configuration.
 	TLSConfig *tls.Config
 	// Limiter is the connection/rate limiter.
@@ -436,9 +436,9 @@ func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext
 			return nil, trace.Wrap(err)
 		}
 
-		serviceConn, err := proxyCtx.Cluster.Dial(reversetunnel.DialParams{
+		serviceConn, err := proxyCtx.Cluster.Dial(reversetunnelclient.DialParams{
 			From:                  clientSrcAddr,
-			To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
+			To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnelclient.LocalNode},
 			OriginalClientDstAddr: clientDstAddr,
 			ServerID:              fmt.Sprintf("%v.%v", server.GetHostID(), proxyCtx.Cluster.GetName()),
 			ConnType:              types.DatabaseTunnel,
@@ -465,7 +465,7 @@ func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext
 // the reverse tunnel connection is down e.g. because the agent is down.
 func isReverseTunnelDownError(err error) bool {
 	return trace.IsConnectionProblem(err) ||
-		strings.Contains(err.Error(), reversetunnel.NoDatabaseTunnel)
+		strings.Contains(err.Error(), reversetunnelclient.NoDatabaseTunnel)
 }
 
 // Proxy starts proxying all traffic received from database client between
@@ -529,7 +529,7 @@ func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utils.TLSConn, para
 
 // getDatabaseServers finds database servers that proxy the database instance
 // encoded in the provided identity.
-func (s *ProxyServer) getDatabaseServers(ctx context.Context, identity tlsca.Identity) (reversetunnel.RemoteSite, []types.DatabaseServer, error) {
+func (s *ProxyServer) getDatabaseServers(ctx context.Context, identity tlsca.Identity) (reversetunnelclient.RemoteSite, []types.DatabaseServer, error) {
 	cluster, err := s.cfg.Tunnel.GetSite(identity.RouteToCluster)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -176,8 +176,12 @@ func newProxySubsys(ctx *srv.ServerContext, srv *Server, req proxySubsysRequest)
 		req.clusterName = ctx.Identity.RouteToCluster
 	}
 	if req.clusterName != "" && srv.proxyTun != nil {
-		_, err := srv.tunnelWithAccessChecker(ctx).GetSite(req.clusterName)
+		checker, err := srv.tunnelWithAccessChecker(ctx)
 		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if _, err := checker.GetSite(req.clusterName); err != nil {
 			return nil, trace.BadParameter("invalid format for proxy request: unknown cluster %q", req.clusterName)
 		}
 	}

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -52,7 +52,12 @@ func (t *proxySitesSubsys) Wait() error {
 // service.Site structures, and writes it serialized as JSON back to the SSH client
 func (t *proxySitesSubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	log.Debugf("proxysites.start(%v)", serverContext)
-	remoteSites, err := t.srv.tunnelWithAccessChecker(serverContext).GetSites()
+	checker, err := t.srv.tunnelWithAccessChecker(serverContext)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	remoteSites, err := checker.GetSites()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -467,6 +467,24 @@ func (s *Server) trackUserConnections(delta int32) int32 {
 	return atomic.AddInt32(&s.userConns, delta)
 }
 
+// TrackUserConnection tracks a user connection that should prevent
+// the server from being terminated if active. The returned function
+// should be called when the connection is terminated.
+func (s *Server) TrackUserConnection() (release func()) {
+	s.trackUserConnections(1)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() { s.trackUserConnections(-1) })
+	}
+}
+
+// ActiveConnections returns the number of connections that are
+// being served.
+func (s *Server) ActiveConnections() int32 {
+	return atomic.LoadInt32(&s.userConns)
+}
+
 // HandleConnection is called every time an SSH server accepts a new
 // connection from a client.
 //

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -80,7 +80,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/proxy"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
@@ -171,7 +171,7 @@ type Config struct {
 	PluginRegistry plugin.Registry
 	// Proxy is a reverse tunnel proxy that handles connections
 	// to local cluster or remote clusters using unified interface
-	Proxy reversetunnel.Tunnel
+	Proxy reversetunnelclient.Tunnel
 	// AuthServers is a list of auth servers this proxy talks to
 	AuthServers utils.NetAddr
 	// DomainName is a domain name served by web handler
@@ -846,7 +846,7 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 // getUserContext returns user context
 //
 // GET /webapi/sites/:site/context
-func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	cn, err := h.cfg.AccessPoint.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2384,7 +2384,7 @@ type getSiteNamespacesResponse struct {
 // Successful response:
 //
 // {"namespaces": [{..namespace resource...}]}
-func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := site.GetClient()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2399,7 +2399,7 @@ func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ ht
 }
 
 // clusterNodesGet returns a list of nodes for a given cluster site.
-func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of nodes.
 	clt, err := sctx.GetUserClient(r.Context(), site)
@@ -2439,7 +2439,7 @@ type getLoginAlertsResponse struct {
 }
 
 // clusterLoginAlertsGet returns a list of on-login alerts for the user.
-func (h *Handler) clusterLoginAlertsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterLoginAlertsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of alerts.
 	clt, err := sctx.GetUserClient(r.Context(), site)
@@ -2510,7 +2510,7 @@ func (h *Handler) siteNodeConnect(
 	r *http.Request,
 	p httprouter.Params,
 	sessionCtx *SessionContext,
-	site reversetunnel.RemoteSite,
+	site reversetunnelclient.RemoteSite,
 ) (interface{}, error) {
 	q := r.URL.Query()
 	params := q.Get("params")
@@ -2886,7 +2886,7 @@ func trackerToLegacySession(tracker types.SessionTracker, clusterName string) se
 // clusterActiveAndPendingSessionsGet gets the list of active and pending sessions for a site.
 //
 // GET /v1/webapi/sites/:site/sessions
-func (h *Handler) clusterActiveAndPendingSessionsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterActiveAndPendingSessionsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2952,7 +2952,7 @@ func toFieldsSlice(rawEvents []apievents.AuditEvent) ([]events.EventFields, erro
 //	"order":    optional ordering of events. Can be either "asc" or "desc"
 //	            for ascending and descending respectively.
 //	            If no order is provided it defaults to descending.
-func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	values := r.URL.Query()
 
 	var eventTypes []string
@@ -2980,7 +2980,7 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 //	"order":    optional ordering of events. Can be either "asc" or "desc"
 //	            for ascending and descending respectively.
 //	            If no order is provided it defaults to descending.
-func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	searchSessionEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchSessionEvents(from, to, limit, order, startKey, nil, "")
 	}
@@ -2989,7 +2989,7 @@ func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Requ
 
 // clusterEventsList returns a list of audit events obtained using the provided
 // searchEvents method.
-func clusterEventsList(ctx context.Context, sctx *SessionContext, site reversetunnel.RemoteSite, values url.Values, searchEvents func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
+func clusterEventsList(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite, values url.Values, searchEvents func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
 	from, err := queryTime(values, "from", time.Now().UTC().AddDate(0, -1, 0))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -3192,7 +3192,7 @@ type eventsListGetResponse struct {
 // Response body (each event is an arbitrary JSON structure)
 //
 // {"events": [{...}, {...}, ...}
-func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	sessionID, err := session.ParseID(p.ByName("sid"))
 	if err != nil {
 		return nil, trace.BadParameter("invalid session ID %q", p.ByName("sid"))
@@ -3371,7 +3371,7 @@ const currentSiteShortcut = "-current-"
 type ContextHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext) (interface{}, error)
 
 // ClusterHandler is a authenticated handler that is called for some existing remote cluster
-type ClusterHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error)
+type ClusterHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error)
 
 // WithClusterAuth wraps a ClusterHandler to ensure that a request is authenticated to this proxy
 // (the same as WithAuth), as well as to grab the remoteSite (which can represent this local cluster
@@ -3391,7 +3391,7 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 // to this proxy, returning the *SessionContext (same as AuthenticateRequest),
 // and also grabs the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
-func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnel.RemoteSite, error) {
+func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnelclient.RemoteSite, error) {
 	sctx, err := h.AuthenticateRequest(w, r, true)
 	if err != nil {
 		h.log.WithError(err).Warn("Failed to authenticate.")
@@ -3408,7 +3408,7 @@ func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.
 
 // getSiteByParams gets the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
-func (h *Handler) getSiteByParams(sctx *SessionContext, p httprouter.Params) (reversetunnel.RemoteSite, error) {
+func (h *Handler) getSiteByParams(sctx *SessionContext, p httprouter.Params) (reversetunnelclient.RemoteSite, error) {
 	clusterName := p.ByName("site")
 	if clusterName == currentSiteShortcut {
 		res, err := h.cfg.ProxyClient.GetClusterName()
@@ -3427,7 +3427,7 @@ func (h *Handler) getSiteByParams(sctx *SessionContext, p httprouter.Params) (re
 	return site, nil
 }
 
-func (h *Handler) getSiteByClusterName(ctx *SessionContext, clusterName string) (reversetunnel.RemoteSite, error) {
+func (h *Handler) getSiteByClusterName(ctx *SessionContext, clusterName string) (reversetunnelclient.RemoteSite, error) {
 	proxy, err := h.ProxyWithRoles(ctx)
 	if err != nil {
 		h.log.WithError(err).Warn("Failed to get proxy with roles.")
@@ -3493,7 +3493,7 @@ func (h *Handler) WithClusterClientProvider(fn ClusterClientHandler) httprouter.
 }
 
 // ProvisionTokenHandler is a authenticated handler that is called for some existing Token
-type ProvisionTokenHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, site reversetunnel.RemoteSite, token types.ProvisionToken) (interface{}, error)
+type ProvisionTokenHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, site reversetunnelclient.RemoteSite, token types.ProvisionToken) (interface{}, error)
 
 // WithProvisionTokenAuth ensures that request is authenticated with a provision token.
 // Provision tokens, when used like this are invalidated as soon as used.
@@ -3696,13 +3696,19 @@ func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, ch
 
 // ProxyWithRoles returns a reverse tunnel proxy verifying the permissions
 // of the given user.
-func (h *Handler) ProxyWithRoles(ctx *SessionContext) (reversetunnel.Tunnel, error) {
+func (h *Handler) ProxyWithRoles(ctx *SessionContext) (reversetunnelclient.Tunnel, error) {
 	accessChecker, err := ctx.GetUserAccessChecker()
 	if err != nil {
 		h.log.WithError(err).Warn("Failed to get client roles.")
 		return nil, trace.Wrap(err)
 	}
-	return reversetunnel.NewTunnelWithRoles(h.cfg.Proxy, accessChecker, h.cfg.AccessPoint), nil
+
+	cn, err := h.cfg.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return reversetunnelclient.NewTunnelWithRoles(h.cfg.Proxy, cn.GetClusterName(), accessChecker, h.cfg.AccessPoint), nil
 }
 
 // ProxyHostPort returns the address of the proxy server using --proxy

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -113,6 +113,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	restricted "github.com/gravitational/teleport/lib/restrictedsession"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
@@ -134,7 +135,7 @@ type WebSuite struct {
 
 	node        *regular.Server
 	proxy       *regular.Server
-	proxyTunnel reversetunnel.Server
+	proxyTunnel reversetunnelclient.Server
 	srvID       string
 
 	user       string
@@ -7352,7 +7353,7 @@ type testProxy struct {
 	clock   clockwork.FakeClock
 	client  auth.ClientI
 	auth    *auth.TestTLSServer
-	revTun  reversetunnel.Server
+	revTun  reversetunnelclient.Server
 	node    *regular.Server
 	proxy   *regular.Server
 	handler *APIHandler
@@ -7912,7 +7913,7 @@ func newKubeConfigFile(ctx context.Context, t *testing.T, clusters ...kubeCluste
 type startKubeOptions struct {
 	clusters    []kubeClusterConfig
 	authServer  *auth.TestTLSServer
-	revTunnel   reversetunnel.Server
+	revTunnel   reversetunnelclient.Server
 	serviceType kubeproxy.KubeServiceType
 }
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -38,7 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -52,7 +52,7 @@ type HandlerConfig struct {
 	// AccessPoint is caching client to auth.
 	AccessPoint auth.ProxyAccessPoint
 	// ProxyClient holds connections to leaf clusters.
-	ProxyClient reversetunnel.Tunnel
+	ProxyClient reversetunnelclient.Tunnel
 	// ProxyPublicAddrs contains web proxy public addresses.
 	ProxyPublicAddrs []utils.NetAddr
 	// CipherSuites is the list of TLS cipher suites that have been configured

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -99,7 +99,7 @@ func MatchName(name string) Matcher {
 // MatchHealthy tries to establish a connection with the server using the
 // `dialAppServer` function. The app server is matched if the function call
 // doesn't return any error.
-func MatchHealthy(proxyClient reversetunnel.Tunnel, clusterName string) Matcher {
+func MatchHealthy(proxyClient reversetunnelclient.Tunnel, clusterName string) Matcher {
 	return func(ctx context.Context, appServer types.AppServer) bool {
 		conn, err := dialAppServer(ctx, proxyClient, clusterName, appServer)
 		if err != nil {
@@ -132,7 +132,7 @@ func MatchAll(matchers ...Matcher) Matcher {
 // cluster, this method will always return "acme" running within the root
 // cluster. Always supply public address and cluster name to deterministically
 // resolve an application.
-func ResolveFQDN(ctx context.Context, clt Getter, tunnel reversetunnel.Tunnel, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+func ResolveFQDN(ctx context.Context, clt Getter, tunnel reversetunnelclient.Tunnel, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
 	// Try and match FQDN to public address of application within cluster.
 	servers, err := Match(ctx, clt, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
 func TestMatchAll(t *testing.T) {
@@ -79,20 +79,20 @@ func TestMatchHealthy(t *testing.T) {
 }
 
 type mockProxyClient struct {
-	reversetunnel.Tunnel
+	reversetunnelclient.Tunnel
 	remoteSite *mockRemoteSite
 }
 
-func (p *mockProxyClient) GetSite(_ string) (reversetunnel.RemoteSite, error) {
+func (p *mockProxyClient) GetSite(_ string) (reversetunnelclient.RemoteSite, error) {
 	return p.remoteSite, nil
 }
 
 type mockRemoteSite struct {
-	reversetunnel.RemoteSite
+	reversetunnelclient.RemoteSite
 	dialErr error
 }
 
-func (r *mockRemoteSite) Dial(_ reversetunnel.DialParams) (net.Conn, error) {
+func (r *mockRemoteSite) Dial(_ reversetunnelclient.DialParams) (net.Conn, error) {
 	if r.dialErr != nil {
 		return nil, r.dialErr
 	}

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -123,7 +123,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 
 // appServerMatcher returns a Matcher function used to find which AppServer can
 // handle the application requests.
-func appServerMatcher(proxyClient reversetunnel.Tunnel, publicAddr string, clusterName string) Matcher {
+func appServerMatcher(proxyClient reversetunnelclient.Tunnel, publicAddr string, clusterName string) Matcher {
 	// Match healthy and PublicAddr servers. Having a list of only healthy
 	// servers helps the transport fail before the request is forwarded to a
 	// server (in cases where there are no healthy servers). This process might

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -34,7 +34,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -42,7 +42,7 @@ import (
 
 // transportConfig is configuration for a rewriting transport.
 type transportConfig struct {
-	proxyClient  reversetunnel.Tunnel
+	proxyClient  reversetunnelclient.Tunnel
 	accessPoint  auth.ReadProxyAccessPoint
 	cipherSuites []uint16
 	identity     *tlsca.Identity
@@ -281,7 +281,7 @@ func (t *transport) DialWebsocket(network, address string) (net.Conn, error) {
 
 // dialAppServer dial and connect to the application service over the reverse
 // tunnel subsystem.
-func dialAppServer(ctx context.Context, proxyClient reversetunnel.Tunnel, clusterName string, server types.AppServer) (net.Conn, error) {
+func dialAppServer(ctx context.Context, proxyClient reversetunnelclient.Tunnel, clusterName string, server types.AppServer) (net.Conn, error) {
 	clusterClient, err := proxyClient.GetSite(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -294,9 +294,9 @@ func dialAppServer(ctx context.Context, proxyClient reversetunnel.Tunnel, cluste
 		from = clientSrcAddr
 	}
 
-	conn, err := clusterClient.Dial(reversetunnel.DialParams{
+	conn, err := clusterClient.Dial(reversetunnelclient.DialParams{
 		From:                  from,
-		To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
+		To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnelclient.LocalNode},
 		OriginalClientDstAddr: originalDst,
 		ServerID:              fmt.Sprintf("%v.%v", server.GetHostID(), clusterName),
 		ConnType:              server.GetTunnelType(),
@@ -345,5 +345,5 @@ func configureTLS(c *transportConfig) (*tls.Config, error) {
 // the reverse tunnel connection is down e.g. because the agent is down.
 func isReverseTunnelDownError(err error) bool {
 	return trace.IsConnectionProblem(err) ||
-		strings.Contains(err.Error(), reversetunnel.NoApplicationTunnel)
+		strings.Contains(err.Error(), reversetunnelclient.NoApplicationTunnel)
 }

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/app"
@@ -39,7 +39,7 @@ import (
 )
 
 // clusterAppsGet returns a list of applications in a form the UI can present.
-func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	identity, err := sctx.GetIdentity()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -282,7 +282,7 @@ type resolveAppResult struct {
 	App types.Application
 }
 
-func (h *Handler) resolveApp(ctx context.Context, clt app.Getter, proxy reversetunnel.Tunnel, params resolveAppParams) (*resolveAppResult, error) {
+func (h *Handler) resolveApp(ctx context.Context, clt app.Getter, proxy reversetunnelclient.Tunnel, params resolveAppParams) (*resolveAppResult, error) {
 	var (
 		server         types.AppServer
 		appClusterName string
@@ -316,7 +316,7 @@ func (h *Handler) resolveApp(ctx context.Context, clt app.Getter, proxy reverset
 
 // resolveDirect takes a public address and cluster name and exactly resolves
 // the application and the server on which it is running.
-func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnel.Tunnel, publicAddr string, clusterName string) (types.AppServer, string, error) {
+func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnelclient.Tunnel, publicAddr string, clusterName string) (types.AppServer, string, error) {
 	clusterClient, err := proxy.GetSite(clusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -341,7 +341,7 @@ func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnel.Tunnel,
 
 // resolveFQDN makes a best effort attempt to resolve FQDN to an application
 // running within a root or leaf cluster.
-func (h *Handler) resolveFQDN(ctx context.Context, clt app.Getter, proxy reversetunnel.Tunnel, fqdn string) (types.AppServer, string, error) {
+func (h *Handler) resolveFQDN(ctx context.Context, clt app.Getter, proxy reversetunnelclient.Tunnel, fqdn string) (types.AppServer, string, error) {
 	return app.ResolveFQDN(ctx, clt, proxy, h.proxyDNSNames(), fqdn)
 }
 

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/assist"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
 // createAssistantConversationResponse is a response for POST /webapi/assistant/conversations.
@@ -262,7 +262,7 @@ func (h *Handler) generateAssistantTitle(_ http.ResponseWriter, r *http.Request,
 }
 
 func (h *Handler) assistant(w http.ResponseWriter, r *http.Request, _ httprouter.Params,
-	sctx *SessionContext, site reversetunnel.RemoteSite,
+	sctx *SessionContext, site reversetunnelclient.RemoteSite,
 ) (any, error) {
 	if err := runAssistant(h, w, r, sctx, site); err != nil {
 		h.log.Warn(trace.DebugReport(err))
@@ -286,8 +286,8 @@ func checkAssistEnabled(a auth.ClientI, ctx context.Context) error {
 
 // runAssistant upgrades the HTTP connection to a websocket and starts a chat loop.
 func runAssistant(h *Handler, w http.ResponseWriter, r *http.Request,
-	sctx *SessionContext, site reversetunnel.RemoteSite,
-) error {
+	sctx *SessionContext, site reversetunnelclient.RemoteSite,
+) (err error) {
 	q := r.URL.Query()
 	conversationID := q.Get("conversation_id")
 	if conversationID == "" {

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/proxy"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/teleagent"
@@ -95,7 +95,7 @@ func (h *Handler) executeCommand(
 	r *http.Request,
 	_ httprouter.Params,
 	sessionCtx *SessionContext,
-	site reversetunnel.RemoteSite,
+	site reversetunnelclient.RemoteSite,
 ) (any, error) {
 	q := r.URL.Query()
 	params := q.Get("params")

--- a/lib/web/connection_diagnostic.go
+++ b/lib/web/connection_diagnostic.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/gravitational/teleport/lib/client/conntest"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // getConnectionDiagnostic returns a connection diagnostic connection diagnostics.
-func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -50,7 +50,7 @@ func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request
 }
 
 // diagnoseConnection executes and returns a connection diagnostic.
-func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	req := conntest.TestConnectionRequest{}
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	dbiam "github.com/gravitational/teleport/lib/srv/db/common/iam"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -76,7 +76,7 @@ func (r *createDatabaseRequest) checkAndSetDefaults() error {
 }
 
 // handleDatabaseCreate creates a database's metadata.
-func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	var req *createDatabaseRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -152,7 +152,7 @@ func (r *updateDatabaseRequest) checkAndSetDefaults() error {
 }
 
 // handleDatabaseUpdate updates the database
-func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("a database name is required")
@@ -241,7 +241,7 @@ type databaseIAMPolicyAWS struct {
 }
 
 // handleDatabaseGetIAMPolicy returns the required IAM policy for database.
-func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("missing database name")

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -45,7 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/utils"
@@ -58,7 +58,7 @@ func (h *Handler) desktopConnectHandle(
 	r *http.Request,
 	p httprouter.Params,
 	sctx *SessionContext,
-	site reversetunnel.RemoteSite,
+	site reversetunnelclient.RemoteSite,
 ) (interface{}, error) {
 	desktopName := p.ByName("desktopName")
 	if desktopName == "" {
@@ -92,7 +92,7 @@ func (h *Handler) createDesktopConnection(
 	clusterName string,
 	log *logrus.Entry,
 	sctx *SessionContext,
-	site reversetunnel.RemoteSite,
+	site reversetunnelclient.RemoteSite,
 ) error {
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  1024,
@@ -285,7 +285,7 @@ func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyC
 type connector struct {
 	log      *logrus.Entry
 	clt      auth.ClientI
-	site     reversetunnel.RemoteSite
+	site     reversetunnelclient.RemoteSite
 	userAddr string
 }
 
@@ -319,7 +319,7 @@ func (c *connector) tryConnect(clusterName, desktopServiceID string) (net.Conn, 
 
 	*c.log = *c.log.WithField("windows-service-uuid", service.GetName())
 	*c.log = *c.log.WithField("windows-service-addr", service.GetAddr())
-	return c.site.DialTCP(reversetunnel.DialParams{
+	return c.site.DialTCP(reversetunnelclient.DialParams{
 		From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: c.userAddr},
 		To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: service.GetAddr()},
 		ConnType: types.WindowsDesktopTunnel,

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -23,7 +23,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/net/websocket"
 
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/desktop"
 )
 
@@ -32,7 +32,7 @@ func (h *Handler) desktopPlaybackHandle(
 	r *http.Request,
 	p httprouter.Params,
 	ctx *SessionContext,
-	site reversetunnel.RemoteSite,
+	site reversetunnelclient.RemoteSite,
 ) (interface{}, error) {
 	sID := p.ByName("sid")
 	if sID == "" {

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
 )
 
@@ -53,7 +53,7 @@ type fileTransferRequest struct {
 	webauthn string
 }
 
-func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	query := r.URL.Query()
 	req := fileTransferRequest{
 		cluster:        site.GetName(),

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -25,12 +25,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // integrationsCreate creates an Integration
-func (h *Handler) integrationsCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) integrationsCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	var req *ui.Integration
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -77,7 +77,7 @@ func (h *Handler) integrationsCreate(w http.ResponseWriter, r *http.Request, p h
 }
 
 // integrationsUpdate updates the Integration based on its name
-func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")
@@ -118,7 +118,7 @@ func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p h
 }
 
 // integrationsDelete removes an Integration based on its name
-func (h *Handler) integrationsDelete(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) integrationsDelete(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")
@@ -137,7 +137,7 @@ func (h *Handler) integrationsDelete(w http.ResponseWriter, r *http.Request, p h
 }
 
 // integrationsGet returns an Integration based on its name
-func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")
@@ -157,7 +157,7 @@ func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p http
 }
 
 // integrationsList returns a page of Integrations
-func (h *Handler) integrationsList(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) integrationsList(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -23,12 +23,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // awsOIDCListDatabases returns a list of databases using the ListDatabases action of the AWS OIDC Integration.
-func (h *Handler) awsOIDCListDatabases(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) awsOIDCListDatabases(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	ctx := r.Context()
 
 	var req ui.AWSOIDCListDatabasesRequest
@@ -66,7 +66,7 @@ func (h *Handler) awsOIDCListDatabases(w http.ResponseWriter, r *http.Request, p
 }
 
 // awsOIDClientRequest receives a request to execute an action for the AWS OIDC integrations.
-func (h *Handler) awsOIDCClientRequest(ctx context.Context, region string, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (*awsoidc.AWSClientRequest, error) {
+func (h *Handler) awsOIDCClientRequest(ctx context.Context, region string, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (*awsoidc.AWSClientRequest, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")

--- a/lib/web/mfa.go
+++ b/lib/web/mfa.go
@@ -27,7 +27,7 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
@@ -357,7 +357,7 @@ type isMFARequiredResponse struct {
 	Required bool `json:"required"`
 }
 
-func (h *Handler) isMFARequired(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) isMFARequired(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	var httpReq *isMFARequiredRequest
 	if err := httplib.ReadJSON(r, &httpReq); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -32,13 +32,13 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // checkAccessToRegisteredResource checks if calling user has access to at least one registered resource.
-func (h *Handler) checkAccessToRegisteredResource(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) checkAccessToRegisteredResource(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of resources.
 	clt, err := c.GetUserClient(r.Context(), site)

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -23,13 +23,13 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // clusterKubesGet returns a list of kube clusters in a form the UI can present.
-func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -58,7 +58,7 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 
 // clusterKubePodsGet returns a list of Kubernetes Pods in a form the
 // UI can present.
-func (h *Handler) clusterKubePodsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterKubePodsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.NewKubernetesServiceClient(r.Context(), h.cfg.ProxyWebAddr.Addr)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -77,7 +77,7 @@ func (h *Handler) clusterKubePodsGet(w http.ResponseWriter, r *http.Request, p h
 }
 
 // clusterDatabasesGet returns a list of db servers in a form the UI can present.
-func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -117,7 +117,7 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 }
 
 // clusterDatabaseGet returns a list of db servers in a form the UI can present.
-func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("database name is required")
@@ -147,7 +147,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 }
 
 // clusterDatabaseServicesList returns a list of DatabaseServices (database agents) in a form the UI can present.
-func (h *Handler) clusterDatabaseServicesList(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDatabaseServicesList(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -171,7 +171,7 @@ func (h *Handler) clusterDatabaseServicesList(w http.ResponseWriter, r *http.Req
 }
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.
-func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -205,7 +205,7 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 }
 
 // clusterDesktopServicesGet returns a list of desktop services in a form the UI can present.
-func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of desktop services.
 	clt, err := sctx.GetUserClient(r.Context(), site)
@@ -231,7 +231,7 @@ func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Reque
 }
 
 // getDesktopHandle returns a desktop.
-func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -271,7 +271,7 @@ func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p htt
 // Response body:
 //
 // {"active": bool}
-func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	desktopName := p.ByName("desktopName")
 	trackers, err := h.auth.proxyClient.GetActiveSessionTrackersWithFilter(r.Context(), &types.SessionTrackerFilter{
 		Kind: string(types.WindowsDesktopSessionKind),

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -48,7 +48,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -107,7 +107,7 @@ type SessionContextConfig struct {
 	Session types.WebSession
 
 	// newRemoteClient is used by tests to override how remote clients are constructed to allow for fake sites
-	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error)
+	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error)
 }
 
 func (c *SessionContextConfig) CheckAndSetDefaults() error {
@@ -218,7 +218,7 @@ func (c *SessionContext) GetClientConnection() *grpc.ClientConn {
 // the requested site. If the site is local a client with the users local role
 // is returned. If the site is remote a client with the users remote role is
 // returned.
-func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
 	// if we're trying to access the local cluster, pass back the local client.
 	if c.cfg.RootClusterName == site.GetName() {
 		return c.cfg.RootClient, nil
@@ -237,7 +237,7 @@ func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnel.R
 //
 // A [singleflight.Group] is leveraged to prevent duplicate requests for remote
 // clients at the same time to race.
-func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
 	cltI, err, _ := c.remoteClientGroup.Do(site.GetName(), func() (interface{}, error) {
 		// check if we already have a connection to this cluster
 		if clt, ok := c.remoteClientCache.getRemoteClient(site); ok {
@@ -273,7 +273,7 @@ func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnel.Re
 }
 
 // newRemoteClient returns a client to a remote cluster with the role of current user.
-func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
 	clt, err := sctx.newRemoteTLSClient(ctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -290,9 +290,9 @@ func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunn
 }
 
 // clusterDialer returns DialContext function using cluster's dial function
-func clusterDialer(remoteCluster reversetunnel.RemoteSite) apiclient.ContextDialer {
+func clusterDialer(remoteCluster reversetunnelclient.RemoteSite) apiclient.ContextDialer {
 	return apiclient.ContextDialerFunc(func(in context.Context, network, _ string) (net.Conn, error) {
-		dialParams := reversetunnel.DialParams{}
+		dialParams := reversetunnelclient.DialParams{}
 		clientSrcAddr, clientDstAddr := utils.ClientAddrFromContext(in)
 		dialParams.From = clientSrcAddr
 		dialParams.OriginalClientDstAddr = clientDstAddr
@@ -377,7 +377,7 @@ func (c *SessionContext) ClientTLSConfig(ctx context.Context, clusterName ...str
 	return tlsConfig, nil
 }
 
-func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reversetunnel.RemoteSite) (auth.ClientI, error) {
+func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reversetunnelclient.RemoteSite) (auth.ClientI, error) {
 	tlsConfig, err := c.ClientTLSConfig(ctx, cluster.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1124,17 +1124,17 @@ type remoteClientCache struct {
 	sync.Mutex
 	clients map[string]struct {
 		auth.ClientI
-		reversetunnel.RemoteSite
+		reversetunnelclient.RemoteSite
 	}
 }
 
-func (c *remoteClientCache) addRemoteClient(site reversetunnel.RemoteSite, remoteClient auth.ClientI) error {
+func (c *remoteClientCache) addRemoteClient(site reversetunnelclient.RemoteSite, remoteClient auth.ClientI) error {
 	c.Lock()
 	defer c.Unlock()
 	if c.clients == nil {
 		c.clients = make(map[string]struct {
 			auth.ClientI
-			reversetunnel.RemoteSite
+			reversetunnelclient.RemoteSite
 		})
 	}
 	var err error
@@ -1143,12 +1143,12 @@ func (c *remoteClientCache) addRemoteClient(site reversetunnel.RemoteSite, remot
 	}
 	c.clients[site.GetName()] = struct {
 		auth.ClientI
-		reversetunnel.RemoteSite
+		reversetunnelclient.RemoteSite
 	}{remoteClient, site}
 	return err
 }
 
-func (c *remoteClientCache) getRemoteClient(site reversetunnel.RemoteSite) (auth.ClientI, bool) {
+func (c *remoteClientCache) getRemoteClient(site reversetunnelclient.RemoteSite) (auth.ClientI, bool) {
 	c.Lock()
 	defer c.Unlock()
 	remoteClt, ok := c.clients[site.GetName()]

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
 func TestRemoteClientCache(t *testing.T) {
@@ -57,12 +57,12 @@ func TestRemoteClientCache(t *testing.T) {
 	require.Zero(t, openCount.Load())
 }
 
-func newMockRemoteSite(name string) reversetunnel.RemoteSite {
+func newMockRemoteSite(name string) reversetunnelclient.RemoteSite {
 	return &mockRemoteSite{name: name}
 }
 
 type mockRemoteSite struct {
-	reversetunnel.RemoteSite
+	reversetunnelclient.RemoteSite
 	name string
 }
 
@@ -98,7 +98,7 @@ func TestGetUserClient(t *testing.T) {
 	sctx := SessionContext{
 		cfg: SessionContextConfig{
 			RootClusterName: "local",
-			newRemoteClient: func(ctx context.Context, sessionContext *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+			newRemoteClient: func(ctx context.Context, sessionContext *SessionContext, site reversetunnelclient.RemoteSite) (auth.ClientI, error) {
 				return newMockClientI(&openCount, nil), nil
 			},
 		},

--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/client/db"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -51,7 +51,7 @@ Should be equivalent to running:
 
 This endpoint returns a tar.gz compressed archive containing the required files to setup mTLS for the database.
 */
-func (h *Handler) signDatabaseCertificate(w http.ResponseWriter, r *http.Request, p httprouter.Params, site reversetunnel.RemoteSite, token types.ProvisionToken) (interface{}, error) {
+func (h *Handler) signDatabaseCertificate(w http.ResponseWriter, r *http.Request, p httprouter.Params, site reversetunnelclient.RemoteSite, token types.ProvisionToken) (interface{}, error) {
 	if !token.GetRoles().Include(types.RoleDatabase) {
 		return nil, trace.AccessDenied("required '%s' role was not provided by the token", types.RoleDatabase)
 	}

--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -51,7 +51,7 @@ type Cluster struct {
 }
 
 // NewClusters creates a slice of Cluster's, containing data about each cluster.
-func NewClusters(remoteClusters []reversetunnel.RemoteSite) ([]Cluster, error) {
+func NewClusters(remoteClusters []reversetunnelclient.RemoteSite) ([]Cluster, error) {
 	clusters := make([]Cluster, 0, len(remoteClusters))
 	for _, site := range remoteClusters {
 		// Other fields such as node count, url, and proxy/auth versions are not set
@@ -88,7 +88,7 @@ func NewClustersFromRemote(remoteClusters []types.RemoteCluster) ([]Cluster, err
 }
 
 // GetClusterDetails retrieves and sets details about a cluster
-func GetClusterDetails(ctx context.Context, site reversetunnel.RemoteSite, opts ...services.MarshalOption) (*Cluster, error) {
+func GetClusterDetails(ctx context.Context, site reversetunnelclient.RemoteSite, opts ...services.MarshalOption) (*Cluster, error) {
 	clt, err := site.CachingAccessPoint()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 )
@@ -143,7 +143,7 @@ func insertServers(ctx context.Context, b *testing.B, svc services.Presence, kin
 	}
 }
 
-func benchmarkGetClusterDetails(ctx context.Context, b *testing.B, site reversetunnel.RemoteSite, nodes int, opts ...services.MarshalOption) {
+func benchmarkGetClusterDetails(ctx context.Context, b *testing.B, site reversetunnelclient.RemoteSite, nodes int, opts ...services.MarshalOption) {
 	var cluster *Cluster
 	var err error
 	for i := 0; i < b.N; i++ {
@@ -155,7 +155,7 @@ func benchmarkGetClusterDetails(ctx context.Context, b *testing.B, site reverset
 }
 
 type mockRemoteSite struct {
-	reversetunnel.RemoteSite
+	reversetunnelclient.RemoteSite
 	accessPoint auth.ProxyAccessPoint
 }
 

--- a/lib/web/user_groups.go
+++ b/lib/web/user_groups.go
@@ -26,11 +26,11 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
-func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (any, error) {
+func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of nodes.
 	clt, err := sctx.GetUserClient(r.Context(), site)

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -33,7 +33,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/devicetrust"
-	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
@@ -753,7 +753,7 @@ func (c *windowsDesktopServiceCollection) writeText(w io.Writer, verbose bool) e
 	t := asciitable.MakeTable([]string{"Name", "Address", "Version"})
 	for _, service := range c.services {
 		addr := service.GetAddr()
-		if addr == reversetunnel.LocalWindowsDesktop {
+		if addr == reversetunnelclient.LocalWindowsDesktop {
 			addr = "<proxy tunnel>"
 		}
 		t.AddRow([]string{service.GetName(), addr, service.GetTeleportVersion()})


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/32688 and #33035 to branch/v12

In order to prevent circular imports this also backports a portion of https://github.com/gravitational/teleport/pull/28357