### PR TITLE
[v13] chore: Move golangci-lint and buf to GHA, bump versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,8 +23,6 @@ jobs:
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport13
-      env:
-        GO_LINT_FLAGS: --timeout=15m
 
     steps:
       - name: Checkout
@@ -37,8 +35,53 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
 
-      - name: Run linter
-        run: make lint
+      # Run various golangci-lint checks.
+      # TODO(codingllama): Using go.work could save a bunch of repetition here.
+      - name: golangci-lint (api)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: api
+      - name: golangci-lint (teleport)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --build-tags libfido2,piv
+      - name: golangci-lint (kube-agent-updater)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: integrations/kube-agent-updater
+      - name: golangci-lint (assets/backport)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: assets/backport
+      - name: golangci-lint (build.assets/tooling)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: build.assets/tooling
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+          version: latest
+      - uses: bufbuild/buf-lint-action@v1
+      - name: buf breaking --against=parent
+        uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+      - name: buf breaking --against=master
+        uses: bufbuild/buf-breaking-action@v1
+        if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
+        with:
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
+
+      # TODO(codingllama): Consider https://github.com/actions-rs/clippy-check
+      #  for Rust.
+      - name: Run (non-action) linters
+        run: make lint-no-actions
 
       - name: Check if protos are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
@@ -47,22 +90,3 @@ jobs:
       - name: Check if Operator CRDs are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make crds-up-to-date
-
-      # The `buf breaking` check is twofold: we always check for compatibility
-      # breaks against the base of the PR, and in backports we check for
-      # compatibility breaks _from_ the tip of master. It's possible to add
-      # fields just to release branches and not master, but it requires
-      # reserving the appropriate field numbers and field names in master (as it
-      # should!).
-
-      # We run a separate fetch because even with a fetch-depth of 0 in
-      # actions/checkout I'm not sure that we're guaranteed to have all the refs
-      # we need (especially the tip of master in backports), but it's a shallow
-      # fetch for a specific tree by hash, so it should be pretty fast.
-
-      - name: Check protos for breakage against parent
-        run: buf breaking . --against "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-
-      - name: Check protos for breakage from master
-        if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
-        run: buf breaking "https://github.com/${{ github.repository }}.git#branch=master" --against .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,9 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport13
 
+    env:
+      GOLANGCI_LINT_VERSION: v1.54.2
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,33 +43,33 @@ jobs:
       - name: golangci-lint (api)
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: api
       - name: golangci-lint (teleport)
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --build-tags libfido2,piv
       - name: golangci-lint (kube-agent-updater)
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: integrations/kube-agent-updater
       - name: golangci-lint (assets/backport)
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: assets/backport
       - name: golangci-lint (build.assets/tooling)
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: build.assets/tooling
 
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-          version: latest
+          version: v1.26.1
       - uses: bufbuild/buf-lint-action@v1
       - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,15 +68,16 @@ jobs:
           github_token: ${{ github.token }}
           version: latest
       - uses: bufbuild/buf-lint-action@v1
-      - name: buf breaking --against=parent
+      - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@v1
         with:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-      - name: buf breaking --against=master
+      - name: buf breaking from self to master
         uses: bufbuild/buf-breaking-action@v1
         if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
         with:
-          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
+          input: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
+          against: "."
 
       # TODO(codingllama): Consider https://github.com/actions-rs/clippy-check
       #  for Rust.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-          version: v1.26.1
+          version: v1.27.0
       - uses: bufbuild/buf-lint-action@v1
       - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ output:
 
 run:
   go: '1.20'
+  build-tags: []
   skip-dirs:
     - (^|/)node_modules/
     - ^api/gen/
@@ -81,4 +82,4 @@ run:
     - ^rfd/
     - ^web/
   skip-dirs-use-default: false
-  timeout: 5m
+  timeout: 15m

--- a/Makefile
+++ b/Makefile
@@ -902,7 +902,14 @@ integration-root: $(TEST_LOG_DIR) $(RENDER_TESTS)
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-api lint-kube-agent-updater lint-go lint-license lint-rust lint-tools lint-protos
+lint: lint-api lint-go link-kube-agent-updater lint-tools lint-protos lint-no-actions
+
+#
+# Lints everything but Go sources.
+# Similar to lint.
+#
+.PHONY: lint-no-actions
+lint-no-actions: lint-sh lint-helm lint-license lint-rust
 
 .PHONY: lint-tools
 lint-tools: lint-build-tooling lint-backport

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -281,16 +281,14 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.11.0
 
 # Install golangci-lint.
-RUN TAG='v1.54.1' && \
-    curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
-    sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
+RUN VERSION='v1.54.2'; \
+    curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
+    sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 
 # Install Buf.
-ARG BUF_VERSION # eg, "1.19.0"
-RUN BIN='/usr/local/bin' && \
-  VERSION="$BUF_VERSION" && \
-  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
-  chmod +x "$BIN/buf"
+ARG BUF_VERSION # eg, "v1.26.1"
+RUN VERSION="$BUF_VERSION"; \
+    go install "github.com/bufbuild/buf/cmd/buf@$VERSION"
 
 # Copy BPF libraries.
 ARG LIBBPF_VERSION

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM docker.io/golang:1.20
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \
@@ -10,16 +10,20 @@ RUN apt-get update && \
 
 # protoc-gen-gogofast
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
-ARG GOGO_PROTO_TAG # eg, "v1.3.2"
+# eg, "v1.3.2"
+ARG GOGO_PROTO_TAG
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
 # protoc-gen-js and protoc-gen-ts
-ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
-ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
+# eg, "1.12.4"
+ARG NODE_GRPC_TOOLS_VERSION
+# eg, "5.0.1"
+ARG NODE_PROTOC_TS_VERSION
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
 # protoc
-ARG PROTOC_VER # eg, "3.20.2"
+# eg, "3.20.2"
+ARG PROTOC_VER
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
   PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
@@ -29,11 +33,10 @@ RUN VERSION="$PROTOC_VER" && \
   rm -f "$PB_FILE"
 
 # buf
-ARG BUF_VERSION # eg, "1.19.0"
-RUN BIN='/usr/local/bin' && \
-  VERSION="$BUF_VERSION" && \
-  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
-  chmod +x "$BIN/buf"
+# eg, "v1.26.1"
+ARG BUF_VERSION
+RUN VERSION="$BUF_VERSION"; \
+    go install "github.com/bufbuild/buf/cmd/buf@$VERSION"
 
 # Pre-install go-runned binaries.
 # This is meant to be the only step that changes depending on the Teleport

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -14,15 +14,18 @@ else
 GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
 endif
 
+# Allow overriding the docker implementation to use for ex. podman.
+DOCKER ?= docker
+
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.
-GRPCBOX_RUN := docker run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
+GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
 
 # grpcbox builds a codegen-focused buildbox.
 # It's leaner, meaner, faster and not supposed to compile code.
 .PHONY: grpcbox
 grpcbox:
-	DOCKER_BUILDKIT=1 docker build \
+	DOCKER_BUILDKIT=1 $(DOCKER) build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -11,7 +11,7 @@ LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= v1.26.1
+BUF_VERSION ?= v1.27.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -11,7 +11,7 @@ LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= 1.26.1
+BUF_VERSION ?= v1.26.1
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -290,7 +290,7 @@ func (touchIDImpl) ListCredentials() ([]CredentialInfo, error) {
 	})
 	if res < 0 {
 		errMsg := C.GoString(errMsgC)
-		return nil, errorFromStatus("listing credentials", int(res), errMsg)
+		return nil, errorFromStatus("listing credentials", res, errMsg)
 	}
 
 	return infos, nil

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -640,6 +640,7 @@ func (c *Client) handleRemoteCopy(data []byte) C.CGOErrCode {
 //export tdp_sd_acknowledge
 func tdp_sd_acknowledge(handle C.uintptr_t, ack *C.CGOSharedDirectoryAcknowledge) C.CGOErrCode {
 	return cgo.Handle(handle).Value().(*Client).sharedDirectoryAcknowledge(tdp.SharedDirectoryAcknowledge{
+		//nolint:unconvert // Avoid hard dependencies on C types.
 		ErrCode:     uint32(ack.err_code),
 		DirectoryID: uint32(ack.directory_id),
 	})
@@ -687,8 +688,9 @@ func tdp_sd_create_request(handle C.uintptr_t, req *C.CGOSharedDirectoryCreateRe
 	return cgo.Handle(handle).Value().(*Client).sharedDirectoryCreateRequest(tdp.SharedDirectoryCreateRequest{
 		CompletionID: uint32(req.completion_id),
 		DirectoryID:  uint32(req.directory_id),
-		FileType:     uint32(req.file_type),
-		Path:         C.GoString(req.path),
+		//nolint:unconvert // Avoid hard dependencies on C types.
+		FileType: uint32(req.file_type),
+		Path:     C.GoString(req.path),
 	})
 }
 


### PR DESCRIPTION
Backports #30649, #31255, #31300 and #32997 to branch/v13.

Backports include the move of golangci-lint and buf to GHA, subsequent pinning and version updates.

I've elected to keep various minor file/comment changes so we don't suffer the same conflicts in the future.

* https://github.com/golangci/golangci-lint/releases/tag/v1.54.2
* https://github.com/bufbuild/buf/releases/tag/v1.27.0