### PR TITLE
[v13] Correct typo in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -902,7 +902,7 @@ integration-root: $(TEST_LOG_DIR) $(RENDER_TESTS)
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-api lint-go link-kube-agent-updater lint-tools lint-protos lint-no-actions
+lint: lint-api lint-go lint-kube-agent-updater lint-tools lint-protos lint-no-actions
 
 #
 # Lints everything but Go sources.


### PR DESCRIPTION
The Makefile had a typo for `lint-kube-agent-updater` which has been corrected.