### PR TITLE
Fix test HTTP proxy server returning early

### DIFF
--- a/api/testhelpers/proxy.go
+++ b/api/testhelpers/proxy.go
@@ -64,7 +64,7 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		trace.WriteError(w, trace.AccessDenied("unable to hijack connection"))
 		return
 	}
-	sconn, _, err := hj.Hijack()
+	sconn, buf, err := hj.Hijack()
 	if err != nil {
 		trace.WriteError(w, err)
 		return
@@ -83,7 +83,7 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		errc <- err
 	}
 	go replicate(sconn, dconn)
-	go replicate(dconn, sconn)
+	go replicate(dconn, io.MultiReader(buf, sconn))
 
 	// Wait until done, error, or 10 second.
 	select {

--- a/api/testhelpers/proxy.go
+++ b/api/testhelpers/proxy.go
@@ -86,9 +86,14 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go replicate(dconn, sconn)
 
 	// Wait until done, error, or 10 second.
-	select {
-	case <-time.After(10 * time.Second):
-	case <-errc:
+	errors := 0
+	for {
+		select {
+		case <-time.After(10 * time.Second):
+			return
+		case <-errc:
+			errors++
+		}
 	}
 }
 

--- a/api/testhelpers/proxy.go
+++ b/api/testhelpers/proxy.go
@@ -93,6 +93,9 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-errc:
 			errors++
+			if errors == 2 {
+				return
+			}
 		}
 	}
 }

--- a/api/testhelpers/proxy.go
+++ b/api/testhelpers/proxy.go
@@ -86,14 +86,14 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go replicate(dconn, sconn)
 
 	// Wait until done, error, or 10 second.
-	errors := 0
+	numFinished := 0
 	for {
 		select {
 		case <-time.After(10 * time.Second):
 			return
 		case <-errc:
-			errors++
-			if errors == 2 {
+			numFinished++
+			if numFinished == 2 {
 				return
 			}
 		}

--- a/api/testhelpers/proxy.go
+++ b/api/testhelpers/proxy.go
@@ -86,17 +86,9 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go replicate(dconn, sconn)
 
 	// Wait until done, error, or 10 second.
-	numFinished := 0
-	for {
-		select {
-		case <-time.After(10 * time.Second):
-			return
-		case <-errc:
-			numFinished++
-			if numFinished == 2 {
-				return
-			}
-		}
+	select {
+	case <-time.After(10 * time.Second):
+	case <-errc:
 	}
 }
 


### PR DESCRIPTION
This change fixes a bug in the local HTTP proxy server we use in a few tests. The server's handler would only wait for one side of the proxied connection to finish before returning, which occasionally caused test flake.

Related: #27651