### PR TITLE
docs: include info for accessing database audit activity

### DIFF
--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -33,6 +33,11 @@ The following PostgreSQL protocol features aren't currently supported:
   except for client certificate authentication and IAM authentication for cloud
   databases.
 
+
+## Are database sessions listed under recorded sessions?
+
+(!docs/pages/includes/database-access/db-audit-events.mdx!)
+
 ## Can database clients use a public address different from the web public address?
 
 <Tabs>

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -224,6 +224,10 @@ Finally, connect to the database:
 $ tsh db connect --db-user=alice --db-name postgres aurora
 ```
 
+### Auditing
+
+(!docs/pages/includes/database-access/db-audit-events.mdx!)
+
 ## Troubleshooting
 
 (!docs/pages/includes/database-access/aws-troubleshooting.mdx!)

--- a/docs/pages/database-access/reference/audit.mdx
+++ b/docs/pages/database-access/reference/audit.mdx
@@ -3,7 +3,6 @@ title: Database Access Audit Events Reference
 description: Audit events reference for Teleport database access.
 ---
 
-## Audit events
 
 (!docs/pages/includes/database-access/db-audit-events.mdx!)
 

--- a/docs/pages/database-access/reference/audit.mdx
+++ b/docs/pages/database-access/reference/audit.mdx
@@ -3,6 +3,10 @@ title: Database Access Audit Events Reference
 description: Audit events reference for Teleport database access.
 ---
 
+## Audit events
+
+(!docs/pages/includes/database-access/db-audit-events.mdx!)
+
 ## db.session.start (TDB00I/W)
 
 Emitted when a client successfully connects to a database, or when a connection

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,6 +1,5 @@
-Database audit events will appear in the Audit Log including database sessions starting,
-query activity and ending. After the session has been uploaded you can retrieve the
-session activity with `tsh play`.
+After the session has been uploaded you can view the
+session activity in the Audit Log and with the command `tsh play`.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,5 +1,6 @@
-You can view database session activity in the Audit Log
-and after the session is uploaded retrieve with the command `tsh play`.
+You can view database session activity in the audit log.
+After a session is uploaded, you can play back the audit data
+with the `tsh play` command.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
@@ -33,6 +34,6 @@ Example output:
     }
 ```
 
-The Audit Log is viewable in **Activity** under **Management** in the Web UI for users
+The audit log is viewable in **Activity** under **Management** in the Web UI for users
 with permission to the `event` resources. Database sessions do not appear
-in the recorded sessions page.
+in the session recordings page.

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,4 +1,4 @@
-After the session has been uploaded you can view the
+After a database session has been uploaded you can view the
 session activity in the Audit Log and with the command `tsh play`.
 
 ```code
@@ -32,6 +32,6 @@ Example output:
     }
 ```
 
-The Audit Log is viewable in Activity under Management in the Web UI for users
+The Audit Log is viewable in **Activity** under **Management** in the Web UI for users
 with permission to the `event` resources. Database sessions do not appear
 in the recorded sessions page.

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -4,7 +4,7 @@ session activity with `tsh play`.
 
 ```code
 # Database session id will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
-$ tsh play --format json <Var name="databasesessionid" />
+$ tsh play --format json <Var name="database.session" />
 ```
 
 Example output:

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,5 +1,5 @@
 You can view database session activity in the Audit Log
-and the session is uploaded retrieve with the command `tsh play`.
+and after the session is uploaded retrieve with the command `tsh play`.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,0 +1,38 @@
+Database audit events will appear in the Audit Log including database sessions starting,
+query activity and ending. After the session has been uploaded you can retrieve the
+session activity with `tsh play`.
+
+```code
+# Database session id will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
+$ tsh play --format json <Var name="databasesessionid" />
+```
+
+Example output:
+```json
+    {
+        "cluster_name": "teleport.example.com",
+        "code": "TDB02I",
+        "db_name": "example",
+        "db_origin": "dynamic",
+        "db_protocol": "postgres",
+        "db_query": "select * from sample;",
+        "db_roles": [
+            "access"
+        ],
+        "db_service": "example",
+        "db_type": "rds",
+        "db_uri": "databases-1.us-east-1.rds.amazonaws.com:5432",
+        "db_user": "alice",
+        "ei": 2,
+        "event": "db.session.query",
+        "sid": "307b49d6-56c7-4d20-8cf0-5bc5348a7101",
+        "success": true,
+        "time": "2023-10-06T10:58:32.88Z",
+        "uid": "a649d925-9dac-44cc-bd04-4387c295580f",
+        "user": "alice"
+    }
+```
+
+The Audit Log is viewable in Activity under Management in the Web UI for users
+with permission to the `event` resources. Database sessions do not appear
+under the recorded sessions listing.

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,8 +1,9 @@
-After a database session has been uploaded you can view the
-session activity in the Audit Log and with the command `tsh play`.
+You can view database session activity in the Audit Log
+and after upoading retrieve with the command `tsh play`.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
+# See the audit log to get a sessions id with a key of sid
 $ tsh play --format json <Var name="database.session" />
 ```
 

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -2,13 +2,14 @@ You can view database session activity in the audit log.
 After a session is uploaded, you can play back the audit data
 with the `tsh play` command.
 
+Database session ID will be in a UUID format (ex: `307b49d6-56c7-4d20-8cf0-5bc5348a7101`)
+See the audit log to get a database session ID with a key of `sid`.
+
+Example:
 ```code
-# Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
-# See the audit log to get a session ID with a key of sid
 $ tsh play --format json <Var name="database.session" />
 ```
 
-Example output:
 ```json
     {
         "cluster_name": "teleport.example.com",

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -3,7 +3,7 @@ and after the session is uploaded retrieve with the command `tsh play`.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
-# See the audit log to get a sessions id with a key of sid
+# See the audit log to get a session ID with a key of sid
 $ tsh play --format json <Var name="database.session" />
 ```
 

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -3,7 +3,7 @@ query activity and ending. After the session has been uploaded you can retrieve 
 session activity with `tsh play`.
 
 ```code
-# Database session id will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
+# Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)
 $ tsh play --format json <Var name="database.session" />
 ```
 
@@ -35,4 +35,4 @@ Example output:
 
 The Audit Log is viewable in Activity under Management in the Web UI for users
 with permission to the `event` resources. Database sessions do not appear
-under the recorded sessions listing.
+in the recorded sessions page.

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -1,5 +1,5 @@
 You can view database session activity in the Audit Log
-and after upoading retrieve with the command `tsh play`.
+and the session is uploaded retrieve with the command `tsh play`.
 
 ```code
 # Database session ID will be in a UUID format (ex: 307b49d6-56c7-4d20-8cf0-5bc5348a7101)


### PR DESCRIPTION
- shows how to get database session activity
- added faq question on whether the database activity will show in recorded sessions which is a frequent question.
- includes info in getting started, faq and audit events