### PR TITLE
terraform: Remove accidental backend.tf commit

### DIFF
--- a/examples/aws/terraform/starter-cluster/backend.tf
+++ b/examples/aws/terraform/starter-cluster/backend.tf
@@ -1,7 +1,0 @@
-terraform {
-  backend "s3" {
-    bucket = "gus-terraform-backend.teleportdemo.com"
-    key    = "gus-starter.teleportdemo.com.tfstate"
-    region = "us-east-1"
-  }
-}


### PR DESCRIPTION
I inadvertently committed the local backend I was using for testing as part of https://github.com/gravitational/teleport/pull/32354