### PR TITLE
docs: Remove surplus connect.sh script content from docs

### DIFF
--- a/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -839,58 +839,27 @@ to a Teleport Auth Service instance. Follow the instructions in our [Trusted Clu
 
 ## Script to quickly connect to instances
 
-Here's a bash script that you can use to quickly connect to instances:
-
-```bash
-#!/bin/bash
-if [[ "$1" != "" ]]; then
-    INSTANCE_TYPE=$1
-else
-    INSTANCE_TYPE="auth"
-fi
-if [[ "$2" != "" ]]; then
-    INSTANCE_ID=$2
-else
-    INSTANCE_ID="0"
-fi
-
-export BASTION_IP=$(terraform output -raw bastion_ip_public)
-echo "Bastion IP: ${BASTION_IP?}"
-export CLUSTER_NAME=$(terraform output -raw cluster_name)
-echo "Cluster name: ${CLUSTER_NAME?}"
-
-if [[ "${INSTANCE_TYPE?}" == "auth" ]]; then
-    export SERVER_IP=$(aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${CLUSTER_NAME?}" "Name=tag:TeleportRole,Values=auth" --query "Reservations[${INSTANCE_ID?}].Instances[*].PrivateIpAddress" --output text)
-    echo "Auth ${INSTANCE_ID?} IP: ${SERVER_IP?}"
-elif [[ "${INSTANCE_TYPE?}" == "proxy" ]]; then
-    export SERVER_IP=$(aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${CLUSTER_NAME?}" "Name=tag:TeleportRole,Values=proxy" --query "Reservations[${INSTANCE_ID?}].Instances[*].PrivateIpAddress" --output text)
-    echo "Proxy ${INSTANCE_ID?} IP: ${SERVER_IP?}"
-elif [[ "${INSTANCE_TYPE?}" == "node" ]]; then
-    export SERVER_IP=$(aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${CLUSTER_NAME?}" "Name=tag:TeleportRole,Values=node" --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
-    echo "Node IP: ${SERVER_IP?}"
-fi
-
-KEYPAIR_NAME=$(terraform output -raw key_name)
-echo "Keypair name: ${KEYPAIR_NAME?}"
-ssh -i ${KEYPAIR_NAME?}.pem -o ProxyCommand="ssh -i ${KEYPAIR_NAME?}.pem -W '[%h]:%p' ec2-user@${BASTION_IP?}" ec2-user@${SERVER_IP?}
-```
-
-Save this as `connect.sh`, run `chmod +x connect.sh` to make it executable, then use it like so:
+You can use the `connect.sh` script in the `examples/aws/terraform/ha-autoscale-cluster` directory to get SSH access to your Teleport
+instances through the deployed bastion instance.
 
 ```code
+# Make the script executable
+$ chmod +x connect.sh
+
+# Example usage
 # Connect to the first Teleport Auth Service instance
 $ ./connect.sh auth 0
 
-# connect to the second Teleport Auth Service instance
+# Connect to the second Teleport Auth Service instance
 $ ./connect.sh auth 1
 
-# connect to the first Teleport Proxy Service instance
+# Connect to the first Teleport Proxy Service instance
 $ ./connect.sh proxy 0
 
-# connect to the second Teleport Proxy Service instance
+# Connect to the second Teleport Proxy Service instance
 $ ./connect.sh proxy 1
 
-# connect to the example Teleport SSH Service instance
+# Connect to the example Teleport SSH Service instance
 $ ./connect.sh node
 ```
 


### PR DESCRIPTION
A better version of `connect.sh` is now committed to the repo, so it doesn't need to live in the Terraform docs any more.