### PR TITLE
[v14] docs: update fips docker address and internal address listing

### DIFF
--- a/docs/pages/choose-an-edition/teleport-team.mdx
+++ b/docs/pages/choose-an-edition/teleport-team.mdx
@@ -234,7 +234,7 @@ of your cluster and the name of your Teleport user:
    ```code
    Node Name    Address    Labels
    ------------ ---------- ----------------------------------------------------------------------------------------
-   <Var name="node-name" /> ⟵ Tunnel   hostname=<Var name="node-name" />,teleport.internal/resource-id=000000000000
+   <Var name="node-name" /> ⟵ Tunnel   hostname=<Var name="node-name" />
    ```
 
 1. Access your server as the `root` user:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -184,7 +184,7 @@ We also provide the following images for FIPS builds of Teleport Enterprise:
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
- `public.ecr.aws/gravitational/teleport-ent-fips-distroless:(=teleport.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `public.ecr.aws/gravitational/teleport-ent-fips-distroless:(=teleport.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 | `public.ecr.aws/gravitational/teleport-ent-fips-distroless-debug(=teleport.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
 For testing, we always recommend that you use the latest release version of

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -184,8 +184,8 @@ We also provide the following images for FIPS builds of Teleport Enterprise:
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
-| `gravitational/teleport-ent-fips-distroless` | No | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
-| `gravitational/teleport-ent-fips-distroless-debug` | Yes | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
+ `public.ecr.aws/gravitational/teleport-ent-fips-distroless:(=teleport.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `public.ecr.aws/gravitational/teleport-ent-fips-distroless-debug(=teleport.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
 For testing, we always recommend that you use the latest release version of
 Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.


### PR DESCRIPTION
backport #33009 and ##33143 to branch/v14