### PR TITLE
fix: typo in error check

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1992,7 +1992,7 @@ func (process *TeleportProcess) initAuthService() error {
 		// the service has started
 		process.BroadcastEvent(Event{Name: AuthTLSReady, Payload: nil})
 		err := tlsServer.Serve()
-		if err != nil && errors.Is(err, http.ErrServerClosed) {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Warningf("TLS server exited with error: %v.", err)
 		}
 		return nil


### PR DESCRIPTION
While working on https://github.com/gravitational/teleport/pull/32911 I noticed the following broken error comparison, which would always log because the error was always wrapped and never exactly matched `http.ErrServerClosed`:

```
if err != nil && err != http.ErrServerClosed {
    log.Warningf("TLS server exited with error: %v.", err)
}
```

I tried to fix it with `errors.Is`, but unfortunately got the condition inverted. This fixes the condition to match the original intended behaviour. It's not useful to log `http.ErrServerClosed` errors because that error is returned every time the server is manually closed.