### PR TITLE
Fix Kubernetes agent updater helm chart reference to bool

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           value: /etc/teleport-tls-ca/ca.pem
         # Used to track whether a Teleport agent was installed using this method.
         - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-          value: true
+          value: "true"
   {{- end }}
 {{- end }}
         args:


### PR DESCRIPTION
This PR fixes a problem where Kubernetes cannot transform the bool value into a string.

```
Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```