### PR TITLE
docs: remove internal label listing

### DIFF
--- a/docs/pages/choose-an-edition/teleport-team.mdx
+++ b/docs/pages/choose-an-edition/teleport-team.mdx
@@ -234,7 +234,7 @@ of your cluster and the name of your Teleport user:
    ```code
    Node Name    Address    Labels
    ------------ ---------- ----------------------------------------------------------------------------------------
-   <Var name="node-name" /> ⟵ Tunnel   hostname=<Var name="node-name" />,teleport.internal/resource-id=000000000000
+   <Var name="node-name" /> ⟵ Tunnel   hostname=<Var name="node-name" />
    ```
 
 1. Access your server as the `root` user:


### PR DESCRIPTION
teleport.internal label no longer shows.