### PR TITLE
Show Connect My Computer button in empty state in Connect

### DIFF
--- a/web/packages/design/src/Button/Button.jsx
+++ b/web/packages/design/src/Button/Button.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { bool, string } from 'prop-types';
 
-import { space, width, height, alignSelf } from 'design/system';
+import { space, width, height, alignSelf, gap } from 'design/system';
 
 const Button = ({ children, setRef, ...props }) => {
   return (
@@ -86,6 +86,9 @@ const themedStyles = props => {
     ...height(props),
     ...textTransform(props),
     ...alignSelf(props),
+    // Since a Button has `display: inline-flex`, we want to be able to set gap within it in case we
+    // need to use an icon.
+    ...gap(props),
   };
 };
 

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import { Text, Indicator, Box } from 'design';
+import { Text, Indicator, Box, Flex } from 'design';
 import * as Icons from 'design/Icon';
 
 import { StyledTable, StyledPanel, StyledTableWrapper } from './StyledTable';
@@ -338,19 +338,23 @@ const EmptyIndicator = ({
   <tfoot>
     <tr>
       <td colSpan={colSpan}>
-        <Text
-          typography="paragraph"
+        <Flex
           m="4"
-          color="text.main"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          gap={2}
+          flexWrap="nowrap"
+          alignItems="center"
+          justifyContent="center"
         >
-          <Icons.Database mr={2} />
-          {emptyText}
-        </Text>
+          <Icons.Database color="text.main" />
+          <Text
+            textAlign="center"
+            typography="paragraph"
+            m="0"
+            color="text.main"
+          >
+            {emptyText}
+          </Text>
+        </Flex>
       </td>
     </tr>
   </tfoot>

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -36,6 +36,7 @@ export function Table<T>({
   state,
   onSort,
   emptyText,
+  emptyHint,
   emptyButton,
   nextPage,
   prevPage,
@@ -126,6 +127,7 @@ export function Table<T>({
     return (
       <EmptyIndicator
         emptyText={emptyText}
+        emptyHint={emptyHint}
         emptyButton={emptyButton}
         colSpan={columns.length}
       />
@@ -337,10 +339,12 @@ function ServersideTable<T>({
 
 const EmptyIndicator = ({
   emptyText,
+  emptyHint,
   emptyButton,
   colSpan,
 }: {
   emptyText: string;
+  emptyHint: string | undefined;
   emptyButton: JSX.Element | undefined;
   colSpan: number;
 }) => (
@@ -357,10 +361,18 @@ const EmptyIndicator = ({
           <Flex
             gap={2}
             flexWrap="nowrap"
-            alignItems="center"
+            alignItems="flex-start"
             justifyContent="center"
           >
-            <Icons.Database color="text.main" />
+            <Icons.Database
+              color="text.main"
+              // line-height and height must match line-height of Text below for the icon to be
+              // aligned to the first line of Text if Text spans multiple lines.
+              css={`
+                line-height: 32px;
+                height: 32px;
+              `}
+            />
             <Text
               textAlign="center"
               typography="paragraph"
@@ -370,6 +382,17 @@ const EmptyIndicator = ({
               {emptyText}
             </Text>
           </Flex>
+
+          {emptyHint && (
+            <Text
+              textAlign="center"
+              typography="paragraph"
+              m="0"
+              color="text.main"
+            >
+              {emptyHint}
+            </Text>
+          )}
 
           {emptyButton}
         </Flex>

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -36,6 +36,7 @@ export function Table<T>({
   state,
   onSort,
   emptyText,
+  emptyButton,
   nextPage,
   prevPage,
   setSearchValue,
@@ -122,7 +123,13 @@ export function Table<T>({
       return <tbody>{rows}</tbody>;
     }
 
-    return <EmptyIndicator emptyText={emptyText} colSpan={columns.length} />;
+    return (
+      <EmptyIndicator
+        emptyText={emptyText}
+        emptyButton={emptyButton}
+        colSpan={columns.length}
+      />
+    );
   };
 
   if (serversideProps) {
@@ -330,9 +337,11 @@ function ServersideTable<T>({
 
 const EmptyIndicator = ({
   emptyText,
+  emptyButton,
   colSpan,
 }: {
   emptyText: string;
+  emptyButton: JSX.Element | undefined;
   colSpan: number;
 }) => (
   <tfoot>
@@ -341,19 +350,28 @@ const EmptyIndicator = ({
         <Flex
           m="4"
           gap={2}
-          flexWrap="nowrap"
+          flexDirection="column"
           alignItems="center"
           justifyContent="center"
         >
-          <Icons.Database color="text.main" />
-          <Text
-            textAlign="center"
-            typography="paragraph"
-            m="0"
-            color="text.main"
+          <Flex
+            gap={2}
+            flexWrap="nowrap"
+            alignItems="center"
+            justifyContent="center"
           >
-            {emptyText}
-          </Text>
+            <Icons.Database color="text.main" />
+            <Text
+              textAlign="center"
+              typography="paragraph"
+              m="0"
+              color="text.main"
+            >
+              {emptyText}
+            </Text>
+          </Flex>
+
+          {emptyButton}
         </Flex>
       </td>
     </tr>

--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -21,9 +21,15 @@ export type TableProps<T> = {
   columns: TableColumn<T>[];
   emptyText: string;
   /**
-   * Optional button that is rendered below emptyText if there's no data.
+   * Optional button that is rendered below emptyText if there's no data, during processing or on
+   * error.
    */
   emptyButton?: JSX.Element;
+  /**
+   * Optional hint that is rendered below emptyText if there's no data, during processing or on
+   * error.
+   */
+  emptyHint?: string;
   pagination?: PaginationConfig;
   isSearchable?: boolean;
   searchableProps?: Extract<keyof T, string>[];

--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -20,6 +20,10 @@ export type TableProps<T> = {
   data: T[];
   columns: TableColumn<T>[];
   emptyText: string;
+  /**
+   * Optional button that is rendered below emptyText if there's no data.
+   */
+  emptyButton?: JSX.Element;
   pagination?: PaginationConfig;
   isSearchable?: boolean;
   searchableProps?: Extract<keyof T, string>[];

--- a/web/packages/design/src/buttons.story.jsx
+++ b/web/packages/design/src/buttons.story.jsx
@@ -55,6 +55,13 @@ export const Buttons = () => (
     </Flex>
 
     <Flex gap={3}>
+      <ButtonPrimary gap={2}>
+        <AddUsers />
+        Add users
+      </ButtonPrimary>
+    </Flex>
+
+    <Flex gap={3}>
       <ButtonLink href="">Button Link</ButtonLink>
       <ButtonText>Button Text</ButtonText>
     </Flex>

--- a/web/packages/design/src/buttons.story.jsx
+++ b/web/packages/design/src/buttons.story.jsx
@@ -33,32 +33,33 @@ export default {
 };
 
 export const Buttons = () => (
-  <>
-    <ButtonPrimary mr={3}>Primary</ButtonPrimary>
-    <ButtonSecondary mr={3}>Secondary</ButtonSecondary>
-    <ButtonBorder mr={3}>Border</ButtonBorder>
-    <ButtonWarning mb={5}>Warning</ButtonWarning>
-    <div />
-    <Button size="large" mr={3}>
-      Large
-    </Button>
-    <Button size="medium" mr={3}>
-      Medium
-    </Button>
-    <Button size="small">Small</Button>
-    <Button block mb={3} mt={4}>
-      block = true
-    </Button>
-    <Button mr={3} disabled>
-      Disabled
-    </Button>
-    <Button mb={3} autoFocus>
-      Focused
-    </Button>
-    <div />
-    <ButtonLink href="">Button Link</ButtonLink>
-    <ButtonText>Button Text</ButtonText>
-    <Flex mb={3}>
+  <Flex gap={4} flexDirection="column" alignItems="flex-start">
+    <Flex gap={3}>
+      <ButtonPrimary>Primary</ButtonPrimary>
+      <ButtonSecondary>Secondary</ButtonSecondary>
+      <ButtonBorder>Border</ButtonBorder>
+      <ButtonWarning>Warning</ButtonWarning>
+    </Flex>
+
+    <Flex gap={3} alignItems="center">
+      <Button size="large">Large</Button>
+      <Button size="medium">Medium</Button>
+      <Button size="small">Small</Button>
+    </Flex>
+
+    <Button block>block = true</Button>
+
+    <Flex gap={3}>
+      <Button disabled>Disabled</Button>
+      <Button autoFocus>Focused</Button>
+    </Flex>
+
+    <Flex gap={3}>
+      <ButtonLink href="">Button Link</ButtonLink>
+      <ButtonText>Button Text</ButtonText>
+    </Flex>
+
+    <Flex gap={3}>
       <ButtonIcon size={2}>
         <AddUsers />
       </ButtonIcon>
@@ -69,7 +70,8 @@ export const Buttons = () => (
         <Trash />
       </ButtonIcon>
     </Flex>
-    <Flex mb={4}>
+
+    <Flex gap={3}>
       <ButtonIcon size={1}>
         <AddUsers />
       </ButtonIcon>
@@ -80,7 +82,8 @@ export const Buttons = () => (
         <Trash />
       </ButtonIcon>
     </Flex>
-    <Flex>
+
+    <Flex gap={3}>
       <ButtonIcon size={0}>
         <AddUsers />
       </ButtonIcon>
@@ -91,5 +94,5 @@ export const Buttons = () => (
         <Trash />
       </ButtonIcon>
     </Flex>
-  </>
+  </Flex>
 );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -124,17 +124,18 @@ export const ConnectMyComputerContextProvider: FC<{
     isAgentConfiguredAttempt.data;
 
   const rootCluster = clustersService.findCluster(rootClusterUri);
+  const { loggedInUser } = rootCluster;
 
   const canUse = useMemo(() => {
     const hasPermissions = hasConnectMyComputerPermissions(
-      rootCluster,
+      loggedInUser,
       mainProcessClient.getRuntimeSettings()
     );
 
     // We check `isAgentConfigured`, because the user should always have access to the agent after configuring it.
     // https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#access-to-ui-and-autostart
     return hasPermissions || isAgentConfigured;
-  }, [isAgentConfigured, mainProcessClient, rootCluster]);
+  }, [isAgentConfigured, mainProcessClient, loggedInUser]);
 
   const agentCompatibility = useMemo(
     () =>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.test.ts
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.test.ts
@@ -16,10 +16,7 @@
 
 import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
 import { Platform } from 'teleterm/mainProcess/types';
-import {
-  makeRootCluster,
-  makeLoggedInUser,
-} from 'teleterm/services/tshd/testHelpers';
+import { makeLoggedInUser } from 'teleterm/services/tshd/testHelpers';
 
 import { hasConnectMyComputerPermissions } from './permissions';
 
@@ -56,22 +53,23 @@ const testCases: {
 ];
 
 test.each(testCases)('$name', testCase => {
-  const cluster = makeRootCluster({
-    loggedInUser: makeLoggedInUser({
-      acl: {
-        tokens: {
-          create: testCase.canCreateToken,
-          edit: false,
-          list: false,
-          use: false,
-          read: false,
-          pb_delete: false,
-        },
+  const loggedInUser = makeLoggedInUser({
+    acl: {
+      tokens: {
+        create: testCase.canCreateToken,
+        edit: false,
+        list: false,
+        use: false,
+        read: false,
+        pb_delete: false,
       },
-    }),
+    },
   });
   const runtimeSettings = makeRuntimeSettings({ platform: testCase.platform });
 
-  const isPermitted = hasConnectMyComputerPermissions(cluster, runtimeSettings);
+  const isPermitted = hasConnectMyComputerPermissions(
+    loggedInUser,
+    runtimeSettings
+  );
   expect(isPermitted).toEqual(testCase.expect);
 });

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.ts
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { Cluster } from 'teleterm/services/tshd/types';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
-
 import * as tsh from 'teleterm/services/tshd/types';
 
 /**
@@ -29,20 +27,16 @@ import * as tsh from 'teleterm/services/tshd/types';
  * https://github.com/gravitational/teleport/pull/28346#discussion_r1246653846
  * */
 export function hasConnectMyComputerPermissions(
-  rootCluster: Cluster,
+  loggedInUser: tsh.LoggedInUser,
   runtimeSettings: RuntimeSettings
 ): boolean {
-  if (rootCluster.leaf) {
-    return false;
-  }
-
   const isUnix =
     runtimeSettings.platform === 'darwin' ||
     runtimeSettings.platform === 'linux';
 
   return (
     isUnix &&
-    rootCluster.loggedInUser?.acl?.tokens.create &&
-    rootCluster.loggedInUser?.userType == tsh.UserType.USER_TYPE_LOCAL
+    loggedInUser?.acl?.tokens.create &&
+    loggedInUser?.userType === tsh.UserType.USER_TYPE_LOCAL
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -62,7 +62,10 @@ function DatabaseList(props: State) {
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
-  const emptyText = getEmptyTableText(emptyTableStatus, 'databases');
+  const { emptyText, emptyHint } = getEmptyTableText(
+    emptyTableStatus,
+    'databases'
+  );
 
   return (
     <>
@@ -120,6 +123,7 @@ function DatabaseList(props: State) {
             ]}
             customSort={customSort}
             emptyText={emptyText}
+            emptyHint={emptyHint}
           />
           <SearchPagination prevPage={prevPage} nextPage={nextPage} />
         </DarkenWhileDisabled>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -32,7 +32,7 @@ import { DatabaseUri } from 'teleterm/ui/uri';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
-import { getEmptyTableText } from '../getEmptyTableText';
+import { getEmptyTableStatus, getEmptyTableText } from '../getEmptyTableText';
 
 import { useDatabases, State } from './useDatabases';
 
@@ -57,12 +57,12 @@ function DatabaseList(props: State) {
   const dbs = fetchAttempt.data?.agentsList.map(makeDatabase) || [];
   const disabled = fetchAttempt.status === 'processing';
   const loggedInUser = useWorkspaceLoggedInUser();
-  const emptyText = getEmptyTableText(
+  const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
-    'databases',
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
+  const emptyText = getEmptyTableText(emptyTableStatus, 'databases');
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -29,6 +29,7 @@ import { IAppContext } from 'teleterm/ui/types';
 import { GatewayProtocol } from 'teleterm/services/tshd/types';
 import { makeDatabase } from 'teleterm/ui/services/clusters';
 import { DatabaseUri } from 'teleterm/ui/uri';
+import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
 import { getEmptyTableText } from '../getEmptyTableText';
@@ -55,7 +56,13 @@ function DatabaseList(props: State) {
   } = props;
   const dbs = fetchAttempt.data?.agentsList.map(makeDatabase) || [];
   const disabled = fetchAttempt.status === 'processing';
-  const emptyText = getEmptyTableText(fetchAttempt.status, 'databases');
+  const loggedInUser = useWorkspaceLoggedInUser();
+  const emptyText = getEmptyTableText(
+    fetchAttempt.status,
+    'databases',
+    agentFilter.search || agentFilter.query,
+    loggedInUser?.acl?.tokens.create
+  );
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -28,11 +28,12 @@ import { retryWithRelogin } from 'teleterm/ui/utils';
 import { IAppContext } from 'teleterm/ui/types';
 import { GatewayProtocol } from 'teleterm/services/tshd/types';
 import { makeDatabase } from 'teleterm/ui/services/clusters';
-import { DatabaseUri } from 'teleterm/ui/uri';
+import { DatabaseUri, routing } from 'teleterm/ui/uri';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
 import { getEmptyTableStatus, getEmptyTableText } from '../getEmptyTableText';
+import { useClusterContext } from '../../clusterContext';
 
 import { useDatabases, State } from './useDatabases';
 
@@ -57,10 +58,13 @@ function DatabaseList(props: State) {
   const dbs = fetchAttempt.data?.agentsList.map(makeDatabase) || [];
   const disabled = fetchAttempt.status === 'processing';
   const loggedInUser = useWorkspaceLoggedInUser();
+  const { clusterUri } = useClusterContext();
+  const canAddResources =
+    routing.isRootCluster(clusterUri) && loggedInUser?.acl?.tokens.create;
   const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
     agentFilter.search || agentFilter.query,
-    loggedInUser?.acl?.tokens.create
+    canAddResources
   );
   const { emptyText, emptyHint } = getEmptyTableText(
     emptyTableStatus,

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -26,9 +26,11 @@ import { SearchPanel, SearchPagination } from 'shared/components/Search';
 
 import { makeKube } from 'teleterm/ui/services/clusters';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
+import { routing } from 'teleterm/ui/uri';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
 import { getEmptyTableStatus, getEmptyTableText } from '../getEmptyTableText';
+import { useClusterContext } from '../../clusterContext';
 
 import { useKubes, State } from './useKubes';
 
@@ -53,10 +55,13 @@ function KubeList(props: State) {
   const kubes = fetchAttempt.data?.agentsList.map(makeKube) || [];
   const disabled = fetchAttempt.status === 'processing';
   const loggedInUser = useWorkspaceLoggedInUser();
+  const { clusterUri } = useClusterContext();
+  const canAddResources =
+    routing.isRootCluster(clusterUri) && loggedInUser?.acl?.tokens.create;
   const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
     agentFilter.search || agentFilter.query,
-    loggedInUser?.acl?.tokens.create
+    canAddResources
   );
   const { emptyText, emptyHint } = getEmptyTableText(emptyTableStatus, 'kubes');
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -25,6 +25,7 @@ import { Danger } from 'design/Alert';
 import { SearchPanel, SearchPagination } from 'shared/components/Search';
 
 import { makeKube } from 'teleterm/ui/services/clusters';
+import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
 import { getEmptyTableText } from '../getEmptyTableText';
@@ -51,7 +52,13 @@ function KubeList(props: State) {
   } = props;
   const kubes = fetchAttempt.data?.agentsList.map(makeKube) || [];
   const disabled = fetchAttempt.status === 'processing';
-  const emptyText = getEmptyTableText(fetchAttempt.status, 'kubes');
+  const loggedInUser = useWorkspaceLoggedInUser();
+  const emptyText = getEmptyTableText(
+    fetchAttempt.status,
+    'kubes',
+    agentFilter.search || agentFilter.query,
+    loggedInUser?.acl?.tokens.create
+  );
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -58,7 +58,7 @@ function KubeList(props: State) {
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
-  const emptyText = getEmptyTableText(emptyTableStatus, 'kubes');
+  const { emptyText, emptyHint } = getEmptyTableText(emptyTableStatus, 'kubes');
 
   return (
     <>
@@ -100,6 +100,7 @@ function KubeList(props: State) {
             ]}
             customSort={customSort}
             emptyText={emptyText}
+            emptyHint={emptyHint}
           />
           <SearchPagination prevPage={prevPage} nextPage={nextPage} />
         </DarkenWhileDisabled>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -28,7 +28,7 @@ import { makeKube } from 'teleterm/ui/services/clusters';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
-import { getEmptyTableText } from '../getEmptyTableText';
+import { getEmptyTableStatus, getEmptyTableText } from '../getEmptyTableText';
 
 import { useKubes, State } from './useKubes';
 
@@ -53,12 +53,12 @@ function KubeList(props: State) {
   const kubes = fetchAttempt.data?.agentsList.map(makeKube) || [];
   const disabled = fetchAttempt.status === 'processing';
   const loggedInUser = useWorkspaceLoggedInUser();
-  const emptyText = getEmptyTableText(
+  const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
-    'kubes',
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
+  const emptyText = getEmptyTableText(emptyTableStatus, 'kubes');
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -69,7 +69,7 @@ function ServerList(props: State) {
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
-  let emptyText = getEmptyTableText(emptyTableStatus, 'servers');
+  let { emptyText, emptyHint } = getEmptyTableText(emptyTableStatus, 'servers');
   let emptyButton: JSX.Element;
 
   if (
@@ -78,8 +78,8 @@ function ServerList(props: State) {
     isRootCluster &&
     canUseConnectMyComputer
   ) {
-    emptyText =
-      'No servers found. You can add them in the Teleport Web UI or by connecting your computer to the cluster.';
+    emptyHint =
+      'You can add them in the Teleport Web UI or by connecting your computer to the cluster.';
     emptyButton = (
       <ButtonPrimary
         type="button"
@@ -143,6 +143,7 @@ function ServerList(props: State) {
             ]}
             customSort={customSort}
             emptyText={emptyText}
+            emptyHint={emptyHint}
             emptyButton={emptyButton}
             data={servers}
           />

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -63,11 +63,12 @@ function ServerList(props: State) {
   const servers = fetchAttempt.data?.agentsList.map(makeServer) || [];
   const disabled = fetchAttempt.status === 'processing';
   const isRootCluster = clusterUri === rootClusterUri;
+  const canAddResources = isRootCluster && loggedInUser?.acl?.tokens.create;
 
   const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
     agentFilter.search || agentFilter.query,
-    loggedInUser?.acl?.tokens.create
+    canAddResources
   );
   let { emptyText, emptyHint } = getEmptyTableText(emptyTableStatus, 'servers');
   let emptyButton: JSX.Element;

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -24,6 +24,7 @@ import { MenuLogin } from 'shared/components/MenuLogin';
 import { SearchPanel, SearchPagination } from 'shared/components/Search';
 
 import { makeServer } from 'teleterm/ui/services/clusters';
+import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
 import { getEmptyTableText } from '../getEmptyTableText';
@@ -51,7 +52,13 @@ function ServerList(props: State) {
   } = props;
   const servers = fetchAttempt.data?.agentsList.map(makeServer) || [];
   const disabled = fetchAttempt.status === 'processing';
-  const emptyText = getEmptyTableText(fetchAttempt.status, 'servers');
+  const loggedInUser = useWorkspaceLoggedInUser();
+  const emptyText = getEmptyTableText(
+    fetchAttempt.status,
+    'servers',
+    agentFilter.search || agentFilter.query,
+    loggedInUser?.acl?.tokens.create
+  );
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -27,7 +27,7 @@ import { makeServer } from 'teleterm/ui/services/clusters';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 
 import { DarkenWhileDisabled } from '../DarkenWhileDisabled';
-import { getEmptyTableText } from '../getEmptyTableText';
+import { getEmptyTableStatus, getEmptyTableText } from '../getEmptyTableText';
 
 import { useServers, State } from './useServers';
 
@@ -53,12 +53,12 @@ function ServerList(props: State) {
   const servers = fetchAttempt.data?.agentsList.map(makeServer) || [];
   const disabled = fetchAttempt.status === 'processing';
   const loggedInUser = useWorkspaceLoggedInUser();
-  const emptyText = getEmptyTableText(
+  const emptyTableStatus = getEmptyTableStatus(
     fetchAttempt.status,
-    'servers',
     agentFilter.search || agentFilter.query,
     loggedInUser?.acl?.tokens.create
   );
+  const emptyText = getEmptyTableText(emptyTableStatus, 'servers');
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/getEmptyTableText.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/getEmptyTableText.ts
@@ -62,16 +62,21 @@ export function getEmptyTableStatus(
 export function getEmptyTableText(
   status: EmptyTableStatus,
   pluralResourceNoun: string
-) {
+): { emptyText: string; emptyHint: string } {
   switch (status.status) {
     case 'error':
-      return `Failed to fetch ${pluralResourceNoun}.`;
+      return {
+        emptyText: `Failed to fetch ${pluralResourceNoun}.`,
+        emptyHint: undefined,
+      };
     case 'processing':
-      return 'Searching…';
+      return {
+        emptyText: 'Searching…',
+        emptyHint: undefined,
+      };
     case 'no-resources': {
-      let message = `No ${pluralResourceNoun} found.`;
-
-      if (status.showEnrollingResourcesHint) {
+      return {
+        emptyText: `No ${pluralResourceNoun} found.`,
         // TODO(ravicious): It'd be nice to include a link to Discover. However, all external links
         // opened by the browser need to be allowlisted (see setWindowOpenHandler), so we should
         // allow opening links only to the currently active cluster and its leafs.
@@ -84,9 +89,10 @@ export function getEmptyTableText(
         // and the main process should get a list of clusters from the tsh daemon.
         //
         // This is time consuming to set up, so for now we're skipping the link.
-        message += ' You can add them in the Teleport Web UI.';
-      }
-      return message;
+        emptyHint: status.showEnrollingResourcesHint
+          ? 'You can add them in the Teleport Web UI.'
+          : undefined,
+      };
     }
     default: {
       assertUnreachable(status);

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import AppContextProvider from 'teleterm/ui/appContextProvider';
@@ -24,11 +24,17 @@ import {
   ClustersServiceState,
 } from 'teleterm/ui/services/clusters';
 import { routing } from 'teleterm/ui/uri';
-import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeRootCluster,
+  makeServer,
+} from 'teleterm/services/tshd/testHelpers';
 
-import * as docTypes from '../services/workspacesService/documentsService/types';
+import { ResourcesService } from 'teleterm/ui/services/resources';
+import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
+import * as docTypes from 'teleterm/ui/services/workspacesService/documentsService/types';
 
 import DocumentCluster from './DocumentCluster';
+import { ResourcesContextProvider } from './resourcesContext';
 
 export default {
   title: 'Teleterm/DocumentCluster',
@@ -48,18 +54,96 @@ const leafClusterDoc = {
   title: 'sample',
 };
 
-export const Online = () => {
+export const OnlineEmptyResources = () => {
   const state = createClusterServiceState();
   state.clusters.set(
     rootClusterDoc.clusterUri,
     makeRootCluster({
       uri: rootClusterDoc.clusterUri,
-      name: 'localhost',
-      proxyHost: 'localhost:3080',
     })
   );
 
-  return renderState(state, rootClusterDoc);
+  return renderState({
+    state,
+    doc: rootClusterDoc,
+    fetchServersPromise: Promise.resolve({
+      agentsList: [],
+      totalCount: 0,
+      startKey: '',
+    }),
+  });
+};
+
+export const OnlineLoadingResources = () => {
+  const state = createClusterServiceState();
+  state.clusters.set(
+    rootClusterDoc.clusterUri,
+    makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    })
+  );
+
+  let rejectPromise: () => void;
+  const promiseRejectedOnUnmount = new Promise<any>((resolve, reject) => {
+    rejectPromise = reject;
+  });
+
+  useEffect(() => {
+    return () => {
+      rejectPromise();
+    };
+  }, [rejectPromise]);
+
+  return renderState({
+    state,
+    doc: rootClusterDoc,
+    fetchServersPromise: promiseRejectedOnUnmount,
+  });
+};
+
+export const OnlineLoadedResources = () => {
+  const state = createClusterServiceState();
+  state.clusters.set(
+    rootClusterDoc.clusterUri,
+    makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    })
+  );
+
+  return renderState({
+    state,
+    doc: rootClusterDoc,
+    fetchServersPromise: Promise.resolve({
+      agentsList: [
+        makeServer(),
+        makeServer({
+          uri: '/clusters/foo/servers/1234',
+          hostname: 'bar',
+          tunnel: true,
+        }),
+      ],
+      totalCount: 2,
+      startKey: '',
+    }),
+  });
+};
+
+export const OnlineErrorLoadingResources = () => {
+  const state = createClusterServiceState();
+  state.clusters.set(
+    rootClusterDoc.clusterUri,
+    makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    })
+  );
+
+  return renderState({
+    state,
+    doc: rootClusterDoc,
+    fetchServersPromise: Promise.reject(
+      new Error('Whoops, something went wrong, sorry!')
+    ),
+  });
 };
 
 export const Offline = () => {
@@ -67,14 +151,12 @@ export const Offline = () => {
   state.clusters.set(
     rootClusterDoc.clusterUri,
     makeRootCluster({
+      connected: false,
       uri: rootClusterDoc.clusterUri,
-      name: 'localhost',
-      proxyHost: 'localhost:3080',
-      authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
     })
   );
 
-  return renderState(state, rootClusterDoc);
+  return renderState({ state, doc: rootClusterDoc });
 };
 
 export const Notfound = () => {
@@ -83,17 +165,20 @@ export const Notfound = () => {
     rootClusterDoc.clusterUri,
     makeRootCluster({
       uri: rootClusterDoc.clusterUri,
-      name: 'localhost',
-      proxyHost: 'localhost:3080',
     })
   );
-  return renderState(state, leafClusterDoc);
+  return renderState({ state, doc: leafClusterDoc });
 };
 
-function renderState(
-  state: ClustersServiceState,
-  doc: docTypes.DocumentCluster
-) {
+function renderState({
+  state,
+  doc,
+  fetchServersPromise,
+}: {
+  state: ClustersServiceState;
+  doc: docTypes.DocumentCluster;
+  fetchServersPromise?: ReturnType<ResourcesService['fetchServers']>;
+}) {
   const appContext = new MockAppContext();
   appContext.clustersService.state = state;
 
@@ -108,11 +193,18 @@ function renderState(
     };
   });
 
+  appContext.resourcesService.fetchServers = () =>
+    fetchServersPromise || Promise.reject('No fetchServersPromise passed');
+
   return (
     <AppContextProvider value={appContext}>
-      <Wrapper>
-        <DocumentCluster visible={true} doc={doc} />
-      </Wrapper>
+      <MockWorkspaceContextProvider>
+        <ResourcesContextProvider>
+          <Wrapper>
+            <DocumentCluster visible={true} doc={doc} />
+          </Wrapper>
+        </ResourcesContextProvider>
+      </MockWorkspaceContextProvider>
     </AppContextProvider>
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -25,6 +25,7 @@ import {
 } from 'teleterm/ui/services/clusters';
 import { routing } from 'teleterm/ui/uri';
 import {
+  makeLoggedInUser,
   makeRootCluster,
   makeServer,
 } from 'teleterm/services/tshd/testHelpers';
@@ -54,12 +55,56 @@ const leafClusterDoc = {
   title: 'sample',
 };
 
-export const OnlineEmptyResources = () => {
+export const OnlineEmptyResourcesAndCanAddResources = () => {
   const state = createClusterServiceState();
   state.clusters.set(
     rootClusterDoc.clusterUri,
     makeRootCluster({
       uri: rootClusterDoc.clusterUri,
+      loggedInUser: makeLoggedInUser({
+        acl: {
+          tokens: {
+            create: true,
+            list: true,
+            edit: true,
+            pb_delete: true,
+            read: true,
+            use: true,
+          },
+        },
+      }),
+    })
+  );
+
+  return renderState({
+    state,
+    doc: rootClusterDoc,
+    fetchServersPromise: Promise.resolve({
+      agentsList: [],
+      totalCount: 0,
+      startKey: '',
+    }),
+  });
+};
+
+export const OnlineEmptyResourcesAndCannotAddResources = () => {
+  const state = createClusterServiceState();
+  state.clusters.set(
+    rootClusterDoc.clusterUri,
+    makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+      loggedInUser: makeLoggedInUser({
+        acl: {
+          tokens: {
+            create: false,
+            list: true,
+            edit: true,
+            pb_delete: true,
+            read: true,
+            use: true,
+          },
+        },
+      }),
     })
   );
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen } from 'design/utils/testing';
+
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
+import {
+  makeRootCluster,
+  makeLoggedInUser,
+} from 'teleterm/services/tshd/testHelpers';
+import * as tsh from 'teleterm/services/tshd/types';
+import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer';
+
+import { ResourcesContextProvider } from './resourcesContext';
+
+import DocumentCluster from '.';
+
+it('displays a button for Connect My Computer in the empty state if the user can use Connect My Computer', async () => {
+  const doc = {
+    kind: 'doc.cluster' as const,
+    clusterUri: '/clusters/localhost' as const,
+    uri: '/docs/123' as const,
+    title: 'sample',
+  };
+
+  const appContext = new MockAppContext({ platform: 'darwin' });
+  appContext.clustersService.setState(draft => {
+    draft.clusters.set(
+      doc.clusterUri,
+      makeRootCluster({
+        uri: doc.clusterUri,
+        loggedInUser: makeLoggedInUser({
+          userType: tsh.UserType.USER_TYPE_LOCAL,
+          acl: {
+            tokens: {
+              create: true,
+              list: true,
+              edit: true,
+              pb_delete: true,
+              read: true,
+              use: true,
+            },
+          },
+        }),
+      })
+    );
+  });
+
+  appContext.workspacesService.setState(draftState => {
+    const rootClusterUri = doc.clusterUri;
+    draftState.rootClusterUri = rootClusterUri;
+    draftState.workspaces[rootClusterUri] = {
+      localClusterUri: doc.clusterUri,
+      documents: [doc],
+      location: doc.uri,
+      accessRequests: undefined,
+    };
+  });
+
+  const emptyResponse = {
+    agentsList: [],
+    totalCount: 0,
+    startKey: '',
+  };
+  jest
+    .spyOn(appContext.resourcesService, 'fetchServers')
+    .mockResolvedValue(emptyResponse);
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={doc.clusterUri}>
+            <DocumentCluster doc={doc} visible={true} />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  await expect(
+    screen.findByRole('button', { name: 'Connect My Computer' })
+  ).resolves.toBeInTheDocument();
+});
+
+it('does not display a button for Connect My Computer in the empty state if the user cannot use Connect My Computer', async () => {
+  const doc = {
+    kind: 'doc.cluster' as const,
+    clusterUri: '/clusters/localhost' as const,
+    uri: '/docs/123' as const,
+    title: 'sample',
+  };
+
+  const appContext = new MockAppContext({ platform: 'linux' });
+  appContext.clustersService.setState(draft => {
+    draft.clusters.set(
+      doc.clusterUri,
+      makeRootCluster({
+        uri: doc.clusterUri,
+        loggedInUser: makeLoggedInUser({
+          userType: tsh.UserType.USER_TYPE_LOCAL,
+          acl: {
+            tokens: {
+              create: false,
+              list: true,
+              edit: true,
+              pb_delete: true,
+              read: true,
+              use: true,
+            },
+          },
+        }),
+      })
+    );
+  });
+
+  appContext.workspacesService.setState(draftState => {
+    const rootClusterUri = doc.clusterUri;
+    draftState.rootClusterUri = rootClusterUri;
+    draftState.workspaces[rootClusterUri] = {
+      localClusterUri: doc.clusterUri,
+      documents: [doc],
+      location: doc.uri,
+      accessRequests: undefined,
+    };
+  });
+
+  const emptyResponse = {
+    agentsList: [],
+    totalCount: 0,
+    startKey: '',
+  };
+  jest
+    .spyOn(appContext.resourcesService, 'fetchServers')
+    .mockResolvedValue(emptyResponse);
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={doc.clusterUri}>
+            <DocumentCluster doc={doc} visible={true} />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  await expect(
+    screen.findByText('No servers found.')
+  ).resolves.toBeInTheDocument();
+
+  expect(
+    screen.queryByRole('button', { name: 'Connect My Computer' })
+  ).not.toBeInTheDocument();
+});

--- a/web/packages/teleterm/src/ui/fixtures/MockWorkspaceContextProvider.tsx
+++ b/web/packages/teleterm/src/ui/fixtures/MockWorkspaceContextProvider.tsx
@@ -21,23 +21,26 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 export const MockWorkspaceContextProvider: React.FC<{
-  rootClusterUri: RootClusterUri;
+  rootClusterUri?: RootClusterUri;
 }> = props => {
   const appContext = useAppContext();
+
+  const rootClusterUri =
+    props.rootClusterUri || appContext.workspacesService.getRootClusterUri();
 
   return (
     <WorkspaceContextProvider
       value={{
         accessRequestsService:
           appContext.workspacesService.getWorkspaceAccessRequestsService(
-            props.rootClusterUri
+            rootClusterUri
           ),
         documentsService:
           appContext.workspacesService.getWorkspaceDocumentService(
-            props.rootClusterUri
+            rootClusterUri
           ),
-        localClusterUri: props.rootClusterUri,
-        rootClusterUri: props.rootClusterUri,
+        localClusterUri: rootClusterUri,
+        rootClusterUri,
       }}
     >
       {props.children}

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -181,6 +181,10 @@ export const routing = {
     return match && Boolean(match.params.leafClusterId);
   },
 
+  isRootCluster(clusterUri: ClusterUri) {
+    return !this.isLeafCluster(clusterUri);
+  },
+
   belongsToProfile(
     clusterUri: ClusterOrResourceUri,
     resourceUri: ClusterOrResourceUri


### PR DESCRIPTION
![cmc button](https://github.com/gravitational/teleport/assets/27113/b8a470f4-c03b-4e1c-89ed-800052e8c794)

Closes #32187.

[Figma](https://www.figma.com/file/jeKtOZrFsIVOtKH7yd8Xiy/Connect-My-Computer-UI?type=design&node-id=118-7026&mode=design&t=2NG1Rq58EUreItK0-4).

I did not add a link to the Web UI because allowlisting Web UI address would require considerably more work, [see the comment in `getEmptyTableText`](https://github.com/gravitational/teleport/blob/72fb20aa4861603fde39ef16ad4a3701e240848c/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/getEmptyTableText.ts#L75-L87) for more details. I'm going to note this debt in [the tracking issue](https://github.com/gravitational/teleport/issues/32185) and come back to it if I end up having some extra time.