### PR TITLE
Remove device trust relationship as an example of token:create permis…

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -383,8 +383,7 @@ spec:
 
 With these permissions, users assigned to the role can generate tokens to enroll  
 a server, application, or database, establish a trust relationship between a root 
-cluster and a new Teleport Proxy Service or leaf cluster, or configure a device 
-trust relationship for a managed device.
+cluster and a new Teleport Proxy Service, or add a new leaf cluster.
 
 Because the token resource isn't scoped to a specific context, such as a node or 
 trusted cluster, you should consider any role that provides token permissions to be 


### PR DESCRIPTION
…sions

Previously, device trust was included as an example:

> With these permissions, users assigned to the role can generate tokens to enroll
> a server, application, or database, establish a trust relationship between a root cluster and a new Teleport Proxy Service or leaf cluster, or configure a device trust relationship for a managed device.

Based on the request:

> The ability to create a join token is a sensitive action within Teleport. Currently the role to create join tokens is not scoped, allowing the creation of any type of join token. This means that the same permissions that allow you to join a server also could establish an entire new proxy / leaf, or also establish a Device Trust relationship through MDM (https://github.com/gravitational/teleport.e/pull/1018#discussion_r1156604808). The ability for the joining to influence the configuration and state of your cluster may result in unexpected security concerns, for that reason you should consider the ability to create join token's akin to an administrative role.

This PR removes that example.