### PR TITLE
Report exit code of rsync processes if they fail in TestWithRsync

### DIFF
--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -481,12 +481,12 @@ func TestWithRsync(t *testing.T) {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			err = cmd.Run()
-			if !assert.NoError(t, err) {
-				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					t.Logf("exit code: %d", exitErr.ExitCode())
-				}
+			var msg string
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				msg = fmt.Sprintf("exit code: %d", exitErr.ExitCode())
 			}
+			require.NoError(t, err, msg)
 
 			// verify that dst exists and that its contents match src
 			dstContents, err := os.ReadFile(dstPath)

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -330,7 +330,7 @@ func TestWithRsync(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				require.EventuallyWithT(t, func(t *assert.CollectT) {
 					pref, err := asrv.GetAuthPreference(ctx)
 					if !assert.NoError(t, err) {
 						return


### PR DESCRIPTION
While at it fix incorrect use of `require` assertions inside of a `require.Eventually` call.