### PR TITLE
Fixes emitting wrong events for ec2 discover flow

### DIFF
--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -1051,7 +1051,7 @@ func ConvertUsageEvent(event *usageeventsv1.UsageEventOneOf, userMD UserMetadata
 
 		return ret, nil
 	case *usageeventsv1.UsageEventOneOf_UiDiscoverDeployEice:
-		ret := &UIDiscoverAutoDiscoveredResourcesEvent{
+		ret := &UIDiscoverDeployEICEEvent{
 			Metadata: discoverMetadataToPrehog(e.UiDiscoverDeployEice.Metadata, userMD),
 			Resource: discoverResourceToPrehog(e.UiDiscoverDeployEice.Resource),
 			Status:   discoverStatusToPrehog(e.UiDiscoverDeployEice.Status),
@@ -1062,7 +1062,7 @@ func ConvertUsageEvent(event *usageeventsv1.UsageEventOneOf, userMD UserMetadata
 
 		return ret, nil
 	case *usageeventsv1.UsageEventOneOf_UiDiscoverCreateNode:
-		ret := &UIDiscoverAutoDiscoveredResourcesEvent{
+		ret := &UIDiscoverCreateNodeEvent{
 			Metadata: discoverMetadataToPrehog(e.UiDiscoverCreateNode.Metadata, userMD),
 			Resource: discoverResourceToPrehog(e.UiDiscoverCreateNode.Resource),
 			Status:   discoverStatusToPrehog(e.UiDiscoverCreateNode.Status),

--- a/lib/usagereporter/teleport/types_discover.go
+++ b/lib/usagereporter/teleport/types_discover.go
@@ -397,7 +397,7 @@ func (u *UIDiscoverDeployEICEEvent) Anonymize(a utils.Anonymizer) prehogv1a.Subm
 }
 
 // UIDiscoverCreateNodeEvent is emitted when the node is created in Teleport.
-type UIDiscoverCreateNodeEvent prehogv1a.UIDiscoverDeployEICEEvent
+type UIDiscoverCreateNodeEvent prehogv1a.UIDiscoverCreateNodeEvent
 
 func (u *UIDiscoverCreateNodeEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))

--- a/lib/usagereporter/teleport/usagereporter_test.go
+++ b/lib/usagereporter/teleport/usagereporter_test.go
@@ -261,6 +261,75 @@ func TestConvertUsageEvent(t *testing.T) {
 			}},
 		},
 		{
+			name: "discover create node event",
+			event: &usageeventsv1.UsageEventOneOf{Event: &usageeventsv1.UsageEventOneOf_UiDiscoverCreateNode{
+				UiDiscoverCreateNode: &usageeventsv1.UIDiscoverCreateNodeEvent{
+					Metadata: &usageeventsv1.DiscoverMetadata{Id: "someid"},
+					Resource: &usageeventsv1.DiscoverResourceMetadata{Resource: usageeventsv1.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &usageeventsv1.DiscoverStepStatus{Status: usageeventsv1.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+			identityUsername: "myuser",
+			errCheck:         require.NoError,
+			expected: &prehogv1a.SubmitEventRequest{Event: &prehogv1a.SubmitEventRequest_UiDiscoverCreateNode{
+				UiDiscoverCreateNode: &prehogv1a.UIDiscoverCreateNodeEvent{
+					Metadata: &prehogv1a.DiscoverMetadata{
+						Id:       "someid",
+						UserName: expectedAnonymizedUserString,
+						Sso:      false,
+					},
+					Resource: &prehogv1a.DiscoverResourceMetadata{Resource: prehogv1a.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &prehogv1a.DiscoverStepStatus{Status: prehogv1a.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+		},
+		{
+			name: "discover deploy eice event",
+			event: &usageeventsv1.UsageEventOneOf{Event: &usageeventsv1.UsageEventOneOf_UiDiscoverDeployEice{
+				UiDiscoverDeployEice: &usageeventsv1.UIDiscoverDeployEICEEvent{
+					Metadata: &usageeventsv1.DiscoverMetadata{Id: "someid"},
+					Resource: &usageeventsv1.DiscoverResourceMetadata{Resource: usageeventsv1.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &usageeventsv1.DiscoverStepStatus{Status: usageeventsv1.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+			identityUsername: "myuser",
+			errCheck:         require.NoError,
+			expected: &prehogv1a.SubmitEventRequest{Event: &prehogv1a.SubmitEventRequest_UiDiscoverDeployEice{
+				UiDiscoverDeployEice: &prehogv1a.UIDiscoverDeployEICEEvent{
+					Metadata: &prehogv1a.DiscoverMetadata{
+						Id:       "someid",
+						UserName: expectedAnonymizedUserString,
+						Sso:      false,
+					},
+					Resource: &prehogv1a.DiscoverResourceMetadata{Resource: prehogv1a.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &prehogv1a.DiscoverStepStatus{Status: prehogv1a.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+		},
+		{
+			name: "discover ec2 instance selection event",
+			event: &usageeventsv1.UsageEventOneOf{Event: &usageeventsv1.UsageEventOneOf_UiDiscoverEc2InstanceSelection{
+				UiDiscoverEc2InstanceSelection: &usageeventsv1.UIDiscoverEC2InstanceSelectionEvent{
+					Metadata: &usageeventsv1.DiscoverMetadata{Id: "someid"},
+					Resource: &usageeventsv1.DiscoverResourceMetadata{Resource: usageeventsv1.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &usageeventsv1.DiscoverStepStatus{Status: usageeventsv1.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+			identityUsername: "myuser",
+			errCheck:         require.NoError,
+			expected: &prehogv1a.SubmitEventRequest{Event: &prehogv1a.SubmitEventRequest_UiDiscoverEc2InstanceSelection{
+				UiDiscoverEc2InstanceSelection: &prehogv1a.UIDiscoverEC2InstanceSelectionEvent{
+					Metadata: &prehogv1a.DiscoverMetadata{
+						Id:       "someid",
+						UserName: expectedAnonymizedUserString,
+						Sso:      false,
+					},
+					Resource: &prehogv1a.DiscoverResourceMetadata{Resource: prehogv1a.DiscoverResource_DISCOVER_RESOURCE_EC2_INSTANCE},
+					Status:   &prehogv1a.DiscoverStepStatus{Status: prehogv1a.DiscoverStatus_DISCOVER_STATUS_SUCCESS},
+				},
+			}},
+		},
+		{
 			name: "access list create event",
 			event: &usageeventsv1.UsageEventOneOf{Event: &usageeventsv1.UsageEventOneOf_AccessListCreate{
 				AccessListCreate: &usageeventsv1.AccessListCreate{


### PR DESCRIPTION
manually tested with https://reporting-dev-onprem.platform.teleport.sh/events (on cloud dev `...trunk.cloud.teleportinfra.dev`) as well as wrote the test that caught the same issue

from: 
![image](https://github.com/gravitational/teleport/assets/43280172/a0c8d951-8c52-4763-ad9e-e3507c1680a2)


fixed: 
<img width="997" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/469c3386-4f8a-40d3-8c66-ceee7ba97937">

