### PR TITLE
Implement Create/Update for auth connectors

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -861,24 +861,33 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	s := newAuthSuite(t)
 
 	ctx := context.Background()
-	// test github create event
 	github, err := types.NewGithubConnector("test", types.GithubConnectorSpecV3{
-		TeamsToLogins: []types.TeamMapping{
+		TeamsToRoles: []types.TeamRolesMapping{
 			{
 				Organization: "octocats",
 				Team:         "dummy",
-				Logins:       []string{"dummy"},
+				Roles:        []string{"dummy"},
 			},
 		},
 	})
+	// test github create event
 	require.NoError(t, err)
-	err = s.a.upsertGithubConnector(ctx, github)
+	github, err = s.a.createGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test github update event
+	github.SetDisplay("llama")
+	github, err = s.a.updateGithubConnector(ctx, github)
+	require.NoError(t, err)
+	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
+	s.mockEmitter.Reset()
+
+	// test github upsert event
+	github.SetDisplay("alpaca")
 	err = s.a.upsertGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
@@ -897,7 +906,6 @@ func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
 	s := newAuthSuite(t)
 
 	ctx := context.Background()
-	// test oidc create event
 	oidc, err := types.NewOIDCConnector("test", types.OIDCConnectorSpecV3{
 		ClientID: "a",
 		ClaimsToRoles: []types.ClaimMapping{
@@ -910,13 +918,24 @@ func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
 		RedirectURLs: []string{"https://proxy.example.com/v1/webapi/oidc/callback"},
 	})
 	require.NoError(t, err)
-	err = s.a.UpsertOIDCConnector(ctx, oidc)
+
+	// test oidc create event
+	oidc, err = s.a.CreateOIDCConnector(ctx, oidc)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test oidc update event
+	oidc.SetDisplay("llama")
+	oidc, err = s.a.UpdateOIDCConnector(ctx, oidc)
+	require.NoError(t, err)
+	require.IsType(t, &apievents.OIDCConnectorCreate{}, s.mockEmitter.LastEvent())
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
+	s.mockEmitter.Reset()
+
+	// test oidc upsert event
+	oidc.SetDisplay("alpaca")
 	err = s.a.UpsertOIDCConnector(ctx, oidc)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorCreate{}, s.mockEmitter.LastEvent())
@@ -957,7 +976,6 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 	err = s.a.CreateRole(ctx, role)
 	require.NoError(t, err)
 
-	// test saml create
 	saml, err := types.NewSAMLConnector("test", types.SAMLConnectorSpecV2{
 		AssertionConsumerService: "a",
 		Issuer:                   "b",
@@ -973,13 +991,23 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.a.UpsertSAMLConnector(ctx, saml)
+	// test saml create
+	saml, err = s.a.CreateSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test saml update event
+	saml.SetDisplay("llama")
+	saml, err = s.a.UpdateSAMLConnector(ctx, saml)
+	require.NoError(t, err)
+	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
+	s.mockEmitter.Reset()
+
+	// test saml upsert event
+	saml.SetDisplay("alapaca")
 	err = s.a.UpsertSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -494,7 +494,11 @@ type WebService interface {
 
 // IdentityService manages identities and users
 type IdentityService interface {
-	// UpsertOIDCConnector updates or creates OIDC connector
+	// CreateOIDCConnector creates a new OIDC connector.
+	CreateOIDCConnector(ctx context.Context, connector types.OIDCConnector) (types.OIDCConnector, error)
+	// UpdateOIDCConnector updates an existing OIDC connector.
+	UpdateOIDCConnector(ctx context.Context, connector types.OIDCConnector) (types.OIDCConnector, error)
+	// UpsertOIDCConnector updates or creates an OIDC connector.
 	UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) error
 	// GetOIDCConnector returns OIDC connector information by id
 	GetOIDCConnector(ctx context.Context, id string, withSecrets bool) (types.OIDCConnector, error)
@@ -509,7 +513,11 @@ type IdentityService interface {
 	// ValidateOIDCAuthCallback validates OIDC auth callback returned from redirect
 	ValidateOIDCAuthCallback(ctx context.Context, q url.Values) (*OIDCAuthResponse, error)
 
-	// UpsertSAMLConnector updates or creates SAML connector
+	// CreateSAMLConnector creates a new SAML connector.
+	CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	// UpdateSAMLConnector updates an existing SAML connector
+	UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	// UpsertSAMLConnector updates or creates a SAML connector
 	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error
 	// GetSAMLConnector returns SAML connector information by id
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
@@ -524,7 +532,11 @@ type IdentityService interface {
 	// GetSAMLAuthRequest returns SAML auth request if found
 	GetSAMLAuthRequest(ctx context.Context, authRequestID string) (*types.SAMLAuthRequest, error)
 
-	// UpsertGithubConnector creates or updates a Github connector
+	// CreateGithubConnector creates a new Github connector.
+	CreateGithubConnector(ctx context.Context, connector types.GithubConnector) (types.GithubConnector, error)
+	// UpdateGithubConnector updates an existing Github connector.
+	UpdateGithubConnector(ctx context.Context, connector types.GithubConnector) (types.GithubConnector, error)
+	// UpsertGithubConnector creates or updates a Github connector.
 	UpsertGithubConnector(ctx context.Context, connector types.GithubConnector) error
 	// GetGithubConnectors returns all configured Github connectors
 	GetGithubConnectors(ctx context.Context, withSecrets bool) ([]types.GithubConnector, error)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2950,6 +2950,46 @@ func (g *GRPCServer) GetOIDCConnectors(ctx context.Context, req *types.Resources
 	}, nil
 }
 
+// CreateOIDCConnector creates a new OIDC connector.
+func (g *GRPCServer) CreateOIDCConnector(ctx context.Context, req *authpb.CreateOIDCConnectorRequest) (*types.OIDCConnectorV3, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := auth.ServerWithRoles.CreateOIDCConnector(ctx, req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	v3, ok := created.(*types.OIDCConnectorV3)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected OIDC connector type: %T", created)
+	}
+
+	return v3, nil
+}
+
+// UpdateOIDCConnector updates an existing OIDC connector.
+func (g *GRPCServer) UpdateOIDCConnector(ctx context.Context, req *authpb.UpdateOIDCConnectorRequest) (*types.OIDCConnectorV3, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := auth.ServerWithRoles.UpdateOIDCConnector(ctx, req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	v3, ok := updated.(*types.OIDCConnectorV3)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected OIDC connector type: %T", updated)
+	}
+
+	return v3, nil
+}
+
 // UpsertOIDCConnector upserts an OIDC connector.
 func (g *GRPCServer) UpsertOIDCConnector(ctx context.Context, oidcConnector *types.OIDCConnectorV3) (*emptypb.Empty, error) {
 	auth, err := g.authenticate(ctx)
@@ -3037,6 +3077,46 @@ func (g *GRPCServer) GetSAMLConnectors(ctx context.Context, req *types.Resources
 	return &types.SAMLConnectorV2List{
 		SAMLConnectors: samlConnectorsV2,
 	}, nil
+}
+
+// CreateSAMLConnector creates a new SAML connector.
+func (g *GRPCServer) CreateSAMLConnector(ctx context.Context, req *authpb.CreateSAMLConnectorRequest) (*types.SAMLConnectorV2, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := auth.ServerWithRoles.CreateSAMLConnector(ctx, req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	v2, ok := created.(*types.SAMLConnectorV2)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected SAML connector type: %T", created)
+	}
+
+	return v2, nil
+}
+
+// UpdateSAMLConnector updates an existing SAML connector.
+func (g *GRPCServer) UpdateSAMLConnector(ctx context.Context, req *authpb.UpdateSAMLConnectorRequest) (*types.SAMLConnectorV2, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := auth.ServerWithRoles.UpdateSAMLConnector(ctx, req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	v2, ok := updated.(*types.SAMLConnectorV2)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected SAML connector type: %T", updated)
+	}
+
+	return v2, nil
 }
 
 // UpsertSAMLConnector upserts a SAML connector.
@@ -3142,6 +3222,52 @@ func (g *GRPCServer) UpsertGithubConnector(ctx context.Context, connector *types
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, nil
+}
+
+// UpdateGithubConnector updates an existing Github connector.
+func (g *GRPCServer) UpdateGithubConnector(ctx context.Context, req *authpb.UpdateGithubConnectorRequest) (*types.GithubConnectorV3, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	githubConnector, err := services.InitGithubConnector(req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := auth.ServerWithRoles.UpdateGithubConnector(ctx, githubConnector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	githubConnectorV3, ok := updated.(*types.GithubConnectorV3)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected GitHub connector type: %T", updated)
+	}
+	return githubConnectorV3, nil
+}
+
+// CreateGithubConnector creates a new  Github connector.
+func (g *GRPCServer) CreateGithubConnector(ctx context.Context, req *authpb.CreateGithubConnectorRequest) (*types.GithubConnectorV3, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	githubConnector, err := services.InitGithubConnector(req.Connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := auth.ServerWithRoles.CreateGithubConnector(ctx, githubConnector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	githubConnectorV3, ok := created.(*types.GithubConnectorV3)
+	if !ok {
+		return nil, trace.Errorf("encountered unexpected GitHub connector type: %T", created)
+	}
+	return githubConnectorV3, nil
 }
 
 // DeleteGithubConnector deletes a Github connector by name.

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -75,6 +75,62 @@ func (a *Server) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 	return nil
 }
 
+// UpdateSAMLConnector updates an existing SAML connector.
+func (a *Server) UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
+	// Validate the SAML connector here, because even though Services.UpsertSAMLConnector
+	// also validates, it does not have a RoleGetter to use to validate the roles, so
+	// has to pass `nil` for the second argument.
+	if err := services.ValidateSAMLConnector(connector, a); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	updated, err := a.Services.UpdateSAMLConnector(ctx, connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.emitter.EmitAuditEvent(ctx, &apievents.SAMLConnectorCreate{
+		Metadata: apievents.Metadata{
+			Type: events.SAMLConnectorCreatedEvent,
+			Code: events.SAMLConnectorCreatedCode,
+		},
+		UserMetadata: authz.ClientUserMetadata(ctx),
+		ResourceMetadata: apievents.ResourceMetadata{
+			Name: connector.GetName(),
+		},
+	}); err != nil {
+		log.WithError(err).Warn("Failed to emit SAML connector create event.")
+	}
+
+	return updated, nil
+}
+
+// CreateSAMLConnector creates a new SAML connector.
+func (a *Server) CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
+	// Validate the SAML connector here, because even though Services.UpsertSAMLConnector
+	// also validates, it does not have a RoleGetter to use to validate the roles, so
+	// has to pass `nil` for the second argument.
+	if err := services.ValidateSAMLConnector(connector, a); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	created, err := a.Services.CreateSAMLConnector(ctx, connector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.emitter.EmitAuditEvent(ctx, &apievents.SAMLConnectorCreate{
+		Metadata: apievents.Metadata{
+			Type: events.SAMLConnectorCreatedEvent,
+			Code: events.SAMLConnectorCreatedCode,
+		},
+		UserMetadata: authz.ClientUserMetadata(ctx),
+		ResourceMetadata: apievents.ResourceMetadata{
+			Name: connector.GetName(),
+		},
+	}); err != nil {
+		log.WithError(err).Warn("Failed to emit SAML connector create event.")
+	}
+
+	return created, nil
+}
+
 // DeleteSAMLConnector deletes a SAML connector.
 func (a *Server) DeleteSAMLConnector(ctx context.Context, connectorID string) error {
 	if err := a.Services.DeleteSAMLConnector(ctx, connectorID); err != nil {

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -163,7 +163,11 @@ type Identity interface {
 	// DeleteMFADevice deletes an MFA device for the user by ID.
 	DeleteMFADevice(ctx context.Context, user, id string) error
 
-	// UpsertOIDCConnector upserts OIDC Connector
+	// CreateOIDCConnector creates a new OIDC connector.
+	CreateOIDCConnector(ctx context.Context, connector types.OIDCConnector) (types.OIDCConnector, error)
+	// UpdateOIDCConnector updates an existing OIDC connector.
+	UpdateOIDCConnector(ctx context.Context, connector types.OIDCConnector) (types.OIDCConnector, error)
+	// UpsertOIDCConnector updates or creates an OIDC connector.
 	UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) error
 
 	// DeleteOIDCConnector deletes OIDC Connector
@@ -181,7 +185,11 @@ type Identity interface {
 	// GetOIDCAuthRequest returns OIDC auth request if found
 	GetOIDCAuthRequest(ctx context.Context, stateToken string) (*types.OIDCAuthRequest, error)
 
-	// UpsertSAMLConnector upserts SAML Connector
+	// CreateSAMLConnector creates a new SAML connector.
+	CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	// UpdateSAMLConnector updates an existing SAML connector
+	UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	// UpsertSAMLConnector updates or creates a SAML connector
 	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error
 
 	// DeleteSAMLConnector deletes OIDC Connector
@@ -205,7 +213,11 @@ type Identity interface {
 	// GetSSODiagnosticInfo returns SSO diagnostic info records.
 	GetSSODiagnosticInfo(ctx context.Context, authKind string, authRequestID string) (*types.SSODiagnosticInfo, error)
 
-	// UpsertGithubConnector creates or updates a new Github connector
+	// CreateGithubConnector creates a new Github connector.
+	CreateGithubConnector(ctx context.Context, connector types.GithubConnector) (types.GithubConnector, error)
+	// UpdateGithubConnector updates an existing Github connector.
+	UpdateGithubConnector(ctx context.Context, connector types.GithubConnector) (types.GithubConnector, error)
+	// UpsertGithubConnector creates or updates a Github connector.
 	UpsertGithubConnector(ctx context.Context, connector types.GithubConnector) error
 
 	// GetGithubConnectors returns all configured Github connectors

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -99,6 +99,7 @@ func TestCRUD(t *testing.T) {
 	t.Run("TestEvents", tt.suite.Events)
 	t.Run("TestEventsClusterConfig", tt.suite.EventsClusterConfig)
 	t.Run("TestNetworkRestrictions", func(t *testing.T) { tt.suite.NetworkRestrictions(t) })
+	t.Run("TestOIDCCRUD", tt.suite.OIDCCRUD)
 }
 
 func TestSemaphore(t *testing.T) {

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -40,7 +40,9 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
@@ -746,6 +748,7 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 			Namespace: apidefaults.Namespace,
 		},
 		Spec: types.SAMLConnectorSpecV2{
+			Display:                  "SAML",
 			Issuer:                   "http://example.com",
 			SSO:                      "https://example.com/saml/sso",
 			AssertionConsumerService: "https://localhost/acs",
@@ -767,21 +770,21 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, connector))
+	require.Empty(t, cmp.Diff(out, connector, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	connectors, err := s.WebS.GetSAMLConnectors(ctx, true)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.SAMLConnector{connector}, connectors))
+	require.Empty(t, cmp.Diff([]types.SAMLConnector{connector}, connectors, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	out2, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), false)
 	require.NoError(t, err)
 	connectorNoSecrets := *connector
 	connectorNoSecrets.Spec.SigningKeyPair.PrivateKey = ""
-	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets))
+	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	connectorsNoSecrets, err := s.WebS.GetSAMLConnectors(ctx, false)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.SAMLConnector{&connectorNoSecrets}, connectorsNoSecrets))
+	require.Empty(t, cmp.Diff([]types.SAMLConnector{&connectorNoSecrets}, connectorsNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.WebS.DeleteSAMLConnector(ctx, connector.GetName())
 	require.NoError(t, err)
@@ -791,6 +794,127 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 
 	_, err = s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
 	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+
+	created, err := s.WebS.CreateSAMLConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, created, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, created.GetRevision())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("not-saml")
+
+	updated, err := s.WebS.UpdateSAMLConnector(ctx, connector)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+	require.Nil(t, updated)
+
+	connector.SetRevision(created.GetRevision())
+	updated, err = s.WebS.UpdateSAMLConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, updated.GetRevision())
+	require.NotEqual(t, created.GetRevision(), updated.GetRevision())
+	require.NotEqual(t, created.GetDisplay(), updated.GetDisplay())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("llama")
+
+	require.NoError(t, s.WebS.UpsertSAMLConnector(ctx, connector))
+	upserted, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, upserted, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, upserted.GetRevision())
+	require.NotEqual(t, updated.GetRevision(), upserted.GetRevision())
+	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
+}
+
+func (s *ServicesTestSuite) OIDCCRUD(t *testing.T) {
+	ctx := context.Background()
+	connector := &types.OIDCConnectorV3{
+		Kind:    types.KindOIDC,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name:      "oidc1",
+			Namespace: apidefaults.Namespace,
+		},
+		Spec: types.OIDCConnectorSpecV3{
+			Display:      "SAML",
+			IssuerURL:    "http://example.com",
+			ClientID:     "aaa",
+			ClientSecret: "bbb",
+			RedirectURLs: []string{"https://localhost:3080/v1/webapi/github/callback"},
+			ClaimsToRoles: []types.ClaimMapping{
+				{
+					Claim: "abc",
+					Value: "xyz",
+					Roles: []string{"admin"},
+				},
+			},
+		},
+	}
+
+	err := s.WebS.UpsertOIDCConnector(ctx, connector)
+	require.NoError(t, err)
+	out, err := s.WebS.GetOIDCConnector(ctx, connector.GetName(), true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(out, connector, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	connectors, err := s.WebS.GetOIDCConnectors(ctx, true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]types.OIDCConnector{connector}, connectors, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	out2, err := s.WebS.GetOIDCConnector(ctx, connector.GetName(), false)
+	require.NoError(t, err)
+	connectorNoSecrets := *connector
+	connectorNoSecrets.Spec.ClientSecret = ""
+	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	connectorsNoSecrets, err := s.WebS.GetOIDCConnectors(ctx, false)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]types.OIDCConnector{&connectorNoSecrets}, connectorsNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	err = s.WebS.DeleteOIDCConnector(ctx, connector.GetName())
+	require.NoError(t, err)
+
+	err = s.WebS.DeleteOIDCConnector(ctx, connector.GetName())
+	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+
+	_, err = s.WebS.GetOIDCConnector(ctx, connector.GetName(), true)
+	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+
+	created, err := s.WebS.CreateOIDCConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, created, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, created.GetRevision())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("not-saml")
+
+	updated, err := s.WebS.UpdateOIDCConnector(ctx, connector)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+	require.Nil(t, updated)
+
+	connector.SetRevision(created.GetRevision())
+	updated, err = s.WebS.UpdateOIDCConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, updated.GetRevision())
+	require.NotEqual(t, created.GetRevision(), updated.GetRevision())
+	require.NotEqual(t, created.GetDisplay(), updated.GetDisplay())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("llama")
+
+	require.NoError(t, s.WebS.UpsertOIDCConnector(ctx, connector))
+	upserted, err := s.WebS.GetOIDCConnector(ctx, connector.GetName(), true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, upserted, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, upserted.GetRevision())
+	require.NotEqual(t, updated.GetRevision(), upserted.GetRevision())
+	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
 }
 
 func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
@@ -872,12 +996,11 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 			ClientSecret: "bbb",
 			RedirectURL:  "https://localhost:3080/v1/webapi/github/callback",
 			Display:      "GitHub",
-			TeamsToLogins: []types.TeamMapping{
+			TeamsToRoles: []types.TeamRolesMapping{
 				{
 					Organization: "gravitational",
 					Team:         "admins",
-					Logins:       []string{"admin"},
-					KubeGroups:   []string{"system:masters"},
+					Roles:        []string{"admin"},
 				},
 			},
 		},
@@ -888,21 +1011,21 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err := s.WebS.GetGithubConnector(ctx, connector.GetName(), true)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, connector))
+	require.Empty(t, cmp.Diff(out, connector, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	connectors, err := s.WebS.GetGithubConnectors(ctx, true)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.GithubConnector{connector}, connectors))
+	require.Empty(t, cmp.Diff([]types.GithubConnector{connector}, connectors, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	out2, err := s.WebS.GetGithubConnector(ctx, connector.GetName(), false)
 	require.NoError(t, err)
 	connectorNoSecrets := *connector
 	connectorNoSecrets.Spec.ClientSecret = ""
-	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets))
+	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	connectorsNoSecrets, err := s.WebS.GetGithubConnectors(ctx, false)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.GithubConnector{&connectorNoSecrets}, connectorsNoSecrets))
+	require.Empty(t, cmp.Diff([]types.GithubConnector{&connectorNoSecrets}, connectorsNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.WebS.DeleteGithubConnector(ctx, connector.GetName())
 	require.NoError(t, err)
@@ -912,6 +1035,40 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 
 	_, err = s.WebS.GetGithubConnector(ctx, connector.GetName(), true)
 	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+
+	created, err := s.WebS.CreateGithubConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, created, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, created.GetRevision())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("not-github")
+
+	updated, err := s.WebS.UpdateGithubConnector(ctx, connector)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+	require.Nil(t, updated)
+
+	connector.SetRevision(created.GetRevision())
+	updated, err = s.WebS.UpdateGithubConnector(ctx, connector)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, updated.GetRevision())
+	require.NotEqual(t, created.GetRevision(), updated.GetRevision())
+	require.NotEqual(t, created.GetDisplay(), updated.GetDisplay())
+
+	connector = utils.CloneProtoMsg(connector)
+	connector.SetRevision(uuid.NewString())
+	connector.SetDisplay("llama")
+
+	require.NoError(t, s.WebS.UpsertGithubConnector(ctx, connector))
+	upserted, err := s.WebS.GetGithubConnector(ctx, connector.GetName(), true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(connector, upserted, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.NotEmpty(t, upserted.GetRevision())
+	require.NotEqual(t, updated.GetRevision(), upserted.GetRevision())
+	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
+
 }
 
 func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {


### PR DESCRIPTION
Updates services.UserService and auth.ClientI to contain the Create and Update methods for all auth connectors and implements them at the client, server, and services layer. Upsert was untouched to prevent breaking e and will be addressed in a follow up PR.

Contributes to #30416.