### PR TITLE
[v13] Reword Troubleshooting section in Connect docs

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -255,27 +255,39 @@ The changes will take effect at the next launch.
 
 ## Troubleshooting
 
-Logging out of a cluster, closing the app and logging in again resets all app state related to that
-cluster. This can help if you encounter a bug which renders the user interface partially unusable.
-It might also help if you have issues with connecting to an active cluster that don't happen in the
-Web UI.
+Resetting the app state might help with UI crashes caused by Teleport Connect getting into an
+abnormal state. This might happen after downgrading Teleport Connect or performing substantial
+server-side changes. Those UI crashes typically manifest as a blank window or an Internal Error
+alert.
+
+To reset the state related to a particular cluster:
+
+1. Log out of the cluster.
+1. Close Teleport Connect.
+1. Open Teleport Connect, then log back in to the cluster.
+
+To completely wipe all app state:
+
+1. Close Teleport Connect.
+1. Remove the internal `tsh` folder and the `app_state.json` file to log out of all clusters and
+   clear all remembered tabs and connections.
 
 <Tabs>
 <TabItem label="macOS">
-To force the app to log you out of all clusters, close the app and remove the `~/Library/Application
-Support/Teleport Connect/tsh` folder. Removing the file `~/Library/Application
-Support/Teleport Connect/app_state.json` will clear all remembered tabs and connections.
+```code
+$ rm -rf ~/Library/Application\ Support/Teleport\ Connect/{tsh,app_state.json}
+```
 </TabItem>
 <TabItem label="Linux">
-To force the app to log you out of all clusters, close the app and remove the `~/.config/Teleport
-Connect/tsh` folder. Removing the file `/.config/Teleport Connect/app_state.json` will clear
-all remembered tabs and connections.
+```code
+$ rm -rf ~/.config/Teleport\ Connect/{tsh,app_state.json}
+```
 </TabItem>
 <TabItem label="Windows">
-To force the app to log you out of all clusters, close the app and remove the
-`C:\Users\%UserName%\AppData\Roaming\Teleport Connect\tsh` folder. Removing the file
-`C:\Users\%UserName%\AppData\Roaming\Teleport Connect\app_state.json` will clear all remembered tabs
-and connections.
+```code
+$ rmdir /s /q C:\Users\%UserName%\AppData\Roaming\"Teleport Connect"\tsh
+$ del C:\Users\%UserName%\AppData\Roaming\"Teleport Connect"\app_state.json
+```
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Backport #32293.

The backport does not include the changes related to the Open Logs Directory button as it's available only in v14+.