### PR TITLE
Add execing into a pod to Connect test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/webtestplan.md
+++ b/.github/ISSUE_TEMPLATE/webtestplan.md
@@ -580,7 +580,15 @@ Use Discover Wizard to enroll new resources and access them:
 - Kubernetes access
    - [ ] Open a new kubernetes tab, run `echo $KUBECONFIG` and check if it points to the file within Connect's app data directory.
    - [ ] Close the tab and open it again (to the same resource). Verify that the kubeconfig path didn't change.
-   - [ ] Run `kubectl get pods` and see if the command succeeds.
+   - [ ] Run `kubectl get pods -A` and verify that the command succeeds. Then create a pod with
+     `kubectl apply -f https://k8s.io/examples/application/shell-demo.yaml` and exec into it with
+     `kubectl exec --stdin --tty shell-demo -- /bin/bash`. Verify that the shell works.
+      - For execing into a pod, you might need to [create a `ClusterRoleBinding` in
+        k8s](https://goteleport.com/docs/kubernetes-access/register-clusters/static-kubeconfig/#kubernetes-authorization)
+        for [the admin role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
+        Then you need to add the k8s group (which maps to the k8s admin role in
+        `ClusterRoleBinding`) to `kubernetes_groups` of your Teleport role.
+      - [ ] Repeat the above check for a k8s cluster connected to a leaf cluster.
    - Verify that the kubeconfig file is removed when the user:
       - [ ] Removes the connection
       - [ ] Logs out of the cluster


### PR DESCRIPTION
With the release of v14, we've ran into two issues related to k8s access which weren't caught by the test plan, #32567 and #33020.

Even if the test plan was followed to the letter, we wouldn't have caught the second issue. It occurs only when execing into a pod and that wasn't a part of the test plan.

In addition there was #32380 which would've been caught only by execing into a k8s cluster of a leaf cluster.

This PR adds execing into a pod to help with catching this kind of issues in the future.