### PR TITLE
[v13] Fix `tsh kube credentials` when root cluster roles don't allow Kube access

### DIFF
--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -793,7 +793,15 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	// via the RBAC rules, but we also need to make sure that the user has
 	// access to the cluster with at least one kubernetes_user or kubernetes_group
 	// defined.
-	if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil {
+	// This is a safety check in order to print a better message to the user even
+	// before hitting Teleport Kubernetes Proxy.
+	// We only enforce this check for root clusters, since we don't have knowledge
+	// of the RBAC role mappings for remote clusters.
+	rootClusterName, err := tc.RootClusterName(cf.Context)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil && rootClusterName == c.teleportCluster {
 		return trace.Wrap(err)
 	}
 	// Cache the new cert on disk for reuse.

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -801,8 +801,10 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil && rootClusterName == c.teleportCluster {
-		return trace.Wrap(err)
+	if rootClusterName == c.teleportCluster {
+		if err := checkIfCertsAreAllowedToAccessCluster(k, c.kubeCluster); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	// Cache the new cert on disk for reuse.
 	if err := tc.LocalAgent().AddKubeKey(k); err != nil {

--- a/tool/tsh/kube_proxy.go
+++ b/tool/tsh/kube_proxy.go
@@ -522,7 +522,20 @@ func issueKubeCert(ctx context.Context, tc *client.TeleportClient, proxy *client
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
-	if err := checkIfCertsAreAllowedToAccessCluster(key, kubeCluster); err != nil {
+	// Make sure the cert is allowed to access the cluster.
+	// At this point we already know that the user has access to the cluster
+	// via the RBAC rules, but we also need to make sure that the user has
+	// access to the cluster with at least one kubernetes_user or kubernetes_group
+	// defined.
+	rootClusterName, err := tc.RootClusterName(ctx)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+	if err := checkIfCertsAreAllowedToAccessCluster(
+		key,
+		rootClusterName,
+		teleportCluster,
+		kubeCluster); err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Backport #33014 to branch/v13