### PR TITLE
Allow for Windows PKI operations to target a different domain

### DIFF
--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -132,7 +132,11 @@ func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 	// domain, with the assumption that some other windows_desktop_service
 	// published a CRL there.
 	crlDN := crlDN(req.ClusterName, req.LDAPConfig, req.CAType)
-	return &certRequest{csrPEM: csrPEM, crlEndpoint: fmt.Sprintf("ldap:///%s?certificateRevocationList?base?objectClass=cRLDistributionPoint", crlDN), keyDER: keyDER}, nil
+	return &certRequest{
+		csrPEM:      csrPEM,
+		crlEndpoint: fmt.Sprintf("ldap:///%s?certificateRevocationList?base?objectClass=cRLDistributionPoint", crlDN),
+		keyDER:      keyDER,
+	}, nil
 }
 
 // AuthInterface is a subset of auth.ClientI

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1933,6 +1933,8 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		CA:                 cert,
 	}
 
+	cfg.WindowsDesktop.PKIDomain = fc.WindowsDesktop.PKIDomain
+
 	var hlrs []servicecfg.HostLabelRule
 	for _, rule := range fc.WindowsDesktop.HostLabels {
 		r, err := regexp.Compile(rule.Match)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2158,6 +2158,12 @@ type WindowsDesktopService struct {
 	ShowDesktopWallpaper bool `yaml:"show_desktop_wallpaper,omitempty"`
 	// LDAP is the LDAP connection parameters.
 	LDAP LDAPConfig `yaml:"ldap"`
+	// PKIDomain optionally configures a separate Active Directory domain
+	// for PKI operations. If empty, the domain from the LDAP config is used.
+	// This can be useful for cases where PKI is configured in a root domain
+	// but Teleport is used to provide access to users and computers in a child
+	// domain.
+	PKIDomain string `yaml:"pki_domain"`
 	// Discovery configures desktop discovery via LDAP.
 	Discovery LDAPDiscoveryConfig `yaml:"discovery,omitempty"`
 	// Hosts is a list of static, AD-connected Windows hosts. This gives users

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -228,6 +228,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 		},
 		ShowDesktopWallpaper:         cfg.WindowsDesktop.ShowDesktopWallpaper,
 		LDAPConfig:                   windows.LDAPConfig(cfg.WindowsDesktop.LDAP),
+		PKIDomain:                    cfg.WindowsDesktop.PKIDomain,
 		DiscoveryBaseDN:              cfg.WindowsDesktop.Discovery.BaseDN,
 		DiscoveryLDAPFilters:         cfg.WindowsDesktop.Discovery.Filters,
 		DiscoveryLDAPAttributeLabels: cfg.WindowsDesktop.Discovery.LabelAttributes,

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -35,6 +35,12 @@ type WindowsDesktopConfig struct {
 	ShowDesktopWallpaper bool
 	// LDAP is the LDAP connection parameters.
 	LDAP LDAPConfig
+	// PKIDomain optionally configures a separate Active Directory domain
+	// for PKI operations. If empty, the domain from the LDAP config is used.
+	// This can be useful for cases where PKI is configured in a root domain
+	// but Teleport is used to provide access to users and computers in a child
+	// domain.
+	PKIDomain string
 
 	// Discovery configures automatic desktop discovery via LDAP.
 	Discovery LDAPDiscoveryConfig

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -173,6 +173,12 @@ type WindowsServiceConfig struct {
 	// LDAPConfig contains parameters for connecting to an LDAP server.
 	// LDAP functionality is disabled if Addr is empty.
 	windows.LDAPConfig
+	// PKIDomain optionally configures a separate Active Directory domain
+	// for PKI operations. If empty, the domain from the LDAP config is used.
+	// This can be useful for cases where PKI is configured in a root domain
+	// but Teleport is used to provide access to users and computers in a child
+	// domain.
+	PKIDomain string
 	// DiscoveryBaseDN is the base DN for searching for Windows Desktops.
 	// Desktop discovery is disabled if this field is empty.
 	DiscoveryBaseDN string
@@ -349,15 +355,21 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		auditCache:  newSharedDirectoryAuditCache(),
 	}
 
+	caLDAPConfig := s.cfg.LDAPConfig
+	if s.cfg.PKIDomain != "" {
+		caLDAPConfig.Domain = s.cfg.PKIDomain
+	}
+	s.cfg.Log.Infof("Windows PKI will be performed against %v", s.cfg.PKIDomain)
+
 	s.ca = windows.NewCertificateStoreClient(windows.CertificateStoreConfig{
 		AccessPoint: s.cfg.AccessPoint,
-		LDAPConfig:  s.cfg.LDAPConfig,
+		LDAPConfig:  caLDAPConfig,
 		Log:         s.cfg.Log,
 		ClusterName: s.clusterName,
 		LC:          s.lc,
 	})
 
-	if s.cfg.LDAPConfig.Addr != "" {
+	if caLDAPConfig.Addr != "" {
 		s.ldapConfigured = true
 		// initialize LDAP - if this fails it will automatically schedule a retry.
 		// we don't want to return an error in this case, because failure to start
@@ -1163,6 +1175,14 @@ type generateCredentialsRequest struct {
 // Directory. See:
 // https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-certificate-requirements-and-enumeration
 func (s *WindowsService) generateCredentials(ctx context.Context, request generateCredentialsRequest) (certDER, keyDER []byte, err error) {
+	// If PKI domain has been overridden, make sure we pass that through
+	// to the cert request, otherwise the CRL in the cert we issue will
+	// point at the wrong domain.
+	lc := s.cfg.LDAPConfig
+	if s.cfg.PKIDomain != "" {
+		lc.Domain = s.cfg.PKIDomain
+	}
+
 	return windows.GenerateWindowsDesktopCredentials(ctx, &windows.GenerateCredentialsRequest{
 		CAType:             types.UserCA,
 		Username:           request.username,
@@ -1170,7 +1190,7 @@ func (s *WindowsService) generateCredentials(ctx context.Context, request genera
 		TTL:                request.ttl,
 		ClusterName:        s.clusterName,
 		ActiveDirectorySID: request.activeDirectorySID,
-		LDAPConfig:         s.cfg.LDAPConfig,
+		LDAPConfig:         lc,
 		AuthClient:         s.cfg.AuthClient,
 		CreateUser:         request.createUser,
 		Groups:             request.groups,


### PR DESCRIPTION
Today, our AD support largely assumes there is a single active directory domain. The certificates that we generate are for users in this domain, the computers we discover via LDAP come from this domain, and the PKI set up we perform targets this domain.

In more complicated AD configurations, PKI is often configured in a root domain, while users, servers, and discovery should be done against a child domain.

The new pki_domain configuration field will allow you to override the default domain specified in the ldap section with a root domain that is used for configuring the NTAuth store and publishing the CRL. Teleport continues to do discovery and issue certificates for the domain specified in the ldap section of the config.