### PR TITLE
Fix title conflict

### DIFF
--- a/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference
+title: Kubernetes Application Discovery Reference
 description: This guide is a comprehensive reference of configuration options for automatically enrolling Kubernetes applications with Teleport.
 ---
 

--- a/docs/pages/reference/introduction.mdx
+++ b/docs/pages/reference/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference
+title: Teleport Reference Guides
 description: Comprehensive guides to configuring and running Teleport
 ---
 


### PR DESCRIPTION
Two docs pages have the title "Reference". Give both pages more specific titles for the benefit of SEO.