### PR TITLE
[v12] Remove deprecated Aurora MySQL version 1 from Database discovery

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -1658,6 +1658,8 @@ const (
 	// RDSEngineMariaDB is RDS engine name for MariaDB instances.
 	RDSEngineMariaDB = "mariadb"
 	// RDSEngineAurora is RDS engine name for Aurora MySQL 5.6 compatible clusters.
+	// This reached EOF on Feb 28, 2023.
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html
 	RDSEngineAurora = "aurora"
 	// RDSEngineAuroraMySQL is RDS engine name for Aurora MySQL 5.7 compatible clusters.
 	RDSEngineAuroraMySQL = "aurora-mysql"

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -304,7 +304,6 @@ func rdsInstanceEngines() []string {
 // only databases with engines Teleport supports.
 func auroraEngines() []string {
 	return []string{
-		services.RDSEngineAurora,
 		services.RDSEngineAuroraMySQL,
 		services.RDSEngineAuroraPostgres,
 	}


### PR DESCRIPTION
backport of #30572 to branch/v12

no conflict.