### PR TITLE
[v12] Disable golangci-lint action cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,21 +45,25 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: api
+          skip-cache: true
       - name: golangci-lint (teleport)
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --build-tags libfido2,piv
+          skip-cache: true
       - name: golangci-lint (assets/backport)
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: assets/backport
+          skip-cache: true
       - name: golangci-lint (build.assets/tooling)
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: build.assets/tooling
+          skip-cache: true
 
       - uses: bufbuild/buf-setup-action@v1
         with:


### PR DESCRIPTION
Backport #30780 to branch/v12.