### PR TITLE
disable TestHSMDualAuthRotation

### DIFF
--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -231,6 +231,10 @@ func testAdminClient(t *testing.T, authDataDir string, authAddr string) {
 
 // Tests multiple CA rotations and rollbacks with 2 HSM auth servers in an HA configuration
 func TestHSMDualAuthRotation(t *testing.T) {
+	// TODO(nklaassen): fix this test and re-enable it.
+	// https://github.com/gravitational/teleport/issues/20217
+	t.Skip("TestHSMDualAuthRotation is temporarily disabled due to flakiness")
+
 	requireHSMAvailable(t)
 	requireETCDAvailable(t)
 


### PR DESCRIPTION
This already has at least 4 flakes this morning so I'm going to re-disable it for now https://github.com/gravitational/teleport/issues/20217