### PR TITLE
Fix access requests function reference from e

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1820,6 +1820,11 @@ func GetResourceIDsByCluster(r types.AccessRequest) map[string][]types.ResourceI
 	return accessrequest.GetResourceIDsByCluster(r)
 }
 
+// TODO(atburke): Remove this once teleport.e reference is switched over
+func GetResourcesByResourceIDs(ctx context.Context, lister client.ListResourcesClient, resourceIDs []types.ResourceID, opts ...accessrequest.ListResourcesRequestOption) ([]types.ResourceWithLabels, error) {
+	return accessrequest.GetResourcesByResourceIDs(ctx, lister, resourceIDs, opts...)
+}
+
 // resourceMatcherToMatcherSlice returns the resourceMatcher in a RoleMatcher slice
 // if the resourceMatcher is not nil, otherwise returns a nil slice.
 func resourceMatcherToMatcherSlice(resourceMatcher *KubeResourcesMatcher) []RoleMatcher {


### PR DESCRIPTION
This change fixes a reference to a function called in teleport.e that was moved in #32887.