### PR TITLE
include url and saml connector name in entity descriptor url errors

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -49,7 +49,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if sc.GetEntityDescriptorURL() != "" {
 		resp, err := http.Get(sc.GetEntityDescriptorURL())
 		if err != nil {
-			return trace.WrapWithMessage(err, "error getting entitydescriptor from %q for SAML connector:%v", sc.GetEntityDescriptorURL(), sc.GetName())
+			return trace.WrapWithMessage(err, "unable to fetch entity descriptor from %q for SAML connector:%v", sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		if resp.StatusCode != http.StatusOK {
 			return trace.BadParameter("status code %v when fetching from %q for SAML connector %v", resp.StatusCode, sc.GetEntityDescriptorURL(), sc.GetName())

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -49,10 +49,10 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if sc.GetEntityDescriptorURL() != "" {
 		resp, err := http.Get(sc.GetEntityDescriptorURL())
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.WrapWithMessage(err, "error getting entitydescriptor from %q for SAML connector:%v", sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		if resp.StatusCode != http.StatusOK {
-			return trace.BadParameter("status code %v when fetching from %q", resp.StatusCode, sc.GetEntityDescriptorURL())
+			return trace.BadParameter("status code %v when fetching from %q for SAML connector %v", resp.StatusCode, sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		defer resp.Body.Close()
 		body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
@@ -60,7 +60,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 			return trace.Wrap(err)
 		}
 		sc.SetEntityDescriptor(string(body))
-		log.Debugf("[SAML] Successfully fetched entity descriptor from %q", sc.GetEntityDescriptorURL())
+		log.Debugf("[SAML] Successfully fetched entity descriptor from %q for connector %v", sc.GetEntityDescriptorURL(), sc.GetName())
 	}
 
 	if sc.GetEntityDescriptor() != "" {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -49,7 +49,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if sc.GetEntityDescriptorURL() != "" {
 		resp, err := http.Get(sc.GetEntityDescriptorURL())
 		if err != nil {
-			return trace.WrapWithMessage(err, "unable to fetch entity descriptor from %q for SAML connector:%v", sc.GetEntityDescriptorURL(), sc.GetName())
+			return trace.WrapWithMessage(err, "unable to fetch entity descriptor from %v for SAML connector %v", sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		if resp.StatusCode != http.StatusOK {
 			return trace.BadParameter("status code %v when fetching from %q for SAML connector %v", resp.StatusCode, sc.GetEntityDescriptorURL(), sc.GetName())

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -52,7 +52,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 			return trace.WrapWithMessage(err, "unable to fetch entity descriptor from %v for SAML connector %v", sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		if resp.StatusCode != http.StatusOK {
-			return trace.BadParameter("status code %v when fetching from %q for SAML connector %v", resp.StatusCode, sc.GetEntityDescriptorURL(), sc.GetName())
+			return trace.BadParameter("status code %v when fetching from %v for SAML connector %v", resp.StatusCode, sc.GetEntityDescriptorURL(), sc.GetName())
 		}
 		defer resp.Body.Close()
 		body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
@@ -60,7 +60,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 			return trace.Wrap(err)
 		}
 		sc.SetEntityDescriptor(string(body))
-		log.Debugf("[SAML] Successfully fetched entity descriptor from %q for connector %v", sc.GetEntityDescriptorURL(), sc.GetName())
+		log.Debugf("[SAML] Successfully fetched entity descriptor from %v for connector %v", sc.GetEntityDescriptorURL(), sc.GetName())
 	}
 
 	if sc.GetEntityDescriptor() != "" {


### PR DESCRIPTION

Errors can occur if a SAML entity descriptor url is no longer available.  Without knowing the connector name it's difficult to know which SAML connector is having the problem just from the entity descriptor url.

```bash
tctl get connectors
```

If a entity descriptor url fails you get the error:
```
ERROR: rpc error: code = Unknown desc = Get "https://gravitational-preview.oktapreview.com/app/exk7073it1Ywz0t8L1d7/sso/saml/metadata": dial tcp 4.4.4.4:443: i/o timeout
```

Updated to this so you get the url and the saml connector name `okta`. 

```
ERROR: rpc error: code = Unknown desc = error getting entitydescriptor from "https://gravitational-preview.oktapreview.com/app/exk7073it1Ywz0t8L1d7/sso/saml/metadata" for SAML connector:okta
        Get "https://gravitational-preview.oktapreview.com/app/exk7073it1Ywz0t8L1d7/sso/saml/metadata": dial tcp 4.4.4.4:443: i/o timeout
```


