### PR TITLE
[v13] docs: include servicenow and opsgenie in plugin index

### DIFF
--- a/docs/pages/includes/access-request-integrations.mdx
+++ b/docs/pages/includes/access-request-integrations.mdx
@@ -7,3 +7,4 @@
 | PagerDuty | Schedule | [Set up PagerDuty](../access-controls/access-request-plugins/ssh-approval-pagerduty.mdx) |
 | Email | Messaging | [Set up email](../access-controls/access-request-plugins/ssh-approval-email.mdx) |
 | Discord | Messaging | [Set up Discord](../access-controls/access-request-plugins/ssh-approval-discord.mdx) |
+| OpsGenie | Incident Management | [Set up OpsGenie](../access-controls/access-request-plugins/opsgenie.mdx) |


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/33220 to branch/v3