### PR TITLE
[TAG] Add colors for review/request nodes

### DIFF
--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import {
   blue,
   green,
+  indigo,
   orange,
   pink,
   purple,
@@ -304,6 +305,55 @@ const colors: ThemeColors = {
         label: {
           background: red[200],
           color: red[700],
+        },
+      },
+      allowedRequest: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+
+      },
+      disallowedRequest: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
+        },
+      },
+      allowedReview: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+      },
+      disallowedReview: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
         },
       },
     },

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import {
   blue,
   green,
+  indigo,
   orange,
   pink,
   purple,
@@ -304,6 +305,55 @@ const colors: ThemeColors = {
         label: {
           background: red[200],
           color: red[700],
+        },
+      },
+      allowedRequest: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+
+      },
+      disallowedRequest: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
+        },
+      },
+      allowedReview: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+      },
+      disallowedReview: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
         },
       },
     },

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { darken, lighten } from '../utils/colorManipulator';
-import { blue, green, orange, pink, purple, red, yellow } from '../palette';
+import { blue, green, indigo, orange, pink, purple, red, yellow } from '../palette';
 
 import { sharedColors, sharedStyles } from './sharedStyles';
 import { DataVisualisationColors, Theme, ThemeColors } from './types';
@@ -291,6 +291,55 @@ const colors: ThemeColors = {
         label: {
           background: red[200],
           color: red[700],
+        },
+      },
+      allowedRequest: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+
+      },
+      disallowedRequest: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
+        },
+      },
+      allowedReview: {
+        background: lighten(indigo[300], 0.9),
+        borderColor: indigo[300],
+        typeColor: indigo[300],
+        iconBackground: indigo[300],
+        handleColor: indigo[400],
+        highlightColor: indigo[300],
+        label: {
+          background: indigo[200],
+          color: indigo[700],
+        },
+      },
+      disallowedReview: {
+        background: lighten(purple[300], 0.9),
+        borderColor: purple[300],
+        typeColor: purple[300],
+        iconBackground: purple[300],
+        handleColor: purple[400],
+        highlightColor: purple[300],
+        label: {
+          background: purple[200],
+          color: purple[700],
         },
       },
     },

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -194,6 +194,10 @@ interface AccessGraphColors {
     resourceGroup: AccessGraphNodeColors;
     allowedAction: AccessGraphNodeColors;
     disallowedAction: AccessGraphNodeColors;
+    allowedRequest: AccessGraphNodeColors;
+    disallowedRequest: AccessGraphNodeColors;
+    allowedReview: AccessGraphNodeColors;
+    disallowedReview: AccessGraphNodeColors;
   };
   edges: {
     dynamicMemberOf: AccessGraphEdgeColors;


### PR DESCRIPTION
Adds colors for new types of TAG nodes to the themes. Colors are pretty much placeholders, just want it to work.