### PR TITLE
Wait for nodes to be availble in disconnection integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2251,6 +2251,19 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 		tc.concurrentConns = 1
 	}
 
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		// once the tunnel is established we need to wait until we have a
+		// connection to the remote auth
+		site := teleport.GetSiteAPI(helpers.Site)
+		if !assert.NotNil(t, site) {
+			return
+		}
+		// we need to wait until we know about the node because direct dial to
+		// unregistered servers is no longer supported
+		_, err := site.GetNode(ctx, defaults.Namespace, teleport.Config.HostUUID)
+		assert.NoError(t, err)
+	}, time.Second*30, 250*time.Millisecond)
+
 	asyncErrors := make(chan error, 1)
 
 	for i := 0; i < tc.concurrentConns; i++ {


### PR DESCRIPTION
Fix for https://github.com/gravitational/teleport/issues/31722

I wasnt able to make this fail locally, but this has been the fix elsewhere