### PR TITLE
Update GHA Docker images to teleport15

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -59,7 +59,7 @@ jobs:
       id-token: write
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         WEBASSETS_SKIP_BUILD: 1
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
 
     steps:
       - name: Checkout base

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
       env:
         GOCACHE: /tmp/gocache
 

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -44,7 +44,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -43,7 +43,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       options: --cap-add=SYS_ADMIN --privileged
       env:
         WEBASSETS_SKIP_BUILD: 1

--- a/.github/workflows/kube-integration-tests-non-root.yaml
+++ b/.github/workflows/kube-integration-tests-non-root.yaml
@@ -48,7 +48,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         WEBASSETS_SKIP_BUILD: 1
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
 
     env:
       GOLANGCI_LINT_VERSION: v1.54.2

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -24,7 +24,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
       env:
         GOCACHE: /tmp/gocache
         WEBASSETS_SKIP_BUILD: 1

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -36,7 +36,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       env:
         # TODO(hugoShaka) remove the '-new' prefix when updating to teleport13 buildbox
         HELM_PLUGINS: /home/ci/.local/share/helm/plugins-new

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -46,7 +46,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      image: ghcr.io/gravitational/teleport-buildbox:teleport15
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:


### PR DESCRIPTION
This commit updates all the Docker images from ghcr.io/gravitational/teleport-buildbox:teleport14 to ghcr.io/gravitational/teleport-buildbox:teleport15 in multiple workflow files.

Continuation of https://github.com/gravitational/teleport/pull/33042