### PR TITLE
Remove access lists and members from the cache.

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
@@ -94,9 +93,7 @@ type testPack struct {
 	okta                    services.Okta
 	integrations            services.Integrations
 	discoveryConfigs        services.DiscoveryConfigs
-	accessLists             services.AccessLists
 	userLoginStates         services.UserLoginStates
-	accessListMembers       services.AccessListMembers
 }
 
 // testFuncs are functions to support testing an object in a cache.
@@ -254,13 +251,6 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.discoveryConfigs = dcSvc
 
-	alSvc, err := local.NewAccessListService(p.backend, p.backend.Clock())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	p.accessLists = alSvc
-	p.accessListMembers = alSvc
-
 	ulsSvc, err := local.NewUserLoginStateService(p.backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -305,7 +295,6 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
 		DiscoveryConfigs:        p.discoveryConfigs,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -702,7 +691,6 @@ func TestCompletenessInit(t *testing.T) {
 			Okta:                    p.okta,
 			Integrations:            p.integrations,
 			DiscoveryConfigs:        p.discoveryConfigs,
-			AccessLists:             p.accessLists,
 			UserLoginStates:         p.userLoginStates,
 			MaxRetryPeriod:          200 * time.Millisecond,
 			EventsC:                 p.eventsC,
@@ -773,7 +761,6 @@ func TestCompletenessReset(t *testing.T) {
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
 		DiscoveryConfigs:        p.discoveryConfigs,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -956,7 +943,6 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
 		DiscoveryConfigs:        p.discoveryConfigs,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -1038,7 +1024,6 @@ func initStrategy(t *testing.T) {
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
 		DiscoveryConfigs:        p.discoveryConfigs,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -2142,33 +2127,6 @@ func TestDiscoveryConfig(t *testing.T) {
 	})
 }
 
-// TestAccessLists tests that CRUD operations on access list resources are
-// replicated from the backend to the cache.
-func TestAccessLists(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[*accesslist.AccessList]{
-		newResource: func(name string) (*accesslist.AccessList, error) {
-			return newAccessList(t, name, p.backend.Clock()), nil
-		},
-		create: func(ctx context.Context, accessList *accesslist.AccessList) error {
-			_, err := p.accessLists.UpsertAccessList(ctx, accessList)
-			return trace.Wrap(err)
-		},
-		list:      p.accessLists.GetAccessLists,
-		cacheGet:  p.cache.GetAccessList,
-		cacheList: p.cache.GetAccessLists,
-		update: func(ctx context.Context, accessList *accesslist.AccessList) error {
-			_, err := p.accessLists.UpsertAccessList(ctx, accessList)
-			return trace.Wrap(err)
-		},
-		deleteAll: p.accessLists.DeleteAllAccessLists,
-	})
-}
-
 // TestUserLoginStates tests that CRUD operations on user login state resources are
 // replicated from the backend to the cache.
 func TestUserLoginStates(t *testing.T) {
@@ -2193,49 +2151,6 @@ func TestUserLoginStates(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.userLoginStates.DeleteAllUserLoginStates,
-	})
-}
-
-// TestAccessListMembers tests that CRUD operations on access list members resources are
-// replicated from the backend to the cache.
-func TestAccessListMembers(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	const accessListName = "test-access-list"
-
-	clock := clockwork.NewFakeClock()
-
-	p.accessLists.UpsertAccessList(context.Background(), newAccessList(t, accessListName, clock))
-
-	testResources(t, p, testFuncs[*accesslist.AccessListMember]{
-		newResource: func(name string) (*accesslist.AccessListMember, error) {
-			return newAccessListMember(t, accessListName, name), nil
-		},
-		create: func(ctx context.Context, member *accesslist.AccessListMember) error {
-			_, err := p.accessListMembers.UpsertAccessListMember(ctx, member)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*accesslist.AccessListMember, error) {
-			members, _, err := p.accessListMembers.ListAccessListMembers(ctx, accessListName, 0, "")
-			return members, trace.Wrap(err)
-		},
-		cacheGet: func(ctx context.Context, memberName string) (*accesslist.AccessListMember, error) {
-			return p.cache.GetAccessListMember(ctx, accessListName, memberName)
-		},
-		cacheList: func(ctx context.Context) ([]*accesslist.AccessListMember, error) {
-			members, _, err := p.cache.ListAccessListMembers(ctx, accessListName, 0, "")
-			return members, trace.Wrap(err)
-		},
-		update: func(ctx context.Context, member *accesslist.AccessListMember) error {
-			_, err := p.accessListMembers.UpsertAccessListMember(ctx, member)
-			return trace.Wrap(err)
-		},
-		deleteAll: func(ctx context.Context) error {
-			return trace.Wrap(p.accessListMembers.DeleteAllAccessListMembersForAccessList(ctx, accessListName))
-		},
 	})
 }
 
@@ -2635,8 +2550,6 @@ func newProxyEvents(events types.Events, ignoreKinds []types.WatchKind) *proxyEv
 func TestCacheWatchKindExistsInEvents(t *testing.T) {
 	t.Parallel()
 
-	clock := clockwork.NewFakeClock()
-
 	cases := map[string]Config{
 		"ForAuth":           ForAuth(Config{}),
 		"ForProxy":          ForProxy(Config{}),
@@ -2693,9 +2606,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindIntegration:             &types.IntegrationV1{},
 		types.KindDiscoveryConfig:         newDiscoveryConfig(t, "discovery-config"),
 		types.KindHeadlessAuthentication:  &types.HeadlessAuthentication{},
-		types.KindAccessList:              newAccessList(t, "access-list", clock),
 		types.KindUserLoginState:          newUserLoginState(t, "user-login-state"),
-		types.KindAccessListMember:        newAccessListMember(t, "access-list", "member"),
 	}
 
 	for name, cfg := range cases {
@@ -2898,56 +2809,6 @@ func TestInvalidDatabases(t *testing.T) {
 	}
 }
 
-func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist.AccessList {
-	t.Helper()
-
-	accessList, err := accesslist.NewAccessList(
-		header.Metadata{
-			Name: name,
-		},
-		accesslist.Spec{
-			Title:       "title",
-			Description: "test access list",
-			Owners: []accesslist.Owner{
-				{
-					Name:        "test-user1",
-					Description: "test user 1",
-				},
-				{
-					Name:        "test-user2",
-					Description: "test user 2",
-				},
-			},
-			Audit: accesslist.Audit{
-				NextAuditDate: clock.Now(),
-			},
-			MembershipRequires: accesslist.Requires{
-				Roles: []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			OwnershipRequires: accesslist.Requires{
-				Roles: []string{"orole1", "orole2"},
-				Traits: map[string][]string{
-					"otrait1": {"ovalue1", "ovalue2"},
-					"otrait2": {"ovalue3", "ovalue4"},
-				},
-			},
-			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
-				Traits: map[string][]string{
-					"gtrait1": {"gvalue1", "gvalue2"},
-					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
-		},
-	)
-	require.NoError(t, err)
-	return accessList
-}
-
 func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryConfig {
 	t.Helper()
 
@@ -2984,26 +2845,6 @@ func newUserLoginState(t *testing.T, name string) *userloginstate.UserLoginState
 	)
 	require.NoError(t, err)
 	return uls
-}
-
-func newAccessListMember(t *testing.T, accessListName, memberName string) *accesslist.AccessListMember {
-	t.Helper()
-
-	member, err := accesslist.NewAccessListMember(
-		header.Metadata{
-			Name: memberName,
-		},
-		accesslist.AccessListMemberSpec{
-			AccessList: accessListName,
-			Name:       memberName,
-			Joined:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			Expires:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			Reason:     "because",
-			AddedBy:    "test-user1",
-		},
-	)
-	require.NoError(t, err)
-	return member
 }
 
 func withKeepalive[T any](fn func(context.Context, T) (*types.KeepAlive, error)) func(context.Context, T) error {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/services"
@@ -173,8 +172,6 @@ type cacheCollections struct {
 	// byKind is a map of registered collections by resource Kind/SubKind
 	byKind map[resourceKind]collection
 
-	accessLists              collectionReader[services.AccessListsGetter]
-	accessListMembers        collectionReader[services.AccessListMembersGetter]
 	apps                     collectionReader[services.AppGetter]
 	nodes                    collectionReader[nodeGetter]
 	tunnelConnections        collectionReader[tunnelConnectionGetter]
@@ -606,24 +603,12 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 		case types.KindHeadlessAuthentication:
 			// For headless authentications, we need only process events. We don't need to keep the cache up to date.
 			collections.byKind[resourceKind] = &genericCollection[*types.HeadlessAuthentication, noReader, noopExecutor]{cache: c, watch: watch}
-		case types.KindAccessList:
-			if c.AccessLists == nil {
-				return nil, trace.BadParameter("missing parameter AccessLists")
-			}
-			collections.accessLists = &genericCollection[*accesslist.AccessList, services.AccessListsGetter, accessListsExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessLists
 		case types.KindUserLoginState:
 			if c.UserLoginStates == nil {
 				return nil, trace.BadParameter("missing parameter UserLoginStates")
 			}
 			collections.userLoginStates = &genericCollection[*userloginstate.UserLoginState, services.UserLoginStatesGetter, userLoginStateExecutor]{cache: c, watch: watch}
 			collections.byKind[resourceKind] = collections.userLoginStates
-		case types.KindAccessListMember:
-			if c.AccessLists == nil {
-				return nil, trace.BadParameter("missing parameter AccessLists")
-			}
-			collections.accessListMembers = &genericCollection[*accesslist.AccessListMember, services.AccessListMembersGetter, accessListMembersExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessListMembers
 		default:
 			return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 		}
@@ -2335,53 +2320,6 @@ func (integrationsExecutor) getReader(cache *Cache, cacheOK bool) services.Integ
 
 var _ executor[types.Integration, services.IntegrationsGetter] = integrationsExecutor{}
 
-type accessListsExecutor struct{}
-
-func (accessListsExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*accesslist.AccessList, error) {
-	var accessLists []*accesslist.AccessList
-	var nextToken string
-	for {
-		var page []*accesslist.AccessList
-		var err error
-
-		page, nextToken, err = cache.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		accessLists = append(accessLists, page...)
-
-		if nextToken == "" {
-			break
-		}
-	}
-	return accessLists, nil
-}
-
-func (accessListsExecutor) upsert(ctx context.Context, cache *Cache, resource *accesslist.AccessList) error {
-	_, err := cache.accessListsCache.UpsertAccessList(ctx, resource)
-	return trace.Wrap(err)
-}
-
-func (accessListsExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.accessListsCache.DeleteAllAccessLists(ctx)
-}
-
-func (accessListsExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.accessListsCache.DeleteAccessList(ctx, resource.GetName())
-}
-
-func (accessListsExecutor) isSingleton() bool { return false }
-
-func (accessListsExecutor) getReader(cache *Cache, cacheOK bool) services.AccessListsGetter {
-	if cacheOK {
-		return cache.accessListsCache
-	}
-	return cache.Config.AccessLists
-}
-
-var _ executor[*accesslist.AccessList, services.AccessListsGetter] = accessListsExecutor{}
-
 type discoveryConfigExecutor struct{}
 
 func (discoveryConfigExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*discoveryconfig.DiscoveryConfig, error) {
@@ -2487,75 +2425,3 @@ func (userLoginStateExecutor) getReader(cache *Cache, cacheOK bool) services.Use
 }
 
 var _ executor[*userloginstate.UserLoginState, services.UserLoginStatesGetter] = userLoginStateExecutor{}
-
-type accessListMembersExecutor struct{}
-
-func (accessListMembersExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
-	// Get all access lists
-	var accessLists []*accesslist.AccessList
-	var nextToken string
-	for {
-		var page []*accesslist.AccessList
-		var err error
-
-		page, nextToken, err = cache.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		accessLists = append(accessLists, page...)
-
-		if nextToken == "" {
-			break
-		}
-	}
-
-	// Get the members of each access list.
-	var members []*accesslist.AccessListMember
-	for _, accessList := range accessLists {
-		for {
-			var page []*accesslist.AccessListMember
-			var err error
-
-			page, nextToken, err = cache.AccessLists.ListAccessListMembers(ctx, accessList.GetName(), 0 /* default page size */, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			members = append(members, page...)
-
-			if nextToken == "" {
-				break
-			}
-		}
-	}
-	return members, nil
-}
-
-func (accessListMembersExecutor) upsert(ctx context.Context, cache *Cache, resource *accesslist.AccessListMember) error {
-	_, err := cache.accessListsCache.UpsertAccessListMember(ctx, resource)
-	return trace.Wrap(err)
-}
-
-func (accessListMembersExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.accessListsCache.DeleteAllAccessListMembers(ctx)
-}
-
-func (accessListMembersExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	member, ok := resource.(*accesslist.AccessListMember)
-	if !ok {
-		return trace.BadParameter("expected *accesslist.AccessListMember, got %T", resource)
-	}
-	return cache.accessListsCache.DeleteAccessListMember(ctx, member.Spec.AccessList, member.GetName())
-}
-
-func (accessListMembersExecutor) isSingleton() bool { return false }
-
-func (accessListMembersExecutor) getReader(cache *Cache, cacheOK bool) services.AccessListMembersGetter {
-	if cacheOK {
-		return cache.accessListsCache
-	}
-	return cache.AccessLists
-}
-
-var _ executor[*accesslist.AccessListMember, services.AccessListMembersGetter] = accessListMembersExecutor{}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2223,7 +2223,6 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		SAMLIdPServiceProviders: cfg.services,
 		UserGroups:              cfg.services,
 		Okta:                    cfg.services.OktaClient(),
-		AccessLists:             cfg.services.AccessListClient(),
 		UserLoginStates:         cfg.services.UserLoginStateClient(),
 		Integrations:            cfg.services,
 		DiscoveryConfigs:        cfg.services.DiscoveryConfigClient(),

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
@@ -43,7 +41,6 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 
 	ctx := context.Background()
 
-	clock := clockwork.NewFakeClock()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 
@@ -52,13 +49,9 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		services.WindowsDesktops
 		services.SAMLIdPServiceProviders
 		types.Events
-		services.AccessLists
 	}
 
 	samlService, err := local.NewSAMLIdPServiceProviderService(bk)
-	require.NoError(t, err)
-
-	accessListService, err := local.NewAccessListService(bk, clock)
 	require.NoError(t, err)
 
 	clt := &client{
@@ -66,7 +59,6 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		WindowsDesktops:         local.NewWindowsDesktopService(bk),
 		SAMLIdPServiceProviders: samlService,
 		Events:                  local.NewEventsService(bk),
-		AccessLists:             accessListService,
 	}
 	// Add node to the backend.
 	node := newNodeServer(t, "node1", "127.0.0.1:22", false /*tunnel*/)
@@ -143,51 +135,8 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	err = clt.UpsertWindowsDesktop(ctx, win)
 	require.NoError(t, err)
 
-	// Add access list to backend
-	accessList, err := accesslist.NewAccessList(header.Metadata{
-		Name: "my-access-list",
-		ID:   5,
-	},
-		accesslist.Spec{
-			Title:       "title",
-			Description: "test access list",
-			Owners: []accesslist.Owner{
-				{
-					Name:        "test-user1",
-					Description: "test user 1",
-				},
-			},
-			Audit: accesslist.Audit{
-				NextAuditDate: time.Now(),
-			},
-			MembershipRequires: accesslist.Requires{
-				Roles: []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			OwnershipRequires: accesslist.Requires{
-				Roles: []string{"orole1", "orole2"},
-				Traits: map[string][]string{
-					"otrait1": {"ovalue1", "ovalue2"},
-					"otrait2": {"ovalue3", "ovalue4"},
-				},
-			},
-			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
-				Traits: map[string][]string{
-					"gtrait1": {"gvalue1", "gvalue2"},
-					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
-		})
-	require.NoError(t, err)
-	_, err = clt.UpsertAccessList(ctx, accessList)
-	require.NoError(t, err)
-
 	// we expect each of the resources above to exist
-	expectedRes := []types.ResourceWithLabels{node, app, samlapp, dbServer, win, accessList}
+	expectedRes := []types.ResourceWithLabels{node, app, samlapp, dbServer, win}
 	assert.Eventually(t, func() bool {
 		res, err = w.GetUnifiedResources(ctx)
 		return len(res) == len(expectedRes)
@@ -210,7 +159,7 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	// this should include the updated node, and shouldn't have any apps included
-	expectedRes = []types.ResourceWithLabels{nodeUpdated, samlapp, dbServer, win, accessList}
+	expectedRes = []types.ResourceWithLabels{nodeUpdated, samlapp, dbServer, win}
 	assert.Eventually(t, func() bool {
 		res, err = w.GetUnifiedResources(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
The access lists and members have been removed from the cache. There's not a lot of value having them in there and they create some uncomfortable questions since members are dependent on access lists and the cache isn't designed for dependent operations like this. By removing them we avoid a lot of pain here.