### PR TITLE
[v13] Remove access lists and members from the cache.

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -115,10 +114,8 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindOktaImportRule},
 		{Kind: types.KindOktaAssignment},
 		{Kind: types.KindIntegration},
-		{Kind: types.KindAccessList},
 		{Kind: types.KindHeadlessAuthentication},
 		{Kind: types.KindUserLoginState},
-		{Kind: types.KindAccessListMember},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	// We don't want to enable partial health for auth cache because auth uses an event stream
@@ -473,7 +470,6 @@ type Cache struct {
 	userGroupsCache              services.UserGroups
 	oktaCache                    services.Okta
 	integrationsCache            services.Integrations
-	accessListsCache             services.AccessLists
 	headlessAuthenticationsCache services.HeadlessAuthenticationService
 	userLoginStateCache          services.UserLoginStates
 	eventsFanout                 *services.FanoutSet
@@ -629,8 +625,6 @@ type Config struct {
 	Okta services.Okta
 	// Integrations is an Integrations service.
 	Integrations services.Integrations
-	// AccessLists is the access list service.
-	AccessLists services.AccessLists
 	// UserLoginStates is the user login state service.
 	UserLoginStates services.UserLoginStates
 	// Backend is a backend for local cache
@@ -802,12 +796,6 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	accessListsCache, err := local.NewAccessListService(config.Backend, config.Clock)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
-
 	userLoginStatesCache, err := local.NewUserLoginStateService(config.Backend)
 	if err != nil {
 		cancel()
@@ -842,7 +830,6 @@ func New(config Config) (*Cache, error) {
 		userGroupsCache:              userGroupsCache,
 		oktaCache:                    oktaCache,
 		integrationsCache:            integrationsCache,
-		accessListsCache:             accessListsCache,
 		headlessAuthenticationsCache: local.NewIdentityService(config.Backend),
 		userLoginStateCache:          userLoginStatesCache,
 		eventsFanout:                 services.NewFanoutSet(),
@@ -2485,45 +2472,6 @@ func (c *Cache) GetIntegration(ctx context.Context, name string) (types.Integrat
 	return rg.reader.GetIntegration(ctx, name)
 }
 
-// ListAccessLists returns a paginated list of all access lists resources.
-func (c *Cache) ListAccessLists(ctx context.Context, pageSize int, nextKey string) ([]*accesslist.AccessList, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessLists")
-	defer span.End()
-
-	rg, err := readCollectionCache(c, c.collections.accessLists)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.ListAccessLists(ctx, pageSize, nextKey)
-}
-
-// GetAccessLists returns a list of all access lists resources.
-func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessLists")
-	defer span.End()
-
-	rg, err := readCollectionCache(c, c.collections.accessLists)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetAccessLists(ctx)
-}
-
-// GetAccessList returns the specified access list resource.
-func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessList")
-	defer span.End()
-
-	rg, err := readCollectionCache(c, c.collections.accessLists)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetAccessList(ctx, name)
-}
-
 // GetUserLoginStates returns the all user login state resources.
 func (c *Cache) GetUserLoginStates(ctx context.Context) ([]*userloginstate.UserLoginState, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetUserLoginStates")
@@ -2535,32 +2483,6 @@ func (c *Cache) GetUserLoginStates(ctx context.Context) ([]*userloginstate.UserL
 	}
 	defer rg.Release()
 	return rg.reader.GetUserLoginStates(ctx)
-}
-
-// ListAccessListMembers returns a paginated list of all access list members.
-func (c *Cache) ListAccessListMembers(ctx context.Context, accessList string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListMembers")
-	defer span.End()
-
-	rg, err := readCollectionCache(c, c.collections.accessListMembers)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.ListAccessListMembers(ctx, accessList, pageSize, pageToken)
-}
-
-// GetAccessListMember returns the specified access list member resource.
-func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListMember")
-	defer span.End()
-
-	rg, err := readCollectionCache(c, c.collections.accessListMembers)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetAccessListMember(ctx, accessList, memberName)
 }
 
 // GetUserLoginState returns the specified user login state resource.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/api/types/userloginstate"
@@ -91,9 +90,7 @@ type testPack struct {
 	userGroups              services.UserGroups
 	okta                    services.Okta
 	integrations            services.Integrations
-	accessLists             services.AccessLists
 	userLoginStates         services.UserLoginStates
-	accessListMembers       services.AccessListMembers
 }
 
 // testFuncs are functions to support testing an object in a cache.
@@ -245,13 +242,6 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.integrations = igSvc
 
-	alSvc, err := local.NewAccessListService(p.backend, p.backend.Clock())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	p.accessLists = alSvc
-	p.accessListMembers = alSvc
-
 	ulsSvc, err := local.NewUserLoginStateService(p.backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -295,7 +285,6 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -690,7 +679,6 @@ func TestCompletenessInit(t *testing.T) {
 			UserGroups:              p.userGroups,
 			Okta:                    p.okta,
 			Integrations:            p.integrations,
-			AccessLists:             p.accessLists,
 			UserLoginStates:         p.userLoginStates,
 			MaxRetryPeriod:          200 * time.Millisecond,
 			EventsC:                 p.eventsC,
@@ -760,7 +748,6 @@ func TestCompletenessReset(t *testing.T) {
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -942,7 +929,6 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -1022,7 +1008,6 @@ func initStrategy(t *testing.T) {
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
 		Integrations:            p.integrations,
-		AccessLists:             p.accessLists,
 		UserLoginStates:         p.userLoginStates,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
@@ -2079,33 +2064,6 @@ func TestIntegrations(t *testing.T) {
 	})
 }
 
-// TestAccessLists tests that CRUD operations on access list resources are
-// replicated from the backend to the cache.
-func TestAccessLists(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[*accesslist.AccessList]{
-		newResource: func(name string) (*accesslist.AccessList, error) {
-			return newAccessList(t, name, p.backend.Clock()), nil
-		},
-		create: func(ctx context.Context, accessList *accesslist.AccessList) error {
-			_, err := p.accessLists.UpsertAccessList(ctx, accessList)
-			return trace.Wrap(err)
-		},
-		list:      p.accessLists.GetAccessLists,
-		cacheGet:  p.cache.GetAccessList,
-		cacheList: p.cache.GetAccessLists,
-		update: func(ctx context.Context, accessList *accesslist.AccessList) error {
-			_, err := p.accessLists.UpsertAccessList(ctx, accessList)
-			return trace.Wrap(err)
-		},
-		deleteAll: p.accessLists.DeleteAllAccessLists,
-	})
-}
-
 // TestUserLoginStates tests that CRUD operations on user login state resources are
 // replicated from the backend to the cache.
 func TestUserLoginStates(t *testing.T) {
@@ -2130,49 +2088,6 @@ func TestUserLoginStates(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.userLoginStates.DeleteAllUserLoginStates,
-	})
-}
-
-// TestAccessListMembers tests that CRUD operations on access list members resources are
-// replicated from the backend to the cache.
-func TestAccessListMembers(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	const accessListName = "test-access-list"
-
-	clock := clockwork.NewFakeClock()
-
-	p.accessLists.UpsertAccessList(context.Background(), newAccessList(t, accessListName, clock))
-
-	testResources(t, p, testFuncs[*accesslist.AccessListMember]{
-		newResource: func(name string) (*accesslist.AccessListMember, error) {
-			return newAccessListMember(t, accessListName, name), nil
-		},
-		create: func(ctx context.Context, member *accesslist.AccessListMember) error {
-			_, err := p.accessListMembers.UpsertAccessListMember(ctx, member)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*accesslist.AccessListMember, error) {
-			members, _, err := p.accessListMembers.ListAccessListMembers(ctx, accessListName, 0, "")
-			return members, trace.Wrap(err)
-		},
-		cacheGet: func(ctx context.Context, memberName string) (*accesslist.AccessListMember, error) {
-			return p.cache.GetAccessListMember(ctx, accessListName, memberName)
-		},
-		cacheList: func(ctx context.Context) ([]*accesslist.AccessListMember, error) {
-			members, _, err := p.cache.ListAccessListMembers(ctx, accessListName, 0, "")
-			return members, trace.Wrap(err)
-		},
-		update: func(ctx context.Context, member *accesslist.AccessListMember) error {
-			_, err := p.accessListMembers.UpsertAccessListMember(ctx, member)
-			return trace.Wrap(err)
-		},
-		deleteAll: func(ctx context.Context) error {
-			return trace.Wrap(p.accessListMembers.DeleteAllAccessListMembersForAccessList(ctx, accessListName))
-		},
 	})
 }
 
@@ -2572,8 +2487,6 @@ func newProxyEvents(events types.Events, ignoreKinds []types.WatchKind) *proxyEv
 func TestCacheWatchKindExistsInEvents(t *testing.T) {
 	t.Parallel()
 
-	clock := clockwork.NewFakeClock()
-
 	cases := map[string]Config{
 		"ForAuth":           ForAuth(Config{}),
 		"ForProxy":          ForProxy(Config{}),
@@ -2628,10 +2541,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindOktaImportRule:          &types.OktaImportRuleV1{},
 		types.KindOktaAssignment:          &types.OktaAssignmentV1{},
 		types.KindIntegration:             &types.IntegrationV1{},
-		types.KindAccessList:              newAccessList(t, "access-list", clock),
 		types.KindHeadlessAuthentication:  &types.HeadlessAuthentication{},
 		types.KindUserLoginState:          newUserLoginState(t, "user-login-state"),
-		types.KindAccessListMember:        newAccessListMember(t, "access-list", "member"),
 	}
 
 	for name, cfg := range cases {
@@ -2834,56 +2745,6 @@ func TestInvalidDatabases(t *testing.T) {
 	}
 }
 
-func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist.AccessList {
-	t.Helper()
-
-	accessList, err := accesslist.NewAccessList(
-		header.Metadata{
-			Name: name,
-		},
-		accesslist.Spec{
-			Title:       "title",
-			Description: "test access list",
-			Owners: []accesslist.Owner{
-				{
-					Name:        "test-user1",
-					Description: "test user 1",
-				},
-				{
-					Name:        "test-user2",
-					Description: "test user 2",
-				},
-			},
-			Audit: accesslist.Audit{
-				NextAuditDate: clock.Now(),
-			},
-			MembershipRequires: accesslist.Requires{
-				Roles: []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			OwnershipRequires: accesslist.Requires{
-				Roles: []string{"orole1", "orole2"},
-				Traits: map[string][]string{
-					"otrait1": {"ovalue1", "ovalue2"},
-					"otrait2": {"ovalue3", "ovalue4"},
-				},
-			},
-			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
-				Traits: map[string][]string{
-					"gtrait1": {"gvalue1", "gvalue2"},
-					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
-		},
-	)
-	require.NoError(t, err)
-	return accessList
-}
-
 func newUserLoginState(t *testing.T, name string) *userloginstate.UserLoginState {
 	t.Helper()
 
@@ -2901,26 +2762,6 @@ func newUserLoginState(t *testing.T, name string) *userloginstate.UserLoginState
 	)
 	require.NoError(t, err)
 	return uls
-}
-
-func newAccessListMember(t *testing.T, accessListName, memberName string) *accesslist.AccessListMember {
-	t.Helper()
-
-	member, err := accesslist.NewAccessListMember(
-		header.Metadata{
-			Name: memberName,
-		},
-		accesslist.AccessListMemberSpec{
-			AccessList: accessListName,
-			Name:       memberName,
-			Joined:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			Expires:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			Reason:     "because",
-			AddedBy:    "test-user1",
-		},
-	)
-	require.NoError(t, err)
-	return member
 }
 
 func withKeepalive[T any](fn func(context.Context, T) (*types.KeepAlive, error)) func(context.Context, T) error {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -172,8 +171,6 @@ type cacheCollections struct {
 	// byKind is a map of registered collections by resource Kind/SubKind
 	byKind map[resourceKind]collection
 
-	accessLists              collectionReader[services.AccessListsGetter]
-	accessListMembers        collectionReader[services.AccessListMembersGetter]
 	apps                     collectionReader[services.AppGetter]
 	nodes                    collectionReader[nodeGetter]
 	tunnelConnections        collectionReader[tunnelConnectionGetter]
@@ -595,12 +592,6 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 				watch: watch,
 			}
 			collections.byKind[resourceKind] = collections.integrations
-		case types.KindAccessList:
-			if c.AccessLists == nil {
-				return nil, trace.BadParameter("missing parameter AccessLists")
-			}
-			collections.accessLists = &genericCollection[*accesslist.AccessList, services.AccessListsGetter, accessListsExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessLists
 		case types.KindHeadlessAuthentication:
 			// For headless authentications, we need only process events. We don't need to keep the cache up to date.
 			collections.byKind[resourceKind] = &genericCollection[*types.HeadlessAuthentication, noReader, noopExecutor]{cache: c, watch: watch}
@@ -610,12 +601,6 @@ func setupCollections(c *Cache, watches []types.WatchKind) (*cacheCollections, e
 			}
 			collections.userLoginStates = &genericCollection[*userloginstate.UserLoginState, services.UserLoginStatesGetter, userLoginStateExecutor]{cache: c, watch: watch}
 			collections.byKind[resourceKind] = collections.userLoginStates
-		case types.KindAccessListMember:
-			if c.AccessLists == nil {
-				return nil, trace.BadParameter("missing parameter AccessLists")
-			}
-			collections.accessListMembers = &genericCollection[*accesslist.AccessListMember, services.AccessListMembersGetter, accessListMembersExecutor]{cache: c, watch: watch}
-			collections.byKind[resourceKind] = collections.accessListMembers
 		default:
 			return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 		}
@@ -2325,53 +2310,6 @@ func (integrationsExecutor) getReader(cache *Cache, cacheOK bool) services.Integ
 
 var _ executor[types.Integration, services.IntegrationsGetter] = integrationsExecutor{}
 
-type accessListsExecutor struct{}
-
-func (accessListsExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*accesslist.AccessList, error) {
-	var accessLists []*accesslist.AccessList
-	var nextToken string
-	for {
-		var page []*accesslist.AccessList
-		var err error
-
-		page, nextToken, err = cache.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		accessLists = append(accessLists, page...)
-
-		if nextToken == "" {
-			break
-		}
-	}
-	return accessLists, nil
-}
-
-func (accessListsExecutor) upsert(ctx context.Context, cache *Cache, resource *accesslist.AccessList) error {
-	_, err := cache.accessListsCache.UpsertAccessList(ctx, resource)
-	return trace.Wrap(err)
-}
-
-func (accessListsExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.accessListsCache.DeleteAllAccessLists(ctx)
-}
-
-func (accessListsExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.accessListsCache.DeleteAccessList(ctx, resource.GetName())
-}
-
-func (accessListsExecutor) isSingleton() bool { return false }
-
-func (accessListsExecutor) getReader(cache *Cache, cacheOK bool) services.AccessListsGetter {
-	if cacheOK {
-		return cache.accessListsCache
-	}
-	return cache.Config.AccessLists
-}
-
-var _ executor[*accesslist.AccessList, services.AccessListsGetter] = accessListsExecutor{}
-
 // noopExecutor can be used when a resource's events do not need to processed by
 // the cache itself, only passed on to other watchers.
 type noopExecutor struct{}
@@ -2430,75 +2368,3 @@ func (userLoginStateExecutor) getReader(cache *Cache, cacheOK bool) services.Use
 }
 
 var _ executor[*userloginstate.UserLoginState, services.UserLoginStatesGetter] = userLoginStateExecutor{}
-
-type accessListMembersExecutor struct{}
-
-func (accessListMembersExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
-	// Get all access lists
-	var accessLists []*accesslist.AccessList
-	var nextToken string
-	for {
-		var page []*accesslist.AccessList
-		var err error
-
-		page, nextToken, err = cache.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		accessLists = append(accessLists, page...)
-
-		if nextToken == "" {
-			break
-		}
-	}
-
-	// Get the members of each access list.
-	var members []*accesslist.AccessListMember
-	for _, accessList := range accessLists {
-		for {
-			var page []*accesslist.AccessListMember
-			var err error
-
-			page, nextToken, err = cache.AccessLists.ListAccessListMembers(ctx, accessList.GetName(), 0 /* default page size */, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			members = append(members, page...)
-
-			if nextToken == "" {
-				break
-			}
-		}
-	}
-	return members, nil
-}
-
-func (accessListMembersExecutor) upsert(ctx context.Context, cache *Cache, resource *accesslist.AccessListMember) error {
-	_, err := cache.accessListsCache.UpsertAccessListMember(ctx, resource)
-	return trace.Wrap(err)
-}
-
-func (accessListMembersExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.accessListsCache.DeleteAllAccessListMembers(ctx)
-}
-
-func (accessListMembersExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	member, ok := resource.(*accesslist.AccessListMember)
-	if !ok {
-		return trace.BadParameter("expected *accesslist.AccessListMember, got %T", resource)
-	}
-	return cache.accessListsCache.DeleteAccessListMember(ctx, member.Spec.AccessList, member.GetName())
-}
-
-func (accessListMembersExecutor) isSingleton() bool { return false }
-
-func (accessListMembersExecutor) getReader(cache *Cache, cacheOK bool) services.AccessListMembersGetter {
-	if cacheOK {
-		return cache.accessListsCache
-	}
-	return cache.AccessLists
-}
-
-var _ executor[*accesslist.AccessListMember, services.AccessListMembersGetter] = accessListMembersExecutor{}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2160,7 +2160,6 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		SAMLIdPServiceProviders: cfg.services,
 		UserGroups:              cfg.services,
 		Okta:                    cfg.services.OktaClient(),
-		AccessLists:             cfg.services.AccessListClient(),
 		UserLoginStates:         cfg.services.UserLoginStateClient(),
 		Integrations:            cfg.services,
 		WebSession:              cfg.services.WebSessions(),


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/33308 to branch/v13.

Note: This backport is manual due to there being no unified resource cache in v13 and needing to deconflict references to DiscoveryConfig, which is not in v13.