### PR TITLE
Automatically forward some spans from tsh to Cloud

### DIFF
--- a/lib/observability/tracing/tracing.go
+++ b/lib/observability/tracing/tracing.go
@@ -195,14 +195,11 @@ func NewTraceProvider(ctx context.Context, cfg Config) (*Provider, error) {
 	res, err := resource.New(ctx,
 		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithFromEnv(),
-		resource.WithProcessPID(),
 		resource.WithProcessExecutableName(),
-		resource.WithProcessExecutablePath(),
 		resource.WithProcessRuntimeName(),
 		resource.WithProcessRuntimeVersion(),
 		resource.WithProcessRuntimeDescription(),
 		resource.WithTelemetrySDK(),
-		resource.WithHost(),
 		resource.WithAttributes(attrs...),
 	)
 	if err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1164,40 +1164,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// If TELEPORT_DEBUG was set, it was already enabled by prior call to initLogger().
 	initLogger(&cf)
 
-	// Connect to the span exporter and initialize the trace provider only if
-	// the --trace flag was set.
-	// kubectl is a special case because it is the only command that we re-execute
-	// in order to be able to access the exit code and stdout/stderr of the command
-	// that was run and determine if we should create a new access request from
-	// the output data.
-	// We don't want to enable tracing for the master invocation of tsh kubectl
-	// because the data that we would be tracing would be the tsh kubectl command.
-	// Instead, we want to enable tracing for the re-executed kubectl command and
-	// we do that in the kubectl command handler.
-	cf.TracingProvider = tracing.NoopProvider()
-	cf.tracer = cf.TracingProvider.Tracer(teleport.ComponentTSH)
-	if cf.SampleTraces && cf.command != kubectl.FullCommand() {
-		// login only needs to be ignored if forwarding to auth
-		var ignored []string
-		if cf.TraceExporter == "" {
-			ignored = []string{login.FullCommand()}
-		}
-		provider, err := newTraceProvider(&cf, command, ignored)
-		if err != nil {
-			log.WithError(err).Debug("failed to set up span forwarding.")
-		} else {
-			// ensure that the provider is shutdown on exit to flush any spans
-			// that haven't been forwarded yet.
-			defer func() {
-				shutdownCtx, cancel := context.WithTimeout(cf.Context, 1*time.Second)
-				defer cancel()
-				err := provider.Shutdown(shutdownCtx)
-				if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-					log.WithError(err).Debugf("failed to shutdown trace provider")
-				}
-			}()
-		}
-	}
+	stopTracing := initializeTracing(&cf)
+	defer stopTracing()
 
 	// start the span for the command and update the config context so that all spans created
 	// in the future will be rooted at this span.
@@ -1472,44 +1440,103 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	return trace.Wrap(err)
 }
 
-// newTraceProvider initializes the tracing provider that will export spans for tsh.
-//
-// If an explicit exporter url was provided via --trace-exporter all spans will be
-// send to the provided exporter. Otherwise all recorded spans are exported to the
-// Auth server which then forwards to the telemetry backend. The ignored list contains
-// certain commands to have exporting spans be a no-op. Since the provider requires
-// connecting to the auth server, this means a user may have to login first before
-// the provider can be created. By ignoring the login command we can avoid having
-// users logging in twice at the expense of not exporting spans for the login command.
-func newTraceProvider(cf *CLIConf, command string, ignored []string) (*tracing.Provider, error) {
-	// don't record any spans for commands that have been allowed
-	for _, c := range ignored {
-		if strings.EqualFold(command, c) {
-			return tracing.NoopProvider(), nil
+// cloudAutomaticSamplingRate is the sampling rate at which traces are captured
+// when tracing is automatically enabled for invocations of some tsh commands
+// when performed against a cloud tenant.
+const cloudAutomaticSamplingRate = 0.25
+
+// isCloudTenant determines if the proxy address provided
+// belongs to a cloud tenant. It currently returns true if
+// the tenant is a production tenant.
+func isCloudTenant(proxyAddress string) bool {
+	return strings.HasSuffix(proxyAddress, ".teleport.sh:443")
+}
+
+func initializeTracing(cf *CLIConf) func() {
+	cf.TracingProvider = tracing.NoopProvider()
+	cf.tracer = cf.TracingProvider.Tracer(teleport.ComponentTSH)
+
+	// flush ensures that the spans are all attempted to be written when tsh exits.
+	flush := func(provider *tracing.Provider) func() {
+		return func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			err := provider.Shutdown(shutdownCtx)
+			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+				log.WithError(err).Debug("failed to shutdown trace provider")
+			}
 		}
 	}
 
-	// an explicit exporter url was provided no need to forward to auth
-	if cf.TraceExporter != "" {
+	// The list of commands that are automatically traced and forward to Cloud.
+	autoForwardedToCloud := []string{"ssh"}
+
+	// A default sampling rate of 1 ensures that all spans for this invocation of
+	// tsh are guaranteed to be recorded. Since Teleport honors the sampling rate
+	// of remote spans this will also cause Teleport to sample any spans it generates
+	// in response to the client request.
+	samplingRate := 1.0
+
+	switch {
+	// kubectl is a special case because it is the only command that we re-execute
+	// in order to be able to access the exit code and stdout/stderr of the command
+	// that was run and determine if we should create a new access request from
+	// the output data.
+	// We don't want to enable tracing for the master invocation of tsh kubectl
+	// because the data that we would be tracing would be the tsh kubectl command.
+	// Instead, we want to enable tracing for the re-executed kubectl command and
+	// we do that in the kubectl command handler.
+	case cf.command == "kubectl":
+		return func() {}
+	// The user explicitly asked for traces to be sent to a particular exporter
+	// instead of forwarding them to Auth. Proceed with creating the provider.
+	case cf.SampleTraces && cf.TraceExporter != "":
 		provider, err := tracing.NewTraceProvider(cf.Context, tracing.Config{
-			Service:     teleport.ComponentTSH,
-			ExporterURL: cf.TraceExporter,
-			// We are using 1 here to record all spans as a result of this tsh command. Teleport
-			// will respect the recording flag of remote spans even if the spans it generates
-			// wouldn't otherwise be recorded due to its configured sampling rate.
-			SamplingRate: 1.0,
+			Service:      teleport.ComponentTSH,
+			ExporterURL:  cf.TraceExporter,
+			SamplingRate: samplingRate,
 		})
+
+		if err != nil {
+			log.WithError(err).Debugf("failed to connect to trace exporter %s", cf.TraceExporter)
+			return func() {}
+		}
 
 		cf.TracingProvider = provider
 		cf.tracer = provider.Tracer(teleport.ComponentTSH)
-		return provider, trace.Wrap(err)
+		return flush(provider)
+	// The login command cannot forward spans to Auth since there is no way to get
+	// an authenticated client to forward with until after the authentication ceremony
+	// is complete. However, if the user explicitly provided an exporter then the login
+	// spans can be sent directly to it.
+	case cf.command == "login":
+		return func() {}
+	// All commands besides ssh are only traced if the user explicitly requested
+	// tracing. For ssh, a random number of spans may be sampled if the Proxy is
+	// for a Cloud tenant.
+	case !cf.SampleTraces && !slices.Contains(autoForwardedToCloud, cf.command):
+		return func() {}
+	case cf.SampleTraces:
 	}
 
-	// create a TeleportClient and generate a provider that forwards
-	// spans to Auth
+	// Parse the config to determine if forwarding is needed for Cloud and
+	// to get a handle to an Auth client.
 	tc, err := makeClient(cf)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		log.WithError(err).Debug("failed to set up span forwarding.")
+		return func() {}
+	}
+
+	if !cf.SampleTraces {
+		// Automatically enable and forward spans to Cloud if the following conditions are met:
+		// 1) The proxy address resembles that of a Cloud tenant
+		// 2) The command being executed is tsh ssh
+		// 3) The user has not already explicitly provided the --trace flag.
+		if isCloudTenant(tc.WebProxyAddr) {
+			samplingRate = cloudAutomaticSamplingRate
+		} else {
+			return func() {}
+		}
 	}
 
 	var provider *tracing.Provider
@@ -1521,12 +1548,9 @@ func newTraceProvider(cf *CLIConf, command string, ignored []string) (*tracing.P
 
 		p, err := tracing.NewTraceProvider(cf.Context,
 			tracing.Config{
-				Service: teleport.ComponentTSH,
-				Client:  clt,
-				// We are using 1 here to record all spans as a result of this tsh command. Teleport
-				// will respect the recording flag of remote spans even if the spans it generates
-				// wouldn't otherwise be recorded due to its configured sampling rate.
-				SamplingRate: 1.0,
+				Service:      teleport.ComponentTSH,
+				Client:       clt,
+				SamplingRate: samplingRate,
 			})
 		if err != nil {
 			return trace.NewAggregate(err, clt.Close())
@@ -1535,12 +1559,13 @@ func newTraceProvider(cf *CLIConf, command string, ignored []string) (*tracing.P
 		provider = p
 		return nil
 	}); err != nil {
-		return nil, trace.Wrap(err)
+		log.WithError(err).Debug("failed to set up span forwarding.")
+		return func() {}
 	}
 
 	cf.TracingProvider = provider
 	cf.tracer = provider.Tracer(teleport.ComponentTSH)
-	return provider, nil
+	return flush(provider)
 }
 
 // onVersion prints version info.


### PR DESCRIPTION
Alters the tracing initialization logic such that 50% of all tsh ssh commands run against Cloud are sampled. Additionally some of the detectors have been dropped to eliminate any details about a users machine being included in the attributes.