### PR TITLE
Deprecate GenerateUserSingleUseCerts for GenerateUserCerts

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1656,6 +1656,7 @@ func (c *Client) GetMFADevices(ctx context.Context, in *proto.GetMFADevicesReque
 
 // Deprecated: Use GenerateUserCerts instead.
 func (c *Client) GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error) {
+	//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 	stream, err := c.grpc.GenerateUserSingleUseCerts(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1654,6 +1654,7 @@ func (c *Client) GetMFADevices(ctx context.Context, in *proto.GetMFADevicesReque
 	return resp, nil
 }
 
+// Deprecated: Use GenerateUserCerts instead.
 func (c *Client) GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error) {
 	stream, err := c.grpc.GenerateUserSingleUseCerts(ctx)
 	if err != nil {

--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -7190,6 +7190,8 @@ func (m *GetMFADevicesResponse) GetDevices() []*types.MFADevice {
 }
 
 // UserSingleUseCertsRequest is a request for a single-use user certificate.
+//
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 type UserSingleUseCertsRequest struct {
 	// Types that are valid to be assigned to Request:
 	//	*UserSingleUseCertsRequest_Init
@@ -7279,6 +7281,8 @@ func (*UserSingleUseCertsRequest) XXX_OneofWrappers() []interface{} {
 }
 
 // UserSingleUseCertsResponse is a response with a single-use user certificate.
+//
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 type UserSingleUseCertsResponse struct {
 	// Types that are valid to be assigned to Response:
 	//	*UserSingleUseCertsResponse_MFAChallenge
@@ -15734,6 +15738,8 @@ type AuthServiceClient interface {
 	GenerateHostCerts(ctx context.Context, in *HostCertsRequest, opts ...grpc.CallOption) (*Certs, error)
 	// GenerateUserSingleUseCerts generates a set of single-use user
 	// certificates.
+	//
+	// Deprecated: Superseded by GenerateUserCerts.
 	GenerateUserSingleUseCerts(ctx context.Context, opts ...grpc.CallOption) (AuthService_GenerateUserSingleUseCertsClient, error)
 	// GenerateOpenSSHCert signs a SSH certificate that can be used
 	// to connect to Agentless nodes.
@@ -19059,6 +19065,8 @@ type AuthServiceServer interface {
 	GenerateHostCerts(context.Context, *HostCertsRequest) (*Certs, error)
 	// GenerateUserSingleUseCerts generates a set of single-use user
 	// certificates.
+	//
+	// Deprecated: Superseded by GenerateUserCerts.
 	GenerateUserSingleUseCerts(AuthService_GenerateUserSingleUseCertsServer) error
 	// GenerateOpenSSHCert signs a SSH certificate that can be used
 	// to connect to Agentless nodes.

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1293,6 +1293,8 @@ message GetMFADevicesResponse {
 }
 
 // UserSingleUseCertsRequest is a request for a single-use user certificate.
+//
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 message UserSingleUseCertsRequest {
   oneof Request {
     UserCertsRequest Init = 1;
@@ -1301,6 +1303,8 @@ message UserSingleUseCertsRequest {
 }
 
 // UserSingleUseCertsResponse is a response with a single-use user certificate.
+//
+// Deprecated: Use [AuthService.GenerateUserCerts] instead.
 message UserSingleUseCertsResponse {
   oneof Response {
     MFAAuthenticateChallenge MFAChallenge = 1;
@@ -2521,6 +2525,8 @@ service AuthService {
   rpc GenerateHostCerts(HostCertsRequest) returns (Certs);
   // GenerateUserSingleUseCerts generates a set of single-use user
   // certificates.
+  //
+  // Deprecated: Superseded by GenerateUserCerts.
   rpc GenerateUserSingleUseCerts(stream UserSingleUseCertsRequest) returns (stream UserSingleUseCertsResponse);
   // GenerateOpenSSHCert signs a SSH certificate that can be used
   // to connect to Agentless nodes.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -611,6 +611,8 @@ type IdentityService interface {
 	// GenerateUserSingleUseCerts is like GenerateUserCerts but issues a
 	// certificate for a single session
 	// (https://github.com/gravitational/teleport/blob/3a1cf9111c2698aede2056513337f32bfc16f1f1/rfd/0014-session-2FA.md#sessions).
+	//
+	// Deprecated: Use GenerateUserCerts instead.
 	GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error)
 
 	// IsMFARequired is a request to check whether MFA is required to

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2726,6 +2726,7 @@ func (g *GRPCServer) GenerateUserSingleUseCerts(stream authpb.AuthService_Genera
 			// If MFA is not required to gain access to the resource then let the client
 			// know and abort the ceremony.
 			if !required {
+				//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 				return trace.Wrap(stream.Send(&authpb.UserSingleUseCertsResponse{
 					Response: &authpb.UserSingleUseCertsResponse_MFAChallenge{
 						MFAChallenge: &authpb.MFAAuthenticateChallenge{
@@ -2755,6 +2756,7 @@ func (g *GRPCServer) GenerateUserSingleUseCerts(stream authpb.AuthService_Genera
 	}
 
 	// 4. send Certs
+	//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 	if err := stream.Send(&authpb.UserSingleUseCertsResponse{
 		Response: &authpb.UserSingleUseCertsResponse_Cert{Cert: respCert},
 	}); err != nil {
@@ -2837,6 +2839,7 @@ func userSingleUseCertsAuthChallenge(gctx *grpcContext, stream authpb.AuthServic
 
 	challenge.MFARequired = mfaRequired
 
+	//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 	if err := stream.Send(&authpb.UserSingleUseCertsResponse{
 		Response: &authpb.UserSingleUseCertsResponse_MFAChallenge{MFAChallenge: challenge},
 	}); err != nil {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2669,6 +2669,8 @@ func (g *GRPCServer) GetMFADevices(ctx context.Context, req *authpb.GetMFADevice
 	return devs, trace.Wrap(err)
 }
 
+// DELETE IN v16, kept for compatibility with older tsh versions (codingllama).
+// (Don't actually delete it, but instead make it always error.)
 func (g *GRPCServer) GenerateUserSingleUseCerts(stream authpb.AuthService_GenerateUserSingleUseCertsServer) error {
 	ctx := stream.Context()
 	actx, err := g.authenticate(ctx)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1643,10 +1643,12 @@ type generateUserSingleUseCertsTestOpts struct {
 
 func testGenerateUserSingleUseCertsStream(ctx context.Context, t *testing.T, cl *Client, opts generateUserSingleUseCertsTestOpts) {
 	runStream := func() (*proto.SingleUseUserCert, error) {
+		//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 		stream, err := cl.GenerateUserSingleUseCerts(ctx)
 		require.NoError(t, err, "GenerateUserSingleUseCerts stream creation failed")
 
 		// Init.
+		//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 		if err := stream.Send(&proto.UserSingleUseCertsRequest{
 			Request: &proto.UserSingleUseCertsRequest_Init{
 				Init: opts.initReq,
@@ -1664,6 +1666,7 @@ func testGenerateUserSingleUseCertsStream(ctx context.Context, t *testing.T, cl 
 		opts.mfaRequiredHandler(t, authnChal.MFARequired)
 		authnSolved := opts.authnHandler(t, authnChal)
 
+		//nolint:staticcheck // SA1019. Kept for backwards compatibility.
 		switch err := stream.Send(&proto.UserSingleUseCertsRequest{
 			Request: &proto.UserSingleUseCertsRequest_MFAResponse{
 				MFAResponse: authnSolved,


### PR DESCRIPTION
Last step in the GenerateUserSingleUseCerts cleanup.

#20343