### PR TITLE
[v14] Allow access requests to use user login state.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1746,17 +1746,7 @@ func certRequestDeviceExtensions(ext tlsca.DeviceExtensions) certRequestOption {
 
 // GetUserOrLoginState will return the given user or the login state associated with the user.
 func (a *Server) GetUserOrLoginState(ctx context.Context, username string) (services.UserState, error) {
-	uls, err := a.GetUserLoginState(ctx, username)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	if err == nil {
-		return uls, nil
-	}
-
-	user, err := a.GetUser(username, false)
-	return user, trace.Wrap(err)
+	return services.GetUserOrLoginState(ctx, a, username)
 }
 
 func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCertRequest) (*proto.OpenSSHCert, error) {

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -37,6 +39,7 @@ import (
 
 // mockGetter mocks the UserAndRoleGetter interface.
 type mockGetter struct {
+	userStates  map[string]*userloginstate.UserLoginState
 	users       map[string]types.User
 	roles       map[string]types.Role
 	nodes       map[string]types.Server
@@ -50,23 +53,27 @@ type mockGetter struct {
 // user inserts a new user with the specified roles and returns the username.
 func (m *mockGetter) user(t *testing.T, roles ...string) string {
 	name := uuid.New().String()
-	user, err := types.NewUser(name)
+	uls, err := userloginstate.New(header.Metadata{
+		Name: name,
+	}, userloginstate.Spec{
+		Roles: roles,
+	})
 	require.NoError(t, err)
 
-	user.SetRoles(roles)
-	m.users[name] = user
+	m.userStates[name] = uls
 	return name
 }
 
-func (m *mockGetter) GetUser(name string, withSecrets bool) (types.User, error) {
-	if withSecrets {
-		return nil, trace.NotImplemented("mock getter does not store secrets")
-	}
-	user, ok := m.users[name]
+func (m *mockGetter) GetUserLoginStates(context.Context) ([]*userloginstate.UserLoginState, error) {
+	return nil, trace.NotImplemented("GetUserLoginStates is not implemented")
+}
+
+func (m *mockGetter) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+	uls, ok := m.userStates[name]
 	if !ok {
-		return nil, trace.NotFound("no such user: %q", name)
+		return nil, trace.NotFound("no such user login state: %q", name)
 	}
-	return user, nil
+	return uls, nil
 }
 
 func (m *mockGetter) GetRole(ctx context.Context, name string) (types.Role, error) {
@@ -75,6 +82,18 @@ func (m *mockGetter) GetRole(ctx context.Context, name string) (types.Role, erro
 		return nil, trace.NotFound("no such role: %q", name)
 	}
 	return role, nil
+}
+
+func (m *mockGetter) GetUser(name string, withSecrets bool) (types.User, error) {
+	if withSecrets {
+		return nil, trace.NotImplemented("")
+	}
+
+	user, ok := m.users[name]
+	if !ok {
+		return nil, trace.NotFound("no such user: %q", name)
+	}
+	return user, nil
 }
 
 func (m *mockGetter) GetRoles(ctx context.Context) ([]types.Role, error) {
@@ -241,15 +260,28 @@ func TestReviewThresholds(t *testing.T) {
 	}
 
 	// describes a collection of users with various roles
-	userDesc := map[string][]string{
+	ulsDesc := map[string][]string{
 		"alice": {"populist", "proletariat", "intelligentsia", "military"},
-		"bob":   {"general", "proletariat", "intelligentsia", "military"},
 		"carol": {"conqueror", "proletariat", "intelligentsia", "military"},
-		"dave":  {"populist", "general", "conqueror"},
 		"erika": {"populist", "idealist"},
 	}
 
+	userStates := make(map[string]*userloginstate.UserLoginState)
+	for name, roles := range ulsDesc {
+		uls, err := userloginstate.New(header.Metadata{
+			Name: name,
+		}, userloginstate.Spec{
+			Roles: roles,
+		})
+		require.NoError(t, err)
+		userStates[name] = uls
+	}
+
 	users := make(map[string]types.User)
+	userDesc := map[string][]string{
+		"bob":  {"general", "proletariat", "intelligentsia", "military"},
+		"dave": {"populist", "general", "conqueror"},
+	}
 
 	for name, roles := range userDesc {
 		user, err := types.NewUser(name)
@@ -260,8 +292,9 @@ func TestReviewThresholds(t *testing.T) {
 	}
 
 	g := &mockGetter{
-		roles: roles,
-		users: users,
+		roles:      roles,
+		userStates: userStates,
+		users:      users,
 	}
 
 	const (
@@ -635,7 +668,7 @@ func TestReviewThresholds(t *testing.T) {
 					ProposedState: rt.propose,
 				}
 
-				author, ok := users[rt.author]
+				author, ok := userStates[rt.author]
 				require.True(t, ok, "scenario=%q, rev=%d", tt.desc, ri)
 
 				err = ApplyAccessReview(req, rev, author)
@@ -1104,21 +1137,24 @@ func TestRolesForResourceRequest(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			user, err := types.NewUser("test-user")
+			uls, err := userloginstate.New(header.Metadata{
+				Name: "test-user",
+			}, userloginstate.Spec{
+				Roles: tc.currentRoles,
+			})
 			require.NoError(t, err)
-			user.SetRoles(tc.currentRoles)
-			users := map[string]types.User{
-				user.GetName(): user,
+			userStates := map[string]*userloginstate.UserLoginState{
+				uls.GetName(): uls,
 			}
 
 			g := &mockGetter{
 				roles:       roles,
-				users:       users,
+				userStates:  userStates,
 				clusterName: "my-cluster",
 			}
 
 			req, err := types.NewAccessRequestWithResources(
-				"some-id", user.GetName(), tc.requestRoles, tc.requestResourceIDs)
+				"some-id", uls.GetName(), tc.requestRoles, tc.requestResourceIDs)
 			require.NoError(t, err)
 
 			clock := clockwork.NewFakeClock()
@@ -1126,7 +1162,7 @@ func TestRolesForResourceRequest(t *testing.T) {
 				Expires: clock.Now().UTC().Add(8 * time.Hour),
 			}
 
-			validator, err := NewRequestValidator(context.Background(), clock, g, user.GetName(), ExpandVars(true))
+			validator, err := NewRequestValidator(context.Background(), clock, g, uls.GetName(), ExpandVars(true))
 			require.NoError(t, err)
 
 			err = validator.Validate(context.Background(), req, identity)
@@ -1147,6 +1183,7 @@ func TestPruneRequestRoles(t *testing.T) {
 
 	g := &mockGetter{
 		roles:       make(map[string]types.Role),
+		userStates:  make(map[string]*userloginstate.UserLoginState),
 		users:       make(map[string]types.User),
 		nodes:       make(map[string]types.Server),
 		kubeServers: make(map[string]types.KubeServer),
@@ -1241,10 +1278,10 @@ func TestPruneRequestRoles(t *testing.T) {
 	}
 
 	user := g.user(t, "response-team")
-	g.users[user].SetTraits(map[string][]string{
+	g.userStates[user].Spec.Traits = map[string][]string{
 		"logins": {"responder"},
 		"team":   {"response-team"},
-	})
+	}
 
 	nodeDesc := []struct {
 		name   string
@@ -1598,9 +1635,12 @@ func TestRequestTTL(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// Setup test user "foo" and "bar" and the mock auth server that
 			// will return users and roles.
-			user, err := types.NewUser("foo")
+			uls, err := userloginstate.New(header.Metadata{
+				Name: "foo",
+			}, userloginstate.Spec{
+				Roles: []string{"bar"},
+			})
 			require.NoError(t, err)
-			user.SetRoles([]string{"bar"})
 
 			role, err := types.NewRole("bar", types.RoleSpecV6{
 				Options: types.RoleOptions{
@@ -1610,8 +1650,8 @@ func TestRequestTTL(t *testing.T) {
 			require.NoError(t, err)
 
 			getter := &mockGetter{
-				users: map[string]types.User{"foo": user},
-				roles: map[string]types.Role{"bar": role},
+				userStates: map[string]*userloginstate.UserLoginState{"foo": uls},
+				roles:      map[string]types.Role{"bar": role},
 			}
 
 			validator, err := NewRequestValidator(context.Background(), clock, getter, "foo", ExpandVars(true))
@@ -1675,7 +1715,6 @@ func TestSessionTTL(t *testing.T) {
 			// will return users and roles.
 			user, err := types.NewUser("foo")
 			require.NoError(t, err)
-			user.SetRoles([]string{"bar"})
 
 			role, err := types.NewRole("bar", types.RoleSpecV6{
 				Options: types.RoleOptions{
@@ -1793,22 +1832,24 @@ func TestAutoRequest(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		user, err := types.NewUser("foo")
+		uls, err := userloginstate.New(header.Metadata{
+			Name: "foo",
+		}, userloginstate.Spec{})
 		require.NoError(t, err)
 
 		getter := &mockGetter{
-			users: make(map[string]types.User),
-			roles: make(map[string]types.Role),
+			userStates: make(map[string]*userloginstate.UserLoginState),
+			roles:      make(map[string]types.Role),
 		}
 
 		for _, r := range test.roles {
 			getter.roles[r.GetName()] = r
-			user.AddRole(r.GetName())
+			uls.Spec.Roles = append(uls.Spec.Roles, r.GetName())
 		}
 
-		getter.users[user.GetName()] = user
+		getter.userStates[uls.GetName()] = uls
 
-		validator, err := NewRequestValidator(context.Background(), clock, getter, user.GetName(), ExpandVars(true))
+		validator, err := NewRequestValidator(context.Background(), clock, getter, uls.GetName(), ExpandVars(true))
 		require.NoError(t, err)
 		test.assertion(t, &validator)
 	}
@@ -2159,19 +2200,22 @@ func getMockGetter(t *testing.T, roleDesc roleTestSet, userDesc map[string][]str
 		roles[name] = role
 	}
 
-	users := make(map[string]types.User)
+	userStates := make(map[string]*userloginstate.UserLoginState)
 
 	for name, roles := range userDesc {
-		user, err := types.NewUser(name)
+		uls, err := userloginstate.New(header.Metadata{
+			Name: name,
+		}, userloginstate.Spec{
+			Roles: roles,
+		})
 		require.NoError(t, err)
 
-		user.SetRoles(roles)
-		users[name] = user
+		userStates[name] = uls
 	}
 
 	g := &mockGetter{
-		roles: roles,
-		users: users,
+		roles:      roles,
+		userStates: userStates,
 	}
 	return g
 }

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -171,7 +171,7 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 		}
 
 		// run the application logic
-		if err := services.ApplyAccessReview(req, params.Review, checker.User); err != nil {
+		if err := services.ApplyAccessReview(req, params.Review, checker.UserState); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -90,3 +90,24 @@ func UnmarshalUserLoginState(data []byte, opts ...MarshalOption) (*userloginstat
 
 	return uls, nil
 }
+
+// UserOrLoginStateGetter defines an interface that can get user login states or users.
+type UserOrLoginStateGetter interface {
+	UserLoginStatesGetter
+	UserGetter
+}
+
+// GetUserOrLoginState will return the given user or the login state associated with the user.
+func GetUserOrLoginState(ctx context.Context, getter UserOrLoginStateGetter, username string) (UserState, error) {
+	uls, err := getter.GetUserLoginState(ctx, username)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	if err == nil {
+		return uls, nil
+	}
+
+	user, err := getter.GetUser(username, false)
+	return user, trace.Wrap(err)
+}

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -276,7 +276,14 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) 
 	req.SetRequestReason(c.reason)
 
 	if c.dryRun {
-		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), client, req, tlsca.Identity{}, services.ExpandVars(true))
+		users := &struct {
+			auth.ClientI
+			services.UserLoginStatesGetter
+		}{
+			ClientI:               client,
+			UserLoginStatesGetter: client.UserLoginStateClient(),
+		}
+		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), users, req, tlsca.Identity{}, services.ExpandVars(true))
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/33317 to branch/v14.

Note: This backport was manual largely due to the `GetUser` refactor in master which added in the context to the GetUser call.