### PR TITLE
[v14] Downgrade `@teleport-access-approver` to `v6`

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -39,7 +39,7 @@ func NewSystemAutomaticAccessApproverRole() types.Role {
 	}
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V6,
 		Metadata: types.Metadata{
 			Name:        teleport.SystemAutomaticAccessApprovalRoleName,
 			Namespace:   apidefaults.Namespace,


### PR DESCRIPTION
Teleport 14 added `@teleport-access-approver` role as `v7` but this prevents downgrades from v14 to v13 because v13 doesn't support role v7.