### PR TITLE
Be able to connect to DBs even when etcd backend is down

### DIFF
--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -961,7 +961,7 @@ func (s *Server) handleConnection(ctx context.Context, clientConn net.Conn) erro
 	defer cancel()
 
 	if err := s.trackSession(cancelCtx, sessionCtx); err != nil {
-		return trace.Wrap(err)
+		s.log.WithError(err).Warnf("could not track session %v", sessionCtx.ID)
 	}
 
 	rec, err := s.newSessionRecorder(sessionCtx)


### PR DESCRIPTION
When etcd backend is down, all the calls to it are stuck forever. By adding context timeout we are able to fail faster. 
when proxying any DB trackSession is called and when etcd is down this makes request for proxying fail. instead by ignoring this error we will be able to use the DBs even when etcd is down as long as the user is authenticated