### PR TITLE
docs: update macos app remove command to delete dir

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -556,7 +556,7 @@ $ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --insecure
 Remove Teleport Connect for MacOS from the Applications directory with this command:
 
 ```code
-$ sudo rm -f /Applications/Teleport\ Connect.app
+$ sudo rm -rf /Applications/Teleport\ Connect.app
 ```
 
 To remove the local user data directory:

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -157,8 +157,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh`-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 
@@ -275,8 +275,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 
@@ -391,8 +391,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 


### PR DESCRIPTION
This command gives an error without `r` since these are dirs.