### PR TITLE
[v13] docs: update macos app remove command to delete dir and correct fips debug container address

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -374,7 +374,7 @@ $ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --insecure
 Remove Teleport Connect for MacOS from the Applications directory with this command:
 
 ```code
-$ sudo rm -f /Applications/Teleport\ Connect.app
+$ sudo rm -rf /Applications/Teleport\ Connect.app
 ```
 
 To remove the local user data directory:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -185,7 +185,7 @@ We also provide the following images for FIPS builds of Teleport Enterprise:
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
 | `public.ecr.aws/gravitational/teleport-ent-fips-distroless:(=teleport.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
-| `public.ecr.aws/gravitational/teleport-ent-fips-distroless-debug(=teleport.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `public.ecr.aws/gravitational/teleport-ent-fips-distroless-debug:(=teleport.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
 For testing, we always recommend that you use the latest release version of
 Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -157,8 +157,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh`-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 
@@ -275,8 +275,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 
@@ -391,8 +391,8 @@ $ docker stop teleport
   If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
 
   ```code
-  $ sudo rm -f /Applications/tsh.app
-  $ sudo rm -f /Applications/Teleport\ Connect.app
+  $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>
 


### PR DESCRIPTION
Backport #33365 and #33422 to branch/v13