### PR TITLE
Use authz helpers for user role checking

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1393,13 +1393,13 @@ func HasBuiltinRole(authContext Context, name string) bool {
 
 // IsLocalUser checks if the identity is a local user.
 func IsLocalUser(authContext Context) bool {
-	_, ok := authContext.Identity.(LocalUser)
+	_, ok := authContext.UnmappedIdentity.(LocalUser)
 	return ok
 }
 
 // IsLocalOrRemoteUser checks if the identity is either a local or remote user.
 func IsLocalOrRemoteUser(authContext Context) bool {
-	switch authContext.Identity.(type) {
+	switch authContext.UnmappedIdentity.(type) {
 	case LocalUser, RemoteUser:
 		return true
 	default:
@@ -1414,6 +1414,6 @@ func IsCurrentUser(authContext Context, username string) bool {
 
 // IsRemoteUser checks if the identity is a remote user.
 func IsRemoteUser(authContext Context) bool {
-	_, ok := authContext.Identity.(RemoteUser)
+	_, ok := authContext.UnmappedIdentity.(RemoteUser)
 	return ok
 }

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -726,12 +726,17 @@ func TestRoleSetForBuiltinRoles(t *testing.T) {
 }
 
 func TestIsUserFunctions(t *testing.T) {
-	localIdentity := Context{Identity: LocalUser{}}
-	remoteIdentity := Context{Identity: RemoteUser{}}
+	localIdentity := Context{
+		Identity:         LocalUser{},
+		UnmappedIdentity: LocalUser{},
+	}
+	remoteIdentity := Context{
+		Identity:         RemoteUser{},
+		UnmappedIdentity: RemoteUser{},
+	}
 	systemIdentity := Context{
-		Identity: BuiltinRole{
-			Role: types.RoleProxy,
-		},
+		Identity:         BuiltinRole{Role: types.RoleProxy},
+		UnmappedIdentity: BuiltinRole{Role: types.RoleProxy},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Replace hasLocalUserRole and hasRemoteUserRole with the corresponding lib/authz helpers. 

Additionally, change the lib/authz helpers to use UnmappedIdentity, which seems more robust than the current implementation.