### PR TITLE
[v14] Fix an issue `tsh` fails when Proxy is in separate mode and web port is TLS-terminated by a load balancer

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1317,9 +1317,15 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		sshProxyAddr = cfg.Proxy.SSHAddr
 		kubeProxyAddr = cfg.Proxy.KubeAddr
 	case cfg.ALBAddr != "":
-		webProxyAddr = cfg.ALBAddr
-		sshProxyAddr = cfg.ALBAddr
-		kubeProxyAddr = cfg.ALBAddr
+		if i.IsSinglePortSetup {
+			webProxyAddr = cfg.ALBAddr
+			sshProxyAddr = cfg.ALBAddr
+			kubeProxyAddr = cfg.ALBAddr
+		} else {
+			webProxyAddr = cfg.ALBAddr
+			sshProxyAddr = i.SSHProxy
+			kubeProxyAddr = i.Config.Proxy.Kube.ListenAddr.Addr
+		}
 	default:
 		webProxyAddr = i.Web
 		sshProxyAddr = i.SSHProxy

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -72,7 +72,6 @@ func TestALPNSNIProxyMultiCluster(t *testing.T) {
 		secondClusterPortSetup    helpers.InstanceListenerSetupFunc
 		disableALPNListenerOnRoot bool
 		disableALPNListenerOnLeaf bool
-		testALPNConnUpgrade       bool
 	}{
 		{
 			name:                      "StandardAndOnePortSetupMasterALPNDisabled",
@@ -89,20 +88,17 @@ func TestALPNSNIProxyMultiCluster(t *testing.T) {
 			name:                   "TwoClusterOnePortSetup",
 			mainClusterPortSetup:   helpers.SingleProxyPortSetup,
 			secondClusterPortSetup: helpers.SingleProxyPortSetup,
-			testALPNConnUpgrade:    true,
 		},
 		{
 			name:                      "OnePortAndStandardListenerSetupLeafALPNDisabled",
 			mainClusterPortSetup:      helpers.SingleProxyPortSetup,
 			secondClusterPortSetup:    helpers.StandardListenerSetup,
 			disableALPNListenerOnLeaf: true,
-			testALPNConnUpgrade:       true,
 		},
 		{
 			name:                   "OnePortAndStandardListenerSetup",
 			mainClusterPortSetup:   helpers.SingleProxyPortSetup,
 			secondClusterPortSetup: helpers.StandardListenerSetup,
-			testALPNConnUpgrade:    true,
 		},
 	}
 
@@ -140,30 +136,28 @@ func TestALPNSNIProxyMultiCluster(t *testing.T) {
 				Port:    helpers.Port(t, suite.leaf.SSH),
 			})
 
-			if tc.testALPNConnUpgrade {
-				t.Run("ALPN conn upgrade", func(t *testing.T) {
-					// Make a mock ALB which points to the Teleport Proxy Service.
-					albProxy := helpers.MustStartMockALBProxy(t, suite.root.Config.Proxy.WebAddr.Addr)
+			t.Run("WebProxyAddr behind ALB", func(t *testing.T) {
+				// Make a mock ALB which points to the Teleport Proxy Service.
+				albProxy := helpers.MustStartMockALBProxy(t, suite.root.Config.Proxy.WebAddr.Addr)
 
-					// Run command in root through ALB address.
-					suite.mustConnectToClusterAndRunSSHCommand(t, helpers.ClientConfig{
-						Login:   username,
-						Cluster: suite.root.Secrets.SiteName,
-						Host:    helpers.Loopback,
-						Port:    helpers.Port(t, suite.root.SSH),
-						ALBAddr: albProxy.Addr().String(),
-					})
-
-					// Run command in leaf through ALB address.
-					suite.mustConnectToClusterAndRunSSHCommand(t, helpers.ClientConfig{
-						Login:   username,
-						Cluster: suite.leaf.Secrets.SiteName,
-						Host:    helpers.Loopback,
-						Port:    helpers.Port(t, suite.leaf.SSH),
-						ALBAddr: albProxy.Addr().String(),
-					})
+				// Run command in root through ALB address.
+				suite.mustConnectToClusterAndRunSSHCommand(t, helpers.ClientConfig{
+					Login:   username,
+					Cluster: suite.root.Secrets.SiteName,
+					Host:    helpers.Loopback,
+					Port:    helpers.Port(t, suite.root.SSH),
+					ALBAddr: albProxy.Addr().String(),
 				})
-			}
+
+				// Run command in leaf through ALB address.
+				suite.mustConnectToClusterAndRunSSHCommand(t, helpers.ClientConfig{
+					Login:   username,
+					Cluster: suite.leaf.Secrets.SiteName,
+					Host:    helpers.Loopback,
+					Port:    helpers.Port(t, suite.leaf.SSH),
+					ALBAddr: albProxy.Addr().String(),
+				})
+			})
 		})
 	}
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2823,17 +2823,19 @@ func (tc *TeleportClient) ConnectToCluster(ctx context.Context) (*ClusterClient,
 	}
 
 	pclt, err := proxyclient.NewClient(ctx, proxyclient.ClientConfig{
-		ProxyAddress:            cfg.proxyAddress,
-		TLSRoutingEnabled:       tc.TLSRoutingEnabled,
-		TLSConfig:               tlsConfig,
-		DialOpts:                tc.Config.DialOpts,
-		UnaryInterceptors:       []grpc.UnaryClientInterceptor{interceptors.GRPCClientUnaryErrorInterceptor},
-		StreamInterceptors:      []grpc.StreamClientInterceptor{interceptors.GRPCClientStreamErrorInterceptor},
-		SSHConfig:               cfg.ClientConfig,
-		ALPNConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
-		InsecureSkipVerify:      tc.InsecureSkipVerify,
-		ViaJumpHost:             len(tc.JumpHosts) > 0,
-		PROXYHeaderGetter:       CreatePROXYHeaderGetter(ctx, tc.PROXYSigner),
+		ProxyAddress:       cfg.proxyAddress,
+		TLSRoutingEnabled:  tc.TLSRoutingEnabled,
+		TLSConfig:          tlsConfig,
+		DialOpts:           tc.Config.DialOpts,
+		UnaryInterceptors:  []grpc.UnaryClientInterceptor{interceptors.GRPCClientUnaryErrorInterceptor},
+		StreamInterceptors: []grpc.StreamClientInterceptor{interceptors.GRPCClientStreamErrorInterceptor},
+		SSHConfig:          cfg.ClientConfig,
+		InsecureSkipVerify: tc.InsecureSkipVerify,
+		ViaJumpHost:        len(tc.JumpHosts) > 0,
+		PROXYHeaderGetter:  CreatePROXYHeaderGetter(ctx, tc.PROXYSigner),
+		// Connections are only upgraded through web port. Do not upgrade when
+		// using SSHProxyAddr in separate port mode.
+		ALPNConnUpgradeRequired: tc.TLSRoutingEnabled && tc.TLSRoutingConnUpgradeRequired,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Backport #33374 to branch/v14