### PR TITLE
Add `user_certificates_generated` prometheus metric

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -606,6 +606,15 @@ var (
 		[]string{teleport.TagRoles, teleport.TagResources},
 	)
 
+	userCertificatesGeneratedMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricUserCertificatesGenerated,
+			Help:      "Tracks the number of user certificates generated",
+		},
+		[]string{teleport.TagPrivateKeyPolicy},
+	)
+
 	prometheusCollectors = []prometheus.Collector{
 		generateRequestsCount, generateThrottledRequestsCount,
 		generateRequestsCurrent, generateRequestsLatencies, UserLoginCount, heartbeatsMissedByAuth,
@@ -613,6 +622,7 @@ var (
 		totalInstancesMetric, enrolledInUpgradesMetric, upgraderCountsMetric,
 		accessRequestsCreatedMetric,
 		registeredAgentsInstallMethod,
+		userCertificatesGeneratedMetric,
 	}
 )
 
@@ -2619,6 +2629,8 @@ func generateCert(a *Server, req certRequest, caType types.CertAuthType) (*proto
 	}
 
 	a.submitCertificateIssuedEvent(&req)
+
+	userCertificatesGeneratedMetric.WithLabelValues(string(attestedKeyPolicy)).Inc()
 
 	return certs, nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -112,6 +112,11 @@ const (
 	TagRoles = "roles"
 	// TagResources is a number of resources requested as a part of access request.
 	TagResources = "resources"
+
+	// UserCertificatesCreated provides total number of user certificates generated.
+	MetricUserCertificatesGenerated = "user_certificates_generated"
+	// TagPrivateKeyPolicy is a private key policy associated with a user's certificates.
+	TagPrivateKeyPolicy = "private_key_policy"
 )
 
 const (


### PR DESCRIPTION
This is needed for Hardware Key support product analytics:
```
> curl -s http://127.0.0.1:3000/metrics | grep user_certificates_generated
# HELP teleport_user_certificates_generated Tracks the number of user certificates generated
# TYPE teleport_user_certificates_generated counter
teleport_user_certificates_generated{private_key_policy="hardware_key"} 2
teleport_user_certificates_generated{private_key_policy="hardware_key_touch"} 1
teleport_user_certificates_generated{private_key_policy="none"} 1
```