### PR TITLE
Add an Access Request configuration guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -429,8 +429,13 @@
               "slug": "/access-controls/access-requests/resource-requests/",
               "forScopes": ["enterprise", "cloud"]
             },
+	    {
+	      "title": "Configure Access Requests",
+              "slug": "/access-controls/access-requests/access-request-configuration/",
+              "forScopes": ["enterprise", "cloud"]
+	    },
             {
-              "title": "Teleport Community Edition Role Access Requests",
+              "title": "Access Requests in Teleport Community Edition",
               "slug": "/access-controls/access-requests/oss-role-requests/",
               "forScopes": ["oss"]
             }

--- a/docs/pages/access-controls/access-requests.mdx
+++ b/docs/pages/access-controls/access-requests.mdx
@@ -1,39 +1,61 @@
 ---
-title: Just-in-time Access Requests
-description: Use Just-in-time Access Requests to request elevated privileges.
+title: Just-in-Time Access Requests
+description: Use just-in-time Access Requests to request elevated privileges.
 layout: tocless-doc
 ---
 
-Teleport Just-in-Time Access Requests allow any user to request access to
-a resource or role depending on need. The request can then be approved or
-denied based on a configurable number of approvers.
+Just-in-time Access Requests allow Teleport users to request access to a
+resource or role depending on need. The request can then be approved or denied
+based on a configurable number of approvers.
 
-Just-in-time Access Requests are a powerful way to implement the principle of
-least privilege in your organization, leaving an attacker with no permanent
-admins to target. Users receive elevated privileges for a limited period of
-time. Request approvers can be configured with limited cluster access so they
-are not high value targets.
+You can use Access Requests to implement the principle of least privilege in
+your organization, leaving an attacker with no permanent admins to target. Users
+receive elevated privileges for a limited period of time. Request approvers can
+be configured with limited cluster access so they are not high value targets.
 
-Just-in-time Access Requests are a feature of Teleport Enterprise.
-Teleport Community Edition users can get a preview of how Access Requests work by
-requesting a role via the Teleport CLI. Full Access Request functionality,
-including Resource Access Requests and an intuitive and searchable UI are
-available in Teleport Enterprise.
+Access Requests are designed to provide temporary permissions to users. If you
+want to grant longstanding permissions to a group of users, with the option to
+renew these permissions after a recurring interval (such as three months),
+consider [Access Lists](../access-lists.mdx). 
 
-For information on how to use Just-in-time Access Requests with Teleport Community 
-Edition, see [Teleport Community Access Requests](./access-requests/oss-role-requests.mdx).
+## See how Access Requests work
 
-## Resource Access Requests
+Teleport Access Requests support two main use cases: **Role Access Requests**
+and **Resource Access Requests**.
+
+With Role Access Requests, engineers can request temporary credentials with
+elevated roles in order to perform critical system-wide tasks.
+
+[Get started with Role Access Requests](./access-requests/role-requests.mdx).
 
 With Resource Access Requests, engineers can easily get access to only the
 individual resources they need, when they need it.
 
 [Get started with Resource Access Requests](./access-requests/resource-requests.mdx).
 
-## Role Access Requests
+## Configure Access Requests
 
-Role Access Requests balance security and flexibility. Engineers can request
-temporary credentials with elevated roles in order to perform critical
-system-wide tasks.
+You can configure all aspects of the Access Request lifecycle in Teleport,
+including:
 
-[Get started with Role Access Requests](./access-requests/role-requests.mdx).
+- When a user must make a request.
+- What permissions a user can request.
+- How long elevated permissions can last.
+- How many users can approve or deny different kinds of requests.
+
+Read the [Access Request
+Configuration](access-requests/access-request-configuration.mdx) guide for an
+overview of the configuration options available for Access Requests.
+
+## Teleport Community Edition users
+
+Just-in-time Access Requests are a feature of Teleport Enterprise. Teleport
+Community Edition users can get a preview of how Access Requests work by
+requesting a role via the Teleport CLI. Full Access Request functionality,
+including Resource Access Requests managing Access Requests via the Web UI are
+available in Teleport Enterprise.
+
+For information on how to use Just-in-time Access Requests with Teleport Community 
+Edition, see [Teleport Community Access Requests](./access-requests/oss-role-requests.mdx).
+
+

--- a/docs/pages/access-controls/access-requests.mdx
+++ b/docs/pages/access-controls/access-requests.mdx
@@ -16,7 +16,7 @@ be configured with limited cluster access so they are not high value targets.
 Access Requests are designed to provide temporary permissions to users. If you
 want to grant longstanding permissions to a group of users, with the option to
 renew these permissions after a recurring interval (such as three months),
-consider [Access Lists](../access-lists.mdx). 
+consider [Access Lists](access-lists.mdx). 
 
 ## See how Access Requests work
 

--- a/docs/pages/access-controls/access-requests/access-request-configuration.mdx
+++ b/docs/pages/access-controls/access-requests/access-request-configuration.mdx
@@ -28,8 +28,8 @@ the elevated access that a user can request, you can define a Teleport role
 that:
 
 - Names other Teleport roles the user can request.
-- Names other Teleport roles that the user can assume in order to request access
-  to a specific Teleport resource, such as a database or Kubernetes cluster.
+- Names other Teleport roles that the user can use to search for resources to
+  request, such as databases or Kubernetes clusters.
 
 You can also configure a Teleport role to prevent the user from requesting
 access to these roles.
@@ -79,8 +79,8 @@ user's roles into two lists of role matchers:
 
 - **Deny:** If the requested role matches any of these, Teleport denies the
   request. 
-- **Allow:** If the requested role matches any of these, Teleport allows the
-  request.
+- **Allow:** If the requested role matches any of these, and no deny matcher
+  also matches the role, Teleport allows the request.
 
 A role matcher can include the following values:
 
@@ -163,41 +163,18 @@ following:
 You can configure the length of time that Teleport will grant a user elevated
 privileges for an approved Access Request.
 
-### The `request.max_duration` field
-
-The `max_duration` option indicates the maximum length of time that a user is
-allowed to have elevated privileges for particular roles. You can specify it
-with a role like the following:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: temp-dba
-spec:
-  allow:
-    request:
-      # Allow access to role `dba` for up to 4 days.
-      roles: ['dba']
-      max_duration: 4d
-```
-
-The value of `max_duration` can never exceed seven days.
-
 ### Calculating the duration of elevated privileges
 
-When Teleport grants a user's Access Request, the `max_duration` field is only
-one factor in determining how long the user's access will last. Teleport uses
-the following logic to make this calculation, which never exceeds
-`max_duration`: 
+Teleport uses the following logic to calculate how long a user has elevated
+privileges: 
 
 1. Calculate the maximum duration of elevated privileges if the Access Request
    were granted. This is the lowest value of:
     - The `--max-duration` flag of the [`tsh request
       create`](../../reference/cli/tsh.mdx#tsh-request-create) command (if the
       user creating the request provides this flag).
-    - The lowest value of a `request.max_duration` field that corresponds to one
-      of the user's requested roles. 
+    - The lowest value of the `request.max_duration` field included in one of
+      the user's requested roles. 
 
 1. Calculate the session TTL of the certificate the user would receive if
    Teleport were to grant the Access Request. This calculation chooses the
@@ -213,6 +190,35 @@ the following logic to make this calculation, which never exceeds
    privileges to either the maximum duration or the session TTL calculated
    earlier, whichever is shorter. Otherwise, set the duration of elevated
    privileges to the session TTL.
+
+### The `request.max_duration` field
+
+The `max_duration` option indicates the maximum length of time that a user is
+allowed to have elevated privileges for particular roles. After a user makes a
+successful Access Request, the user can authenticate to Teleport with the
+elevated access until the maximum duration has elapsed. 
+
+Each time the user authenticates to Teleport, Teleport calculates the TTL of the
+user's Teleport session using a formula that we describe in the [previous
+section](#calculating-the-duration-of-elevated-privileges). The user can have
+multiple sessions with elevated privileges before the maximum duration elapses.
+
+You can specify the `max_duration` option with a role like the following:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: temp-dba
+spec:
+  allow:
+    request:
+      # Allow access to role `dba` for up to 4 days.
+      roles: ['dba']
+      max_duration: 4d
+```
+
+The value of `max_duration` can never exceed seven days.
 
 ### How long Access Requests are valid
 
@@ -387,7 +393,7 @@ functions:
 |`contains([]string, val)`|Returns `true` if the list of strings in the first argument contains the element in the second argument and `false` otherwise.|
 |`expr1 && expr2`|Evaluates to `true` if both `expr1` and `expr2` evaluate to `true`.|
 |`expr1 \|\| expr2`|Evaluates to `true` if `expr1`, `expr2`, or both evaluate to `true`.|
-|`!expr`|Evaluates to the opposite of `expr`.|
+|`!expr`|Negates `expr`.|
 
 ## Suggested reviewers
 
@@ -519,7 +525,7 @@ them, use the `allow.review_requests.preview_as_roles` and
 
 ```yaml
 kind: role
-version: v5
+version: v6
 metadata:
   name: reviewer
 spec:

--- a/docs/pages/access-controls/access-requests/access-request-configuration.mdx
+++ b/docs/pages/access-controls/access-requests/access-request-configuration.mdx
@@ -1,0 +1,622 @@
+---
+title: Configure Access Requests
+description: Describes the options available for configuring just-in-time access to roles and resources in your Teleport cluster.
+tocDepth: 3
+---
+
+This guide explains the considerations you should make when configuring Teleport
+Access Requests, which enable a Teleport user to obtain elevated permissions by
+getting approval from one or more users in the same Teleport cluster.
+
+Access Requests are configurable on a role-by-role basis. When a user
+authenticates to Teleport, including through a single sign-on provider, the
+Teleport Auth Service reconciles all of a user's roles to determine the Access
+Request configuration for that user. Teleport then applies this configuration to
+any Access Requests the user creates.
+
+For examples of the full Access Request lifecycle, follow one of the how-to
+guides:
+
+- [Role requests in commercial Teleport editions](role-requests.mdx)
+- [Resource requests in commercial Teleport editions](resource-requests.mdx)
+- [Role requests in Teleport Community Edition](oss-role-requests.mdx)
+
+## The access a user can request
+
+By default, a Teleport user cannot request elevated permissions. To configure
+the elevated access that a user can request, you can define a Teleport role
+that:
+
+- Names other Teleport roles the user can request.
+- Names other Teleport roles that the user can assume in order to request access
+  to a specific Teleport resource, such as a database or Kubernetes cluster.
+
+You can also configure a Teleport role to prevent the user from requesting
+access to these roles.
+
+### Restrict role requests
+
+When a user submits an Access Request, they can specify the roles they would
+like to request access to. 
+
+You can allow a user to request access to certain roles—and deny access to other
+roles—by using the following configuration options: 
+
+- `allow.request.roles`
+- `allow.request.claims_to_roles`
+- `deny.request.roles`
+- `deny.request.claims_to_roles`
+
+Here is an example, which allows the `employee` user to request the `dev` and
+`dba` role, and specifies some more complex restrictions that we will explain
+below:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: employee
+spec:
+  allow:
+    request:
+      roles:
+        - 'dev'
+        - 'dba'
+      claims_to_roles:
+        - claim: groups
+          value: admins
+          roles: ['*']
+  deny:
+    request:
+      claims_to_roles:
+        - claim: groups
+          value: contractors
+          roles: ['*']
+```
+
+The Teleport Auth Service combines the values of these fields for all of a
+user's roles into two lists of role matchers:
+
+- **Deny:** If the requested role matches any of these, Teleport denies the
+  request. 
+- **Allow:** If the requested role matches any of these, Teleport allows the
+  request.
+
+A role matcher can include the following values:
+
+- The literal name of a role (such as `admin`).
+- A wildcard character, which matches one or more characters in a role name. For
+  example, `db-*` matches `db-reader` and `db-writer`.
+- A [Go regular expression](https://pkg.go.dev/regexp/syntax) inside a string
+  that begins with `^` and ends with `$`. For example, if you define roles by
+  AWS region, a role matcher could use the regular expression
+  `^db-writer-us-(east|west)-[0-9]+` to match the `db-writer-us-east-1` and
+  `db-writer-us-west-2` roles.
+
+To add the values of `claims_to_roles` to the lists of role matchers, the Auth
+Service evalutes template expressions with the user's traits. See the [Role
+Templates](../guides/role-templates.mdx#templating-in-access-reqeusts) for more
+information on how Teleport executes template expressions with user traits in
+the `claims_to_roles` field.
+
+In the `employee` role above, if the user is in the `admins` group (as declared
+by their single sign-on provider), this role allows them to request access to
+all roles.  If they are in the `contractors` group, this role denies them access
+to request any roles.
+
+### Restrict resource requests
+
+Users can also submit Access Requests for a specific Teleport resource.
+
+The following fields in a Teleport role indicate which roles a user assumes when
+they search for a Teleport resource:
+
+- `allow.request.search_as_roles`
+- `deny.request.search_as_roles`
+
+For example, the following role enables a user to search for resources by
+assuming all roles _except_ for the `k8s-viewer` role:
+
+```yaml
+# requester.yaml
+kind: role
+version: v6
+metadata:
+  name: k8s-denier
+spec:
+  allow:
+    request:
+      search_as_roles:
+        - '*'
+ deny:
+   request:
+      search_as_roles:
+        - k8s-viewer
+```
+
+As with [configuring role requests](#restrict-role-requests), the
+`request.search_as_roles` field is a list of role matchers that can include
+literal role names, wildcards, and regular expressions.
+
+The Teleport Auth Service combines the values of these fields for all of a
+user's Teleport roles in order to validate the user's Access Requests. 
+
+When a user attempts to list Teleport resources (such as servers and databases)
+or Kubernetes resources (such as pods and deployments), the Auth Service checks
+the roles that the user is allowed to search as. If a user's Teleport roles _or_
+a role specified in `search_as_roles` allow the user to search for a resource,
+the Teleport Auth Service will return information about the resource.
+
+When a user requests access to a resource ID, the Teleport Auth Service does the
+following:
+
+1. Collects all the roles named in `allow.request.search_as_roles`, filtering
+   these to exclude roles specified in `deny.request.search_as_roles` or
+   `deny.request.roles`. 
+1. Determines which of the remaining roles can access the requested resource.
+   For a Resource Access Request to be valid, one of the role matchers listed in
+   a user's `search_as_roles` configuration must match a role that permits
+   access to the requested resources.
+
+## How long access lasts
+
+You can configure the length of time that Teleport will grant a user elevated
+privileges for an approved Access Request.
+
+### The `request.max_duration` field
+
+The `max_duration` option indicates the maximum length of time that a user is
+allowed to have elevated privileges for particular roles. You can specify it
+with a role like the following:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: temp-dba
+spec:
+  allow:
+    request:
+      # Allow access to role `dba` for up to 4 days.
+      roles: ['dba']
+      max_duration: 4d
+```
+
+The value of `max_duration` can never exceed seven days.
+
+### Calculating the duration of elevated privileges
+
+When Teleport grants a user's Access Request, the `max_duration` field is only
+one factor in determining how long the user's access will last. Teleport uses
+the following logic to make this calculation, which never exceeds
+`max_duration`: 
+
+1. Calculate the maximum duration of elevated privileges if the Access Request
+   were granted. This is the lowest value of:
+    - The `--max-duration` flag of the [`tsh request
+      create`](../../reference/cli/tsh.mdx#tsh-request-create) command (if the
+      user creating the request provides this flag).
+    - The lowest value of a `request.max_duration` field that corresponds to one
+      of the user's requested roles. 
+
+1. Calculate the session TTL of the certificate the user would receive if
+   Teleport were to grant the Access Request. This calculation chooses the
+   lowest value of: 
+   - The requested session expiration time, which is the value of the
+     `--session-ttl` flag of [`tsh request
+     create`](../../reference/cli/tsh.mdx#tsh-request-create).
+   - The remaining time in the user's current Teleport session.
+   - The lowest value of the `options.max_session_ttl` field in the user's
+     requested roles.
+
+1. If the maximum duration is greater than zero, set the duration of elevated
+   privileges to either the maximum duration or the session TTL calculated
+   earlier, whichever is shorter. Otherwise, set the duration of elevated
+   privileges to the session TTL.
+
+### How long Access Requests are valid
+
+Teleport uses the following logic to determine how long an Access Request is
+valid while it awaits approval:
+
+1. Begin with with the base expiration of the Access Request, which a user can
+   set with the `--request-ttl` flag of the [`tsh request
+   create`](../../reference/cli/tsh.mdx#tsh-request-create) command. If this is
+   unset, the request TTL is one hour.
+
+1. If the user's Teleport session is due to expire before the base expiration
+   time, Teleport sets the Access Request expiration to the end of the Teleport
+   session.
+
+1. If any of the Teleport roles requested by the Access Request has an
+   `options.max_session_ttl` that expires before the expiration time, Teleport
+   sets the expiration of the Access Request to that time.
+
+1. Return an error if the value of `--request-ttl` is greater than the request
+   TTL calculated in the previous step.
+
+## How clients request access
+
+A user's Teleport roles determine how they submit Access Requests, whether
+Access Requests are optional or mandatory, and whether a user must provide a
+reason when making a request.
+
+A role's `options.request_access` setting specifies a strategy for producing
+Access Requests. It can include one of the following values:
+
+|Value|Meaning|
+|---|---|
+|`optional`|The default. The user does not need to specify a reason when making a request. The user must initiate a request manually when they log in to Teleport.|
+|`always`| When a user signs in to Teleport, their client automatically generates an Access Request for all roles available to the user, without providing a reason.|
+|`reason`| When a user signs in to Teleport, their client automatically generates an Access Request for all roles available to the user. The user must provide a reason when authenticating.|
+
+If a role includes the `reason` strategy, you can specify a prompt to remind the
+user to provide a reason if the user attempts to create an Access Request
+without one. To do so, set the `options.request_prompt` option in a role.
+
+For example, the following role prompts the user with the text, "Please provide
+your ticket ID":
+
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: employee
+spec:
+  allow:
+    request:
+      roles:
+        - 'dba'
+  options:
+    request_access: reason
+    request_prompt: Please provide your ticket ID
+```
+
+The Teleport Auth Service uses the following logic to combine strategies
+specified in the `request_access` fields of different roles that belong to a
+user:
+
+1. If one of the user's roles includes either the `reason` or the `always`
+   strategy, Teleport will automatically request all available roles for the
+   user when they authenticate.
+1. If one of the user's roles includes the `reason` strategy, the user must
+   provide a reason when authenticating.
+
+## Review thresholds
+
+You can configure a user's roles to specify the criteria that an Access Request
+must meet before Teleport approves or denies it. To do so, configure the
+`allow.request.thresholds` field. 
+
+### The `allow.request.thresholds` field
+
+Here is an example of a role that specifies review thresholds for requestable
+roles:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: devops
+spec:
+  allow:
+    request:
+      roles: ['dbadmin']
+      thresholds:
+        - approve: 3
+          deny: 2
+          filter: '!contains(reviewer.traits.team, "dev")'
+        - approve: 1
+          deny: 1
+          filter: 'contains(reviewer.roles, "admin")'
+```
+
+Note that there is no corresponding `deny.requests.thresholds` field, and
+Teleport rejects roles that include one.
+
+Each threshold includes the following fields:
+
+|Field|Description|
+|---|---|
+|`approve`|The number of reviewers that must approve the Access Request for it to be approved. The default is 1.|
+|`deny`|The number of reviewers that must deny the Access Request for it to be denied. The default is 1.|
+|`filter`|A condition that the Access Request or its review must satisfy before a review is added to a threshold's approval or denial count. Described in more detail in the [next section](#threshold-filters).|
+
+In the `devops` role above, there are two thresholds associated with the
+`dbadmin` role. As a result, one of the following conditions must obtain before
+the request is approved is denied:
+
+1. Three users must approve the request, and two users must deny it, as long as
+   those users do not have a `tream` trait with the value `dev`.
+1. One user must approve the review, and one user must deny it, as long as the
+   user submitting the review has the `admin` role.
+
+### Threshold filters
+
+When Teleport processes an Access Request for a specific role, it checks whether
+the request has met the critera specified in one of the thresholds in
+`allow.request.thresholds` associated with that role. 
+
+The value of `filter` is an expression that uses the Teleport [predicate
+language](../../reference/predicate-language.mdx).
+
+For example, the following configuration includes three thresholds, two of which
+have filters:
+
+```yaml
+spec:
+  allow:
+    request:
+      roles: ['dbadmin']
+      thresholds:
+        - approve: 3
+          deny: 1
+        - filter: 'contains(reviewer.roles, "super-approver")'
+          approve: 2
+          deny: 1
+        - filter: '!equals(request.reason, "") && contains(reviewer.roles, "super-approver")'
+          approve: 1
+          deny: 1
+```
+
+The first threshold requires three users to approve and one user to deny.
+However, if each reviewer has the `super-approver` role, the request only needs
+two approvals. And if the request has a non-empty reason, it only needs a single
+approval from a user with the `super-approver` role.
+
+Filter expressions can draw on the following data associated with each Access
+Request review: the request, the reviewer, and the review itself:
+
+|Field|Type|Description|
+|---|---|---|
+|`reviewer.roles`|`[]string`|The reviewer's roles.|
+|`reviewer.traits`|`map[string][]string`|The reviewer's traits.|
+|`review.reason`|`string`|The reason given for the review.|
+|`review.annotations`|`map[string][]string`|Annotations added to the review. These are added by programmatic Teleport clients that approve or deny an Access Request.|
+|`request.roles`|`[]string`|The roles included in the request.|
+|`request.reason`|`string`|The reason provided in the request.|
+|`request.system_annotations`|`map[string][]string`|[Request annotations](#request-annotations).|
+
+You can use these fields in expressions that include the following operators and
+functions:
+
+|Operator/Function|Description|
+|---|---|
+|`equals(val1,val2)`|Returns `true` if `val1` is equal to `val2` and `false` otherwise|
+|`contains([]string, val)`|Returns `true` if the list of strings in the first argument contains the element in the second argument and `false` otherwise.|
+|`expr1 && expr2`|Evaluates to `true` if both `expr1` and `expr2` evaluate to `true`.|
+|`expr1 \|\| expr2`|Evaluates to `true` if `expr1`, `expr2`, or both evaluate to `true`.|
+|`!expr`|Evaluates to the opposite of `expr`.|
+
+## Suggested reviewers
+
+You can configure a Teleport role to suggest reviewers for Access Requests.
+
+Teleport combines all reviewers named in the `allow.request.suggested_reviewers`
+fields of a user's roles. If an Access Request has no suggested reviewers,
+Teleport adds the user's suggested reviewers to the request.
+
+The following role adds the suggested reviewers `user1` and `user2`:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: employee
+spec:
+  allow:
+    request:
+      roles:
+        - 'dev'
+        - 'dba'
+      suggested_reviewers:
+       - 'user1'
+       - 'user2'
+```
+
+Suggested reviewers apply to all of the roles a user can request access to, not
+just the roles named in the same `role` resource as the suggested reviewers.
+
+While Teleport will accept a role with a nonempty
+`deny.request.suggested_reviewers` field, it only considers the
+`allow.request.suggested_reviewers` field when evaluating Access Requests.
+
+## Roles that a reviewer can grant access to
+
+Teleport users must be authorized to review Access Requests for a particular
+role. You can configure a user's Teleport roles to allow the user to review Access
+Requests for some Teleport roles, and deny the user the ability to review
+requests for other roles. 
+
+### Allowing and denying reviews for specific roles
+
+To allow a user to review requests for certain roles but not others, edit the
+following role fields:
+
+- `allow.review_requests.roles`
+- `allow.review_requests.claims_to_roles`
+- `deny.review_requests.roles`
+- `deny.review_requests.claims_to_roles`
+
+The Auth Service evalutes the `claims_to_roles` field using template expressions
+with the user's traits. See the [Role
+Templates](../guides/role-templates.mdx#templating-in-access-reqeusts) for more
+information on how Teleport executes template expressions with user traits in
+the `claims_to_roles` field.
+
+For a user to review an Access Request for a particular role, at least one allow
+rule must grant the user access to review requests for that role. No deny rule
+must disallow access to review that role.
+
+### `where` expressions
+
+Unlike the `requests.roles` and `requests.claims_to_roles` fields, the
+`review_requests.roles` and `review_requests.claims_to_roles` fields allow you
+to grant or deny permissions to review an Access Request for a role based on a
+`where` expression. If the expression holds for an Access Request, Teleport
+applies the allow or deny rules for the `review_requests_claims_to_roles` and
+`review_requests.roles` fields.
+
+For example, the following configuration allows a reviewer to review requests
+for all roles _unless_ the role is `contractor-prod` and the request reason is
+empty:
+
+```yaml
+metadata:
+  name: reviewer
+# ...
+allow:
+  review_requests:
+    roles: ['*']
+deny:
+  review_requests:
+    roles: ['contractor-prod']
+    where: 'request.reason == ""'
+```
+
+When validating an Access Request review, Teleport considers each `where`
+expression within all of a reviewer's roles. If one `where` expression holds for
+the review, Teleport ensures that the reviewer is authorized to review requests
+for the corresponding roles, which are defined in the same Teleport role as the
+`where` expression.
+
+If a user is requesting the `contractor-prod` role, for example, and leaves an
+empty reason in the request, a user with the `reviewer` role defined above will
+not be able to review the request.
+
+`where` expressions can draw on the following data associated with an Access
+Request:
+
+|Field|Type|Description|
+|---|---|---|
+|`reviewer.roles`|`[]string`|The reviewer's Teleport roles.|
+|`reviewer.traits`|`map[string][]string`|The reviewer's Teleport traits.|
+|`request.roles`|`[]string`|The roles requested by the Access Request.|
+|`request.reason`|`string`|The reason for the request.|
+|`request.system_annotations`|`map[string][]string`|[Request annotations](#request-annotations).|
+
+You can use these fields in expressions that include the following operators and
+functions:
+
+|Operator/Function|Description|
+|---|---|
+|`equals(val1,val2)`|Returns `true` if `val1` is equal to `val2` and `false` otherwise|
+|`contains([]string, val)`|Returns `true` if the list of strings in the first argument contains the element in the second argument and `false` otherwise.|
+|`expr1 && expr2`|Evaluates to `true` if both `expr1` and `expr2` evaluate to `true`.|
+|`expr1 \|\| expr2`|Evaluates to `true` if `expr1`, `expr2`, or both evaluate to `true`.|
+|`!expr`|Evaluates to the opposite of `expr`.|
+
+## Inspecting requested resources  
+
+A Teleport user can view information about a resource without having access to
+that resource. This is useful for inspecting a resource before granting another
+user access to it by approving that user's Access Requests.
+
+To grant or deny a user the ability to list Teleport resources without accessing
+them, use the `allow.review_requests.preview_as_roles` and
+`deny.review_requests.preview_as_roles` fields in the user's roles:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: reviewer
+spec:
+  allow:
+    review_requests:
+      roles:
+        - access
+      preview_as_roles:
+        - access
+```
+
+When a user attempts to list Teleport resources, for example, by using a `tsh
+ls` command, the Teleport Auth Service checks whether the user's
+`preview_as_roles` grant access to list the resource and, if so, lists the
+resources. This also applies to users attempting to list Kubernetes resources
+protected by Teleport, such as deployments and pods.
+
+Without the ability to preview a resource, reviewers can only see the resource's
+UUID as provided by the Access Request.
+
+## Request annotations
+
+When a user creates an Access Request, the Teleport Auth Service can write
+arbitrary metadata to the request. Teleport integrations that consume the access
+request can read the metadata in order to direct their behavior.
+
+Annotations are key value pairs in which a single key corresponds to a list of
+values. All values are strings.
+
+### Plugins that support request annotations
+
+The following Teleport-supported Access Request plugins read request
+annotations:
+
+|Integration|Annotation keys|How it uses annotations|
+|---|---|---|
+|Pagerduty|`pagerduty_notify_service`, `pagerduty_services`|Opens an incident in the service named in `pagerduty_notify_service` when a user submits an Access Request. If a user is on the on-call rotation for a service named in `pagerduty_services`, Teleport will approve any Access Request opened by the user.|
+|Opsgenie|`teleport.dev/notify-services`, `teleport.dev/schedules`|The integration approves a user's Access Request if the user is on call for the of the services listed in `teleport.dev/schedules`. It also creates an alert in the services named in `teleport.dev/notify-services` when a user creates an Access Request. |
+|ServiceNow|`teleport.dev/notify-services`, `teleport.dev/schedules`|The integration approves a user's Access Request if the user is on call for the of the services listed in `teleport.dev/schedules`. It also creates an alert in the services named in `teleport.dev/notify-services` when a user creates an Access Request. |
+
+### Allowing and denying annotations
+
+The Teleport Auth Service evaluates Access Request annotations in a user's roles
+by applying the following logic: for all allowed annotation values with a given
+key, check whether there is also a denied annotation value with the same key. If
+there is, skip it. Otherwise, add the annotation to the Access Request.
+
+For example, let's say we have defined a role with the following fields:
+
+```yaml
+allow:
+  request:
+    annotations:
+      pagerduty_services:
+        - data-writer
+        - data-reader
+```
+
+We have also defined a role with these fields:
+
+```yaml
+deny:
+  request:
+    annotations:
+      pagerduty_services:
+        - data-reader
+```
+
+In this case, the final annotation mapping for the user's Access Requests would
+contain the annotation:
+
+```yaml
+pagerduty_services:
+ - data-writer
+```
+
+### Reading annotations in custom plugins
+
+If you [write your own Access Request plugin](../../api/access-plugin.mdx), the
+program can access system annotations using a function similar to the following:
+
+```go
+func getMyAnnotation(req types.AccessRequest) ([]string, error) {
+	result, ok := req.GetSystemAnnotations()["my-annotation"]
+	if !ok {
+		return nil, trace.NotFound("annotation not found")
+	}
+	return result, nil
+}
+```
+
+This function uses the `GetSystemAnnotations` method of the
+`types.AccessRequest` type to get all the annotation values of an Access
+Requests with the key `my-annotation`.
+
+## Further reading
+
+For a full description of the configuration options within a Teleport role,
+refer to the [Access Controls
+Reference](docs/pages/access-controls/reference.mdx).

--- a/docs/pages/access-controls/access-requests/access-request-configuration.mdx
+++ b/docs/pages/access-controls/access-requests/access-request-configuration.mdx
@@ -94,8 +94,8 @@ A role matcher can include the following values:
   `db-writer-us-west-2` roles.
 
 To add the values of `claims_to_roles` to the lists of role matchers, the Auth
-Service evalutes template expressions with the user's traits. See the [Role
-Templates](../guides/role-templates.mdx#templating-in-access-reqeusts) for more
+Service evaluates template expressions with the user's traits. See the [Role
+Templates](../guides/role-templates.mdx#templating-in-access-requests) for more
 information on how Teleport executes template expressions with user traits in
 the `claims_to_roles` field.
 
@@ -115,7 +115,7 @@ they search for a Teleport resource:
 - `deny.request.search_as_roles`
 
 For example, the following role enables a user to search for resources by
-assuming all roles _except_ for the `k8s-viewer` role:
+assuming all roles *except* for the `k8s-viewer` role:
 
 ```yaml
 # requester.yaml
@@ -143,7 +143,7 @@ user's Teleport roles in order to validate the user's Access Requests.
 
 When a user attempts to list Teleport resources (such as servers and databases)
 or Kubernetes resources (such as pods and deployments), the Auth Service checks
-the roles that the user is allowed to search as. If a user's Teleport roles _or_
+the roles that the user is allowed to search as. If a user's Teleport roles *or*
 a role specified in `search_as_roles` allow the user to search for a resource,
 the Teleport Auth Service will return information about the resource.
 
@@ -170,12 +170,11 @@ privileges:
 
 1. Calculate the maximum duration of elevated privileges if the Access Request
    were granted. This is the lowest value of:
-    - The `--max-duration` flag of the [`tsh request
-      create`](../../reference/cli/tsh.mdx#tsh-request-create) command (if the
-      user creating the request provides this flag).
-    - The lowest value of the `request.max_duration` field included in one of
-      the user's requested roles. 
-
+   - The `--max-duration` flag of the [`tsh request
+     create`](../../reference/cli/tsh.mdx#tsh-request-create) command (if the
+     user creating the request provides this flag).
+   - The lowest value of the `request.max_duration` field included in one of
+     the user's requested roles. 
 1. Calculate the session TTL of the certificate the user would receive if
    Teleport were to grant the Access Request. This calculation chooses the
    lowest value of: 
@@ -185,7 +184,6 @@ privileges:
    - The remaining time in the user's current Teleport session.
    - The lowest value of the `options.max_session_ttl` field in the user's
      requested roles.
-
 1. If the maximum duration is greater than zero, set the duration of elevated
    privileges to either the maximum duration or the session TTL calculated
    earlier, whichever is shorter. Otherwise, set the duration of elevated
@@ -229,15 +227,12 @@ valid while it awaits approval:
    set with the `--request-ttl` flag of the [`tsh request
    create`](../../reference/cli/tsh.mdx#tsh-request-create) command. If this is
    unset, the request TTL is one hour.
-
 1. If the user's Teleport session is due to expire before the base expiration
    time, Teleport sets the Access Request expiration to the end of the Teleport
    session.
-
 1. If any of the Teleport roles requested by the Access Request has an
    `options.max_session_ttl` that expires before the expiration time, Teleport
    sets the expiration of the Access Request to that time.
-
 1. Return an error if the value of `--request-ttl` is greater than the request
    TTL calculated in the previous step.
 
@@ -334,14 +329,14 @@ In the `devops` role above, there are two thresholds associated with the
 the request is approved is denied:
 
 1. Three users must approve the request, and two users must deny it, as long as
-   those users do not have a `tream` trait with the value `dev`.
+   those users do not have a `team` trait with the value `dev`.
 1. One user must approve the review, and one user must deny it, as long as the
    user submitting the review has the `admin` role.
 
 ### Threshold filters
 
 When Teleport processes an Access Request for a specific role, it checks whether
-the request has met the critera specified in one of the thresholds in
+the request has met the criteria specified in one of the thresholds in
 `allow.request.thresholds` associated with that role. 
 
 The value of `filter` is an expression that uses the Teleport [predicate
@@ -445,9 +440,9 @@ following role fields:
 - `deny.review_requests.roles`
 - `deny.review_requests.claims_to_roles`
 
-The Auth Service evalutes the `claims_to_roles` field using template expressions
-with the user's traits. See the [Role
-Templates](../guides/role-templates.mdx#templating-in-access-reqeusts) for more
+The Auth Service evaluates the `claims_to_roles` field using template
+expressions with the user's traits. See the [Role
+Templates](../guides/role-templates.mdx#templating-in-access-requests) for more
 information on how Teleport executes template expressions with user traits in
 the `claims_to_roles` field.
 
@@ -465,7 +460,7 @@ applies the allow or deny rules for the `review_requests_claims_to_roles` and
 `review_requests.roles` fields.
 
 For example, the following configuration allows a reviewer to review requests
-for all roles _unless_ the role is `contractor-prod` and the request reason is
+for all roles *unless* the role is `contractor-prod` and the request reason is
 empty:
 
 ```yaml
@@ -625,4 +620,4 @@ Requests with the key `my-annotation`.
 
 For a full description of the configuration options within a Teleport role,
 refer to the [Access Controls
-Reference](docs/pages/access-controls/reference.mdx).
+Reference](../reference.mdx).

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -623,29 +623,6 @@ local                 /teleport.example.com/kube_cluster/local
 
 ```
 
-### Allow reviewers to see the hostnames of SSH nodes
-
-It is possible for a reviewer to view Resource Access Requests for SSH Nodes to
-which that reviewer does not have access.
-In this case, the reviewer will not be able to view the hostname of the requested node
-and they will only see the node's UUID.
-
-To give the reviewer permission to view the Node hostname, use the
-`allow.review_requests.preview_as_roles` field in the reviewer's role, e.g.:
-
-```
-kind: role
-spec:
-  allow:
-    review_requests:
-      preview_as_roles: [access]
-```
-
-This can often be set to the same value as `allow.review_requests.roles`.
-When any of the `preview_as_roles` set for the reviewer would allow access to
-the requested node, the hostname will be displayed in the Review Request page of
-the Teleport Web UI.
-
 ### Integrating with an external tool
 
 With Teleport's Access Request plugins, users can manage Access Requests from
@@ -653,12 +630,6 @@ within your organization's existing messaging and project management solutions.
 
 (!docs/pages/includes/access-request-integrations.mdx!)
 
-### Using TTLs with Access Requests
-
-`tsh request create` supports flags to control TTLs for the request and
-elevated access. See the [CLI
-Reference](../../reference/cli/tsh.mdx#tsh-request-create) for more
-details.
-
 ## Next Steps
+
 - Learn more about [Access Lists](../access-lists.mdx)

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -162,8 +162,8 @@ within your organization's existing messaging and project management solutions.
 
 ### Learn how to configure Access Requests
 
-See the [Access Request Concepts](./access-request-concepts.mdx) guide for a
-detailed description of all the options you can configure to set up a
+See the [Access Request Configuration](./access-request-configuration.mdx) guide
+for a detailed description of all the options you can configure to set up a
 just-in-time Access Request workflow for your organization.
 
 ### Set up Access Lists

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -153,101 +153,22 @@ to the original set of roles.
 
 ## Next Steps
 
-### Integrating with an external tool
+### Integrate with an external tool
 
 With Teleport's Access Request plugins, users can manage Access Requests from
 within your organization's existing messaging and project management solutions.
 
 (!docs/pages/includes/access-request-integrations.mdx!)
 
-### Advanced RBAC
+### Learn how to configure Access Requests
 
-Teleport roles support a number of advanced features for further configuring
-access requests. They are highlighted in the example role below.
+See the [Access Request Concepts](./access-request-concepts.mdx) guide for a
+detailed description of all the options you can configure to set up a
+just-in-time Access Request workflow for your organization.
 
-```yaml
-kind: role
-version: v5
-metadata:
-  name: employee
-spec:
-  allow:
-    request:
-      # The `roles` list can be a mixture of literal roles and
-      # wildcard matchers and/or regular expressions.
-      roles:
-        - 'common'   # the literal role named "common"
-        - 'dev-*'    # a glob - any role beginning with 'dev-'
-        - '^dev-.*$' # a regular expression (identical to the glob example above)
+### Set up Access Lists
 
-        # provides access to dev-alpha-prod, but not dev-beta-prod
-        - 'dev-{{regexp.not_match("beta")}}-prod'
+Access Lists enable you to assign privileges to groups of users for a fixed
+period of time. Learn more about Access Lists in the
+[documentation](../access-lists.mdx).
 
-      # The `claims_to_roles` mapping works the same as it does in
-      # the OIDC connector, with the added benefit that the roles being mapped to
-      # can also be matchers. the below mapping says that users with
-      # in the SSO provider's `admins` groups can request any role in the system.
-      claims_to_roles:
-        - claim: groups
-          value: admins
-          roles: ['*']
-
-      # Teleport can attach annotations to pending Access Requests. these
-      # annotations may be literals, or be variable interpolation expressions,
-      # effectively creating a means for propagating selected claims from an
-      # external identity provider to the plugin system.
-      annotations:
-        foo: ['bar']
-        groups: ['{{external.groups}}']
-  options:
-    # The `request_access` field can be set to 'always' or 'reason' to tell
-    # tsh or the web UI to always create an Access Request on login. If it is
-    # set to 'reason', the user will be required to indicate *why* they are
-    # generating the Access Request.
-    request_access: reason
-
-    # The `request_prompt` field can be used to customize the text that the
-    # user sees when they are be prompted to enter a reason for the request.
-    request_prompt: Please provide your ticket ID
-```
-
-### Using TTLs with Access Requests
-
-Users can also create Access Requests with the `tsh request create` command.
-`tsh request create` supports flags to control TTLs for the request and
-elevated access. See the [CLI
-Reference](../../reference/cli/tsh.mdx#tsh-request-create) for more
-details.
-
-### Max duration for Access Requests
-
-By default, Teleport will allow users to request access to a role until the
-current session expires. This can be overridden by setting the `max_duration`
-when requesting access to a role. The `max_duration` option allows users to
-extend their access up to 7 days. The `max_duration` can be set in the Web UI
-or via the `--max-duration` flag when using the `tsh` CLI.
-
-To enable the `max_duration` feature, the `max_duration` option must be set in
-a user's role definition:
-```yaml
-kind: role
-version: v5
-metadata:
-  name: contractor
-spec:
-  allow:
-    request:
-      # Allow access to role `dba` for up to 4 days.
-      roles: ['dba']
-      max_duration: 4d
-```
-
-Max duration extends access to a role for the specified duration, but each
-session is still limited by the `max_session_ttl` option in the role definition.
-For example, if the `max_session_ttl` is set to 1 hour, the user will be able
-to request access to the role for up to 4 days, but each session will expire
-after 1 hour. The user will need to assume the role again to continue using it.
-If the `max_session_ttl` is not set, the session will expire after 12 hours.
-
-## Next Steps
-- Learn more about [Access Lists](../access-lists.mdx)


### PR DESCRIPTION
Fixes #22496
Fixes #13927
Fixes #6557
Fixes #31095
Fixes #29980
Fixes #17630

The current approach to documenting Access Requests is to include how-to guides for various scenarios. The downside of this approach is that we don't have a great place to put general conceptual discussions of Access Request configuration fields. This leads to confusion among users regarding the way Teleport handles certain Access Request configuration options.

This change adds a conceptual guide that explains all of the fields in a Teleport role that are relevant to configuring Access Requests.

This change also moves conceptual discussions from other guides into the new guide. To limit the scope of this change, it is not intended to overhaul the existing guides. If a discussion of a particular configuration field was buried in another guide, this change moves it into the new guide:
- `preview_as_roles` discussion in the Role Requests guide
- TTL information in the Role Requests guide
- The reference role in the Role Requests page