### PR TITLE
Drop MFARequired TODO

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -7606,7 +7606,6 @@ type IsMFARequiredResponse struct {
 	Required bool `protobuf:"varint,1,opt,name=Required,proto3" json:"Required,omitempty"`
 	// MFARequired informs whether MFA is required to access the corresponding
 	// resource.
-	// TODO(codingllama): Address redundancy between Required and MFARequired.
 	MFARequired          MFARequired `protobuf:"varint,2,opt,name=MFARequired,proto3,enum=proto.MFARequired" json:"MFARequired,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1346,7 +1346,6 @@ message IsMFARequiredResponse {
   bool Required = 1;
   // MFARequired informs whether MFA is required to access the corresponding
   // resource.
-  // TODO(codingllama): Address redundancy between Required and MFARequired.
   MFARequired MFARequired = 2;
 }
 


### PR DESCRIPTION
After a brief experiment trying to address the TODO I came to the conclusion that exposing the "summed-up" boolean from the API is actually the best call.

Related to #20343.