### PR TITLE
Improve tsh ssh parallel output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 15.0.0 (xx/xx/24)
+
+### Breaking changes
+
+#### `tsh ssh`
+
+When running a command on multiple nodes with `tsh ssh`, each line of output
+is now labeled with the hostname of the node it was written by. Users that
+rely on parsing the output from multiple nodes should pass the `--log-dir` flag
+to `tsh ssh`, which will create a directory where the separated output of each node
+will be written.
+
 ## 14.0.0 (09/20/23)
 
 Teleport 14 brings the following new major features and improvements:

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -6107,28 +6107,28 @@ func testCmdLabels(t *testing.T, suite *integrationTestSuite) {
 	// test label patterns that match both nodes, and each
 	// node individually.
 	tts := []struct {
-		desc    string
-		command []string
-		labels  map[string]string
-		expect  string
+		desc        string
+		command     []string
+		labels      map[string]string
+		expectLines []string
 	}{
 		{
-			desc:    "Both",
-			command: []string{"echo", "two"},
-			labels:  map[string]string{"spam": "eggs"},
-			expect:  "two\ntwo\n",
+			desc:        "Both",
+			command:     []string{"echo", "two"},
+			labels:      map[string]string{"spam": "eggs"},
+			expectLines: []string{"[server-01] two", "[server-02] two"},
 		},
 		{
-			desc:    "Worker only",
-			command: []string{"echo", "worker"},
-			labels:  map[string]string{"role": "worker"},
-			expect:  "worker\n",
+			desc:        "Worker only",
+			command:     []string{"echo", "worker"},
+			labels:      map[string]string{"role": "worker"},
+			expectLines: []string{"worker"},
 		},
 		{
-			desc:    "Database only",
-			command: []string{"echo", "database"},
-			labels:  map[string]string{"role": "database"},
-			expect:  "database\n",
+			desc:        "Database only",
+			command:     []string{"echo", "database"},
+			labels:      map[string]string{"role": "database"},
+			expectLines: []string{"database"},
 		},
 	}
 
@@ -6142,7 +6142,11 @@ func testCmdLabels(t *testing.T, suite *integrationTestSuite) {
 
 			output, err := runCommand(t, teleport, tt.command, cfg, 1)
 			require.NoError(t, err)
-			require.Equal(t, tt.expect, output)
+			outputLines := strings.Split(strings.TrimSpace(output), "\n")
+			require.Len(t, outputLines, len(tt.expectLines))
+			for _, line := range tt.expectLines {
+				require.Contains(t, outputLines, line)
+			}
 		})
 	}
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -471,6 +471,10 @@ type Config struct {
 	// WebauthnLogin allows tests to override the Webauthn Login func.
 	// Defaults to [wancli.Login].
 	WebauthnLogin WebauthnLoginFunc
+
+	// SSHLogDir is the directory to log the output of multiple SSH commands to.
+	// If not set, no logs will be created.
+	SSHLogDir string
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1262,9 +1266,14 @@ func (tc *TeleportClient) RootClusterName(ctx context.Context) (string, error) {
 	return name, nil
 }
 
+type targetNode struct {
+	hostname string
+	addr     string
+}
+
 // getTargetNodes returns a list of node addresses this SSH command needs to
 // operate on.
-func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetResourcesClient, options SSHOptions) ([]string, error) {
+func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetResourcesClient, options SSHOptions) ([]targetNode, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/getTargetNodes",
@@ -1273,7 +1282,12 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 	defer span.End()
 
 	if options.HostAddress != "" {
-		return []string{options.HostAddress}, nil
+		return []targetNode{
+			{
+				hostname: options.HostAddress,
+				addr:     options.HostAddress,
+			},
+		}, nil
 	}
 
 	// use the target node that was explicitly provided if valid
@@ -1286,7 +1300,12 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 		}
 
 		addr := net.JoinHostPort(tc.Host, strconv.Itoa(tc.HostPort))
-		return []string{addr}, nil
+		return []targetNode{
+			{
+				hostname: tc.Host,
+				addr:     addr,
+			},
+		}, nil
 	}
 
 	// find the nodes matching the labels that were provided
@@ -1295,10 +1314,13 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, clt client.GetReso
 		return nil, trace.Wrap(err)
 	}
 
-	retval := make([]string, 0, len(nodes))
+	retval := make([]targetNode, 0, len(nodes))
 	for _, resource := range nodes {
 		// always dial nodes by UUID
-		retval = append(retval, fmt.Sprintf("%s:0", resource.GetName()))
+		retval = append(retval, targetNode{
+			hostname: resource.GetHostname(),
+			addr:     fmt.Sprintf("%s:0", resource.GetName()),
+		})
 	}
 
 	return retval, nil
@@ -1556,7 +1578,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 	if len(nodeAddrs) > 1 {
 		return tc.runShellOrCommandOnMultipleNodes(ctx, clt, nodeAddrs, command)
 	}
-	return tc.runShellOrCommandOnSingleNode(ctx, clt, nodeAddrs[0], command, runLocally)
+	return tc.runShellOrCommandOnSingleNode(ctx, clt, nodeAddrs[0].addr, command, runLocally)
 }
 
 // ConnectToNode attempts to establish a connection to the node resolved to by the provided
@@ -1565,7 +1587,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 // fail the error from the connection attempt with the already provisioned certificates will
 // be returned. The client from whichever attempt succeeds first will be returned.
 func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient, nodeDetails NodeDetails, user string) (*NodeClient, error) {
-	node := nodeName(nodeDetails.Addr)
+	node := nodeName(targetNode{addr: nodeDetails.Addr})
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ConnectToNode",
@@ -1615,7 +1637,8 @@ func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient,
 		}
 
 		sshConfig := clt.ProxyClient.SSHConfig(user)
-		clt, err := NewNodeClient(ctx, sshConfig, conn, nodeDetails.ProxyFormat(), nodeDetails.Addr, tc, details.FIPS)
+		clt, err := NewNodeClient(ctx, sshConfig, conn, nodeDetails.ProxyFormat(), nodeDetails.Addr, tc, details.FIPS,
+			WithNodeHostname(nodeDetails.hostname), WithSSHLogDir(tc.SSHLogDir))
 		directResultC <- clientRes{clt: clt, err: err}
 	}()
 
@@ -1715,7 +1738,7 @@ func (m MFARequiredUnknownErr) Is(err error) bool {
 // if it is required, then the mfa ceremony is attempted. The target host is dialed once the ceremony
 // completes and new certificates are retrieved.
 func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *ClusterClient, nodeDetails NodeDetails, user string) (*NodeClient, error) {
-	node := nodeName(nodeDetails.Addr)
+	node := nodeName(targetNode{addr: nodeDetails.Addr})
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/connectToNodeWithMFA",
@@ -1750,7 +1773,8 @@ func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *Cluster
 		return nil, trace.Wrap(err)
 	}
 
-	nodeClient, err := NewNodeClient(ctx, cfg, conn, nodeDetails.ProxyFormat(), nodeDetails.Addr, tc, details.FIPS)
+	nodeClient, err := NewNodeClient(ctx, cfg, conn, nodeDetails.ProxyFormat(), nodeDetails.Addr, tc, details.FIPS,
+		WithNodeHostname(nodeDetails.hostname), WithSSHLogDir(tc.SSHLogDir))
 	return nodeClient, trace.Wrap(err)
 }
 
@@ -1823,8 +1847,12 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil))
 }
 
-func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodeAddrs []string, command []string) error {
+func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodes []targetNode, command []string) error {
 	cluster := clt.ClusterName()
+	nodeAddrs := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		nodeAddrs = append(nodeAddrs, node.addr)
+	}
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/runShellOrCommandOnMultipleNodes",
@@ -1839,7 +1867,7 @@ func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, 
 	// There was a command provided, run a non-interactive session against each match
 	if len(command) > 0 {
 		fmt.Printf("\x1b[1mWARNING\x1b[0m: Multiple nodes matched label selector, running command on all.\n")
-		return tc.runCommandOnNodes(ctx, clt, nodeAddrs, command)
+		return tc.runCommandOnNodes(ctx, clt, nodes, command)
 	}
 
 	// Issue "shell" request to the first matching node.
@@ -2666,8 +2694,13 @@ func commandLimit(ctx context.Context, getter roleGetter, mfaRequired bool) int 
 	}
 }
 
+type execResult struct {
+	hostname   string
+	exitStatus int
+}
+
 // runCommandOnNodes executes a given bash command on a bunch of remote nodes.
-func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterClient, nodeAddresses []string, command []string) error {
+func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterClient, nodes []targetNode, command []string) error {
 	cluster := clt.ClusterName()
 	ctx, span := tc.Tracer.Start(
 		ctx,
@@ -2685,7 +2718,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 	mfaRequiredCheck, err := clt.AuthClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
 		Target: &proto.IsMFARequiredRequest_Node{
 			Node: &proto.NodeLogin{
-				Node:  nodeName(nodeAddresses[0]),
+				Node:  nodeName(targetNode{addr: nodes[0].addr}),
 				Login: tc.Config.HostLogin,
 			},
 		},
@@ -2694,16 +2727,24 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 		return trace.Wrap(err)
 	}
 
+	if tc.SSHLogDir != "" {
+		if err := os.MkdirAll(tc.SSHLogDir, 0700); err != nil {
+			return trace.ConvertSystemError(err)
+		}
+	}
+
+	resultsCh := make(chan execResult, len(nodes))
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(commandLimit(ctx, clt.AuthClient, mfaRequiredCheck.Required))
-	for _, address := range nodeAddresses {
-		address := address
+	for _, node := range nodes {
+		node := node
 		g.Go(func() error {
 			ctx, span := tc.Tracer.Start(
 				gctx,
 				"teleportClient/executingCommand",
 				oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-				oteltrace.WithAttributes(attribute.String("node", address)),
+				oteltrace.WithAttributes(attribute.String("node", node.addr)),
 			)
 			defer span.End()
 
@@ -2711,26 +2752,93 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 				ctx,
 				clt,
 				NodeDetails{
-					Addr:      address,
+					Addr:      node.addr,
 					Namespace: tc.Namespace,
 					Cluster:   cluster,
 					MFACheck:  mfaRequiredCheck,
+					hostname:  node.hostname,
 				},
 				tc.Config.HostLogin,
 			)
 			if err != nil {
+				// Returning the error here would cancel all the other goroutines, so
+				// print the error instead to let them all finish.
 				fmt.Fprintln(tc.Stderr, err)
-				return trace.Wrap(err)
+				return nil
 			}
 			defer nodeClient.Close()
 
-			fmt.Printf("Running command on %v:\n", nodeName(address))
+			displayName := nodeName(node)
+			fmt.Printf("Running command on %v:\n", displayName)
 
-			return trace.Wrap(nodeClient.RunCommand(ctx, command))
+			if err := nodeClient.RunCommand(ctx, command, WithLabeledOutput()); err != nil && tc.ExitStatus == 0 {
+				fmt.Fprintln(tc.Stderr, err)
+				return nil
+			}
+			resultsCh <- execResult{
+				hostname:   displayName,
+				exitStatus: tc.ExitStatus,
+			}
+			return nil
 		})
 	}
 
-	return trace.Wrap(g.Wait())
+	// Non-command-related errors will have already been reported by the goroutines,
+	// and command-related errors will be reported in writeCommandResults.
+	g.Wait()
+
+	close(resultsCh)
+	results := make([]execResult, 0, len(resultsCh))
+	for result := range resultsCh {
+		results = append(results, result)
+	}
+
+	return trace.Wrap(tc.writeCommandResults(results))
+}
+
+func (tc *TeleportClient) writeCommandResults(nodes []execResult) error {
+	fmt.Println()
+	var succeededNodes []string
+	var failedNodes []string
+	for _, node := range nodes {
+		if node.exitStatus != 0 {
+			failedNodes = append(failedNodes, node.hostname)
+			fmt.Printf("[%v] failed with exit code %d\n", node.hostname, node.exitStatus)
+		} else {
+			succeededNodes = append(succeededNodes, node.hostname)
+			fmt.Printf("[%v] success\n", node.hostname)
+		}
+	}
+	fmt.Printf("\n%d host(s) succeeded; %d host(s) failed\n", len(succeededNodes), len(failedNodes))
+
+	if tc.SSHLogDir != "" {
+		if len(succeededNodes) > 0 {
+			successFile, err := os.Create(filepath.Join(tc.SSHLogDir, "hosts.succeeded"))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			defer successFile.Close()
+			for _, node := range succeededNodes {
+				fmt.Fprintln(successFile, node)
+			}
+		}
+
+		if len(failedNodes) > 0 {
+			failFile, err := os.Create(filepath.Join(tc.SSHLogDir, "hosts.failed"))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			defer failFile.Close()
+			for _, node := range failedNodes {
+				fmt.Fprintln(failFile, node)
+			}
+		}
+	}
+
+	if len(failedNodes) > 0 {
+		return trace.Errorf("%d command(s) failed", len(failedNodes))
+	}
+	return nil
 }
 
 func (tc *TeleportClient) newSessionEnv() map[string]string {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -95,6 +97,13 @@ type NodeClient struct {
 	// addr set in TC.WebProxyAddr. This is needed to report the correct address
 	// to SSH_TELEPORT_WEBPROXY_ADDR used by some features like "teleport status".
 	ProxyPublicAddr string
+
+	// hostname is the node's hostname, for more user-friendly logging.
+	hostname string
+
+	// sshLogDir is the directory to log the output of multiple SSH commands to.
+	// If not set, no logs will be created.
+	sshLogDir string
 }
 
 // AddCloser adds an [io.Closer] that will be closed when the
@@ -1186,10 +1195,13 @@ func (proxy *ProxyClient) NewTracingClient(ctx context.Context, clusterName stri
 }
 
 // nodeName removes the port number from the hostname, if present
-func nodeName(node string) string {
-	n, _, err := net.SplitHostPort(node)
+func nodeName(node targetNode) string {
+	if node.hostname != "" {
+		return node.hostname
+	}
+	n, _, err := net.SplitHostPort(node.addr)
 	if err != nil {
-		return node
+		return node.addr
 	}
 	return n
 }
@@ -1243,7 +1255,7 @@ func (proxy *ProxyClient) dialAuthServer(ctx context.Context, clusterName string
 		// it to the end of our own message:
 		serverErrorMsg, _ := io.ReadAll(proxyErr)
 		return nil, trace.ConnectionProblem(err, "failed connecting to node %v. %s",
-			nodeName(strings.Split(address, "@")[0]), serverErrorMsg)
+			nodeName(targetNode{addr: strings.Split(address, "@")[0]}), serverErrorMsg)
 	}
 	return utils.NewPipeNetConn(
 		proxyReader,
@@ -1266,11 +1278,14 @@ type NodeDetails struct {
 	// MFACheck is optional parameter passed if MFA check was already done.
 	// It can be nil.
 	MFACheck *proto.IsMFARequiredResponse
+
+	// hostname is the node's hostname, for more user-friendly logging.
+	hostname string
 }
 
 // String returns a user-friendly name
 func (n NodeDetails) String() string {
-	parts := []string{nodeName(n.Addr)}
+	parts := []string{nodeName(targetNode{addr: n.Addr})}
 	if n.Cluster != "" {
 		parts = append(parts, "on cluster", n.Cluster)
 	}
@@ -1390,7 +1405,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeDet
 		// it to the end of our own message:
 		serverErrorMsg, _ := io.ReadAll(proxyErr)
 		return nil, trace.ConnectionProblem(err, "failed connecting to node %v. %s",
-			nodeName(nodeAddress.Addr), serverErrorMsg)
+			nodeName(targetNode{addr: nodeAddress.Addr}), serverErrorMsg)
 	}
 
 	pipeNetConn := utils.NewPipeNetConn(
@@ -1459,9 +1474,27 @@ func (proxy *ProxyClient) PortForwardToNode(ctx context.Context, nodeAddress Nod
 	return nc, trace.Wrap(err)
 }
 
+// NodeClientOption is a functional argument for NewNodeClient.
+type NodeClientOption func(nc *NodeClient)
+
+// WithNodeHostname sets the hostname to display for the connected node.
+func WithNodeHostname(hostname string) NodeClientOption {
+	return func(nc *NodeClient) {
+		nc.hostname = hostname
+	}
+}
+
+// WithSSHLogDir sets the directory to write command output to when running
+// commands on multiple nodes.
+func WithSSHLogDir(logDir string) NodeClientOption {
+	return func(nc *NodeClient) {
+		nc.sshLogDir = logDir
+	}
+}
+
 // NewNodeClient constructs a NodeClient that is connected to the node at nodeAddress.
 // The nodeName field is optional and is used only to present better error messages.
-func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Conn, nodeAddress, nodeName string, tc *TeleportClient, fipsEnabled bool) (*NodeClient, error) {
+func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Conn, nodeAddress, nodeName string, tc *TeleportClient, fipsEnabled bool, opts ...NodeClientOption) (*NodeClient, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"NewNodeClient",
@@ -1472,13 +1505,14 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 	)
 	defer span.End()
 
+	if nodeName == "" {
+		nodeName = nodeAddress
+	}
+
 	sshconn, chans, reqs, err := newClientConn(ctx, conn, nodeAddress, sshConfig)
 	if err != nil {
 		if utils.IsHandshakeFailedError(err) {
 			conn.Close()
-			if nodeName == "" {
-				nodeName = nodeAddress
-			}
 			// TODO(codingllama): Improve error message below for device trust.
 			//  An alternative we have here is querying the cluster to check if device
 			//  trust is required, a check similar to `IsMFARequired`.
@@ -1500,6 +1534,11 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 		Tracer:          tc.Tracer,
 		FIPSEnabled:     fipsEnabled,
 		ProxyPublicAddr: tc.WebProxyAddr,
+		hostname:        nodeName,
+	}
+
+	for _, opt := range opts {
+		opt(nc)
 	}
 
 	// Start a goroutine that will run for the duration of the client to process
@@ -1562,8 +1601,85 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 	return nil
 }
 
+// lineLabeledWriter is an io.Writer that prepends a label to each line it writes.
+type lineLabeledWriter struct {
+	linePrefix        []byte
+	w                 io.Writer
+	shouldWritePrefix bool
+}
+
+func newLineLabeledWriter(w io.Writer, label string) io.Writer {
+	return &lineLabeledWriter{
+		linePrefix:        []byte(fmt.Sprintf("[%v] ", label)),
+		w:                 w,
+		shouldWritePrefix: true,
+	}
+}
+
+func (lw *lineLabeledWriter) writeChunk(b []byte, bytesWritten int, newline bool) (int, error) {
+	n, err := lw.w.Write(b)
+	bytesWritten += n
+	if err != nil {
+		return bytesWritten, trace.Wrap(err)
+	}
+	if newline {
+		n, err = lw.w.Write([]byte("\n"))
+		bytesWritten += n
+	}
+	return bytesWritten, trace.Wrap(err)
+}
+
+func (lw *lineLabeledWriter) Write(input []byte) (int, error) {
+	bytesWritten := 0
+	var line []byte
+	rest := input
+	var found bool
+	for {
+		line, rest, found = bytes.Cut(rest, []byte("\n"))
+		// Write the prefix unless we're either continuing a line from the last
+		// write or we're at the end.
+		if lw.shouldWritePrefix && (len(line) > 0 || found) {
+			// Write the prefix on its own to not mess with the eventual returned
+			// number of bytes written.
+			if _, err := lw.w.Write(lw.linePrefix); err != nil {
+				return bytesWritten, trace.Wrap(err)
+			}
+		}
+		var err error
+		if bytesWritten, err = lw.writeChunk(line, bytesWritten, found); err != nil {
+			return bytesWritten, trace.Wrap(err)
+		}
+		lw.shouldWritePrefix = true
+
+		if !found {
+			// If there were leftovers, the line will continue on the next write, so
+			// skip the first prefix next time.
+			lw.shouldWritePrefix = len(line) == 0
+			break
+		}
+	}
+
+	return bytesWritten, nil
+}
+
+// RunCommandOptions is a set of options for NodeClient.RunCommand.
+type RunCommandOptions struct {
+	labelLines bool
+}
+
+// RunCommandOption is a functional argument for NodeClient.RunCommand.
+type RunCommandOption func(opts *RunCommandOptions)
+
+// WithLabeledOutput labels each line of output from a command with the node's
+// hostname.
+func WithLabeledOutput() RunCommandOption {
+	return func(opts *RunCommandOptions) {
+		opts.labelLines = true
+	}
+}
+
 // RunCommand executes a given bash command on the node.
-func (c *NodeClient) RunCommand(ctx context.Context, command []string) error {
+func (c *NodeClient) RunCommand(ctx context.Context, command []string, opts ...RunCommandOption) error {
 	ctx, span := c.Tracer.Start(
 		ctx,
 		"nodeClient/RunCommand",
@@ -1571,7 +1687,38 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string) error {
 	)
 	defer span.End()
 
-	nodeSession, err := newSession(ctx, c, nil, c.TC.newSessionEnv(), c.TC.Stdin, c.TC.Stdout, c.TC.Stderr, c.TC.EnableEscapeSequences)
+	var options RunCommandOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// Set up output streams
+	stdout := c.TC.Stdout
+	stderr := c.TC.Stderr
+	if c.hostname != "" {
+		if options.labelLines {
+			stdout = newLineLabeledWriter(c.TC.Stdout, c.hostname)
+			stderr = newLineLabeledWriter(c.TC.Stderr, c.hostname)
+		}
+
+		if c.sshLogDir != "" {
+			stdoutFile, err := os.Create(filepath.Join(c.sshLogDir, c.hostname+".stdout"))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			defer stdoutFile.Close()
+			stderrFile, err := os.Create(filepath.Join(c.sshLogDir, c.hostname+".stderr"))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			defer stderrFile.Close()
+
+			stdout = io.MultiWriter(stdout, stdoutFile)
+			stderr = io.MultiWriter(stderr, stderrFile)
+		}
+	}
+
+	nodeSession, err := newSession(ctx, c, nil, c.TC.newSessionEnv(), c.TC.Stdin, stdout, stderr, c.TC.EnableEscapeSequences)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -133,7 +133,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 	log.Debug("Attempting to issue a single-use user certificate with an MFA check.")
 	key, err = c.performMFACeremony(ctx, mfaClt,
 		ReissueParams{
-			NodeName:       nodeName(target.Addr),
+			NodeName:       nodeName(targetNode{addr: target.Addr}),
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -488,6 +488,10 @@ type CLIConf struct {
 
 	// PIVSlot specifies a specific PIV slot to use with hardware key support.
 	PIVSlot string
+
+	// SSHLogDir is the directory to log the output of multiple SSH commands to.
+	// If not set, no logs will be created.
+	SSHLogDir string
 }
 
 // Stdout returns the stdout writer.
@@ -723,6 +727,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	ssh.Flag("participant-req", "Displays a verbose list of required participants in a moderated session.").BoolVar(&cf.displayParticipantRequirements)
 	ssh.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
 	ssh.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&cf.disableAccessRequest)
+	ssh.Flag("log-dir", "Directory to log separated command output, when executing on multiple nodes. If set, output from each node will also be labeled in the terminal.").StringVar(&cf.SSHLogDir)
 
 	// Daemon service for teleterm client
 	daemon := app.Command("daemon", "Daemon is the tsh daemon service.").Hidden()
@@ -3784,6 +3789,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	c.Reason = cf.Reason
 	c.Invited = cf.Invited
 	c.DisplayParticipantRequirements = cf.displayParticipantRequirements
+	c.SSHLogDir = cf.SSHLogDir
 	return c, nil
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1297,36 +1297,49 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 		auth            *auth.Server
 		cluster         string
 		user            types.User
+		logSuccess      []string
 	}{
 		{
-			name:            "default auth preference runs commands on multiple nodes without mfa",
-			authPreference:  defaultPreference,
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			target:          "env=stage",
-			stderrAssertion: require.Empty,
+			name:           "default auth preference runs commands on multiple nodes without mfa",
+			authPreference: defaultPreference,
+			proxyAddr:      rootProxyAddr.String(),
+			auth:           rootAuth.GetAuthServer(),
+			target:         "env=stage",
+			stderrAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Contains(t, i, "[test-stage-1] error\n", i2...)
+				require.Contains(t, i, "[test-stage-2] error\n", i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
-				require.Equal(t, "test\ntest\n", i, i2...)
+				require.Contains(t, i, "[test-stage-1] test\n", i2...)
+				require.Contains(t, i, "[test-stage-2] test\n", i2...)
 			},
 			errAssertion: require.NoError,
+			logSuccess:   []string{stage1Hostname, stage2Hostname},
 		},
 		{
-			name:            "webauthn auth preference runs commands on multiple matches without mfa",
-			target:          "env=stage",
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			stderrAssertion: require.Empty,
+			name:      "webauthn auth preference runs commands on multiple matches without mfa",
+			target:    "env=stage",
+			proxyAddr: rootProxyAddr.String(),
+			auth:      rootAuth.GetAuthServer(),
+			stderrAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Contains(t, i, "[test-stage-1] error\n", i2...)
+				require.Contains(t, i, "[test-stage-2] error\n", i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
-				require.Equal(t, "test\ntest\n", i, i2...)
+				require.Contains(t, i, "[test-stage-1] test\n", i2...)
+				require.Contains(t, i, "[test-stage-2] test\n", i2...)
 			},
 			errAssertion: require.NoError,
+			logSuccess:   []string{stage1Hostname, stage2Hostname},
 		},
 		{
-			name:            "webauthn auth preference runs commands on a single match without mfa",
-			target:          "env=prod",
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			stderrAssertion: require.Empty,
+			name:      "webauthn auth preference runs commands on a single match without mfa",
+			target:    "env=prod",
+			proxyAddr: rootProxyAddr.String(),
+			auth:      rootAuth.GetAuthServer(),
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1353,16 +1366,21 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 					RequireMFAType: types.RequireMFAType_SESSION,
 				},
 			},
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			webauthnLogin:   successfulChallenge("localhost"),
-			target:          "env=stage",
-			stderrAssertion: require.Empty,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			webauthnLogin: successfulChallenge("localhost"),
+			target:        "env=stage",
+			stderrAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Contains(t, i, "[test-stage-1] error\n", i2...)
+				require.Contains(t, i, "[test-stage-2] error\n", i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
-				require.Equal(t, "test\ntest\n", i, i2...)
+				require.Contains(t, i, "[test-stage-1] test\n", i2...)
+				require.Contains(t, i, "[test-stage-2] test\n", i2...)
 			},
 			mfaPromptCount: 2,
 			errAssertion:   require.NoError,
+			logSuccess:     []string{stage1Hostname, stage2Hostname},
 		},
 		{
 			name: "command runs on a single match with mfa set via auth preference",
@@ -1376,11 +1394,13 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 					RequireMFAType: types.RequireMFAType_SESSION,
 				},
 			},
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			webauthnLogin:   successfulChallenge("localhost"),
-			target:          "env=prod",
-			stderrAssertion: require.Empty,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			webauthnLogin: successfulChallenge("localhost"),
+			target:        "env=prod",
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1418,25 +1438,32 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 					},
 				},
 			},
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			roles:           []string{"access", sshLoginRole.GetName(), perSessionMFARole.GetName()},
-			webauthnLogin:   successfulChallenge("localhost"),
-			target:          "env=stage",
-			stderrAssertion: require.Empty,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			roles:         []string{"access", sshLoginRole.GetName(), perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("localhost"),
+			target:        "env=stage",
+			stderrAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Contains(t, i, "[test-stage-1] error\n", i2...)
+				require.Contains(t, i, "[test-stage-2] error\n", i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
-				require.Equal(t, "test\ntest\n", i, i2...)
+				require.Contains(t, i, "[test-stage-1] test\n", i2...)
+				require.Contains(t, i, "[test-stage-2] test\n", i2...)
 			},
 			mfaPromptCount: 2,
 			errAssertion:   require.NoError,
+			logSuccess:     []string{stage1Hostname, stage2Hostname},
 		},
 		{
-			name:            "role permits access without mfa",
-			target:          sshHostID,
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			roles:           []string{sshLoginRole.GetName()},
-			stderrAssertion: require.Empty,
+			name:      "role permits access without mfa",
+			target:    sshHostID,
+			proxyAddr: rootProxyAddr.String(),
+			auth:      rootAuth.GetAuthServer(),
+			roles:     []string{sshLoginRole.GetName()},
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1466,9 +1493,11 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
-			stderrAssertion: require.Empty,
-			mfaPromptCount:  1,
-			errAssertion:    require.NoError,
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
+			mfaPromptCount: 1,
+			errAssertion:   require.NoError,
 		},
 		{
 			name: "failed ceremony when role requires per session mfa",
@@ -1506,12 +1535,14 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 					},
 				},
 			},
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			target:          sshHostID,
-			roles:           []string{perSessionMFARole.GetName()},
-			webauthnLogin:   failedChallenge("localhost"),
-			stderrAssertion: require.Empty,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			target:        sshHostID,
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: failedChallenge("localhost"),
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1519,13 +1550,15 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			headless:     true,
 		},
 		{
-			name:            "command runs on a leaf node with mfa set via role",
-			target:          sshLeafHostID,
-			proxyAddr:       leafProxyAddr,
-			auth:            leafAuth.GetAuthServer(),
-			roles:           []string{perSessionMFARole.GetName()},
-			webauthnLogin:   successfulChallenge("leafcluster"),
-			stderrAssertion: require.Empty,
+			name:          "command runs on a leaf node with mfa set via role",
+			target:        sshLeafHostID,
+			proxyAddr:     leafProxyAddr,
+			auth:          leafAuth.GetAuthServer(),
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("leafcluster"),
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1533,41 +1566,47 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			errAssertion:   require.NoError,
 		},
 		{
-			name:            "command runs on a leaf node via root without mfa",
-			target:          sshLeafHostID,
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			cluster:         "leafcluster",
-			roles:           []string{sshLoginRole.GetName()},
-			webauthnLogin:   successfulChallenge("localhost"),
-			stderrAssertion: require.Empty,
+			name:          "command runs on a leaf node via root without mfa",
+			target:        sshLeafHostID,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			cluster:       "leafcluster",
+			roles:         []string{sshLoginRole.GetName()},
+			webauthnLogin: successfulChallenge("localhost"),
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
 			errAssertion: require.NoError,
 		},
 		{
-			name:            "command runs on a leaf node without mfa",
-			target:          sshLeafHostID,
-			proxyAddr:       leafProxyAddr,
-			auth:            leafAuth.GetAuthServer(),
-			roles:           []string{sshLoginRole.GetName()},
-			stderrAssertion: require.Empty,
-			webauthnLogin:   successfulChallenge("leafcluster"),
+			name:      "command runs on a leaf node without mfa",
+			target:    sshLeafHostID,
+			proxyAddr: leafProxyAddr,
+			auth:      leafAuth.GetAuthServer(),
+			roles:     []string{sshLoginRole.GetName()},
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
+			webauthnLogin: successfulChallenge("leafcluster"),
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
 			errAssertion: require.NoError,
 		},
 		{
-			name:            "command runs on a leaf node via root with mfa set via role",
-			target:          sshLeafHostID,
-			proxyAddr:       rootProxyAddr.String(),
-			auth:            rootAuth.GetAuthServer(),
-			cluster:         "leafcluster",
-			roles:           []string{perSessionMFARole.GetName()},
-			webauthnLogin:   successfulChallenge("localhost"),
-			stderrAssertion: require.Empty,
+			name:          "command runs on a leaf node via root with mfa set via role",
+			target:        sshLeafHostID,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			cluster:       "leafcluster",
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("localhost"),
+			stderrAssertion: func(tt require.TestingT, i interface{}, i2 ...interface{}) {
+				require.Equal(t, "error\n", i, i2...)
+			},
 			stdoutAssertion: func(t require.TestingT, i interface{}, i2 ...interface{}) {
 				require.Equal(t, "test\n", i, i2...)
 			},
@@ -1665,7 +1704,12 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			if tt.headless {
 				args = append(args, "--headless", "--proxy", tt.proxyAddr, "--user", user.GetName())
 			}
-			args = append(args, tt.target, "echo", "test")
+			var logDir string
+			if len(tt.logSuccess) > 0 {
+				logDir = t.TempDir()
+				args = append(args, "--log-dir", logDir)
+			}
+			args = append(args, tt.target, "echo", "test", "&&", "echo", "error", ">&2")
 
 			err = Run(ctx,
 				args,
@@ -1684,6 +1728,30 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			tt.stdoutAssertion(t, stdout.String())
 			tt.stderrAssertion(t, stderr.String())
 			require.Equal(t, tt.mfaPromptCount, int(device.Counter()), "device sign count mismatch")
+
+			// Check for logs if enabled.
+			if len(tt.logSuccess) > 0 {
+				succeededFile := filepath.Join(logDir, "hosts.succeeded")
+				assert.FileExists(t, succeededFile)
+				succeededContents, err := os.ReadFile(succeededFile)
+				assert.NoError(t, err)
+
+				for _, host := range tt.logSuccess {
+					assert.Contains(t, string(succeededContents), host)
+					stdoutFile := filepath.Join(logDir, host+".stdout")
+					assert.FileExists(t, stdoutFile)
+					contents, err := os.ReadFile(stdoutFile)
+					assert.NoError(t, err)
+					assert.Equal(t, "test\n", string(contents))
+
+					stderrFile := filepath.Join(logDir, host+".stderr")
+					assert.FileExists(t, stderrFile)
+					contents, err = os.ReadFile(stderrFile)
+					assert.NoError(t, err)
+					assert.Equal(t, "error\n", string(contents))
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
This change improves the output of `tsh ssh` when run on multiple nodes. Stdout and stderr are now labeled with the hostname of the node they came from.
```sh
$ tsh ssh env=dev go version
WARNING: Multiple nodes matched label selector, running command on all.
Running command on node1.example.com:
Running command on node2.example.com:
[node2.example.com] go version go1.21.3
[node1.example.com] go: command not found
[node3.example.com] go version go1.21.3

[node1.example.com] failed with exit code 127
[node3.example.com] success
[node2.example.com] success

2 host(s) succeeded; 1 host(s) failed
ERROR: 1 command(s) failed
```
Additionally, if the `--log-dir <DIR>` flag is passed to `tsh ssh`, separated logs for each node will be created in `<DIR>` with the following contents:
- For each node `node`, the files `node.stdout` and `node.stderr` will contain that node's stdout and stderr output, respectively.
- `hosts.succeeded` will contain the hostnames of nodes that exited with code 0, with one hostname per line.
- `hosts.failed` will contain the nodes with nonzero exit codes, in the same format as `hosts.succeeded`.

Resolves #6635.

Changelog: Improved readability of `tsh ssh` output when running commands on multiple nodes