### PR TITLE
Make initialization of Connect synchronous

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -42,7 +42,7 @@ if (app.requestSingleInstanceLock()) {
   app.exit(1);
 }
 
-async function initializeApp(): Promise<void> {
+function initializeApp(): void {
   updateSessionDataPath();
   let devRelaunchScheduled = false;
   const settings = getRuntimeSettings();
@@ -52,7 +52,7 @@ async function initializeApp(): Promise<void> {
     appStateFileStorage,
     configFileStorage,
     configJsonSchemaFileStorage,
-  } = await createFileStorages(settings.userDataDir);
+  } = createFileStorages(settings.userDataDir);
 
   runConfigFileMigration(configFileStorage);
   const configService = createConfigService({
@@ -238,23 +238,19 @@ function initMainLogger(settings: types.RuntimeSettings) {
 }
 
 function createFileStorages(userDataDir: string) {
-  return Promise.all([
-    createFileStorage({
+  return {
+    appStateFileStorage: createFileStorage({
       filePath: path.join(userDataDir, 'app_state.json'),
       debounceWrites: true,
     }),
-    createFileStorage({
+    configFileStorage: createFileStorage({
       filePath: path.join(userDataDir, 'app_config.json'),
       debounceWrites: false,
       discardUpdatesOnLoadError: true,
     }),
-    createFileStorage({
+    configJsonSchemaFileStorage: createFileStorage({
       filePath: path.join(userDataDir, 'schema_app_config.json'),
       debounceWrites: false,
     }),
-  ]).then(storages => ({
-    appStateFileStorage: storages[0],
-    configFileStorage: storages[1],
-    configJsonSchemaFileStorage: storages[2],
-  }));
+  };
 }


### PR DESCRIPTION
In order to support deep links (#32188), we need to [add listeners for certain events](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#macos-code) to make the app respond to opening it from a custom protocol link in the Web UI.

While playing with it, I noticed that nothing would happen if I clicked the link while the app wasn't running, the app would launch but it didn't show the dialog box I wired up in the event listener.

It turns out it's because `initializeApp` where I added the listener, and where we keep most of our other `app` and `process` listeners, is async. This means it doesn't get processed immediately on app launch, at best it happens during the next tick. This is too late for registering the `open-url` listener and the event is simply dropped.

This PR replaces the async actions during initialization with their sync equivalents, making `initializeApp` sync. The only async actions were file system operations related to `createFileStorage` – this is a function we use to store and read certain JSON blobs from disk, such as app config and app state that is persisted between app launches.

I packaged the app on all three platforms and verified that it launches without any problems.

## Blocking the main process 😈

Generally, [Electron discourages blocking the main process](https://www.electronjs.org/docs/latest/tutorial/performance#3-blocking-the-main-process). If the main process is blocked, the UI will freeze until the main process is unblocked.

However, during initialization there's no UI. The main app window is not even shown until we call `windowsManager.createWindow()` in `main.ts`. Currently, `windowsManager.createWindow()` gets called only after the calls to `createFileStorage` finish. This means two things:

1. Since there's no UI during initialization, blocking the main process doesn't freeze the UI.
2. If the calls to `createFileStorage` are blocked on filesystem access, even today this means that the user will not see the window until those operations finish.

This means that this change doesn't introduce any adverse effects for the user, unless there's something I'm not aware of related to what Electron does during app start.

### An alternative

An alternative to blocking the main process would be to segregate what happens during startup. We'd set up the listeners in sync code and the rest of the initialization process, such as calling `createFileStorage`, would happen in async code.

I did craft a quick proof of concept. The problem with this approach is that the `open-url` handler would likely need to know when the frontend app is ready in some way. Currently, all IPC communication is set up through our `MainProcess` class which depends on a couple of file storages initialized through `createFileStorage`.

So we'd either have to solve this problem or add some IPC handlers in another object which doesn't depend on file storage. This is not impossible but certainly adds some complexity.

## Blocking the main process 😌

I did some quick tests where I tested the current app initialization, the segregated approach and the sync approach. With `performance.now()`, I measured the type from initial load of `main.ts` (taking a measurement right after imports) and then made another measurement once `app.whenReady` has resolved.

On both my MBP and on Windows VM, the sync version performed better than others.

My MBP:

|   Method  |   First run  |   Second run  |   Third run  |
|---|---|---|---|
|   Current  |   136ms  |   125ms  |   122ms  |
|   Sync  |   79ms  |   79ms  |   78ms  |
|   Segregated  |   136ms  |   118ms  |   129ms  |

Windows VM:



Method | First run | Second run | Third run | Fourth run | Fifth run
-- | -- | -- | -- | -- | --
Sync | 374ms | 280ms | 130ms | 114ms | 124ms
Segregated | 465ms | 141ms | 143ms | 141ms | 148ms
