### PR TITLE
Enable optimistic locking support for SAML connectors

### DIFF
--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
 	"github.com/gravitational/teleport/lib/utils"
@@ -89,16 +91,47 @@ func TestEditGithubConnector(t *testing.T) {
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error got %T", err)
 }
 
-func TestEditOIDConnector(t *testing.T) {
+// TestEditEnterpriseResources asserts that tctl edit
+// behaves as expected for enterprise resources. These resources cannot
+// be tested in parallel because they alter the modules to enable features.
+// The tests are grouped to amortize the cost of creating and auth server since
+// that is the most expensive part of testing editing the resource.
+func TestEditEnterpriseResources(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
-		TestFeatures:  modules.Features{OIDC: true},
+		TestFeatures: modules.Features{
+			OIDC: true,
+			SAML: true,
+		},
 	})
-	ctx := context.Background()
 	log := utils.NewLoggerForTests()
 	fc, fds := testhelpers.DefaultConfig(t)
 	_ = testhelpers.MakeAndRunTestAuthServer(t, log, fc, fds)
 	rootClient := testhelpers.MakeDefaultAuthClient(t, log, fc)
+
+	tests := []struct {
+		kind string
+		edit func(t *testing.T, fc *config.FileConfig, clt auth.ClientI)
+	}{
+		{
+			kind: types.KindOIDCConnector,
+			edit: testEditOIDCConnector,
+		},
+		{
+			kind: types.KindSAMLConnector,
+			edit: testEditSAMLConnector,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			test.edit(t, fc, rootClient)
+		})
+	}
+}
+
+func testEditOIDCConnector(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
+	ctx := context.Background()
 	expected, err := types.NewOIDCConnector("oidc", types.OIDCConnectorSpecV3{
 		ClientID:     "12345",
 		ClientSecret: "678910",
@@ -113,7 +146,7 @@ func TestEditOIDConnector(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "creating initial connector resource")
-	created, err := rootClient.CreateOIDCConnector(ctx, expected.(*types.OIDCConnectorV3))
+	created, err := clt.CreateOIDCConnector(ctx, expected.(*types.OIDCConnectorV3))
 	require.NoError(t, err, "persisting initial connector resource")
 
 	editor := func(name string) error {
@@ -134,7 +167,7 @@ func TestEditOIDConnector(t *testing.T) {
 	_, err = runEditCommand(t, fc, []string{"edit", "connector/oidc"}, withEditor(editor))
 	require.NoError(t, err, "expected editing oidc connector to succeed")
 
-	actual, err := rootClient.GetOIDCConnector(ctx, expected.GetName(), false)
+	actual, err := clt.GetOIDCConnector(ctx, expected.GetName(), false)
 	require.NoError(t, err, "retrieving oidc connector after edit")
 	require.Empty(t, cmp.Diff(created, actual, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Namespace"),
 		cmpopts.IgnoreFields(types.OIDCConnectorSpecV3{}, "ClientID", "ClientSecret"),
@@ -146,5 +179,74 @@ func TestEditOIDConnector(t *testing.T) {
 	// since the created revision is stale.
 	_, err = runEditCommand(t, fc, []string{"edit", "connector/oidc"}, withEditor(editor))
 	assert.Error(t, err, "stale connector was allowed to be updated")
-	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error got %T", err)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
+}
+
+func testEditSAMLConnector(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
+	ctx := context.Background()
+
+	expected, err := types.NewSAMLConnector("saml", types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "original-acs",
+		EntityDescriptor: `<?xml version="1.0" encoding="UTF-8"?>
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test">
+      <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate></ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="test" />
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="test" />
+      </md:IDPSSODescriptor>
+    </md:EntityDescriptor>`,
+		Display: "SAML",
+		AttributesToRoles: []types.AttributeMapping{
+			{
+				Name:  "test",
+				Value: "test",
+				Roles: []string{"access"},
+			},
+		},
+	})
+	require.NoError(t, err, "creating initial connector resource")
+
+	created, err := clt.CreateSAMLConnector(ctx, expected.(*types.SAMLConnectorV2))
+	require.NoError(t, err, "persisting initial connector resource")
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+
+		expected.SetRevision(created.GetRevision())
+		expected.SetSigningKeyPair(created.GetSigningKeyPair())
+		expected.SetAssertionConsumerService("updated-acs")
+
+		collection := &connectorsCollection{saml: []types.SAMLConnector{expected}}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+
+	}
+
+	// Edit the connector and validate that the expected field is updated.
+	_, err = runEditCommand(t, fc, []string{"edit", "connector/saml"}, withEditor(editor))
+	require.NoError(t, err, "expected editing saml connector to succeed")
+
+	actual, err := clt.GetSAMLConnector(ctx, expected.GetName(), true)
+	require.NoError(t, err, "retrieving saml connector after edit")
+	require.Empty(t, cmp.Diff(created, actual, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Namespace"),
+		cmpopts.IgnoreFields(types.SAMLConnectorSpecV2{}, "AssertionConsumerService"),
+	))
+	require.NotEqual(t, created.GetAssertionConsumerService(), actual.GetAssertionConsumerService(), "acs should have been modified by edit")
+	require.Equal(t, expected.GetAssertionConsumerService(), actual.GetAssertionConsumerService(), "acs should match the retrieved connector")
+
+	// Try editing the connector a second time this, time the revisions will not match
+	// since the created revision is stale.
+	_, err = runEditCommand(t, fc, []string{"edit", "connector/saml"}, withEditor(editor))
+	assert.Error(t, err, "stale connector was allowed to be updated")
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -143,6 +143,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindUser:            rc.updateUser,
 		types.KindGithubConnector: rc.updateGithubConnector,
 		types.KindOIDCConnector:   rc.updateOIDCConnector,
+		types.KindSAMLConnector:   rc.updateSAMLConnector,
 	}
 	rc.config = config
 
@@ -870,6 +871,20 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.
 		return trace.Wrap(err)
 	}
 	fmt.Printf("authentication connector '%s' has been %s\n", connectorName, UpsertVerb(exists, rc.IsForced()))
+	return nil
+}
+
+func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	// Create services.SAMLConnector from raw YAML to extract the connector name.
+	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err = client.UpdateSAMLConnector(ctx, conn); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("authentication connector '%s' has been updated\n", conn.GetName())
 	return nil
 }
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1405,15 +1405,46 @@ version: v3`
 	require.NoError(t, err)
 }
 
-func TestCreateOIDCConnector(t *testing.T) {
+// TestCreateEnterpriseResources asserts that tctl create
+// behaves as expected for enterprise resources. These resources cannot
+// be tested in parallel because they alter the modules to enable features.
+// The tests are grouped to amortize the cost of creating and auth server since
+// that is the most expensive part of testing editing the resource.
+func TestCreateEnterpriseResources(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
-		TestFeatures:  modules.Features{OIDC: true},
+		TestFeatures: modules.Features{
+			OIDC: true,
+			SAML: true,
+		},
 	})
 
 	fc, fds := testhelpers.DefaultConfig(t)
 	makeAndRunTestAuthServer(t, withFileConfig(fc), withFileDescriptors(fds), withFakeClock(clockwork.NewFakeClock()))
 
+	tests := []struct {
+		kind   string
+		create func(t *testing.T, fc *config.FileConfig)
+	}{
+		{
+			kind:   types.KindOIDCConnector,
+			create: testCreateOIDCConnector,
+		},
+		{
+			kind:   types.KindSAMLConnector,
+			create: testCreateSAMLConnector,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			test.create(t, fc)
+		})
+	}
+
+}
+
+func testCreateOIDCConnector(t *testing.T, fc *config.FileConfig) {
 	// Ensure there are no connectors to start
 	buf, err := runResourceCommand(t, fc, []string{"get", types.KindOIDCConnector, "--format=json"})
 	require.NoError(t, err)
@@ -1459,6 +1490,83 @@ spec:
 	// the force flag.
 	expected.SetRevision(uuid.NewString())
 	connectorBytes, err := services.MarshalOIDCConnector(&expected, services.PreserveResourceID())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(connectorYAMLPath, connectorBytes, 0644))
+
+	_, err = runResourceCommand(t, fc, []string{"create", connectorYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err))
+
+	_, err = runResourceCommand(t, fc, []string{"create", "-f", connectorYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateSAMLConnector(t *testing.T, fc *config.FileConfig) {
+	// Ensure there are no connectors to start
+	buf, err := runResourceCommand(t, fc, []string{"get", types.KindSAMLConnector, "--format=json"})
+	require.NoError(t, err)
+	connectors := mustDecodeJSON[[]*types.SAMLConnectorV2](t, buf)
+	require.Empty(t, connectors)
+
+	const connectorYAML = `kind: saml
+version: v2
+metadata:
+  name: saml
+spec:
+  acs: test
+  audience: test
+  issuer: test
+  sso: test
+  service_provider_issuer: test
+  display: SAML
+  attributes_to_roles:
+  - name: test
+    roles:
+    - access
+    value: test
+  entity_descriptor: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test">
+      <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate></ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="test" />
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="test" />
+      </md:IDPSSODescriptor>
+    </md:EntityDescriptor>` + "\n"
+
+	// Create the connector
+	connectorYAMLPath := filepath.Join(t.TempDir(), "connector.yaml")
+	require.NoError(t, os.WriteFile(connectorYAMLPath, []byte(connectorYAML), 0644))
+	_, err = runResourceCommand(t, fc, []string{"create", connectorYAMLPath})
+	require.NoError(t, err)
+
+	// Fetch the connector
+	buf, err = runResourceCommand(t, fc, []string{"get", types.KindSAMLConnector, "--format=json"})
+	require.NoError(t, err)
+	connectors = mustDecodeJSON[[]*types.SAMLConnectorV2](t, buf)
+	require.Len(t, connectors, 1)
+
+	var expected types.SAMLConnectorV2
+	require.NoError(t, yaml.Unmarshal([]byte(connectorYAML), &expected))
+
+	require.Empty(t, cmp.Diff(
+		[]*types.SAMLConnectorV2{&expected},
+		connectors,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Namespace"),
+		cmpopts.IgnoreFields(types.SAMLConnectorSpecV2{}, "SigningKeyPair"), // get retrieves the connector without secrets
+	))
+
+	// Explicitly change the revision and try creating the user with and without
+	// the force flag.
+	expected.SetRevision(uuid.NewString())
+	connectorBytes, err := services.MarshalSAMLConnector(&expected, services.PreserveResourceID())
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(connectorYAMLPath, connectorBytes, 0644))
 


### PR DESCRIPTION
Updates tctl edit and the web ui to start using optimistic locking. The functionality to support optimistic locking already existed, the APIs used by both clients were updated to use create/update instead of upsert so that optimistic locking could be enforced. Most of the changes introduced are tests to ensure that tctl edit, tctl create behave as expected.

Note: the web ui changes are include in the e ref update.

Contributes to #30416.
Depends on https://github.com/gravitational/teleport.e/pull/2433.