### PR TITLE
Fix Flaky Test Detector

### DIFF
--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -82,12 +82,6 @@ jobs:
           flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" -e "integrations/operator/**/*" -e "tool/tsh/**/*" -e "integration/**/*" -e "build.assets/**/*" -e "lib/auth/webauthncli/**/*" -e "lib/auth/touchid/**/*" -e "api/**/*" -e "integrations/kube-agent-updater/**/*" -e "examples/teleport-usage/**/*" -e "integrations/access/**" -e "integrations/lib/**" -e "integrations/lib/backoff/backoff_test.go" -e "e2e/**/*"
           target: test-go-unit
 
-      - name: Run libfido2 difftest
-        uses: ./.github/actions/difftest
-        with:
-          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "lib/auth/webauthncli/**/*"
-          target: test-go-libfido2
-
       - name: Run touch-id difftest
         uses: ./.github/actions/difftest
         with:


### PR DESCRIPTION
#33403 removed the test-go-libfido2 make target but the flaky test detector was still trying to invoke it resulting in all runs to fail.