### PR TITLE
Dynamic Discovery Matchers for Databases

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -701,6 +702,9 @@ type ReadDiscoveryAccessPoint interface {
 	GetApps(context.Context) ([]types.Application, error)
 	// GetApp returns the specified application resource.
 	GetApp(ctx context.Context, name string) (types.Application, error)
+
+	// ListDiscoveryConfigs returns a paginated list of Discovery Config resources.
+	ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error)
 }
 
 // DiscoveryAccessPoint is an API interface implemented by a certificate authority (CA) to be

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2282,17 +2282,28 @@ func (process *TeleportProcess) newLocalCacheForDatabase(clt auth.ClientI, cache
 	return auth.NewDatabaseWrapper(clt, cache), nil
 }
 
+// combinedDiscoveryClient is an auth.Client client with other, specific, services added to it.
+type combinedDiscoveryClient struct {
+	auth.ClientI
+	services.DiscoveryConfigsGetter
+}
+
 // newLocalCacheForDiscovery returns a new instance of access point for a discovery service.
 func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cacheName []string) (auth.DiscoveryAccessPoint, error) {
+	client := combinedDiscoveryClient{
+		ClientI:                clt,
+		DiscoveryConfigsGetter: clt.DiscoveryConfigClient(),
+	}
+
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
-		return clt, nil
+		return client, nil
 	}
 	cache, err := process.NewLocalCache(clt, cache.ForDiscovery, cacheName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return auth.NewDiscoveryWrapper(clt, cache), nil
+	return auth.NewDiscoveryWrapper(client, cache), nil
 }
 
 // newLocalCacheForProxy returns new instance of access point configured for a local proxy.

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -43,8 +43,10 @@ type DiscoveryConfig struct {
 	PollInterval time.Duration
 }
 
-// IsEmpty validates if the Discovery Service config has no cloud matchers.
+// IsEmpty validates if the Discovery Service config has no matchers and no discovery group.
+// DiscoveryGroup is used to dynamically load Matchers when changing DiscoveryConfig resources.
 func (d DiscoveryConfig) IsEmpty() bool {
 	return len(d.AWSMatchers) == 0 && len(d.AzureMatchers) == 0 &&
-		len(d.GCPMatchers) == 0 && len(d.KubernetesMatchers) == 0
+		len(d.GCPMatchers) == 0 && len(d.KubernetesMatchers) == 0 &&
+		d.DiscoveryGroup == ""
 }

--- a/lib/service/servicecfg/discovery_test.go
+++ b/lib/service/servicecfg/discovery_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicecfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestDiscoveryConfig_IsEmpty(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    DiscoveryConfig
+		expected bool
+	}{
+		{
+			name: "returns false when discovery group is present",
+			input: DiscoveryConfig{
+				DiscoveryGroup: "my-discovery-group",
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when has at least one aws matcher",
+			input: DiscoveryConfig{
+				AWSMatchers: []types.AWSMatcher{{
+					Types: []string{"ec2"},
+				}},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when has at least one azure matcher",
+			input: DiscoveryConfig{
+				AzureMatchers: []types.AzureMatcher{{
+					Types: []string{"aks"},
+				}},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when has at least one gcp matcher",
+			input: DiscoveryConfig{
+				GCPMatchers: []types.GCPMatcher{{
+					Types: []string{"gke"},
+				}},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when has at least one Kube matcher",
+			input: DiscoveryConfig{
+				KubernetesMatchers: []types.KubernetesMatcher{{
+					Types: []string{"app"},
+				}},
+			},
+			expected: false,
+		},
+		{
+			name:     "returns true when there are no matchers and no discovery group",
+			input:    DiscoveryConfig{},
+			expected: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.IsEmpty()
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -31,7 +31,7 @@ import (
 const databaseEventPrefix = "db/"
 
 func (s *Server) startDatabaseWatchers() error {
-	if len(s.databaseFetchers) == 0 {
+	if len(s.databaseFetchers) == 0 && s.dynamicMatcherWatcher == nil {
 		return nil
 	}
 
@@ -60,11 +60,12 @@ func (s *Server) startDatabaseWatchers() error {
 	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
-		Fetchers:       s.databaseFetchers,
+		FetchersFn:     s.getAllDatabaseFetchers,
 		Log:            s.Log.WithField("kind", types.KindDatabase),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
 		Origin:         types.OriginCloud,
+		Clock:          s.clock,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -91,6 +92,18 @@ func (s *Server) startDatabaseWatchers() error {
 		}
 	}()
 	return nil
+}
+
+func (s *Server) getAllDatabaseFetchers() []common.Fetcher {
+	allFetchers := make([]common.Fetcher, 0, len(s.databaseFetchers))
+
+	s.muDynamicFetchers.RLock()
+	for _, fetcherSet := range s.dynamicDatabaseFetchers {
+		allFetchers = append(allFetchers, fetcherSet...)
+	}
+	s.muDynamicFetchers.RUnlock()
+
+	return append(allFetchers, s.databaseFetchers...)
 }
 
 func (s *Server) getCurrentDatabases() types.ResourcesWithLabelsMap {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 	"k8s.io/client-go/kubernetes"
@@ -38,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -115,11 +117,15 @@ type Config struct {
 	// PollInterval is the cadence at which the discovery server will run each of its
 	// discovery cycles.
 	PollInterval time.Duration
+
+	// clock is passed to watchers to handle poll intervals.
+	// Mostly used in tests.
+	clock clockwork.Clock
 }
 
 func (c *Config) CheckAndSetDefaults() error {
-	if c.Matchers.IsEmpty() {
-		return trace.BadParameter("no matchers configured for discovery")
+	if c.Matchers.IsEmpty() && c.DiscoveryGroup == "" {
+		return trace.BadParameter("no matchers or discovery group configured for discovery")
 	}
 	if c.Emitter == nil {
 		return trace.BadParameter("no Emitter configured for discovery")
@@ -164,6 +170,10 @@ kubernetes matchers are present.`)
 		c.PollInterval = 5 * time.Minute
 	}
 
+	if c.clock == nil {
+		c.clock = clockwork.NewRealClock()
+	}
+
 	c.Log = c.Log.WithField(trace.Component, teleport.ComponentDiscovery)
 	c.Matchers.Azure = services.SimplifyAzureMatchers(c.Matchers.Azure)
 	return nil
@@ -200,6 +210,16 @@ type Server struct {
 	kubeAppsFetchers []common.Fetcher
 	// databaseFetchers holds all database fetchers.
 	databaseFetchers []common.Fetcher
+
+	// dynamicMatcherWatcher is an initialized Watcher for DiscoveryConfig resources.
+	// Each new event must update the existing resources.
+	dynamicMatcherWatcher types.Watcher
+
+	// dynamicDatabaseFetchers holds the current Database Fetchers for the Dynamic Matchers (those coming from DiscoveryConfig resource).
+	// The key is the DiscoveryConfig name.
+	dynamicDatabaseFetchers map[string][]common.Fetcher
+	muDynamicFetchers       sync.RWMutex
+
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
 	// reconciler periodically reconciles the labels of discovered instances
@@ -220,11 +240,22 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 
 	localCtx, cancelfn := context.WithCancel(ctx)
 	s := &Server{
-		Config:          cfg,
-		ctx:             localCtx,
-		cancelfn:        cancelfn,
-		usageEventCache: make(map[string]struct{}),
+		Config:                  cfg,
+		ctx:                     localCtx,
+		cancelfn:                cancelfn,
+		usageEventCache:         make(map[string]struct{}),
+		dynamicDatabaseFetchers: make(map[string][]common.Fetcher),
 	}
+
+	if err := s.startDynamicMatchersWatcher(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	databaseFetchers, err := s.databaseFetchersFromMatchers(cfg.Matchers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	s.databaseFetchers = databaseFetchers
 
 	if err := s.initAWSWatchers(cfg.Matchers.AWS); err != nil {
 		return nil, trace.Wrap(err)
@@ -249,6 +280,38 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 	}
 
 	return s, nil
+}
+
+// startDynamicMatchersWatcher starts a watcher for DiscoveryConfig events.
+// After initialization, it starts a goroutine that receives and handles events.
+func (s *Server) startDynamicMatchersWatcher(ctx context.Context) error {
+	if s.DiscoveryGroup == "" {
+		return nil
+	}
+
+	watcher, err := s.AccessPoint.NewWatcher(ctx, types.Watch{
+		Kinds: []types.WatchKind{{
+			Kind: types.KindDiscoveryConfig,
+		}},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Wait for OpInit event so the watcher is ready.
+	select {
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.BadParameter("failed to watch for DiscoveryConfig: received an unexpected event while waiting for the initial OpInit")
+		}
+	case <-watcher.Done():
+		return trace.Wrap(watcher.Error())
+	}
+
+	s.dynamicMatcherWatcher = watcher
+
+	go s.startDynamicWatcherUpdater()
+	return nil
 }
 
 // initAWSWatchers starts AWS resource watchers based on types provided.
@@ -282,15 +345,8 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		s.reconciler = lr
 	}
 
-	// Add database fetchers.
-	databaseMatchers, otherMatchers := splitMatchers(otherMatchers, db.IsAWSMatcherType)
-	if len(databaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.CloudClients, databaseMatchers)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		s.databaseFetchers = append(s.databaseFetchers, databaseFetchers...)
-	}
+	// Database fetchers were added in databaseFetchersFromMatchers.
+	_, otherMatchers = splitMatchers(otherMatchers, db.IsAWSMatcherType)
 
 	// Add kube fetchers.
 	for _, matcher := range otherMatchers {
@@ -365,6 +421,36 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 	return nil
 }
 
+// databaseFetchersFromMatchers converts Matchers into a set of Database Fetchers.
+func (s *Server) databaseFetchersFromMatchers(matchers Matchers) ([]common.Fetcher, error) {
+	var fetchers []common.Fetcher
+
+	// AWS
+	awsDatabaseMatchers, _ := splitMatchers(matchers.AWS, db.IsAWSMatcherType)
+	if len(awsDatabaseMatchers) > 0 {
+		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.CloudClients, awsDatabaseMatchers)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		fetchers = append(fetchers, databaseFetchers...)
+	}
+
+	// Azure
+	azureDatabaseMatchers, _ := splitMatchers(matchers.Azure, db.IsAzureMatcherType)
+	if len(azureDatabaseMatchers) > 0 {
+		databaseFetchers, err := db.MakeAzureFetchers(s.CloudClients, azureDatabaseMatchers)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		fetchers = append(fetchers, databaseFetchers...)
+	}
+
+	// There are no Database Matchers for GCP Matchers.
+	// There are no Database Matchers for Kube Matchers.
+
+	return fetchers, nil
+}
+
 // initAzureWatchers starts Azure resource watchers based on types provided.
 func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMatcher) error {
 	vmMatchers, otherMatchers := splitMatchers(matchers, func(matcherType string) bool {
@@ -385,15 +471,8 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMa
 		}
 	}
 
-	// Add database fetchers.
-	databaseMatchers, otherMatchers := splitMatchers(otherMatchers, db.IsAzureMatcherType)
-	if len(databaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAzureFetchers(s.CloudClients, databaseMatchers)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		s.databaseFetchers = append(s.databaseFetchers, databaseFetchers...)
-	}
+	// Database fetchers were added in databaseFetchersFromMatchers.
+	_, otherMatchers = splitMatchers(otherMatchers, db.IsAzureMatcherType)
 
 	// Add kube fetchers.
 	for _, matcher := range otherMatchers {
@@ -908,6 +987,99 @@ func (s *Server) Start() error {
 	return nil
 }
 
+// startDynamicWatcherUpdater watches for DiscoveryConfig resource change events.
+// Before consuming changes, it iterates over all DiscoveryConfigs and
+// For deleted resources, it deletes the matchers.
+// For new/updated resources, it replaces the set of fetchers.
+func (s *Server) startDynamicWatcherUpdater() {
+	// Add all existing DiscoveryConfigs as matchers.
+	nextKey := ""
+	for {
+		dcs, respNextKey, err := s.AccessPoint.ListDiscoveryConfigs(s.ctx, 0, nextKey)
+		if err != nil {
+			s.Log.WithError(err).Warnf("failed to list discovery configs")
+			return
+		}
+		for _, dc := range dcs {
+			if dc.GetDiscoveryGroup() != s.DiscoveryGroup {
+				continue
+			}
+
+			if err := s.upsertDynamicMatchers(dc); err != nil {
+				s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
+				continue
+			}
+		}
+		if respNextKey == "" {
+			break
+		}
+		nextKey = respNextKey
+	}
+
+	// Consume DiscoveryConfig events to update Matchers as they change.
+	for {
+		select {
+		case event := <-s.dynamicMatcherWatcher.Events():
+			switch event.Type {
+			case types.OpPut:
+				dc, ok := event.Resource.(*discoveryconfig.DiscoveryConfig)
+				if !ok {
+					s.Log.Warnf("dynamic matcher watcher: unexpected resource type %T", event.Resource)
+					return
+				}
+
+				if dc.GetDiscoveryGroup() != s.DiscoveryGroup {
+					// Let's assume there's a DiscoveryConfig DC1 has DiscoveryGroup DG1, which this process is monitoring.
+					// If the user updates the DiscoveryGroup to DG2, then DC1 must be removed from the scope of this process.
+					// We blindly delete it, in the worst case, this is a no-op.
+					s.muDynamicFetchers.Lock()
+					delete(s.dynamicDatabaseFetchers, event.Resource.GetName())
+					s.muDynamicFetchers.Unlock()
+					continue
+				}
+
+				if err := s.upsertDynamicMatchers(dc); err != nil {
+					s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
+					continue
+				}
+
+			case types.OpDelete:
+				s.muDynamicFetchers.Lock()
+				delete(s.dynamicDatabaseFetchers, event.Resource.GetName())
+				s.muDynamicFetchers.Unlock()
+
+			default:
+				s.Log.Warnf("Skipping unknown event type %s", event.Type)
+			}
+		case <-s.dynamicMatcherWatcher.Done():
+			s.Log.Warnf("dynamic matcher watcher error: %v", s.dynamicMatcherWatcher.Error())
+			return
+		}
+	}
+}
+
+// upsertDynamicMatchers upserts the internal set of dynamic matchers given a particular discovery config.
+func (s *Server) upsertDynamicMatchers(dc *discoveryconfig.DiscoveryConfig) error {
+	matchers := Matchers{
+		AWS:        dc.Spec.AWS,
+		Azure:      dc.Spec.Azure,
+		GCP:        dc.Spec.GCP,
+		Kubernetes: dc.Spec.Kube,
+	}
+
+	databaseFetchers, err := s.databaseFetchersFromMatchers(matchers)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO(marco): add other matcher types (VMs, Kubes, KubeApps)
+
+	s.muDynamicFetchers.Lock()
+	s.dynamicDatabaseFetchers[dc.GetName()] = databaseFetchers
+	s.muDynamicFetchers.Unlock()
+	return nil
+}
+
 // Stop stops the discovery service.
 func (s *Server) Stop() {
 	s.cancelfn()
@@ -919,6 +1091,11 @@ func (s *Server) Stop() {
 	}
 	if s.gcpWatcher != nil {
 		s.gcpWatcher.Stop()
+	}
+	if s.dynamicMatcherWatcher != nil {
+		if err := s.dynamicMatcherWatcher.Close(); err != nil {
+			s.Log.Warnf("dynamic matcher watcher closing error: ", trace.Wrap(err))
+		}
 	}
 }
 

--- a/lib/srv/discovery/kube_services_watcher.go
+++ b/lib/srv/discovery/kube_services_watcher.go
@@ -69,7 +69,7 @@ func (s *Server) startKubeAppsWatchers() error {
 	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
-		Fetchers:       s.kubeAppsFetchers,
+		FetchersFn:     common.StaticFetchers(s.kubeAppsFetchers),
 		Interval:       5 * time.Minute,
 		Log:            s.Log.WithField("kind", types.KindApp),
 		DiscoveryGroup: s.DiscoveryGroup,

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -67,7 +67,7 @@ func (s *Server) startKubeWatchers() error {
 	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
-		Fetchers:       s.kubeFetchers,
+		FetchersFn:     common.StaticFetchers(s.kubeFetchers),
 		Log:            s.Log.WithField("kind", types.KindKubernetesCluster),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,


### PR DESCRIPTION
Context https://github.com/gravitational/teleport/issues/25494

The DiscoveryService monitors cloud/kube resources and merges them as Teleport resources.
It uses a static configuration that is present in the `discovery_service` section of the `teleport.yaml` used by the teleport process.

This PR adds a watcher to the `discovery_service` that will monitor changes in DiscoveryConfig resources.
Every time a new DiscoveryConfig is created/updated, the service will update its internal matchers to include those coming from the DiscoveryConfig.
When a DiscoveryConfig is deleted, the corresponding matchers are removed as well.

To reduce the scope, we are only focusing on the Database matchers.
Follow up PRs will include other resource types.

It always starts the Database Matcher, even if no static configuration exists.
When a new Poll (default is every 5 minutes) starts, it will iterate over all the fetchers:
- static configuration (aka `discovery_service` from `teleport.yaml`)
- list of dynamic fetchers (updated by the DiscoveryConfig watcher)