### PR TITLE
[v13] Web: Fix passing in color to wrong field name

### DIFF
--- a/web/packages/design/src/SVGIcon/Calendar.tsx
+++ b/web/packages/design/src/SVGIcon/Calendar.tsx
@@ -48,7 +48,7 @@ export function Calendar({ size = 24, fill }: SVGIconProps) {
   return (
     <SVGIcon
       size={size}
-      color={fill}
+      fill={fill}
       className="icon icon-calendar"
       viewBox="0 0 24 24"
     >

--- a/web/packages/design/src/SVGIcon/ListMagnifyingGlass.tsx
+++ b/web/packages/design/src/SVGIcon/ListMagnifyingGlass.tsx
@@ -52,7 +52,7 @@ export function ListMagnifyingGlass({
   return (
     <SVGIcon
       size={size}
-      color={fill}
+      fill={fill}
       className="icon icon-listmagnifyingglass"
       viewBox="0 0 24 24"
       {...otherProps}

--- a/web/packages/design/src/SVGIcon/Notification.tsx
+++ b/web/packages/design/src/SVGIcon/Notification.tsx
@@ -48,7 +48,7 @@ export function Notification({ size = 24, fill, ...otherProps }: SVGIconProps) {
   return (
     <SVGIcon
       size={size}
-      color={fill}
+      fill={fill}
       className="icon icon-notification"
       viewBox="0 0 24 24"
       {...otherProps}


### PR DESCRIPTION
in master and v14, the color field gets passed as `color`, but in v13 it's `fill` (prevented from passing in custom colors)