### PR TITLE
Prevent remote proxies from impersonating users from different clusters

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4795,7 +4795,12 @@ func (a *ServerWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) 
 	if proxyClusterName != "" &&
 		proxyClusterName != clusterName.GetClusterName() &&
 		proxyClusterName != identityClusterName {
-		log.Warnf("received Kube CSR for %v", identityClusterName)
+		log.WithFields(
+			logrus.Fields{
+				"proxy_cluster_name":    proxyClusterName,
+				"identity_cluster_name": identityClusterName,
+			},
+		).Warn("KubeCSR request denied because the proxy and identity clusters didn't match")
 		return nil, trace.AccessDenied("can not sign certs for users via a different cluster proxy")
 	}
 	return a.authServer.ProcessKubeCSR(req)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -77,6 +77,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -4782,7 +4783,37 @@ func (a *ServerWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) 
 	if !a.hasBuiltinRole(types.RoleProxy) {
 		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
+	clusterName, err := a.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	proxyClusterName := a.context.Identity.GetIdentity().TeleportCluster
+	identityClusterName, err := extractOriginalClusterNameFromCSR(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if proxyClusterName != "" &&
+		proxyClusterName != clusterName.GetClusterName() &&
+		proxyClusterName != identityClusterName {
+		log.Warnf("received Kube CSR for %v", identityClusterName)
+		return nil, trace.AccessDenied("can not sign certs for users via a different cluster proxy")
+	}
 	return a.authServer.ProcessKubeCSR(req)
+}
+
+func extractOriginalClusterNameFromCSR(req KubeCSR) (string, error) {
+	csr, err := tlsca.ParseCertificateRequestPEM(req.CSR)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Extract identity from the CSR. Pass zero time for id.Expiry, it won't be
+	// used here.
+	id, err := tlsca.FromSubject(csr.Subject, time.Time{})
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return id.TeleportCluster, nil
 }
 
 // GetDatabaseServers returns all registered database servers.

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -665,7 +665,8 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if user, err = a.extractIdentityFromImpersonationHeader(impersonateUser); err != nil {
+		proxyClusterName := user.GetIdentity().TeleportCluster
+		if user, err = a.extractIdentityFromImpersonationHeader(proxyClusterName, impersonateUser); err != nil {
 			trace.WriteError(w, err)
 			return
 		}
@@ -790,7 +791,7 @@ func isProxyRole(identity authz.IdentityGetter) bool {
 // extractIdentityFromImpersonationHeader extracts the identity from the impersonation
 // header and returns it. If the impersonation header holds an identity of a
 // system role, an error is returned.
-func (a *Middleware) extractIdentityFromImpersonationHeader(impersonate string) (authz.IdentityGetter, error) {
+func (a *Middleware) extractIdentityFromImpersonationHeader(proxyCluster string, impersonate string) (authz.IdentityGetter, error) {
 	// Unmarshal the impersonated user from the header.
 	var impersonatedIdentity tlsca.Identity
 	if err := json.Unmarshal([]byte(impersonate), &impersonatedIdentity); err != nil {
@@ -802,6 +803,11 @@ func (a *Middleware) extractIdentityFromImpersonationHeader(impersonate string) 
 		// make sure that this user does not have system role
 		// since system roles are not allowed to be impersonated.
 		return nil, trace.AccessDenied("can not impersonate a system role")
+	case proxyCluster != "" && proxyCluster != a.ClusterName && proxyCluster != impersonatedIdentity.TeleportCluster:
+		// If a remote proxy is impersonating a user from a different cluster, we
+		// must reject the request. This is because the proxy is not allowed to
+		// impersonate a user from a different cluster.
+		return nil, trace.AccessDenied("can not impersonate users via a different cluster proxy")
 	case impersonatedIdentity.TeleportCluster != a.ClusterName:
 		// if the impersonated user is from a different cluster, we need to
 		// use him as remote user.


### PR DESCRIPTION
This PR prevents root proxies from impersonating users from different clusters when accessing a leaf cluster.

During authentication, the proxy presents its certificate and sends the impersonation header.

A malicious attacker in possession of the root cluster proxy cert-key pair could bypass the root-leaf cluster permissions boundary by impersonating local users. This PR prevents that and remote proxies can only impersonate users belonging to their cluster.

KubeCSR Flow:
```mermaid
sequenceDiagram
    ROOT PROXY->>+LEAF PROXY: Forward the request identity cert
    LEAF PROXY ->> LEAF AUTH SRV: Sign identity via KubeCSR
    LEAF AUTH SRV -->> LEAF PROXY: Identity cert
    LEAF PROXY ->> LEAF KUBE SERVICE: Forward the request using cert
    LEAF KUBE SERVICE -->> LEAF PROXY: Return response
    LEAF PROXY -->> ROOT PROXY: Return response
```

Impersonation Flow:
```mermaid
sequenceDiagram
    ROOT PROXY->>+LEAF PROXY: Forward the request identity by Impersonating
    LEAF PROXY ->> LEAF KUBE SERVICE: Forward the request identity by Impersonating
    LEAF KUBE SERVICE -->> LEAF PROXY: Return response
    LEAF PROXY -->> ROOT PROXY: Return response
```

Contributes to gravitational/teleport-private#968
Signed-off-by: Tiago Silva <tiago.silva@goteleport.com>