### PR TITLE
[v14] Fix flaky test `TestWithRsync/with_headless_tsh`

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -68,6 +68,9 @@ var (
 		// TestServer_Authenticate_headless takes about 4-5 seconds to run, so if other tests are changed
 		// in the same PR that take >1 second total, it may cause the flaky test detector to time out.
 		"TestServer_Authenticate_headless",
+
+		// TestWithRsync takes ~10 seconds to run
+		"TestWithRsync",
 	}
 )
 
@@ -158,7 +161,7 @@ func diff(repoPath string, ref string, changedFiles []string, elapsed time.Durat
 
 // test builds and prints go test flags
 func test(repoPath string, ref string, changedFiles []string) {
-	var dirs = make(StringSet)
+	dirs := make(StringSet)
 	methods := make([]string, 0)
 
 	dollarSign := "$"

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -265,6 +265,8 @@ func TestSSHLoadAllCAs(t *testing.T) {
 
 // TestWithRsync tests that Teleport works with rsync.
 func TestWithRsync(t *testing.T) {
+	disableAgent(t)
+
 	_, err := exec.LookPath("rsync")
 	require.NoError(t, err)
 
@@ -478,13 +480,11 @@ func TestWithRsync(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
 			cmd := tt.createCmd(ctx, testDir, srcPath, dstPath)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			err = cmd.Run()
+			out, err := cmd.CombinedOutput()
 			var msg string
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) {
-				msg = fmt.Sprintf("exit code: %d", exitErr.ExitCode())
+				msg = fmt.Sprintf("exit code: %d\nout: %s", exitErr.ExitCode(), out)
 			}
 			require.NoError(t, err, msg)
 


### PR DESCRIPTION
Backport #33538 to branch/v14