### PR TITLE
Show Connect My Computer CTA only if versions are compatible

### DIFF
--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -156,6 +156,7 @@ export const makeRuntimeSettings = (
   installationId: '123e4567-e89b-12d3-a456-426614174000',
   arch: 'arm64',
   osVersion: '22.2.0',
+  // Should be kept in sync with the default proxyVersion of makeRootCluster.
   appVersion: '11.1.0',
   isLocalBuild: runtimeSettings?.appVersion === '1.0.0-dev',
   username: 'alice',

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -63,7 +63,7 @@ export const makeRootCluster = (
   proxyHost: 'teleport-local:3080',
   authClusterId: 'fefe3434-fefe-3434-fefe-3434fefe3434',
   loggedInUser: makeLoggedInUser(),
-  proxyVersion: '1.0.0',
+  proxyVersion: '11.1.0',
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.story.tsx
@@ -54,6 +54,16 @@ export function Success() {
   const appContext = new MockAppContext({ appVersion: cluster.proxyVersion });
   appContext.connectMyComputerService.waitForNodeToJoin = async () =>
     makeServer();
+  // Report the agent as running so that the autostart behavior doesn't kick in and attempt to start
+  // the agent over and over.
+  appContext.mainProcessClient.subscribeToAgentUpdate = (
+    rootClusterUri,
+    callback
+  ) => {
+    callback({ status: 'running' });
+
+    return { cleanup: () => {} };
+  };
   return <ShowState cluster={cluster} appContext={appContext} />;
 }
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -58,7 +58,8 @@ function ServerList(props: State) {
   const { documentsService, rootClusterUri } = useWorkspaceContext();
   const { clusterUri } = useClusterContext();
   const loggedInUser = useWorkspaceLoggedInUser();
-  const { canUse: canUseConnectMyComputer } = useConnectMyComputerContext();
+  const { canUse: hasPermissionsForConnectMyComputer, agentCompatibility } =
+    useConnectMyComputerContext();
 
   const servers = fetchAttempt.data?.agentsList.map(makeServer) || [];
   const disabled = fetchAttempt.status === 'processing';
@@ -70,13 +71,16 @@ function ServerList(props: State) {
     agentFilter.search || agentFilter.query,
     canAddResources
   );
+  const canUseConnectMyComputer =
+    isRootCluster &&
+    hasPermissionsForConnectMyComputer &&
+    agentCompatibility === 'compatible';
   let { emptyText, emptyHint } = getEmptyTableText(emptyTableStatus, 'servers');
   let emptyButton: JSX.Element;
 
   if (
     emptyTableStatus.status === 'no-resources' &&
     emptyTableStatus.showEnrollingResourcesHint &&
-    isRootCluster &&
     canUseConnectMyComputer
   ) {
     emptyHint =

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -269,8 +269,8 @@ function renderState({
   const appContext = new MockAppContext({ platform });
   appContext.clustersService.state = state;
 
+  const rootClusterUri = routing.ensureRootClusterUri(doc.clusterUri);
   appContext.workspacesService.setState(draftState => {
-    const rootClusterUri = routing.ensureRootClusterUri(doc.clusterUri);
     draftState.rootClusterUri = rootClusterUri;
     draftState.workspaces[rootClusterUri] = {
       localClusterUri: doc.clusterUri,
@@ -286,7 +286,7 @@ function renderState({
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ConnectMyComputerContextProvider rootClusterUri={doc.clusterUri}>
+        <ConnectMyComputerContextProvider rootClusterUri={rootClusterUri}>
           <ResourcesContextProvider>
             <Wrapper>
               <DocumentCluster visible={true} doc={doc} />


### PR DESCRIPTION
The previous version would advertise Connect My Computer but then after clicking the CTA the user would see a screen explaining that they can't use Connect My Computer because of version incompatibility.

This PR fixes this by advertising Connect My Computer only if we know that the versions are compatible.