### PR TITLE
Fix assist audit query prompt

### DIFF
--- a/gen/go/eventschema/getters.go
+++ b/gen/go/eventschema/getters.go
@@ -101,7 +101,10 @@ func (d *TableSchemaDetails) CreateView() string {
 	return sb.String()
 }
 
-func sqlViewNameForEvent(eventName string) string {
+// SQLViewNameForEvent returns a SQL compatible view name for a given event.
+// [event code]  -> [athena view name]
+// session.start -> session_start
+func SQLViewNameForEvent(eventName string) string {
 	viewName := strings.ReplaceAll(eventName, ".", "_")
 	return strings.ReplaceAll(viewName, "-", "_")
 }
@@ -152,7 +155,7 @@ func GetViewsDetails() ([]*TableSchemaDetails, error) {
 			return nil, trace.Wrap(err)
 		}
 		tb.Name = eventName
-		tb.SQLViewName = sqlViewNameForEvent(eventName)
+		tb.SQLViewName = SQLViewNameForEvent(eventName)
 		out = append(out, tb)
 	}
 	return out, nil

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -138,7 +138,7 @@ Today's date is DATE('%s')`, time.Now().Format("2006-01-02")),
 		},
 		{
 			Role:    openai.ChatMessageRoleUser,
-			Content: fmt.Sprintf("The schema of the table `%s` is:\n\n%s", eventType, tableSchema),
+			Content: fmt.Sprintf("The schema of the table `%s` is:\n\n%s", eventschema.SQLViewNameForEvent(eventType), tableSchema),
 		},
 		{
 			Role:    openai.ChatMessageRoleUser,


### PR DESCRIPTION
## What 


before: for "show me all SSH sessions" the AI prompt output contained event type code instead of athena view name: 
![Screenshot 2023-10-17 at 14 03 36](https://github.com/gravitational/teleport/assets/22402974/a1041301-2b9c-47e5-a153-dd234d6b31b3)

after: 
![Screenshot 2023-10-17 at 14 05 17](https://github.com/gravitational/teleport/assets/22402974/01a39c4e-0ff3-4724-94c6-58d98b78b847)
