### PR TITLE
Add ListUsers to the services.IdentityService

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -942,6 +942,11 @@ func (c *Client) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, 
 	return users, nil
 }
 
+// ListUsers returns a page of users.
+func (c *Client) ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error) {
+	return nil, "", trace.NotImplemented("ListUsers is not implemented yet")
+}
+
 // DeleteUser deletes a user by name.
 func (c *Client) DeleteUser(ctx context.Context, user string) error {
 	//nolint:staticcheck // SA1019. Kept for backward compatibility.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2737,6 +2737,11 @@ func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]typ
 	return users, trace.Wrap(err)
 }
 
+// ListUsers returns a page of users.
+func (a *ServerWithRoles) ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error) {
+	return nil, "", trace.NotImplemented("ListUsers is not implemented yet")
+}
+
 func (a *ServerWithRoles) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -590,6 +590,9 @@ type IdentityService interface {
 	// GetUsers returns a list of usernames registered in the system
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
 
+	// ListUsers returns a page of users.
+	ListUsers(ctx context.Context, pageSize int, pageToken string, withSecrets bool) ([]types.User, string, error)
+
 	// ChangePassword changes user password
 	ChangePassword(ctx context.Context, req *proto.ChangePasswordRequest) error
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1164,6 +1164,7 @@ func (userExecutor) getReader(cache *Cache, cacheOK bool) userGetter {
 type userGetter interface {
 	GetUser(ctx context.Context, user string, withSecrets bool) (types.User, error)
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
+	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
 }
 
 var _ executor[types.User, userGetter] = userExecutor{}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -60,6 +60,8 @@ type UsersService interface {
 	DeleteUser(ctx context.Context, user string) error
 	// GetUsers returns a list of users registered with the local auth server
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
+	// ListUsers returns a page of users.
+	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
 	// DeleteAllUsers deletes all users
 	DeleteAllUsers(ctx context.Context) error
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/google/go-cmp/cmp"
@@ -37,6 +38,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -71,6 +74,145 @@ func NewIdentityService(backend backend.Backend) *IdentityService {
 func (s *IdentityService) DeleteAllUsers(ctx context.Context) error {
 	startKey := backend.ExactKey(webPrefix, usersPrefix)
 	return trace.Wrap(s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
+}
+
+func (s *IdentityService) listUsersWithSecrets(ctx context.Context, pageSize int, pageToken string) ([]types.User, string, error) {
+	rangeStart := backend.Key(webPrefix, usersPrefix, pageToken)
+	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
+
+	// Adjust page size, so it can't be too large.
+	if pageSize <= 0 || pageSize > apidefaults.DefaultChunkSize {
+		pageSize = apidefaults.DefaultChunkSize
+	}
+
+	// Artificially inflate the limit to account for user secrets
+	// which have the same prefix.
+	limit := pageSize * 4
+
+	rangeStream := backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit)
+
+	var (
+		out      []types.User
+		prevUser string
+		items    userItems
+	)
+	for rangeStream.Next() {
+		item := rangeStream.Item()
+
+		name, suffix, err := splitUsernameAndSuffix(string(item.Key))
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		if prevUser == "" {
+			prevUser = name
+		}
+
+		if name != prevUser {
+			user, err := userFromUserItems(prevUser, items)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			out = append(out, user)
+
+			prevUser = name
+			items = userItems{}
+
+			if len(out) == pageSize {
+				break
+			}
+		}
+
+		items.Set(suffix, item)
+	}
+
+	next := rangeStream.Next()
+
+	if len(out) == 0 {
+		// When there is only a single user the transition logic to detect when a user
+		// is complete will never be hit. If the stream is exhausted and the items have
+		// processed a user resource then return it.
+		if !next && items.complete() {
+			user, err := userFromUserItems(prevUser, items)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			out = append(out, user)
+		}
+	} else {
+		// If there are no more users it is possible that the previous user being processed
+		// was never added to out because there was no additional user to transition to.
+		// Add the user from the collected items and return the full output.
+		if len(out) != pageSize && out[len(out)-1].GetName() != prevUser {
+			user, err := userFromUserItems(prevUser, items)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			out = append(out, user)
+		}
+	}
+
+	var nextToken string
+	// If the stream has more data or while processing the stream the last user
+	// caused a transition but was not added to out we want to send a token so
+	// that the final user may be returned in the next page.
+	if next || len(out) > 0 && out[len(out)-1].GetName() != prevUser {
+		nextToken = nextUserToken(out[len(out)-1])
+	}
+
+	return out, nextToken, trace.Wrap(rangeStream.Done())
+}
+
+// nextUserToken returns the last token for the given user. This
+// allows the listing operation to provide a token which doesn't divulge
+// the next user in the list while still allowing listing to operate
+// without missing any users.
+func nextUserToken(user types.User) string {
+	return string(backend.RangeEnd(backend.ExactKey(user.GetName())))[utf8.RuneLen(backend.Separator):]
+}
+
+// ListUsers returns a page of users.
+func (s *IdentityService) ListUsers(ctx context.Context, pageSize int, pageToken string, withSecrets bool) ([]types.User, string, error) {
+	if withSecrets {
+		users, next, err := s.listUsersWithSecrets(ctx, pageSize, pageToken)
+		return users, next, trace.Wrap(err)
+	}
+
+	rangeStart := backend.Key(webPrefix, usersPrefix, pageToken)
+	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
+
+	// Adjust page size, so it can't be too large.
+	if pageSize <= 0 || pageSize > apidefaults.DefaultChunkSize {
+		pageSize = apidefaults.DefaultChunkSize
+	}
+
+	// Artificially inflate the limit to account for user secrets
+	// which have the same prefix.
+	limit := pageSize * 4
+
+	rangeStream := stream.FilterMap(
+		backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit),
+		func(item backend.Item) (backend.Item, bool) {
+			return item, bytes.HasSuffix(item.Key, []byte(paramsPrefix))
+		})
+
+	var err error
+	userStream := stream.MapWhile(rangeStream, func(item backend.Item) (types.User, bool) {
+		var user types.User
+		user, err = services.UnmarshalUser(item.Value, services.WithRevision(item.Revision))
+		return user, err == nil
+	})
+
+	users, more := stream.Take(userStream, pageSize)
+	var nextToken string
+	if more && userStream.Next() {
+		nextToken = nextUserToken(users[len(users)-1])
+	}
+
+	return users, nextToken, trace.NewAggregate(err, userStream.Done())
 }
 
 // GetUsers returns a list of users registered with the local auth server

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -19,10 +19,12 @@ package local_test
 import (
 	"context"
 	"crypto/x509"
+	"encoding/base32"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +36,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/types"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
@@ -41,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -1088,4 +1093,144 @@ func TestIdentityService_UpdateAndSwapUser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIdentityService_ListUsers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+	identity := newIdentityService(t, clock)
+
+	password, err := bcrypt.GenerateFromPassword([]byte("insecure"), bcrypt.MinCost)
+	require.NoError(t, err, "creating password failed")
+
+	dev1, err := services.NewTOTPDevice("otp1", base32.StdEncoding.EncodeToString([]byte("abc123")), time.Now())
+	require.NoError(t, err, "creating otp device failed")
+	dev2, err := services.NewTOTPDevice("otp2", base32.StdEncoding.EncodeToString([]byte("xyz789")), time.Now())
+	require.NoError(t, err, "creating otp device failed")
+
+	// Validate that no users returns an empty page.
+	users, next, err := identity.ListUsers(ctx, 0, "", false)
+	assert.NoError(t, err, "no error returned when no users exist")
+	assert.Empty(t, users, "users returned from listing when no users exist")
+	assert.Empty(t, next, "next page token returned from listing when no users exist")
+
+	users, next, err = identity.ListUsers(ctx, 0, "", true)
+	assert.NoError(t, err, "no error returned when no users exist")
+	assert.Empty(t, users, "users returned from listing when no users exist")
+	assert.Empty(t, next, "next page token returned from listing when no users exist")
+
+	// Validate that listing works when there is only a single user
+	user, err := types.NewUser("fish0")
+	require.NoError(t, err, "creating new user %s", user)
+
+	user, err = identity.CreateUser(ctx, user)
+	require.NoError(t, err, "creating user %s failed", user)
+	expectedUsers := []types.User{user}
+
+	users, next, err = identity.ListUsers(ctx, 0, "", false)
+	assert.NoError(t, err, "no error returned when no users exist")
+	assert.Empty(t, next, "next page token returned from listing when no more users exist")
+	assert.Empty(t, cmp.Diff(expectedUsers, users, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
+
+	users, next, err = identity.ListUsers(ctx, 0, "", true)
+	assert.NoError(t, err, "no error returned when no users exist")
+	assert.Empty(t, next, "next page token returned from listing when no users exist")
+	assert.Empty(t, cmp.Diff(expectedUsers, users), "not all users returned from listing operation")
+
+	// Create a number of users.
+	usernames := []string{"llama", "alpaca", "fox", "fish", "fish+", "fish2"}
+	for i, name := range usernames {
+		user, err := types.NewUser(name)
+		require.NoError(t, err, "creating new user %s", name)
+
+		// Set varying number of devices so the listing logic
+		// doesn't cleanly land on a user resource.
+		devices := []*types.MFADevice{dev1}
+		switch {
+		case i%2 == 0:
+			devices = append(devices, dev2)
+		case i == 3:
+			devices = nil
+		case i == 1:
+			devices = append(devices, dev2)
+			for j := 0; j < 20; j++ {
+				dev, err := services.NewTOTPDevice(uuid.NewString(), base32.StdEncoding.EncodeToString([]byte("abc123")), time.Now())
+				require.NoError(t, err, "creating otp device failed")
+				devices = append(devices, dev)
+			}
+		}
+
+		user.SetLocalAuth(&types.LocalAuthSecrets{
+			PasswordHash: password,
+			MFA:          devices,
+		})
+
+		created, err := identity.CreateUser(ctx, user)
+		require.NoError(t, err, "creating user %s failed", user)
+		expectedUsers = append(expectedUsers, created)
+	}
+	slices.SortFunc(expectedUsers, func(a, b types.User) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+
+	// List a few users at a time and validate that all users are eventually returned.
+	var retrieved []types.User
+	for next := ""; ; {
+		users, nextToken, err := identity.ListUsers(ctx, 2, next, false)
+		require.NoError(t, err, "no error returned when no users exist")
+
+		for _, user := range users {
+			assert.Empty(t, user.GetLocalAuth(), "expected no secrets to be returned with user %s", user.GetName())
+		}
+
+		retrieved = append(retrieved, users...)
+		next = nextToken
+		if next == "" {
+			break
+		}
+
+		if len(retrieved) > len(expectedUsers) {
+			t.Fatalf("listing users has accumulated %d users even though only %d users exist", len(retrieved), len(expectedUsers))
+		}
+	}
+
+	slices.SortFunc(retrieved, func(a, b types.User) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+	assert.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
+
+	// Validate that listing all users at once returns all expected users with secrets.
+	users, next, err = identity.ListUsers(ctx, 200, "", true)
+	require.NoError(t, err, "unexpected error listing users")
+	assert.Empty(t, next, "got a next page token when page size was greater than number of items")
+	slices.SortFunc(users, func(a, b types.User) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+
+	devicesSort := func(a *types.MFADevice, b *types.MFADevice) bool { return a.GetName() < b.GetName() }
+
+	require.Empty(t, cmp.Diff(expectedUsers, users, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")
+
+	// List a few users at a time and validate that all users are eventually returned with their secrets.
+	retrieved = []types.User{}
+	for next := ""; ; {
+		users, nextToken, err := identity.ListUsers(ctx, 2, next, true)
+		require.NoError(t, err, "no error returned when no users exist")
+
+		retrieved = append(retrieved, users...)
+		next = nextToken
+		if next == "" {
+			break
+		}
+
+		if len(retrieved) > len(expectedUsers) {
+			t.Fatalf("listing users has accumulated %d users even though only %d users exist", len(retrieved), len(expectedUsers))
+		}
+	}
+
+	slices.SortFunc(retrieved, func(a, b types.User) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+	require.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")
 }


### PR DESCRIPTION
Listing users is only implemented in the cache and backend implementation of the interface. All clients and servers return not implemented and will be updated in a future PR. Because the list operation is so unique for users due to user resources, and user secrets being stored at the same prefix I wanted it to be reviewed on its own.