### PR TITLE
Deflake TestChaosUpload

### DIFF
--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -649,8 +649,10 @@ func emitStream(ctx context.Context, t *testing.T, streamer events.Streamer, inE
 
 // readStream reads and decodes the audit stream from uploadID
 func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *eventstest.MemoryUploader) []apievents.AuditEvent {
+	t.Helper()
+
 	parts, err := uploader.GetParts(uploadID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var outEvents []apievents.AuditEvent
 	var reader *events.ProtoReader
@@ -659,10 +661,11 @@ func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *ev
 			reader = events.NewProtoReader(bytes.NewReader(part))
 		} else {
 			err := reader.Reset(bytes.NewReader(part))
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		out, err := reader.ReadAll(ctx)
-		require.Nil(t, err, "part crash %#v", part)
+		require.NoError(t, err, "part crash %#v", part)
+
 		outEvents = append(outEvents, out...)
 	}
 	return outEvents


### PR DESCRIPTION
This test attempted to verify that the uploader is able to operate correctly even when faults are injected into the system.

It ended up being flaky for a number of reasons, but the biggest issue is that it wasn't simulating a real world scenario.

1. It used a fake clock, but never advanced it, so the uploader's scan loop didn't correctly "tick" and only ran once.
2. It invoked many uploader scans in parallel while also running the uploader's own scan loop in the background. In any real deployment we only have one scan loop running, so this test is creating an environment that never exists in the wild.

Closes #33099