### PR TITLE
Update synchronization period in Okta docs.

### DIFF
--- a/docs/pages/application-access/okta/architecture.mdx
+++ b/docs/pages/application-access/okta/architecture.mdx
@@ -44,7 +44,7 @@ manage assignments.
 ### Synchronization
 
 The synchronization process runs periodically in the Okta Service, occurring every
-2 minutes. This service will import both Okta applications and user groups into
+10 minutes. This service will import both Okta applications and user groups into
 Teleport, cleaning up any resources that no longer exist in Okta.
 
 #### Okta Import Rules


### PR DESCRIPTION
The Okta synchronization time in the Okta docs has been updated to reflect its current state, which is 10 minutes instead of 2 minutes.