### PR TITLE
Clean up a few log entries

### DIFF
--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -279,7 +279,7 @@ func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {
 
 	// Log the discovery request being sent. Useful for debugging to know what
 	// proxies the tunnel server thinks exist.
-	c.log.Debugf("Sending discovery request with proxies %v to %v.", req, c.sconn.RemoteAddr())
+	c.log.Debugf("Sending discovery request with proxies %v to %v.", req.ProxyNames(), c.sconn.RemoteAddr())
 
 	if _, err := discoveryCh.SendRequest(chanDiscoveryReq, false, payload); err != nil {
 		c.markInvalid(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -162,11 +162,10 @@ func NewSessionContext(cfg SessionContextConfig) (*SessionContext, error) {
 
 // String returns the text representation of this context
 func (c *SessionContext) String() string {
-	return fmt.Sprintf("WebSession(user=%v,id=%v,expires=%v,bearer=%v,bearer_expires=%v)",
+	return fmt.Sprintf("WebSession(user=%v,id=%v,expires=%v,bearer_expires=%v)",
 		c.cfg.User,
-		c.cfg.Session.GetName(),
+		c.cfg.Session.GetShortName(),
 		c.cfg.Session.GetExpiryTime(),
-		c.cfg.Session.GetBearerToken(),
 		c.cfg.Session.GetBearerTokenExpiryTime(),
 	)
 }


### PR DESCRIPTION
- log proxy names, not the string-ified Go struct
- don't log the full web session ID or the bearer token