### PR TITLE
Manually fire OpInit in NodeJoinWait test

### DIFF
--- a/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
@@ -149,6 +149,8 @@ func TestNodeJoinWaitRun_WatchesForOpPutIfNodeWasNotFound(t *testing.T) {
 	accessAndIdentity := &mockAccessAndIdentity{
 		callCounts: make(map[string]int),
 		events:     events,
+		// Setting to true because we manually fire OpPut from test body.
+		requireManualOpInitFire: true,
 	}
 
 	nodeJoinWait, err := NewNodeJoinWait(&NodeJoinWaitConfig{AgentsDir: t.TempDir()})
@@ -175,6 +177,8 @@ func TestNodeJoinWaitRun_WatchesForOpPutIfNodeWasNotFound(t *testing.T) {
 
 	err = accessAndIdentity.events.WaitSomeWatchers(ctx)
 	require.NoError(t, err)
+	accessAndIdentity.events.Fire(types.Event{Type: types.OpInit})
+
 	// Fire an event with another node first to verify that NodeJoinWait does the comparison correctly.
 	accessAndIdentity.events.Fire(types.Event{
 		Type:     types.OpPut,
@@ -225,8 +229,20 @@ type mockAccessAndIdentity struct {
 	role       types.Role
 	callCounts map[string]int
 	events     *mockEvents
-	node       types.Server
-	nodeErr    error
+	// requireManualOpInitFire makes mockAccessAndIdentity.NewWatcher skip firing OpInit.
+	//
+	// In regular tests where this field is false, the code under tests calls
+	// mockAccessAndIdentity.NewWatcher (which fires OpInit), waits for OpInit, and then calls another
+	// method on mockAccessAndIdentity which fires an event.
+	//
+	// In tests where events such as OpPut are triggered directly from the test body and not as a
+	// result of the code under tests calling methods on mockAccessAndIdentity, setting it to true
+	// allows manually firing OpInit first before firing other events. This ensures that the first
+	// event that watchers observe is OpInit.
+	//
+	requireManualOpInitFire bool
+	node                    types.Server
+	nodeErr                 error
 }
 
 func (m *mockAccessAndIdentity) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
@@ -256,7 +272,9 @@ func (m *mockAccessAndIdentity) NewWatcher(ctx context.Context, watch types.Watc
 		return nil, trace.Wrap(err)
 	}
 
-	m.events.Fire(types.Event{Type: types.OpInit})
+	if !m.requireManualOpInitFire {
+		m.events.Fire(types.Event{Type: types.OpInit})
+	}
 
 	return watcher, nil
 }


### PR DESCRIPTION
## The problem

Flaky Test Reporter reported [a failing run of `TestNodeJoinWaitRun_WatchesForOpPutIfNodeWasNotFound`](https://github.com/gravitational/teleport.e/actions/runs/6559280043/job/17814579218#step:7:718):

```
        	Error Trace:	/__w/teleport.e/teleport.e/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go:189
        	Error:      	Received unexpected error:
        	            	unexpected event type "Put" received from node watcher
```

This can only happen in `initializeWatcher` function which waits for `OpInit`.

The direct cause of this is that this test fires some `OpPut` events. However, before firing those events, it doesn't ensure the watchers receive `OpInit` first, it merely waits for some watchers to be created:

https://github.com/gravitational/teleport/blob/163e04e16712a3cfa55a360ee75f87b385d5c28d/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go#L176-L182

https://github.com/gravitational/teleport/blob/163e04e16712a3cfa55a360ee75f87b385d5c28d/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go#L318-L335

I lifted the implementation of `WaitSomeWatchers` and other fake watcher structs from `integrations/lib/watcherjob/helpers_test.go`, so I went to see how that place takes care of this problem:

https://github.com/gravitational/teleport/blob/163e04e16712a3cfa55a360ee75f87b385d5c28d/integrations/lib/watcherjob/helpers_test.go#L126-L127

It waits for the watchers first and only then fires `OpInit`. connectmycomputer tests work slightly differently – `NewWatcher` creates the underlying watcher and then fires `OpInit`. This is fine for majority of the tests where everything happens inside a single goroutine.

https://github.com/gravitational/teleport/blob/163e04e16712a3cfa55a360ee75f87b385d5c28d/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go#L253-L262

However, in `TestNodeJoinWaitRun_WatchesForOpPutIfNodeWasNotFound` there's one goroutine which creates a watcher and waits for `OpInit` and another goroutine, represented by the test body, which waits for a watcher to be created and then fires `OpPut`.

So it's totally possible for `OpPut` to be fired first, after the first goroutine creates a watcher but before it fires `OpInit`. It's possible to recreate this by adding `time.Sleep(time.Second)` before firing `OpInit` in `NewWatcher`.

## The fix

This PR adds a new boolean field to `mockAccessAndIdentity` called `requireManualOpInitFire` that, when set to true, makes `NewWatcher` not call `OpInit`. Instead, it expects the goroutine which fires other events to fire `OpInit` first. This way we can be sure that `OpInit` is read first before any other events such as `OpPut`.