### PR TITLE
Configure Connect to intercept deep link clicks

### DIFF
--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -32,11 +32,15 @@ if (!isMac && env.CONNECT_TSH_BIN_PATH === undefined) {
 // Holds tsh.app Info.plist during build. Used in afterPack.
 let tshAppPlist;
 
+// appId must be a reverse DNS string since it's also used as CFBundleURLName on macOS, see
+// protocols.name below.
+const appId = 'gravitational.teleport.connect';
+
 /**
  * @type { import('electron-builder').Configuration }
  */
 module.exports = {
-  appId: 'gravitational.teleport.connect',
+  appId,
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   afterSign: 'notarize.js',
@@ -74,6 +78,26 @@ module.exports = {
     '!node_modules/node-pty/build/*/.forge-meta',
     '!node_modules/node-pty/build/Debug/.deps/**',
     '!node_modules/node-pty/bin',
+  ],
+  protocols: [
+    {
+      // name ultimately becomes CFBundleURLName which is the URL identifier. [1] Apple recommends
+      // to set it to a reverse DNS string. [2]
+      //
+      // [1] https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleurltypes/cfbundleurlname
+      // [2] https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app#Register-your-URL-scheme
+      name: appId,
+      schemes: ['teleport-connect'],
+      // Not much documentation is available on the role attribute. It ultimately gets mapped to
+      // CFBundleTypeRole in Info.plist.
+      //
+      // It seems that this field is largely related to how macOS thinks of "documents". Since Connect
+      // doesn't let you really edit anything and we won't be passing any docs, let's just set it to
+      // 'Viewer'.
+      //
+      // https://cocoadev.github.io/CFBundleTypeRole/
+      role: 'Viewer',
+    },
   ],
   mac: {
     target: 'dmg',

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -87,7 +87,7 @@ module.exports = {
       // [1] https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleurltypes/cfbundleurlname
       // [2] https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app#Register-your-URL-scheme
       name: appId,
-      schemes: ['teleport-connect'],
+      schemes: ['teleport'],
       // Not much documentation is available on the role attribute. It ultimately gets mapped to
       // CFBundleTypeRole in Info.plist.
       //

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -32,11 +32,11 @@ import {
 } from 'teleterm/services/config';
 import { createFileStorage } from 'teleterm/services/fileStorage';
 import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
-import { CONNECT_CUSTOM_PROTOCOL } from 'teleterm/ui/uri';
+import { TELEPORT_CUSTOM_PROTOCOL } from 'teleterm/ui/uri';
 
 // Set the app as a default protocol client only if it wasn't started through `electron .`.
 if (!process.defaultApp) {
-  app.setAsDefaultProtocolClient(CONNECT_CUSTOM_PROTOCOL);
+  app.setAsDefaultProtocolClient(TELEPORT_CUSTOM_PROTOCOL);
 }
 
 if (app.requestSingleInstanceLock()) {
@@ -319,5 +319,5 @@ function setUpDeepLinks(
 // We don't know the exact position of the URL is in argv. Chromium might inject its own arguments
 // into argv. See https://www.electronjs.org/docs/latest/api/app#event-second-instance.
 function findCustomProtocolUrlInArgv(argv: string[]) {
-  return argv.find(arg => arg.startsWith(`${CONNECT_CUSTOM_PROTOCOL}://`));
+  return argv.find(arg => arg.startsWith(`${TELEPORT_CUSTOM_PROTOCOL}://`));
 }

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -284,7 +284,8 @@ function setUpDeepLinks(
   if (settings.platform === 'darwin') {
     // Deep link click on macOS.
     app.on('open-url', (event, url) => {
-      // macOS does bring focus to the _application_ itself. However, if the app has one window and
+      // When macOS launches an app as a result of a deep link click, macOS does bring focus to the
+      // _application_ itself if the app is already running. However, if the app has one window and
       // the window is minimized, it'll remain so. So we have to focus the window ourselves.
       windowsManager.focusWindow();
 
@@ -301,6 +302,9 @@ function setUpDeepLinks(
 
   // Deep link click if the app is already opened (Windows or Linux).
   app.on('second-instance', (event, argv) => {
+    // There's already a second-instance listener that gives focus to the main window, so we don't
+    // do this in this listener.
+
     const url = findCustomProtocolUrlInArgv(argv);
     if (url) {
       logger.info(`Deep link launch from second-instance, URI: ${url}`);

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -74,7 +74,7 @@ export type DocumentUri = `/docs/${DocumentId}`;
 type GatewayId = string;
 export type GatewayUri = `/gateways/${GatewayId}`;
 
-export const CONNECT_CUSTOM_PROTOCOL = 'teleport-connect' as const;
+export const TELEPORT_CUSTOM_PROTOCOL = 'teleport' as const;
 
 export const routing = {
   parseClusterUri(uri: string) {

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -74,6 +74,8 @@ export type DocumentUri = `/docs/${DocumentId}`;
 type GatewayId = string;
 export type GatewayUri = `/gateways/${GatewayId}`;
 
+export const CONNECT_CUSTOM_PROTOCOL = 'teleport-connect' as const;
+
 export const routing = {
   parseClusterUri(uri: string) {
     const leafMatch = routing.parseUri(uri, paths.leafCluster);


### PR DESCRIPTION
* Part of #32188.

This PR configures Teleport Connect so that it's able to intercept clicks on links with the custom `teleport-connect` protocol. This will be used to link from a Discover tile in the Web UI to Connect My Computer (#32185).

This is just the wiring done according to [the official tutorial](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app). In subsequent PRs I'm going to parse those URLs and then pass them to the frontend app.

FWIW, the official tutorial is lacking in some regards, for example I had to figure how to handle cold start on Windows by browsing issues in the Electron repo. I already made [an issue with my feedback about the tutorial](https://github.com/electron/electron/issues/40173).

Here's [a fiddle with deep links](https://jsfiddle.net/ravicious/1tvz0kxm/5/) you can use for testing. Remember that this will only work if you installed a packaged app.