### PR TITLE
Fix table alignment in `tctl tokens ls` examples

### DIFF
--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -64,7 +64,7 @@ but filter and limit access to the servers based on their AWS region.
    $ tctl tokens ls
    # Token                            Type        Labels Expiry Time (UTC)               
    # -------------------------------- ----------- ------ ------------------------------- 
-   # (=presets.tokens.first=)         Node,Db,App        10 Aug 23 19:49 UTC (4m11s) 
+   # (=presets.tokens.first=) Node,Db,App        10 Aug 23 19:49 UTC (4m11s) 
    ```
 
 1. Copy the token and assign it to an environment variable on the computer you are enrolling 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -328,7 +328,7 @@ your Teleport username:
    $ tctl tokens ls
    Token                                                    Type            Labels   Expiry Time (UTC)
    -------------------------------------------------------- --------------- -------- ---------------------------
-   (=presets.tokens.first=)                                 trusted_cluster          28 Apr 22 19:19 UTC (4m48s)
+   (=presets.tokens.first=)                         trusted_cluster          28 Apr 22 19:19 UTC (4m48s)
    ```
 
 1. Create a resource configuration file called `trusted_cluster.yaml` with the


### PR DESCRIPTION
Fixes #32640

On two docs pages, `tctl tokens ls` examples use a built-time variable to specify a preset token value. The pages space the values of the example tables to anticipate the variable, not the variable's replacement value, meaning that the tables appear incorrect on the rendered docs site. This change fixes the spacing within the tables.