### PR TITLE
[docs] add missing database matchers for discovery config reference

### DIFF
--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -70,6 +70,8 @@ var SupportedAWSMatchers = append([]string{
 
 // SupportedAWSDatabaseMatchers is a list of the AWS databases currently
 // supported by the Teleport discovery service.
+// IMPORTANT: when adding new Database matchers, make sure reference configs
+// for both Discovery and Database Service are updated in docs.
 var SupportedAWSDatabaseMatchers = []string{
 	AWSMatcherRDS,
 	AWSMatcherRDSProxy,

--- a/api/types/matchers_azure.go
+++ b/api/types/matchers_azure.go
@@ -44,6 +44,8 @@ const (
 
 // SupportedAzureMatchers is list of Azure services currently supported by the
 // Teleport discovery service.
+// IMPORTANT: when adding new Database matchers, make sure reference configs
+// for both Discovery and Database Service are updated in docs.
 var SupportedAzureMatchers = []string{
 	AzureMatcherVM,
 	AzureMatcherKubernetes,

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -7,39 +7,56 @@ discovery_service:
     # managing discovered resources.
     discovery_group: "disc-group"
     aws:
-       # AWS resource types. Valid options are:
-       # ec2 - discovers and registers AWS EC2 instances
-       # eks - discovers and registers AWS EKS clusters
-     - types: ["ec2"]
-       # AWS regions to search for resources from
-       regions: ["us-east-1","us-west-1"]
-       # AWS resource tags to match when registering resources
-       # Optional section: Defaults to "*":"*"
-       tags:
-         "*": "*"
-       # Optional section: install is used to provide parameters to the AWS SSM document.
-       # If the install section isn't provided, the below defaults are used.
-       # Only applicable for EC2 discovery.
-       install:
-         join_params:
-           # token_name is the name of the Teleport invite token to use.
-           # Optional, defaults to: "aws-discovery-iam-token".
-           token_name:  "aws-discovery-iam-token"
-         # script_name is the name of the Teleport install script to use.
-         # Optional, defaults to: "default-installer".
-         script_name: "default-installer"
-       # Optional section: ssm is used to configure which AWS SSM document to use
-       # If the ssm section isnt provided the below defaults are used.
-       ssm:
-         # document_name is the name of the SSM document that should be
-         # executed when installing teleport on matching nodes
-         # Optional, defaults to: "TeleportDiscoveryInstaller".
-         document_name: "TeleportDiscoveryInstaller"
+      # AWS resource types. Valid options are:
+      # 'ec2' - discovers and registers AWS EC2 instances.
+      # 'eks' - discovers and registers AWS EKS clusters.
+      # 'rds' - discovers and registers AWS RDS and Aurora databases.
+      # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
+      # 'redshift' - discovers and registers AWS Redshift databases.
+      # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
+      # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
+      # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
+      # 'opensearch' - discovers and registers AWS OpenSearch Redis databases.
+    - types: ["ec2"]
+      # AWS regions to search for resources from
+      regions: ["us-east-1","us-west-1"]
+      # AWS resource tags to match when registering resources
+      # Optional section: Defaults to "*":"*"
+      tags:
+        "*": "*"
+      # Optional AWS role that the Discovery Service will assume to discover
+      # and register AWS-hosted databases and EKS clusters.
+      assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
+      # Optional AWS external ID that the Discovery Service will use to assume
+      # a role in an external AWS account.
+      external_id: "example-external-id"
+      # Optional section: install is used to provide parameters to the AWS SSM document.
+      # If the install section isn't provided, the below defaults are used.
+      # Only applicable for EC2 discovery.
+      install:
+        join_params:
+          # token_name is the name of the Teleport invite token to use.
+          # Optional, defaults to: "aws-discovery-iam-token".
+          token_name:  "aws-discovery-iam-token"
+        # script_name is the name of the Teleport install script to use.
+        # Optional, defaults to: "default-installer".
+        script_name: "default-installer"
+      # Optional section: ssm is used to configure which AWS SSM document to use
+      # If the ssm section isnt provided the below defaults are used.
+      ssm:
+        # document_name is the name of the SSM document that should be
+        # executed when installing teleport on matching nodes
+        # Optional, defaults to: "TeleportDiscoveryInstaller".
+        document_name: "TeleportDiscoveryInstaller"
     # Matchers for discovering Azure-hosted resources.
     azure:
       # Azure resource types. Valid options are:
       # 'aks' - discovers and registers Azure AKS Kubernetes Clusters.
       # 'vm' - discovers and registers Azure virtual machines.
+      # 'mysql' - discovers and registers Azure MySQL databases.
+      # 'postgres' - discovers and registers Azure PostgreSQL databases.
+      # 'redis' - discovers and registers Azure Cache for Redis databases.
+      # 'sqlserver' - discovers and registers Azure SQL Server databases.
     - types: ["aks"]
       # Azure regions to search for resources from. Valid options are:
       # '*' - discovers resources in all regions (default).


### PR DESCRIPTION
will adjust accordingly when backporting