### PR TITLE
docs: improve formatting of bool options

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -47,12 +47,13 @@ teleport:
         # DynamoDB-specific section:
 
         # continuous_backups is used to enable continuous backups.
-        continuous_backups: [true|false]
+        # default: false
+        continuous_backups: true
 
         # auto_scaling is used to enable (and define settings for) auto
         # scaling.
         # default: false
-        auto_scaling:  [true|false]
+        auto_scaling: true
 
         # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
         # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
@@ -323,7 +324,7 @@ auth_service:
     # certificates expire in the middle of an active session. (default is 'no')
     disconnect_expired_cert: no
 
-    # keep_alive_interval determines the interval at which Teleport will 
+    # keep_alive_interval determines the interval at which Teleport will
     # send keep-alive messages for client and reverse tunnel connections.
     # The default is set to 5 minutes (300 seconds) to stay lower than the
     # common load balancer timeout of 350 seconds.

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -885,11 +885,11 @@ teleport:
 
     # continuous_backups is used to optionally enable continuous backups.
     # default: false
-    continuous_backups: [true|false]
+    continuous_backups: true
 
     # auto_scaling is used to optionally enable (and define settings for) auto scaling.
     # default: false
-    auto_scaling:  [true|false]
+    auto_scaling: true
     # Enables either Pay-Per-Request or Provisioned billing for the DynamoDB table. Set when Teleport creates the table.
     # If billing_mode is set to "pay_per_request", read/write capacity and auto_scaling settings will be ignored.
     # Possible values: "pay_per_request" and "provisioned"


### PR DESCRIPTION
We should not use `[true|false]` syntax when describing fields in a YAML file, as the square brackets may be interpreted as a YAML list instead of a scalar boolean value.