### PR TITLE
Downgrade create-github-app-token to a pre-nodejs 20 version

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate GitHub Token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.0.5 # Cannot upgrade past v1.1 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
           app_id: ${{ secrets.REVIEWERS_APP_ID }}
           private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}


### PR DESCRIPTION
Because the bloat check runs in a centos7 container, we need github action versions that run an older nodejs release, and is thus are compatible with a older GLIBC.

### Testing

I added a [trigger for my branch](https://github.com/gravitational/teleport/commit/45c369cea7b4ab65639bd8f384e64a9a6bdc6f7b), and got the following run:

https://github.com/gravitational/teleport/actions/runs/6566810826