### PR TITLE
Enable optimistic locking support for roles

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -764,8 +764,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/user/status", h.WithAuth(h.getUserStatus))
 
 	h.GET("/webapi/roles", h.WithAuth(h.getRolesHandle))
-	h.POST("/webapi/roles", h.WithAuth(h.upsertRoleHandle))
-	h.PUT("/webapi/roles/:name", h.WithAuth(h.upsertRoleHandle))
+	h.POST("/webapi/roles", h.WithAuth(h.createRoleHandle))
+	h.PUT("/webapi/roles/:name", h.WithAuth(h.updateRoleHandle))
 	h.DELETE("/webapi/roles/:name", h.WithAuth(h.deleteRole))
 	h.GET("/webapi/presetroles", h.WithUnauthenticatedHighLimiter(h.getPresetRoles))
 

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -18,19 +18,26 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
@@ -309,69 +316,100 @@ func TestGetRoles(t *testing.T) {
 	require.Contains(t, roles[0].Content, "name: test")
 }
 
-func TestUpsertRole(t *testing.T) {
-	m := &mockedResourceAPIGetter{}
+func TestRoleCRUD(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
 
-	existingRoles := make(map[string]types.Role)
-	m.mockUpsertRole = func(ctx context.Context, role types.Role) (types.Role, error) {
-		existingRoles[role.GetName()] = role
-		return role, nil
-	}
-	m.mockGetRole = func(ctx context.Context, name string) (types.Role, error) {
-		role, ok := existingRoles[name]
-		if ok {
-			return role, nil
+	proxy := env.proxies[0]
+
+	// Authenticate to get a session token and cookies.
+	pack := proxy.authPack(t, "test-user@example.com", nil)
+
+	expected, err := types.NewRole("test-role", types.RoleSpecV6{})
+	require.NoError(t, err, "creating initial role resource")
+
+	createPayload := func(r types.Role) ui.ResourceItem {
+		raw, err := services.MarshalRole(r, services.PreserveResourceID())
+		require.NoError(t, err, "marshaling role")
+
+		return ui.ResourceItem{
+			Kind:    types.KindRole,
+			Name:    r.GetName(),
+			Content: string(raw),
 		}
-		return nil, trace.NotFound("")
 	}
 
-	// Test bad request kind.
-	invalidKind := `kind: invalid-kind
-metadata:
-  name: test`
-	role, err := upsertRole(context.Background(), m, invalidKind, "", httprouter.Params{})
-	require.Nil(t, role)
-	require.Error(t, err)
-	require.True(t, trace.IsBadParameter(err))
-	require.Contains(t, err.Error(), "kind")
+	unmarshalResponse := func(resp []byte) types.Role {
+		var item ui.ResourceItem
+		require.NoError(t, json.Unmarshal(resp, &item), "response from server contained an invalid resource item")
 
-	goodContent := `kind: role
-metadata:
-  name: test-goodcontent
-spec:
-  allow:
-    logins:
-    - testing
-version: v3`
+		var r types.RoleV6
+		require.NoError(t, yaml.Unmarshal([]byte(item.Content), &r), "resource item content was not a role")
+		return &r
+	}
 
-	// Updating non-existing role fails.
-	role, err = upsertRole(context.Background(), m, goodContent, "PUT", httprouter.Params{httprouter.Param{Key: "name", Value: "test-goodcontent"}})
-	require.Nil(t, role)
-	require.Error(t, err)
-	require.True(t, trace.IsNotFound(err))
+	// Create the initial role.
+	resp, err := pack.clt.PostJSON(ctx, pack.clt.Endpoint("webapi", "roles"), createPayload(expected))
+	require.NoError(t, err, "expected creating the initial role to succeed")
+	require.Equal(t, http.StatusOK, resp.Code(), "unexpected status code creating role")
 
-	// Creating non-existing role succeeds.
-	role, err = upsertRole(context.Background(), m, goodContent, "POST", httprouter.Params{})
-	require.NoError(t, err)
-	require.Contains(t, role.Content, "name: test-goodcontent")
+	created := unmarshalResponse(resp.Bytes())
 
-	// Creating existing role fails.
-	role, err = upsertRole(context.Background(), m, goodContent, "POST", httprouter.Params{})
-	require.Nil(t, role)
-	require.Error(t, err)
-	require.True(t, trace.IsAlreadyExists(err))
+	// Validate that creating the role again fails.
+	resp, err = pack.clt.PostJSON(ctx, pack.clt.Endpoint("webapi", "roles"), createPayload(expected))
+	assert.Error(t, err, "expected an error creating a duplicate role")
+	assert.True(t, trace.IsAlreadyExists(err), "expected an already exists error got %T", err)
+	assert.Equal(t, http.StatusConflict, resp.Code(), "unexpected status code creating duplicate role")
 
-	// Updating existing role succeeds.
-	role, err = upsertRole(context.Background(), m, goodContent, "PUT", httprouter.Params{httprouter.Param{Key: "name", Value: "test-goodcontent"}})
-	require.NoError(t, err)
-	require.Contains(t, role.Content, "name: test-goodcontent")
+	// Update the role.
+	created.SetLogins(types.Allow, []string{"test"})
+	resp, err = pack.clt.PutJSON(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), createPayload(created))
+	require.NoError(t, err, "unexpected error updating the role")
+	require.Equal(t, http.StatusOK, resp.Code(), "unexpected status code updating the role")
 
-	// Renaming existing role fails.
-	goodContentRenamed := strings.ReplaceAll(goodContent, "test-goodcontent", "test-goodcontent-new-name")
-	role, err = upsertRole(context.Background(), m, goodContentRenamed, "PUT", httprouter.Params{httprouter.Param{Key: "name", Value: "test-goodcontent"}})
-	require.Nil(t, role)
-	require.Error(t, err)
-	require.True(t, trace.IsBadParameter(err))
+	updated := unmarshalResponse(resp.Bytes())
+
+	require.Empty(t, cmp.Diff(created, updated,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision", "Namespace"),
+		cmpopts.IgnoreFields(types.RoleConditions{}, "Namespaces"),
+	))
+	require.NotEqual(t, expected.GetLogins(types.Allow), updated.GetLogins(types.Allow), "expected update to modify the logins")
+	require.Equal(t, []string{"test"}, updated.GetLogins(types.Allow), "logins should have been updated to test. got %s", updated.GetLogins(types.Allow))
+
+	// Validate that a stale revision prevents updates.
+	resp, err = pack.clt.PutJSON(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), createPayload(expected))
+	assert.Error(t, err, "expected an error updating a role with a stale revision")
+	assert.True(t, trace.IsCompareFailed(err), "expected a compare failed error got %T", err)
+	assert.Equal(t, http.StatusPreconditionFailed, resp.Code(), "unexpected status code updating the role")
+
+	// Validate that renaming the role prevents updates.
+	updated.SetName(uuid.NewString())
+	resp, err = pack.clt.PutJSON(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), createPayload(updated))
+	assert.Error(t, err, "expected and error when renaming a role")
+	assert.True(t, trace.IsBadParameter(err), "expected a bad parameter error got %T", err)
+	assert.Equal(t, http.StatusBadRequest, resp.Code(), "unexpected status code updating the role")
+
+	// Validate that updating a nonexistent role fails.
+	updated.SetName(uuid.NewString())
+	resp, err = pack.clt.PutJSON(ctx, pack.clt.Endpoint("webapi", "roles", updated.GetName()), createPayload(updated))
+	assert.Error(t, err, "expected updating a nonexistent role to fail")
+	assert.True(t, trace.IsCompareFailed(err), "expected a compare failed error got %T", err)
+	assert.Equal(t, http.StatusPreconditionFailed, resp.Code(), "unexpected status code updating the role")
+
+	// Validate that the role can be deleted
+	_, err = pack.clt.Delete(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()))
+	require.NoError(t, err, "unexpected error deleting role")
+
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "roles"), nil)
+	assert.NoError(t, err, "unexpected error listing role")
+
+	var items []ui.ResourceItem
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &items), "invalid resource item received")
+	assert.Equal(t, http.StatusOK, resp.Code(), "unexpected status code getting roles")
+
+	for _, item := range items {
+		assert.NotEqual(t, "test-role", item.Name, "expected test-role to be deleted")
+	}
 }
 
 func TestGetGithubConnectors(t *testing.T) {


### PR DESCRIPTION
Updates tctl edit and the web ui to use the new UpdateRole RPC which uses optimistic locking to enforce that concurrent modifications to a role are not possible.

A few small improvements  were also done on the github connector tests which the role tests were based on.

Contributes to #30416.