### PR TITLE
MFA for admin actions: Add server side check

### DIFF
--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -59,7 +59,7 @@ func CredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse
 func getMFACredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
 	values := metadata.ValueFromIncomingContext(ctx, mfaResponseToken)
 	if len(values) == 0 {
-		return nil, trace.BadParameter("request metadata missing MFA credentials")
+		return nil, trace.NotFound("request metadata missing MFA credentials")
 	}
 	mfaChallengeResponseEnc := values[0]
 

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -30,7 +30,8 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 )
 
-const MFAResponseToken = "mfa_challenge_response"
+// ResponseMetadataKey is the context metadata key for an MFA response in a gRPC request.
+const ResponseMetadataKey = "mfa_challenge_response"
 
 // ErrAdminActionMFARequired is an error indicating that an admin-level
 // API request failed due to missing MFA verification.
@@ -57,7 +58,7 @@ func CredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse
 }
 
 func getMFACredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
-	values := metadata.ValueFromIncomingContext(ctx, MFAResponseToken)
+	values := metadata.ValueFromIncomingContext(ctx, ResponseMetadataKey)
 	if len(values) == 0 {
 		return nil, trace.NotFound("request metadata missing MFA credentials")
 	}
@@ -94,7 +95,7 @@ func (mc *perRPCCredentials) GetRequestMetadata(ctx context.Context, _ ...string
 	}
 
 	return map[string]string{
-		MFAResponseToken: enc,
+		ResponseMetadataKey: enc,
 	}, nil
 }
 

--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -262,7 +262,7 @@ func (a *Server) VerifyAccountRecovery(ctx context.Context, req *proto.VerifyAcc
 		}
 
 		if err := a.verifyAuthnWithRecoveryLock(ctx, startToken, func() error {
-			_, _, err := a.validateMFAAuthResponse(
+			_, _, err := a.ValidateMFAAuthResponse(
 				ctx, req.GetMFAAuthenticateResponse(), startToken.GetUser(), false /* passwordless */)
 			return err
 		}); err != nil {

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -87,6 +87,10 @@ type accessPoint interface {
 
 	// ConnectionDiagnosticTraceAppender adds a method to append traces into ConnectionDiagnostics.
 	services.ConnectionDiagnosticTraceAppender
+
+	// ValidateMFAAuthResponse validates an MFA or passwordless challenge.
+	// Returns the device used to solve the challenge (if applicable) and the username.
+	ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error)
 }
 
 // ReadNodeAccessPoint is a read only API interface implemented by a certificate authority (CA) to be

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3124,7 +3124,7 @@ func (a *Server) DeleteMFADeviceSync(ctx context.Context, req *proto.DeleteMFADe
 			return trace.Wrap(err)
 		}
 
-		if _, _, err := a.validateMFAAuthResponse(
+		if _, _, err := a.ValidateMFAAuthResponse(
 			ctx, req.ExistingMFAResponse, user, false, /* passwordless */
 		); err != nil {
 			return trace.Wrap(err)
@@ -5699,7 +5699,7 @@ func (a *Server) validateMFAAuthResponseForRegister(
 	}
 
 	if err := a.WithUserLock(ctx, username, func() error {
-		_, _, err := a.validateMFAAuthResponse(
+		_, _, err := a.ValidateMFAAuthResponse(
 			ctx, resp, username, false /* passwordless */)
 		return err
 	}); err != nil {
@@ -5709,13 +5709,10 @@ func (a *Server) validateMFAAuthResponseForRegister(
 	return true, nil
 }
 
-// validateMFAAuthResponse validates an MFA or passwordless challenge.
+// ValidateMFAAuthResponse validates an MFA or passwordless challenge.
 // Returns the device used to solve the challenge (if applicable) and the
 // username.
-func (a *Server) validateMFAAuthResponse(
-	ctx context.Context,
-	resp *proto.MFAAuthenticateResponse, user string, passwordless bool,
-) (*types.MFADevice, string, error) {
+func (a *Server) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
 	// Sanity check user/passwordless.
 	if user == "" && !passwordless {
 		return nil, "", trace.BadParameter("user required")

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -188,7 +188,7 @@ func TestCreateAuthenticateChallenge_WithAuth(t *testing.T) {
 	// TODO(codingllama): Use a public endpoint to verify?
 	mfaResp, err := u.webDev.SolveAuthn(res)
 	require.NoError(t, err)
-	_, _, err = srv.Auth().validateMFAAuthResponse(ctx, mfaResp, u.username, false /* passwordless */)
+	_, _, err = srv.Auth().ValidateMFAAuthResponse(ctx, mfaResp, u.username, false /* passwordless */)
 	require.NoError(t, err)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -60,6 +60,7 @@ import (
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -279,6 +280,78 @@ func HasRemoteBuiltinRole(authContext authz.Context, name string) bool {
 // name matches.
 func (a *ServerWithRoles) hasRemoteBuiltinRole(name string) bool {
 	return HasRemoteBuiltinRole(a.context, name)
+}
+
+func (a *ServerWithRoles) authorizeAdminAction(ctx context.Context) error {
+	// Builtin roles do not require MFA to perform admin actions.
+	switch a.context.Identity.(type) {
+	case authz.BuiltinRole, authz.RemoteBuiltinRole:
+		return nil
+	}
+
+	authpref, err := a.authServer.GetAuthPreference(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Admin actions do not require MFA when MFA is not enabled.
+	if authpref.GetSecondFactor() == constants.SecondFactorOff {
+		return nil
+	}
+
+	// Skip MFA check if the user is a Bot.
+	if user, err := a.authServer.GetUser(ctx, a.context.Identity.GetIdentity().Username, false); err == nil && user.IsBot() {
+		log.Debugf("Skipping admin action MFA check for bot identity: %v", a.context.Identity.GetIdentity())
+		return nil
+	}
+
+	// Skip mfa if the identity is being impersonated by the Bot or Admin built in role.
+	if impersonator := a.context.Identity.GetIdentity().Impersonator; impersonator != "" {
+		impersonatorUser, err := a.authServer.GetUser(ctx, impersonator, false)
+		if err == nil && impersonatorUser.IsBot() {
+			log.Debugf("Skipping admin action MFA check for bot-impersonated identity: %v", a.context.Identity.GetIdentity())
+			return nil
+		}
+
+		// If we don't find a user matching the impersonator, it may be the admin role impersonating.
+		// Check that the impersonator matches the Auth Host Service FQDN.
+		if trace.IsNotFound(err) {
+			clusterName, err := a.authServer.GetDomainName()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if impersonator == HostFQDN(a.authServer.ServerID, clusterName) {
+				log.Debugf("Skipping admin action MFA check for admin-impersonated identity: %v", a.context.Identity.GetIdentity())
+				return nil
+			}
+		}
+	}
+
+	// MFA is required.
+	return trace.Wrap(a.verifySingleRequestMFA(ctx))
+}
+
+// verifySingleRequestMFA that MFA is verified specifically for this request, such as with
+// an MFA verified private key policy or MFA verification in the request context. Other
+// MFA verification methods, like short-lived MFA verified certificates, do not count as
+// single request MFA.
+func (a *ServerWithRoles) verifySingleRequestMFA(ctx context.Context) error {
+	// Certain hardware-key based private key policies require MFA for each request.
+	if a.context.Identity.GetIdentity().PrivateKeyPolicy.MFAVerified() {
+		return nil
+	}
+
+	mfaResp, err := mfa.CredentialsFromContext(ctx)
+	if trace.IsNotFound(err) {
+		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
+	}
+
+	if _, _, err := a.authServer.validateMFAAuthResponse(ctx, mfaResp, a.context.User.GetName(), false); err != nil {
+		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
+	}
+
+	return nil
 }
 
 // DevicesClient allows ServerWithRoles to implement ClientI.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -60,7 +60,6 @@ import (
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
-	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -280,78 +279,6 @@ func HasRemoteBuiltinRole(authContext authz.Context, name string) bool {
 // name matches.
 func (a *ServerWithRoles) hasRemoteBuiltinRole(name string) bool {
 	return HasRemoteBuiltinRole(a.context, name)
-}
-
-func (a *ServerWithRoles) authorizeAdminAction(ctx context.Context) error {
-	// Builtin roles do not require MFA to perform admin actions.
-	switch a.context.Identity.(type) {
-	case authz.BuiltinRole, authz.RemoteBuiltinRole:
-		return nil
-	}
-
-	authpref, err := a.authServer.GetAuthPreference(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	// Admin actions do not require MFA when MFA is not enabled.
-	if authpref.GetSecondFactor() == constants.SecondFactorOff {
-		return nil
-	}
-
-	// Skip MFA check if the user is a Bot.
-	if user, err := a.authServer.GetUser(ctx, a.context.Identity.GetIdentity().Username, false); err == nil && user.IsBot() {
-		log.Debugf("Skipping admin action MFA check for bot identity: %v", a.context.Identity.GetIdentity())
-		return nil
-	}
-
-	// Skip mfa if the identity is being impersonated by the Bot or Admin built in role.
-	if impersonator := a.context.Identity.GetIdentity().Impersonator; impersonator != "" {
-		impersonatorUser, err := a.authServer.GetUser(ctx, impersonator, false)
-		if err == nil && impersonatorUser.IsBot() {
-			log.Debugf("Skipping admin action MFA check for bot-impersonated identity: %v", a.context.Identity.GetIdentity())
-			return nil
-		}
-
-		// If we don't find a user matching the impersonator, it may be the admin role impersonating.
-		// Check that the impersonator matches the Auth Host Service FQDN.
-		if trace.IsNotFound(err) {
-			clusterName, err := a.authServer.GetDomainName()
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			if impersonator == HostFQDN(a.authServer.ServerID, clusterName) {
-				log.Debugf("Skipping admin action MFA check for admin-impersonated identity: %v", a.context.Identity.GetIdentity())
-				return nil
-			}
-		}
-	}
-
-	// MFA is required.
-	return trace.Wrap(a.verifySingleRequestMFA(ctx))
-}
-
-// verifySingleRequestMFA that MFA is verified specifically for this request, such as with
-// an MFA verified private key policy or MFA verification in the request context. Other
-// MFA verification methods, like short-lived MFA verified certificates, do not count as
-// single request MFA.
-func (a *ServerWithRoles) verifySingleRequestMFA(ctx context.Context) error {
-	// Certain hardware-key based private key policies require MFA for each request.
-	if a.context.Identity.GetIdentity().PrivateKeyPolicy.MFAVerified() {
-		return nil
-	}
-
-	mfaResp, err := mfa.CredentialsFromContext(ctx)
-	if trace.IsNotFound(err) {
-		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
-	}
-
-	if _, _, err := a.authServer.validateMFAAuthResponse(ctx, mfaResp, a.context.User.GetName(), false); err != nil {
-		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
-	}
-
-	return nil
 }
 
 // DevicesClient allows ServerWithRoles to implement ClientI.
@@ -3144,7 +3071,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 	var verifiedMFADeviceID string
 	if req.MFAResponse != nil {
-		dev, _, err := a.authServer.validateMFAAuthResponse(
+		dev, _, err := a.authServer.ValidateMFAAuthResponse(
 			ctx, req.GetMFAResponse(), req.Username, false /* passwordless */)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -7077,7 +7004,7 @@ func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context,
 			return err
 		}
 
-		mfaDevice, _, err := a.authServer.validateMFAAuthResponse(ctx, mfaResp, headlessAuthn.User, false /* passwordless */)
+		mfaDevice, _, err := a.authServer.ValidateMFAAuthResponse(ctx, mfaResp, headlessAuthn.User, false /* passwordless */)
 		if err != nil {
 			emitHeadlessLoginEvent(ctx, events.UserHeadlessLoginApprovedFailureCode, a.authServer.emitter, headlessAuthn, err)
 			return trace.Wrap(err)
@@ -7249,6 +7176,11 @@ func (a *ServerWithRoles) DeleteClusterMaintenanceConfig(ctx context.Context) er
 	}
 
 	return a.authServer.DeleteClusterMaintenanceConfig(ctx)
+}
+
+// ValidateMFAAuthResponse not implemented: can only be called locally.
+func (a *ServerWithRoles) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
+	return nil, "", trace.NotImplemented(notImplementedMessage)
 }
 
 // NewAdminAuthServer returns auth server authorized as admin,

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api"
@@ -47,14 +46,12 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
-	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -7022,168 +7019,5 @@ func inlineEventually(t *testing.T, cond func() bool, waitFor time.Duration, tic
 				return
 			}
 		}
-	}
-}
-
-// TestAuthorizeAdminAction tests authorizeAdminAction.
-func TestAuthorizeAdminAction(t *testing.T) {
-	ctx := context.Background()
-	srv := newTestTLSServer(t)
-	srv.AuthServer.AuthServer.ServerID = uuid.NewString()
-
-	localUser := configureForMFA(t, srv)
-	adminRole := authz.BuiltinRole{
-		Role:     types.RoleAdmin,
-		Username: HostFQDN(srv.AuthServer.AuthServer.ServerID, srv.ClusterName()),
-	}
-	bot, err := srv.Auth().createBot(ctx, &proto.CreateBotRequest{
-		Name:  "robot",
-		Roles: []string{services.RoleNameForUser(localUser.User)},
-	})
-	require.NoError(t, err)
-
-	for _, tc := range []struct {
-		name           string
-		getAuthContext func(t *testing.T) authz.Context
-		getMFAResponse func(t *testing.T, swr *ServerWithRoles) *proto.MFAAuthenticateResponse
-		assertErr      require.ErrorAssertionFunc
-	}{
-		{
-			name: "NOK local user no mfa",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username: localUser.User,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
-			},
-		}, {
-			name: "NOK local user with mfa verified cert",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username:    localUser.User,
-					MFAVerified: localUser.WebDev.MFA.Id,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
-			},
-		}, {
-			name: "OK local user with context mfa",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username: localUser.User,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			getMFAResponse: func(t *testing.T, swr *ServerWithRoles) *proto.MFAAuthenticateResponse {
-				mfaChal, err := swr.authServer.mfaAuthChallenge(ctx, localUser.User, false)
-				require.NoError(t, err)
-				mfaResp, err := localUser.WebDev.SolveAuthn(mfaChal)
-				require.NoError(t, err)
-				return mfaResp
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "OK local user with mfa verified private key policy",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username:         localUser.User,
-					PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "OK admin",
-			getAuthContext: func(t *testing.T) authz.Context {
-				authContext, err := authz.ContextForBuiltinRole(adminRole, types.DefaultSessionRecordingConfig())
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "OK bot",
-			getAuthContext: func(t *testing.T) authz.Context {
-				botUser := authz.LocalUser{Username: bot.UserName, Identity: tlsca.Identity{Username: bot.UserName}}
-				authContext, err := authz.ContextForLocalUser(ctx, botUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "OK admin impersonating local user",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username:     localUser.User,
-					Impersonator: adminRole.Username,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "OK bot impersonating local user",
-			getAuthContext: func(t *testing.T) authz.Context {
-				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
-					Username:     localUser.User,
-					Impersonator: bot.UserName,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: require.NoError,
-		}, {
-			name: "NOK local user with admin role name",
-			getAuthContext: func(t *testing.T) authz.Context {
-				// Create a user with the same name as the admin role.
-				user, _, err := CreateUserAndRole(srv.Auth(), adminRole.Username, []string{"role"}, nil)
-				require.NoError(t, err)
-
-				localUser := authz.LocalUser{Username: user.GetName(), Identity: tlsca.Identity{
-					Username: adminRole.Username,
-				}}
-				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
-				require.NoError(t, err)
-				return *authContext
-			},
-			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := ctx
-			swr := &ServerWithRoles{
-				authServer: srv.Auth(),
-				alog:       srv.AuthServer.AuditLog,
-				context:    tc.getAuthContext(t),
-			}
-
-			if tc.getMFAResponse != nil {
-				// Attach mfa response to the context the way a grpc call would.
-				mfaResp := tc.getMFAResponse(t, swr)
-				encodedMFAResp, err := mfa.EncodeMFAChallengeResponseCredentials(mfaResp)
-				require.NoError(t, err)
-				md := metadata.MD{}
-				md.Append(mfa.MFAResponseToken, encodedMFAResp)
-				ctx = metadata.NewIncomingContext(ctx, md)
-			}
-
-			tc.assertErr(t, swr.authorizeAdminAction(ctx))
-		})
 	}
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api"
@@ -46,12 +47,14 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -7019,5 +7022,168 @@ func inlineEventually(t *testing.T, cond func() bool, waitFor time.Duration, tic
 				return
 			}
 		}
+	}
+}
+
+// TestAuthorizeAdminAction tests authorizeAdminAction.
+func TestAuthorizeAdminAction(t *testing.T) {
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+	srv.AuthServer.AuthServer.ServerID = uuid.NewString()
+
+	localUser := configureForMFA(t, srv)
+	adminRole := authz.BuiltinRole{
+		Role:     types.RoleAdmin,
+		Username: HostFQDN(srv.AuthServer.AuthServer.ServerID, srv.ClusterName()),
+	}
+	bot, err := srv.Auth().createBot(ctx, &proto.CreateBotRequest{
+		Name:  "robot",
+		Roles: []string{services.RoleNameForUser(localUser.User)},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name           string
+		getAuthContext func(t *testing.T) authz.Context
+		getMFAResponse func(t *testing.T, swr *ServerWithRoles) *proto.MFAAuthenticateResponse
+		assertErr      require.ErrorAssertionFunc
+	}{
+		{
+			name: "NOK local user no mfa",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username: localUser.User,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
+			},
+		}, {
+			name: "NOK local user with mfa verified cert",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username:    localUser.User,
+					MFAVerified: localUser.WebDev.MFA.Id,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
+			},
+		}, {
+			name: "OK local user with context mfa",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username: localUser.User,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			getMFAResponse: func(t *testing.T, swr *ServerWithRoles) *proto.MFAAuthenticateResponse {
+				mfaChal, err := swr.authServer.mfaAuthChallenge(ctx, localUser.User, false)
+				require.NoError(t, err)
+				mfaResp, err := localUser.WebDev.SolveAuthn(mfaChal)
+				require.NoError(t, err)
+				return mfaResp
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "OK local user with mfa verified private key policy",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username:         localUser.User,
+					PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "OK admin",
+			getAuthContext: func(t *testing.T) authz.Context {
+				authContext, err := authz.ContextForBuiltinRole(adminRole, types.DefaultSessionRecordingConfig())
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "OK bot",
+			getAuthContext: func(t *testing.T) authz.Context {
+				botUser := authz.LocalUser{Username: bot.UserName, Identity: tlsca.Identity{Username: bot.UserName}}
+				authContext, err := authz.ContextForLocalUser(ctx, botUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "OK admin impersonating local user",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username:     localUser.User,
+					Impersonator: adminRole.Username,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "OK bot impersonating local user",
+			getAuthContext: func(t *testing.T) authz.Context {
+				localUser := authz.LocalUser{Username: localUser.User, Identity: tlsca.Identity{
+					Username:     localUser.User,
+					Impersonator: bot.UserName,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: require.NoError,
+		}, {
+			name: "NOK local user with admin role name",
+			getAuthContext: func(t *testing.T) authz.Context {
+				// Create a user with the same name as the admin role.
+				user, _, err := CreateUserAndRole(srv.Auth(), adminRole.Username, []string{"role"}, nil)
+				require.NoError(t, err)
+
+				localUser := authz.LocalUser{Username: user.GetName(), Identity: tlsca.Identity{
+					Username: adminRole.Username,
+				}}
+				authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+				require.NoError(t, err)
+				return *authContext
+			},
+			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := ctx
+			swr := &ServerWithRoles{
+				authServer: srv.Auth(),
+				alog:       srv.AuthServer.AuditLog,
+				context:    tc.getAuthContext(t),
+			}
+
+			if tc.getMFAResponse != nil {
+				// Attach mfa response to the context the way a grpc call would.
+				mfaResp := tc.getMFAResponse(t, swr)
+				encodedMFAResp, err := mfa.EncodeMFAChallengeResponseCredentials(mfaResp)
+				require.NoError(t, err)
+				md := metadata.MD{}
+				md.Append(mfa.MFAResponseToken, encodedMFAResp)
+				ctx = metadata.NewIncomingContext(ctx, md)
+			}
+
+			tc.assertErr(t, swr.authorizeAdminAction(ctx))
+		})
 	}
 }

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -491,6 +491,13 @@ func (c *Client) DiscoveryConfigClient() services.DiscoveryConfigs {
 	return c.APIClient.DiscoveryConfigClient()
 }
 
+// ValidateMFAAuthResponse validates an MFA or passwordless challenge.
+// Returns the device used to solve the challenge (if applicable) and the
+// username.
+func (c *Client) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
+	return nil, "", trace.NotImplemented(notImplementedMessage)
+}
+
 // WebService implements features used by Web UI clients
 type WebService interface {
 	// GetWebSessionInfo checks if a web session is valid, returns session id in case if
@@ -955,4 +962,8 @@ type ClientI interface {
 	// which is what we want when handling things like ambiguous host errors and resource-based access requests,
 	// but may result in confusing behavior if it is used outside of those contexts.
 	GetSSHTargets(ctx context.Context, req *proto.GetSSHTargetsRequest) (*proto.GetSSHTargetsResponse, error)
+
+	// ValidateMFAAuthResponse validates an MFA or passwordless challenge.
+	// Returns the device used to solve the challenge (if applicable) and the username.
+	ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error)
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2402,7 +2402,7 @@ func doMFAPresenceChallenge(ctx context.Context, actx *grpcContext, stream authp
 		return trace.BadParameter("expected MFAAuthenticateResponse, got %T", challengeResp)
 	}
 
-	if _, _, err := actx.authServer.validateMFAAuthResponse(ctx, challengeResp, user, passwordless); err != nil {
+	if _, _, err := actx.authServer.ValidateMFAAuthResponse(ctx, challengeResp, user, passwordless); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -2558,7 +2558,7 @@ func addMFADeviceAuthChallenge(gctx *grpcContext, stream authpb.AuthService_AddM
 	}
 	// Only validate if there was a challenge.
 	if authChallenge.TOTP != nil || authChallenge.WebauthnChallenge != nil {
-		if _, _, err := auth.validateMFAAuthResponse(ctx, authResp, user, passwordless); err != nil {
+		if _, _, err := auth.ValidateMFAAuthResponse(ctx, authResp, user, passwordless); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -2700,7 +2700,7 @@ func deleteMFADeviceAuthChallenge(gctx *grpcContext, stream authpb.AuthService_D
 	if authResp == nil {
 		return trace.BadParameter("expected MFAAuthenticateResponse, got %T", req)
 	}
-	if _, _, err := auth.validateMFAAuthResponse(ctx, authResp, user, passwordless); err != nil {
+	if _, _, err := auth.ValidateMFAAuthResponse(ctx, authResp, user, passwordless); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -2936,7 +2936,7 @@ func userSingleUseCertsAuthChallenge(gctx *grpcContext, stream authpb.AuthServic
 	if authResp == nil {
 		return nil, trace.BadParameter("expected MFAAuthenticateResponse, got %T", req.Request)
 	}
-	mfaDev, _, err := auth.validateMFAAuthResponse(ctx, authResp, user, passwordless)
+	mfaDev, _, err := auth.ValidateMFAAuthResponse(ctx, authResp, user, passwordless)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4659,7 +4659,6 @@ func (g *GRPCServer) ListUnifiedResources(ctx context.Context, req *authpb.ListU
 	}
 
 	return auth.ListUnifiedResources(ctx, req)
-
 }
 
 // ListResources retrieves a paginated list of resources.

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -297,7 +297,7 @@ func (a *Server) authenticateUser(ctx context.Context, req AuthenticateUserReque
 					Webauthn: wantypes.CredentialAssertionResponseToProto(req.Webauthn),
 				},
 			}
-			dev, _, err := a.validateMFAAuthResponse(ctx, mfaResponse, user, passwordless)
+			dev, _, err := a.ValidateMFAAuthResponse(ctx, mfaResponse, user, passwordless)
 			return dev, trace.Wrap(err)
 		}
 		authErr = authenticateWebauthnError
@@ -391,7 +391,7 @@ func (a *Server) authenticatePasswordless(ctx context.Context, req AuthenticateU
 			Webauthn: wantypes.CredentialAssertionResponseToProto(req.Webauthn),
 		},
 	}
-	dev, user, err := a.validateMFAAuthResponse(ctx, mfaResponse, "", true /* passwordless */)
+	dev, user, err := a.ValidateMFAAuthResponse(ctx, mfaResponse, "", true /* passwordless */)
 	if err != nil {
 		log.Debugf("Passwordless authentication failed: %v", err)
 		return nil, "", trace.Wrap(authenticateWebauthnError)

--- a/lib/auth/okta/service_test.go
+++ b/lib/auth/okta/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -131,8 +132,10 @@ func TestOktaAssignments(t *testing.T) {
 	require.Empty(t, cmp.Diff(a1, a,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
-	_, err = svc.UpdateOktaAssignmentStatus(ctx, &oktapb.UpdateOktaAssignmentStatusRequest{Name: a1.GetName(),
-		Status: types.OktaAssignmentSpecV1_PROCESSING})
+	_, err = svc.UpdateOktaAssignmentStatus(ctx, &oktapb.UpdateOktaAssignmentStatusRequest{
+		Name:   a1.GetName(),
+		Status: types.OktaAssignmentSpecV1_PROCESSING,
+	})
 	require.NoError(t, err)
 
 	require.NoError(t, a1.SetStatus(constants.OktaAssignmentStatusProcessing))
@@ -160,6 +163,17 @@ func TestOktaAssignments(t *testing.T) {
 	require.Empty(t, listResp.Assignments)
 }
 
+type testClient struct {
+	services.ClusterConfiguration
+	services.Trust
+	services.RoleGetter
+	services.UserGetter
+}
+
+func (c *testClient) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
+	return nil, "", nil
+}
+
 func initSvc(t *testing.T, kind string) (context.Context, *Service) {
 	ctx := context.Background()
 	backend, err := memory.New(memory.Config{})
@@ -176,12 +190,7 @@ func initSvc(t *testing.T, kind string) (context.Context, *Service) {
 	require.NoError(t, clusterConfigSvc.SetClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig()))
 	require.NoError(t, clusterConfigSvc.SetSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig()))
 
-	accessPoint := struct {
-		services.ClusterConfiguration
-		services.Trust
-		services.RoleGetter
-		services.UserGetter
-	}{
+	accessPoint := &testClient{
 		ClusterConfiguration: clusterConfigSvc,
 		Trust:                trustSvc,
 		RoleGetter:           roleSvc,

--- a/lib/auth/userpreferences/userpreferencesv1/service_test.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -151,6 +152,17 @@ func TestService_UpsertUserPreferences(t *testing.T) {
 	}
 }
 
+type testClient struct {
+	services.ClusterConfiguration
+	services.Trust
+	services.RoleGetter
+	services.UserGetter
+}
+
+func (c *testClient) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
+	return nil, "", nil
+}
+
 func initSvc(t *testing.T) (map[string]context.Context, *Service) {
 	ctx := context.Background()
 	backend, err := memory.New(memory.Config{})
@@ -167,12 +179,7 @@ func initSvc(t *testing.T) (map[string]context.Context, *Service) {
 	require.NoError(t, clusterConfigSvc.SetClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig()))
 	require.NoError(t, clusterConfigSvc.SetSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig()))
 
-	accessPoint := struct {
-		services.ClusterConfiguration
-		services.Trust
-		services.RoleGetter
-		services.UserGetter
-	}{
+	accessPoint := &testClient{
 		ClusterConfiguration: clusterConfigSvc,
 		Trust:                trustSvc,
 		RoleGetter:           roleSvc,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -387,7 +387,7 @@ func (a *authorizer) authorizeAdminAction(ctx context.Context, authContext *Cont
 		return nil
 	}
 
-	// Skip mfa if the identity is being impersonated by the Bot or Admin built in role.
+	// Skip MFA if the identity is being impersonated by the Bot or Admin built in role.
 	if impersonator := authContext.Identity.GetIdentity().Impersonator; impersonator != "" {
 		impersonatorUser, err := a.accessPoint.GetUser(ctx, impersonator, false)
 		if err == nil && impersonatorUser.IsBot() {
@@ -413,7 +413,7 @@ func (a *authorizer) authorizeAdminAction(ctx context.Context, authContext *Cont
 		return nil
 	}
 
-	// mfa is required to be passed through the request context.
+	// MFA is required to be passed through the request context.
 	mfaResp, err := mfa.CredentialsFromContext(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -25,12 +25,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"github.com/vulcand/predicate/builder"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils"
@@ -110,15 +114,16 @@ type AuthorizerAccessPoint interface {
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
-	// GetRole returns role by name
+	// GetRole returns role by name.
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
+	// GetUser returns user by name.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
-	// GetCertAuthority returns cert authority by id
+	// GetCertAuthority returns cert authority by id.
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 
-	// GetCertAuthorities returns a list of cert authorities
+	// GetCertAuthorities returns a list of cert authorities.
 	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error)
 
 	// GetClusterAuditConfig returns cluster audit configuration.
@@ -129,6 +134,10 @@ type AuthorizerAccessPoint interface {
 
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+
+	// ValidateMFAAuthResponse validates an MFA or passwordless challenge.
+	// Returns the device used to solve the challenge (if applicable) and the username.
+	ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error)
 }
 
 // authorizer creates new local authorizer
@@ -162,6 +171,11 @@ type Context struct {
 	// disableDeviceAuthorization disables device verification.
 	// Inherited from the authorizer that creates the context.
 	disableDeviceAuthorization bool
+
+	// AdminActionVerified is whether this auth request is verified for admin actions. This
+	// either means that the request was MFA verified through the context or Hardware Key support,
+	// or the identity does not require admin MFA (built in roles, bot impersonated user, etc).
+	adminActionAuthorized bool
 }
 
 // LockTargets returns a list of LockTargets inferred from the context's
@@ -293,6 +307,10 @@ func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
 		}
 	}
 
+	if err := a.checkAdminActionVerification(ctx, authContext); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return authContext, nil
 }
 
@@ -330,6 +348,82 @@ func (a *authorizer) fromUser(ctx context.Context, userI interface{}) (*Context,
 	default:
 		return nil, trace.AccessDenied("unsupported context type %T", userI)
 	}
+}
+
+// checkAdminActionVerification checks if this auth request is verified for admin actions.
+func (a *authorizer) checkAdminActionVerification(ctx context.Context, authContext *Context) error {
+	if err := a.authorizeAdminAction(ctx, authContext); err != nil {
+		if trace.IsNotFound(err) {
+			// missing MFA verification should be a noop.
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+
+	authContext.adminActionAuthorized = true
+	return nil
+}
+
+func (a *authorizer) authorizeAdminAction(ctx context.Context, authContext *Context) error {
+	// Builtin roles do not require MFA to perform admin actions.
+	switch authContext.Identity.(type) {
+	case BuiltinRole, RemoteBuiltinRole:
+		return nil
+	}
+
+	authpref, err := a.accessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Admin actions do not require MFA when MFA is not enabled.
+	if authpref.GetSecondFactor() == constants.SecondFactorOff {
+		return nil
+	}
+
+	// Skip MFA check if the user is a Bot.
+	if user, err := a.accessPoint.GetUser(ctx, authContext.Identity.GetIdentity().Username, false); err == nil && user.IsBot() {
+		a.logger.Debugf("Skipping admin action MFA check for bot identity: %v", authContext.Identity.GetIdentity())
+		return nil
+	}
+
+	// Skip mfa if the identity is being impersonated by the Bot or Admin built in role.
+	if impersonator := authContext.Identity.GetIdentity().Impersonator; impersonator != "" {
+		impersonatorUser, err := a.accessPoint.GetUser(ctx, impersonator, false)
+		if err == nil && impersonatorUser.IsBot() {
+			a.logger.Debugf("Skipping admin action MFA check for bot-impersonated identity: %v", authContext.Identity.GetIdentity())
+			return nil
+		}
+
+		// If we don't find a user matching the impersonator, it may be the admin role impersonating.
+		// Check that the impersonator matches a host service FQDN - <host-id>.<clustername>
+		if trace.IsNotFound(err) {
+			hostFQDNParts := strings.SplitN(impersonator, ".", 2)
+			if hostFQDNParts[1] == a.clusterName {
+				if _, err := uuid.Parse(hostFQDNParts[0]); err == nil {
+					a.logger.Debugf("Skipping admin action MFA check for admin-impersonated identity: %v", authContext.Identity.GetIdentity())
+					return nil
+				}
+			}
+		}
+	}
+
+	// Certain hardware-key based private key policies require MFA for each request.
+	if authContext.Identity.GetIdentity().PrivateKeyPolicy.MFAVerified() {
+		return nil
+	}
+
+	// mfa is required to be passed through the request context.
+	mfaResp, err := mfa.CredentialsFromContext(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, _, err := a.accessPoint.ValidateMFAAuthResponse(ctx, mfaResp, authContext.User.GetName(), false); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }
 
 // ErrIPPinningMissing is returned when user cert should be pinned but isn't.
@@ -1201,6 +1295,14 @@ func AuthorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, auth
 		return nil, err
 	}
 	return authCtx, nil
+}
+
+// AuthorizeAdminAction will ensure that the user is authorized to perform admin actions.
+func AuthorizeAdminAction(ctx context.Context, authCtx *Context) error {
+	if !authCtx.adminActionAuthorized {
+		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
+	}
+	return nil
 }
 
 // LocalUser is a local user

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -590,8 +590,9 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				}
 				encodedMFAResp, err := mfa.EncodeMFAChallengeResponseCredentials(mfaResp)
 				require.NoError(t, err)
-				md := metadata.MD{}
-				md.Append(mfa.MFAResponseToken, encodedMFAResp)
+				md := metadata.MD(map[string][]string{
+					mfa.ResponseMetadataKey: {encodedMFAResp},
+				})
 				ctx = metadata.NewIncomingContext(ctx, md)
 			}
 			userCtx := context.WithValue(ctx, contextUser, tt.user)


### PR DESCRIPTION
Adds `AuthorizeAdminAction`, as server side check for MFA for admin actions.

Requests that include this check will require MFA for normal users, either with MFA passed through the request context or with a MFA verified private key policy.

Many requests will gain this check as part of [RFD 131](https://github.com/gravitational/teleport/blob/master/rfd/0131-adminitrative-actions-mfa.md#administrative-actions).

e PR: https://github.com/gravitational/teleport.e/pull/2535