### PR TITLE
[v14] Configure Connect to intercept deep link clicks

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -32,11 +32,11 @@ import {
 } from 'teleterm/services/config';
 import { createFileStorage } from 'teleterm/services/fileStorage';
 import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
-import { CONNECT_CUSTOM_PROTOCOL } from 'teleterm/ui/uri';
+import { TELEPORT_CUSTOM_PROTOCOL } from 'teleterm/ui/uri';
 
 // Set the app as a default protocol client only if it wasn't started through `electron .`.
 if (!process.defaultApp) {
-  app.setAsDefaultProtocolClient(CONNECT_CUSTOM_PROTOCOL);
+  app.setAsDefaultProtocolClient(TELEPORT_CUSTOM_PROTOCOL);
 }
 
 if (app.requestSingleInstanceLock()) {
@@ -319,5 +319,5 @@ function setUpDeepLinks(
 // We don't know the exact position of the URL is in argv. Chromium might inject its own arguments
 // into argv. See https://www.electronjs.org/docs/latest/api/app#event-second-instance.
 function findCustomProtocolUrlInArgv(argv: string[]) {
-  return argv.find(arg => arg.startsWith(`${CONNECT_CUSTOM_PROTOCOL}://`));
+  return argv.find(arg => arg.startsWith(`${TELEPORT_CUSTOM_PROTOCOL}://`));
 }

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -284,7 +284,8 @@ function setUpDeepLinks(
   if (settings.platform === 'darwin') {
     // Deep link click on macOS.
     app.on('open-url', (event, url) => {
-      // macOS does bring focus to the _application_ itself. However, if the app has one window and
+      // When macOS launches an app as a result of a deep link click, macOS does bring focus to the
+      // _application_ itself if the app is already running. However, if the app has one window and
       // the window is minimized, it'll remain so. So we have to focus the window ourselves.
       windowsManager.focusWindow();
 
@@ -301,6 +302,9 @@ function setUpDeepLinks(
 
   // Deep link click if the app is already opened (Windows or Linux).
   app.on('second-instance', (event, argv) => {
+    // There's already a second-instance listener that gives focus to the main window, so we don't
+    // do this in this listener.
+
     const url = findCustomProtocolUrlInArgv(argv);
     if (url) {
       logger.info(`Deep link launch from second-instance, URI: ${url}`);

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -74,7 +74,7 @@ export type DocumentUri = `/docs/${DocumentId}`;
 type GatewayId = string;
 export type GatewayUri = `/gateways/${GatewayId}`;
 
-export const CONNECT_CUSTOM_PROTOCOL = 'teleport-connect' as const;
+export const TELEPORT_CUSTOM_PROTOCOL = 'teleport' as const;
 
 export const routing = {
   parseClusterUri(uri: string) {

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -74,6 +74,8 @@ export type DocumentUri = `/docs/${DocumentId}`;
 type GatewayId = string;
 export type GatewayUri = `/gateways/${GatewayId}`;
 
+export const CONNECT_CUSTOM_PROTOCOL = 'teleport-connect' as const;
+
 export const routing = {
   parseClusterUri(uri: string) {
     const leafMatch = routing.parseUri(uri, paths.leafCluster);


### PR DESCRIPTION
Backport #33637 to branch/v14 (partially).

Changes to electron-builder config which actually make the OS recognize Connect as a handler for `teleport://` links have been extracted to #33688. This way #33688 can act as a sort of feature flag which will disable deep link support until merged.