### PR TITLE
[v14] Remove access list from unified watcher

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -645,7 +645,6 @@ func (c *UnifiedResourceCache) resourceKinds() []types.WatchKind {
 		{Kind: types.KindSAMLIdPServiceProvider},
 		{Kind: types.KindWindowsDesktop},
 		{Kind: types.KindKubeServer},
-		{Kind: types.KindAccessList},
 	}
 }
 


### PR DESCRIPTION
This removes AccessLists from the unified watcher in v14. Was missed in a backport
https://github.com/gravitational/teleport/pull/33322