### PR TITLE
[v14] Enable Connect My Computer Discover tile & deep links in Connect

### DIFF
--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -90,9 +90,9 @@ test('displays all resources by default', () => {
   create({});
 
   expect(
-    screen.getAllByTestId(ResourceKind.Server)
-    // TODO(ravicious): Uncomment for v14.2.
-    // .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
+    screen
+      .getAllByTestId(ResourceKind.Server)
+      .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
   ).toHaveLength(SERVERS.length);
   expect(screen.getAllByTestId(ResourceKind.Desktop)).toHaveLength(
     WINDOWS_DESKTOPS.length
@@ -131,9 +131,9 @@ describe('location state', () => {
     create({ initialEntry: 'server' });
 
     expect(
-      screen.getAllByTestId(ResourceKind.Server)
-      // TODO(ravicious): Uncomment for v14.2.
-      // .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
+      screen
+        .getAllByTestId(ResourceKind.Server)
+        .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
     ).toHaveLength(SERVERS.length);
 
     // we assert three databases for servers because the naming convention includes "server"

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -514,6 +514,41 @@ exports[`render with URL loc state set to "server" 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="c11"
+      data-testid="7"
+    >
+      <div
+        class="c12"
+      >
+        Guided
+      </div>
+      <div
+        class="c13"
+      >
+        <div
+          class="c14"
+          width="24px"
+        >
+          <img
+            class="c15"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c16"
+        >
+          
+          <div
+            class="c18"
+          >
+            Connect My Computer
+          </div>
+        </div>
+      </div>
+    </div>
     <a
       class="c19 c11"
       data-testid="1"
@@ -1456,6 +1491,41 @@ exports[`render with all access 1`] = `
             class="c14"
           >
             Ubuntu 14.04+
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c7"
+      data-testid="7"
+    >
+      <div
+        class="c8"
+      >
+        Guided
+      </div>
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          width="24px"
+        >
+          <img
+            class="c11"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c12"
+        >
+          
+          <div
+            class="c14"
+          >
+            Connect My Computer
           </div>
         </div>
       </div>
@@ -3045,6 +3115,42 @@ exports[`render with no access 1`] = `
         </div>
       </div>
     </a>
+    <div
+      class="c7"
+      data-testid="7"
+    >
+      <div
+        class="c8"
+        data-testid="tooltip"
+      >
+        Lacking Permissions
+      </div>
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          width="24px"
+        >
+          <img
+            class="c11"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c12"
+        >
+          
+          <div
+            class="c14"
+          >
+            Connect My Computer
+          </div>
+        </div>
+      </div>
+    </div>
     <div
       class="c7"
       data-testid="4"
@@ -4878,6 +4984,41 @@ exports[`render with partial access 1`] = `
             class="c14"
           >
             Ubuntu 14.04+
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c7"
+      data-testid="7"
+    >
+      <div
+        class="c8"
+      >
+        Guided
+      </div>
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          width="24px"
+        >
+          <img
+            class="c11"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c12"
+        >
+          
+          <div
+            class="c14"
+          >
+            Connect My Computer
           </div>
         </div>
       </div>

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -85,16 +85,15 @@ export const SERVERS: ResourceSpec[] = [
     event: DiscoverEventResource.Ec2Instance,
     nodeMeta: { location: ServerLocation.Aws },
   },
-  // TODO(ravicious): Uncomment for v14.2.
-  // {
-  //   name: 'Connect My Computer',
-  //   kind: ResourceKind.ConnectMyComputer,
-  //   keywords: baseServerKeywords + 'connect my computer',
-  //   icon: 'Laptop',
-  //   event: DiscoverEventResource.Server,
-  //   supportedPlatforms: [Platform.macOS, Platform.Linux],
-  //   supportedAuthTypes: ['local', 'passwordless'],
-  // },
+  {
+    name: 'Connect My Computer',
+    kind: ResourceKind.ConnectMyComputer,
+    keywords: baseServerKeywords + 'connect my computer',
+    icon: 'Laptop',
+    event: DiscoverEventResource.Server,
+    supportedPlatforms: [Platform.macOS, Platform.Linux],
+    supportedAuthTypes: ['local', 'passwordless'],
+  },
 ];
 
 export const APPLICATIONS: ResourceSpec[] = [

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -32,11 +32,15 @@ if (!isMac && env.CONNECT_TSH_BIN_PATH === undefined) {
 // Holds tsh.app Info.plist during build. Used in afterPack.
 let tshAppPlist;
 
+// appId must be a reverse DNS string since it's also used as CFBundleURLName on macOS, see
+// protocols.name below.
+const appId = 'gravitational.teleport.connect';
+
 /**
  * @type { import('electron-builder').Configuration }
  */
 module.exports = {
-  appId: 'gravitational.teleport.connect',
+  appId,
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   afterSign: 'notarize.js',
@@ -74,6 +78,26 @@ module.exports = {
     '!node_modules/node-pty/build/*/.forge-meta',
     '!node_modules/node-pty/build/Debug/.deps/**',
     '!node_modules/node-pty/bin',
+  ],
+  protocols: [
+    {
+      // name ultimately becomes CFBundleURLName which is the URL identifier. [1] Apple recommends
+      // to set it to a reverse DNS string. [2]
+      //
+      // [1] https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleurltypes/cfbundleurlname
+      // [2] https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app#Register-your-URL-scheme
+      name: appId,
+      schemes: ['teleport'],
+      // Not much documentation is available on the role attribute. It ultimately gets mapped to
+      // CFBundleTypeRole in Info.plist.
+      //
+      // It seems that this field is largely related to how macOS thinks of "documents". Since Connect
+      // doesn't let you really edit anything and we won't be passing any docs, let's just set it to
+      // 'Viewer'.
+      //
+      // https://cocoadev.github.io/CFBundleTypeRole/
+      role: 'Viewer',
+    },
   ],
   mac: {
     target: 'dmg',


### PR DESCRIPTION
Backport #33637 (partially). Do not merge before #32185 release (slated for v14.2).

As discussed in https://github.com/gravitational/teleport/pull/33684#issuecomment-1770898592, these changes will make it so that the packaged build of Connect will be recognized by the OS as a valid handler for `teleport://` links.

We should merge it only before the launch of [the Connect My Computer Discover tile](https://github.com/gravitational/teleport/issues/32185) (slated for v14.2) so that previous builds of Connect are not recognized as handlers for `teleport://`.

Changelog: Added a guided flow for joining your computer to the Teleport cluster using Teleport Connect; find it in the Web UI under Enroll New Resource -> Connect My Computer (available only for local users, see the prerequisites at https://goteleport.com/docs/connect-your-client/teleport-connect/#connect-my-computer)