### PR TITLE
Send deep link clicks to frontend app in Connect

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -292,7 +292,7 @@ function setUpDeepLinks(
       windowsManager.focusWindow();
 
       logger.info(`Deep link launch from open-url, URL: ${url}`);
-      launchDeepLink(logger, url);
+      launchDeepLink(logger, windowsManager, url);
     });
     return;
   }
@@ -311,7 +311,7 @@ function setUpDeepLinks(
     const url = findCustomProtocolUrlInArgv(argv);
     if (url) {
       logger.info(`Deep link launch from second-instance, URI: ${url}`);
-      launchDeepLink(logger, url);
+      launchDeepLink(logger, windowsManager, url);
     }
   });
 
@@ -322,7 +322,7 @@ function setUpDeepLinks(
     return;
   }
   logger.info(`Deep link launch from process.argv, URL: ${url}`);
-  launchDeepLink(logger, url);
+  launchDeepLink(logger, windowsManager, url);
 }
 
 // We don't know the exact position of the URL is in argv. Chromium might inject its own arguments
@@ -331,7 +331,11 @@ function findCustomProtocolUrlInArgv(argv: string[]) {
   return argv.find(arg => arg.startsWith(`${TELEPORT_CUSTOM_PROTOCOL}://`));
 }
 
-function launchDeepLink(logger: Logger, rawUrl: string): void {
+function launchDeepLink(
+  logger: Logger,
+  windowsManager: WindowsManager,
+  rawUrl: string
+): void {
   const result = parseDeepLink(rawUrl);
 
   if (result.status === 'error') {
@@ -356,4 +360,8 @@ function launchDeepLink(logger: Logger, rawUrl: string): void {
 
     logger.error(`Skipping deep link launch, ${reason}`);
   }
+
+  // Always pass the result to the frontend app so that the error can be shown to the user.
+  // Otherwise the app would receive focus but nothing would be visible in the UI.
+  windowsManager.launchDeepLink(result);
 }

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -41,6 +41,10 @@ export class MockMainProcessClient implements MainProcessClient {
     return { cleanup: () => undefined };
   }
 
+  subscribeToDeepLinkLaunch() {
+    return { cleanup: () => undefined };
+  }
+
   getRuntimeSettings(): RuntimeSettings {
     return makeRuntimeSettings(this.runtimeSettings);
   }

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -123,6 +123,8 @@ export class MockMainProcessClient implements MainProcessClient {
   removeAgentDirectory() {
     return Promise.resolve();
   }
+
+  signalFrontendAppReadiness() {}
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -33,6 +33,14 @@ export class MockMainProcessClient implements MainProcessClient {
     });
   }
 
+  subscribeToNativeThemeUpdate() {
+    return { cleanup: () => undefined };
+  }
+
+  subscribeToAgentUpdate() {
+    return { cleanup: () => undefined };
+  }
+
   getRuntimeSettings(): RuntimeSettings {
     return makeRuntimeSettings(this.runtimeSettings);
   }
@@ -80,10 +88,6 @@ export class MockMainProcessClient implements MainProcessClient {
     return true;
   }
 
-  subscribeToNativeThemeUpdate() {
-    return { cleanup: () => undefined };
-  }
-
   downloadAgent() {
     return Promise.resolve();
   }
@@ -114,10 +118,6 @@ export class MockMainProcessClient implements MainProcessClient {
 
   getAgentLogs(): string {
     return '';
-  }
-
-  subscribeToAgentUpdate() {
-    return { cleanup: () => undefined };
   }
 
   removeAgentDirectory() {

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -128,7 +128,7 @@ export class MockMainProcessClient implements MainProcessClient {
     return Promise.resolve();
   }
 
-  signalFrontendAppReadiness() {}
+  signalUserInterfaceReadiness() {}
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -119,6 +119,7 @@ export default class MainProcess {
   }
 
   async dispose(): Promise<void> {
+    this.windowsManager.dispose();
     await Promise.all([
       // sending usage events on tshd shutdown has 10-seconds timeout
       terminateWithTimeout(this.tshdProcess, 10_000, () => {

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -33,7 +33,11 @@ import {
 import { FileStorage, RuntimeSettings } from 'teleterm/types';
 import { subscribeToFileStorageEvents } from 'teleterm/services/fileStorage';
 import { LoggerColor, createFileLoggerService } from 'teleterm/services/logger';
-import { ChildProcessAddresses } from 'teleterm/mainProcess/types';
+import {
+  ChildProcessAddresses,
+  MainProcessIpc,
+  RendererIpc,
+} from 'teleterm/mainProcess/types';
 import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import Logger from 'teleterm/logger';
@@ -104,7 +108,7 @@ export default class MainProcess {
           return;
         }
         window.webContents.send(
-          'renderer-connect-my-computer-agent-update',
+          RendererIpc.ConnectMyComputerAgentUpdate,
           rootClusterUri,
           state
         );
@@ -202,7 +206,7 @@ export default class MainProcess {
   }
 
   private _initIpc() {
-    ipcMain.on('main-process-get-runtime-settings', event => {
+    ipcMain.on(MainProcessIpc.GetRuntimeSettings, event => {
       event.returnValue = this.settings;
     });
 

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -104,7 +104,7 @@ export default class MainProcess {
           return;
         }
         window.webContents.send(
-          'main-process-connect-my-computer-agent-update',
+          'renderer-connect-my-computer-agent-update',
           rootClusterUri,
           state
         );

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -172,8 +172,8 @@ export default function createMainProcessClient(): MainProcessClient {
      * Signals to the windows manager that the UI has been fully initialized, that is the user has
      * interacted with the relevant modals during startup and is free to use the app.
      */
-    signalFrontendAppReadiness(args: { success: boolean }) {
-      ipcRenderer.send('windows-manager-signal-frontend-app-readiness', args);
+    signalUserInterfaceReadiness(args: { success: boolean }) {
+      ipcRenderer.send('windows-manager-signal-user-interface-readiness', args);
     },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -61,6 +61,17 @@ export default function createMainProcessClient(): MainProcessClient {
         cleanup: () => ipcRenderer.removeListener(channel, onChange),
       };
     },
+    subscribeToDeepLinkLaunch: listener => {
+      const ipcListener = (event, args) => {
+        listener(args);
+      };
+      const channel = 'renderer-deep-link-launch';
+
+      ipcRenderer.addListener(channel, ipcListener);
+      return {
+        cleanup: () => ipcRenderer.removeListener(channel, ipcListener),
+      };
+    },
 
     /*
      * Messages sent from the renderer to the main process.

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -157,5 +157,12 @@ export default function createMainProcessClient(): MainProcessClient {
         clusterProperties
       );
     },
+    /**
+     * Signals to the windows manager that the UI has been fully initialized, that is the user has
+     * interacted with the relevant modals during startup and is free to use the app.
+     */
+    signalFrontendAppReadiness(args: { success: boolean }) {
+      ipcRenderer.send('windows-manager-signal-frontend-app-readiness', args);
+    },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -148,7 +148,7 @@ export type MainProcessClient = {
   removeAgentDirectory(args: { rootClusterUri: RootClusterUri }): Promise<void>;
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
-  signalFrontendAppReadiness(args: { success: boolean }): void;
+  signalUserInterfaceReadiness(args: { success: boolean }): void;
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -86,6 +86,19 @@ export type RuntimeSettings = {
 };
 
 export type MainProcessClient = {
+  /** Subscribes to updates of the native theme. Returns a cleanup function. */
+  subscribeToNativeThemeUpdate: (
+    listener: (value: { shouldUseDarkColors: boolean }) => void
+  ) => {
+    cleanup: () => void;
+  };
+  subscribeToAgentUpdate: (
+    rootClusterUri: RootClusterUri,
+    listener: (state: AgentProcessState) => void
+  ) => {
+    cleanup: () => void;
+  };
+
   getRuntimeSettings(): RuntimeSettings;
   getResolvedChildProcessAddresses(): Promise<ChildProcessAddresses>;
   openTerminalContextMenu(): void;
@@ -114,12 +127,6 @@ export type MainProcessClient = {
   /** Opens config file and returns a path to it. */
   openConfigFile(): Promise<string>;
   shouldUseDarkColors(): boolean;
-  /** Subscribes to updates of the native theme. Returns a cleanup function. */
-  subscribeToNativeThemeUpdate: (
-    listener: (value: { shouldUseDarkColors: boolean }) => void
-  ) => {
-    cleanup: () => void;
-  };
   downloadAgent(): Promise<void>;
   createAgentConfigFile(
     properties: AgentConfigFileClusterProperties
@@ -135,14 +142,6 @@ export type MainProcessClient = {
   removeAgentDirectory(args: { rootClusterUri: RootClusterUri }): Promise<void>;
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
-  subscribeToAgentUpdate: SubscribeToAgentUpdate;
-};
-
-export type SubscribeToAgentUpdate = (
-  rootClusterUri: RootClusterUri,
-  listener: (state: AgentProcessState) => void
-) => {
-  cleanup: () => void;
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { AgentConfigFileClusterProperties } from 'teleterm/mainProcess/createAgentConfigFile';
+import { DeepLinkParseResult } from 'teleterm/deepLinks';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { Kind } from 'teleterm/ui/services/workspacesService';
@@ -95,6 +96,11 @@ export type MainProcessClient = {
   subscribeToAgentUpdate: (
     rootClusterUri: RootClusterUri,
     listener: (state: AgentProcessState) => void
+  ) => {
+    cleanup: () => void;
+  };
+  subscribeToDeepLinkLaunch: (
+    listener: (args: DeepLinkParseResult) => void
   ) => {
     cleanup: () => void;
   };

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -142,6 +142,7 @@ export type MainProcessClient = {
   removeAgentDirectory(args: { rootClusterUri: RootClusterUri }): Promise<void>;
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
+  signalFrontendAppReadiness(args: { success: boolean }): void;
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -237,3 +237,30 @@ export enum FileStorageEventType {
   GetFilePath = 'GetFilePath',
   GetFileLoadingError = 'GetFileLoadingError',
 }
+
+/*
+ * IPC channel enums
+ *
+ * The enum values are used as IPC channels [1], so they should be unique across all enums. That's
+ * why the values are prefixed with the recipient name.
+ *
+ * The enums are grouped by the recipient, e.g. RendererIpc contains messages sent from the main
+ * process to the renderer, WindowsManagerIpc contains messages sent from the renderer to the
+ * windows manager (which lives in the main process).
+ *
+ * [1] https://www.electronjs.org/docs/latest/tutorial/ipc
+ */
+
+export enum RendererIpc {
+  NativeThemeUpdate = 'renderer-native-theme-update',
+  ConnectMyComputerAgentUpdate = 'renderer-connect-my-computer-agent-update',
+  DeepLinkLaunch = 'renderer-deep-link-launch',
+}
+
+export enum MainProcessIpc {
+  GetRuntimeSettings = 'main-process-get-runtime-settings',
+}
+
+export enum WindowsManagerIpc {
+  SignalUserInterfaceReadiness = 'windows-manager-signal-user-interface-readiness',
+}

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -157,8 +157,8 @@ export class WindowsManager {
   }
 
   /**
-   * dispose exists as a cleanup function MainProcess can call during 'will-quit' event of the
-   * Electron app.
+   * dispose exists as a cleanup function that the MainProcess can call during 'will-quit' event of
+   * the Electron app.
    *
    * dispose doesn't have to close the window as that's typically done by Electron itself. It should
    * however clean up any other remaining resources.

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -66,7 +66,7 @@ export class WindowsManager {
     });
 
     ipcMain.once(
-      'windows-manager-signal-frontend-app-readiness',
+      'windows-manager-signal-user-interface-readiness',
       (event, args) => {
         if (args.success) {
           this.frontendAppInit.resolve();

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -28,7 +28,11 @@ import {
 
 import Logger from 'teleterm/logger';
 import { FileStorage } from 'teleterm/services/fileStorage';
-import { RuntimeSettings } from 'teleterm/mainProcess/types';
+import {
+  RendererIpc,
+  RuntimeSettings,
+  WindowsManagerIpc,
+} from 'teleterm/mainProcess/types';
 import { darkTheme, lightTheme } from 'teleterm/ui/ThemeProvider/theme';
 import { DeepLinkParseResult } from 'teleterm/deepLinks';
 
@@ -66,7 +70,7 @@ export class WindowsManager {
     });
 
     ipcMain.once(
-      'windows-manager-signal-user-interface-readiness',
+      WindowsManagerIpc.SignalUserInterfaceReadiness,
       (event, args) => {
         if (args.success) {
           this.frontendAppInit.resolve();
@@ -137,7 +141,7 @@ export class WindowsManager {
     });
 
     nativeTheme.on('updated', () => {
-      window.webContents.send('renderer-native-theme-update', {
+      window.webContents.send(RendererIpc.NativeThemeUpdate, {
         shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
       });
     });
@@ -178,7 +182,7 @@ export class WindowsManager {
     }
 
     this.window.webContents.send(
-      'renderer-deep-link-launch',
+      RendererIpc.DeepLinkLaunch,
       deepLinkParseResult
     );
   }

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -99,7 +99,7 @@ export class WindowsManager {
     });
 
     nativeTheme.on('updated', () => {
-      window.webContents.send('main-process-native-theme-update', {
+      window.webContents.send('renderer-native-theme-update', {
         shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
       });
     });

--- a/web/packages/teleterm/src/ui/AppInitializer.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer.tsx
@@ -32,9 +32,11 @@ export const AppInitializer = () => {
       await ctx.init();
       await initUi(ctx);
       setIsUiReady(true);
+      ctx.mainProcessClient.signalFrontendAppReadiness({ success: true });
     } catch (error) {
       setIsUiReady(true);
       ctx.notificationsService.notifyError(error?.message);
+      ctx.mainProcessClient.signalFrontendAppReadiness({ success: false });
     }
   }, [ctx]);
 

--- a/web/packages/teleterm/src/ui/AppInitializer.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer.tsx
@@ -32,11 +32,11 @@ export const AppInitializer = () => {
       await ctx.init();
       await initUi(ctx);
       setIsUiReady(true);
-      ctx.mainProcessClient.signalFrontendAppReadiness({ success: true });
+      ctx.mainProcessClient.signalUserInterfaceReadiness({ success: true });
     } catch (error) {
       setIsUiReady(true);
       ctx.notificationsService.notifyError(error?.message);
-      ctx.mainProcessClient.signalFrontendAppReadiness({ success: false });
+      ctx.mainProcessClient.signalUserInterfaceReadiness({ success: false });
     }
   }, [ctx]);
 

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -156,17 +156,17 @@ export default class AppContext implements IAppContext {
         let reason: string;
         switch (result.reason) {
           case 'unknown-protocol': {
-            reason = `The received URL is of an unknown protocol.`;
+            reason = `The URL of the link is of an unknown protocol.`;
             break;
           }
           case 'unsupported-uri': {
             reason =
-              'The received URL does not point at a resource that can be launched from a deep link. ' +
-              'Either this version of Teleport Connect does not support launching this resource or the URL is incorrect.';
+              'The received link does not point at a resource or an action that can be launched from a link. ' +
+              'Either this version of Teleport Connect does not support it or the link is incorrect.';
             break;
           }
           case 'malformed-url': {
-            reason = `The URL of the deep link appears to be malformed.`;
+            reason = `The URL of the link appears to be malformed.`;
             break;
           }
           default: {
@@ -175,7 +175,7 @@ export default class AppContext implements IAppContext {
         }
 
         this.notificationsService.notifyWarning({
-          title: 'Cannot open the deep link',
+          title: 'Cannot open the link',
           description: reason,
         });
         return;


### PR DESCRIPTION
* Part of #32188.

#33637 set up Connect to make the OS recognize that it supports `teleport://` links. #33639 made it so that the deep links are parsed. This PR sends the parsed result to the frontend app so that it can show the relevant UI.

I'm open to suggestions regarding naming and code organization – we haven't done something like this before, so a lot of the decisions behind naming and code organization are rather arbitrary.

Here's [a fiddle with deep links](https://jsfiddle.net/ravicious/1tvz0kxm/7/) you can use for testing. Remember that this will only work after you build a a packaged app and install it (`yarn build-term && CONNECT_TSH_BIN_PATH=$PWD/build/tsh CSC_IDENTITY_AUTO_DISCOVERY=false yarn package-term`).

## Waiting for the frontend app

When the main process of Connect gets notified by the OS about the deep link click, the frontend app might not be initialized yet. This happens when the app wasn't running when the user clicked a deep link.

I needed to implement some kind of a waiting mechanism so that the renderer (which runs the frontend app) can notify the main process about the frontend app being ready. I took inspiration from Electron's [`app.whenReady`](https://www.electronjs.org/docs/latest/api/app#appwhenready). This function returns a promise which is resolved when Electron is initialized. I added `WindowsManager.whenFrontendAppIsReady` which resolves when the frontend app is ready. To accomplish this, I send a one-way message from the renderer to the main process, as explained in [the official inter-process communication tutorial](https://www.electronjs.org/docs/latest/tutorial/ipc#pattern-1-renderer-to-main-one-way). We already use this method of communication for many other things within the app.

## What it means for the frontend app to be ready

The frontend app is considered to be ready after `AppContext.init` as well as `initUi` resolve. This means that the frontend app won't be considered ready until the user goes through the telemetry modal shown on the very first launch of the app.

There's one problem though – if the user has opened some tabs and then closed the app, on next launch we show a modal asking if they want to restore the tabs. This is not considered to be a part of UI initialization process – that is because if you're logged into multiple root clusters ("workspaces"), we ask you about restoring tabs for this workspace only just before switching to it.

I'm going to address this caveat in the next PR which actually implements the in-app behavior of clicking on a Connect My Computer link.