### PR TITLE
[v12] [docs] add missing database matchers for discovery config reference

### DIFF
--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -7,38 +7,48 @@ discovery_service:
     # managing discovered resources.
     discovery_group: "disc-group"
     aws:
-       # AWS resource types. Valid options are:
-       # ec2 - discovers and registers AWS EC2 instances
-       # eks - discovers and registers AWS EKS clusters
-     - types: ["ec2"]
-       # AWS regions to search for resources from
-       regions: ["us-east-1","us-west-1"]
-       # AWS resource tags to match when registering resources
-       # Optional section: Defaults to "*":"*"
-       tags:
-         "*": "*"
-       # Optional section: install is used to provide parameters to the AWS SSM document.
-       # If the install section isn't provided, the below defaults are used.
-       # Only applicable for EC2 discovery.
-       install:
-         join_params:
-           # token_name is the name of the Teleport invite token to use.
-           # Optional, defaults to: "aws-discovery-iam-token".
-           token_name:  "aws-discovery-iam-token"
-         # script_name is the name of the Teleport install script to use.
-         # Optional, defaults to: "default-installer".
-         script_name: "default-installer"
-       # Optional section: ssm is used to configure which AWS SSM document to use
-       # If the ssm section isnt provided the below defaults are used.
-       ssm:
-         # document_name is the name of the SSM document that should be
-         # executed when installing teleport on matching nodes
-         # Optional, defaults to: "TeleportDiscoveryInstaller".
-         document_name: "TeleportDiscoveryInstaller"
+      # AWS resource types. Valid options are:
+      # 'ec2' - discovers and registers AWS EC2 instances.
+      # 'eks' - discovers and registers AWS EKS clusters.
+      # 'rds' - discovers and registers AWS RDS and Aurora databases.
+      # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
+      # 'redshift' - discovers and registers AWS Redshift databases.
+      # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
+      # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
+      # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
+    - types: ["ec2"]
+      # AWS regions to search for resources from
+      regions: ["us-east-1","us-west-1"]
+      # AWS resource tags to match when registering resources
+      # Optional section: Defaults to "*":"*"
+      tags:
+        "*": "*"
+      # Optional section: install is used to provide parameters to the AWS SSM document.
+      # If the install section isn't provided, the below defaults are used.
+      # Only applicable for EC2 discovery.
+      install:
+        join_params:
+          # token_name is the name of the Teleport invite token to use.
+          # Optional, defaults to: "aws-discovery-iam-token".
+          token_name:  "aws-discovery-iam-token"
+        # script_name is the name of the Teleport install script to use.
+        # Optional, defaults to: "default-installer".
+        script_name: "default-installer"
+      # Optional section: ssm is used to configure which AWS SSM document to use
+      # If the ssm section isnt provided the below defaults are used.
+      ssm:
+        # document_name is the name of the SSM document that should be
+        # executed when installing teleport on matching nodes
+        # Optional, defaults to: "TeleportDiscoveryInstaller".
+        document_name: "TeleportDiscoveryInstaller"
     # Matchers for discovering Azure-hosted resources.
     azure:
       # Azure resource types. Valid options are:
       # 'aks' - discovers and registers Azure AKS Kubernetes Clusters.
+      # 'mysql' - discovers and registers Azure MySQL databases.
+      # 'postgres' - discovers and registers Azure PostgreSQL databases.
+      # 'redis' - discovers and registers Azure Cache for Redis databases.
+      # 'sqlserver' - discovers and registers Azure SQL Server databases.
     - types: ["aks"]
       # Azure regions to search for resources from. Valid options are:
       # '*' - discovers resources in all regions (default).


### PR DESCRIPTION
Backport #33657 to branch/v12

Changes:
- Dropped comments for go files.
- Removed `opensearch` matcher type, `assume_role_arn/external_id` parameters as they are not supported yet.