### PR TITLE
Return predicate failed message in unified resource requests

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4598,6 +4598,14 @@ func TestListUnifiedResources_WithPredicate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Resources, 1)
 	require.Empty(t, resp.NextKey)
+
+	// fail with bad predicate expression
+	_, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		PredicateExpression: `labels.name == "tifa`,
+		Limit:               10,
+		SortBy:              types.SortBy{IsDesc: true, Field: types.ResourceMetadataName},
+	})
+	require.Error(t, err)
 }
 
 // go test ./lib/auth -bench=BenchmarkListUnifiedResources -run=^$ -v -benchtime 1x

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -210,6 +210,7 @@ func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey []byte, ma
 			iterateRange = tree.AscendRange
 			endKey = backend.RangeEnd(backend.Key(prefix))
 		}
+		var iteratorErr error
 		iterateRange(&item{Key: startKey}, &item{Key: endKey}, func(item *item) bool {
 			// get resource from resource map
 			resourceFromMap, ok := cache.resources[item.Value]
@@ -221,8 +222,9 @@ func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey []byte, ma
 			// check if the resource matches our filter
 			match, err := matchFn(resourceFromMap)
 			if err != nil {
-				// do something with this error eventually but continue for now
-				return true
+				iteratorErr = err
+				// stop the iterator so we can return the error
+				return false
 			}
 
 			if !match {
@@ -238,7 +240,7 @@ func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey []byte, ma
 			res = append(res, resourceFromMap)
 			return true
 		})
-		return nil
+		return iteratorErr
 	})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -269,7 +271,7 @@ func (c *UnifiedResourceCache) IterateUnifiedResources(ctx context.Context, matc
 	startKey := getStartKey(req)
 	result, nextKey, err := c.getRange(ctx, startKey, matchFn, req)
 	if err != nil {
-		return nil, "", trace.Wrap(err, "getting unified resource range")
+		return nil, "", trace.Wrap(err)
 	}
 
 	resources := make([]types.ResourceWithLabels, 0, len(result))
@@ -285,7 +287,7 @@ func (c *UnifiedResourceCache) GetUnifiedResources(ctx context.Context) ([]types
 	req := &proto.ListUnifiedResourcesRequest{Limit: backend.NoLimit, SortBy: types.SortBy{IsDesc: false, Field: sortByName}}
 	result, _, err := c.getRange(ctx, backend.Key(prefix), func(rwl types.ResourceWithLabels) (bool, error) { return true, nil }, req)
 	if err != nil {
-		return nil, trace.Wrap(err, "getting unified resource range")
+		return nil, trace.Wrap(err)
 	}
 
 	resources := make([]types.ResourceWithLabels, 0, len(result))
@@ -297,7 +299,7 @@ func (c *UnifiedResourceCache) GetUnifiedResources(ctx context.Context) ([]types
 }
 
 // GetUnifiedResourcesByIDs will take a list of ids and return any items found in the unifiedResourceCache tree by id and that return true from matchFn
-func (c *UnifiedResourceCache) GetUnifiedResourcesByIDs(ctx context.Context, ids []string, matchFn func(types.ResourceWithLabels) bool) ([]types.ResourceWithLabels, error) {
+func (c *UnifiedResourceCache) GetUnifiedResourcesByIDs(ctx context.Context, ids []string, matchFn func(types.ResourceWithLabels) (bool, error)) ([]types.ResourceWithLabels, error) {
 	var resources []types.ResourceWithLabels
 
 	err := c.read(ctx, func(cache *UnifiedResourceCache) error {
@@ -308,14 +310,18 @@ func (c *UnifiedResourceCache) GetUnifiedResourcesByIDs(ctx context.Context, ids
 				continue
 			}
 			resource := cache.resources[res.Value]
-			if matched := matchFn(resource); matched {
+			match, err := matchFn(resource)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if match {
 				resources = append(resources, resource.CloneResource())
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, trace.Wrap(err, "getting unified resources by id")
+		return nil, trace.Wrap(err)
 	}
 
 	return resources, nil
@@ -561,9 +567,9 @@ func (c *UnifiedResourceCache) read(ctx context.Context, fn func(cache *UnifiedR
 	c.mu.Lock()
 
 	if !c.stale {
-		fn(c)
+		err := fn(c)
 		c.mu.Unlock()
-		return nil
+		return err
 	}
 
 	c.mu.Unlock()
@@ -589,9 +595,9 @@ func (c *UnifiedResourceCache) read(ctx context.Context, fn func(cache *UnifiedR
 
 	if !c.stale {
 		// primary became healthy while we were waiting
-		fn(c)
+		err := fn(c)
 		c.mu.Unlock()
-		return nil
+		return err
 	}
 	c.mu.Unlock()
 
@@ -600,8 +606,8 @@ func (c *UnifiedResourceCache) read(ctx context.Context, fn func(cache *UnifiedR
 		return trace.Wrap(err)
 	}
 
-	fn(ttlCache)
-	return nil
+	err = fn(ttlCache)
+	return err
 }
 
 func (c *UnifiedResourceCache) notifyStale() {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1223,7 +1223,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	noAccessPack := proxy.authPack(t, "test-no-access@example.com", []types.Role{noAccessRole})
 
 	// shouldnt get any results with no access
-	query = url.Values{}
+	query = url.Values{"sort": []string{"name:asc"}}
 	re, err = noAccessPack.clt.Get(context.Background(), endpoint, query)
 	require.NoError(t, err)
 	res = clusterNodesGetResponse{}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -308,9 +308,12 @@ export function UnifiedResources<T>(props: UnifiedResourcesProps<T>) {
           <ErrorBoxInternal>
             <Danger>
               {attempt.statusText}
-              <Box flex="0 0 auto" ml={2}>
-                <ButtonLink onClick={onRetryClicked}>Retry</ButtonLink>
-              </Box>
+              {/* we don't want them to try another request with BAD REQUEST, it will just fail again. */}
+              {attempt.statusCode !== 400 && (
+                <Box flex="0 0 auto" ml={2}>
+                  <ButtonLink onClick={onRetryClicked}>Retry</ButtonLink>
+                </Box>
+              )}
             </Danger>
           </ErrorBoxInternal>
         </ErrorBox>

--- a/web/packages/shared/hooks/useAttemptNext.ts
+++ b/web/packages/shared/hooks/useAttemptNext.ts
@@ -55,6 +55,7 @@ export default function useAttemptNext(status = '' as Attempt['status']) {
 export type Attempt = {
   status: 'processing' | 'failed' | 'success' | '';
   statusText?: string;
+  statusCode?: number;
 };
 
 type Callback = (fn?: any) => Promise<any>;

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -18,6 +18,7 @@ import { useState, useRef, useCallback } from 'react';
 
 import { ResourcesResponse, ResourceFilter } from 'teleport/services/agents';
 import { UrlResourcesParams } from 'teleport/config';
+import { ApiError } from 'teleport/services/api/parseError';
 
 import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
 
@@ -132,7 +133,11 @@ export function useKeyBasedPagination<T>({
         setAttempt({ status: '', statusText: '' });
         return;
       }
-      setAttempt({ status: 'failed', statusText: err.message });
+      let statusCode;
+      if (err instanceof ApiError && err.response) {
+        statusCode = err.response.status;
+      }
+      setAttempt({ status: 'failed', statusText: err.message, statusCode });
     }
   };
 


### PR DESCRIPTION
This will properly return a match error during iteration or fetching by IDs so we can parse it on the UI. Currently, we "fail silently". 