### PR TITLE
Pin d3-color version to ^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "private": true,
   "resolutions": {
     "react": "16.14.0",
+    "**/d3-color": "^3.1.0",
     "**/minimist": "^1.2.8",
     "**/@types/react": "^16.9.49",
     "**/trim": "0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6526,12 +6526,7 @@ d3-array@2, d3-array@^2.3.0:
   dependencies:
     internmap "1 - 2"
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
-"d3-color@1 - 3", d3-color@^3.1.0:
+"d3-color@1 - 2", "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==


### PR DESCRIPTION
This PR attempts to update d3-color to 3.1.0 in order to address this Dependabot alert: https://github.com/gravitational/teleport/security/dependabot/211

This dependency is currently depended on via two channels from the root `nivo`: https://github.com/gravitational/teleport/blob/master/web/packages/e-imports/package.json#L8

`@nivo/colors@0.83.0` depends directly on `d3-color "^3.1.0"`, however `@nivo/core@0.83.0` depends on `d3-interpolate "^2.0.1"`.  And `d3-interplolate` `2.x` depends on `d3-color "1 - 2"`.

However when looking at the `d3` dependency chain we almost always see `d3-color` depended on as `d3-color "1 - 3"`.  For that reason I believe this is probably just an oversight by the `nivo` maintainers and we can likely safely pin this version to `3.x`