### PR TITLE
Always use lowercase when pinning resources

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -417,9 +417,9 @@ export function Resources() {
 
 export function resourceKey(resource: UnifiedResource) {
   if (resource.kind === 'node') {
-    return `${resource.hostname}/${resource.id}/node`;
+    return `${resource.hostname}/${resource.id}/node`.toLowerCase();
   }
-  return `${resource.name}/${resource.kind}`;
+  return `${resource.name}/${resource.kind}`.toLowerCase();
 }
 
 export function resourceName(resource: UnifiedResource) {


### PR DESCRIPTION
We recently made a change to sort our resources with a[ case-insensitive name](https://github.com/gravitational/teleport/pull/33470/files#diff-618cd82792a04bac0fd7d6beebdbbb16b689ddfbd58ac5c035578f13d37aac05R390-R393) to give the expected sorting order. This change to the frontend will make the key generator also lowercase. 

There were a couple ways to go about this. We could have
1. lowercased every ID before getting it in `GetUnifiedResourcesById`
2. lowercased the resource ID before storing it in the pinned resources preferences
3. the current approach.

Because we generate the key on the frontend, it seems best to lowercase it here, so that any interaction in the future will not have this issue.


Also, we could add a 'unified_resource_id' to all the resources stored in the cache but this change would be confusing for those resources like `Server` or `DatabaseServer` etc anywhere outside the context of the unified resource UI.

