### PR TITLE
[v12] Update Rust `tempfile` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,15 +1240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,16 +1510,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -27,7 +27,7 @@ png = "0.17.6"
 
 [build-dependencies]
 cbindgen = "0.24.3"
-tempfile = "3.3.0"
+tempfile = "=3.4.0"
 
 [features]
 fips = ["rdp-rs/fips"]


### PR DESCRIPTION
This was updated in `master` through https://github.com/gravitational/teleport/pull/22301

However it was never backported to v12.  Backporting to v12 to address GHSA-mc8h-8q98-g5hr - https://github.com/gravitational/teleport-sec-scan-3/security/dependabot/1