### PR TITLE
Remove CodeQL Scanning for release branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'master', 'branch/v12', 'branch/v13', 'branch/v14' ]
+        branch: [ 'master' ]
         language: [ 'go', 'javascript' ]
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'master' ]
+        branch: [ 'master' ] # release branches are scanned in teleport-sec-scan repos (see RFD 147)
         language: [ 'go', 'javascript' ]
 
     steps:

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -16,5 +16,3 @@ This checklist is to be run prior to cutting the release branch.
     `public.ecr.aws`
 - [ ] Update the list of OCI images to rebuild nightly in
   [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)
-- [ ] Update `.github/workflow/codeql.yml` configuration to list the new release
-  branch. The oldest release branch listed can simultaneously be removed.


### PR DESCRIPTION
In RFD 147 (PR #32233) we setup mirroring for the Teleport release branches to the `teleport-sec-scan` repos.  There are several advantages to moving the CodeQL scanning to these repos:
* It removes the manual process described in `preflight` to update the CodeQL scanning branch
* It solves the issue of alerts being repeatedly opened and closed as they are found on release branches and only fixed in master, for example: https://github.com/gravitational/teleport/security/code-scanning/560

CodeQL has already been configured on these repos and the initial findings triaged: https://github.com/gravitational/teleport-sec-scan-1/blob/master/.github/workflows/codeql-mirror.yml