### PR TITLE
Web: Redirect to login upon missing session cookie

### DIFF
--- a/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { render, screen, waitFor } from 'design/utils/testing';
+
+import session from 'teleport/services/websession';
+import { ApiError } from 'teleport/services/api/parseError';
+import api from 'teleport/services/api';
+import history from 'teleport/services/history';
+
+import Authenticated from './Authenticated';
+
+jest.mock('shared/libs/logger', () => {
+  const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  return {
+    create: () => mockLogger,
+  };
+});
+
+describe('session', () => {
+  beforeEach(() => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => true);
+    jest.spyOn(session, 'validateCookieAndSession').mockResolvedValue(null);
+    jest.spyOn(session, 'ensureSession').mockImplementation();
+    jest.spyOn(session, 'getInactivityTimeout').mockImplementation(() => 0);
+    jest.spyOn(session, 'clear').mockImplementation();
+    jest.spyOn(api, 'get').mockResolvedValue(null);
+    jest.spyOn(api, 'delete').mockResolvedValue(null);
+    jest.spyOn(history, 'goToLogin').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('valid session and valid cookie', async () => {
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    const targetEl = await screen.findByText(/hello world/i);
+
+    expect(targetEl).toBeInTheDocument();
+    expect(session.isValid).toHaveBeenCalledTimes(1);
+    expect(session.validateCookieAndSession).toHaveBeenCalledTimes(1);
+    expect(session.ensureSession).toHaveBeenCalledTimes(1);
+    expect(history.goToLogin).not.toHaveBeenCalled();
+  });
+
+  test('valid session and invalid cookie', async () => {
+    const mockForbiddenError = new ApiError('some error', {
+      status: 403,
+    } as Response);
+
+    jest
+      .spyOn(session, 'validateCookieAndSession')
+      .mockRejectedValue(mockForbiddenError);
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() => expect(history.goToLogin).toHaveBeenCalledTimes(1));
+    expect(session.clear).toHaveBeenCalledTimes(1);
+
+    expect(screen.queryByText(/hello world/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/go to login/i)).not.toBeInTheDocument();
+    expect(session.ensureSession).not.toHaveBeenCalled();
+  });
+
+  test('invalid session', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => false);
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() => expect(session.clear).toHaveBeenCalledTimes(1));
+    expect(history.goToLogin).toHaveBeenCalledTimes(1);
+
+    expect(screen.queryByText(/hello world/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/go to login/i)).not.toBeInTheDocument();
+    expect(session.validateCookieAndSession).not.toHaveBeenCalled();
+    expect(session.ensureSession).not.toHaveBeenCalled();
+  });
+
+  test('non-authenticated related error', async () => {
+    jest
+      .spyOn(session, 'validateCookieAndSession')
+      .mockRejectedValue(new Error('some network error'));
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    const targetEl = await screen.findByText('some network error');
+    expect(targetEl).toBeInTheDocument();
+
+    expect(screen.queryByText(/hello world/i)).not.toBeInTheDocument();
+    expect(session.ensureSession).not.toHaveBeenCalled();
+    expect(history.goToLogin).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
@@ -14,13 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { throttle } from 'shared/utils/highbar';
 import Logger from 'shared/libs/logger';
+import useAttempt from 'shared/hooks/useAttemptNext';
+import { getErrMessage } from 'shared/utils/errorType';
 
 import session from 'teleport/services/websession';
 import history from 'teleport/services/history';
 import localStorage from 'teleport/services/localStorage';
+import { ApiError } from 'teleport/services/api/parseError';
+
+import { ErrorDialogue } from './ErrorDialogue';
 
 const logger = Logger.create('/components/Authenticated');
 const ACTIVITY_CHECKER_INTERVAL_MS = 30 * 1000;
@@ -39,11 +44,37 @@ const events = [
 ];
 
 const Authenticated: React.FC = ({ children }) => {
-  React.useEffect(() => {
-    if (!session.isValid()) {
-      logger.warn('invalid session');
-      session.clear();
-      history.goToLogin(true);
+  const { attempt, setAttempt } = useAttempt('processing');
+
+  useEffect(() => {
+    const checkUserIsAuthenticated = async () => {
+      try {
+        if (!session.isValid()) {
+          logger.warn('invalid session');
+          session.clear();
+          history.goToLogin(true);
+          return;
+        }
+
+        await session.validateCookieAndSession();
+        setAttempt({ status: 'success' });
+      } catch (e) {
+        if (e instanceof ApiError && e.response?.status == 403) {
+          session.logout(true /* rememberLocation */);
+          // No need to update attempt, as `logout` will
+          // redirect user to login page.
+          return;
+        }
+        // Error unrelated to authentication failure (network blip).
+        setAttempt({ status: 'failed', statusText: getErrMessage(e) });
+      }
+    };
+
+    checkUserIsAuthenticated();
+  }, []);
+
+  useEffect(() => {
+    if (attempt.status !== 'success') {
       return;
     }
 
@@ -55,13 +86,17 @@ const Authenticated: React.FC = ({ children }) => {
     }
 
     return startActivityChecker(inactivityTtl);
-  }, []);
+  }, [attempt.status]);
 
-  if (!session.isValid()) {
-    return null;
+  if (attempt.status === 'success') {
+    return <>{children}</>;
   }
 
-  return <>{children}</>;
+  if (attempt.status === 'failed') {
+    return <ErrorDialogue errMsg={attempt.statusText} />;
+  }
+
+  return null;
 };
 
 export default Authenticated;

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
@@ -16,10 +16,10 @@
 
 import React from 'react';
 
-import { ErrorDialogue } from './ErrorDialogue';
+import { ErrorDialog } from './ErrorDialogue';
 
 export default {
   title: 'Teleport/Authenticate/ErrorDialogue',
 };
 
-export const Story = () => <ErrorDialogue errMsg="some error message" />;
+export const Story = () => <ErrorDialog errMsg="some error message" />;

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ErrorDialogue } from './ErrorDialogue';
+
+export default {
+  title: 'Teleport/Authenticate/ErrorDialogue',
+};
+
+export const Story = () => <ErrorDialogue errMsg="some error message" />;

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
@@ -25,7 +25,7 @@ import Dialog, {
 
 import history from 'teleport/services/history';
 
-export function ErrorDialogue({ errMsg }: { errMsg: string }) {
+export function ErrorDialog({ errMsg }: { errMsg: string }) {
   return (
     <Dialog
       dialogCss={() => ({ maxWidth: '500px', width: '100%' })}
@@ -36,7 +36,7 @@ export function ErrorDialogue({ errMsg }: { errMsg: string }) {
       </DialogHeader>
       <DialogContent>
         <Alert kind="danger" children={errMsg} />
-        <Text mb={3}>Try again by refreshing the browser.</Text>
+        <Text mb={3}>Try again by refreshing the page.</Text>
       </DialogContent>
       <DialogFooter>
         <ButtonSecondary

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Text, Alert, ButtonSecondary } from 'design';
+import Dialog, {
+  DialogHeader,
+  DialogTitle,
+  DialogContent,
+  DialogFooter,
+} from 'design/Dialog';
+
+import history from 'teleport/services/history';
+
+export function ErrorDialogue({ errMsg }: { errMsg: string }) {
+  return (
+    <Dialog
+      dialogCss={() => ({ maxWidth: '500px', width: '100%' })}
+      open={true}
+    >
+      <DialogHeader>
+        <DialogTitle>An error has occured</DialogTitle>
+      </DialogHeader>
+      <DialogContent>
+        <Alert kind="danger" children={errMsg} />
+        <Text mb={3}>Try again by refreshing the browser.</Text>
+      </DialogContent>
+      <DialogFooter>
+        <ButtonSecondary
+          onClick={() => history.goToLogin(true /* rememberLocation */)}
+        >
+          Go to Login
+        </ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -33,9 +33,9 @@ const logger = Logger.create('services/session');
 let sesstionCheckerTimerId = null;
 
 const session = {
-  logout() {
+  logout(rememberLocation = false) {
     api.delete(cfg.api.webSessionPath).finally(() => {
-      history.goToLogin();
+      history.goToLogin(rememberLocation);
     });
 
     this.clear();
@@ -75,6 +75,11 @@ const session = {
     return this._renewToken(req).then(token => token.sessionExpires);
   },
 
+  /**
+   * isValid first extracts bearer token from HTML if
+   * not already extracted and sets in the local storage.
+   * Then checks if token is not expired.
+   */
   isValid() {
     return this._timeLeft() > 0;
   },
@@ -190,12 +195,21 @@ const session = {
   },
 
   _fetchStatus() {
-    api.get(cfg.api.userStatusPath).catch(err => {
+    this.validateCookieAndSession().catch(err => {
       // this indicates that session is no longer valid (caused by server restarts or updates)
       if (err.response.status == 403) {
         this.logout();
       }
     });
+  },
+
+  /**
+   * validateCookieAndSessionFromBackend makes an authenticated request
+   * which just checks if the cookie sent from browser is valid and user
+   * session is still valid.
+   */
+  validateCookieAndSession() {
+    return api.get(cfg.api.userStatusPath);
   },
 
   _startTokenChecker() {

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -205,8 +205,7 @@ const session = {
 
   /**
    * validateCookieAndSessionFromBackend makes an authenticated request
-   * which just checks if the cookie sent from browser is valid and user
-   * session is still valid.
+   * which checks if the cookie and the user session are still valid.
    */
   validateCookieAndSession() {
     return api.get(cfg.api.userStatusPath);


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/20996

Why: We use [non-persistent (session) cookie](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#expire-and-max-age-attributes). When you close a browser, session cookies get cleared from the browser. Then when you re-open browser, load the teleport app, try to make a teleport api call to a protected endpoint [WithAuth](https://github.com/gravitational/teleport/blob/3c68797ea3ff5ec3cabc8f4bf9bdd68e641bb36b/lib/web/apiserver.go#L4038), it fails to authn because a cookie wasn't sent with the request.

There is three kind of dialogue shown depending on which webapp route you take.

#### AppLauncher component catches error (from trying to `getFqdn`)
Reproduce (chrome, but works on any browser): 
1) login to teleport and successfully launch an app
2) close the browser
3) reopen browser and launch the app (copy and paste app URL)

![image](https://github.com/gravitational/teleport/assets/43280172/b3d1db2c-7cc2-48dc-b7ab-1f7927c89d41)


#### Enterprise: the WaitingRoom catches error (from trying to `getUserContext`)
1) login to teleport
2) close the browser
3) reopen browser and go to some teleport URL

<img width="1112" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/045edc43-790f-44b0-9f9b-f02d42981661">

#### Open source: the root CatchError catches error (from trying to `getUserPreferences`)
<img width="591" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/f6657a9d-4524-45ce-9188-380fab83e341">



Our component tree looks like this:

```ts
<CatchError> // our root error catcher if the childrens did not  handle it
  <Authenticated>  // <----- where we should be checking validity of cookie and session
    <AppLauncher/>
    <WaitingRoom>   // only in enterprise
        {... childrens subjected to waiting room}
    </WaitingRoom>
  </Authenticated>
</CatchError>
```

Prior to this PR, in the `Authenticated` layer we were only checking for valid session stored in local storage. But gives false positives. Now we just make the api call to the `/status` endpoint right away and fail earlier in the tree (instead of 15 seconds later from starting an interval timer that polls this endpoint)

All the above scenarios, the user will be redirected to the login right away. On rare occassions where the `/status` just fails to fetch, this is what the user will see:

<img width="615" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/b85dd855-867d-4a1b-b75e-a913aaa5e566">


