### PR TITLE
refactor ExternalCloudAudit for bootstrap script

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -284,10 +284,10 @@ const (
 	KindExternalCloudAudit = "external_cloud_audit"
 	// MetaNameExternalCloudAuditDraft is the exact name of the singleton resource
 	// holding external cloud audit draft configuration.
-	MetaNameExternalCloudAuditDraft = "external-cloud-audit-draft"
+	MetaNameExternalCloudAuditDraft = "draft"
 	// MetaNameExternalCloudAuditCluster is the exact name of the singleton resource
 	// holding external cloud audit cluster configuration.
-	MetaNameExternalCloudAuditCluster = "external-cloud-audit-cluster"
+	MetaNameExternalCloudAuditCluster = "cluster"
 
 	// KindClusterConfig is the resource that holds cluster level configuration.
 	// Deprecated: This does not correspond to an actual resource anymore but is

--- a/api/types/externalcloudaudit/externalcloudaudit.go
+++ b/api/types/externalcloudaudit/externalcloudaudit.go
@@ -17,14 +17,25 @@ limitations under the License.
 package externalcloudaudit
 
 import (
+	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/aws"
+)
+
+const (
+	externalCloudAuditPolicyNamePrefix      = "ExternalCloudAuditPolicy-"
+	externalCloudAuditLongtermBucketPrefix  = "s3://teleport-longterm-"
+	externalCloudAuditTransientBucketPrefix = "s3://teleport-transient-"
 )
 
 // ExternalCloudAudit is internal representation of an external cloud audit resource.
@@ -84,6 +95,65 @@ func NewDraftExternalCloudAudit(metadata header.Metadata, spec ExternalCloudAudi
 	return externalaudit, nil
 }
 
+// GenerateDraftExternalCloudAudit creates a new draft ExternalCloudAudit with
+// randomized resource names.
+func GenerateDraftExternalCloudAudit(integrationName, region string) (*ExternalCloudAudit, error) {
+	// S3 bucket names can't use underscores, Glue tables can't use hyphens,
+	// Athena workgroups can use either.
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+	// https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
+	// https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings.html
+	nonce := uuid.NewString()
+	underscoreNonce := strings.ReplaceAll(nonce, "-", "_")
+	draft, err := NewDraftExternalCloudAudit(header.Metadata{},
+		ExternalCloudAuditSpec{
+			IntegrationName:        integrationName,
+			PolicyName:             externalCloudAuditPolicyNamePrefix + nonce,
+			Region:                 region,
+			SessionsRecordingsURI:  externalCloudAuditLongtermBucketPrefix + nonce + "/sessions",
+			AuditEventsLongTermURI: externalCloudAuditLongtermBucketPrefix + nonce + "/events",
+			AthenaResultsURI:       externalCloudAuditTransientBucketPrefix + nonce + "/results",
+			AthenaWorkgroup:        "teleport_events_" + underscoreNonce,
+			GlueDatabase:           "teleport_events_" + underscoreNonce,
+			GlueTable:              "teleport_events",
+		})
+	return draft, trace.Wrap(err)
+}
+
+var (
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+	matchS3BucketName = regexp.MustCompile(`^[a-z0-9\.-]{3,63}$`).MatchString
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+	// Taken from the "safe characters" list + /, more restrictive than required.
+	matchS3Prefix = regexp.MustCompile(`^[a-zA-Z0-9!_.*'()/-]{0,512}$`).MatchString
+)
+
+// ValidateS3URI validates a URI indicating an S3 bucket and prefix for storing
+// audit logs (session recordings or events).
+func ValidateS3URI(uri string) error {
+	// s3:// + at least 3 char bucket name = 8
+	if len(uri) < 8 {
+		return trace.BadParameter("S3 URI too short")
+	}
+	// s3:// + 63 char bucket name + / + 1024 char key = 1093
+	// ^ this would be the absolute max but we need room after the prefix to
+	// store records, so I'll arbitrarily set a limit of 512 here
+	if len(uri) > 512 {
+		return trace.BadParameter("max length of S3 URI is 512 characters")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return trace.BadParameter("S3 URI failed to parse")
+	}
+	if !matchS3BucketName(u.Host) {
+		return trace.BadParameter("S3 bucket name %q includes illegal special character", u.Host)
+	}
+	if !matchS3Prefix(u.Path) {
+		return trace.BadParameter("S3 prefix %q includes illegal special character", u.Path)
+	}
+	return nil
+}
+
 // NewClusterExternalCloudAudit will create a new cluster external cloud audit.
 func NewClusterExternalCloudAudit(metadata header.Metadata, spec ExternalCloudAuditSpec) (*ExternalCloudAudit, error) {
 	externalaudit := &ExternalCloudAudit{
@@ -108,8 +178,12 @@ func NewClusterExternalCloudAudit(metadata header.Metadata, spec ExternalCloudAu
 // CheckAndSetDefaults validates fields and populates empty fields with default values.
 func (a *ExternalCloudAudit) CheckAndSetDefaults() error {
 	a.SetKind(types.KindExternalCloudAudit)
-	a.SetVersion(types.V1)
 	a.SetExpiry(time.Time{})
+	if version := a.GetVersion(); len(version) == 0 {
+		a.SetVersion(types.V1)
+	} else if version != types.V1 {
+		return trace.BadParameter("unrecognized external_cloud_audit version %q", version)
+	}
 
 	if err := a.ResourceHeader.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
@@ -118,29 +192,29 @@ func (a *ExternalCloudAudit) CheckAndSetDefaults() error {
 	if a.Spec.IntegrationName == "" {
 		return trace.BadParameter("external cloud audit integration_name required")
 	}
-	if a.Spec.PolicyName == "" {
-		return trace.BadParameter("external cloud audit policy_name required")
+	if err := aws.IsValidIAMPolicyName(a.Spec.PolicyName); err != nil {
+		return trace.Wrap(err, "validating policy_name")
 	}
-	if a.Spec.Region == "" {
-		return trace.BadParameter("external cloud audit region required")
+	if err := aws.IsValidRegion(a.Spec.Region); err != nil {
+		return trace.Wrap(err, "validating region")
 	}
-	if a.Spec.SessionsRecordingsURI == "" {
-		return trace.BadParameter("external cloud audit sessions_recordings_uri required")
+	if err := ValidateS3URI(a.Spec.SessionsRecordingsURI); err != nil {
+		return trace.Wrap(err, "validating sessions_recordings_uri")
 	}
-	if a.Spec.AthenaWorkgroup == "" {
-		return trace.BadParameter("external cloud audit athena_workgroup required")
+	if err := ValidateS3URI(a.Spec.AuditEventsLongTermURI); err != nil {
+		return trace.Wrap(err, "validating audit_events_long_term_uri")
 	}
-	if a.Spec.GlueDatabase == "" {
-		return trace.BadParameter("external cloud audit glue_database required")
+	if err := ValidateS3URI(a.Spec.AthenaResultsURI); err != nil {
+		return trace.Wrap(err, "validating athena_results_uri")
 	}
-	if a.Spec.GlueTable == "" {
-		return trace.BadParameter("external cloud audit glue_table required")
+	if err := aws.IsValidAthenaWorkgroupName(a.Spec.AthenaWorkgroup); err != nil {
+		return trace.Wrap(err, "validating athena_workgroup")
 	}
-	if a.Spec.AuditEventsLongTermURI == "" {
-		return trace.BadParameter("external cloud audit audit_events_long_term_uri required")
+	if err := aws.IsValidGlueResourceName(a.Spec.GlueDatabase); err != nil {
+		return trace.Wrap(err, "validating glue_database")
 	}
-	if a.Spec.AthenaResultsURI == "" {
-		return trace.BadParameter("external cloud audit athena_results_uri required")
+	if err := aws.IsValidGlueResourceName(a.Spec.GlueTable); err != nil {
+		return trace.Wrap(err, "validating glue_table")
 	}
 
 	return nil

--- a/api/utils/aws/identifiers.go
+++ b/api/utils/aws/identifiers.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -52,6 +53,20 @@ func IsValidIAMRoleName(roleName string) error {
 	return nil
 }
 
+// IsValidIAMPolicyName checks whether the policy name is a valid AWS IAM Policy
+// identifier.
+//
+// > Length Constraints: Minimum length of 1. Maximum length of 128.
+// > Pattern: [\w+=,.@-]+
+// https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html
+func IsValidIAMPolicyName(policyName string) error {
+	// The same regex is used for role and policy names.
+	if len(policyName) == 0 || len(policyName) > 128 || !matchRoleName(policyName) {
+		return trace.BadParameter("policy name is invalid")
+	}
+	return nil
+}
+
 // IsValidRegion ensures the region looks to be valid.
 // It does not do a full validation, because AWS doesn't provide documentation for that.
 // However, they usually only have the following chars: [a-z0-9\-]
@@ -60,6 +75,32 @@ func IsValidRegion(region string) error {
 		return nil
 	}
 	return trace.BadParameter("region %q is invalid", region)
+}
+
+// IsValidPartition checks if partition is a valid AWS partition
+func IsValidPartition(partition string) error {
+	if slices.Contains(validPartitions, partition) {
+		return nil
+	}
+	return trace.BadParameter("partition %q is invalid", partition)
+}
+
+// IsValidAthenaWorkgroupName checks whether the name is a valid AWS Athena
+// workgroup name.
+func IsValidAthenaWorkgroupName(workgroup string) error {
+	if matchAthenaWorkgroupName(workgroup) {
+		return nil
+	}
+	return trace.BadParameter("athena workgroup name %q is invalid", workgroup)
+}
+
+// IsValidGlueResourceName check whether the name is valid for an AWS Glue
+// database or table used with AWS Athena
+func IsValidGlueResourceName(name string) error {
+	if matchGlueName(name) {
+		return nil
+	}
+	return trace.BadParameter("glue resource name %q is invalid", name)
 }
 
 const (
@@ -117,4 +158,18 @@ var (
 	// Reference:
 	// https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/smithy-aws-go-codegen/src/main/resources/software/amazon/smithy/aws/go/codegen/endpoints.json
 	matchRegion = regexp.MustCompile(`^[a-z]{2}(-gov|-iso|-isob)?-\w+-\d+$`)
+
+	// https://docs.aws.amazon.com/athena/latest/APIReference/API_CreateWorkGroup.html
+	matchAthenaWorkgroupName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`).MatchString
+
+	// https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
+	// More strict than strictly necessary, but a good baseline
+	// > database, table, and column names must be 255 characters or fewer
+	// > Athena accepts mixed case in DDL and DML queries, but lower cases the names when it executes the query
+	// > avoid using mixed case for table or column names
+	// > special characters other than underscore (_) are not supported
+	matchGlueName = regexp.MustCompile(`^[a-z0-9_]{1,255}$`).MatchString
+
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+	validPartitions = []string{"aws", "aws-cn", "aws-us-gov"}
 )

--- a/api/utils/aws/identifiers_test.go
+++ b/api/utils/aws/identifiers_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsValidAccountID(t *testing.T) {
-	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
-		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-	}
+func isBadParamErrFn(t require.TestingT, err error, i ...any) {
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+}
 
+func TestIsValidAccountID(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		accountID string
@@ -77,10 +77,6 @@ func TestIsValidAccountID(t *testing.T) {
 }
 
 func TestIsValidIAMRoleName(t *testing.T) {
-	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
-		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-	}
-
 	for _, tt := range []struct {
 		name     string
 		role     string
@@ -128,11 +124,55 @@ func TestIsValidIAMRoleName(t *testing.T) {
 	}
 }
 
-func TestIsValidRegion(t *testing.T) {
-	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
-		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+func TestIsValidIAMPolicyName(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		policy   string
+		errCheck require.ErrorAssertionFunc
+	}{
+		{
+			name:     "valid",
+			policy:   "valid",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "valid with numbers",
+			policy:   "00VALID11",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "only one symbol",
+			policy:   "_",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "all symbols",
+			policy:   "Test+1=2,3.4@5-6_7",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "empty",
+			policy:   "",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "too large",
+			policy:   strings.Repeat("p", 129),
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "invalid symbols",
+			policy:   "policy/admin",
+			errCheck: isBadParamErrFn,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidIAMPolicyName(tt.policy))
+		})
 	}
+}
 
+func TestIsValidRegion(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		region   string
@@ -181,10 +221,6 @@ func TestIsValidRegion(t *testing.T) {
 }
 
 func TestCheckRoleARN(t *testing.T) {
-	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
-		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-	}
-
 	for _, tt := range []struct {
 		name     string
 		arn      string
@@ -243,6 +279,110 @@ func TestCheckRoleARN(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.errCheck(t, CheckRoleARN(tt.arn))
+		})
+	}
+}
+
+func TestIsValidPartition(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		partition string
+		errCheck  require.ErrorAssertionFunc
+	}{
+		{
+			name:      "aws",
+			partition: "aws",
+			errCheck:  require.NoError,
+		},
+		{
+			name:      "china",
+			partition: "aws-cn",
+			errCheck:  require.NoError,
+		},
+		{
+			name:      "govcloud",
+			partition: "aws-us-gov",
+			errCheck:  require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidPartition(tt.partition))
+		})
+	}
+}
+
+func TestIsValidAthenaWorkgroupName(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		workgroup string
+		errCheck  require.ErrorAssertionFunc
+	}{
+		{
+			name:      "valid",
+			workgroup: "test-Workgroup-123_456",
+			errCheck:  require.NoError,
+		},
+		{
+			name:      "empty",
+			workgroup: "",
+			errCheck:  isBadParamErrFn,
+		},
+		{
+			name:      "too long",
+			workgroup: strings.Repeat("w", 129),
+			errCheck:  isBadParamErrFn,
+		},
+		{
+			name:      "symbols",
+			workgroup: "!bad%workgroup",
+			errCheck:  isBadParamErrFn,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidAthenaWorkgroupName(tt.workgroup))
+		})
+	}
+}
+
+func TestIsValidGlueResourceName(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		resourceName string
+		errCheck     require.ErrorAssertionFunc
+	}{
+		{
+			name:         "valid",
+			resourceName: "test_database_123_456",
+			errCheck:     require.NoError,
+		},
+		{
+			name:         "empty",
+			resourceName: "",
+			errCheck:     isBadParamErrFn,
+		},
+		{
+			name:         "too long",
+			resourceName: strings.Repeat("g", 256),
+			errCheck:     isBadParamErrFn,
+		},
+		{
+			name:         "hyphen",
+			resourceName: "bad-table",
+			errCheck:     isBadParamErrFn,
+		},
+		{
+			name:         "capital",
+			resourceName: "bad-Table",
+			errCheck:     isBadParamErrFn,
+		},
+		{
+			name:         "symbols",
+			resourceName: "!bad%table",
+			errCheck:     isBadParamErrFn,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidGlueResourceName(tt.resourceName))
 		})
 	}
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -213,9 +213,9 @@ type CommandLineFlags struct {
 	// `teleport integration configure listdatabases-iam` command
 	IntegrationConfListDatabasesIAMArguments IntegrationConfListDatabasesIAM
 
-	// IntegrationConfExternalCloudAuditIAMArguments contains the arguments of the
-	// `teleport integration configure externalcloudaudit-iam` command
-	IntegrationConfExternalCloudAuditIAMArguments IntegrationConfExternalCloudAuditIAM
+	// IntegrationConfExternalCloudAuditArguments contains the arguments of the
+	// `teleport integration configure externalcloudaudit` command
+	IntegrationConfExternalCloudAuditArguments IntegrationConfExternalCloudAudit
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -267,9 +267,11 @@ type IntegrationConfListDatabasesIAM struct {
 	Role string
 }
 
-// IntegrationConfExternalCloudAuditIAM contains the arguments of the
+// IntegrationConfExternalCloudAudit contains the arguments of the
 // `teleport integration configure externalcloudaudit-iam` command
-type IntegrationConfExternalCloudAuditIAM struct {
+type IntegrationConfExternalCloudAudit struct {
+	// Bootstrap is whether to bootstrap infrastructure (default: false).
+	Bootstrap bool
 	// Region is the AWS Region used.
 	Region string
 	// Role is the AWS IAM Role associated with the OIDC integration.
@@ -288,7 +290,7 @@ type IntegrationConfExternalCloudAuditIAM struct {
 	GlueDatabase string
 	// GlueTable is the name of the Glue table used.
 	GlueTable string
-	// Partition is the AWS partition to use (optional).
+	// Partition is the AWS partition to use (default: aws).
 	Partition string
 }
 

--- a/lib/integrations/awsoidc/externalcloudaudit_iam_config.go
+++ b/lib/integrations/awsoidc/externalcloudaudit_iam_config.go
@@ -61,7 +61,7 @@ func (d *DefaultConfigureExternalCloudAuditClient) GetCallerIdentity(ctx context
 func ConfigureExternalCloudAudit(
 	ctx context.Context,
 	clt ConfigureExternalCloudAuditClient,
-	params *config.IntegrationConfExternalCloudAuditIAM,
+	params *config.IntegrationConfExternalCloudAudit,
 ) error {
 	policyCfg := &awslib.ExternalCloudAuditPolicyConfig{
 		Partition:           params.Partition,

--- a/lib/integrations/awsoidc/externalcloudaudit_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalcloudaudit_iam_config_test.go
@@ -37,7 +37,7 @@ func TestConfigureExternalCloudAudit(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc                 string
-		params               *config.IntegrationConfExternalCloudAuditIAM
+		params               *config.IntegrationConfExternalCloudAudit
 		stsAccount           string
 		existingRolePolicies map[string]map[string]string
 		expectedRolePolicies map[string]map[string]string
@@ -46,7 +46,7 @@ func TestConfigureExternalCloudAudit(t *testing.T) {
 		{
 			// A passing case with the account from sts:GetCallerIdentity
 			desc: "passing",
-			params: &config.IntegrationConfExternalCloudAuditIAM{
+			params: &config.IntegrationConfExternalCloudAudit{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -115,7 +115,7 @@ func TestConfigureExternalCloudAudit(t *testing.T) {
 		},
 		{
 			desc: "alternate partition and region",
-			params: &config.IntegrationConfExternalCloudAuditIAM{
+			params: &config.IntegrationConfExternalCloudAudit{
 				Partition:            "aws-cn",
 				Region:               "cn-north-1",
 				Role:                 "test-role",
@@ -184,7 +184,7 @@ func TestConfigureExternalCloudAudit(t *testing.T) {
 		},
 		{
 			desc: "bad uri",
-			params: &config.IntegrationConfExternalCloudAuditIAM{
+			params: &config.IntegrationConfExternalCloudAudit{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -206,7 +206,7 @@ func TestConfigureExternalCloudAudit(t *testing.T) {
 		},
 		{
 			desc: "role not found",
-			params: &config.IntegrationConfExternalCloudAuditIAM{
+			params: &config.IntegrationConfExternalCloudAudit{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "bad-role",

--- a/lib/services/externalcloudaudit_test.go
+++ b/lib/services/externalcloudaudit_test.go
@@ -98,7 +98,7 @@ var draftExternalAuditYAML = `---
 kind: external_cloud_audit
 version: v1
 metadata:
-  name: external-cloud-audit-draft
+  name: draft
 spec:
   integration_name: "aws-integration-1"
   policy_name: "test-policy-1"
@@ -115,7 +115,7 @@ var clusterExternalAuditYAML = `---
 kind: external_cloud_audit
 version: v1
 metadata:
-  name: external-cloud-audit-cluster
+  name: cluster
 spec:
   integration_name: "aws-integration-1"
   policy_name: "test-policy-1"

--- a/lib/services/local/externalcloudaudit_test.go
+++ b/lib/services/local/externalcloudaudit_test.go
@@ -167,10 +167,9 @@ func TestExternalCloudAuditService(t *testing.T) {
 
 		// Then draft is returned with generated values
 		spec := generateResp.Spec
-		nonce := strings.TrimPrefix(spec.PolicyName, externalCloudAuditPolicyNamePrefix)
+		nonce := strings.TrimPrefix(spec.PolicyName, "ExternalCloudAuditPolicy-")
 		underscoreNonce := strings.ReplaceAll(nonce, "-", "_")
 		require.Equal(t, "test-integration", spec.IntegrationName)
-		require.Equal(t, externalCloudAuditPolicyNamePrefix+nonce, spec.PolicyName)
 		require.Equal(t, "us-west-2", spec.Region)
 		require.Equal(t, "s3://teleport-longterm-"+nonce+"/sessions", spec.SessionsRecordingsURI)
 		require.Equal(t, "s3://teleport-longterm-"+nonce+"/events", spec.AuditEventsLongTermURI)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -474,17 +474,18 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfListDatabasesCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Region)
 	integrationConfListDatabasesCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Role)
 
-	integrationConfExternalAuditCmd := integrationConfigureCmd.Command("externalcloudaudit-iam", "Adds required IAM permissions for external cloud audit logs")
-	integrationConfExternalAuditCmd.Flag("aws-region", "AWS region.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.Region)
-	integrationConfExternalAuditCmd.Flag("role", "The IAM Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.Role)
-	integrationConfExternalAuditCmd.Flag("policy", "The name for the Policy to attach to the IAM role.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.Policy)
-	integrationConfExternalAuditCmd.Flag("session-recordings", "The S3 URI where session recordings are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.SessionRecordingsURI)
-	integrationConfExternalAuditCmd.Flag("audit-events", "The S3 URI where audit events are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.AuditEventsURI)
-	integrationConfExternalAuditCmd.Flag("athena-results", "The S3 URI where athena results are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.AthenaResultsURI)
-	integrationConfExternalAuditCmd.Flag("athena-workgroup", "The name of the Athena workgroup used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.AthenaWorkgroup)
-	integrationConfExternalAuditCmd.Flag("glue-database", "The name of the Glue database used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.GlueDatabase)
-	integrationConfExternalAuditCmd.Flag("glue-table", "The name of the Glue table used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.GlueTable)
-	integrationConfExternalAuditCmd.Flag("aws-partition", "AWS partition (default: aws).").Default("aws").StringVar(&ccf.IntegrationConfExternalCloudAuditIAMArguments.Partition)
+	integrationConfExternalAuditCmd := integrationConfigureCmd.Command("externalcloudaudit", "Bootstraps required infrastructure and adds required IAM permissions for external cloud audit logs")
+	integrationConfExternalAuditCmd.Flag("bootstrap", "Bootstrap required infrastructure.").Default("false").BoolVar(&ccf.IntegrationConfExternalCloudAuditArguments.Bootstrap)
+	integrationConfExternalAuditCmd.Flag("aws-region", "AWS region.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.Region)
+	integrationConfExternalAuditCmd.Flag("role", "The IAM Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.Role)
+	integrationConfExternalAuditCmd.Flag("policy", "The name for the Policy to attach to the IAM role.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.Policy)
+	integrationConfExternalAuditCmd.Flag("session-recordings", "The S3 URI where session recordings are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.SessionRecordingsURI)
+	integrationConfExternalAuditCmd.Flag("audit-events", "The S3 URI where audit events are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.AuditEventsURI)
+	integrationConfExternalAuditCmd.Flag("athena-results", "The S3 URI where athena results are stored.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.AthenaResultsURI)
+	integrationConfExternalAuditCmd.Flag("athena-workgroup", "The name of the Athena workgroup used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.AthenaWorkgroup)
+	integrationConfExternalAuditCmd.Flag("glue-database", "The name of the Glue database used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.GlueDatabase)
+	integrationConfExternalAuditCmd.Flag("glue-table", "The name of the Glue table used.").Required().StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.GlueTable)
+	integrationConfExternalAuditCmd.Flag("aws-partition", "AWS partition (default: aws).").Default("aws").StringVar(&ccf.IntegrationConfExternalCloudAuditArguments.Partition)
 
 	// parse CLI commands+flags:
 	utils.UpdateAppUsageTemplate(app, options.Args)
@@ -580,7 +581,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	case integrationConfListDatabasesCmd.FullCommand():
 		err = onIntegrationConfListDatabasesIAM(ccf.IntegrationConfListDatabasesIAMArguments)
 	case integrationConfExternalAuditCmd.FullCommand():
-		err = onIntegrationConfExternalAuditCmd(ccf.IntegrationConfExternalCloudAuditIAMArguments)
+		err = onIntegrationConfExternalAuditCmd(ccf.IntegrationConfExternalCloudAuditArguments)
 	}
 	if err != nil {
 		utils.FatalError(err)
@@ -1007,7 +1008,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params config.IntegrationConfExternalCloudAuditIAM) error {
+func onIntegrationConfExternalAuditCmd(params config.IntegrationConfExternalCloudAudit) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {


### PR DESCRIPTION
This commit refactors some of the `ExternalCloudAudit` code to facilitate the [linked teleport.e PR](https://github.com/gravitational/teleport.e/pull/2488) which adds endpoints to generate a new ExternalCloudAudit configures and a one-off teleport script for bootstrapping the required resources and configuring IAM permissions.

note to self: fix e ref before merging