### PR TITLE
Improve UX for headless kube proxy by giving user more time when reissuing expired certificates

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -34,7 +34,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgconn"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -568,9 +567,12 @@ func mustCreateKubeLocalProxyMiddleware(t *testing.T, teleportCluster, kubeClust
 	certs := make(alpnproxy.KubeClientCerts)
 	certs.Add(teleportCluster, kubeCluster, cert)
 
-	return alpnproxy.NewKubeMiddleware(certs, func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
-		return tls.Certificate{}, nil
-	}, clockwork.NewRealClock(), nil)
+	return alpnproxy.NewKubeMiddleware(alpnproxy.KubeMiddlewareConfig{
+		Certs: certs,
+		CertReissuer: func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
+			return tls.Certificate{}, nil
+		},
+	})
 }
 
 func makeNodeConfig(nodeName, proxyAddr string) *servicecfg.Config {

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -83,9 +83,8 @@ type Values struct {
 	// SelectCluster is the name of the kubernetes cluster to set in
 	// current-context.
 	SelectCluster string
-	// OverrideContext is the name of the context to set when adding a new cluster.
+	// OverrideContext is the name of the context or template used when adding a new cluster.
 	// If empty, the context name will be generated from the {teleport-cluster}-{kube-cluster}.
-	// It can only be used when adding a single cluster.
 	OverrideContext string
 }
 

--- a/lib/kube/kubeconfig/localproxy_test.go
+++ b/lib/kube/kubeconfig/localproxy_test.go
@@ -161,8 +161,9 @@ func TestLocalProxy(t *testing.T) {
 			}},
 		}
 
-		newConfig := CreateLocalProxyConfig(&initialConfig, values)
-		err := Save(kubeconfigPath, *newConfig)
+		newConfig, err := CreateLocalProxyConfig(&initialConfig, values)
+		require.NoError(t, err)
+		err = Save(kubeconfigPath, *newConfig)
 		require.NoError(t, err)
 
 		generatedConfig, err := Load(kubeconfigPath)

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -553,7 +553,11 @@ func TestKubeMiddleware(t *testing.T) {
 					ServerName: tt.reqClusterName,
 				},
 			}
-			km := NewKubeMiddleware(tt.startCerts, certReissuer, tt.clock, nil)
+			km := NewKubeMiddleware(KubeMiddlewareConfig{
+				Certs:        tt.startCerts,
+				CertReissuer: certReissuer,
+				Clock:        tt.clock,
+			})
 
 			// HandleRequest will reissue certificate if needed
 			km.HandleRequest(responsewriters.NewMemoryResponseWriter(), &req)

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -205,7 +205,10 @@ func (k *kube) writeKubeconfig(key *keys.PrivateKey, cas map[string]tls.Certific
 		},
 	}
 
-	config := kubeconfig.CreateLocalProxyConfig(clientcmdapi.NewConfig(), values)
+	config, err := kubeconfig.CreateLocalProxyConfig(clientcmdapi.NewConfig(), values)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	if err := kubeconfig.Save(k.KubeconfigPath(), *config); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -133,7 +133,12 @@ func (k *kube) makeKubeMiddleware() (alpnproxy.LocalProxyHTTPMiddleware, error) 
 
 	certs := make(alpnproxy.KubeClientCerts)
 	certs.Add(k.cfg.ClusterName, k.cfg.TargetName, cert)
-	return alpnproxy.NewKubeMiddleware(certs, certReissuer.reissueCert, k.cfg.Clock, k.cfg.Log), nil
+	return alpnproxy.NewKubeMiddleware(alpnproxy.KubeMiddlewareConfig{
+		Certs:        certs,
+		CertReissuer: certReissuer.reissueCert,
+		Clock:        k.cfg.Clock,
+		Logger:       k.cfg.Log,
+	}), nil
 }
 
 func (k *kube) makeForwardProxyForKube() error {

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -421,7 +421,7 @@ func makeAndStartKubeLocalProxy(cf *CLIConf, config *clientcmdapi.Config, cluste
 		return nil, "", trace.Wrap(err)
 	}
 
-	localProxy, err := makeKubeLocalProxy(cf, tc, clusters, config, cf.LocalProxyPort)
+	localProxy, err := makeKubeLocalProxy(cf, tc, clusters, config, cf.LocalProxyPort, "")
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR improves convenience of UX when running local kube proxy in headless mode. When local kube proxy works in regular mode we have short timeout before returning error to the client while reissuing expired certificates, because we want to attract their attention to the terminal with the proxy. But when running in headless mode user is already working in the reexeced shell and sees that they need to relogin, so we wait for longer to let user to perform headless login flow.

Changelog: Added support for "--set-context-name" to "tsh proxy kube"

Closes #33761