### PR TITLE
[v13] Require SSH prefix in when proxying connection to a host

### DIFF
--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -294,6 +294,7 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 }
 
 // checkedPrefixReader checks that read data has the specified prefix.
+// All changes should be mirrored to the implementation to 'checkedPrefixConn' in /lib/srv/transport/transportv1/transport.go
 type checkedPrefixReader struct {
 	io.ReadWriteCloser
 

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -320,7 +320,7 @@ func (c *checkedPrefixReader) Read(b []byte) (int, error) {
 
 	if !bytes.HasPrefix(big, small) {
 		c.requiredPointer = -1
-		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
+		return 0, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 
 	// Advance pointer by confirmed portion of the prefix.

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -302,9 +302,12 @@ type checkedPrefixReader struct {
 }
 
 func (c *checkedPrefixReader) Read(b []byte) (int, error) {
-	// If pointer reached end of required prefix the check is done.
 	if len(c.requiredPrefix) == c.requiredPointer {
+		// If pointer reached end of required prefix the check was already successful.
 		return c.ReadWriteCloser.Read(b)
+	} else if c.requiredPointer < 0 {
+		// If it's negative, it means check has already failed
+		return 0, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 
 	n, err := c.ReadWriteCloser.Read(b)
@@ -316,6 +319,7 @@ func (c *checkedPrefixReader) Read(b []byte) (int, error) {
 	}
 
 	if !bytes.HasPrefix(big, small) {
+		c.requiredPointer = -1
 		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -354,6 +354,7 @@ func getDestinationAddress(clientSrc, listenerAddr net.Addr) (net.Addr, error) {
 }
 
 // checkedPrefixConn checks that read data has the specified prefix.
+// All changes should be mirrored to the implementation to 'checkedPrefixReader' in /lib/srv/regular/proxy.go
 type checkedPrefixConn struct {
 	net.Conn
 

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -15,6 +15,7 @@
 package transportv1
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -310,6 +311,12 @@ func (s *Service) ProxySSH(stream transportv1pb.TransportService_ProxySSHServer)
 		return trace.Wrap(err, "failed sending cluster details ")
 	}
 
+	hostConn = &checkedPrefixConn{
+		Conn: hostConn,
+		// SSH connection MUST start with "SSH-2.0" bytes according to https://datatracker.ietf.org/doc/html/rfc4253#section-4.2
+		requiredPrefix: []byte("SSH-2.0"),
+	}
+
 	// copy data to/from the host/user
 	return trace.Wrap(utils.ProxyConn(monitorCtx, hostConn, userConn))
 }
@@ -344,6 +351,38 @@ func getDestinationAddress(clientSrc, listenerAddr net.Addr) (net.Addr, error) {
 		IP:   net.IPv6loopback,
 		Port: int(la.Port()),
 	}, nil
+}
+
+// checkedPrefixConn checks that read data has the specified prefix.
+type checkedPrefixConn struct {
+	net.Conn
+
+	requiredPrefix  []byte
+	requiredPointer int
+}
+
+func (c *checkedPrefixConn) Read(b []byte) (int, error) {
+	// If pointer reached end of required prefix the check is done.
+	if len(c.requiredPrefix) == c.requiredPointer {
+		return c.Conn.Read(b)
+	}
+
+	n, err := c.Conn.Read(b)
+
+	// Decide which is smaller, read data or remaining portion of the required prefix
+	small, big := c.requiredPrefix[c.requiredPointer:], b[:n]
+	if len(small) > len(big) {
+		big, small = small, big
+	}
+
+	if !bytes.HasPrefix(big, small) {
+		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
+	}
+
+	// Advance pointer by confirmed portion of the prefix.
+	c.requiredPointer += len(small)
+
+	return n, err
 }
 
 // sshStream implements the [streamutils.Source] interface


### PR DESCRIPTION
Logical backport #33000 to branch/v13

It's not identical backport - I returned to first version of the original PR with checking read side - we can't put restriction on the write side inside `router.DialHost()` because there's a chance we'll do handshake with ProxyHelloSignature for old nodes. Also covers transport's `ProxySSH()` (`checkedPrefixConn` is identical to `checkedPrefixReader` but over `net.Conn`) .