### PR TITLE
[v12] Require SSH prefix when proxying connection to a host

### DIFF
--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -292,9 +292,12 @@ type checkedPrefixReader struct {
 }
 
 func (c *checkedPrefixReader) Read(b []byte) (int, error) {
-	// If pointer reached end of required prefix the check is done.
 	if len(c.requiredPrefix) == c.requiredPointer {
+		// If pointer reached end of required prefix the check was already successful.
 		return c.ReadWriteCloser.Read(b)
+	} else if c.requiredPointer < 0 {
+		// If it's negative, it means check has already failed
+		return 0, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 
 	n, err := c.ReadWriteCloser.Read(b)
@@ -306,6 +309,7 @@ func (c *checkedPrefixReader) Read(b []byte) (int, error) {
 	}
 
 	if !bytes.HasPrefix(big, small) {
+		c.requiredPointer = -1
 		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -270,10 +270,49 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 	if teleportVersion != "" && utils.CheckVersion(teleportVersion, utils.MinIPPropagationVersion) != nil {
 		t.doHandshake(ctx, clientSrcAddr, ch, conn)
 	}
+
+	checkedReader := &checkedPrefixReader{
+		ReadWriteCloser: ch,
+		// SSH connection MUST start with "SSH-2.0" bytes according to https://datatracker.ietf.org/doc/html/rfc4253#section-4.2
+		requiredPrefix: []byte("SSH-2.0"),
+	}
+
 	go func() {
-		t.close(utils.ProxyConn(ctx, ch, conn))
+		t.close(utils.ProxyConn(ctx, checkedReader, conn))
 	}()
 	return nil
+}
+
+// checkedPrefixReader checks that read data has the specified prefix.
+type checkedPrefixReader struct {
+	io.ReadWriteCloser
+
+	requiredPrefix  []byte
+	requiredPointer int
+}
+
+func (c *checkedPrefixReader) Read(b []byte) (int, error) {
+	// If pointer reached end of required prefix the check is done.
+	if len(c.requiredPrefix) == c.requiredPointer {
+		return c.ReadWriteCloser.Read(b)
+	}
+
+	n, err := c.ReadWriteCloser.Read(b)
+
+	// Decide which is smaller, read data or remaining portion of the required prefix
+	small, big := c.requiredPrefix[c.requiredPointer:], b[:n]
+	if len(small) > len(big) {
+		big, small = small, big
+	}
+
+	if !bytes.HasPrefix(big, small) {
+		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
+	}
+
+	// Advance pointer by confirmed portion of the prefix.
+	c.requiredPointer += len(small)
+
+	return n, err
 }
 
 func (t *proxySubsys) close(err error) {

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -310,7 +310,7 @@ func (c *checkedPrefixReader) Read(b []byte) (int, error) {
 
 	if !bytes.HasPrefix(big, small) {
 		c.requiredPointer = -1
-		return n, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
+		return 0, trace.AccessDenied("required prefix %q was not found", c.requiredPrefix)
 	}
 
 	// Advance pointer by confirmed portion of the prefix.


### PR DESCRIPTION
Logical backport https://github.com/gravitational/teleport/pull/33000 to branch/v12

It's not identical backport - I returned to first version of the original PR with checking read side - we can't put restriction on the write side inside router.DialHost() because there's a chance we'll do handshake with ProxyHelloSignature for old nodes.