### PR TITLE
Fix Assume Roles switch back, don't delete role if access list is using it.

### DIFF
--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -126,8 +127,45 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 				// Mask the actual error here as it could be used to enumerate users
 				// within the system.
 				log.Warnf("Failed to delete role: role %v is used by user cert authority %v", name, a.GetClusterName())
-				return trace.BadParameter("failed to delete a role that is still in use by a user, check the system server logs for more details")
+				return trace.BadParameter("failed to delete a role that is still in use by a certificate authority, check the system server logs for more details")
 			}
+		}
+	}
+
+	var nextToken string
+	for {
+		var accessLists []*accesslist.AccessList
+		var err error
+		accessLists, nextToken, err = a.Services.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		for _, accessList := range accessLists {
+			for _, r := range accessList.Spec.Grants.Roles {
+				if r == name {
+					log.Warnf("Failed to delete role: role %v is granted by access list %s", name, accessList.GetName())
+					return trace.BadParameter("failed to delete a role that is still in use by an access list, check the system server logs for more details")
+				}
+			}
+
+			for _, r := range accessList.Spec.MembershipRequires.Roles {
+				if r == name {
+					log.Warnf("Failed to delete role: role %v is required by members of access list %s", name, accessList.GetName())
+					return trace.BadParameter("failed to delete a role that is still in use by an access list, check the system server logs for more details")
+				}
+			}
+
+			for _, r := range accessList.Spec.OwnershipRequires.Roles {
+				if r == name {
+					log.Warnf("Failed to delete role: role %v is required by owners of access list %s", name, accessList.GetName())
+					return trace.BadParameter("failed to delete a role that is still in use by an access list, check the system server logs for more details")
+				}
+			}
+		}
+
+		if nextToken == "" {
+			break
 		}
 	}
 

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -117,7 +117,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 				// Mask the actual error here as it could be used to enumerate users
 				// within the system.
 				log.Warnf("Failed to delete role: role %v is used by user %v.", name, u.GetName())
-				return errDeleteRoleUser
+				return trace.Wrap(errDeleteRoleUser)
 			}
 		}
 	}
@@ -133,7 +133,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 				// Mask the actual error here as it could be used to enumerate users
 				// within the system.
 				log.Warnf("Failed to delete role: role %v is used by user cert authority %v", name, a.GetClusterName())
-				return errDeleteRoleCA
+				return trace.Wrap(errDeleteRoleCA)
 			}
 		}
 	}
@@ -151,21 +151,21 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 			for _, r := range accessList.Spec.Grants.Roles {
 				if r == name {
 					log.Warnf("Failed to delete role: role %v is granted by access list %s", name, accessList.GetName())
-					return errDeleteRoleAccessList
+					return trace.Wrap(errDeleteRoleAccessList)
 				}
 			}
 
 			for _, r := range accessList.Spec.MembershipRequires.Roles {
 				if r == name {
 					log.Warnf("Failed to delete role: role %v is required by members of access list %s", name, accessList.GetName())
-					return errDeleteRoleAccessList
+					return trace.Wrap(errDeleteRoleAccessList)
 				}
 			}
 
 			for _, r := range accessList.Spec.OwnershipRequires.Roles {
 				if r == name {
 					log.Warnf("Failed to delete role: role %v is required by owners of access list %s", name, accessList.GetName())
-					return errDeleteRoleAccessList
+					return trace.Wrap(errDeleteRoleAccessList)
 				}
 			}
 		}

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -18,6 +18,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gravitational/trace"
 
@@ -99,9 +100,9 @@ func (a *Server) UpsertRole(ctx context.Context, role types.Role) (types.Role, e
 }
 
 var (
-	errDeleteRoleUser       = trace.BadParameter("failed to delete a role that is still in use by a user, check the system server logs for more details")
-	errDeleteRoleCA         = trace.BadParameter("failed to delete a role that is still in use by a certificate authority, check the system server logs for more details")
-	errDeleteRoleAccessList = trace.BadParameter("failed to delete a role that is still in use by an access list, check the system server logs for more details")
+	errDeleteRoleUser       = errors.New("failed to delete a role that is still in use by a user, check the system server logs for more details")
+	errDeleteRoleCA         = errors.New("failed to delete a role that is still in use by a certificate authority, check the system server logs for more details")
+	errDeleteRoleAccessList = errors.New("failed to delete a role that is still in use by an access list, check the system server logs for more details")
 )
 
 // DeleteRole deletes a role and emits a related audit event.

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -94,7 +94,7 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Deletion should fail.
-	require.ErrorContains(t, p.a.DeleteRole(ctx, role.GetName()), "failed to delete a role that is still in use by a user")
+	require.ErrorIs(t, errDeleteRoleUser, p.a.DeleteRole(ctx, role.GetName()))
 	require.NoError(t, p.a.DeleteUser(ctx, user.GetName()))
 
 	clusterName, err := p.a.GetClusterName()
@@ -107,7 +107,7 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, p.a.UpsertCertAuthority(ctx, ca))
 
 	// Deletion should fail.
-	require.ErrorContains(t, p.a.DeleteRole(ctx, role.GetName()), "failed to delete a role that is still in use by a certificate authority")
+	require.ErrorIs(t, errDeleteRoleCA, p.a.DeleteRole(ctx, role.GetName()))
 
 	// Clear out the roles for the CA.
 	ca.SetRoles([]string{})
@@ -139,21 +139,21 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Deletion should fail due to the grant.
-	require.ErrorContains(t, p.a.DeleteRole(ctx, role.GetName()), "failed to delete a role that is still in use by an access list")
+	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
 
 	accessList.Spec.Grants.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
 	// Deletion should fail due to membership requires.
-	require.ErrorContains(t, p.a.DeleteRole(ctx, role.GetName()), "failed to delete a role that is still in use by an access list")
+	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
 
 	accessList.Spec.MembershipRequires.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
 	// Deletion should fail due to ownership requires.
-	require.ErrorContains(t, p.a.DeleteRole(ctx, role.GetName()), "failed to delete a role that is still in use by an access list")
+	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
 
 	accessList.Spec.OwnershipRequires.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -94,7 +94,7 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Deletion should fail.
-	require.ErrorIs(t, errDeleteRoleUser, p.a.DeleteRole(ctx, role.GetName()))
+	require.ErrorIs(t, p.a.DeleteRole(ctx, role.GetName()), errDeleteRoleUser)
 	require.NoError(t, p.a.DeleteUser(ctx, user.GetName()))
 
 	clusterName, err := p.a.GetClusterName()
@@ -107,7 +107,7 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, p.a.UpsertCertAuthority(ctx, ca))
 
 	// Deletion should fail.
-	require.ErrorIs(t, errDeleteRoleCA, p.a.DeleteRole(ctx, role.GetName()))
+	require.ErrorIs(t, p.a.DeleteRole(ctx, role.GetName()), errDeleteRoleCA)
 
 	// Clear out the roles for the CA.
 	ca.SetRoles([]string{})
@@ -139,21 +139,21 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Deletion should fail due to the grant.
-	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
+	require.ErrorIs(t, p.a.DeleteRole(ctx, role.GetName()), errDeleteRoleAccessList)
 
 	accessList.Spec.Grants.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
 	// Deletion should fail due to membership requires.
-	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
+	require.ErrorIs(t, p.a.DeleteRole(ctx, role.GetName()), errDeleteRoleAccessList)
 
 	accessList.Spec.MembershipRequires.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
 	// Deletion should fail due to ownership requires.
-	require.ErrorIs(t, errDeleteRoleAccessList, p.a.DeleteRole(ctx, role.GetName()))
+	require.ErrorIs(t, p.a.DeleteRole(ctx, role.GetName()), errDeleteRoleAccessList)
 
 	accessList.Spec.OwnershipRequires.Roles = []string{"non-existent-role"}
 	_, err = p.a.UpsertAccessList(ctx, accessList)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -431,7 +431,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	// Add in a login hook for generating state during user login.
-	ulsGenerator, err := userloginstate.NewGenerator(userloginstate.GeneratorConfig{
+	as.ulsGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         log,
 		AccessLists: services,
 		Access:      services,
@@ -442,7 +442,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	as.RegisterLoginHook(ulsGenerator.LoginHook(services.UserLoginStates))
+	as.RegisterLoginHook(as.ulsGenerator.LoginHook(services.UserLoginStates))
 
 	return &as, nil
 }
@@ -791,6 +791,9 @@ type Server struct {
 
 	// accessMonitoringEnabled is a flag that indicates whether access monitoring is enabled.
 	accessMonitoringEnabled bool
+
+	// ulsGenerator is the user login state generator.
+	ulsGenerator *userloginstate.Generator
 }
 
 // SetSAMLService registers svc as the SAMLService that provides the SAML
@@ -3453,10 +3456,17 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
+		// Make sure to refresh the user login state.
+		userState, err := a.ulsGenerator.Refresh(ctx, user, a.UserLoginStates)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		// Updating traits is needed for guided SSH flow in Discover.
-		traits = user.GetTraits()
+		traits = userState.GetTraits()
 		// Updating roles is needed for guided Connect My Computer flow in Discover.
-		roles = user.GetRoles()
+		roles = userState.GetRoles()
 
 	} else if req.AccessRequestID != "" {
 		accessRequest, err := a.getValidatedAccessRequest(ctx, identity, req.User, req.AccessRequestID)
@@ -3490,7 +3500,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		}
 
 		// Get default/static roles.
-		user, err := a.GetUser(ctx, req.User, false)
+		userState, err := a.GetUserOrLoginState(ctx, req.User)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to switchback")
 		}
@@ -3499,7 +3509,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		allowedResourceIDs = nil
 
 		// Calculate expiry time.
-		roleSet, err := services.FetchRoles(user.GetRoles(), a, user.GetTraits())
+		roleSet, err := services.FetchRoles(userState.GetRoles(), a, userState.GetTraits())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3508,7 +3518,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 
 		// Set default roles and expiration.
 		expiresAt = prevSession.GetLoginTime().UTC().Add(sessionTTL)
-		roles = user.GetRoles()
+		roles = userState.GetRoles()
 		accessRequests = nil
 	}
 


### PR DESCRIPTION
When switching back to the regular user permissions after assuming roles via an access request, Teleport will now use the user login state to ensure that access list permissions are taken into account.

Additionally, users will not be able to delete roles if they are in use by an access list. Finally, when refreshing the user while extending a web session, the user login state will be regenerated and used for permissions.