### PR TITLE
Fix the top bar going outside the window

### DIFF
--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -140,7 +140,6 @@ function SearchBar() {
         position: relative;
         flex: 4;
         flex-shrink: 1;
-        min-width: calc(${props => props.theme.space[7]}px * 2);
         height: 100%;
         border: 1px ${props => props.theme.colors.buttons.border.border} solid;
         border-radius: ${props => props.theme.radii[2]}px;
@@ -185,7 +184,9 @@ function SearchBar() {
 const Input = styled.input`
   height: 38px;
   width: 100%;
-  min-width: calc(${props => props.theme.space[9]}px * 2);
+  // min-width causes the filters and the actual input text to be broken into
+  // two lines when there is no space
+  min-width: calc(${props => props.theme.space[8]}px * 2);
   background: transparent;
   color: inherit;
   box-sizing: border-box;

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -59,6 +59,7 @@ const CentralContainer = styled(Flex).attrs({ gap: 3 })`
   align-items: center;
   justify-content: center;
   height: 100%;
+  min-width: 0;
   max-width: calc(${props => props.theme.space[10]}px * 9);
 `;
 


### PR DESCRIPTION
Before:
<img width="602" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/9704c1a0-d32b-48ce-91e4-110843de0797">

After:
<img width="558" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/ba73e320-f3b3-4939-ad7b-c4e3d8fae61e">

Changelog: Fix the top bar breaking layout when the window is narrow in Connect.