### PR TITLE
Enforce body size limits for http responses

### DIFF
--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -207,7 +206,7 @@ func executeSTSIdentityRequest(ctx context.Context, client utils.HTTPDoClient, r
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/inventory/metadata/metadata.go
+++ b/lib/inventory/metadata/metadata.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -255,7 +255,7 @@ func (c *fetchConfig) fetchContainerOrchestrator(ctx context.Context) string {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		return ""
 	}
@@ -328,7 +328,7 @@ func (c *fetchConfig) awsHTTPGetSuccess(ctx context.Context) bool {
 	}
 	defer resp.Body.Close()
 
-	imdsToken, err := io.ReadAll(resp.Body)
+	imdsToken, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		return false
 	}

--- a/lib/utils/ec2.go
+++ b/lib/utils/ec2.go
@@ -18,11 +18,12 @@ package utils
 
 import (
 	"context"
-	"io"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
 )
 
 // GetRawEC2IdentityDocument fetches the PKCS7 RSA2048 InstanceIdentityDocument
@@ -39,7 +40,7 @@ func GetRawEC2IdentityDocument(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	iidBytes, err := io.ReadAll(output.Content)
+	iidBytes, err := ReadAtMost(output.Content, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1206,7 +1206,7 @@ func getAuthSettings(ctx context.Context, authClient auth.ClientI) (webclient.Au
 // traces forwards spans from the web ui to the upstream collector configured for the proxy. If tracing is
 // disabled then the forwarding is a noop.
 func (h *Handler) traces(w http.ResponseWriter, r *http.Request, _ httprouter.Params, _ *SessionContext) (interface{}, error) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, teleport.MaxHTTPRequestSize))
+	body, err := utils.ReadAtMost(r.Body, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		h.log.WithError(err).Error("Failed to read traces request")
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
This change enforces limits on the response size for http requests across Teleport. The `e` reference is also being updated as the referenced commit includes similar fixes: https://github.com/gravitational/teleport.e/pull/2479