### PR TITLE
[Web] Fix navigation switcher order

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -174,13 +174,13 @@ export function Navigation({
           onChange={handleCategoryChange}
           value={view}
           items={[
+            { category: NavigationCategory.Resources },
             {
               category: NavigationCategory.Management,
               requiresAttention: ctx.storeNotifications.hasNotificationsByKind(
                 NotificationKind.AccessList
               ),
             },
-            { category: NavigationCategory.Resources },
           ]}
         />
       )}


### PR DESCRIPTION
## Purpose

Minor fix for a UX regression where the items in the `Resources`/`Management` dropdown  were flipped.

## Demo

### Before

![image](https://github.com/gravitational/teleport/assets/56373201/b4af6e64-e186-42b6-9829-1e3440b83260)

### After

![image](https://github.com/gravitational/teleport/assets/56373201/9b04ed4e-68a5-4fe5-9315-bad771e2cb8f)
