### PR TITLE
Disambiguate directory sharing's disabled and inactive states

### DIFF
--- a/web/packages/teleport/src/DesktopSession/TopBar.tsx
+++ b/web/packages/teleport/src/DesktopSession/TopBar.tsx
@@ -59,11 +59,7 @@ export default function TopBar(props: Props) {
           <FolderShared
             style={primaryOnTrue(isSharingDirectory)}
             pr={3}
-            title={
-              isSharingDirectory
-                ? 'Directory Sharing Enabled'
-                : 'Directory Sharing Disabled'
-            }
+            title={directorySharingTitle(canShareDirectory, isSharingDirectory)}
           />
           <Clipboard
             style={primaryOnTrue(clipboardSharingEnabled)}
@@ -87,6 +83,16 @@ export default function TopBar(props: Props) {
       </Flex>
     </TopNav>
   );
+}
+
+function directorySharingTitle(canShare: boolean, isSharing: boolean): string {
+  if (!canShare) {
+    return 'Directory Sharing Disabled';
+  }
+  if (!isSharing) {
+    return 'Directory Sharing Inactive';
+  }
+  return 'Directory Sharing Enabled';
 }
 
 export const TopBarHeight = 40;

--- a/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -400,7 +400,7 @@ exports[`connected settings false 1`] = `
           <span
             class="c5 icon icon-foldershared"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           >
             <svg
               fill="currentColor"
@@ -1211,7 +1211,7 @@ exports[`disconnected 1`] = `
           <span
             class="c5 icon icon-foldershared"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           >
             <svg
               fill="currentColor"
@@ -1921,7 +1921,7 @@ exports[`processing 1`] = `
           <span
             class="c5 icon icon-foldershared"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           >
             <svg
               fill="currentColor"
@@ -2231,7 +2231,7 @@ exports[`tdp processing 1`] = `
           <span
             class="c5 icon icon-foldershared"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           >
             <svg
               fill="currentColor"


### PR DESCRIPTION
Prior to this change, the UI would show "disabled" when directory sharing is disabled due to RBAC and when it is enabled but inactive.

Closes #33748