### PR TITLE
Set `-reviewers="${{ secrets.reviewers }}"` on changelog workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -50,4 +50,4 @@ jobs:
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
       - name: Validate the changelog entry
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"


### PR DESCRIPTION
The workflow is currently failing because this required parameter is unset. Strictly speaking it is not required for this workflow's logic, however removing/updating this requirement in the bot is significantly more effort than just passing the parameter here.