### PR TITLE
docs: reword tctl instructions

### DIFF
--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,6 +1,6 @@
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
 verify that you can run `tctl` commands using your current credentials. 
-`tctl` is supported on MacOS and Linux machines.
+`tctl` is supported on macOS and Linux machines.
 
 For example:
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,7 +1,8 @@
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
-verify that you can run `tctl` commands on your administrative workstation 
-using your current credentials. For example:
+verify that you can run `tctl` commands using your current credentials. 
+`tctl` is supported on MacOS and Linux machines.
 
+For example:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />


### PR DESCRIPTION
- removes administrative workstation which was causing some confusion
- clarifies that usage of `tctl` is supported for MacOS and Linux machines