### PR TITLE
Replace audit_retention_period with retention_period

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -57,7 +57,7 @@ teleport:
 
         # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
         # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-        audit_retention_period: 365d
+        retention_period: 365d
 
         # minimum/maximum read capacity in units
         read_min_capacity: int

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -51,7 +51,7 @@ For High Availability configurations, users can refer to our
 configure the SSH events and recorded sessions to be stored on network storage.
 When these backends are in use, audit events will eventually expire and be
 removed from the log. The default retention period is 1 year, but this can be
-overridden using the `audit_retention_period` configuration parameter.
+overridden using the `retention_period` configuration parameter.
 
 It is even possible to store audit logs in multiple places at the same time. For
 more information on how to configure the audit log, refer to the `storage`

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -822,7 +822,7 @@ teleport:
 
     # By default, Teleport stores audit events with an AWS TTL of 1 year.
     # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-    audit_retention_period: 365d
+    retention_period: 365d
 
     # Enables either Pay Per Request or Provisioned billing for the DynamoDB table. Set when Teleport creates the table.
     # Possible values: "pay_per_request" and "provisioned"

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -102,7 +102,7 @@ type Config struct {
 	// WriteCapacityUnits is Dynamodb write capacity units
 	WriteCapacityUnits int64 `json:"write_capacity_units"`
 	// RetentionPeriod is a default retention period for events.
-	RetentionPeriod *types.Duration `json:"audit_retention_period"`
+	RetentionPeriod *types.Duration `json:"retention_period"`
 	// Clock is a clock interface, used in tests
 	Clock clockwork.Clock
 	// UIDGenerator is unique ID generator


### PR DESCRIPTION
This PR is related to issue #31878

As a summery, Teleport doesn't recognize config name `audit_retention_period` and only recognizes `retention_period`.

This PR removes references for `audit_retention_period`.