### PR TITLE
Transform d3-color@3.1.0 ES Module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ const config = require('@gravitational/build/jest/config');
 
 process.env.TZ = 'UTC';
 
-const esModules = ['strip-ansi', 'ansi-regex'].join('|');
+const esModules = ['strip-ansi', 'ansi-regex', 'd3-color'].join('|');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {


### PR DESCRIPTION
[Updated d3-color dependency](https://github.com/gravitational/teleport/pull/33709) is now published as ES Module. Unfortunately, `jest` can't parse it yet, so it causes test failures https://github.com/gravitational/teleport.e/actions/runs/6611322529/job/17955640469.

Added to the list of modules that should be transformed.