### PR TITLE
[v13] Disambiguate directory sharing's disabled and inactive states

### DIFF
--- a/web/packages/teleport/src/DesktopSession/TopBar.tsx
+++ b/web/packages/teleport/src/DesktopSession/TopBar.tsx
@@ -59,11 +59,7 @@ export default function TopBar(props: Props) {
           <StyledFolderShared
             style={primaryOnTrue(isSharingDirectory)}
             pr={3}
-            title={
-              isSharingDirectory
-                ? 'Directory Sharing Enabled'
-                : 'Directory Sharing Disabled'
-            }
+            title={directorySharingTitle(canShareDirectory, isSharingDirectory)}
           />
           <StyledClipboard
             style={primaryOnTrue(clipboardSharingEnabled)}
@@ -87,6 +83,16 @@ export default function TopBar(props: Props) {
       </Flex>
     </TopNav>
   );
+}
+
+function directorySharingTitle(canShare: boolean, isSharing: boolean): string {
+  if (!canShare) {
+    return 'Directory Sharing Disabled';
+  }
+  if (!isSharing) {
+    return 'Directory Sharing Inactive';
+  }
+  return 'Directory Sharing Enabled';
 }
 
 export const TopBarHeight = 40;

--- a/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -428,7 +428,7 @@ exports[`connected settings false 1`] = `
           <span
             class="c5 c6 icon icon-folder-shared c7"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           />
           <span
             class="c5 c6 icon icon-clipboard-text c8"
@@ -1161,7 +1161,7 @@ exports[`disconnected 1`] = `
           <span
             class="c5 c6 icon icon-folder-shared c7"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           />
           <span
             class="c5 c6 icon icon-clipboard-text c8"
@@ -1832,7 +1832,7 @@ exports[`processing 1`] = `
           <span
             class="c5 c6 icon icon-folder-shared c7"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           />
           <span
             class="c5 c6 icon icon-clipboard-text c8"
@@ -2103,7 +2103,7 @@ exports[`tdp processing 1`] = `
           <span
             class="c5 c6 icon icon-folder-shared c7"
             style="color: rgba(255, 255, 255, 0.72);"
-            title="Directory Sharing Disabled"
+            title="Directory Sharing Inactive"
           />
           <span
             class="c5 c6 icon icon-clipboard-text c8"


### PR DESCRIPTION
Prior to this change, the UI would show "disabled" when directory sharing is disabled due to RBAC and when it is enabled but inactive.

Closes #33748
Backports #33771