### PR TITLE
Update docs with database user auto provisioning modes

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -120,7 +120,7 @@ The table below documents the behavior of each option if multiple roles are assi
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. **Note:** IP pinning is currently in Preview mode | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `drop`, `keep`), it will evaluate to the option specified by all of the roles. If some roles specify both `drop` or `keep` it will evaluate to `keep`|
-| `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx) (`off`, `keep`, `best_effort_drop`) | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
+| `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx). Options: `off` (disable database user auto-provisioning), `keep` (disables the user at session end, removing the roles and locking it), and `best_effort_drop` (try to drop the user at session end, if it doesn't succeed, fallback to disabling it). | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
 
 ## Preset roles
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -120,7 +120,7 @@ The table below documents the behavior of each option if multiple roles are assi
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. **Note:** IP pinning is currently in Preview mode | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `drop`, `keep`), it will evaluate to the option specified by all of the roles. If some roles specify both `drop` or `keep` it will evaluate to `keep`|
-| `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx) | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
+| `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx) (`off`, `keep`, `best_effort_drop`) | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
 
 ## Preset roles
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -120,6 +120,7 @@ The table below documents the behavior of each option if multiple roles are assi
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. **Note:** IP pinning is currently in Preview mode | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `drop`, `keep`), it will evaluate to the option specified by all of the roles. If some roles specify both `drop` or `keep` it will evaluate to `keep`|
+| `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx) | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |
 
 ## Preset roles
 

--- a/docs/pages/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mysql.mdx
@@ -70,10 +70,6 @@ GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO 'teleport-admin'
 Users created by Teleport will be assigned the `teleport-auto-user` role in the
 database, which will be created automatically if it doesn't exist.
 
-Teleport will not delete the automatically created user at the end of the
-session. Instead, the user will be stripped of all roles and the user account
-will be locked.
-
 Next, enable the database admin on the Teleport Database Service configuration:
 
 <Tabs>

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -69,10 +69,6 @@ to ensure that your configuration is correct.
 Users created by Teleport will be placed in the `teleport-auto-user` group in
 the database, which will be created automatically if it doesn't exist.
 
-Teleport will not delete the automatically created user at the end of the session.
-Instead, the user will be stripped of all roles, updated with `nologin` trait
-and reactivated during the next connection.
-
 Next, enable the database admin on the Teleport database configuration:
 
 <Tabs>

--- a/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
@@ -8,8 +8,8 @@ metadata:
   name: auto-db-users
 spec:
   options:
-    # create_db_user enables automatic user provisioning for matching databases
-    create_db_user: true
+    # create_db_user_mode enables automatic user provisioning for matching databases
+    create_db_user_mode: keep
   allow:
     db_labels:
       "*": "*"
@@ -25,3 +25,13 @@ spec:
 With automatic user provisioning, users always connect to the database with
 their Teleport username so the `db_users` role field is ignored for roles
 that have database user provisioning enabled.
+
+The available provisioning modes are:
+
+* `off`: Disables user provisioning.
+
+* `keep`: Enables user provisioning and disables users at session end.
+
+* `best_effort_drop`: Enables user provisioning and tries to drop user
+  at session end. If the drop fails, fallback to disabling them (same as `keep`
+  mode).

--- a/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
@@ -30,8 +30,8 @@ The available provisioning modes are:
 
 * `off`: Disables user provisioning.
 
-* `keep`: Enables user provisioning and disables users at session end. session.
-  The user will be stripped of all roles and the user account will be locked.
+* `keep`: Enables user provisioning and disables users at session end. The user
+  will be stripped of all roles and the user account will be locked.
 
 * `best_effort_drop`: Enables user provisioning and tries to drop user
   at session end. If the drop fails, fallback to disabling them (same as `keep`

--- a/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning-common-teleport-role.mdx
@@ -30,7 +30,8 @@ The available provisioning modes are:
 
 * `off`: Disables user provisioning.
 
-* `keep`: Enables user provisioning and disables users at session end.
+* `keep`: Enables user provisioning and disables users at session end. session.
+  The user will be stripped of all roles and the user account will be locked.
 
 * `best_effort_drop`: Enables user provisioning and tries to drop user
   at session end. If the drop fails, fallback to disabling them (same as `keep`

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -102,7 +102,7 @@ spec:
     #          and off (disable host user creation)
     create_host_user_mode: drop
     # Controls whether this role requires automatic database user provisioning.
-    create_db_user: true
+    create_db_user_mode: keep
     # Specifies role specific options for identity provider access.
     idp:
       # Specifies role specific options for SAML identity provider access.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -102,6 +102,10 @@ spec:
     #          and off (disable host user creation)
     create_host_user_mode: drop
     # Controls whether this role requires automatic database user provisioning.
+    # Options: off (disable database user auto-provisioning), keep (disables the
+    # user at session end, removing the roles and locking it), and
+    # best_effort_drop (try to drop the user at session end, if it doesn't
+    # succeed, fallback to disabling it).
     create_db_user_mode: keep
     # Specifies role specific options for identity provider access.
     idp:


### PR DESCRIPTION
#32792 introduced a new role option to configure if provisioned database users should be kept (disabled) or dropped. This PR updates the auto-provisioning docs to add this new option.

Note: `create_db_user` will still work (`true = keep` and `false = off`), but it is preferred that users specify the mode (similar to the `create_host_user_mode` and `create_host_user` options).