### PR TITLE
Disable fuzz_parser_eval_bool_predicate in oss-fuzz

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -26,9 +26,6 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/desktop/tdp \
     FuzzDecode fuzz_decode
 
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/services \
-    FuzzParserEvalBoolPredicate fuzz_parser_eval_bool_predicate
-
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/restrictedsession \
     FuzzParseIPSpec fuzz_parse_ip_spec
 


### PR DESCRIPTION
This test seems to false positive with timeouts semi-frequently.  These timeouts are not reproducible outside of oss-fuzz.  The most recent example here: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63385