### PR TITLE
Prevent SSO Redirects to other origins

### DIFF
--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -21,7 +21,6 @@ package httplib
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"mime"
 	"net"
 	"net/http"
@@ -268,7 +267,6 @@ func OriginLocalRedirectURI(redirectURL string) (string, error) {
 	} else if strings.Contains(resultURI, "@") {
 		return "", trace.BadParameter("Basic Auth not allowed in redirect")
 	}
-	fmt.Printf("Valid redirect: %s\n", resultURI)
 	return resultURI, nil
 }
 

--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -250,7 +250,7 @@ func RewritePaths(next http.Handler, rewrites ...RewritePair) http.Handler {
 	})
 }
 
-// OriginLocalRedirectURI will take an incoming URL including optionally the host and schema and provide the URI
+// OriginLocalRedirectURI will take an incoming URL including optionally the host and scheme and return the URI
 // associated with the URL.  Additionally, it will ensure that the URI does not include any techniques potentially
 // used to redirect to a different origin.
 func OriginLocalRedirectURI(redirectURL string) (string, error) {
@@ -262,7 +262,7 @@ func OriginLocalRedirectURI(redirectURL string) (string, error) {
 	}
 
 	resultURI := parsedURL.RequestURI()
-	if len(resultURI) > 1 && resultURI[0] == '/' && resultURI[1] == '/' {
+	if strings.HasPrefix(resultURI, "//") {
 		return "", trace.BadParameter("Invalid double slash redirect")
 	} else if strings.Contains(resultURI, "@") {
 		return "", trace.BadParameter("Basic Auth not allowed in redirect")

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -453,6 +453,18 @@ func TestOriginLocalRedirectURI(t *testing.T) {
 			expected: "",
 			errCheck: require.Error,
 		},
+		{
+			name:     "ftp scheme",
+			input:    "ftp://localhost",
+			expected: "",
+			errCheck: require.Error,
+		},
+		{
+			name:     "invalid url",
+			input:    "https://foo com",
+			expected: "",
+			errCheck: require.Error,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -415,43 +415,43 @@ func TestOriginLocalRedirectURI(t *testing.T) {
 		name     string
 		input    string
 		expected string
-		wantErr  bool
+		errCheck require.ErrorAssertionFunc
 	}{
 		{
 			name:     "empty",
 			input:    "",
 			expected: "/",
-			wantErr:  false,
+			errCheck: require.NoError,
 		},
 		{
 			name:     "simple path",
 			input:    "/foo",
 			expected: "/foo",
-			wantErr:  false,
+			errCheck: require.NoError,
 		},
 		{
 			name:     "host only",
 			input:    "https://localhost",
 			expected: "/",
-			wantErr:  false,
+			errCheck: require.NoError,
 		},
 		{
 			name:     "host and simple path",
 			input:    "https://localhost/bar",
 			expected: "/bar",
-			wantErr:  false,
+			errCheck: require.NoError,
 		},
 		{
 			name:     "double slash redirect with host",
 			input:    "https://localhost//goteleport.com/",
 			expected: "",
-			wantErr:  true,
+			errCheck: require.Error,
 		},
 		{
 			name:     "basic auth redirect with host",
 			input:    "https://localhost/@goteleport.com/",
 			expected: "",
-			wantErr:  true,
+			errCheck: require.Error,
 		},
 	}
 
@@ -459,11 +459,7 @@ func TestOriginLocalRedirectURI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := OriginLocalRedirectURI(tc.input)
 			require.Equal(t, tc.expected, result)
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			tc.errCheck(t, err)
 		})
 	}
 }

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -407,3 +407,63 @@ func TestSetRedirectPageContentSecurityPolicy(t *testing.T) {
 		require.Contains(t, actualCsp, expectedCspSubString)
 	}
 }
+
+func TestOriginLocalRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "/",
+			wantErr:  false,
+		},
+		{
+			name:     "simple path",
+			input:    "/foo",
+			expected: "/foo",
+			wantErr:  false,
+		},
+		{
+			name:     "host only",
+			input:    "https://localhost",
+			expected: "/",
+			wantErr:  false,
+		},
+		{
+			name:     "host and simple path",
+			input:    "https://localhost/bar",
+			expected: "/bar",
+			wantErr:  false,
+		},
+		{
+			name:     "double slash redirect with host",
+			input:    "https://localhost//goteleport.com/",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "basic auth redirect with host",
+			input:    "https://localhost/@goteleport.com/",
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := OriginLocalRedirectURI(tc.input)
+			require.Equal(t, tc.expected, result)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4253,12 +4253,11 @@ func SSOSetWebSessionAndRedirectURL(w http.ResponseWriter, r *http.Request, resp
 		return trace.Wrap(err)
 	}
 
-	parsedURL, err := url.Parse(response.ClientRedirectURL)
+	parsedRedirectURL, err := httplib.OriginLocalRedirectURI(response.ClientRedirectURL)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	response.ClientRedirectURL = parsedURL.RequestURI()
+	response.ClientRedirectURL = parsedRedirectURL
 
 	return nil
 }


### PR DESCRIPTION
This change fixes https://github.com/gravitational/security-findings/issues/69

Through the `url.Parse` and then `.RequestURI()` it is expected to be a path which will redirect to the same origin.  However there are potential patterns that customers could be phished to inject which would result in a redirect to another domain.  This is done after the auth process, as such this would NOT result in secrets being sent to the attacker controlled domain.

In this change I removed the unused `SafeRedirect` function and instead added a new function `OriginLocalRedirectURI` which will ensure that the provided URI's will remain Origin local after being interpreted by the browser.