### PR TITLE
Add the no-changelog label to automated PRs

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -89,12 +89,12 @@ jobs:
           # for docker images replace version number after <docker image name>:
           jq --arg major ${{ steps.get-branch.outputs.major }} \
              --arg version ${{ steps.get-branch.outputs.version }} \
-             '.variables.teleport.major_version |= $major | 
-              .variables.teleport.version |= $version | 
-              .variables.teleport.plugin.version |= $version | 
-              .variables.teleport.latest_oss_docker_image |= sub(":.*";":")+$version | 
-              .variables.teleport.latest_oss_debug_docker_image |= sub(":.*";":")+$version | 
-              .variables.teleport.latest_ent_docker_image |= sub(":.*";":")+$version | 
+             '.variables.teleport.major_version |= $major |
+              .variables.teleport.version |= $version |
+              .variables.teleport.plugin.version |= $version |
+              .variables.teleport.latest_oss_docker_image |= sub(":.*";":")+$version |
+              .variables.teleport.latest_oss_debug_docker_image |= sub(":.*";":")+$version |
+              .variables.teleport.latest_ent_docker_image |= sub(":.*";":")+$version |
               .variables.teleport.latest_ent_debug_docker_image |= sub(":.*";":")+$version' \
               docs/config.json > docs/confignew.json
           cat docs/confignew.json
@@ -104,6 +104,6 @@ jobs:
           git switch -c $BRANCH_NAME
           git commit -am "[auto] docs: Update version to ${{ github.event.release.tag_name }}"
           git push --set-upstream origin $BRANCH_NAME
-          gh pr create --fill --label=automated --label=documentation --base=${{ steps.get-branch.outputs.branch }}
+          gh pr create --fill --label=automated --label=documentation --label=no-changelog --base=${{ steps.get-branch.outputs.branch }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -136,4 +136,4 @@ create-update-pr: update-ami-ids-terraform
 	git checkout -b $(AUTO_BRANCH_NAME)
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
-	gh pr create --fill --label automated --label terraform
+	gh pr create --fill --label=automated --label=terraform --label=no-changelog


### PR DESCRIPTION
These are for things like version updates in the docs and AWS AMI IDs.