### PR TITLE
Add missing redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1909,6 +1909,11 @@
       "permanent": true
     },
     {
+      "source": "/desktop-access/",
+      "destination": "/desktop-access/introduction/",
+      "permanent": true
+    },
+    {
       "source": "/kubernetes-access/",
       "destination": "/kubernetes-access/introduction/",
       "permanent": true


### PR DESCRIPTION
Ensure that users visiting `/docs/desktop-access/` are redirected to the introduction page for the Desktop Access docs section.