### PR TITLE
Remove custom BoringSSL build

### DIFF
--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -17,6 +17,7 @@ jobs:
         runner: [ ubuntu-22.04-32core, ['self-hosted', 'linux', 'arm64'] ]
     # Use bigger worker. Clang takes a while to build.
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 720
 
     permissions:
       contents: read
@@ -35,6 +36,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure required packages are installed
+        run: |
+          os_id=$(awk -F= '/^ID/{print $2}' /etc/os-release)
+          if [[ ! "$os_id" =~ ^ubuntu.* ]]; then
+            sudo dnf upgrade-minimal -y
+            sudo dnf install -y make
+          fi
 
       # We need to keep env vars in sync, so, we can't use standard build actions
       - name: Build buildbox assets image

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ###################################################################################
 #                                                                                 #
 #      DO NOT USE FOR PRODUCTION BUILD OR ANYTHING OTHER THAN CI TESTING!         #
@@ -82,7 +84,7 @@ RUN mkdir -p /opt && cd /opt &&  \
     curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make &&  \
-    BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install
+    BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers
 
 ## BUILDBOX ###################################################################
 #
@@ -251,9 +253,11 @@ RUN make -C /opt/pam_teleport install
 ENV SOFTHSM2_PATH "/usr/lib/softhsm/libsofthsm2.so"
 
 # Install bats.
-RUN curl -fsSL https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar -xz && \
-    cd bats-core-1.2.1 && ./install.sh /usr/local && cd .. && \
-    rm -r bats-core-1.2.1
+RUN git clone --depth=1 https://github.com/bats-core/bats-core.git -b v1.2.1 && \
+    cd bats-core && \
+    [ "$(git rev-parse HEAD)" = 'dcaec03e32e0b152f8ef9cf14b75296cf5caeaff' ] && \
+    ./install.sh /usr/local && cd .. && \
+    rm -r bats-core
 
 # Install shellcheck.
 RUN scversion='v0.9.0' && \

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # This Dockerfile is used to build Teleport on ARM only.
 # We are using the official Debian 12 image as a base image
 # because the final binary must be compatible with distroless

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -5,8 +5,19 @@ ARG RUST_VERSION
 # git2 packages are not available on ARM64, so we need to build it from source.
 FROM centos:7 AS git2
 
+ARG BUILDARCH
+ARG TARGETARCH
 ARG DEVTOOLSET
 
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+
+# Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y \
     ca-certificates  \
@@ -20,14 +31,18 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    centos-release-scl \
-    ${DEVTOOLSET}-gcc* \
-    ${DEVTOOLSET}-make && \
+    centos-release-scl && \
     yum clean all
 
-RUN wget https://github.com/git/git/archive/refs/tags/v2.42.0.tar.gz && \
-    tar xf v2.42.0.tar.gz && \
-    cd git-2.42.0/ && \
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
+    yum clean all
+
+RUN git clone --depth=1 https://github.com/git/git.git -b v2.42.0 && \
+    cd git && \
+    [ "$(git rev-parse HEAD)" = '43c8a30d150ecede9709c1f2527c8fba92c65f40' ] && \
     scl enable ${DEVTOOLSET} "make configure && \
     ./configure --prefix=/usr/local && \
     make -j"$(nproc)" all && \
@@ -35,7 +50,7 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.42.0.tar.gz && \
 
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
 ARG BUILDARCH
-FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDARCH} AS teleport-buildbox-centos7-assets
+FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport15-${BUILDARCH} AS teleport-buildbox-centos7-assets
 
 ## LIBFIDO2 ###################################################################
 
@@ -43,6 +58,15 @@ FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDAR
 FROM centos:7 AS libfido2
 
 ARG DEVTOOLSET
+ARG TARGETARCH
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
 
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
@@ -50,11 +74,15 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum install -y \
         cmake3 \
-        ${DEVTOOLSET}-gcc* \
         git \
         libudev-devel \
         perl-IPC-Cmd \
         zlib-devel && \
+    yum clean all
+
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* && \
     yum clean all
 
 # Install libudev-zero.
@@ -108,6 +136,15 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
 FROM centos:7 AS libbpf
 
 ARG DEVTOOLSET
+ARG TARGETARCH
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -116,10 +153,14 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
-        ${DEVTOOLSET}-gcc* \
-        ${DEVTOOLSET}-make \
         elfutils-libelf-devel-static \
         scl-utils && \
+    yum clean all
+
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
     yum clean all
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -128,13 +169,22 @@ ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
     curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable ${DEVTOOLSET} "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
+    scl enable ${DEVTOOLSET} "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers"
 
 ## LIBPCSCLITE #####################################################################
 
 FROM centos:7 AS libpcsclite
 
 ARG DEVTOOLSET
+ARG TARGETARCH
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -145,6 +195,10 @@ RUN yum groupinstall -y 'Development Tools' && \
         libudev-devel \
         scl-utils \
         centos-release-scl \
+    yum clean all
+
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc* && \
     yum clean all
 
@@ -169,21 +223,28 @@ ENV LANGUAGE=en_US.UTF-8 \
 ARG GOLANG_VERSION
 ARG RUST_VERSION
 ARG DEVTOOLSET
+ARG TARGETARCH
 
 ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    #required by libbpf
-    centos-release-scl \
     # required by libbpf
-    ${DEVTOOLSET}-* \
+    centos-release-scl \
     # required by libbpf
     elfutils-libelf-devel-static \
     net-tools \
@@ -198,6 +259,12 @@ RUN yum groupinstall -y 'Development Tools' && \
     zlib-static && \
     yum clean all && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8
+
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
+    yum clean all
 
 # Override the old git in /usr/local installed by yum. We need git 2+ on GitHub Actions.
 COPY --from=git2 /opt/git /

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -1,6 +1,20 @@
+# syntax=docker/dockerfile:1
+
 FROM centos:7 AS centos-devtoolset
 
 ARG DEVTOOLSET
+ARG TARGETARCH
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+RUN if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
+    cat <<EOF > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
+[${DEVTOOLSET}-build]
+name=${DEVTOOLSET} - Build
+baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/
+gpgcheck=0
+enabled=1
+EOF
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -12,10 +26,6 @@ RUN yum groupinstall -y 'Development Tools' && \
         centos-release-scl \
         # required by Clang/LLVM
         cmake3 \
-        # required by libbpf and Clang
-        ${DEVTOOLSET}-gcc* \
-        # required by libbpf
-        ${DEVTOOLSET}-make \
         # required by libbpf
         elfutils-libelf-devel \
         # required by libbpf
@@ -29,19 +39,29 @@ RUN yum groupinstall -y 'Development Tools' && \
         zlib-static && \
     yum clean all
 
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
+    yum clean all
+
 # Use just created devtool image with newer GCC and Cmake
-FROM centos-devtoolset as clang10
+FROM centos-devtoolset as clang12
 
 ARG DEVTOOLSET
 
-# Compile Clang 10.0.1 from source. It is needed to create BPF files.
-# Centos 7 doesn't provide it as a package unfortunately.
+# Compile Clang 12.0.0 from source. It is needed to create BoringSSL and BPF files.
+# CentOS 7 doesn't provide it as a package unfortunately.
+# This version of Clang is explicitly required for FIPS compliance when building BoringSSL.
+# For more information please refer to the section 12. Guidance and Secure Operation of:
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf
 # LLVM_INCLUDE_BENCHMARKS must be off, otherwise compilation fails,
 # CLANG_BUILD_TOOLS must be on, it builds clang binary,
 # LLVM_BUILD_TOOLS must be on, it builds llvm-strip binary.
 # the rest is disabled to speedup the compilation.
-RUN git clone --branch llvmorg-10.0.1 --depth=1 https://github.com/llvm/llvm-project.git && \
+RUN git clone --branch llvmorg-12.0.0 --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project/ && \
+    [ "$(git rev-parse HEAD)" = 'd28af7c654d8db0b68c175db5ce212d74fb5e9bc' ] && \
     mkdir build && cd build/ && \
     scl enable ${DEVTOOLSET} 'bash -c "cmake3 \
     -DCLANG_BUILD_TOOLS=ON \
@@ -68,4 +88,4 @@ RUN git clone --branch llvmorg-10.0.1 --depth=1 https://github.com/llvm/llvm-pro
 FROM scratch AS buildbox-centos7-assets
 
 # Copy Clang into the final image.
-COPY --from=clang10 /opt/llvm /opt/llvm/
+COPY --from=clang12 /opt/llvm /opt/llvm/

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -1,8 +1,20 @@
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
 ARG BUILDARCH
-FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport14-${BUILDARCH} AS teleport-buildbox-centos7-assets
+FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport15-${BUILDARCH} AS teleport-buildbox-centos7-assets
 
 FROM centos:7 AS libbpf
+
+ARG BUILDARCH
+ARG TARGETARCH
+ARG DEVTOOLSET
+
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -11,10 +23,14 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
-        devtoolset-11-gcc* \
-        devtoolset-11-make \
         elfutils-libelf-devel-static \
         scl-utils && \
+    yum clean all
+
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
     yum clean all
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -23,55 +39,13 @@ ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
     curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
-
-FROM centos:7 AS boringssl
-# The below tools are required in order to build and compile the module:
-# Clang compiler version 7.0.1
-# Go programming language version 1.12.7
-# Ninja build system version 1.9.0
-#
-# We also need the FIPS 140-2 validated release of BoringSSL: ae223d6138807a13006342edfeef32e813246b39
-# For more information please refer to the section 12. Guidance and Secure Operation of:
-# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
-
-# Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-    cmake3 \
-    llvm-toolset-7.0-clang-7.0.1 \
-    git
-
-RUN mkdir -p /opt && cd /opt && \
-    curl -fsSLO https://go.dev/dl/go1.12.7.linux-amd64.tar.gz && \
-    echo "66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9" "go1.12.7.linux-amd64.tar.gz" | sha256sum --check && \
-    tar xf go1.12.7.linux-amd64.tar.gz && \
-    rm -f go1.12.7.linux-amd64.tar.gz && \
-    chmod a+w /opt/go && \
-    chmod a+w /var/lib && \
-    chmod a-w /
-ENV GOPATH="/go" \
-    GOROOT="/opt/go" \
-    PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin"
-
-RUN git clone https://github.com/ninja-build/ninja.git && \
-    cd ninja && \
-    git checkout v1.9.0 && \
-    ./configure.py --bootstrap && \
-    mv ninja /usr/bin
-
-RUN mkdir -p /opt && cd /opt && \
-    git clone https://github.com/google/boringssl.git && \
-    cd boringssl && \
-    git checkout ae223d6138807a13006342edfeef32e813246b39 && \
-    mkdir build && \
-    cd build && \
-    scl enable llvm-toolset-7.0 "cd /opt/boringssl/build && cmake3 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -GNinja .. && ninja"
+    scl enable ${DEVTOOLSET} "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers"
 
 FROM centos:7
+
+ARG BUILDARCH
+ARG TARGETARCH
+ARG DEVTOOLSET
 
 ENV LANGUAGE=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
@@ -83,21 +57,30 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
+# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
+# published to the official CentOS SCL repos.
+ENV DEVTOOLSET=${DEVTOOLSET} \
+    TARGETARCH=${TARGETARCH}
+
+RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
+    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+
+# Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    #required by libbpf
-    centos-release-scl \
     # required by libbpf
-    devtoolset-11-* \
+    centos-release-scl \
+    # required by Clang/LLVM
+    cmake3 \
     # required by libbpf
     elfutils-libelf-devel-static \
     git \
     net-tools \
-    # required to create bindings for Rust's boring-rs crate
-    llvm-toolset-7.0-clang-7.0.1 \
+    # required by boringssl
+    ninja-build \
     # required by Teleport PAM support
     pam-devel \
     perl-IPC-Cmd \
@@ -109,9 +92,15 @@ RUN yum groupinstall -y 'Development Tools' && \
     zlib-static && \
     yum clean all
 
+# As mentioned above, these packages are unsigned.
+RUN yum install --nogpgcheck -y \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make && \
+    yum clean all
+
 # Install Go.
 ARG GOLANG_VERSION
-RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/${GOLANG_VERSION}.linux-${BUILDARCH}.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -144,25 +133,16 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     cargo --version && \
     rustc --version && \
     rustup component add rustfmt clippy && \
-    rustup target add aarch64-unknown-linux-gnu
+    rustup target add ${TARGETARCH}-unknown-linux-gnu
 
 ARG WASM_PACK_VERSION
 # Install wasm-pack for targeting WebAssembly from Rust.
 RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
 
-# Copy BoringSSL into the final image
-COPY --from=boringssl /opt/boringssl /opt/boringssl
-
-# set boring-rs crate env variables to point to pre-built binaries
-# https://github.com/cloudflare/boring#support-for-pre-built-binaries
-ENV BORING_BSSL_PATH=/opt/boringssl
-ENV BORING_BSSL_INCLUDE_PATH=/opt/boringssl/include
-
 ARG LIBBPF_VERSION
 COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 
-# Download pre-built CentOS 7 assets with clang needed to build BPF tools.
-ARG BUILDARCH
+# Download pre-built CentOS 7 assets with clang needed to build BoringSSL and BPF tools.
 COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-connect
+++ b/build.assets/Dockerfile-connect
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # This Dockerfile makes the "build box connect" the container used
 # to build the Teleport Connect.
 #

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM docker.io/golang:1.21
 
 # Image layers go from less likely to most likely to change.

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # #############################################################################
 # This Dockerfile aims to be the single source of truth for linux buildboxes on
 # all supported architectures.
@@ -12,8 +14,7 @@ FROM centos:7 AS base
 ARG TARGETARCH
 
 # Aliases
-FROM $BUILDBOX_PREFIX/buildbox-multiarch-clang7:$BUILDBOX_VERSION-$TARGETARCH AS clang7-boringcrypto
-FROM $BUILDBOX_PREFIX/buildbox-multiarch-clang10:$BUILDBOX_VERSION-$TARGETARCH AS clang10
+FROM $BUILDBOX_PREFIX/buildbox-multiarch-clang12:$BUILDBOX_VERSION-$TARGETARCH AS clang12
 
 # Root target with ci user
 FROM $BUILDBOX_PREFIX/buildbox-multiarch-base:$BUILDBOX_VERSION-$TARGETARCH AS gcc
@@ -103,14 +104,14 @@ ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
     curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install
+    make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers
 
 ## Integral image for 64-bit targets #############################################
 #
 FROM gcc AS deps-64
 
-# Make clang10 available
-COPY --from=clang10 /opt/llvm /opt/llvm
+# Make clang12 available
+COPY --from=clang12 /opt/llvm /opt/llvm
 ENV PATH="/opt/llvm/bin:$PATH"
 
 ARG RUST_VERSION
@@ -175,44 +176,6 @@ COPY --from=libpcsclite \
 ARG LIBBPF_VERSION
 COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 
-## BORINGSSL ########################################################################
-#
-FROM clang7-boringcrypto AS boringssl
-# The below tools are required in order to build and compile the module:
-# Clang compiler version 7.0.1
-# Go programming language version 1.12.7
-# Ninja build system version 1.9.0
-#
-# We also need the FIPS 140-2 validated release of BoringSSL: ae223d6138807a13006342edfeef32e813246b39
-# For more information please refer to the section 12. Guidance and Secure Operation of:
-# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
-
-RUN mkdir -p /opt && cd /opt && \
-    curl -sLO https://go.dev/dl/go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
-    tar xf go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
-    rm -f go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
-    chmod a+w /opt/go && \
-    chmod a+w /var/lib && \
-    chmod a-w /
-ENV GOEXPERIMENT=boringcrypto \
-    GOPATH="/go" \
-    GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/go/bin"
-
-RUN git clone https://github.com/ninja-build/ninja.git && \
-    cd ninja && \
-    git checkout v1.9.0 && \
-    ./configure.py --bootstrap && \
-    mv ninja /usr/bin
-
-RUN mkdir -p /opt && cd /opt && \
-    git clone https://github.com/google/boringssl.git && \
-    cd boringssl && \
-    git checkout ae223d6138807a13006342edfeef32e813246b39 && \
-    mkdir build && \
-    cd build && \
-    cd /opt/boringssl/build && cmake3 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -GNinja .. && ninja
-
 ## Intermediate targets ########################################################
 #
 FROM gcc AS deps-arm
@@ -225,13 +188,6 @@ FROM gcc AS deps-386
 FROM deps-64 AS deps-arm64
 FROM deps-64 AS deps-amd64
 
-# Copy BoringSSL into the final image
-COPY --from=boringssl /opt/boringssl /opt/boringssl
-
-# set boring-rs crate env variables to point to pre-built binaries
-# https://github.com/cloudflare/boring#support-for-pre-built-binaries
-ENV BORING_BSSL_PATH=/opt/boringssl
-ENV BORING_BSSL_INCLUDE_PATH=/opt/boringssl/include
 ENV GOEXPERIMENT=boringcrypto
 
 # Install node.

--- a/build.assets/Dockerfile-multiarch-base
+++ b/build.assets/Dockerfile-multiarch-base
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # #############################################################################
 # This image provides platform setup and GCC required for all platforms.
 #
@@ -13,7 +15,7 @@ FROM centos:7 AS base
 ARG TARGETARCH
 
 ARG GCC_VERSION=10.4.0
-ARG CMAKE3_VERSION=3.12.3
+ARG CMAKE3_VERSION=3.20.1
 
 # #############################################################################
 # Platform-specific customisation.
@@ -111,7 +113,7 @@ ENV CXX=/usr/local/bin/g++
 ENV PATH=/usr/local/bin:$PATH
 
 # Install CMake3. CMake3 is required for most dependencies.
-RUN wget https://cmake.org/files/v3.12/cmake-${CMAKE3_VERSION}.tar.gz && \
+RUN wget https://cmake.org/files/v3.20/cmake-${CMAKE3_VERSION}.tar.gz && \
     tar xzvf cmake-${CMAKE3_VERSION}.tar.gz && \
     cd cmake-${CMAKE3_VERSION} && \
     ./bootstrap --prefix=/usr/local && \

--- a/build.assets/Dockerfile-multiarch-clang
+++ b/build.assets/Dockerfile-multiarch-clang
@@ -1,4 +1,6 @@
-# This image builds clang from source. clang7 is required to build boringssl, clang10 is required for BPF.
+# syntax=docker/dockerfile:1
+
+# This image builds clang from source. clang12 is required to build boringssl, clang10+ is required for BPF.
 ARG BUILDBOX_VERSION
 ARG BUILDBOX_PREFIX
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -71,13 +71,6 @@ endif
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache
 endif
 
-ifeq ("$(RUNTIME_ARCH)","arm64")
-	# devtoolset-11 is not available on CentOS 7 aarch64
-	DEVTOOLSET ?= devtoolset-10
-else
-	DEVTOOLSET ?= devtoolset-11
-endif
-
 #
 # Build 'teleport' release inside a docker container
 #
@@ -155,6 +148,7 @@ buildbox-centos7:
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
+		--build-arg TARGETARCH=$(HOST_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
@@ -174,9 +168,11 @@ buildbox-centos7-fips:
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
+		--build-arg TARGETARCH=$(HOST_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
+		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
@@ -525,6 +521,7 @@ print-buildbox-version:
 build-centos7-assets:
 	docker build \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
+		--build-arg TARGETARCH=$(HOST_ARCH) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .
 
@@ -533,8 +530,10 @@ build-centos7-assets:
 #################################################################################
 
 GCC_VERSION ?= 10.4.0
-CLANG_BPF_VERSION ?= 10.0.1
-CLANG_FIPS_VERSION ?= 7.0.1
+# This version of Clang is explicitly required for FIPS compliance when building BoringSSL.
+# For more information please refer to the section 12. Guidance and Secure Operation of:
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf
+CLANG_VERSION ?= 12.0.0
 BUILDBOX_PREFIX ?= ghcr.io/gravitational
 
 #
@@ -552,28 +551,14 @@ build-multiarch-base:
 		--file Dockerfile-multiarch-base .
 
 #
-# Build Dockerfile-multiarch-clang on GHA with clang-10, based on -base
+# Build Dockerfile-multiarch-clang on GHA with clang-12, based on -base
 #
-.PHONY:build-multiarch-clang10
-build-multiarch-clang10: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-clang10:$(BUILDBOX_VERSION)-$(ARCH)
-build-multiarch-clang10:
+.PHONY:build-multiarch-clang12
+build-multiarch-clang12: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-clang12:$(BUILDBOX_VERSION)-$(ARCH)
+build-multiarch-clang12:
 	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
 		--cache-from type=gha \
-		--build-arg CLANG_VERSION=$(CLANG_BPF_VERSION) \
-		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
-		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
-		--tag $(BUILDBOX) \
-		--file Dockerfile-multiarch-clang .
-
-#
-# Build Dockerfile-multiarch-clang on GHA with clang-7, based on -base
-#
-.PHONY:build-multiarch-clang7
-build-multiarch-clang7: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-clang7:$(BUILDBOX_VERSION)-$(ARCH)
-build-multiarch-clang7:
-	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
-		--cache-from type=gha \
-		--build-arg CLANG_VERSION=$(CLANG_FIPS_VERSION) \
+		--build-arg CLANG_VERSION=$(CLANG_VERSION) \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
 		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
 		--tag $(BUILDBOX) \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -10,8 +10,10 @@ NODE_VERSION ?= 18.18.2
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1
 WASM_PACK_VERSION ?= 0.11.0
-LIBBPF_VERSION ?= 1.0.1
+LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
+
+DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
 BUF_VERSION ?= v1.27.0

--- a/common.mk
+++ b/common.mk
@@ -1,7 +1,7 @@
 # Common makefile shared between Teleport OSS and Ent.
 
 # libbpf version required by the build.
-LIBBPF_VER := 1.0.1
+LIBBPF_VER := 1.2.2
 
 # Is this build targeting the same OS & architecture it is being compiled on, or
 # will it require cross-compilation? We need to know this (especially for ARM) so we
@@ -23,8 +23,8 @@ ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
 with_bpf := yes
 BPF_TAG := bpf
 BPF_MESSAGE := with-BPF-support
-CLANG ?= $(shell which clang || which clang-10)
-LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-10)
+CLANG ?= $(shell which clang || which clang-12)
+LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-12)
 KERNEL_ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
 INCLUDES :=
 ER_BPF_BUILDDIR := lib/bpf/bytecode

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.3.2 // replaced
 	github.com/alicebob/miniredis/v2 v2.31.0
 	github.com/andybalholm/brotli v1.0.6
-	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1
+	github.com/aquasecurity/libbpfgo v0.5.1-libbpf-1.2
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.45.25
 	github.com/aws/aws-sdk-go-v2 v1.21.2

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1 h1:Et7WT8CEpaO03v7FIVk85GMRRbwjF7sgoBgQhH5T30k=
-github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
+github.com/aquasecurity/libbpfgo v0.5.1-libbpf-1.2 h1:Y7QB6jUsMyr0Bd+rAj67X2/ezNYLuxwp3kkjw5M3Q+4=
+github.com/aquasecurity/libbpfgo v0.5.1-libbpf-1.2/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
The `boring` crate will compile BoringSSL on demand.

Remove unneeded Clang 7 build and replace Clang 10 with Clang 12. BoringSSL in FIPS mode explicitly requires Clang 12.0.0, while libbpf and related tools only require Clang 10+, so standardized everything on Clang 12.0.0 so that we don't need multiple Clang installations.

This also required libbpf to be bumped, as 1.0.1 no longer compiled. Both 1.1.x and 1.2.x seem to build fine, so went ahead and bumped to 1.2.2 (latest libbpf). As a result, `aquasecurity/libbpfgo` was also bumped to match the new version.

Additionally, add a few missing git commit hash validations that were noticed as all the `Dockerfile`s were being reviewed/updated.