### PR TITLE
Remove "Preview" designation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ that supports efficient searching, sorting, and filtering operations. Teleport
 Cloud customers will have their audit log automatically migrated to this new
 backend.
 
-See the documentation [here](docs/pages/reference/backends.mdx#athena-preview).
+See the documentation [here](docs/pages/reference/backends.mdx#athena).
 
 #### Access lists
 

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -6,7 +6,7 @@ videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="warning">
-  Device Trust is currently in Preview mode and supports following components:
+  Device Trust supports the following components:
 
   - User devices: macOS and Windows.
   - Teleport client: `tsh` and Teleport connect.

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -3,8 +3,8 @@ title: Manage Trusted Devices
 description: Learn how to manage Trusted Devices
 ---
 
-<Admonition type="warning" title="Preview Note: Supported Device Type">
-The device trust preview works on macOS and Windows devices. Support for other operating
+<Admonition type="warning" title="Supported Device Type">
+Device trust works on macOS and Windows devices. Support for other operating
 systems and access features is planned for upcoming Teleport versions.
 </Admonition>
 

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -4,9 +4,9 @@ description: Learn how to enforce trusted devices with Teleport
 videoBanner: gBQyj_X1LVw
 ---
 
-<Admonition type="warning" title="Preview Note: Supported Resources">
-The device trust preview only supports SSH, Database and Kubernetes resources.
-Support for other resources is planned for upcoming Teleport versions.
+<Admonition type="warning" title="Supported Resources">
+Device trust only supports SSH, Database and Kubernetes resources. Support for
+other resources is planned for upcoming Teleport versions.
 </Admonition>
 
 Resources protected by the device mode "required" will enforce the use of a
@@ -75,9 +75,8 @@ Enterprise clusters run in `optional` mode by default. Changing the mode to
 accesses.
 
 <Admonition type="warning" title="Web UI">
-The Web UI is not capable of trusted device access during the device trust
-preview. Only `tsh` and Teleport Connect are able to fulfill device mode
-`required`.
+The Web UI is not capable of trusted device access. Only `tsh` and Teleport
+Connect are able to fulfill device mode `required`.
 </Admonition>
 
 To enable device mode `required` update your configuration as follows:

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -5,7 +5,7 @@ videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="warning">
-  Device Trust is currently in Preview mode and supports following components:
+  Device Trust supports the following components:
 
   - User devices: macOS and Windows.
   - Teleport client: `tsh` and Teleport connect.

--- a/docs/pages/access-controls/guides/headless.mdx
+++ b/docs/pages/access-controls/guides/headless.mdx
@@ -3,10 +3,6 @@ title: Headless WebAuthn
 description: Headless WebAuthn
 ---
 
-<Notice type="warning">
-  Headless WebAuthn is currently in Preview mode.
-</Notice>
-
 Headless WebAuthn provides a secure way to authenticate with WebAuthn from a
 machine without access to a WebAuthn device. This enables the use of WebAuthn
 features which are usually not usable in WebAuthn-incompatible environments.

--- a/docs/pages/access-controls/guides/ip-pinning.mdx
+++ b/docs/pages/access-controls/guides/ip-pinning.mdx
@@ -4,8 +4,6 @@ description: How to enable IP pinning for Teleport users
 ---
 
 <Admonition type="warning">
-IP Pinning is currently in Preview mode.
-
 IP Pinning requires Teleport Enterprise.
 </Admonition>
 

--- a/docs/pages/access-controls/login-rules.mdx
+++ b/docs/pages/access-controls/login-rules.mdx
@@ -4,10 +4,6 @@ description: Transform User Traits with Login Rules
 layout: tocless-doc
 ---
 
-<Admonition type="warning" title="Preview">
-  Login Rules are currently in Preview mode.
-</Admonition>
-
 When users log in to your Teleport cluster with a configured SSO provider,
 **Login Rules** can transform the traits provided by your IdP to meet your needs
 for configuring access within Teleport.

--- a/docs/pages/access-controls/login-rules/guide.mdx
+++ b/docs/pages/access-controls/login-rules/guide.mdx
@@ -3,10 +3,6 @@ title: Set Up Login Rules
 description: Set up Login Rules to transform user traits
 ---
 
-<Admonition type="warning" title="Preview">
-  Login Rules are currently in Preview mode.
-</Admonition>
-
 This guide will walk you through the process of writing, testing, and adding the
 first Login Rule to your Teleport cluster.
 

--- a/docs/pages/access-controls/login-rules/kubernetes.mdx
+++ b/docs/pages/access-controls/login-rules/kubernetes.mdx
@@ -3,10 +3,6 @@ title: Deploy Login Rules using Kubernetes Operator
 description: Use Teleport's Kubernetes Operator to deploy Login Rules to your cluster
 ---
 
-<Admonition type="warning" title="Preview">
-  Login Rules and the Teleport Kubernetes Operator are currently in Preview mode.
-</Admonition>
-
 This guide will explain how to:
 
 - Use Teleport's Kubernetes Operator to deploy Login Rules to your Teleport cluster

--- a/docs/pages/access-controls/login-rules/reference.mdx
+++ b/docs/pages/access-controls/login-rules/reference.mdx
@@ -4,10 +4,6 @@ description: Reference documentation for Login Rules
 tocDepth: 3
 ---
 
-<Admonition type="warning" title="Preview">
-  Login Rules are currently in Preview mode.
-</Admonition>
-
 This page provides details on the expression language that powers Login Rules.
 To learn how to add the first login rule to your cluster, checkout out the
 [Login Rules Guide](./guide.mdx).

--- a/docs/pages/access-controls/login-rules/terraform.mdx
+++ b/docs/pages/access-controls/login-rules/terraform.mdx
@@ -3,10 +3,6 @@ title: Deploy Login Rules via Terraform
 description: Use Teleport's Terraform Provider to deploy Login Rules to your cluster
 ---
 
-<Admonition type="warning" title="Preview">
-  Login Rules are currently in Preview mode.
-</Admonition>
-
 This guide will explain how to:
 
 - Use Teleport's Terraform Provider to deploy Login Rules to your Teleport cluster

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -67,7 +67,7 @@ user:
 | `max_kubernetes_connections` | Defines the maximum number of concurrent Kubernetes sessions per user | |
 | `record_session` |Defines the [Session recording mode](../reference/audit.mdx#modes).|The strictest value takes precedence.|
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
-| `pin_source_ip` | Enable source IP pinning for SSH certificates. **Note:** IP pinning is currently in Preview mode | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
+| `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `drop`, `keep`), it will evaluate to the option specified by all of the roles. If some roles specify both `drop` or `keep` it will evaluate to `keep`|
 | `create_db_user_mode` | Allow [database user auto provisioning](../database-access/auto-user-provisioning.mdx). Options: `off` (disable database user auto-provisioning), `keep` (disables the user at session end, removing the roles and locking it), and `best_effort_drop` (try to drop the user at session end, if it doesn't succeed, fallback to disabling it). | Logical "OR" i.e. if any role allows database user auto-provisioning, it's allowed |

--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -3,10 +3,6 @@ title: Try out Teleport Assist
 description: This tutorial will guide you through the steps needed to run Teleport Assist on your own infrastructure.
 ---
 
-<Admonition type="tip" title="Preview">
-  Teleport Assist is currently in Preview.
-</Admonition>
-
 This guide will help you understand how to set up and use Teleport Assist, an
 AI-powered assistant that helps you run commands, debug issues and navigate your
 infrastructure.

--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -3,6 +3,10 @@ title: Try out Teleport Assist
 description: This tutorial will guide you through the steps needed to run Teleport Assist on your own infrastructure.
 ---
 
+<Admonition type="tip" title="Preview">
+  Teleport Assist is currently in Preview.
+</Admonition>
+
 This guide will help you understand how to set up and use Teleport Assist, an
 AI-powered assistant that helps you run commands, debug issues and navigate your
 infrastructure.

--- a/docs/pages/application-access/okta.mdx
+++ b/docs/pages/application-access/okta.mdx
@@ -3,9 +3,6 @@ title: Okta Integration with Application Access
 description: Guides for using Teleport Okta integration.
 layout: tocless-doc
 ---
-<Admonition type="warning" title="Preview">
-Okta application access is currently in Preview mode.
-</Admonition>
 
 Configure Teleport to import and grant access to Okta applications and user groups.
 

--- a/docs/pages/application-access/okta/architecture.mdx
+++ b/docs/pages/application-access/okta/architecture.mdx
@@ -3,10 +3,6 @@ title: Architecture of the Okta Service
 description: An overview of the architecture of the Okta Service.
 ---
 
-<Admonition type="warning" title="Preview">
-Okta application access is currently in Preview mode.
-</Admonition>
-
 This document will go into details on how the Okta Service is organized and how
 it functions.
 

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -3,10 +3,6 @@ title: Setting up the Okta Service
 description: How to set up the Okta Service with some basic configurations
 ---
 
-<Admonition type="warning" title="Preview">
-Okta application access is currently in Preview mode.
-</Admonition>
-
 Teleport can import and grant access to Okta applications and user groups. Okta applications
 can be accessed through Teleport's application access UI, and access to these applications along
 with user groups can be managed by Teleport's RBAC along with access requests.

--- a/docs/pages/application-access/okta/reference.mdx
+++ b/docs/pages/application-access/okta/reference.mdx
@@ -5,10 +5,6 @@ description: Configuration and CLI reference documentation for Teleport Okta ser
 
 ## Configuration
 
-<Admonition type="warning" title="Preview">
-Okta application access is currently in Preview mode.
-</Admonition>
-
 (!docs/pages/includes/backup-warning.mdx!)
 
 The following snippet shows the full YAML configuration of the Okta Service

--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -10,8 +10,8 @@ description: How Teleport implements a single-port setup with TLS routing
   scopeOnly={true}
   min="13.0"
 >
-  Support for TLS Routing behind layer 7 (HTTP/HTTPS) load balancers and
-  reverse proxies is available in Preview starting from Teleport `13.0`.
+  Support for TLS Routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
+  proxies is available starting from Teleport `13.0`.
 </Details>
 
 In TLS routing mode [Teleport proxy](./proxy.mdx) multiplexes all client

--- a/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
@@ -17,12 +17,6 @@ Teleport audit logs for query activity are only supported for the ClickHouse
 HTTP interface. Teleport support for ClickHouse's native interfaces does not
 include audit logs for database query activity.
 
-<Admonition type="warning" title="Preview">
-
-Database access for ClickHouse Database is currently in Preview mode.
-
-</Admonition>
-
 This guide will help you to:
 
 - Install and configure a Teleport database agent.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -86,7 +86,6 @@ spec:
     # enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
     # certificates, preventing a compromised certificate from being used on another
     # network. The default is false.
-    # Note: Source IP pinning is currently in Preview mode.
     pin_source_ip: true
     # Specify a list of names and associated values to be included in user SSH keys.
     # The key type can only be "ssh" and the mode can only be "extension".

--- a/docs/pages/includes/tls-multiplexing-warnings.mdx
+++ b/docs/pages/includes/tls-multiplexing-warnings.mdx
@@ -3,9 +3,9 @@ these proxies terminating TLS themselves and then rewriting their requests to th
 the additional SNI/ALPN parts of the request in the process.
 
 Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
-proxies is available in Preview starting from Teleport `13.0`. Please ensure
-your Teleport cluster and Teleport clients are up to date. If the problem
-persists, please submit a [GitHub
+proxies is available starting from Teleport `13.0`. Please ensure your Teleport
+cluster and Teleport clients are up to date. If the problem persists, please
+submit a [GitHub
 issue](https://github.com/gravitational/teleport/issues/new/choose).
 
 For older versions, in order for ALPN to work correctly, the Teleport Proxy

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -10,8 +10,8 @@ description: How to upgrade an existing Teleport cluster to single-port TLS rout
   scopeOnly={true}
   min="13.0"
 >
-  Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and
-  reverse proxies is available in Preview starting from Teleport `13.0`.
+  Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
+  proxies is available starting from Teleport `13.0`.
 </Details>
 
 In TLS routing mode, all Teleport client connections are wrapped in TLS and

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -46,7 +46,7 @@ used, events are written to the filesystem in JSON format. The `dir` backend rot
 the event file approximately once every 24 hours, but never deletes captured events.
 
 For High Availability configurations, users can refer to our
-[Athena](./backends.mdx#athena-preview), [DynamoDB](./backends.mdx#dynamodb) or
+[Athena](./backends.mdx#athena), [DynamoDB](./backends.mdx#dynamodb) or
 [Firestore](./backends.mdx#firestore) chapters for information on how to
 configure the SSH events and recorded sessions to be stored on network storage.
 When these backends are in use, audit events will eventually expire and be

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -182,10 +182,6 @@ teleport:
   The PostgreSQL cluster state and audit log storage is available starting from Teleport `13.3`.
 </Details>
 
-<Admonition type="warning" title="Preview">
-  The PostgreSQL cluster state and audit log storage is currently in Preview.
-</Admonition>
-
 <Admonition
   type="tip"
   title="Tip"
@@ -961,10 +957,9 @@ Config option priority is applied in the following order:
   are not supported in certain regions or environments or are only supported in GovCloud.
 </Admonition>
 
-## Athena (Preview)
+## Athena 
 
-The Athena audit log back-end is available starting from Teleport v14.0, and is
-currently in preview.
+The Athena audit log back-end is available starting from Teleport v14.0.
 
 <Notice type="danger">
 
@@ -1386,10 +1381,6 @@ teleport:
 >
   Azure Blob Storage for session storage is available starting from Teleport `13.3`.
 </Details>
-
-<Admonition type="warning" title="Preview">
-  Azure Blob Storage for session storage is currently in Preview.
-</Admonition>
 
 <Admonition
   type="tip"

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -188,7 +188,6 @@ spec:
     # Enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
     # certificates, preventing a compromised certificate from being used on another
     # network. The default is false.
-    # Note: Source IP pinning is currently in Preview mode.
     pin_source_ip: true
     # Specify a list of names and associated values to be included in user SSH keys.
     # The key type can only be "ssh" and the mode can only be "extension".


### PR DESCRIPTION
Teleport is moving away from the concept of a preview feature. This change reflects this move on the docs site.