### PR TITLE
Fix potential SEO issues

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2947,6 +2947,21 @@
       "source": "/database-access/rbac/configuring-auto-user-provisioning/",
       "destination": "/database-access/auto-user-provisioning/",
       "permanent": true
+    },
+    {	
+      "source": "/database-access/guides/rds-proxy/",
+      "destination": "/database-access/guides/",
+      "permanent": true
+    },
+    {
+      "source": "/deploy-a-cluster/deployments/aws-terraform/",
+      "destination": "/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-id/guides/github-actions/",
+      "destination": "/machine-id/deployment/github-actions/",
+      "permanent": true
     }
   ]
 }

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: Teleport CLI Reference
+title: CLI References
 description: Detailed guide and reference documentation for Teleport's command line interface (CLI) tools.
 ---
 

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -1,5 +1,5 @@
 ---
-title: teleport CLI reference
+title: teleport CLI Reference
 description: Comprehensive reference of subcommands, flags, and arguments for the teleport CLI tool.
 ---
 


### PR DESCRIPTION
- Fix clashing reference page titles ("Teleport CLI Reference" and "teleport CLI reference").
- Add missing redirects: The Teleport blog encountered 404s navigating to three pages. This change adds redirects for these pages in case other sites link to them as well.