### PR TITLE
Fix enterprise github connector marshaling

### DIFF
--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -176,7 +177,11 @@ func MarshalOSSGithubConnector(githubConnector types.GithubConnector, opts ...Ma
 
 	switch githubConnector := githubConnector.(type) {
 	case *types.GithubConnectorV3:
-		if githubConnector.Spec.EndpointURL != "" {
+		// Only return an error if the endpoint url is set and the build is OSS
+		// so that the enterprise marshaler can call this marshaler to produce
+		// the final output without receiving an error.
+		if modules.GetModules().BuildType() == modules.BuildOSS &&
+			githubConnector.Spec.EndpointURL != "" {
 			return nil, fmt.Errorf("GitHub endpoint URL is set: %w", ErrRequiresEnterprise)
 		}
 


### PR DESCRIPTION
#32653 refactored github connector marshaling so that enterprise could call the oss marshaler instead of maintaining a copy of it in two repos. However, the check on the EndpointURL was not omitted in ent builds.