### PR TITLE
ci: update inputs for create-github-app-token step

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -24,8 +24,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.REVIEWERS_APP_ID }}
-          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -55,8 +55,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1.0.5 # Cannot upgrade past v1.1 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
-          app_id: ${{ secrets.REVIEWERS_APP_ID }}
-          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,8 +39,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.REVIEWERS_APP_ID }}
-          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v4

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -62,8 +62,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.REVIEWERS_APP_ID }}
-          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
 
       - name: Checkout shared-workflows
         uses: actions/checkout@v4

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -71,8 +71,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout Release Branch
         uses: actions/checkout@v4

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
As per https://github.com/actions/create-github-app-token#inputs, we should be using `app-id` and `private-key`.

This has been showing up in warnings in our runs for some time now:

    Warning: Input 'app_id' has been deprecated with message
    'app_id' is deprecated and will be removed in a future version.
    Use 'app-id' instead.
    Warning: Input 'private_key' has been deprecated with message:
    'private_key' is deprecated and will be removed in a future version.
    Use 'private-key' instead.