### PR TITLE
Support MariaDB auto provisioned user deletion

### DIFF
--- a/lib/srv/db/autousers_test.go
+++ b/lib/srv/db/autousers_test.go
@@ -165,6 +165,14 @@ func TestAutoUsersMySQL(t *testing.T) {
 			expectConnectionErr: false,
 			expectDatabaseUser:  "user1",
 		},
+		"MariaDB activate/delete users": {
+			mode:                types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+			databaseRoles:       []string{"reader", "writer"},
+			serverVersion:       "5.5.5-10.11.0-MariaDB",
+			teleportUser:        "user1",
+			expectConnectionErr: false,
+			expectDatabaseUser:  "user1",
+		},
 		"MariaDB long name": {
 			mode:                types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			databaseRoles:       []string{"reader", "writer"},

--- a/lib/srv/db/mysql/sql/mariadb_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mariadb_delete_user.sql
@@ -1,0 +1,35 @@
+CREATE PROCEDURE teleport_delete_user(IN username VARCHAR(32))
+BEGIN
+    -- Defaults to dropping user.
+    DECLARE state VARCHAR(5);
+    DECLARE is_active INT DEFAULT 0;
+    DECLARE view_count INT DEFAULT 0;
+    DECLARE procedure_count INT DEFAULT 0;
+
+    SELECT COUNT(USER) INTO is_active FROM information_schema.processlist WHERE USER = username;
+    IF is_active = 1 THEN
+        -- Throw a custom error code when user is still active from other sessions.
+        SIGNAL SQLSTATE 'TP000' SET MESSAGE_TEXT = 'User has active connections';
+    ELSE
+        -- MariaDB DROP USER doesn't fail if the user owns views/procedures.
+        -- However,dropping the user causes the view/procedure to no longer be
+        -- usable, even if a user with same name recreated.
+        SELECT COUNT(*) INTO procedure_count FROM information_schema.routines WHERE routine_type = 'PROCEDURE' AND DEFINER = CONCAT(username, '@%');
+        SELECT COUNT(*) INTO view_count FROM information_schema.views WHERE DEFINER = CONCAT(username, '@%');
+
+        IF procedure_count > 0 OR view_count > 0 THEN
+            SET state = 'TP004';
+            CALL teleport_deactivate_user(username);
+        ELSE
+            SET state = 'TP003';
+            SET @sql := CONCAT('DROP USER ', username);
+            PREPARE stmt FROM @sql;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+        END IF;
+    END IF;
+
+    -- Issue this as the last query so we can retrieve if the user was dropped
+    -- or deactivated.
+    SELECT state;
+END

--- a/lib/srv/db/mysql/sql/mariadb_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mariadb_delete_user.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE teleport_delete_user(IN username VARCHAR(32))
+CREATE PROCEDURE teleport_delete_user(IN username VARCHAR(80))
 BEGIN
     -- Defaults to dropping user.
     DECLARE state VARCHAR(5);


### PR DESCRIPTION
A different procedure from MySQL is required because `DROP USER` doesn't return an error if the user is the definer of a view or procedure. So, the MariaDB procedure checks if the user owns any of those resources before dropping it, returning to disabling the user.

**Note: Dropping a user that owns a procedure or a view causes them to be unaccessible ~even if the user is recreated~.**

There is no way of giving direct access to the `information_schema` tables. The user has visibility on items based on their permissions. Given this, the `teleport-admin` requires access to all databases (`GRANT SELECT ON *.* TO 'teleport-admin'`) to have visibility on all procedures and views. The procedure will always drop the user if permission is not given, as the queries won't return anything.

changelog: Support MariaDB auto-provisioned users deletion.