### PR TITLE
Clean up logging of watcher kinds

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -53,6 +53,21 @@ type resourceCollector interface {
 	initializationChan() <-chan struct{}
 }
 
+func watchKindsString(kinds []types.WatchKind) string {
+	var sb strings.Builder
+	for i, k := range kinds {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(k.Kind)
+		if k.SubKind != "" {
+			sb.WriteString("/")
+			sb.WriteString(k.SubKind)
+		}
+	}
+	return sb.String()
+}
+
 // ResourceWatcherConfig configures resource watcher.
 type ResourceWatcherConfig struct {
 	// Component is a component used in logs.
@@ -111,7 +126,8 @@ func newResourceWatcher(ctx context.Context, collector resourceCollector, cfg Re
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cfg.Log = cfg.Log.WithField("resource-kind", collector.resourceKinds())
+
+	cfg.Log = cfg.Log.WithField("resource-kind", watchKindsString(collector.resourceKinds()))
 	ctx, cancel := context.WithCancel(ctx)
 	p := &resourceWatcher{
 		ResourceWatcherConfig: cfg,
@@ -185,13 +201,9 @@ func (p *resourceWatcher) WaitInitialization() error {
 		case <-p.collector.initializationChan():
 			return nil
 		case <-t.C:
-			p.Log.Debugf("ResourceWatcher %s is not yet initialized.", p.collector.resourceKinds())
+			p.Log.Debug("ResourceWatcher %s is not yet initialized.")
 		case <-p.ctx.Done():
-			var kindStrings []string
-			for _, kind := range p.collector.resourceKinds() {
-				kindStrings = append(kindStrings, kind.Kind)
-			}
-			return trace.BadParameter("ResourceWatcher %s failed to initialize.", strings.Join(kindStrings, ", "))
+			return trace.BadParameter("ResourceWatcher %s failed to initialize.", watchKindsString(p.collector.resourceKinds()))
 		}
 	}
 }


### PR DESCRIPTION
We were logging the raw struct, which is hard to read.

Log only the values of kind strings instead.

Before:
```
2023-10-26T12:30:14-06:00 DEBU [NODE:1]    Closed, returning from watch loop. pid:15179.1 resource-kind:[{lock false  map[]   {} [] 0}] services/watcher.go:250
```

After:
```
2023-10-26T12:30:14-06:00 DEBU [NODE:1]    Closed, returning from watch loop. pid:15179.1 resource-kind:[lock] services/watcher.go:250
```
