### PR TITLE
Add bulk actions to Unified Resources component

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -23,10 +23,8 @@ import Menu, { MenuItem } from 'design/Menu';
 import { StyledCheckbox } from 'design/Checkbox';
 import { ArrowUp, ArrowDown, ChevronDown } from 'design/Icon';
 
-import { ResourceFilter, SortType } from 'teleport/services/agents';
-
 import { HoverTooltip } from './UnifiedResources';
-import { SharedUnifiedResource } from './types';
+import { SharedUnifiedResource, UnifiedResourcesQueryParams } from './types';
 
 const kindToLabel: Record<SharedUnifiedResource['resource']['kind'], string> = {
   app: 'Application',
@@ -44,8 +42,8 @@ const sortFieldOptions = [
 
 interface FilterPanelProps {
   availableKinds: SharedUnifiedResource['resource']['kind'][];
-  params: ResourceFilter;
-  setParams: (params: ResourceFilter) => void;
+  params: UnifiedResourcesQueryParams;
+  setParams: (params: UnifiedResourcesQueryParams) => void;
   selectVisible: () => void;
   selected: boolean;
   shouldUnpin: boolean;
@@ -101,7 +99,9 @@ export function FilterPanel({
   );
 }
 
-function oppositeSort(sort: SortType): SortType {
+function oppositeSort(
+  sort: UnifiedResourcesQueryParams['sort']
+): UnifiedResourcesQueryParams['sort'] {
   switch (sort.dir) {
     case 'ASC':
       return { ...sort, dir: 'DESC' };

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -77,7 +77,6 @@ const story = ({
   const params = { sort: { dir: 'ASC', fieldName: 'name' } } as const;
   return () => {
     const { fetch, attempt, resources } = useUnifiedResourcesFetch({
-      params,
       fetchFunc,
     });
     return (

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -27,7 +27,11 @@ import { nodes } from 'teleport/Nodes/fixtures';
 import { UrlResourcesParams } from 'teleport/config';
 import { ResourcesResponse } from 'teleport/services/agents';
 
-import { UnifiedResources, UnifiedResourcesPinning } from './UnifiedResources';
+import {
+  UnifiedResources,
+  UnifiedResourcesPinning,
+  useUnifiedResourcesFetch,
+} from './UnifiedResources';
 import { SharedUnifiedResource } from './types';
 
 export default {
@@ -70,29 +74,43 @@ const story = ({
   ) => Promise<ResourcesResponse<SharedUnifiedResource['resource']>>;
   pinning?: UnifiedResourcesPinning;
 }) => {
-  return () => (
-    <UnifiedResources
-      availableKinds={['app', 'db', 'node', 'kube_cluster', 'windows_desktop']}
-      Header={pinAllButton => (
-        <Flex justifyContent="end" height="50px">
-          {pinAllButton}
-        </Flex>
-      )}
-      params={{ sort: { dir: 'ASC', fieldName: 'name' } }}
-      setParams={() => undefined}
-      pinning={pinning}
-      updateUnifiedResourcesPreferences={() => undefined}
-      onLabelClick={() => undefined}
-      EmptySearchResults={undefined}
-      fetchFunc={fetchFunc}
-      mapToResource={resource => ({
-        resource,
-        ui: {
-          ActionButton: <ButtonBorder size="small">Connect</ButtonBorder>,
-        },
-      })}
-    />
-  );
+  const params = { sort: { dir: 'ASC', fieldName: 'name' } } as const;
+  return () => {
+    const { fetch, attempt, resources } = useUnifiedResourcesFetch({
+      params,
+      fetchFunc,
+    });
+    return (
+      <UnifiedResources
+        availableKinds={[
+          'app',
+          'db',
+          'node',
+          'kube_cluster',
+          'windows_desktop',
+        ]}
+        Header={pinAllButton => (
+          <Flex justifyContent="end" height="50px">
+            {pinAllButton}
+          </Flex>
+        )}
+        params={params}
+        setParams={() => undefined}
+        pinning={pinning}
+        updateUnifiedResourcesPreferences={() => undefined}
+        onLabelClick={() => undefined}
+        NoResources={undefined}
+        fetchResources={fetch}
+        resourcesFetchAttempt={attempt}
+        resources={resources.map(resource => ({
+          resource,
+          ui: {
+            ActionButton: <ButtonBorder size="small">Connect</ButtonBorder>,
+          },
+        }))}
+      />
+    );
+  };
 };
 
 export const Empty = story({

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -36,7 +36,6 @@ import {
   ResourceLabel,
   ResourceFilter,
 } from 'teleport/services/agents';
-import { UrlResourcesParams } from 'teleport/config';
 import { FeatureBox } from 'teleport/components/Layout';
 import { TextIcon } from 'teleport/Discover/Shared';
 import {
@@ -130,15 +129,13 @@ interface UnifiedResourcesProps {
 }
 
 export function useUnifiedResourcesFetch<T>(props: {
-  params: ResourceFilter;
   fetchFunc(
-    params: UrlResourcesParams,
+    paginationParams: { limit: number; startKey: string },
     signal: AbortSignal
   ): Promise<ResourcesResponse<T>>;
 }) {
   return useKeyBasedPagination({
     fetchFunc: props.fetchFunc,
-    filter: props.params,
     initialFetchSize: INITIAL_FETCH_SIZE,
     fetchMoreSize: FETCH_MORE_SIZE,
   });

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -114,7 +114,8 @@ interface UnifiedResourcesProps {
   //TODO(gzdunek): the pin button should be moved to some other place
   //according to the new designs
   Header(pinAllButton: React.ReactElement): React.ReactElement;
-  EmptySearchResults: React.ReactElement;
+  /** Rendered when resource list and search query are empty. */
+  NoResources: React.ReactElement;
   /**
    * If pinning is supported, the functions to get and update pinned resources
    * can be passed here.
@@ -414,10 +415,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         {resourcesFetchAttempt.status === 'failed' && resources.length > 0 && (
           <ButtonSecondary onClick={onRetryClicked}>Load more</ButtonSecondary>
         )}
-        {noResults &&
-          isSearchEmpty &&
-          !params.pinnedOnly &&
-          props.EmptySearchResults}
+        {noResults && isSearchEmpty && !params.pinnedOnly && props.NoResources}
         {noResults && params.pinnedOnly && isSearchEmpty && <NoPinned />}
         {noResults && !isSearchEmpty && (
           <NoResults

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -105,7 +105,7 @@ export type UnifiedResourcesPinning =
 interface UnifiedResourcesProps {
   params: UnifiedResourcesQueryParams;
   resourcesFetchAttempt: Attempt;
-  fetchResources: (options?: { force?: boolean }) => Promise<void>;
+  fetchResources(options?: { force?: boolean }): Promise<void>;
   resources: SharedUnifiedResource[];
   //TODO(gzdunek): the pin button should be moved to some other place
   //according to the new designs

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -110,7 +110,11 @@ interface UnifiedResourcesProps {
   //TODO(gzdunek): the pin button should be moved to some other place
   //according to the new designs
   Header(pinAllButton: React.ReactElement): React.ReactElement;
-  /** Rendered when resource list and search query are empty. */
+  /**
+   * Typically used to inform the user that there are no matching resources when
+   * they want to list resources without filtering the list with a search query.
+   * Rendered only when the resource list is empty and there's no search query.
+   * */
   NoResources: React.ReactElement;
   /**
    * If pinning is supported, the functions to get and update pinned resources
@@ -123,19 +127,6 @@ interface UnifiedResourcesProps {
   updateUnifiedResourcesPreferences(
     preferences: UnifiedResourcePreferences
   ): void;
-}
-
-export function useUnifiedResourcesFetch<T>(props: {
-  fetchFunc(
-    paginationParams: { limit: number; startKey: string },
-    signal: AbortSignal
-  ): Promise<ResourcesResponse<T>>;
-}) {
-  return useKeyBasedPagination({
-    fetchFunc: props.fetchFunc,
-    initialFetchSize: INITIAL_FETCH_SIZE,
-    fetchMoreSize: FETCH_MORE_SIZE,
-  });
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -422,6 +413,19 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
       </ListFooter>
     </FeatureBox>
   );
+}
+
+export function useUnifiedResourcesFetch<T>(props: {
+  fetchFunc(
+    paginationParams: { limit: number; startKey: string },
+    signal: AbortSignal
+  ): Promise<ResourcesResponse<T>>;
+}) {
+  return useKeyBasedPagination({
+    fetchFunc: props.fetchFunc,
+    initialFetchSize: INITIAL_FETCH_SIZE,
+    fetchMoreSize: FETCH_MORE_SIZE,
+  });
 }
 
 function getResourcePinningSupport(

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -31,11 +31,7 @@ import { Danger } from 'design/Alert';
 
 import './unifiedStyles.css';
 
-import {
-  ResourcesResponse,
-  ResourceLabel,
-  ResourceFilter,
-} from 'teleport/services/agents';
+import { ResourcesResponse, ResourceLabel } from 'teleport/services/agents';
 import { FeatureBox } from 'teleport/components/Layout';
 import { TextIcon } from 'teleport/Discover/Shared';
 import {
@@ -56,7 +52,7 @@ import {
 } from 'shared/hooks/useInfiniteScroll';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
-import { SharedUnifiedResource } from './types';
+import { SharedUnifiedResource, UnifiedResourcesQueryParams } from './types';
 import {
   makeUnifiedResourceCardNode,
   makeUnifiedResourceCardDatabase,
@@ -107,7 +103,7 @@ export type UnifiedResourcesPinning =
     };
 
 interface UnifiedResourcesProps {
-  params: ResourceFilter;
+  params: UnifiedResourcesQueryParams;
   resourcesFetchAttempt: Attempt;
   fetchResources: (options?: { force?: boolean }) => Promise<void>;
   resources: SharedUnifiedResource[];
@@ -122,7 +118,7 @@ interface UnifiedResourcesProps {
    */
   pinning: UnifiedResourcesPinning;
   availableKinds: SharedUnifiedResource['resource']['kind'][];
-  setParams(params: ResourceFilter): void;
+  setParams(params: UnifiedResourcesQueryParams): void;
   onLabelClick(label: ResourceLabel): void;
   updateUnifiedResourcesPreferences(
     preferences: UnifiedResourcePreferences

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -406,7 +406,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
             ))}
         </ResourcesContainer>
       )}
-      <div ref={setTrigger} data-testid="scroll-trigger" />
+      <div ref={setTrigger} />
       <ListFooter>
         {resourcesFetchAttempt.status === 'failed' && resources.length > 0 && (
           <ButtonSecondary onClick={onRetryClicked}>Load more</ButtonSecondary>

--- a/web/packages/shared/components/UnifiedResources/index.ts
+++ b/web/packages/shared/components/UnifiedResources/index.ts
@@ -15,3 +15,4 @@ limitations under the License.
 */
 
 export * from './UnifiedResources';
+export * from './types';

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -85,3 +85,17 @@ export type SharedUnifiedResource = {
     | UnifiedResourceUserGroup;
   ui: UnifiedResourceUi;
 };
+
+export type UnifiedResourcesQueryParams = {
+  /** query is query expression using the predicate language. */
+  query?: string;
+  /** search contains search words/phrases separated by space. */
+  search?: string;
+  sort?: {
+    fieldName: string;
+    dir: 'ASC' | 'DESC';
+  };
+  pinnedOnly?: boolean;
+  // TODO(bl-nero): Remove this once filters are expressed as advanced search.
+  kinds?: string[];
+};

--- a/web/packages/shared/hooks/useInfiniteScroll/index.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { useInfiniteScroll } from './useInfiniteScroll';
+export { useKeyBasedPagination } from './useKeyBasedPagination';

--- a/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
@@ -16,8 +16,6 @@
 
 import 'whatwg-fetch';
 import { RenderResult } from '@testing-library/react-hooks';
-
-import { UrlResourcesParams } from 'teleport/config';
 import { ApiError } from 'teleport/services/api/parseError';
 
 import { Node } from 'teleport/services/nodes';
@@ -60,15 +58,27 @@ export function newApiAbortError() {
  * of resources. To simulate a search, `params.search` is used as a resource
  * name prefix.
  */
-export function newFetchFunc(
-  clusterId: string,
-  numResources: number,
-  newAbortError: () => Error = newDOMAbortError
-) {
-  return async (params: UrlResourcesParams, signal?: AbortSignal) => {
+export function newFetchFunc({
+  clusterId = 'test-cluster',
+  search,
+  numResources,
+  newAbortError = newDOMAbortError,
+}: {
+  clusterId?: string;
+  search?: string;
+  numResources: number;
+  newAbortError?: () => Error;
+}) {
+  return async (
+    params: {
+      limit: number;
+      startKey: string;
+    },
+    signal?: AbortSignal
+  ) => {
     const { startKey, limit } = params;
     const startIndex = parseInt(startKey || '0');
-    const namePrefix = params.search ?? 'r';
+    const namePrefix = search ?? 'r';
     const endIndex = startIndex + limit;
     const nextStartKey =
       endIndex < numResources ? endIndex.toString() : undefined;

--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
@@ -21,38 +21,32 @@ import { render, screen } from 'design/utils/testing';
 import { mockIntersectionObserver } from 'jsdom-testing-mocks';
 
 import { useInfiniteScroll } from './useInfiniteScroll';
-import { newFetchFunc, resourceNames } from './testUtils';
 
 const mio = mockIntersectionObserver();
 
 function hookProps() {
   return {
-    fetchFunc: newFetchFunc('test-cluster', 7),
-    trigger: null,
-    filter: {},
-    initialFetchSize: 2,
-    fetchMoreSize: 3,
+    fetch: jest.fn(),
   };
 }
 
-test('fetches data whenever an element is in view', async () => {
-  const { result, waitForNextUpdate } = renderHook(useInfiniteScroll, {
-    initialProps: hookProps(),
+test('calls fetch function whenever an element is in view', async () => {
+  const props = hookProps();
+  const { result } = renderHook(useInfiniteScroll, {
+    initialProps: props,
   });
   render(<div ref={result.current.setTrigger} data-testid="trigger" />);
   const trigger = screen.getByTestId('trigger');
-  expect(resourceNames(result)).toEqual([]);
+  expect(props.fetch).toHaveBeenCalledTimes(0);
 
   act(() => mio.enterNode(trigger));
-  await waitForNextUpdate();
-  expect(resourceNames(result)).toEqual(['r0', 'r1']);
+  expect(props.fetch).toHaveBeenCalledTimes(1);
 
   act(() => mio.leaveNode(trigger));
-  expect(resourceNames(result)).toEqual(['r0', 'r1']);
+  expect(props.fetch).toHaveBeenCalledTimes(1);
 
   act(() => mio.enterNode(trigger));
-  await waitForNextUpdate();
-  expect(resourceNames(result)).toEqual(['r0', 'r1', 'r2', 'r3', 'r4']);
+  expect(props.fetch).toHaveBeenCalledTimes(2);
 });
 
 test('supports changing nodes', async () => {
@@ -64,26 +58,19 @@ test('supports changing nodes', async () => {
   );
   const trigger1 = screen.getByTestId('trigger1');
   const trigger2 = screen.getByTestId('trigger2');
-  let props = hookProps();
-  const { result, rerender, waitForNextUpdate } = renderHook(
-    useInfiniteScroll,
-    {
-      initialProps: props,
-    }
-  );
+  const props = hookProps();
+  const { result, rerender } = renderHook(useInfiniteScroll, {
+    initialProps: props,
+  });
   result.current.setTrigger(trigger1);
 
   act(() => mio.enterNode(trigger1));
-  await waitForNextUpdate();
-  expect(resourceNames(result)).toEqual(['r0', 'r1']);
+  expect(props.fetch).toHaveBeenCalledTimes(1);
 
   rerender(props);
   result.current.setTrigger(trigger2);
 
-  // Should only register entering trigger2, reading resources r2 through r4.
-  act(() => mio.leaveNode(trigger1));
-  act(() => mio.enterNode(trigger1));
+  // Should register entering trigger2.
   act(() => mio.enterNode(trigger2));
-  await waitForNextUpdate();
-  expect(resourceNames(result)).toEqual(['r0', 'r1', 'r2', 'r3', 'r4']);
+  expect(props.fetch).toHaveBeenCalledTimes(2);
 });

--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useLayoutEffect, useRef } from 'react';
+import { useLayoutEffect, useRef, useCallback } from 'react';
 
 /**
  * Calls fetch function whenever the `trigger` element intersects the
@@ -31,7 +31,7 @@ export function useInfiniteScroll({
   const observer = useRef<IntersectionObserver | null>(null);
   const trigger = useRef<Element | null>(null);
 
-  const recreateObserver = () => {
+  const recreateObserver = useCallback(() => {
     observer.current?.disconnect();
     if (trigger.current) {
       observer.current = new IntersectionObserver(entries => {
@@ -41,7 +41,7 @@ export function useInfiniteScroll({
       });
       observer.current.observe(trigger.current);
     }
-  };
+  }, [fetch]);
 
   const setTrigger = (el: Element | null) => {
     trigger.current = el;
@@ -60,7 +60,7 @@ export function useInfiniteScroll({
     return () => {
       observer.current?.disconnect();
     };
-  }, [fetch]);
+  }, [recreateObserver]);
 
   return { setTrigger };
 }

--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -18,7 +18,9 @@ import { useLayoutEffect, useRef, useCallback } from 'react';
 
 /**
  * Calls fetch function whenever the `trigger` element intersects the
- * viewport until the list is exhausted or an error happens.
+ * viewport.
+ * It also triggers the initial request when the `trigger` element
+ * is rendered for the first time.
  *
  * Callers must set the `trigger` element by passing the [`State.setTrigger`] function
  * as the `ref` prop of the element they want to use as the trigger.
@@ -56,6 +58,7 @@ export function useInfiniteScroll({
   // switching this to `useEffect` and rapidly changing filtering data on the
   // resources list page).
   useLayoutEffect(() => {
+    // triggers the initial request
     recreateObserver();
     return () => {
       observer.current?.disconnect();

--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -16,28 +16,20 @@
 
 import { useLayoutEffect, useRef } from 'react';
 
-import { Attempt } from 'shared/hooks/useAttemptNext';
-
-import {
-  useKeyBasedPagination,
-  Props as PaginationProps,
-} from './useKeyBasedPagination';
-
 /**
- * Fetches a part of resource list whenever the `trigger` element intersects the
+ * Calls fetch function whenever the `trigger` element intersects the
  * viewport until the list is exhausted or an error happens.
  *
  * Callers must set the `trigger` element by passing the [`State.setTrigger`] function
  * as the `ref` prop of the element they want to use as the trigger.
- *
- * Use the [`State.forceFetch`] to continue after an error.
  */
-export function useInfiniteScroll<T>(props: PaginationProps<T>): State<T> {
+export function useInfiniteScroll({
+  fetch,
+}: {
+  fetch: () => Promise<void>;
+}): InfiniteScroll {
   const observer = useRef<IntersectionObserver | null>(null);
   const trigger = useRef<Element | null>(null);
-
-  const { fetch, forceFetch, attempt, resources } =
-    useKeyBasedPagination(props);
 
   const recreateObserver = () => {
     observer.current?.disconnect();
@@ -70,23 +62,14 @@ export function useInfiniteScroll<T>(props: PaginationProps<T>): State<T> {
     };
   }, [fetch]);
 
-  return { setTrigger, forceFetch, attempt, resources };
+  return { setTrigger };
 }
 
-export type State<T> = {
-  /**
-   * Fetches a new batch of data. Cancels a pending request, if there is one.
-   * Disregards whether error has previously occurred.
-   */
-  forceFetch: () => Promise<void>;
-
+type InfiniteScroll = {
   /**
    * Sets an element that will be observed and will trigger a fetch once it
    * becomes visible. The element doesn't need to become fully visible; a single
    * pixel will be enough to trigger.
    */
   setTrigger: (el: Element | null) => void;
-
-  attempt: Attempt;
-  resources: T[];
 };

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
@@ -20,7 +20,10 @@ import { ApiError } from 'teleport/services/api/parseError';
 
 import { Node } from 'teleport/services/nodes';
 
-import { useKeyBasedPagination, Props } from './useKeyBasedPagination';
+import {
+  useKeyBasedPagination,
+  KeyBasedPaginationOptions,
+} from './useKeyBasedPagination';
 import {
   newApiAbortError,
   newDOMAbortError,
@@ -29,7 +32,7 @@ import {
   resourceNames,
 } from './testUtils';
 
-function hookProps(overrides: Partial<Props<Node>> = {}) {
+function hookProps(overrides: Partial<KeyBasedPaginationOptions<Node>> = {}) {
   return {
     fetchFunc: newFetchFunc('test-cluster', 7),
     clusterId: 'test-cluster',
@@ -142,7 +145,7 @@ test("doesn't restart if params didn't change on rerender", async () => {
 });
 
 describe("doesn't react to fetch() calls before the previous one finishes", () => {
-  let props: Props<Node>, fetchSpy;
+  let props: KeyBasedPaginationOptions<Node>, fetchSpy;
 
   beforeEach(() => {
     props = hookProps();
@@ -270,7 +273,7 @@ describe.each`
       throw new ErrorType('OMGOMG');
     });
     await act(result.current.fetch);
-    await act(result.current.forceFetch);
+    await act(() => result.current.fetch({ force: true }));
 
     expect(result.current.attempt.status).toBe('success');
     expect(resourceNames(result)).toEqual(['r0', 'r1', 'r2', 'r3', 'r4']);
@@ -304,7 +307,7 @@ test('forceFetch spawns another request, even if there is one pending', async ()
     f1 = result.current.fetch();
   });
   act(() => {
-    f2 = result.current.forceFetch();
+    f2 = result.current.fetch({ force: true });
   });
   await act(async () => Promise.all([f1, f2]));
   expect(resourceNames(result)).toEqual(['r0', 'r1']);

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -42,9 +42,31 @@ import { ResourceActionButton } from './ResourceActionButton';
 import SearchPanel from './SearchPanel';
 
 export function UnifiedResources() {
-  const teleCtx = useTeleport();
   const { clusterId, isLeafCluster } = useStickyClusterId();
   const enabled = localStorage.areUnifiedResourcesEnabled();
+
+  if (!enabled) {
+    history.replace(cfg.getNodesRoute(clusterId));
+  }
+
+  return (
+    <Wrapper
+      key={clusterId} // when the current cluster changes, remount the component
+      clusterId={clusterId}
+      isLeafCluster={isLeafCluster}
+    />
+  );
+}
+
+function Wrapper({
+  clusterId,
+  isLeafCluster,
+}: {
+  clusterId: string;
+  isLeafCluster: boolean;
+}) {
+  const teleCtx = useTeleport();
+
   const pinningNotSupported = localStorage.arePinnedResourcesDisabled();
   const {
     getClusterPinnedResources,
@@ -64,10 +86,6 @@ export function UnifiedResources() {
         preferences.unifiedResourcePreferences.defaultTab ===
         UnifiedTabPreference.Pinned,
     });
-
-  if (!enabled) {
-    history.replace(cfg.getNodesRoute(clusterId));
-  }
 
   const getCurrentClusterPinnedResources = useCallback(
     () => getClusterPinnedResources(clusterId),
@@ -157,7 +175,6 @@ export function UnifiedResources() {
           )
         );
       }}
-      key={clusterId} // when the current cluster changes, remount the component
       pinning={pinning}
       onLabelClick={onLabelClick}
       EmptySearchResults={

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -50,7 +50,7 @@ export function UnifiedResources() {
   }
 
   return (
-    <Wrapper
+    <ClusterResources
       key={clusterId} // when the current cluster changes, remount the component
       clusterId={clusterId}
       isLeafCluster={isLeafCluster}
@@ -58,7 +58,7 @@ export function UnifiedResources() {
   );
 }
 
-function Wrapper({
+function ClusterResources({
   clusterId,
   isLeafCluster,
 }: {

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -193,7 +193,7 @@ function Wrapper({
       }}
       pinning={pinning}
       onLabelClick={onLabelClick}
-      EmptySearchResults={
+      NoResources={
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -103,12 +103,20 @@ function Wrapper({
       };
 
   const { fetch, resources, attempt } = useUnifiedResourcesFetch({
-    params: params,
     fetchFunc: useCallback(
-      async (params, signal) => {
+      async (paginationParams, signal) => {
         const response = await teleCtx.resourceService.fetchUnifiedResources(
           clusterId,
-          params,
+          {
+            search: params.search,
+            query: params.query,
+            pinnedOnly: params.pinnedOnly,
+            sort: params.sort,
+            kinds: params.kinds,
+            searchAsRoles: '',
+            limit: paginationParams.limit,
+            startKey: paginationParams.startKey,
+          },
           signal
         );
 
@@ -118,7 +126,15 @@ function Wrapper({
           totalCount: response.agents.length,
         };
       },
-      [clusterId, teleCtx.resourceService]
+      [
+        clusterId,
+        params.kinds,
+        params.pinnedOnly,
+        params.query,
+        params.search,
+        params.sort,
+        teleCtx.resourceService,
+      ]
     ),
   });
 


### PR DESCRIPTION
in support of https://github.com/gravitational/teleport/issues/30419
This is in support of bulk actions for other pages like access requests. it allows us to pass in custom functions/components to be added in the 'bulk actions' section. Left a `TODO` to remove Pinning in the same way but it's a much larger refactor so I left it out of this PR.

Also, a small update to a type.

This is in support of Unified Access Requests (which is coming in an `e` PR)