### PR TITLE
[v13] Clarify Opsgenie prerequisites

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -18,11 +18,26 @@ Opsgenie.
 
 ## Prerequisites
 
-(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+- A Teleport Enterprise Cloud account.
+
+- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
+  
+  You can verify the tools you have installed by running the following commands:
+
+  ```code
+  $ tctl version
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+  
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+  You can download these tools by following the appropriate [Installation 
+  instructions](../../installation.mdx#installation-instructions) for your environment and Teleport edition.
 
 - An Opsgenie account with the ability to create API keys with the 'read' and
   'create and update' access rights.
-- The Opsgenie integration is currently only available in Teleport Cloud.
+
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create services


### PR DESCRIPTION
Backports #33030

Closes #32519

Inline the `commercial-prereqs-tabs.mdx` partial within the Prerequisites section and modify the language to clarify that this plugin only supports Teleport Enterprise Cloud.