### PR TITLE
Remove redundant node setup in GitHub workflows

### DIFF
--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -25,11 +25,6 @@ jobs:
         run: |
           echo "node: ${NODE_VERSION}"
 
-      - name: Setup Node Toolchain
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -17,13 +17,9 @@ jobs:
       - name: Checkout OSS Teleport
         uses: actions/checkout@v4
 
-      - name: Determine Toolchain Versions
+      - name: Print Node version
         run: |
-          echo NODE_VERSION=$(make -s -C build.assets print-node-version) >> $GITHUB_ENV
-
-      - name: Print versions
-        run: |
-          echo "node: ${NODE_VERSION}"
+          node --version
 
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -19,13 +19,9 @@ jobs:
       - name: Checkout OSS Teleport
         uses: actions/checkout@v4
 
-      - name: Determine Toolchain Versions
+      - name: Print Node version
         run: |
-          echo NODE_VERSION=$(make -s -C build.assets print-node-version) >> $GITHUB_ENV
-
-      - name: Print versions
-        run: |
-          echo "node: ${NODE_VERSION}"
+          node --version
 
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -27,11 +27,6 @@ jobs:
         run: |
           echo "node: ${NODE_VERSION}"
 
-      - name: Setup Node Toolchain
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -66,7 +66,7 @@ const cfg = {
     second_factor: 'off' as Auth2faType,
     authType: 'local' as AuthType,
     preferredLocalMfa: '' as PreferredMfaType,
-    // motd is message of the day, displayed to users before login.
+    // motd is the message of the day, displayed to users before login.
     motd: '',
   },
 


### PR DESCRIPTION
The Node setup step in both the `lint-ui.yaml` and `unit-tests-ui.yaml` GitHub workflows has been removed. Node installation fails very often, making those CI jobs very unstable. Simplifying these workflows should reduce potential points of failure.

Ubuntu images in GHA have preinstalled Nodejs that we can use  https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#nodejs