### PR TITLE
Fix discrepancies with dynamo events retention period

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -57,7 +57,7 @@ teleport:
 
         # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
         # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-        audit_retention_period: 365d
+        retention_period: 365d
 
         # minimum/maximum read capacity in units
         read_min_capacity: int

--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -20,6 +20,7 @@ teleport:
         audit_events_uri:
           - 'dynamodb://events_table_name'
           - 'firestore://events_table_name'
+          - 'postgresql://user_name@database-address/events_table_name'
           - 'file:///var/lib/teleport/log'
           - 'stdout://'
 
@@ -57,6 +58,12 @@ teleport:
 
         # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
         # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
+        #
+        # NOTE: Only the DynamoDB events backend respects the retention_period. All other event backends
+        # consume the retention period via a query parameter in the audit_events_uri. See the examples below
+        # for how to configure the retention period for other backends.
+        # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
+        # Postgres: postgresql://user_name@database-address/teleport_audit?retention_period=10d
         retention_period: 365d
 
         # minimum/maximum read capacity in units

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -51,7 +51,7 @@ For High Availability configurations, users can refer to our
 configure the SSH events and recorded sessions to be stored on network storage.
 When these backends are in use, audit events will eventually expire and be
 removed from the log. The default retention period is 1 year, but this can be
-overridden using the `audit_retention_period` configuration parameter.
+overridden using the `retention_period` configuration parameter.
 
 It is even possible to store audit logs in multiple places at the same time. For
 more information on how to configure the audit log, refer to the `storage`

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -818,7 +818,7 @@ teleport:
 
     # By default, Teleport stores audit events with an AWS TTL of 1 year.
     # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-    audit_retention_period: 365d
+    retention_period: 365d
 
     # Enables either Pay Per Request or Provisioned billing for the DynamoDB table. Set when Teleport creates the table.
     # Possible values: "pay_per_request" and "provisioned"

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -174,8 +174,8 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	if cfg.WriteCapacityUnits == 0 {
 		cfg.WriteCapacityUnits = DefaultWriteCapacityUnits
 	}
-	if cfg.RetentionPeriod == nil {
-		duration := types.Duration(DefaultRetentionPeriod)
+	if cfg.RetentionPeriod == nil || cfg.RetentionPeriod.Duration() == 0 {
+		duration := DefaultRetentionPeriod
 		cfg.RetentionPeriod = &duration
 	}
 	if cfg.Clock == nil {
@@ -241,7 +241,7 @@ const (
 
 	// DefaultRetentionPeriod is a default data retention period in events table.
 	// The default is 1 year.
-	DefaultRetentionPeriod = 365 * 24 * time.Hour
+	DefaultRetentionPeriod = types.Duration(365 * 24 * time.Hour)
 )
 
 // New returns new instance of DynamoDB backend.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -94,21 +94,21 @@ var tableSchema = []*dynamodb.AttributeDefinition{
 // of Teleport YAML
 type Config struct {
 	// Region is where DynamoDB Table will be used to store k/v
-	Region string `json:"region,omitempty"`
+	Region string
 	// Tablename where to store K/V in DynamoDB
-	Tablename string `json:"table_name,omitempty"`
+	Tablename string
 	// ReadCapacityUnits is Dynamodb read capacity units
-	ReadCapacityUnits int64 `json:"read_capacity_units"`
+	ReadCapacityUnits int64
 	// WriteCapacityUnits is Dynamodb write capacity units
-	WriteCapacityUnits int64 `json:"write_capacity_units"`
+	WriteCapacityUnits int64
 	// RetentionPeriod is a default retention period for events.
-	RetentionPeriod *types.Duration `json:"retention_period"`
+	RetentionPeriod *types.Duration
 	// Clock is a clock interface, used in tests
 	Clock clockwork.Clock
 	// UIDGenerator is unique ID generator
 	UIDGenerator utils.UID
 	// Endpoint is an optional non-AWS endpoint
-	Endpoint string `json:"endpoint,omitempty"`
+	Endpoint string
 
 	// ReadMaxCapacity is the maximum provisioned read capacity.
 	ReadMaxCapacity int64

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -102,7 +102,7 @@ type Config struct {
 	// WriteCapacityUnits is Dynamodb write capacity units
 	WriteCapacityUnits int64 `json:"write_capacity_units"`
 	// RetentionPeriod is a default retention period for events.
-	RetentionPeriod *types.Duration `json:"audit_retention_period"`
+	RetentionPeriod *types.Duration `json:"retention_period"`
 	// Clock is a clock interface, used in tests
 	Clock clockwork.Clock
 	// UIDGenerator is unique ID generator

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -346,6 +347,87 @@ func TestConfig_SetFromURL(t *testing.T) {
 			require.NoError(t, tt.cfg.SetFromURL(uri))
 
 			tt.cfgAssertion(t, tt.cfg)
+		})
+	}
+}
+
+func TestConfig_CheckAndSetDefaults(t *testing.T) {
+	zero := types.NewDuration(0)
+	hour := types.NewDuration(time.Hour)
+
+	tests := []struct {
+		name        string
+		config      *Config
+		assertionFn func(t *testing.T, cfg *Config, err error)
+	}{
+		{
+			name:   "table name required",
+			config: &Config{},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got %T", err)
+			},
+		},
+		{
+			name: "nil retention period uses default",
+			config: &Config{
+				Tablename:       "test",
+				RetentionPeriod: nil,
+			},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.NoError(t, err)
+				require.Equal(t, DefaultRetentionPeriod.Duration(), cfg.RetentionPeriod.Duration())
+			},
+		},
+		{
+			name: "zero retention period uses default",
+			config: &Config{
+				Tablename:       "test",
+				RetentionPeriod: &zero,
+			},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.NoError(t, err)
+				require.Equal(t, DefaultRetentionPeriod.Duration(), cfg.RetentionPeriod.Duration())
+			},
+		},
+		{
+			name: "supplied retention period is used",
+			config: &Config{
+				Tablename:       "test",
+				RetentionPeriod: &hour,
+			},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.NoError(t, err)
+				require.Equal(t, hour.Duration(), cfg.RetentionPeriod.Duration())
+			},
+		},
+		{
+			name:   "zero capacity uses defaults",
+			config: &Config{Tablename: "test"},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.NoError(t, err)
+				require.Equal(t, int64(DefaultReadCapacityUnits), cfg.ReadCapacityUnits)
+				require.Equal(t, int64(DefaultWriteCapacityUnits), cfg.WriteCapacityUnits)
+			},
+		},
+		{
+			name: "supplied capacity is used",
+			config: &Config{
+				Tablename:          "test",
+				ReadCapacityUnits:  1,
+				WriteCapacityUnits: 7,
+			},
+			assertionFn: func(t *testing.T, cfg *Config, err error) {
+				require.NoError(t, err)
+				require.Equal(t, int64(1), cfg.ReadCapacityUnits)
+				require.Equal(t, int64(7), cfg.WriteCapacityUnits)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.config.CheckAndSetDefaults()
+			test.assertionFn(t, test.config, err)
 		})
 	}
 }


### PR DESCRIPTION
1) The audit config documentation now correctly advises to use the json tag of the corresponding field in the `types.AuditConfigSpec` instead of `audit_retention_period`. 
https://github.com/gravitational/teleport/blob/913c3fb70bb0a3d4a428c274c795f53e7a5062a1/api/proto/teleport/legacy/types/types.proto#L1539-L1543

2) Only the DynamoDB events backend consumes the retention_period defined in the storage config. All other backends consume the value via a query parameter in the `audit_events_uri`. Documentation now points this out, and the list of uris was updated to include Postgres.

3) The DynamoDB events backend now uses the default retention period if a nil or a zero duration is provided in the config.


Fixes https://github.com/gravitational/teleport/issues/31878