### PR TITLE
Support Redshift auto provisioned user deletion

### DIFF
--- a/lib/srv/db/postgres/sql/redshift-delete-user.sql
+++ b/lib/srv/db/postgres/sql/redshift-delete-user.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE PROCEDURE teleport_delete_user(username varchar)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Only drop if the user doesn't have other active sessions.
+    IF EXISTS (SELECT usename FROM pg_stat_activity WHERE usename = username) THEN
+        RAISE NOTICE 'User has active connections';
+    ELSE
+        BEGIN
+            EXECUTE 'DROP USER ' || QUOTE_IDENT(username);
+        EXCEPTION WHEN OTHERS THEN
+            -- Redshift only support OTHERS as exception condition, so we handle
+            -- any error that might happen.
+
+            -- Drop user/role will fail if user has dependent objects.
+            -- In this scenario, fallback into disabling the user.
+            CALL teleport_deactivate_user(username);
+        END;
+    END IF;
+END;$$;


### PR DESCRIPTION
A few differences from the regular PostgreSQL deletion procedure:
- ["The only supported condition in an exception block is OTHERS, which matches every error type except query cancellation".](https://docs.aws.amazon.com/redshift/latest/dg/stored-procedure-trapping-errors.html) This means we will handle any unexpected error, too (and proceed to disable the user as a fallback). 
- ["When an error occurs inside the NONATOMIC procedure, the error is not re-thrown if it is handled by an exception block.".](https://docs.aws.amazon.com/redshift/latest/dg/stored-procedure-trapping-errors.html) If a regular procedure happens to have an exception, this exception is re-thrown if the exception handler succeeds.

Given these differences, the Redshift procedure is slightly simple as it doesn't need to return any state (as it won't be accessible in case of exception). Also, on the application side, we handle the `DROP USER` as an OK error to happen.

Alternatively, to match assert the procedure error, we could turn the procedure into a `NOATOMIC` procedure, which does not throw the exception if it is handled. However, that would make the `teleport_deactivate_user` procedure non-atomic (which might not be desired), called from the delete one.

changelog: Support Redshift auto-provisioned users deletion.