### PR TITLE
 Expose ServerInfo resource in `tctl`

### DIFF
--- a/api/types/server_info.go
+++ b/api/types/server_info.go
@@ -169,6 +169,9 @@ func (s *ServerInfoV1) SetNewLabels(labels map[string]string) {
 func (s *ServerInfoV1) setStaticFields() {
 	s.Kind = KindServerInfo
 	s.Version = V1
+	if s.SubKind == "" {
+		s.SubKind = SubKindCloudInfo
+	}
 }
 
 // CheckAndSetDefaults validates the Resource and sets any empty fields to

--- a/api/types/server_info.go
+++ b/api/types/server_info.go
@@ -155,7 +155,10 @@ func (s *ServerInfoV1) MatchSearch(searchValues []string) bool {
 
 // GetNewLabels gets the labels to apply to matched Nodes.
 func (s *ServerInfoV1) GetNewLabels() map[string]string {
-	return s.Spec.NewLabels
+	if len(s.Spec.NewLabels) > 0 {
+		return s.Spec.NewLabels
+	}
+	return s.Metadata.Labels
 }
 
 // SetNewLabels sets the labels to apply to matched Nodes.

--- a/api/types/server_info.go
+++ b/api/types/server_info.go
@@ -155,10 +155,7 @@ func (s *ServerInfoV1) MatchSearch(searchValues []string) bool {
 
 // GetNewLabels gets the labels to apply to matched Nodes.
 func (s *ServerInfoV1) GetNewLabels() map[string]string {
-	if len(s.Spec.NewLabels) > 0 {
-		return s.Spec.NewLabels
-	}
-	return s.Metadata.Labels
+	return s.Spec.NewLabels
 }
 
 // SetNewLabels sets the labels to apply to matched Nodes.
@@ -169,9 +166,7 @@ func (s *ServerInfoV1) SetNewLabels(labels map[string]string) {
 func (s *ServerInfoV1) setStaticFields() {
 	s.Kind = KindServerInfo
 	s.Version = V1
-	if s.SubKind == "" {
-		s.SubKind = SubKindCloudInfo
-	}
+	s.SubKind = SubKindCloudInfo
 }
 
 // CheckAndSetDefaults validates the Resource and sets any empty fields to

--- a/api/types/server_info.go
+++ b/api/types/server_info.go
@@ -181,8 +181,14 @@ func (s *ServerInfoV1) CheckAndSetDefaults() error {
 	return trace.Wrap(s.Metadata.CheckAndSetDefaults())
 }
 
-// GetServerInfoName gets the name of the ServerInfo generated for a discovered
-// EC2 instance with this account ID and instance ID.
-func (a *AWSInfo) GetServerInfoName() string {
-	return fmt.Sprintf("aws-%v-%v", a.AccountID, a.InstanceID)
+// ServerInfoNameFromAWS gets the name of the ServerInfo that matches the node
+// with the given AWS account ID and instance ID.
+func ServerInfoNameFromAWS(accountID, instanceID string) string {
+	return fmt.Sprintf("aws-%v-%v", accountID, instanceID)
+}
+
+// ServerInfoNameFromNodeName gets the name of the ServerInfo that matches the
+// node with the given name.
+func ServerInfoNameFromNodeName(name string) string {
+	return fmt.Sprintf("si-%v", name)
 }

--- a/lib/auth/server_info.go
+++ b/lib/auth/server_info.go
@@ -75,10 +75,10 @@ func (a *Server) ReconcileServerInfos(ctx context.Context) error {
 func getServerInfoNames(node types.Server) []string {
 	var names []string
 	if meta := node.GetCloudMetadata(); meta != nil && meta.AWS != nil {
-		names = append(names, meta.AWS.GetServerInfoName())
+		names = append(names, types.ServerInfoNameFromAWS(meta.AWS.AccountID, meta.AWS.InstanceID))
 	}
 	// Manually added ServerInfos should override any other ServerInfos.
-	names = append(names, "si-"+node.GetName())
+	names = append(names, types.ServerInfoNameFromNodeName(node.GetName()))
 	return names
 }
 

--- a/lib/auth/server_info.go
+++ b/lib/auth/server_info.go
@@ -44,7 +44,7 @@ func (a *Server) ReconcileServerInfos(ctx context.Context) error {
 
 		for moreNodes := true; moreNodes; {
 			nodes, moreNodes = stream.Take(nodeStream, batchSize)
-			updates, err := a.setCloudLabelsOnNodes(ctx, nodes)
+			updates, err := a.setLabelsOnNodes(ctx, nodes)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -79,7 +79,7 @@ func getServerInfoNames(node types.Server) []string {
 	return names
 }
 
-func (a *Server) setCloudLabelsOnNodes(ctx context.Context, nodes []types.Server) (failedUpdates int, err error) {
+func (a *Server) setLabelsOnNodes(ctx context.Context, nodes []types.Server) (failedUpdates int, err error) {
 	for _, node := range nodes {
 		serverInfoNames := getServerInfoNames(node)
 		serverInfos := make([]types.ServerInfo, 0, len(serverInfoNames))
@@ -109,7 +109,7 @@ func (a *Server) setCloudLabelsOnNodes(ctx context.Context, nodes []types.Server
 func (a *Server) updateLabelsOnNode(ctx context.Context, node types.Server, serverInfos []types.ServerInfo) error {
 	newLabels := make(map[string]string)
 	for _, si := range serverInfos {
-		for k, v := range si.GetStaticLabels() {
+		for k, v := range si.GetNewLabels() {
 			newLabels[k] = v
 		}
 	}

--- a/lib/auth/server_info_test.go
+++ b/lib/auth/server_info_test.go
@@ -99,7 +99,6 @@ func TestReconcileLabels(t *testing.T) {
 		Labels: map[string]string{"a": "1", "b": "2"},
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)
-	awsServerInfo.SetSubKind(types.SubKindCloudInfo)
 	require.NoError(t, pack.a.UpsertServerInfo(ctx, awsServerInfo))
 
 	regularServerInfo, err := types.NewServerInfo(types.Metadata{
@@ -107,7 +106,6 @@ func TestReconcileLabels(t *testing.T) {
 		Labels: map[string]string{"b": "3", "c": "4"},
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)
-	regularServerInfo.SetSubKind(types.SubKindCloudInfo)
 	require.NoError(t, pack.a.UpsertServerInfo(ctx, regularServerInfo))
 
 	go pack.a.ReconcileServerInfos(ctx)

--- a/lib/auth/server_info_test.go
+++ b/lib/auth/server_info_test.go
@@ -95,7 +95,7 @@ func TestReconcileLabels(t *testing.T) {
 
 	// Update the server's labels.
 	awsServerInfo, err := types.NewServerInfo(types.Metadata{
-		Name:   "aws-my-account-my-instance",
+		Name:   types.ServerInfoNameFromAWS("my-account", "my-instance"),
 		Labels: map[string]string{"a": "1", "b": "2"},
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestReconcileLabels(t *testing.T) {
 	require.NoError(t, pack.a.UpsertServerInfo(ctx, awsServerInfo))
 
 	regularServerInfo, err := types.NewServerInfo(types.Metadata{
-		Name:   "si-" + serverName,
+		Name:   types.ServerInfoNameFromNodeName(serverName),
 		Labels: map[string]string{"b": "3", "c": "4"},
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)

--- a/lib/auth/server_info_test.go
+++ b/lib/auth/server_info_test.go
@@ -95,16 +95,18 @@ func TestReconcileLabels(t *testing.T) {
 
 	// Update the server's labels.
 	awsServerInfo, err := types.NewServerInfo(types.Metadata{
-		Name:   types.ServerInfoNameFromAWS("my-account", "my-instance"),
-		Labels: map[string]string{"a": "1", "b": "2"},
-	}, types.ServerInfoSpecV1{})
+		Name: types.ServerInfoNameFromAWS("my-account", "my-instance"),
+	}, types.ServerInfoSpecV1{
+		NewLabels: map[string]string{"a": "1", "b": "2"},
+	})
 	require.NoError(t, err)
 	require.NoError(t, pack.a.UpsertServerInfo(ctx, awsServerInfo))
 
 	regularServerInfo, err := types.NewServerInfo(types.Metadata{
-		Name:   types.ServerInfoNameFromNodeName(serverName),
-		Labels: map[string]string{"b": "3", "c": "4"},
-	}, types.ServerInfoSpecV1{})
+		Name: types.ServerInfoNameFromNodeName(serverName),
+	}, types.ServerInfoSpecV1{
+		NewLabels: map[string]string{"b": "3", "c": "4"},
+	})
 	require.NoError(t, err)
 	require.NoError(t, pack.a.UpsertServerInfo(ctx, regularServerInfo))
 

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -218,6 +218,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAuditQuery, nil
 	case types.KindSecurityReport:
 		return types.KindSecurityReport, nil
+	case types.KindServerInfo, types.KindServerInfo + "s":
+		return types.KindServerInfo, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -218,7 +218,7 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAuditQuery, nil
 	case types.KindSecurityReport:
 		return types.KindSecurityReport, nil
-	case types.KindServerInfo, types.KindServerInfo + "s":
+	case types.KindServerInfo:
 		return types.KindServerInfo, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -97,14 +96,13 @@ func ToEC2Instances(insts []*ec2.Instance) []EC2Instance {
 func (i *EC2Instances) ServerInfos() ([]types.ServerInfo, error) {
 	serverInfos := make([]types.ServerInfo, 0, len(i.Instances))
 	for _, instance := range i.Instances {
-		name := fmt.Sprintf("aws-%v-%v", i.AccountID, instance.InstanceID)
 		tags := make(map[string]string, len(instance.Tags))
 		for k, v := range instance.Tags {
 			tags[labels.FormatCloudLabelKey(labels.AWSLabelNamespace, k)] = v
 		}
 
 		si, err := types.NewServerInfo(types.Metadata{
-			Name: name,
+			Name: types.ServerInfoNameFromAWS(i.AccountID, instance.InstanceID),
 		}, types.ServerInfoSpecV1{
 			NewLabels: tags,
 		})

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -96,7 +97,7 @@ func ToEC2Instances(insts []*ec2.Instance) []EC2Instance {
 func (i *EC2Instances) ServerInfos() ([]types.ServerInfo, error) {
 	serverInfos := make([]types.ServerInfo, 0, len(i.Instances))
 	for _, instance := range i.Instances {
-		name := i.AccountID + "-" + instance.InstanceID
+		name := fmt.Sprintf("aws-%v-%v", i.AccountID, instance.InstanceID)
 		tags := make(map[string]string, len(instance.Tags))
 		for k, v := range instance.Tags {
 			tags[labels.FormatCloudLabelKey(labels.AWSLabelNamespace, k)] = v

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -238,7 +238,7 @@ func TestEC2Watcher(t *testing.T) {
 func TestConvertEC2InstancesToServerInfos(t *testing.T) {
 	t.Parallel()
 	expected, err := types.NewServerInfo(types.Metadata{
-		Name: "myaccount-myinstance",
+		Name: "aws-myaccount-myinstance",
 	}, types.ServerInfoSpecV1{
 		NewLabels: map[string]string{"aws/foo": "bar"},
 	})

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1297,3 +1297,24 @@ func (c *securityReportCollection) writeText(w io.Writer, verbose bool) error {
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }
+
+type serverInfoCollection struct {
+	serverInfos []types.ServerInfo
+}
+
+func (c *serverInfoCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.serverInfos))
+	for i, resource := range c.serverInfos {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *serverInfoCollection) writeText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Labels"})
+	for _, si := range c.serverInfos {
+		t.AddRow([]string{si.GetName(), printMetadataLabels(si.GetNewLabels())})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1138,7 +1138,7 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.Cli
 
 	exists := (err == nil)
 	if !rc.force && exists {
-		return trace.AlreadyExists("Server info %q already exists", name)
+		return trace.AlreadyExists("server info %q already exists", name)
 	}
 
 	err = client.UpsertServerInfo(ctx, si)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1129,7 +1129,7 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.Cli
 		return trace.Wrap(err)
 	}
 
-	// Check if the server info already exists.
+	// Check if the ServerInfo already exists.
 	name := si.GetName()
 	_, err = client.GetServerInfo(ctx, name)
 	if err != nil && !trace.IsNotFound(err) {
@@ -1138,14 +1138,14 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.Cli
 
 	exists := (err == nil)
 	if !rc.force && exists {
-		return trace.AlreadyExists("server info %q already exists", name)
+		return trace.AlreadyExists("Server info %q already exists", name)
 	}
 
 	err = client.UpsertServerInfo(ctx, si)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("server info %q has been %s\n",
+	fmt.Printf("Server info %q has been %s\n",
 		name, UpsertVerb(exists, rc.force),
 	)
 	return nil

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -40,6 +40,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
+	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/externalcloudaudit"
@@ -138,6 +139,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindDiscoveryConfig:          rc.createDiscoveryConfig,
 		types.KindAuditQuery:               rc.createAuditQuery,
 		types.KindSecurityReport:           rc.createSecurityReport,
+		types.KindServerInfo:               rc.createServerInfo,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:            rc.updateUser,
@@ -1121,6 +1123,34 @@ func (rc *ResourceCommand) createAccessList(ctx context.Context, client auth.Cli
 	return nil
 }
 
+func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	si, err := services.UnmarshalServerInfo(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Check if the server info already exists.
+	name := si.GetName()
+	_, err = client.GetServerInfo(ctx, name)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	exists := (err == nil)
+	if !rc.force && exists {
+		return trace.AlreadyExists("server info %q already exists", name)
+	}
+
+	err = client.UpsertServerInfo(ctx, si)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("server info %q has been %s\n",
+		name, UpsertVerb(exists, rc.force),
+	)
+	return nil
+}
+
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err error) {
 	singletonResources := []string{
@@ -1474,7 +1504,11 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Security report %q has been deleted\n", rc.ref.Name)
-
+	case types.KindServerInfo:
+		if err := client.DeleteServerInfo(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Server info %q has been deleted\n", rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -2307,6 +2341,19 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			return nil, trace.Wrap(err)
 		}
 		return &securityReportCollection{items: resources}, nil
+	case types.KindServerInfo:
+		if rc.ref.Name != "" {
+			si, err := client.GetServerInfo(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &serverInfoCollection{serverInfos: []types.ServerInfo{si}}, nil
+		}
+		serverInfos, err := stream.Collect(client.GetServerInfos(ctx))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &serverInfoCollection{serverInfos: serverInfos}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -751,14 +751,6 @@ spec:
   - types: ["ec2"]
     regions: ["eu-west-2"]
 `
-	serverInfoYAML = `kind: server_info
-metadata:
-	name: foo
-spec:
-	new_labels:
-		a: 1
-		b: 2
-`
 )
 
 func TestCreateClusterAuthPreference_WithSupportForSecondFactorWithoutQuotes(t *testing.T) {


### PR DESCRIPTION
This change adds the ability for users to create ServerInfo resources with `tctl`.

In addition to matching a node by its AWS info, a ServerInfo can now match a node by its ID.  For a node with name `<name>`, the ServerInfo that matches it should be named `si-<name>`. If both types of ServerInfo exist, the labels provided by both will be merged, with labels from the ID ServerInfo taking precedent if they conflict.

Resolves #31261.

Changelog: Exposed ServerInfo resource in `tctl`