### PR TITLE
Break up rdpdr.rs, add support for the first directory sharing pdus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "getrandom 0.2.8",
- "ironrdp-graphics",
- "ironrdp-pdu",
- "ironrdp-session",
+ "ironrdp-graphics 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-session 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
  "js-sys",
  "log",
  "time",
@@ -1243,22 +1243,20 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bytes",
- "ironrdp-connector",
- "ironrdp-pdu",
+ "ironrdp-connector 0.1.0",
+ "ironrdp-pdu 0.1.0",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-pdu",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "thiserror",
  "tracing",
 ]
@@ -1266,11 +1264,24 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
+dependencies = [
+ "ironrdp-error 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
+ "rand_core 0.6.4",
+ "sspi",
+ "tracing",
+ "winapi",
+]
+
+[[package]]
+name = "ironrdp-connector"
+version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
- "ironrdp-error",
- "ironrdp-pdu",
- "ironrdp-svc",
+ "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-svc 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
  "rand_core 0.6.4",
  "sspi",
  "tracing",
@@ -1280,7 +1291,27 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
+
+[[package]]
+name = "ironrdp-error"
+version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
+
+[[package]]
+name = "ironrdp-graphics"
+version = "0.1.0"
+dependencies = [
+ "bit_field",
+ "bitflags 2.4.1",
+ "bitvec",
+ "byteorder",
+ "ironrdp-error 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "lazy_static",
+ "num-derive 0.4.1",
+ "num-traits",
+ "thiserror",
+]
 
 [[package]]
 name = "ironrdp-graphics"
@@ -1291,12 +1322,33 @@ dependencies = [
  "bitflags 2.4.1",
  "bitvec",
  "byteorder",
- "ironrdp-error",
- "ironrdp-pdu",
+ "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
  "lazy_static",
  "num-derive 0.4.1",
  "num-traits",
  "thiserror",
+]
+
+[[package]]
+name = "ironrdp-pdu"
+version = "0.1.0"
+dependencies = [
+ "bit_field",
+ "bitflags 2.4.1",
+ "byteorder",
+ "der-parser",
+ "ironrdp-error 0.1.0",
+ "md-5 0.10.5",
+ "num-bigint",
+ "num-derive 0.4.1",
+ "num-integer",
+ "num-traits",
+ "pkcs1 0.7.5",
+ "sha1",
+ "tap",
+ "thiserror",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1308,7 +1360,7 @@ dependencies = [
  "bitflags 2.4.1",
  "byteorder",
  "der-parser",
- "ironrdp-error",
+ "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
  "md-5 0.10.5",
  "num-bigint",
  "num-derive 0.4.1",
@@ -1324,22 +1376,33 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-error",
- "ironrdp-pdu",
- "ironrdp-svc",
+ "ironrdp-error 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
- "ironrdp-pdu",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
+]
+
+[[package]]
+name = "ironrdp-session"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.1",
+ "ironrdp-connector 0.1.0",
+ "ironrdp-error 0.1.0",
+ "ironrdp-graphics 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
+ "tracing",
 ]
 
 [[package]]
@@ -1348,12 +1411,20 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-connector",
- "ironrdp-error",
- "ironrdp-graphics",
- "ironrdp-pdu",
- "ironrdp-svc",
+ "ironrdp-connector 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-graphics 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-svc 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
  "tracing",
+]
+
+[[package]]
+name = "ironrdp-svc"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.1",
+ "ironrdp-pdu 0.1.0",
 ]
 
 [[package]]
@@ -1362,13 +1433,12 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-pdu",
+ "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
 ]
 
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1378,7 +1448,6 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
 dependencies = [
  "bytes",
  "ironrdp-async",
@@ -2229,12 +2298,12 @@ dependencies = [
  "cbindgen",
  "env_logger",
  "ironrdp-cliprdr",
- "ironrdp-connector",
- "ironrdp-pdu",
+ "ironrdp-connector 0.1.0",
+ "ironrdp-pdu 0.1.0",
  "ironrdp-rdpdr",
  "ironrdp-rdpsnd",
- "ironrdp-session",
- "ironrdp-svc",
+ "ironrdp-session 0.1.0",
+ "ironrdp-svc 0.1.0",
  "ironrdp-tls",
  "ironrdp-tokio",
  "iso7816",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "getrandom 0.2.8",
- "ironrdp-graphics 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-session 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "ironrdp-session",
  "js-sys",
  "log",
  "time",
@@ -1243,20 +1243,22 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bytes",
- "ironrdp-connector 0.1.0",
- "ironrdp-pdu 0.1.0",
+ "ironrdp-connector",
+ "ironrdp-pdu",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-pdu 0.1.0",
- "ironrdp-svc 0.1.0",
+ "ironrdp-pdu",
+ "ironrdp-svc",
  "thiserror",
  "tracing",
 ]
@@ -1264,24 +1266,11 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
- "ironrdp-error 0.1.0",
- "ironrdp-pdu 0.1.0",
- "ironrdp-svc 0.1.0",
- "rand_core 0.6.4",
- "sspi",
- "tracing",
- "winapi",
-]
-
-[[package]]
-name = "ironrdp-connector"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
-dependencies = [
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-svc 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "ironrdp-svc",
  "rand_core 0.6.4",
  "sspi",
  "tracing",
@@ -1291,39 +1280,19 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-
-[[package]]
-name = "ironrdp-error"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",
  "bitvec",
  "byteorder",
- "ironrdp-error 0.1.0",
- "ironrdp-pdu 0.1.0",
- "lazy_static",
- "num-derive 0.4.1",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "ironrdp-graphics"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
-dependencies = [
- "bit_field",
- "bitflags 2.4.1",
- "bitvec",
- "byteorder",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-error",
+ "ironrdp-pdu",
  "lazy_static",
  "num-derive 0.4.1",
  "num-traits",
@@ -1333,34 +1302,13 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",
  "byteorder",
  "der-parser",
- "ironrdp-error 0.1.0",
- "md-5 0.10.5",
- "num-bigint",
- "num-derive 0.4.1",
- "num-integer",
- "num-traits",
- "pkcs1 0.7.5",
- "sha1",
- "tap",
- "thiserror",
- "x509-cert",
-]
-
-[[package]]
-name = "ironrdp-pdu"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
-dependencies = [
- "bit_field",
- "bitflags 2.4.1",
- "byteorder",
- "der-parser",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-error",
  "md-5 0.10.5",
  "num-bigint",
  "num-derive 0.4.1",
@@ -1376,69 +1324,51 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-error 0.1.0",
- "ironrdp-pdu 0.1.0",
- "ironrdp-svc 0.1.0",
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "ironrdp-svc",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
- "ironrdp-pdu 0.1.0",
- "ironrdp-svc 0.1.0",
+ "ironrdp-pdu",
+ "ironrdp-svc",
 ]
 
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-connector 0.1.0",
- "ironrdp-error 0.1.0",
- "ironrdp-graphics 0.1.0",
- "ironrdp-pdu 0.1.0",
- "ironrdp-svc 0.1.0",
- "tracing",
-]
-
-[[package]]
-name = "ironrdp-session"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
-dependencies = [
- "bitflags 2.4.1",
- "ironrdp-connector 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-graphics 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
- "ironrdp-svc 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-connector",
+ "ironrdp-error",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "ironrdp-svc",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bitflags 2.4.1",
- "ironrdp-pdu 0.1.0",
-]
-
-[[package]]
-name = "ironrdp-svc"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88#2075833ff2d02e6cea256e8a24e4e6e5e805ce88"
-dependencies = [
- "bitflags 2.4.1",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2075833ff2d02e6cea256e8a24e4e6e5e805ce88)",
+ "ironrdp-pdu",
 ]
 
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1448,6 +1378,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=1dae856fface011307b5ca28be5778fd1ba41b44#1dae856fface011307b5ca28be5778fd1ba41b44"
 dependencies = [
  "bytes",
  "ironrdp-async",
@@ -2298,12 +2229,12 @@ dependencies = [
  "cbindgen",
  "env_logger",
  "ironrdp-cliprdr",
- "ironrdp-connector 0.1.0",
- "ironrdp-pdu 0.1.0",
+ "ironrdp-connector",
+ "ironrdp-pdu",
  "ironrdp-rdpdr",
  "ironrdp-rdpsnd",
- "ironrdp-session 0.1.0",
- "ironrdp-svc 0.1.0",
+ "ironrdp-session",
+ "ironrdp-svc",
  "ironrdp-tls",
  "ironrdp-tokio",
  "iso7816",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -31,26 +31,26 @@ x509-parser = "0.14"
 sspi = { version = "0.10.1", features = ["network_client", "dns_resolver"] }
 static_init = "1.0.3"
 
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
 
 # Uncomment the following lines to use local crates instead of the ones from github
-# ironrdp-connector = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-connector" }
-# ironrdp-tls = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tls" }
-# ironrdp-session = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-session" }
-# ironrdp-pdu = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-tokio = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tokio" }
-# ironrdp-rdpsnd = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpsnd" }
-# ironrdp-rdpdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpdr" }
-# ironrdp-svc = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-svc" }
-# ironrdp-cliprdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-cliprdr" }
+ironrdp-connector = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-connector" }
+ironrdp-tls = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tls" }
+ironrdp-session = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-session" }
+ironrdp-pdu = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-pdu" }
+ironrdp-tokio = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tokio" }
+ironrdp-rdpsnd = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpsnd" }
+ironrdp-rdpdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpdr" }
+ironrdp-svc = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-svc" }
+ironrdp-cliprdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-cliprdr" }
 
 # Uncomment the following lines to use local crates instead of the ones from github
 # ironrdp-connector = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-connector" }

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -31,26 +31,27 @@ x509-parser = "0.14"
 sspi = { version = "0.10.1", features = ["network_client", "dns_resolver"] }
 static_init = "1.0.3"
 
-# ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-# ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# Update when https://github.com/Devolutions/IronRDP/pull/235 lands
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
 
 # Uncomment the following lines to use local crates instead of the ones from github
-ironrdp-connector = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-connector" }
-ironrdp-tls = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tls" }
-ironrdp-session = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-session" }
-ironrdp-pdu = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-pdu" }
-ironrdp-tokio = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tokio" }
-ironrdp-rdpsnd = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpsnd" }
-ironrdp-rdpdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpdr" }
-ironrdp-svc = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-svc" }
-ironrdp-cliprdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-cliprdr" }
+# ironrdp-connector = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-connector" }
+# ironrdp-tls = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tls" }
+# ironrdp-session = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-session" }
+# ironrdp-pdu = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-pdu" }
+# ironrdp-tokio = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tokio" }
+# ironrdp-rdpsnd = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpsnd" }
+# ironrdp-rdpdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpdr" }
+# ironrdp-svc = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-svc" }
+# ironrdp-cliprdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-cliprdr" }
 
 # Uncomment the following lines to use local crates instead of the ones from github
 # ironrdp-connector = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-connector" }

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -101,6 +101,7 @@ impl Client {
                 params.cert_der,
                 params.key_der,
                 pin,
+                cgo_handle,
             )),
             "IronRDP".to_string(),
         )
@@ -307,6 +308,14 @@ impl Client {
                             )
                             .await?;
                         }
+                        ClientFunction::HandleTdpSdInfoResponse(res) => {
+                            Client::handle_tdp_sd_info_response(
+                                &mut write_stream,
+                                x224_processor.clone(),
+                                res,
+                            )
+                            .await?;
+                        }
                         ClientFunction::WriteCliprdr(f) => {
                             Client::write_cliprdr(x224_processor.clone(), &mut write_stream, f)
                                 .await?;
@@ -483,6 +492,25 @@ impl Client {
         Ok(())
     }
 
+    async fn handle_tdp_sd_info_response(
+        write_stream: &mut RdpWriteStream,
+        x224_processor: Arc<Mutex<X224Processor>>,
+        res: tdp::SharedDirectoryInfoResponse,
+    ) -> ClientResult<()> {
+        global::TOKIO_RT
+            .spawn_blocking(move || {
+                let mut x224_processor = Self::x224_lock(&x224_processor)?;
+                let teleport_rdpdr_backend = x224_processor
+                    .get_svc_processor_mut::<Rdpdr>()
+                    .ok_or(ClientError::InternalError)?
+                    .downcast_backend_mut::<TeleportRdpdrBackend>()
+                    .ok_or(ClientError::InternalError)?;
+                teleport_rdpdr_backend.handle_tdp_sd_info_response(res)?;
+                Ok(())
+            })
+            .await?
+    }
+
     async fn add_drive(
         x224_processor: Arc<Mutex<X224Processor>>,
         sda: tdp::SharedDirectoryAnnounce,
@@ -573,6 +601,8 @@ pub enum ClientFunction {
     WriteRdpdr(RdpdrPdu),
     /// Corresponds to [`Client::handle_tdp_sd_announce`]
     HandleTdpSdAnnounce(tdp::SharedDirectoryAnnounce),
+    /// Corresponds to [`Client::handle_tdp_sd_info_response`]
+    HandleTdpSdInfoResponse(tdp::SharedDirectoryInfoResponse),
     /// Corresponds to [`Client::write_cliprdr`]
     WriteCliprdr(Box<dyn ClipboardFn>),
     /// Corresponds to [`Client::update_clipboard`]

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -96,7 +96,6 @@ impl Client {
 
         let mut rdpdr = Rdpdr::new(
             Box::new(TeleportRdpdrBackend::new(
-                SCARD_DEVICE_ID,
                 client_handle.clone(),
                 params.cert_der,
                 params.key_der,
@@ -518,20 +517,10 @@ impl Client {
         global::TOKIO_RT
             .spawn_blocking(move || {
                 let mut x224_processor = Self::x224_lock(&x224_processor)?;
-
                 let rdpdr = x224_processor
                     .get_svc_processor_mut::<Rdpdr>()
                     .ok_or(ClientError::InternalError)?;
-                // Add drive to rdpdr
                 let pdu = rdpdr.add_drive(sda.directory_id, sda.name);
-
-                let teleport_rdpdr_backend = rdpdr
-                    .downcast_backend_mut::<TeleportRdpdrBackend>()
-                    .ok_or(ClientError::InternalError)?;
-                // Add device_id to teleport rdpdr backend
-                teleport_rdpdr_backend.add_active_device_id(sda.directory_id);
-
-                // Return the ClientDeviceListAnnounce for sending to the server.
                 Ok(pdu)
             })
             .await?

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -102,7 +102,7 @@ impl Client {
                 pin,
                 cgo_handle,
             )),
-            "IronRDP".to_string(),
+            "Teleport".to_string(),
         )
         .with_smartcard(SCARD_DEVICE_ID);
 

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -33,7 +33,8 @@ use ironrdp_session::image::DecodedImage;
 use rdpdr::path::UnixPath;
 use rdpdr::tdp::{
     FileSystemObject, FileType, SharedDirectoryAcknowledge, SharedDirectoryDeleteResponse,
-    SharedDirectoryMoveResponse, SharedDirectoryWriteResponse, TdpErrCode,
+    SharedDirectoryInfoResponse, SharedDirectoryMoveResponse, SharedDirectoryWriteResponse,
+    TdpErrCode,
 };
 use std::convert::TryFrom;
 use std::ffi::CString;
@@ -191,8 +192,8 @@ pub unsafe extern "C" fn client_handle_tdp_sd_info_response(
     cgo_handle: CgoHandle,
     res: CGOSharedDirectoryInfoResponse,
 ) -> CGOErrCode {
-    warn!("unimplemented: client_handle_tdp_sd_info_response");
-    CGOErrCode::ErrCodeSuccess
+    let res = SharedDirectoryInfoResponse::from(res);
+    call_function_on_handle(cgo_handle, ClientFunction::HandleTdpSdInfoResponse(res))
 }
 
 /// client_handle_tdp_sd_create_response handles a TDP Shared Directory Create Response

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -17,54 +17,26 @@ pub(crate) mod path;
 pub(crate) mod scard;
 pub(crate) mod tdp;
 
-use self::scard::{padded_atr, Contexts, TRANSMIT_DATA_LIMIT};
+use self::scard::ScardBackend;
 use self::tdp::{SharedDirectoryInfoRequest, SharedDirectoryInfoResponse};
 use crate::client::{ClientFunction, ClientHandle};
-use crate::rdpdr::scard::TELEPORT_READER_NAME;
 use crate::{tdp_sd_info_request, CGOErrCode, CGOSharedDirectoryInfoRequest, CgoHandle};
-use ironrdp_pdu::utils::CharacterSet;
-use ironrdp_pdu::{custom_err, other_err, PduResult};
-use ironrdp_rdpdr::pdu::efs::{DeviceCreateRequest, FilesystemRequest};
-use ironrdp_rdpdr::pdu::esc::{
-    rpce, CardProtocol, CardState, CardStateFlags, ConnectCall, ConnectReturn, ContextCall,
-    EstablishContextReturn, GetDeviceTypeIdCall, GetDeviceTypeIdReturn, GetReaderIconReturn,
-    GetStatusChangeCall, GetStatusChangeReturn, HCardAndDispositionCall, ListReadersReturn,
-    ReadCacheCall, ReadCacheReturn, ReaderStateCommonCall, ScardCall, StatusReturn, TransmitCall,
-    TransmitReturn, WriteCacheCall,
+use ironrdp_pdu::{custom_err, PduResult};
+use ironrdp_rdpdr::pdu::efs::{
+    DeviceControlRequest, DeviceCreateRequest, FilesystemRequest, NtStatus,
+    ServerDeviceAnnounceResponse,
 };
+use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
-use ironrdp_rdpdr::{
-    pdu::{
-        efs::{
-            DeviceControlRequest, DeviceControlResponse, NtStatus, ServerDeviceAnnounceResponse,
-        },
-        esc::{LongReturn, ReturnCode, ScardIoCtlCode},
-    },
-    RdpdrBackend,
-};
+use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_svc::impl_as_any;
-use iso7816::command::Command as CardCommand;
 use std::collections::HashMap;
-use std::vec;
-use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct TeleportRdpdrBackend {
-    /// Active device ids for this session.
-    ///
-    /// The smartcard device id is always active, and always the first element in this vector.
-    active_device_ids: Vec<u32>,
     /// The client handle for this backend, used to send messages to the RDP server.
     client_handle: ClientHandle,
-    /// contexts holds all the active contexts for the server, established using
-    /// SCARD_IOCTL_ESTABLISHCONTEXT. Some IOCTLs are context-specific and pass it as argument.
-    ///
-    /// contexts also holds a cache and connected smartcard handles for each context.
-    contexts: Contexts,
-    uuid: Uuid,
-    cert_der: Vec<u8>,
-    key_der: Vec<u8>,
-    pin: String,
+    scard: ScardBackend,
     cgo_handle: CgoHandle,
 
     /// CompletionId -> SharedDirectoryInfoResponseHandler
@@ -78,17 +50,13 @@ impl RdpdrBackend for TeleportRdpdrBackend {
         &mut self,
         pdu: ServerDeviceAnnounceResponse,
     ) -> PduResult<()> {
-        if !self.active_device_ids.contains(&pdu.device_id) {
-            return Err(other_err!(
-                "TeleportRdpdrBackend::handle_server_device_announce_response",
-                "got ServerDeviceAnnounceResponse for unknown device_id",
-            ));
-        }
-
         if pdu.result_code != NtStatus::Success {
-            return Err(other_err!(
+            return Err(custom_err!(
                 "TeleportRdpdrBackend::handle_server_device_announce_response",
-                "ServerDeviceAnnounceResponse for smartcard redirection failed"
+                TeleportRdpdrBackendError(format!(
+                    "ServerDeviceAnnounceResponse failed with NtStatus: {:?}",
+                    pdu.result_code
+                ))
             ));
         }
 
@@ -101,82 +69,10 @@ impl RdpdrBackend for TeleportRdpdrBackend {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: ScardCall,
     ) -> PduResult<()> {
-        match req.io_control_code {
-            ScardIoCtlCode::AccessStartedEvent => match call {
-                ScardCall::AccessStartedEventCall(_) => self.handle_access_started_event(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::EstablishContext => match call {
-                ScardCall::EstablishContextCall(_) => self.handle_establish_context(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::ListReadersW => match call {
-                ScardCall::ListReadersCall(_) => self.handle_list_readers(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::GetStatusChangeW => match call {
-                ScardCall::GetStatusChangeCall(call) => self.handle_get_status_change(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::ConnectW => match call {
-                ScardCall::ConnectCall(call) => self.handle_connect(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::BeginTransaction => match call {
-                ScardCall::HCardAndDispositionCall(_) => self.handle_begin_transaction(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::Transmit => match call {
-                ScardCall::TransmitCall(call) => self.handle_transmit(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::StatusW | ScardIoCtlCode::StatusA => match call {
-                ScardCall::StatusCall(_) => self.handle_status(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::ReleaseContext => match call {
-                ScardCall::ContextCall(call) => self.handle_release_context(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::EndTransaction => match call {
-                ScardCall::HCardAndDispositionCall(_) => self.handle_end_transaction(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::Disconnect => match call {
-                ScardCall::HCardAndDispositionCall(call) => self.handle_disconnect(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::Cancel => match call {
-                ScardCall::ContextCall(call) => self.handle_cancel(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::IsValidContext => match call {
-                ScardCall::ContextCall(_) => self.handle_is_valid_context(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::GetDeviceTypeId => match call {
-                ScardCall::GetDeviceTypeIdCall(call) => self.handle_get_device_type_id(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::ReadCacheW => match call {
-                ScardCall::ReadCacheCall(call) => self.handle_read_cache(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::WriteCacheW => match call {
-                ScardCall::WriteCacheCall(call) => self.handle_write_cache(req, call),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            ScardIoCtlCode::GetReaderIcon => match call {
-                ScardCall::GetReaderIconCall(_) => self.handle_get_reader_icon(req),
-                _ => Self::unsupported_combo_error(req.io_control_code, call),
-            },
-            _ => Err(custom_err!(
-                "TeleportRdpdrBackend::handle_scard_call",
-                TeleportRdpdrBackendError(format!(
-                    "received unhandled ScardIoCtlCode: {:?}",
-                    req.io_control_code
-                ))
-            )),
+        if let Some(resp) = self.scard.handle(req, call)? {
+            self.write_rdpdr(RdpdrPdu::DeviceControlResponse(resp))
+        } else {
+            Ok(())
         }
     }
 
@@ -189,7 +85,6 @@ impl RdpdrBackend for TeleportRdpdrBackend {
 
 impl TeleportRdpdrBackend {
     pub fn new(
-        smartcard_device_id: u32,
         client_handle: ClientHandle,
         cert_der: Vec<u8>,
         key_der: Vec<u8>,
@@ -197,335 +92,11 @@ impl TeleportRdpdrBackend {
         cgo_handle: CgoHandle,
     ) -> Self {
         Self {
-            active_device_ids: vec![smartcard_device_id],
             client_handle,
-            contexts: Contexts::new(),
-            uuid: Uuid::new_v4(),
-            cert_der,
-            key_der,
-            pin,
+            scard: ScardBackend::new(cert_der, key_der, pin),
             cgo_handle,
             pending_sd_info_resp_handlers: HashMap::new(),
         }
-    }
-
-    pub fn add_active_device_id(&mut self, device_id: u32) {
-        self.active_device_ids.push(device_id);
-    }
-
-    fn get_scard_device_id(&self) -> PduResult<u32> {
-        if self.active_device_ids.is_empty() {
-            return Err(custom_err!(
-                "TeleportRdpdrBackend::get_scard_device_id",
-                TeleportRdpdrBackendError("no active devices".to_string())
-            ));
-        }
-        Ok(self.active_device_ids[0])
-    }
-
-    fn handle_access_started_event(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        let scard_device_id = self.get_scard_device_id()?;
-        if req.header.device_id != scard_device_id {
-            return Err(custom_err!(
-                "TeleportRdpdrBackend::handle_scard_access_started_event_call",
-                TeleportRdpdrBackendError(
-                    format!(
-                        "got ScardAccessStartedEventCall for unknown device_id [{}], expected [{}]",
-                        req.header.device_id, scard_device_id
-                    )
-                    .to_string()
-                ),
-            ));
-        }
-
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_establish_context(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        let ctx = self.contexts.establish();
-
-        self.write_rdpdr_response(
-            req,
-            Box::new(EstablishContextReturn::new(ReturnCode::Success, ctx)),
-        )
-    }
-
-    fn handle_list_readers(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<()> {
-        self.write_rdpdr_response(
-            req,
-            Box::new(ListReadersReturn::new(
-                ReturnCode::Success,
-                vec![scard::TELEPORT_READER_NAME.to_string()],
-            )),
-        )
-    }
-
-    fn handle_get_status_change(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: GetStatusChangeCall,
-    ) -> PduResult<()> {
-        let timeout = call.timeout;
-        let context_id = call.context.value;
-
-        if timeout != scard::TIMEOUT_INFINITE && timeout != scard::TIMEOUT_IMMEDIATE {
-            // We've never seen one of these but we log a warning here in case we ever come
-            // across one and need to debug a related issue.
-            warn!(
-                "logic for a non-infinite/non-immediate timeout [{}] is not implemented",
-                timeout
-            );
-        }
-
-        let get_status_change_ret = Self::create_get_status_change_return(call);
-
-        // We have no status change to report, cache a response
-        // for later in case we get an SCARD_IOCTL_CANCEL.
-        if Self::has_no_change(&get_status_change_ret) {
-            if timeout != scard::TIMEOUT_INFINITE {
-                return Err(other_err!(
-                    "TeleportRdpdrBackend::handle_list_readers",
-                    "got no change for non-infinite timeout",
-                ));
-            }
-
-            // Received a GetStatusChangeCall with an infinite timeout, so we're adding
-            // a corresponding DeviceControlResponse holding a GetStatusChangeReturn
-            // with its return code set to SCARD_E_CANCELLED to this Context. This value will
-            // be returned when we get an SCARD_IOCTL_CANCEL call for this Context.
-            self.contexts.set_scard_cancel_response(
-                context_id,
-                DeviceControlResponse::new(
-                    req,
-                    NtStatus::Success,
-                    Box::new(GetStatusChangeReturn::new(
-                        ReturnCode::Cancelled,
-                        get_status_change_ret.into_inner().reader_states,
-                    )),
-                ),
-            )?;
-
-            debug!("blocking GetStatusChange call indefinitely (since our status never changes) until we receive an SCARD_IOCTL_CANCEL");
-
-            return Ok(());
-        }
-
-        // We have some status change to report, send it to the server.
-        self.write_rdpdr_response(req, Box::new(get_status_change_ret))
-    }
-
-    fn handle_connect(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: ConnectCall,
-    ) -> PduResult<()> {
-        let handle = self.contexts.connect(
-            call.common.context,
-            call.common.context.value,
-            self.uuid,
-            &self.cert_der,
-            &self.key_der,
-            self.pin.clone(),
-        )?;
-
-        self.write_rdpdr_response(
-            req,
-            Box::new(ConnectReturn::new(
-                ReturnCode::Success,
-                handle,
-                CardProtocol::SCARD_PROTOCOL_T1,
-            )),
-        )
-    }
-
-    fn handle_begin_transaction(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_transmit(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: TransmitCall,
-    ) -> PduResult<()> {
-        let cmd =
-            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer).map_err(|err| {
-                custom_err!(
-                    "TeleportRdpdrBackend::handle_transmit",
-                    TeleportRdpdrBackendError(format!(
-                        "failed to parse smartcard command {:?}: {:?}",
-                        &call.send_buffer, err
-                    ))
-                )
-            })?;
-
-        let card = self.contexts.get_card(&call.handle)?;
-        let resp = card.handle(cmd)?;
-
-        self.write_rdpdr_response(
-            req,
-            Box::new(TransmitReturn::new(
-                ReturnCode::Success,
-                None,
-                resp.encode(),
-            )),
-        )
-    }
-
-    fn handle_status(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<()> {
-        let enc = match req.io_control_code {
-            ScardIoCtlCode::StatusW => CharacterSet::Unicode,
-            ScardIoCtlCode::StatusA => CharacterSet::Ansi,
-            _ => {
-                return Err(custom_err!(
-                    "TeleportRdpdrBackend::handle_status",
-                    TeleportRdpdrBackendError(format!(
-                        "got unexpected ScardIoCtlCode with a StatusCall: {:?}",
-                        req.io_control_code
-                    ))
-                ));
-            }
-        };
-
-        let (atr_length, atr) = padded_atr::<32>();
-
-        self.write_rdpdr_response(
-            req,
-            Box::new(StatusReturn::new(
-                ReturnCode::Success,
-                vec![TELEPORT_READER_NAME.to_string()],
-                // SPECIFICMODE state means that the card is ready to handle commands in a specific
-                // mode, no other negotiation is necessary. Real smartcards would probably negotiate
-                // some mode first.
-                CardState::SpecificMode,
-                CardProtocol::SCARD_PROTOCOL_T1,
-                atr,
-                atr_length,
-                enc,
-            )),
-        )
-    }
-
-    fn handle_release_context(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: ContextCall,
-    ) -> PduResult<()> {
-        self.contexts.release(call.context.value);
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_end_transaction(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_disconnect(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: HCardAndDispositionCall,
-    ) -> PduResult<()> {
-        self.contexts.disconnect(call.handle)?;
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_cancel(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: ContextCall,
-    ) -> PduResult<()> {
-        let resp = self
-            .contexts
-            .take_scard_cancel_response(call.context.value)?;
-        if let Some(resp) = resp {
-            self.send_device_ctl_response(resp)?;
-        } else {
-            warn!("Received SCARD_IOCTL_CANCEL for a context without a pending SCARD_IOCTL_GETSTATUSCHANGEW");
-        }
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_is_valid_context(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        // TODO: Currently we're always just sending ReturnCode::Success (based on awly's pre-
-        // IronRDP code). Should we instead be checking if we have such a context in our cache?
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_get_device_type_id(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: GetDeviceTypeIdCall,
-    ) -> PduResult<()> {
-        if self.contexts.exists(call.context.value) {
-            // Reader type describes the type of the physical connection to the smartcard reader (e.g.
-            // USB/serial/TPM). Type "vendor" means a proprietary vendor bus.
-            //
-            // See "ReaderType" in
-            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/smclib/ns-smclib-_scard_reader_capabilitiesconst SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
-            const SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
-            self.write_rdpdr_response(
-                req,
-                Box::new(GetDeviceTypeIdReturn::new(
-                    ReturnCode::Success,
-                    SCARD_READER_TYPE_VENDOR,
-                )),
-            )
-        } else {
-            Err(custom_err!(
-                "TeleportRdpdrBackend::handle_get_device_type_id",
-                TeleportRdpdrBackendError(format!(
-                    "got GetDeviceTypeIdCall for unknown context [{}]",
-                    call.context.value
-                ))
-            ))
-        }
-    }
-
-    fn handle_read_cache(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: ReadCacheCall,
-    ) -> PduResult<()> {
-        let (data, return_code) = match self.contexts.read_cache(call)? {
-            Some(data) => (data, ReturnCode::Success),
-            None => (vec![], ReturnCode::CacheItemNotFound),
-        };
-        self.write_rdpdr_response(req, Box::new(ReadCacheReturn::new(return_code, data)))
-    }
-
-    fn handle_write_cache(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        call: WriteCacheCall,
-    ) -> PduResult<()> {
-        self.contexts.write_cache(call)?;
-        self.write_rdpdr_response(req, Box::new(LongReturn::new(ReturnCode::Success)))
-    }
-
-    fn handle_get_reader_icon(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-    ) -> PduResult<()> {
-        self.write_rdpdr_response(
-            req,
-            Box::new(GetReaderIconReturn::new(
-                ReturnCode::UnsupportedFeature,
-                vec![],
-            )),
-        )
     }
 
     fn tdp_sd_info_request(&self, req: SharedDirectoryInfoRequest) -> PduResult<()> {
@@ -840,96 +411,18 @@ impl TeleportRdpdrBackend {
         Ok(())
     }
 
-    fn create_get_status_change_return(
-        call: GetStatusChangeCall,
-    ) -> rpce::Pdu<GetStatusChangeReturn> {
-        let mut reader_states = vec![];
-        for state in call.states {
-            match state.reader.as_str() {
-                // PnP is Plug-and-Play. This special reader "name" is used to monitor for
-                // new readers being plugged in.
-                "\\\\?PnP?\\Notification" => {
-                    reader_states.push(ReaderStateCommonCall {
-                        current_state: state.common.current_state,
-                        event_state: state.common.current_state,
-                        atr_length: state.common.atr_length,
-                        atr: state.common.atr,
-                    });
-                }
-                // This is our actual emulated smartcard reader. We always advertise its state as
-                // "present".
-                scard::TELEPORT_READER_NAME => {
-                    let (atr_length, atr) = scard::padded_atr::<36>();
-                    reader_states.push(ReaderStateCommonCall {
-                        current_state: state.common.current_state,
-                        event_state: CardStateFlags::SCARD_STATE_CHANGED
-                            | CardStateFlags::SCARD_STATE_PRESENT,
-                        atr_length,
-                        atr,
-                    });
-                }
-                // All other reader names are unknown and unexpected.
-                _ => {
-                    warn!(
-                        "got unexpected reader name [{}], ignoring",
-                        state.reader.as_str()
-                    );
-                    reader_states.push(ReaderStateCommonCall {
-                        current_state: state.common.current_state,
-                        event_state: CardStateFlags::SCARD_STATE_CHANGED
-                            | CardStateFlags::SCARD_STATE_UNKNOWN
-                            | CardStateFlags::SCARD_STATE_IGNORE,
-                        atr_length: state.common.atr_length,
-                        atr: state.common.atr,
-                    });
-                }
-            }
-        }
-
-        GetStatusChangeReturn::new(ReturnCode::Success, reader_states)
-    }
-
-    fn has_no_change(pdu: &rpce::Pdu<GetStatusChangeReturn>) -> bool {
-        pdu.into_inner_ref()
-            .reader_states
-            .iter()
-            .all(|state| state.current_state == state.event_state)
-    }
-
-    fn write_rdpdr_response(
-        &mut self,
-        req: DeviceControlRequest<ScardIoCtlCode>,
-        resp: Box<dyn rpce::Encode>,
-    ) -> PduResult<()> {
-        let resp = DeviceControlResponse::new(req, NtStatus::Success, resp);
-        self.send_device_ctl_response(resp)
-    }
-
-    fn send_device_ctl_response(&mut self, resp: DeviceControlResponse) -> PduResult<()> {
+    fn write_rdpdr(&mut self, pdu: RdpdrPdu) -> PduResult<()> {
         self.client_handle
-            .blocking_send(ClientFunction::WriteRdpdr(RdpdrPdu::DeviceControlResponse(
-                resp,
-            )))
+            .blocking_send(ClientFunction::WriteRdpdr(pdu))
             .map_err(|e| {
                 custom_err!(
-                    "TeleportRdpdrBackend::write_rdpdr_dev_ctl_resp",
+                    "TeleportRdpdrBackend::write_rdpdr",
                     // Due to a long chain of trait dependencies in IronRDP that are impractical to unwind at this point,
                     // we can't put _e in the source field of the error because it isn't Sync (because ClientFunction itself
                     // isn't sync). We compromise here by just wrapping its Debug output in a TeleportRdpdrBackendError.
                     TeleportRdpdrBackendError(format!("{:?}", e))
                 )
             })
-    }
-
-    /// This function returns the error for unsupported combinations of [`ScardIoCtlCode`] and [`ScardCall`].
-    fn unsupported_combo_error(ioctl: ScardIoCtlCode, call: ScardCall) -> PduResult<()> {
-        Err(custom_err!(
-            "TeleportRdpdrBackend::unsupported_combo_error",
-            TeleportRdpdrBackendError(format!(
-                "received unsupported combination of ScardIoCtlCode [{:?}] with ScardCall [{:?}]",
-                ioctl, call
-            ))
-        ))
     }
 }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -12,35 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod filesystem;
 mod flags;
 pub(crate) mod path;
 pub(crate) mod scard;
 pub(crate) mod tdp;
 
+use self::filesystem::FilesystemBackend;
 use self::scard::ScardBackend;
-use self::tdp::{SharedDirectoryInfoRequest, SharedDirectoryInfoResponse};
+use self::tdp::SharedDirectoryInfoResponse;
 use crate::client::{ClientFunction, ClientHandle};
-use crate::{tdp_sd_info_request, CGOErrCode, CGOSharedDirectoryInfoRequest, CgoHandle};
+use crate::CgoHandle;
 use ironrdp_pdu::{custom_err, PduResult};
 use ironrdp_rdpdr::pdu::efs::{
-    DeviceControlRequest, DeviceCreateRequest, FilesystemRequest, NtStatus,
-    ServerDeviceAnnounceResponse,
+    DeviceControlRequest, FilesystemRequest, NtStatus, ServerDeviceAnnounceResponse,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_svc::impl_as_any;
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct TeleportRdpdrBackend {
     /// The client handle for this backend, used to send messages to the RDP server.
     client_handle: ClientHandle,
+    /// The backend for smart card redirection.
     scard: ScardBackend,
-    cgo_handle: CgoHandle,
-
-    /// CompletionId -> SharedDirectoryInfoResponseHandler
-    pending_sd_info_resp_handlers: HashMap<u32, SharedDirectoryInfoResponseHandler>,
+    /// The backend for directory sharing.
+    fs: FilesystemBackend,
 }
 
 impl_as_any!(TeleportRdpdrBackend);
@@ -70,16 +69,15 @@ impl RdpdrBackend for TeleportRdpdrBackend {
         call: ScardCall,
     ) -> PduResult<()> {
         if let Some(resp) = self.scard.handle(req, call)? {
-            self.write_rdpdr(RdpdrPdu::DeviceControlResponse(resp))
+            self.write_rdpdr(resp.into())
         } else {
+            // Nothing to send back to the server
             Ok(())
         }
     }
 
     fn handle_fs_request(&mut self, req: FilesystemRequest) -> PduResult<()> {
-        match req {
-            FilesystemRequest::DeviceCreateRequest(req) => self.handle_fs_device_create(req),
-        }
+        self.fs.handle(req)
     }
 }
 
@@ -94,321 +92,20 @@ impl TeleportRdpdrBackend {
         Self {
             client_handle,
             scard: ScardBackend::new(cert_der, key_der, pin),
-            cgo_handle,
-            pending_sd_info_resp_handlers: HashMap::new(),
+            fs: FilesystemBackend::new(cgo_handle),
         }
-    }
-
-    fn tdp_sd_info_request(&self, req: SharedDirectoryInfoRequest) -> PduResult<()> {
-        debug!("{:?}", req);
-        let c_string = req.path.to_cstring()?;
-        unsafe {
-            let err = tdp_sd_info_request(
-                self.cgo_handle,
-                &mut CGOSharedDirectoryInfoRequest {
-                    completion_id: req.completion_id,
-                    directory_id: req.directory_id,
-                    path: c_string.as_ptr(),
-                },
-            );
-            if err != CGOErrCode::ErrCodeSuccess {
-                TeleportRdpdrBackendError(format!(
-                    "failed to send TDP Shared Directory Info Request: {:?}",
-                    err
-                ));
-            };
-        }
-        Ok(())
     }
 
     pub fn handle_tdp_sd_info_response(
         &mut self,
         tdp_res: SharedDirectoryInfoResponse,
     ) -> PduResult<()> {
-        if let Some((rdp_req, handler)) = self
-            .pending_sd_info_resp_handlers
-            .remove(&tdp_res.completion_id)
-        {
-            let rdp_responses = handler(self, rdp_req, tdp_res)?;
-            return Ok(rdp_responses);
+        if let Some(resp) = self.fs.handle_tdp_sd_info_response(tdp_res)? {
+            self.write_rdpdr(resp)
+        } else {
+            // Nothing to send back to the server
+            Ok(())
         }
-
-        // Err(try_error(&format!(
-        //     "received invalid completion id: {}",
-        //     tdp_res.completion_id
-        // )))
-
-        Ok(())
-    }
-
-    fn handle_tdp_sd_info_response_internal(
-        &mut self,
-        rdp_req: DeviceCreateRequest,
-        tdp_res: SharedDirectoryInfoResponse,
-    ) -> PduResult<()> {
-        // match tdp_res.err_code {
-        //     TdpErrCode::Failed | TdpErrCode::AlreadyExists => {
-        //         return Err(try_error(&format!(
-        //             "received unexpected TDP error code in SharedDirectoryInfoResponse: {:?}",
-        //             tdp_res.err_code,
-        //         )));
-        //     }
-        //     TdpErrCode::Nil => {
-        //         // The file exists
-        //         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L214
-        //         if tdp_res.fso.file_type == FileType::Directory {
-        //             if rdp_req.create_disposition == flags::CreateDisposition::FILE_CREATE {
-        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L221
-        //                 return cli.prep_device_create_response(
-        //                     &rdp_req,
-        //                     NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
-        //                     0,
-        //                 );
-        //             }
-
-        //             if rdp_req
-        //                 .create_options
-        //                 .contains(flags::CreateOptions::FILE_NON_DIRECTORY_FILE)
-        //             {
-        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L227
-        //                 return cli.prep_device_create_response(
-        //                     &rdp_req,
-        //                     NTSTATUS::STATUS_ACCESS_DENIED,
-        //                     0,
-        //                 );
-        //             }
-        //         } else if rdp_req
-        //             .create_options
-        //             .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
-        //         {
-        //             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L237
-        //             return cli.prep_device_create_response(
-        //                 &rdp_req,
-        //                 NTSTATUS::STATUS_NOT_A_DIRECTORY,
-        //                 0,
-        //             );
-        //         }
-        //     }
-        //     TdpErrCode::DoesNotExist => {
-        //         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L242
-        //         if rdp_req
-        //             .create_options
-        //             .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
-        //         {
-        //             if rdp_req.create_disposition.intersects(
-        //                 flags::CreateDisposition::FILE_OPEN_IF
-        //                     | flags::CreateDisposition::FILE_CREATE,
-        //             ) {
-        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L252
-        //                 return cli.tdp_sd_create(rdp_req, FileType::Directory);
-        //             } else {
-        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L258
-        //                 return cli.prep_device_create_response(
-        //                     &rdp_req,
-        //                     NTSTATUS::STATUS_NO_SUCH_FILE,
-        //                     0,
-        //                 );
-        //             }
-        //         }
-        //     }
-        // }
-        Ok(())
-    }
-
-    fn handle_fs_device_create(&mut self, rdp_req: DeviceCreateRequest) -> PduResult<()> {
-        // Send a TDP Shared Directory Info Request
-        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L210
-        let tdp_req = SharedDirectoryInfoRequest::from(&rdp_req);
-        self.tdp_sd_info_request(tdp_req)?;
-
-        // Add a [`SharedDirectoryInfoResponseHandler`] to the handler cache.
-        // When we receive a TDP [`SharedDirectoryInfoResponse`] with this `completion_id`
-        // (the result of the `self.tdp_sd_info_request(tdp_req)` call above), this handler
-        // will be called.
-        self.pending_sd_info_resp_handlers.insert(
-            rdp_req.device_io_request.completion_id,
-            (
-                rdp_req,
-                |_self: &mut Self,
-                 rdp_req: DeviceCreateRequest,
-                 tdp_res: SharedDirectoryInfoResponse|
-                 -> PduResult<()> { Ok(()) },
-            ),
-        );
-
-        // Add a TDP Shared Directory Info Response handler to the handler cache.
-        // When we receive a TDP Shared Directory Info Response with this completion_id,
-        // this handler will be called.
-        // self.pending_sd_info_resp_handlers.insert(
-        //     rdp_req.device_io_request.completion_id,
-        //     Box::new(
-        //         |cli: &mut Self, res: SharedDirectoryInfoResponse| -> PduResult<()> {
-        //             match res.err_code {
-        //                 TdpErrCode::Failed | TdpErrCode::AlreadyExists => {
-        //                     return Err(try_error(&format!(
-        //                         "received unexpected TDP error code in SharedDirectoryInfoResponse: {:?}",
-        //                         res.err_code,
-        //                     )));
-        //                 }
-        //                 TdpErrCode::Nil => {
-        //                     // The file exists
-        //                     // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L214
-        //                     if res.fso.file_type == FileType::Directory {
-        //                         if rdp_req.create_disposition
-        //                             == flags::CreateDisposition::FILE_CREATE
-        //                         {
-        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L221
-        //                             return cli.prep_device_create_response(
-        //                                 &rdp_req,
-        //                                 NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
-        //                                 0,
-        //                             );
-        //                         }
-
-        //                         if rdp_req
-        //                             .create_options
-        //                             .contains(flags::CreateOptions::FILE_NON_DIRECTORY_FILE)
-        //                         {
-        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L227
-        //                             return cli.prep_device_create_response(
-        //                                 &rdp_req,
-        //                                 NTSTATUS::STATUS_ACCESS_DENIED,
-        //                                 0,
-        //                             );
-        //                         }
-        //                     } else if rdp_req
-        //                         .create_options
-        //                         .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
-        //                     {
-        //                         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L237
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_NOT_A_DIRECTORY,
-        //                             0,
-        //                         );
-        //                     }
-        //                 }
-        //                 TdpErrCode::DoesNotExist => {
-        //                     // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L242
-        //                     if rdp_req
-        //                         .create_options
-        //                         .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
-        //                     {
-        //                         if rdp_req.create_disposition.intersects(
-        //                             flags::CreateDisposition::FILE_OPEN_IF
-        //                                 | flags::CreateDisposition::FILE_CREATE,
-        //                         ) {
-        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L252
-        //                             return cli.tdp_sd_create(
-        //                                 rdp_req,
-        //                                 FileType::Directory,
-        //                             );
-        //                         } else {
-        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L258
-        //                             return cli.prep_device_create_response(
-        //                                 &rdp_req,
-        //                                 NTSTATUS::STATUS_NO_SUCH_FILE,
-        //                                 0,
-        //                             );
-        //                         }
-        //                     }
-        //                 }
-        //             }
-
-        //             // The actual creation of files and error mapping in FreeRDP happens here, for reference:
-        //             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/winpr/libwinpr/file/file.c#L781
-        //             match rdp_req.create_disposition {
-        //                 flags::CreateDisposition::FILE_SUPERSEDE => {
-        //                     // If the file already exists, replace it with the given file. If it does not, create the given file.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         return cli.tdp_sd_overwrite(rdp_req);
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
-        //                     }
-        //                 }
-        //                 flags::CreateDisposition::FILE_OPEN => {
-        //                     // If the file already exists, open it instead of creating a new file. If it does not, fail the request and do not create a new file.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         let file_id = cli.generate_file_id();
-        //                         cli.file_cache.insert(
-        //                             file_id,
-        //                             FileCacheObject::new(UnixPath::from(&rdp_req.path), res.fso),
-        //                         );
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_SUCCESS,
-        //                             file_id,
-        //                         );
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_NO_SUCH_FILE,
-        //                             0,
-        //                         )
-        //                     }
-        //                 }
-        //                 flags::CreateDisposition::FILE_CREATE => {
-        //                     // If the file already exists, fail the request and do not create or open the given file. If it does not, create the given file.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
-        //                             0,
-        //                         );
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
-        //                     }
-        //                 }
-        //                 flags::CreateDisposition::FILE_OPEN_IF => {
-        //                     // If the file already exists, open it. If it does not, create the given file.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         let file_id = cli.generate_file_id();
-        //                         cli.file_cache.insert(
-        //                             file_id,
-        //                             FileCacheObject::new(UnixPath::from(&rdp_req.path), res.fso),
-        //                         );
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_SUCCESS,
-        //                             file_id,
-        //                         );
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
-        //                     }
-        //                 }
-        //                 flags::CreateDisposition::FILE_OVERWRITE => {
-        //                     // If the file already exists, open it and overwrite it. If it does not, fail the request.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         return cli.tdp_sd_overwrite(rdp_req);
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.prep_device_create_response(
-        //                             &rdp_req,
-        //                             NTSTATUS::STATUS_NO_SUCH_FILE,
-        //                             0,
-        //                         )
-        //                     }
-        //                 }
-        //                 flags::CreateDisposition::FILE_OVERWRITE_IF => {
-        //                     // If the file already exists, open it and overwrite it. If it does not, create the given file.
-        //                     if res.err_code == TdpErrCode::Nil {
-        //                         return cli.tdp_sd_overwrite(rdp_req);
-        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
-        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
-        //                     }
-        //                 }
-        //                 _ => {
-        //                     return Err(invalid_data_error(&format!(
-        //                         "received unknown CreateDisposition value for RDP {rdp_req:?}"
-        //                     )));
-        //                 }
-        //             }
-
-        //             Err(try_error("Programmer error, this line should never be reached"))
-        //         },
-        //     ),
-        // );
-
-        Ok(())
     }
 
     fn write_rdpdr(&mut self, pdu: RdpdrPdu) -> PduResult<()> {
@@ -437,12 +134,3 @@ impl std::fmt::Display for TeleportRdpdrBackendError {
 }
 
 impl std::error::Error for TeleportRdpdrBackendError {}
-
-type SharedDirectoryInfoResponseHandler = (
-    DeviceCreateRequest,
-    fn(
-        &mut TeleportRdpdrBackend,
-        DeviceCreateRequest,
-        SharedDirectoryInfoResponse,
-    ) -> PduResult<()>,
-);

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -18,10 +18,13 @@ pub(crate) mod scard;
 pub(crate) mod tdp;
 
 use self::scard::{padded_atr, Contexts, TRANSMIT_DATA_LIMIT};
+use self::tdp::{SharedDirectoryInfoRequest, SharedDirectoryInfoResponse};
 use crate::client::{ClientFunction, ClientHandle};
 use crate::rdpdr::scard::TELEPORT_READER_NAME;
+use crate::{tdp_sd_info_request, CGOErrCode, CGOSharedDirectoryInfoRequest, CgoHandle};
 use ironrdp_pdu::utils::CharacterSet;
 use ironrdp_pdu::{custom_err, other_err, PduResult};
+use ironrdp_rdpdr::pdu::efs::{DeviceCreateRequest, FilesystemRequest};
 use ironrdp_rdpdr::pdu::esc::{
     rpce, CardProtocol, CardState, CardStateFlags, ConnectCall, ConnectReturn, ContextCall,
     EstablishContextReturn, GetDeviceTypeIdCall, GetDeviceTypeIdReturn, GetReaderIconReturn,
@@ -41,6 +44,7 @@ use ironrdp_rdpdr::{
 };
 use ironrdp_svc::impl_as_any;
 use iso7816::command::Command as CardCommand;
+use std::collections::HashMap;
 use std::vec;
 use uuid::Uuid;
 
@@ -61,6 +65,10 @@ pub struct TeleportRdpdrBackend {
     cert_der: Vec<u8>,
     key_der: Vec<u8>,
     pin: String,
+    cgo_handle: CgoHandle,
+
+    /// CompletionId -> SharedDirectoryInfoResponseHandler
+    pending_sd_info_resp_handlers: HashMap<u32, SharedDirectoryInfoResponseHandler>,
 }
 
 impl_as_any!(TeleportRdpdrBackend);
@@ -171,6 +179,12 @@ impl RdpdrBackend for TeleportRdpdrBackend {
             )),
         }
     }
+
+    fn handle_fs_request(&mut self, req: FilesystemRequest) -> PduResult<()> {
+        match req {
+            FilesystemRequest::DeviceCreateRequest(req) => self.handle_fs_device_create(req),
+        }
+    }
 }
 
 impl TeleportRdpdrBackend {
@@ -180,6 +194,7 @@ impl TeleportRdpdrBackend {
         cert_der: Vec<u8>,
         key_der: Vec<u8>,
         pin: String,
+        cgo_handle: CgoHandle,
     ) -> Self {
         Self {
             active_device_ids: vec![smartcard_device_id],
@@ -189,6 +204,8 @@ impl TeleportRdpdrBackend {
             cert_der,
             key_der,
             pin,
+            cgo_handle,
+            pending_sd_info_resp_handlers: HashMap::new(),
         }
     }
 
@@ -511,6 +528,318 @@ impl TeleportRdpdrBackend {
         )
     }
 
+    fn tdp_sd_info_request(&self, req: SharedDirectoryInfoRequest) -> PduResult<()> {
+        debug!("{:?}", req);
+        let c_string = req.path.to_cstring()?;
+        unsafe {
+            let err = tdp_sd_info_request(
+                self.cgo_handle,
+                &mut CGOSharedDirectoryInfoRequest {
+                    completion_id: req.completion_id,
+                    directory_id: req.directory_id,
+                    path: c_string.as_ptr(),
+                },
+            );
+            if err != CGOErrCode::ErrCodeSuccess {
+                TeleportRdpdrBackendError(format!(
+                    "failed to send TDP Shared Directory Info Request: {:?}",
+                    err
+                ));
+            };
+        }
+        Ok(())
+    }
+
+    pub fn handle_tdp_sd_info_response(
+        &mut self,
+        tdp_res: SharedDirectoryInfoResponse,
+    ) -> PduResult<()> {
+        if let Some((rdp_req, handler)) = self
+            .pending_sd_info_resp_handlers
+            .remove(&tdp_res.completion_id)
+        {
+            let rdp_responses = handler(self, rdp_req, tdp_res)?;
+            return Ok(rdp_responses);
+        }
+
+        // Err(try_error(&format!(
+        //     "received invalid completion id: {}",
+        //     tdp_res.completion_id
+        // )))
+
+        Ok(())
+    }
+
+    fn handle_tdp_sd_info_response_internal(
+        &mut self,
+        rdp_req: DeviceCreateRequest,
+        tdp_res: SharedDirectoryInfoResponse,
+    ) -> PduResult<()> {
+        // match tdp_res.err_code {
+        //     TdpErrCode::Failed | TdpErrCode::AlreadyExists => {
+        //         return Err(try_error(&format!(
+        //             "received unexpected TDP error code in SharedDirectoryInfoResponse: {:?}",
+        //             tdp_res.err_code,
+        //         )));
+        //     }
+        //     TdpErrCode::Nil => {
+        //         // The file exists
+        //         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L214
+        //         if tdp_res.fso.file_type == FileType::Directory {
+        //             if rdp_req.create_disposition == flags::CreateDisposition::FILE_CREATE {
+        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L221
+        //                 return cli.prep_device_create_response(
+        //                     &rdp_req,
+        //                     NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
+        //                     0,
+        //                 );
+        //             }
+
+        //             if rdp_req
+        //                 .create_options
+        //                 .contains(flags::CreateOptions::FILE_NON_DIRECTORY_FILE)
+        //             {
+        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L227
+        //                 return cli.prep_device_create_response(
+        //                     &rdp_req,
+        //                     NTSTATUS::STATUS_ACCESS_DENIED,
+        //                     0,
+        //                 );
+        //             }
+        //         } else if rdp_req
+        //             .create_options
+        //             .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
+        //         {
+        //             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L237
+        //             return cli.prep_device_create_response(
+        //                 &rdp_req,
+        //                 NTSTATUS::STATUS_NOT_A_DIRECTORY,
+        //                 0,
+        //             );
+        //         }
+        //     }
+        //     TdpErrCode::DoesNotExist => {
+        //         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L242
+        //         if rdp_req
+        //             .create_options
+        //             .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
+        //         {
+        //             if rdp_req.create_disposition.intersects(
+        //                 flags::CreateDisposition::FILE_OPEN_IF
+        //                     | flags::CreateDisposition::FILE_CREATE,
+        //             ) {
+        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L252
+        //                 return cli.tdp_sd_create(rdp_req, FileType::Directory);
+        //             } else {
+        //                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L258
+        //                 return cli.prep_device_create_response(
+        //                     &rdp_req,
+        //                     NTSTATUS::STATUS_NO_SUCH_FILE,
+        //                     0,
+        //                 );
+        //             }
+        //         }
+        //     }
+        // }
+        Ok(())
+    }
+
+    fn handle_fs_device_create(&mut self, rdp_req: DeviceCreateRequest) -> PduResult<()> {
+        // Send a TDP Shared Directory Info Request
+        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L210
+        let tdp_req = SharedDirectoryInfoRequest::from(&rdp_req);
+        self.tdp_sd_info_request(tdp_req)?;
+
+        // Add a [`SharedDirectoryInfoResponseHandler`] to the handler cache.
+        // When we receive a TDP [`SharedDirectoryInfoResponse`] with this `completion_id`
+        // (the result of the `self.tdp_sd_info_request(tdp_req)` call above), this handler
+        // will be called.
+        self.pending_sd_info_resp_handlers.insert(
+            rdp_req.device_io_request.completion_id,
+            (
+                rdp_req,
+                |_self: &mut Self,
+                 rdp_req: DeviceCreateRequest,
+                 tdp_res: SharedDirectoryInfoResponse|
+                 -> PduResult<()> { Ok(()) },
+            ),
+        );
+
+        // Add a TDP Shared Directory Info Response handler to the handler cache.
+        // When we receive a TDP Shared Directory Info Response with this completion_id,
+        // this handler will be called.
+        // self.pending_sd_info_resp_handlers.insert(
+        //     rdp_req.device_io_request.completion_id,
+        //     Box::new(
+        //         |cli: &mut Self, res: SharedDirectoryInfoResponse| -> PduResult<()> {
+        //             match res.err_code {
+        //                 TdpErrCode::Failed | TdpErrCode::AlreadyExists => {
+        //                     return Err(try_error(&format!(
+        //                         "received unexpected TDP error code in SharedDirectoryInfoResponse: {:?}",
+        //                         res.err_code,
+        //                     )));
+        //                 }
+        //                 TdpErrCode::Nil => {
+        //                     // The file exists
+        //                     // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L214
+        //                     if res.fso.file_type == FileType::Directory {
+        //                         if rdp_req.create_disposition
+        //                             == flags::CreateDisposition::FILE_CREATE
+        //                         {
+        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L221
+        //                             return cli.prep_device_create_response(
+        //                                 &rdp_req,
+        //                                 NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
+        //                                 0,
+        //                             );
+        //                         }
+
+        //                         if rdp_req
+        //                             .create_options
+        //                             .contains(flags::CreateOptions::FILE_NON_DIRECTORY_FILE)
+        //                         {
+        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L227
+        //                             return cli.prep_device_create_response(
+        //                                 &rdp_req,
+        //                                 NTSTATUS::STATUS_ACCESS_DENIED,
+        //                                 0,
+        //                             );
+        //                         }
+        //                     } else if rdp_req
+        //                         .create_options
+        //                         .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
+        //                     {
+        //                         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L237
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_NOT_A_DIRECTORY,
+        //                             0,
+        //                         );
+        //                     }
+        //                 }
+        //                 TdpErrCode::DoesNotExist => {
+        //                     // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L242
+        //                     if rdp_req
+        //                         .create_options
+        //                         .contains(flags::CreateOptions::FILE_DIRECTORY_FILE)
+        //                     {
+        //                         if rdp_req.create_disposition.intersects(
+        //                             flags::CreateDisposition::FILE_OPEN_IF
+        //                                 | flags::CreateDisposition::FILE_CREATE,
+        //                         ) {
+        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L252
+        //                             return cli.tdp_sd_create(
+        //                                 rdp_req,
+        //                                 FileType::Directory,
+        //                             );
+        //                         } else {
+        //                             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L258
+        //                             return cli.prep_device_create_response(
+        //                                 &rdp_req,
+        //                                 NTSTATUS::STATUS_NO_SUCH_FILE,
+        //                                 0,
+        //                             );
+        //                         }
+        //                     }
+        //                 }
+        //             }
+
+        //             // The actual creation of files and error mapping in FreeRDP happens here, for reference:
+        //             // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/winpr/libwinpr/file/file.c#L781
+        //             match rdp_req.create_disposition {
+        //                 flags::CreateDisposition::FILE_SUPERSEDE => {
+        //                     // If the file already exists, replace it with the given file. If it does not, create the given file.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         return cli.tdp_sd_overwrite(rdp_req);
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
+        //                     }
+        //                 }
+        //                 flags::CreateDisposition::FILE_OPEN => {
+        //                     // If the file already exists, open it instead of creating a new file. If it does not, fail the request and do not create a new file.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         let file_id = cli.generate_file_id();
+        //                         cli.file_cache.insert(
+        //                             file_id,
+        //                             FileCacheObject::new(UnixPath::from(&rdp_req.path), res.fso),
+        //                         );
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_SUCCESS,
+        //                             file_id,
+        //                         );
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_NO_SUCH_FILE,
+        //                             0,
+        //                         )
+        //                     }
+        //                 }
+        //                 flags::CreateDisposition::FILE_CREATE => {
+        //                     // If the file already exists, fail the request and do not create or open the given file. If it does not, create the given file.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_OBJECT_NAME_COLLISION,
+        //                             0,
+        //                         );
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
+        //                     }
+        //                 }
+        //                 flags::CreateDisposition::FILE_OPEN_IF => {
+        //                     // If the file already exists, open it. If it does not, create the given file.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         let file_id = cli.generate_file_id();
+        //                         cli.file_cache.insert(
+        //                             file_id,
+        //                             FileCacheObject::new(UnixPath::from(&rdp_req.path), res.fso),
+        //                         );
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_SUCCESS,
+        //                             file_id,
+        //                         );
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
+        //                     }
+        //                 }
+        //                 flags::CreateDisposition::FILE_OVERWRITE => {
+        //                     // If the file already exists, open it and overwrite it. If it does not, fail the request.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         return cli.tdp_sd_overwrite(rdp_req);
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.prep_device_create_response(
+        //                             &rdp_req,
+        //                             NTSTATUS::STATUS_NO_SUCH_FILE,
+        //                             0,
+        //                         )
+        //                     }
+        //                 }
+        //                 flags::CreateDisposition::FILE_OVERWRITE_IF => {
+        //                     // If the file already exists, open it and overwrite it. If it does not, create the given file.
+        //                     if res.err_code == TdpErrCode::Nil {
+        //                         return cli.tdp_sd_overwrite(rdp_req);
+        //                     } else if res.err_code == TdpErrCode::DoesNotExist {
+        //                         return cli.tdp_sd_create(rdp_req, FileType::File);
+        //                     }
+        //                 }
+        //                 _ => {
+        //                     return Err(invalid_data_error(&format!(
+        //                         "received unknown CreateDisposition value for RDP {rdp_req:?}"
+        //                     )));
+        //                 }
+        //             }
+
+        //             Err(try_error("Programmer error, this line should never be reached"))
+        //         },
+        //     ),
+        // );
+
+        Ok(())
+    }
+
     fn create_get_status_change_return(
         call: GetStatusChangeCall,
     ) -> rpce::Pdu<GetStatusChangeReturn> {
@@ -615,3 +944,12 @@ impl std::fmt::Display for TeleportRdpdrBackendError {
 }
 
 impl std::error::Error for TeleportRdpdrBackendError {}
+
+type SharedDirectoryInfoResponseHandler = (
+    DeviceCreateRequest,
+    fn(
+        &mut TeleportRdpdrBackend,
+        DeviceCreateRequest,
+        SharedDirectoryInfoResponse,
+    ) -> PduResult<()>,
+);

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -1,0 +1,511 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ironrdp_pdu::{custom_err, other_err, PduResult};
+use ironrdp_rdpdr::pdu::{
+    efs::{self},
+    RdpdrPdu,
+};
+use std::collections::HashMap;
+
+use crate::{tdp_sd_info_request, CGOErrCode, CGOSharedDirectoryInfoRequest, CgoHandle};
+
+use super::{
+    path::UnixPath,
+    tdp::{self, TdpErrCode},
+};
+
+/// `FilesystemBackend` implements the filesystem redirection backend as described in [\[MS-RDPEFS\]: Remote Desktop Protocol: File System Virtual Channel Extension].
+/// It does so in concert with the TDP directory sharing extension described in [RFD 0067].
+///
+/// [\[MS-RDPEFS\]: Remote Desktop Protocol: File System Virtual Channel Extension]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5
+/// [RFD 0067]: https://github.com/gravitational/teleport/blob/master/rfd/0067-desktop-access-file-system-sharing.md
+#[derive(Debug)]
+pub struct FilesystemBackend {
+    cgo_handle: CgoHandle,
+    /// FileId-indexed cache of FileCacheObjects.
+    /// See the documentation of FileCacheObject
+    /// for more detail on how this is used.
+    file_cache: FileCache,
+    /// CompletionId -> SharedDirectoryInfoResponseHandler
+    pending_tdp_sd_info_resp_handlers: HashMap<u32, SharedDirectoryInfoResponseHandler>,
+}
+
+impl FilesystemBackend {
+    pub fn new(cgo_handle: CgoHandle) -> Self {
+        Self {
+            cgo_handle,
+            file_cache: FileCache::new(),
+            pending_tdp_sd_info_resp_handlers: HashMap::new(),
+        }
+    }
+
+    pub fn handle(&mut self, req: efs::FilesystemRequest) -> PduResult<()> {
+        match req {
+            efs::FilesystemRequest::DeviceCreateRequest(req) => self.handle_fs_device_create(req),
+        }
+    }
+
+    fn handle_fs_device_create(&mut self, req: efs::DeviceCreateRequest) -> PduResult<()> {
+        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L210
+
+        // Send a tdp::SharedDirectoryInfoRequest to the browser.
+        self.send_tdp_sd_info_request(tdp::SharedDirectoryInfoRequest::from(&req))?;
+        // When we get a tdp::SharedDirectoryInfoResponse back, we'll call the handler we're about to add.
+        self.pending_tdp_sd_info_resp_handlers.insert(
+            req.device_io_request.completion_id,
+            (req, Self::handle_fs_device_create_continued),
+        );
+
+        Ok(())
+    }
+
+    fn handle_fs_device_create_continued(
+        &mut self,
+        req: efs::DeviceCreateRequest,
+        res: tdp::SharedDirectoryInfoResponse,
+    ) -> PduResult<Option<RdpdrPdu>> {
+        match res.err_code {
+            TdpErrCode::Failed | TdpErrCode::AlreadyExists => {
+                return Err(custom_err!(
+                    "FilesystemBackend::pending_tdp_sd_info_resp_handlers",
+                    FilesystemBackendError(format!(
+                        "received unexpected TDP error code in SharedDirectoryInfoResponse: {:?}",
+                        res.err_code,
+                    ))
+                ));
+            }
+            TdpErrCode::Nil => {
+                // The file exists
+                // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L214
+                if res.fso.file_type == tdp::FileType::Directory {
+                    if req.create_disposition == efs::CreateDisposition::FILE_CREATE {
+                        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L221
+                        return Self::make_device_create_response(
+                            &req,
+                            efs::NtStatus::ObjectNameCollision,
+                            0,
+                        );
+                    }
+
+                    if req
+                        .create_options
+                        .contains(efs::CreateOptions::FILE_NON_DIRECTORY_FILE)
+                    {
+                        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L227
+                        return Self::make_device_create_response(
+                            &req,
+                            efs::NtStatus::AccessDenied,
+                            0,
+                        );
+                    }
+                } else if req
+                    .create_options
+                    .contains(efs::CreateOptions::FILE_DIRECTORY_FILE)
+                {
+                    // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L237
+                    return Self::make_device_create_response(
+                        &req,
+                        efs::NtStatus::NotADirectory,
+                        0,
+                    );
+                }
+            }
+            TdpErrCode::DoesNotExist => {
+                // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L242
+                if req
+                    .create_options
+                    .contains(efs::CreateOptions::FILE_DIRECTORY_FILE)
+                {
+                    if req.create_disposition.intersects(
+                        efs::CreateDisposition::FILE_OPEN_IF | efs::CreateDisposition::FILE_CREATE,
+                    ) {
+                        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L252
+                        self.tdp_sd_create(req, tdp::FileType::Directory)?;
+                        return Ok(None);
+                    } else {
+                        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L258
+                        return Self::make_device_create_response(
+                            &req,
+                            efs::NtStatus::NoSuchFile,
+                            0,
+                        );
+                    }
+                }
+            }
+        }
+
+        // The actual creation of files and error mapping in FreeRDP happens here, for reference:
+        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/winpr/libwinpr/file/file.c#L781
+        match req.create_disposition {
+            efs::CreateDisposition::FILE_SUPERSEDE => {
+                // If the file already exists, replace it with the given file. If it does not, create the given file.
+                if res.err_code == TdpErrCode::Nil {
+                    self.tdp_sd_overwrite(req)?;
+                    return Ok(None);
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    self.tdp_sd_create(req, tdp::FileType::File)?;
+                    return Ok(None);
+                }
+            }
+            efs::CreateDisposition::FILE_OPEN => {
+                // If the file already exists, open it instead of creating a new file. If it does not, fail the request and do not create a new file.
+                if res.err_code == TdpErrCode::Nil {
+                    let file_id = self
+                        .file_cache
+                        .insert(FileCacheObject::new(UnixPath::from(&(*req.path)), res.fso))?;
+                    return Self::make_device_create_response(
+                        &req,
+                        efs::NtStatus::Success,
+                        file_id,
+                    );
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    return Self::make_device_create_response(&req, efs::NtStatus::NoSuchFile, 0);
+                }
+            }
+            efs::CreateDisposition::FILE_CREATE => {
+                // If the file already exists, fail the request and do not create or open the given file. If it does not, create the given file.
+                if res.err_code == TdpErrCode::Nil {
+                    return Self::make_device_create_response(
+                        &req,
+                        efs::NtStatus::ObjectNameCollision,
+                        0,
+                    );
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    self.tdp_sd_create(req, tdp::FileType::File)?;
+                    return Ok(None);
+                }
+            }
+            efs::CreateDisposition::FILE_OPEN_IF => {
+                // If the file already exists, open it. If it does not, create the given file.
+                if res.err_code == TdpErrCode::Nil {
+                    let file_id = self
+                        .file_cache
+                        .insert(FileCacheObject::new(UnixPath::from(&(*req.path)), res.fso))?;
+                    return Self::make_device_create_response(
+                        &req,
+                        efs::NtStatus::Success,
+                        file_id,
+                    );
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    self.tdp_sd_create(req, tdp::FileType::File)?;
+                    return Ok(None);
+                }
+            }
+            efs::CreateDisposition::FILE_OVERWRITE => {
+                // If the file already exists, open it and overwrite it. If it does not, fail the request.
+                if res.err_code == TdpErrCode::Nil {
+                    self.tdp_sd_overwrite(req)?;
+                    return Ok(None);
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    return Self::make_device_create_response(&req, efs::NtStatus::NoSuchFile, 0);
+                }
+            }
+            efs::CreateDisposition::FILE_OVERWRITE_IF => {
+                // If the file already exists, open it and overwrite it. If it does not, create the given file.
+                if res.err_code == TdpErrCode::Nil {
+                    self.tdp_sd_overwrite(req)?;
+                    return Ok(None);
+                } else if res.err_code == TdpErrCode::DoesNotExist {
+                    self.tdp_sd_create(req, tdp::FileType::File)?;
+                    return Ok(None);
+                }
+            }
+            _ => {
+                return Err(custom_err!(
+                    "FilesystemBackend::pending_tdp_sd_info_resp_handlers",
+                    FilesystemBackendError(format!(
+                        "received unknown CreateDisposition value for RDP {req:?}",
+                        req = req
+                    ))
+                ));
+            }
+        }
+
+        Err(other_err!(
+            "FilesystemBackend::pending_tdp_sd_info_resp_handlers",
+            "Programmer error, this line should never be reached"
+        ))
+    }
+
+    fn send_tdp_sd_info_request(&self, req: tdp::SharedDirectoryInfoRequest) -> PduResult<()> {
+        debug!("sending tdp: {:?}", req);
+        let c_string = req.path.to_cstring()?;
+        unsafe {
+            let err = tdp_sd_info_request(
+                self.cgo_handle,
+                &mut CGOSharedDirectoryInfoRequest {
+                    completion_id: req.completion_id,
+                    directory_id: req.directory_id,
+                    path: c_string.as_ptr(),
+                },
+            );
+            if err != CGOErrCode::ErrCodeSuccess {
+                FilesystemBackendError(format!(
+                    "failed to send TDP Shared Directory Info Request: {:?}",
+                    err
+                ));
+            };
+        }
+        Ok(())
+    }
+
+    pub fn handle_tdp_sd_info_response(
+        &mut self,
+        res: tdp::SharedDirectoryInfoResponse,
+    ) -> PduResult<Option<RdpdrPdu>> {
+        if let Some((rdp_req, handler)) = self
+            .pending_tdp_sd_info_resp_handlers
+            .remove(&res.completion_id)
+        {
+            handler(self, rdp_req, res)
+        } else {
+            Err(custom_err!(
+                "FilesystemBackend::handle_tdp_sd_info_response",
+                FilesystemBackendError(format!(
+                    "received invalid completion id: {}",
+                    res.completion_id
+                ))
+            ))
+        }
+    }
+
+    /// Helper function for sending a TDP SharedDirectoryCreateRequest based on an
+    /// RDP DeviceCreateRequest and handling the TDP SharedDirectoryCreateResponse.
+    fn tdp_sd_create(
+        &mut self,
+        rdp_req: efs::DeviceCreateRequest,
+        file_type: tdp::FileType,
+    ) -> PduResult<()> {
+        todo!()
+    }
+
+    /// Helper function for combining a TDP SharedDirectoryDeleteRequest
+    /// with a TDP SharedDirectoryCreateRequest to overwrite a file, based
+    /// on an RDP DeviceCreateRequest.
+    fn tdp_sd_overwrite(&mut self, rdp_req: efs::DeviceCreateRequest) -> PduResult<()> {
+        todo!()
+    }
+
+    fn make_device_create_response(
+        device_create_request: &efs::DeviceCreateRequest,
+        io_status: efs::NtStatus,
+        new_file_id: u32,
+    ) -> PduResult<Option<RdpdrPdu>> {
+        // See https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L187-L228
+        let information = if io_status != efs::NtStatus::Success
+            || device_create_request.create_disposition.intersects(
+                efs::CreateDisposition::FILE_SUPERSEDE
+                    | efs::CreateDisposition::FILE_OPEN
+                    | efs::CreateDisposition::FILE_CREATE
+                    | efs::CreateDisposition::FILE_OVERWRITE,
+            ) {
+            Ok(efs::Information::FILE_SUPERSEDED)
+        } else if device_create_request.create_disposition == efs::CreateDisposition::FILE_OPEN_IF {
+            Ok(efs::Information::FILE_OPENED)
+        } else if device_create_request.create_disposition
+            == efs::CreateDisposition::FILE_OVERWRITE_IF
+        {
+            Ok(efs::Information::FILE_OVERWRITTEN)
+        } else {
+            Err(other_err!(
+                "FilesystemBackend::make_device_create_response",
+                "program error, CreateDispositionFlags check should be exhaustive"
+            ))
+        }?;
+
+        Ok(Some(RdpdrPdu::DeviceCreateResponse(
+            efs::DeviceCreateResponse {
+                device_io_reply: efs::DeviceIoResponse::new(
+                    device_create_request.device_io_request,
+                    io_status,
+                ),
+                file_id: new_file_id,
+                information,
+            },
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct FileCache {
+    cache: HashMap<u32, FileCacheObject>,
+    next_file_id: u32,
+}
+
+impl FileCache {
+    fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+            next_file_id: 0,
+        }
+    }
+
+    /// Insert a [`FileCacheObject`] into the file cache.
+    ///
+    /// Returns the `file_id` of the inserted [`FileCacheObject`],
+    /// or an error if the `file_id` already exists in the cache.
+    fn insert(&mut self, file: FileCacheObject) -> PduResult<u32> {
+        self.next_file_id = self.next_file_id.wrapping_add(1);
+        if self.cache.insert(self.next_file_id, file).is_none() {
+            Ok(self.next_file_id)
+        } else {
+            Err(other_err!(
+                "FileCache::insert",
+                "attempted to insert a FileCacheObject into the file cache with a file_id that already exists in the cache"
+            ))
+        }
+    }
+
+    /// Retrieves a FileCacheObject from the file cache,
+    /// without removing it from the cache.
+    fn get(&self, file_id: u32) -> Option<&FileCacheObject> {
+        self.cache.get(&file_id)
+    }
+    /// Retrieves a mutable FileCacheObject from the file cache,
+    /// without removing it from the cache.
+    fn get_mut(&mut self, file_id: u32) -> Option<&mut FileCacheObject> {
+        self.cache.get_mut(&file_id)
+    }
+
+    /// Retrieves a FileCacheObject from the file cache,
+    /// removing it from the cache.
+    fn remove(&mut self, file_id: u32) -> Option<FileCacheObject> {
+        self.cache.remove(&file_id)
+    }
+}
+
+/// FileCacheObject is an in-memory representation of
+/// of a file or directory holding the metadata necessary
+/// for RDP drive redirection. They are stored in map indexed
+/// by their RDP FileId.
+///
+/// The lifecycle for a FileCacheObject is a function of the
+/// MajorFunction of RDP DeviceIoRequests:
+///
+/// | Sequence | MajorFunction | results in                                               |
+/// | -------- | ------------- | ---------------------------------------------------------|
+/// | 1        | IRP_MJ_CREATE | A new FileCacheObject is created and assigned a FileId   |
+/// | -------- | ------------- | ---------------------------------------------------------|
+/// | 2        | <other>       | The FCO is retrieved from the cache by the FileId in the |
+/// |          |               | DeviceIoRequest and metadata is used to craft a response |
+/// | -------- | ------------- | ---------------------------------------------------------|
+/// | 3        | IRP_MJ_CLOSE  | The FCO is deleted from the cache                        |
+/// | -------- | ------------- | ---------------------------------------------------------|
+#[derive(Debug, Clone)]
+struct FileCacheObject {
+    path: UnixPath,
+    delete_pending: bool,
+    /// The tdp::FileSystemObject pertaining to the file or directory at path.
+    fso: tdp::FileSystemObject,
+    /// A vector of the contents of the directory at path.
+    contents: Vec<tdp::FileSystemObject>,
+
+    /// Book-keeping variable, see Iterator implementation
+    contents_i: usize,
+    /// Book-keeping variable, see Iterator implementation
+    dot_sent: bool,
+    /// Book-keeping variable, see Iterator implementation
+    dotdot_sent: bool,
+}
+
+impl FileCacheObject {
+    fn new(path: UnixPath, fso: tdp::FileSystemObject) -> Self {
+        Self {
+            path,
+            delete_pending: false,
+            fso,
+            contents: Vec::new(),
+
+            contents_i: 0,
+            dot_sent: false,
+            dotdot_sent: false,
+        }
+    }
+}
+
+/// FileCacheObject is used as an iterator for the implementation of
+/// IRP_MJ_DIRECTORY_CONTROL, which requires that we iterate through
+/// all the files of a directory one by one. In this case, the directory
+/// is the FileCacheObject itself, with it's own fso field representing
+/// the directory, and its contents being represented by tdp::FileSystemObject's
+/// in its contents field.
+///
+/// We account for an idiosyncrasy of the RDP protocol here: when fielding an
+/// IRP_MJ_DIRECTORY_CONTROL, RDP first expects to receive an entry for the "."
+/// directory, and next an entry for the ".." directory. Only after those two
+/// directories have been sent do we begin sending the actual contents of this
+/// directory (the contents field). (This is why we maintain dot_sent and dotdot_sent
+/// fields on each FileCacheObject)
+///
+/// Note that this implementation only makes sense in the case that this FileCacheObject
+/// is itself a directory (fso.file_type == FileType::Directory). We leave it up to the
+/// caller to ensure iteration makes sense in the given context that it's used.
+impl Iterator for FileCacheObject {
+    type Item = tdp::FileSystemObject;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // On the first call to next, return the "." directory
+        if !self.dot_sent {
+            self.dot_sent = true;
+            Some(tdp::FileSystemObject {
+                last_modified: self.fso.last_modified,
+                size: self.fso.size,
+                file_type: self.fso.file_type,
+                is_empty: tdp::FALSE,
+                path: UnixPath::from(".".to_string()),
+            })
+        } else if !self.dotdot_sent {
+            // On the second call to next, return the ".." directory
+            self.dotdot_sent = true;
+            Some(tdp::FileSystemObject {
+                last_modified: self.fso.last_modified,
+                size: 0,
+                file_type: tdp::FileType::Directory,
+                is_empty: tdp::FALSE,
+                path: UnixPath::from("..".to_string()),
+            })
+        } else {
+            // "." and ".." have been sent, now start iterating through
+            // the actual contents of the directory
+            if self.contents_i < self.contents.len() {
+                let i = self.contents_i;
+                self.contents_i += 1;
+                return Some(self.contents[i].clone());
+            }
+            None
+        }
+    }
+}
+
+/// A generic error type for the FilesystemBackend that can contain any arbitrary error message.
+#[derive(Debug)]
+struct FilesystemBackendError(pub String);
+
+impl std::fmt::Display for FilesystemBackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#?}", self)
+    }
+}
+
+impl std::error::Error for FilesystemBackendError {}
+
+type SharedDirectoryInfoResponseHandler = (
+    efs::DeviceCreateRequest,
+    fn(
+        &mut FilesystemBackend,
+        efs::DeviceCreateRequest,
+        tdp::SharedDirectoryInfoResponse,
+    ) -> PduResult<Option<RdpdrPdu>>,
+);

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -368,18 +368,18 @@ impl FileCache {
         }
     }
 
-    /// Retrieves a FileCacheObject from the file cache,
+    /// Retrieves a [`FileCacheObject`] from the file cache,
     /// without removing it from the cache.
     fn get(&self, file_id: u32) -> Option<&FileCacheObject> {
         self.cache.get(&file_id)
     }
-    /// Retrieves a mutable FileCacheObject from the file cache,
+    /// Retrieves a mutable [`FileCacheObject`] from the file cache,
     /// without removing it from the cache.
     fn get_mut(&mut self, file_id: u32) -> Option<&mut FileCacheObject> {
         self.cache.get_mut(&file_id)
     }
 
-    /// Retrieves a FileCacheObject from the file cache,
+    /// Retrieves a [`FileCacheObject`] from the file cache,
     /// removing it from the cache.
     fn remove(&mut self, file_id: u32) -> Option<FileCacheObject> {
         self.cache.remove(&file_id)

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
@@ -78,19 +78,25 @@ impl UnixPath {
 
 impl From<&WindowsPath> for UnixPath {
     fn from(p: &WindowsPath) -> UnixPath {
-        Self::from(to_unix_path(&p.path))
+        Self {
+            path: to_unix_path(&p.path),
+        }
     }
 }
 
 impl From<&str> for UnixPath {
     fn from(p: &str) -> UnixPath {
-        Self::from(to_unix_path(&p))
+        Self {
+            path: to_unix_path(&p),
+        }
     }
 }
 
 impl From<String> for UnixPath {
-    fn from(path: String) -> UnixPath {
-        Self { path }
+    fn from(p: String) -> UnixPath {
+        Self {
+            path: to_unix_path(&p),
+        }
     }
 }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -13,27 +13,508 @@
 // limitations under the License.
 
 use crate::piv;
-use ironrdp_pdu::{other_err, PduResult};
-use ironrdp_rdpdr::pdu::efs::DeviceControlResponse;
-use ironrdp_rdpdr::pdu::esc::{ReadCacheCall, ScardContext, ScardHandle, WriteCacheCall};
+use ironrdp_pdu::utils::CharacterSet;
+use ironrdp_pdu::{custom_err, other_err, PduResult};
+use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
+use ironrdp_rdpdr::pdu::esc::{
+    rpce, CardProtocol, CardState, CardStateFlags, ConnectCall, ConnectReturn, ContextCall,
+    EstablishContextReturn, GetDeviceTypeIdCall, GetDeviceTypeIdReturn, GetReaderIconReturn,
+    GetStatusChangeCall, GetStatusChangeReturn, HCardAndDispositionCall, ListReadersReturn,
+    LongReturn, ReadCacheCall, ReadCacheReturn, ReaderStateCommonCall, ReturnCode, ScardCall,
+    ScardContext, ScardHandle, ScardIoCtlCode, StatusReturn, TransmitCall, TransmitReturn,
+    WriteCacheCall,
+};
+use iso7816::Command as CardCommand;
 use std::collections::HashMap;
 use uuid::Uuid;
 
 #[derive(Debug)]
-pub struct Contexts {
+pub struct ScardBackend {
+    /// contexts holds all the active contexts for the server, established using
+    /// SCARD_IOCTL_ESTABLISHCONTEXT. Some IOCTLs are context-specific and pass it as argument.
+    ///
+    /// contexts also holds a cache and connected smartcard handles for each context.
+    contexts: Contexts,
+    uuid: Uuid,
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
+    pin: String,
+}
+
+impl ScardBackend {
+    pub fn new(cert_der: Vec<u8>, key_der: Vec<u8>, pin: String) -> Self {
+        Self {
+            contexts: Contexts::new(),
+            uuid: Uuid::new_v4(),
+            cert_der,
+            key_der,
+            pin,
+        }
+    }
+
+    pub fn handle(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ScardCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        match req.io_control_code {
+            ScardIoCtlCode::AccessStartedEvent => match call {
+                ScardCall::AccessStartedEventCall(_) => self.handle_access_started_event(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::EstablishContext => match call {
+                ScardCall::EstablishContextCall(_) => self.handle_establish_context(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::ListReadersW => match call {
+                ScardCall::ListReadersCall(_) => self.handle_list_readers(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::GetStatusChangeW => match call {
+                ScardCall::GetStatusChangeCall(call) => self.handle_get_status_change(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::ConnectW => match call {
+                ScardCall::ConnectCall(call) => self.handle_connect(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::BeginTransaction => match call {
+                ScardCall::HCardAndDispositionCall(_) => self.handle_begin_transaction(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::Transmit => match call {
+                ScardCall::TransmitCall(call) => self.handle_transmit(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::StatusW | ScardIoCtlCode::StatusA => match call {
+                ScardCall::StatusCall(_) => self.handle_status(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::ReleaseContext => match call {
+                ScardCall::ContextCall(call) => self.handle_release_context(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::EndTransaction => match call {
+                ScardCall::HCardAndDispositionCall(_) => self.handle_end_transaction(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::Disconnect => match call {
+                ScardCall::HCardAndDispositionCall(call) => self.handle_disconnect(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::Cancel => match call {
+                ScardCall::ContextCall(call) => self.handle_cancel(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::IsValidContext => match call {
+                ScardCall::ContextCall(_) => self.handle_is_valid_context(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::GetDeviceTypeId => match call {
+                ScardCall::GetDeviceTypeIdCall(call) => self.handle_get_device_type_id(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::ReadCacheW => match call {
+                ScardCall::ReadCacheCall(call) => self.handle_read_cache(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::WriteCacheW => match call {
+                ScardCall::WriteCacheCall(call) => self.handle_write_cache(req, call),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            ScardIoCtlCode::GetReaderIcon => match call {
+                ScardCall::GetReaderIconCall(_) => self.handle_get_reader_icon(req),
+                _ => Self::unsupported_combo_error(req.io_control_code, call),
+            },
+            _ => Err(custom_err!(
+                "TeleportRdpdrBackend::handle_scard_call",
+                SmartcardBackendError(format!(
+                    "received unhandled ScardIoCtlCode: {:?}",
+                    req.io_control_code
+                ))
+            )),
+        }
+    }
+
+    fn handle_access_started_event(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_establish_context(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let ctx = self.contexts.establish();
+
+        Self::dev_ctl_resp_return(req, EstablishContextReturn::new(ReturnCode::Success, ctx))
+    }
+
+    fn handle_list_readers(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Self::dev_ctl_resp_return(
+            req,
+            ListReadersReturn::new(ReturnCode::Success, vec![TELEPORT_READER_NAME.to_string()]),
+        )
+    }
+
+    fn handle_get_status_change(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: GetStatusChangeCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let timeout = call.timeout;
+        let context_id = call.context.value;
+
+        if timeout != TIMEOUT_INFINITE && timeout != TIMEOUT_IMMEDIATE {
+            // We've never seen one of these but we log a warning here in case we ever come
+            // across one and need to debug a related issue.
+            warn!(
+                "logic for a non-infinite/non-immediate timeout [{}] is not implemented",
+                timeout
+            );
+        }
+
+        let get_status_change_ret = Self::create_get_status_change_return(call);
+
+        // We have no status change to report, cache a response
+        // for later in case we get an SCARD_IOCTL_CANCEL.
+        if Self::has_no_change(&get_status_change_ret) {
+            if timeout != TIMEOUT_INFINITE {
+                return Err(other_err!(
+                    "TeleportRdpdrBackend::handle_list_readers",
+                    "got no change for non-infinite timeout",
+                ));
+            }
+
+            // Received a GetStatusChangeCall with an infinite timeout, so we're adding
+            // a corresponding DeviceControlResponse holding a GetStatusChangeReturn
+            // with its return code set to SCARD_E_CANCELLED to this Context. This value will
+            // be returned when we get an SCARD_IOCTL_CANCEL call for this Context.
+            self.contexts.set_scard_cancel_response(
+                context_id,
+                DeviceControlResponse::new(
+                    req,
+                    NtStatus::Success,
+                    Box::new(GetStatusChangeReturn::new(
+                        ReturnCode::Cancelled,
+                        get_status_change_ret.into_inner().reader_states,
+                    )),
+                ),
+            )?;
+
+            debug!("blocking GetStatusChange call indefinitely (since our status never changes) until we receive an SCARD_IOCTL_CANCEL");
+
+            return Ok(None);
+        }
+
+        // We have some status change to report, send it to the server.
+        Self::dev_ctl_resp_return(req, get_status_change_ret)
+    }
+
+    fn create_get_status_change_return(
+        call: GetStatusChangeCall,
+    ) -> rpce::Pdu<GetStatusChangeReturn> {
+        let mut reader_states = vec![];
+        for state in call.states {
+            match state.reader.as_str() {
+                // PnP is Plug-and-Play. This special reader "name" is used to monitor for
+                // new readers being plugged in.
+                "\\\\?PnP?\\Notification" => {
+                    reader_states.push(ReaderStateCommonCall {
+                        current_state: state.common.current_state,
+                        event_state: state.common.current_state,
+                        atr_length: state.common.atr_length,
+                        atr: state.common.atr,
+                    });
+                }
+                // This is our actual emulated smartcard reader. We always advertise its state as
+                // "present".
+                TELEPORT_READER_NAME => {
+                    let (atr_length, atr) = padded_atr::<36>();
+                    reader_states.push(ReaderStateCommonCall {
+                        current_state: state.common.current_state,
+                        event_state: CardStateFlags::SCARD_STATE_CHANGED
+                            | CardStateFlags::SCARD_STATE_PRESENT,
+                        atr_length,
+                        atr,
+                    });
+                }
+                // All other reader names are unknown and unexpected.
+                _ => {
+                    warn!(
+                        "got unexpected reader name [{}], ignoring",
+                        state.reader.as_str()
+                    );
+                    reader_states.push(ReaderStateCommonCall {
+                        current_state: state.common.current_state,
+                        event_state: CardStateFlags::SCARD_STATE_CHANGED
+                            | CardStateFlags::SCARD_STATE_UNKNOWN
+                            | CardStateFlags::SCARD_STATE_IGNORE,
+                        atr_length: state.common.atr_length,
+                        atr: state.common.atr,
+                    });
+                }
+            }
+        }
+
+        GetStatusChangeReturn::new(ReturnCode::Success, reader_states)
+    }
+
+    fn has_no_change(pdu: &rpce::Pdu<GetStatusChangeReturn>) -> bool {
+        pdu.into_inner_ref()
+            .reader_states
+            .iter()
+            .all(|state| state.current_state == state.event_state)
+    }
+
+    fn handle_connect(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ConnectCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let handle = self.contexts.connect(
+            call.common.context,
+            call.common.context.value,
+            self.uuid,
+            &self.cert_der,
+            &self.key_der,
+            self.pin.clone(),
+        )?;
+
+        Self::dev_ctl_resp_return(
+            req,
+            ConnectReturn::new(ReturnCode::Success, handle, CardProtocol::SCARD_PROTOCOL_T1),
+        )
+    }
+
+    fn handle_begin_transaction(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_transmit(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: TransmitCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let cmd =
+            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer).map_err(|err| {
+                custom_err!(
+                    "TeleportRdpdrBackend::handle_transmit",
+                    SmartcardBackendError(format!(
+                        "failed to parse smartcard command {:?}: {:?}",
+                        &call.send_buffer, err
+                    ))
+                )
+            })?;
+
+        let card = self.contexts.get_card(&call.handle)?;
+        let resp = card.handle(cmd)?;
+
+        Self::dev_ctl_resp_return(
+            req,
+            TransmitReturn::new(ReturnCode::Success, None, resp.encode()),
+        )
+    }
+
+    fn handle_status(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let enc = match req.io_control_code {
+            ScardIoCtlCode::StatusW => CharacterSet::Unicode,
+            ScardIoCtlCode::StatusA => CharacterSet::Ansi,
+            _ => {
+                return Err(custom_err!(
+                    "TeleportRdpdrBackend::handle_status",
+                    SmartcardBackendError(format!(
+                        "got unexpected ScardIoCtlCode with a StatusCall: {:?}",
+                        req.io_control_code
+                    ))
+                ));
+            }
+        };
+
+        let (atr_length, atr) = padded_atr::<32>();
+
+        Self::dev_ctl_resp_return(
+            req,
+            StatusReturn::new(
+                ReturnCode::Success,
+                vec![TELEPORT_READER_NAME.to_string()],
+                // SPECIFICMODE state means that the card is ready to handle commands in a specific
+                // mode, no other negotiation is necessary. Real smartcards would probably negotiate
+                // some mode first.
+                CardState::SpecificMode,
+                CardProtocol::SCARD_PROTOCOL_T1,
+                atr,
+                atr_length,
+                enc,
+            ),
+        )
+    }
+
+    fn handle_release_context(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ContextCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        self.contexts.release(call.context.value);
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_end_transaction(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_disconnect(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: HCardAndDispositionCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        self.contexts.disconnect(call.handle)?;
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_cancel(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ContextCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let resp = self
+            .contexts
+            .take_scard_cancel_response(call.context.value)?;
+        if let Some(resp) = resp {
+            Ok(Some(resp))
+        } else {
+            // TODO: Currently we're just returning ReturnCode::Success here (based on awly's pre-
+            // IronRDP code). Should we instead be returning SCARD_E_CANCELLED (or something else)?
+            warn!("Received SCARD_IOCTL_CANCEL for a context without a pending SCARD_IOCTL_GETSTATUSCHANGEW");
+            Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+        }
+    }
+
+    fn handle_is_valid_context(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        // TODO: Currently we're always just sending ReturnCode::Success (based on awly's pre-
+        // IronRDP code). Should we instead be checking if we have such a context in our cache
+        // and returning an SCARD_E_INVALID_HANDLE (or something else)?
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_get_device_type_id(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: GetDeviceTypeIdCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        if self.contexts.exists(call.context.value) {
+            // Reader type describes the type of the physical connection to the smartcard reader (e.g.
+            // USB/serial/TPM). Type "vendor" means a proprietary vendor bus.
+            //
+            // See "ReaderType" in
+            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/smclib/ns-smclib-_scard_reader_capabilitiesconst SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
+            const SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
+            Self::dev_ctl_resp_return(
+                req,
+                GetDeviceTypeIdReturn::new(ReturnCode::Success, SCARD_READER_TYPE_VENDOR),
+            )
+        } else {
+            Err(custom_err!(
+                "TeleportRdpdrBackend::handle_get_device_type_id",
+                SmartcardBackendError(format!(
+                    "got GetDeviceTypeIdCall for unknown context [{}]",
+                    call.context.value
+                ))
+            ))
+        }
+    }
+
+    fn handle_read_cache(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ReadCacheCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        let (data, return_code) = match self.contexts.read_cache(call)? {
+            Some(data) => (data, ReturnCode::Success),
+            None => (vec![], ReturnCode::CacheItemNotFound),
+        };
+        Self::dev_ctl_resp_return(req, ReadCacheReturn::new(return_code, data))
+    }
+
+    fn handle_write_cache(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: WriteCacheCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        self.contexts.write_cache(call)?;
+        Self::dev_ctl_resp_return(req, LongReturn::new(ReturnCode::Success))
+    }
+
+    fn handle_get_reader_icon(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Self::dev_ctl_resp_return(
+            req,
+            GetReaderIconReturn::new(ReturnCode::UnsupportedFeature, vec![]),
+        )
+    }
+
+    /// This function returns the error for unsupported combinations of [`ScardIoCtlCode`] and [`ScardCall`].
+    fn unsupported_combo_error(
+        ioctl: ScardIoCtlCode,
+        call: ScardCall,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Err(custom_err!(
+            "TeleportRdpdrBackend::unsupported_combo_error",
+            SmartcardBackendError(format!(
+                "received unsupported combination of ScardIoCtlCode [{:?}] with ScardCall [{:?}]",
+                ioctl, call
+            ))
+        ))
+    }
+
+    /// Helper function for creating a DeviceControlResponse from a DeviceControlRequest and an
+    /// output buffer wrapped in an Ok(Some(...)), a common pattern in this object's methods.
+    fn dev_ctl_resp_return(
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        output_buffer: impl rpce::Encode + 'static,
+    ) -> PduResult<Option<DeviceControlResponse>> {
+        Ok(Some(DeviceControlResponse::new(
+            req,
+            NtStatus::Success,
+            Box::new(output_buffer),
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct Contexts {
     contexts: HashMap<u32, ContextInternal>,
     next_id: u32,
 }
 
 impl Contexts {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             next_id: 1,
             contexts: HashMap::new(),
         }
     }
 
-    pub fn establish(&mut self) -> ScardContext {
+    fn establish(&mut self) -> ScardContext {
         let ctx_internal = ContextInternal::new();
         let id = self.next_id;
         self.next_id += 1;
@@ -42,7 +523,7 @@ impl Contexts {
         ctx
     }
 
-    pub fn connect(
+    fn connect(
         &mut self,
         ctx: ScardContext,
         id: u32,
@@ -56,47 +537,37 @@ impl Contexts {
         Ok(handle)
     }
 
-    pub fn disconnect(&mut self, handle: ScardHandle) -> PduResult<()> {
+    fn disconnect(&mut self, handle: ScardHandle) -> PduResult<()> {
         self.get_internal_mut(handle.context.value)?
             .disconnect(handle.value);
         Ok(())
     }
 
-    pub fn set_scard_cancel_response(
-        &mut self,
-        id: u32,
-        resp: DeviceControlResponse,
-    ) -> PduResult<()> {
+    fn set_scard_cancel_response(&mut self, id: u32, resp: DeviceControlResponse) -> PduResult<()> {
         self.get_internal_mut(id)?.set_scard_cancel_response(resp)
     }
 
-    pub fn take_scard_cancel_response(
-        &mut self,
-        id: u32,
-    ) -> PduResult<Option<DeviceControlResponse>> {
+    fn take_scard_cancel_response(&mut self, id: u32) -> PduResult<Option<DeviceControlResponse>> {
         Ok(self.get_internal_mut(id)?.take_scard_cancel_response())
     }
 
-    pub fn get_card(
-        &mut self,
-        handle: &ScardHandle,
-    ) -> PduResult<&mut piv::Card<TRANSMIT_DATA_LIMIT>> {
+    fn get_card(&mut self, handle: &ScardHandle) -> PduResult<&mut piv::Card<TRANSMIT_DATA_LIMIT>> {
         self.get_internal_mut(handle.context.value)?
             .get(handle.value)
             .ok_or_else(|| other_err!("Contexts::get_card", "unknown ScardHandle"))
     }
 
-    pub fn exists(&self, id: u32) -> bool {
+    fn exists(&self, id: u32) -> bool {
         self.contexts.contains_key(&id)
     }
 
-    pub fn read_cache(&mut self, call: ReadCacheCall) -> PduResult<Option<Vec<u8>>> {
+    fn read_cache(&mut self, call: ReadCacheCall) -> PduResult<Option<Vec<u8>>> {
         Ok(self
             .get_internal_mut(call.common.context.value)?
             .cache_read(&call.lookup_name))
     }
 
-    pub fn write_cache(&mut self, call: WriteCacheCall) -> PduResult<()> {
+    fn write_cache(&mut self, call: WriteCacheCall) -> PduResult<()> {
         self.get_internal_mut(call.common.context.value)?
             .cache_write(call.lookup_name, call.common.data);
         Ok(())
@@ -108,7 +579,7 @@ impl Contexts {
             .ok_or_else(|| other_err!("Contexts::get_internal_mut", "unknown context id"))
     }
 
-    pub fn release(&mut self, id: u32) {
+    fn release(&mut self, id: u32) {
         self.contexts.remove(&id);
     }
 }
@@ -200,7 +671,7 @@ const STATIC_ATR: [u8; 11] = [
     0x3B, 0x95, 0x13, 0x81, 0x01, 0x80, 0x73, 0xFF, 0x01, 0x00, 0x0B,
 ];
 
-pub fn padded_atr<const SIZE: usize>() -> (u32, [u8; SIZE]) {
+fn padded_atr<const SIZE: usize>() -> (u32, [u8; SIZE]) {
     let mut atr = [0; SIZE];
     let len = STATIC_ATR.len().min(SIZE);
     atr[..len].copy_from_slice(&STATIC_ATR[..len]);
@@ -208,8 +679,20 @@ pub fn padded_atr<const SIZE: usize>() -> (u32, [u8; SIZE]) {
 }
 
 pub const SCARD_DEVICE_ID: u32 = 1;
-pub const TELEPORT_READER_NAME: &str = "Teleport";
+const TELEPORT_READER_NAME: &str = "Teleport";
 // TRANSMIT_DATA_LIMIT is the maximum size of transmit request/response short data, in bytes.
-pub const TRANSMIT_DATA_LIMIT: usize = 1024;
-pub const TIMEOUT_INFINITE: u32 = 0xffffffff;
-pub const TIMEOUT_IMMEDIATE: u32 = 0;
+const TRANSMIT_DATA_LIMIT: usize = 1024;
+const TIMEOUT_INFINITE: u32 = 0xffffffff;
+const TIMEOUT_IMMEDIATE: u32 = 0;
+
+/// A generic error type for the TeleportRdpdrBackend that can contain any arbitrary error message.
+#[derive(Debug)]
+struct SmartcardBackendError(pub String);
+
+impl std::fmt::Display for SmartcardBackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#?}", self)
+    }
+}
+
+impl std::error::Error for SmartcardBackendError {}

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -5,6 +5,7 @@ use crate::{
     CGOSharedDirectoryListResponse, CGOSharedDirectoryReadResponse,
 };
 use ironrdp_pdu::{custom_err, PduResult};
+use ironrdp_rdpdr::pdu::efs::DeviceCreateRequest;
 
 /// SharedDirectoryAnnounce is sent by the TDP client to the server
 /// to announce a new directory to be shared over TDP.
@@ -46,6 +47,16 @@ pub struct SharedDirectoryInfoRequest {
     pub completion_id: u32,
     pub directory_id: u32,
     pub path: UnixPath,
+}
+
+impl From<&DeviceCreateRequest> for SharedDirectoryInfoRequest {
+    fn from(req: &DeviceCreateRequest) -> SharedDirectoryInfoRequest {
+        SharedDirectoryInfoRequest {
+            completion_id: req.device_io_request.completion_id,
+            directory_id: req.device_io_request.device_id,
+            path: UnixPath::from(&(*req.path)),
+        }
+    }
 }
 
 /// SharedDirectoryInfoResponse is sent by the TDP client to the server

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -314,6 +314,10 @@ pub enum FileType {
     Directory = 1,
 }
 
+pub const FALSE: u8 = 0;
+#[allow(dead_code)]
+pub const TRUE: u8 = 1;
+
 /// A generic error type that can contain any arbitrary error message.
 ///
 /// TODO: This is a temporary solution until we can figure out a better error handling system.

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -24,9 +24,10 @@ tracing-web = "0.1.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 console_error_panic_hook = "0.1.7"
 
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "2075833ff2d02e6cea256e8a24e4e6e5e805ce88" }
+# Update when https://github.com/Devolutions/IronRDP/pull/235 lands
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "1dae856fface011307b5ca28be5778fd1ba41b44" }
 
 # Uncomment the following lines and comment out the ones above to use local crates instead of the ones from github
 # ironrdp-session = { path = "/path/to/your/local/IronRDP/crates/ironrdp-session" }


### PR DESCRIPTION
Adds support for RDP `DeviceCreateRequest` and `DeviceCreateResponse` and TDP `SharedDirectoryInfoRequest` and `SharedDirectoryInfoResponse`

Smartcard functionality is broken out from `rdpdr.rs` and placed in `scard.rs`, while a new `filesystem.rs` is created to hold directory sharing functionality.

Corresponds with https://github.com/Devolutions/IronRDP/pull/235