### PR TITLE
provide more user friendly error message on ssh access denied

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1482,8 +1482,8 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 			// TODO(codingllama): Improve error message below for device trust.
 			//  An alternative we have here is querying the cluster to check if device
 			//  trust is required, a check similar to `IsMFARequired`.
-			log.Infof("Access denied to %v connecting to %v: %v", sshConfig.User, nodeName, err)
-			return nil, trace.AccessDenied(`access denied to %v connecting to %v. User does not have permissions. Confirm SSH user`, sshConfig.User, nodeName)
+			log.Infof("Access denied connecting to %v as %v: %v", nodeName, sshConfig.User, err)
+			return nil, trace.AccessDenied(`access denied connecting to %v as %v. User does not have permissions. Confirm SSH user`, nodeName, sshConfig.User)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1483,7 +1483,7 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 			//  An alternative we have here is querying the cluster to check if device
 			//  trust is required, a check similar to `IsMFARequired`.
 			log.Infof("Access denied to %v connecting to %v: %v", sshConfig.User, nodeName, err)
-			return nil, trace.AccessDenied(`access denied to %v connecting to %v`, sshConfig.User, nodeName)
+			return nil, trace.AccessDenied(`access denied to %v connecting to %v. User does not have permissions. Confirm SSH user`, sshConfig.User, nodeName)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1451,8 +1451,8 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			stdoutAssertion: require.Empty,
 			stderrAssertion: func(t require.TestingT, v any, i ...any) {
 				out, ok := v.(string)
-				require.True(t, ok, i...)
-				require.Contains(t, out, fmt.Sprintf("access denied to %s connecting to", user.Username), i...)
+				require.True(t, ok, i...) ./tool/tsh/common/tsh_test.go
+				require.Contains(t, out, fmt.Sprintf("access denied connecting to %v as %v", sshHostID, user.Username), i...)
 			},
 			errAssertion: require.Error,
 		},

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1451,7 +1451,7 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			stdoutAssertion: require.Empty,
 			stderrAssertion: func(t require.TestingT, v any, i ...any) {
 				out, ok := v.(string)
-				require.True(t, ok, i...) ./tool/tsh/common/tsh_test.go
+				require.True(t, ok, i...)
 				require.Contains(t, out, fmt.Sprintf("access denied connecting to %v as %v", sshHostID, user.Username), i...)
 			},
 			errAssertion: require.Error,

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1586,7 +1586,8 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			stderrAssertion: func(t require.TestingT, v any, i ...any) {
 				out, ok := v.(string)
 				require.True(t, ok, i...)
-				require.Contains(t, out, "access denied to invalid connecting to", i...)
+				require.Contains(t, out, "access denied connecting to", i...)
+				require.Contains(t, out, "as invalid", i...)
 			},
 			errAssertion: require.Error,
 		},
@@ -1601,7 +1602,8 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			stderrAssertion: func(t require.TestingT, v any, i ...any) {
 				out, ok := v.(string)
 				require.True(t, ok, i...)
-				require.Contains(t, out, "access denied to invalid connecting to", i...)
+				require.Contains(t, out, "access denied connecting to", i...)
+				require.Contains(t, out, "as invalid", i...)
 			},
 			errAssertion: require.Error,
 		},

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1587,7 +1587,6 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 				out, ok := v.(string)
 				require.True(t, ok, i...)
 				require.Contains(t, out, "access denied connecting to", i...)
-				require.Contains(t, out, "as invalid", i...)
 			},
 			errAssertion: require.Error,
 		},
@@ -1603,7 +1602,6 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 				out, ok := v.(string)
 				require.True(t, ok, i...)
 				require.Contains(t, out, "access denied connecting to", i...)
-				require.Contains(t, out, "as invalid", i...)
 			},
 			errAssertion: require.Error,
 		},


### PR DESCRIPTION
This provides a similar format error to access denied for Windows login users. 

changelog: improve user message on ssh access denied message