### PR TITLE
Manually set labels in the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: gomod
     directory: "/api"
@@ -50,6 +54,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: gomod
     directory: "/assets/aws"
@@ -72,6 +80,10 @@ updates:
       - rosstimothy
       - tcsc
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: gomod
     directory: "/assets/backport"
@@ -90,6 +102,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: gomod
     directory: "/build.assets/tooling"
@@ -112,6 +128,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: gomod
     directory: "/integrations/kube-agent-updater"
@@ -131,6 +151,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
 
   - package-ecosystem: cargo
     directory: "/"
@@ -150,6 +174,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "rust"
+      - "no-changelog"
 
   - package-ecosystem: cargo
     directory: "/lib/srv/desktop/rdp/rdpclient"
@@ -169,6 +197,10 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+    labels:
+      - "dependencies"
+      - "rust"
+      - "no-changelog"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -182,3 +214,7 @@ updates:
       - jentfoo
       - fheinecke
       - camscale
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "no-changelog"


### PR DESCRIPTION
Adds the no-changelog label and the default automatic labels that are added by Dependabot. According to the docs setting labels in the config prevents the automatic labels from being added.