### PR TITLE
AWS OIDC IdP Configure script: remove region

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -249,8 +249,6 @@ type IntegrationConfAWSOIDCIdP struct {
 	Cluster string
 	// Name is the integration name.
 	Name string
-	// Region is the AWS Region used to set up the client.
-	Region string
 	// Role is the AWS Role to associate with the Integration
 	Role string
 	// ProxyPublicURL is the IdP Issuer URL (Teleport Proxy Public Address).

--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -36,7 +36,6 @@ var baseIdPIAMConfigReq = func() IdPIAMConfigureRequest {
 	return IdPIAMConfigureRequest{
 		Cluster:            "mycluster",
 		IntegrationName:    "myintegration",
-		Region:             "us-east-1",
 		IntegrationRole:    "integrationrole",
 		ProxyPublicAddress: "https://proxy.example.com",
 	}
@@ -56,7 +55,6 @@ func TestIdPIAMConfigReqDefaults(t *testing.T) {
 			expected: IdPIAMConfigureRequest{
 				Cluster:            "mycluster",
 				IntegrationName:    "myintegration",
-				Region:             "us-east-1",
 				IntegrationRole:    "integrationrole",
 				ProxyPublicAddress: "https://proxy.example.com",
 				issuer:             "proxy.example.com",
@@ -76,15 +74,6 @@ func TestIdPIAMConfigReqDefaults(t *testing.T) {
 			req: func() IdPIAMConfigureRequest {
 				req := baseIdPIAMConfigReq()
 				req.IntegrationName = ""
-				return req
-			},
-			errCheck: badParameterCheck,
-		},
-		{
-			name: "missing region",
-			req: func() IdPIAMConfigureRequest {
-				req := baseIdPIAMConfigReq()
-				req.Region = ""
 				return req
 			},
 			errCheck: badParameterCheck,
@@ -216,4 +205,18 @@ func (m *mockIdPIAMConfigClient) CreateOpenIDConnectProvider(ctx context.Context
 	return &iam.CreateOpenIDConnectProviderOutput{
 		OpenIDConnectProviderArn: aws.String("arn:something"),
 	}, nil
+}
+
+func TestNewIdPIAMConfigureClient(t *testing.T) {
+	t.Run("no aws_region env var, returns an error", func(t *testing.T) {
+		_, err := NewIdPIAMConfigureClient(context.Background())
+		require.ErrorContains(t, err, "please set the AWS_REGION environment variable")
+	})
+
+	t.Run("aws_region env var was set, success", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "some-region")
+		idpClient, err := NewIdPIAMConfigureClient(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, idpClient)
+	})
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -465,11 +465,6 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.Wrap(err)
 	}
 
-	awsRegion := queryParams.Get("awsRegion")
-	if err := aws.IsValidRegion(awsRegion); err != nil {
-		return nil, trace.BadParameter("invalid awsRegion")
-	}
-
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
 		return nil, trace.BadParameter("invalid role %q", role)
@@ -481,7 +476,6 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		"integration", "configure", "awsoidc-idp",
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--name=%s", integrationName),
-		fmt.Sprintf("--aws-region=%s", awsRegion),
 		fmt.Sprintf("--role=%s", role),
 		fmt.Sprintf("--proxy-public-url=%s", h.PublicProxyAddr()),
 	}

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -272,7 +272,6 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 			expectedTeleportArgs: "integration configure awsoidc-idp " +
 				"--cluster=localhost " +
 				"--name=myintegration " +
-				"--aws-region=us-east-1 " +
 				"--role=myRole " +
 				"--proxy-public-url=" + proxyPublicURL.String(),
 		},
@@ -287,22 +286,12 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 			expectedTeleportArgs: "integration configure awsoidc-idp " +
 				"--cluster=localhost " +
 				"--name=myintegration " +
-				"--aws-region=us-east-1 " +
 				"--role=Test+1=2,3.4@5-6_7 " +
 				"--proxy-public-url=" + proxyPublicURL.String(),
 		},
 		{
-			name: "missing aws-region",
-			reqQuery: url.Values{
-				"role":            []string{"myRole"},
-				"integrationName": []string{"myintegration"},
-			},
-			errCheck: isBadParamErrFn,
-		},
-		{
 			name: "missing role",
 			reqQuery: url.Values{
-				"awsRegion":       []string{"us-east-1"},
 				"integrationName": []string{"myintegration"},
 			},
 			errCheck: isBadParamErrFn,
@@ -310,8 +299,7 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 		{
 			name: "missing integration name",
 			reqQuery: url.Values{
-				"awsRegion": []string{"us-east-1"},
-				"role":      []string{"role"},
+				"role": []string{"role"},
 			},
 			errCheck: isBadParamErrFn,
 		},

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -463,8 +463,6 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		IntegrationConfAWSOIDCIdPArguments.Cluster)
 	integrationConfAWSOIDCIdPCmd.Flag("name", "Integration name.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Name)
-	integrationConfAWSOIDCIdPCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.
-		IntegrationConfAWSOIDCIdPArguments.Region)
 	integrationConfAWSOIDCIdPCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Role)
 	integrationConfAWSOIDCIdPCmd.Flag("proxy-public-url", "Proxy Public URL (eg https://mytenant.teleport.sh).").Required().StringVar(&ccf.
@@ -960,7 +958,7 @@ func onIntegrationConfEICEIAM(params config.IntegrationConfEICEIAM) error {
 func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error {
 	ctx := context.Background()
 
-	iamClient, err := awsoidc.NewIdPIAMConfigureClient(ctx, params.Region)
+	iamClient, err := awsoidc.NewIdPIAMConfigureClient(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -968,7 +966,6 @@ func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error 
 	err = awsoidc.ConfigureIdPIAM(ctx, iamClient, awsoidc.IdPIAMConfigureRequest{
 		Cluster:            params.Cluster,
 		IntegrationName:    params.Name,
-		Region:             params.Region,
 		IntegrationRole:    params.Role,
 		ProxyPublicAddress: params.ProxyPublicURL,
 	})


### PR DESCRIPTION
We are asking for a region when configuring the AWS IAM OIDC IdP. The region is actually irrelevant for the configuration: IAM resources are global.
This can cause some confusion for the user:
- is the integration only for this region?

Our recommended way to run this script is in AWS CloudShell which has an env var (AWS_REGION) that the Go AWS SDK uses to decide which region to use.

If the user is running this script elsehwere, where they don't have the env var set, an error message will be shown:
... please set the AWS_REGION evironment variable.

Which should be helpful enough for them to fix the issue.