### PR TITLE
Installer Scripts: use bash instead of sh

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -50,7 +50,7 @@ on_gcp() {
     sudo apt-get install -y ${PACKAGE_LIST}
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
     if [ "$ID" = "rhel" ]; then
-      VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
+      VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
@@ -59,7 +59,7 @@ on_gcp() {
     if [ "$ID" = "opensuse-tumbleweed" ]; then
       VERSION_ID="15" # tumbleweed uses dated VERSION_IDs like 20230702
     else
-      VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
+      VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
     fi
     sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
     sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"


### PR DESCRIPTION
The agentless version of this script uses `bash`.
Using `bash` over `sh` should help the maintenance of the script. It's being used for the agentless version and the node join script `sh` is sometimes an alias to `bash`, and testing this script in those systems might lead to assume that the script is working fine, even tho when running in a real `sh` it will fail.

changelog: use `bash` instead of `sh` for the Server Auto-Discovery installer script

Related #31914