### PR TITLE
Enable optimistic locking support for users

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -67,6 +67,7 @@ import (
 	secreportsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -852,13 +853,39 @@ func (c *Client) CreateUser(ctx context.Context, user types.User) (types.User, e
 		return nil, trace.BadParameter("unsupported user type %T", user)
 	}
 
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	if _, err := c.grpc.CreateUser(ctx, userV2); err != nil {
+	resp, err := userspb.NewUsersServiceClient(c.conn).CreateUser(ctx, &userspb.CreateUserRequest{User: userV2})
+	if err != nil {
+		// TODO(tross): DELETE IN 16.0.0
+		if trace.IsNotImplemented(err) {
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			if _, err := c.grpc.CreateUser(ctx, userV2); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			created, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{Name: user.GetName()})
+			return created, trace.Wrap(err)
+		}
+
 		return nil, trace.Wrap(err)
 	}
 
-	created, err := c.GetUser(ctx, user.GetName(), false)
-	return created, trace.Wrap(err)
+	return resp.User, trace.Wrap(err)
+}
+
+// UpsertUser creates a new user or updates an existing user.
+func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, error) {
+	userV2, ok := user.(*types.UserV2)
+	if !ok {
+		return nil, trace.BadParameter("unsupported user type %T", user)
+	}
+
+	resp, err := userspb.NewUsersServiceClient(c.conn).UpsertUser(ctx, &userspb.UpsertUserRequest{User: userV2})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resp.User, trace.Wrap(err)
 }
 
 // UpdateUser updates an existing user in a backend.
@@ -868,14 +895,24 @@ func (c *Client) UpdateUser(ctx context.Context, user types.User) (types.User, e
 		return nil, trace.BadParameter("unsupported user type %T", user)
 	}
 
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	_, err := c.grpc.UpdateUser(ctx, userV2)
+	resp, err := userspb.NewUsersServiceClient(c.conn).UpdateUser(ctx, &userspb.UpdateUserRequest{User: userV2})
 	if err != nil {
+		// TODO(tross): DELETE IN 16.0.0
+		if trace.IsNotImplemented(err) {
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			if _, err := c.grpc.UpdateUser(ctx, userV2); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			updated, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{Name: user.GetName()})
+			return updated, trace.Wrap(err)
+		}
+
 		return nil, trace.Wrap(err)
 	}
 
-	updated, err := c.GetUser(ctx, userV2.GetName(), false)
-	return updated, trace.Wrap(err)
+	return resp.User, trace.Wrap(err)
 }
 
 // GetUser returns a list of usernames registered in the system.
@@ -884,26 +921,37 @@ func (c *Client) GetUser(ctx context.Context, name string, withSecrets bool) (ty
 	if name == "" {
 		return nil, trace.BadParameter("missing username")
 	}
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	user, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{
-		Name:        name,
-		WithSecrets: withSecrets,
-	})
+	resp, err := userspb.NewUsersServiceClient(c.conn).GetUser(ctx, &userspb.GetUserRequest{Name: name, WithSecrets: withSecrets})
 	if err != nil {
+		// TODO(tross): DELETE IN 16.0.0
+		if trace.IsNotImplemented(err) {
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			user, err := c.grpc.GetUser(ctx, &proto.GetUserRequest{
+				Name:        name,
+				WithSecrets: withSecrets,
+			})
+			return user, trace.Wrap(err)
+		}
+
 		return nil, trace.Wrap(err)
 	}
-	return user, nil
+	return resp.User, nil
 }
 
 // GetCurrentUser returns current user as seen by the server.
 // Useful especially in the context of remote clusters which perform role and trait mapping.
 func (c *Client) GetCurrentUser(ctx context.Context) (types.User, error) {
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	currentUser, err := c.grpc.GetCurrentUser(ctx, &emptypb.Empty{})
+	resp, err := userspb.NewUsersServiceClient(c.conn).GetUser(ctx, &userspb.GetUserRequest{CurrentUser: true})
 	if err != nil {
+		// TODO(tross): DELETE IN 16.0.0
+		if trace.IsNotImplemented(err) {
+			//nolint:staticcheck // SA1019. Kept for backward compatibility.
+			currentUser, err := c.grpc.GetCurrentUser(ctx, &emptypb.Empty{})
+			return currentUser, trace.Wrap(err)
+		}
 		return nil, trace.Wrap(err)
 	}
-	return currentUser, nil
+	return resp.User, nil
 }
 
 // GetCurrentUserRoles returns current user's roles.
@@ -949,8 +997,14 @@ func (c *Client) ListUsers(ctx context.Context, pageSize int, nextToken string, 
 
 // DeleteUser deletes a user by name.
 func (c *Client) DeleteUser(ctx context.Context, user string) error {
-	//nolint:staticcheck // SA1019. Kept for backward compatibility.
-	_, err := c.grpc.DeleteUser(ctx, &proto.DeleteUserRequest{Name: user})
+	_, err := userspb.NewUsersServiceClient(c.conn).DeleteUser(ctx, &userspb.DeleteUserRequest{Name: user})
+	// TODO(tross): DELETE IN 16.0.0
+	if trace.IsNotImplemented(err) {
+		//nolint:staticcheck // SA1019. Kept for backward compatibility.
+		_, err := c.grpc.DeleteUser(ctx, &proto.DeleteUserRequest{Name: user})
+		return trace.Wrap(err)
+	}
+
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2704,6 +2704,9 @@ func (a *ServerWithRoles) DeleteAccessRequest(ctx context.Context, name string) 
 	return a.authServer.DeleteAccessRequest(ctx, name)
 }
 
+// GetUsers returns all existing users
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.ListUsers] instead.
 func (a *ServerWithRoles) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
@@ -2742,6 +2745,9 @@ func (a *ServerWithRoles) ListUsers(ctx context.Context, pageSize int, nextToken
 	return nil, "", trace.NotImplemented("ListUsers is not implemented yet")
 }
 
+// GetUser returns a single user matching the request.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.GetUser] instead.
 func (a *ServerWithRoles) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
@@ -2782,6 +2788,8 @@ func (a *ServerWithRoles) GetUser(ctx context.Context, name string, withSecrets 
 
 // GetCurrentUser returns current user as seen by the server.
 // Useful especially in the context of remote clusters which perform role and trait mapping.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.GetUser] instead.
 func (a *ServerWithRoles) GetCurrentUser(ctx context.Context) (types.User, error) {
 	// check access to roles
 	for _, role := range a.context.User.GetRoles() {
@@ -3396,6 +3404,8 @@ func (a *ServerWithRoles) ChangeUserAuthentication(ctx context.Context, req *pro
 }
 
 // CreateUser inserts a new user entry in a backend.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.CreateUser] instead.
 func (a *ServerWithRoles) CreateUser(ctx context.Context, user types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
@@ -3406,6 +3416,8 @@ func (a *ServerWithRoles) CreateUser(ctx context.Context, user types.User) (type
 
 // UpdateUser updates an existing user in a backend.
 // Captures the auth user who modified the user record.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
@@ -3415,6 +3427,9 @@ func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) (type
 	return updated, trace.Wrap(err)
 }
 
+// UpsertUser create or updates an existing user.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (a *ServerWithRoles) UpsertUser(ctx context.Context, u types.User) (types.User, error) {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -453,7 +453,17 @@ func (c *Client) UserLoginStateClient() services.UserLoginStates {
 }
 
 // UpsertUser user updates user entry.
+// TODO(tross): DELETE IN 16.0.0
 func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, error) {
+	upserted, err := c.APIClient.UpsertUser(ctx, user)
+	if err == nil {
+		return upserted, nil
+	}
+
+	if !trace.IsNotImplemented(err) {
+		return nil, trace.Wrap(err)
+	}
+
 	data, err := services.MarshalUser(user)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -467,7 +477,7 @@ func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, e
 		return nil, trace.Wrap(err)
 	}
 
-	upserted, err := c.GetUser(ctx, user.GetName(), false)
+	upserted, err = c.GetUser(ctx, user.GetName(), false)
 	return upserted, trace.Wrap(err)
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -53,6 +53,7 @@ import (
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	userpreferencespb "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
@@ -67,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/trust/trustv1"
 	"github.com/gravitational/teleport/lib/auth/userloginstate"
 	"github.com/gravitational/teleport/lib/auth/userpreferences/userpreferencesv1"
+	"github.com/gravitational/teleport/lib/auth/users/usersv1"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -120,6 +122,11 @@ type GRPCServer struct {
 	*logrus.Entry
 	APIConfig
 	server *grpc.Server
+
+	// usersService is used to forward deprecated users requests to
+	// the new service so that logic only needs to exist in one place.
+	// TODO(tross) DELETE IN 16.0.0
+	usersService *usersv1.Service
 
 	// TraceServiceServer exposes the exporter server so that the auth server may
 	// collect and forward spans
@@ -768,38 +775,28 @@ func (g *GRPCServer) ClearAlertAcks(ctx context.Context, req *authpb.ClearAlertA
 	return &emptypb.Empty{}, nil
 }
 
+// GetUser returns a user matching the provided name if one exists.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.GetUser] instead.
 func (g *GRPCServer) GetUser(ctx context.Context, req *authpb.GetUserRequest) (*types.UserV2, error) {
-	auth, err := g.authenticate(ctx)
+	resp, err := g.usersService.GetUser(ctx, &userspb.GetUserRequest{Name: req.Name, WithSecrets: req.WithSecrets})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	user, err := auth.ServerWithRoles.GetUser(ctx, req.Name, req.WithSecrets)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	v2, ok := user.(*types.UserV2)
-	if !ok {
-		log.Warnf("expected type services.UserV2, got %T for user %q", user, user.GetName())
-		return nil, trace.Errorf("encountered unexpected user type")
-	}
-	return v2, nil
+
+	return resp.User, nil
 }
 
+// GetCurrentUser returns the currently authenticated user.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.GetUser] instead.
 func (g *GRPCServer) GetCurrentUser(ctx context.Context, req *emptypb.Empty) (*types.UserV2, error) {
-	auth, err := g.authenticate(ctx)
+	resp, err := g.usersService.GetUser(ctx, &userspb.GetUserRequest{CurrentUser: true})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	user, err := auth.ServerWithRoles.GetCurrentUser(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	v2, ok := user.(*types.UserV2)
-	if !ok {
-		log.Warnf("expected type services.UserV2, got %T for user %q", user, user.GetName())
-		return nil, trace.Errorf("encountered unexpected user type")
-	}
-	return v2, nil
+
+	return resp.User, nil
 }
 
 func (g *GRPCServer) GetCurrentUserRoles(_ *emptypb.Empty, stream authpb.AuthService_GetCurrentUserRolesServer) error {
@@ -824,6 +821,9 @@ func (g *GRPCServer) GetCurrentUserRoles(_ *emptypb.Empty, stream authpb.AuthSer
 	return nil
 }
 
+// GetUsers returns all users.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.ListUsers] instead.
 func (g *GRPCServer) GetUsers(req *authpb.GetUsersRequest, stream authpb.AuthService_GetUsersServer) error {
 	auth, err := g.authenticate(stream.Context())
 	if err != nil {
@@ -1162,30 +1162,25 @@ func (g *GRPCServer) Ping(ctx context.Context, req *authpb.PingRequest) (*authpb
 }
 
 // CreateUser inserts a new user entry in a backend.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.CreateUser] instead.
 func (g *GRPCServer) CreateUser(ctx context.Context, req *types.UserV2) (*emptypb.Empty, error) {
-	auth, err := g.authenticate(ctx)
+	resp, err := g.usersService.CreateUser(ctx, &userspb.CreateUserRequest{User: req})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := services.ValidateUser(req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := services.ValidateUserRoles(ctx, req, auth); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if _, err := auth.ServerWithRoles.CreateUser(ctx, req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	log.Infof("%q user created", req.GetName())
+	log.Infof("%q user created", resp.User.GetName())
 
 	return &emptypb.Empty{}, nil
 }
 
-// UpdateUser updates an existing user in a backend.
+// UpdateUser updates an existing user in a backend. This does not use the
+// users service like other user CRUD methods to preserve update semantics.
+// This results in all updates blindly overwriting the existing user. Updating
+// users with [usersv1.Service.UpdateUser] is protected by optimistic locking.
+// TODO(tross): DELETE IN 16.0.0
+// Deprecated: use [usersv1.Service.UpdateUser] instead.
 func (g *GRPCServer) UpdateUser(ctx context.Context, req *types.UserV2) (*emptypb.Empty, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
@@ -1211,18 +1206,14 @@ func (g *GRPCServer) UpdateUser(ctx context.Context, req *types.UserV2) (*emptyp
 
 // DeleteUser deletes an existng user in a backend by username.
 func (g *GRPCServer) DeleteUser(ctx context.Context, req *authpb.DeleteUserRequest) (*emptypb.Empty, error) {
-	auth, err := g.authenticate(ctx)
+	resp, err := g.usersService.DeleteUser(ctx, &userspb.DeleteUserRequest{Name: req.Name})
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := auth.ServerWithRoles.DeleteUser(ctx, req.Name); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	log.Infof("%q user deleted", req.Name)
 
-	return &emptypb.Empty{}, nil
+	return resp, nil
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.
@@ -5590,12 +5581,26 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	usersService, err := usersv1.NewService(usersv1.ServiceConfig{
+		Authorizer: cfg.Authorizer,
+		Cache:      cfg.AuthServer.Cache,
+		Backend:    cfg.AuthServer.Services,
+		Emitter:    cfg.Emitter,
+		Reporter:   cfg.AuthServer.Services.UsageReporter,
+		Clock:      cfg.AuthServer.GetClock(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,
 		Entry: logrus.WithFields(logrus.Fields{
 			trace.Component: teleport.Component(teleport.ComponentAuth, teleport.ComponentGRPC),
 		}),
-		server: server,
+		server:       server,
+		usersService: usersService,
 	}
 
 	authpb.RegisterAuthServiceServer(server, authServer)
@@ -5689,6 +5694,8 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	userloginstatev1.RegisterUserLoginStateServiceServer(server, userLoginStateServer)
+
+	userspb.RegisterUsersServiceServer(server, usersService)
 
 	// Only register the service if this is an open source build. Enterprise builds
 	// register the actual service via an auth plugin, if we register here then all

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -147,7 +147,7 @@ func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*
 	return v2, nil
 }
 
-func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*types.UserV2, error) {
+func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.GetUserResponse, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -155,7 +155,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*ty
 
 	if req.Name == "" && req.CurrentUser {
 		user, err := s.getCurrentUser(ctx, authCtx)
-		return user, trace.Wrap(err)
+		return &userspb.GetUserResponse{User: user}, trace.Wrap(err)
 	}
 
 	if req.WithSecrets {
@@ -202,10 +202,10 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*ty
 		return nil, trace.BadParameter("encountered unexpected user type")
 	}
 
-	return v2, nil
+	return &userspb.GetUserResponse{User: v2}, nil
 }
 
-func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest) (*types.UserV2, error) {
+func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.CreateUserResponse, error) {
 	if _, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindUser, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -251,10 +251,10 @@ func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest
 		return nil, trace.BadParameter("encountered unexpected user type")
 	}
 
-	return v2, nil
+	return &userspb.CreateUserResponse{User: v2}, nil
 }
 
-func (s *Service) UpdateUser(ctx context.Context, req *userspb.UpdateUserRequest) (*types.UserV2, error) {
+func (s *Service) UpdateUser(ctx context.Context, req *userspb.UpdateUserRequest) (*userspb.UpdateUserResponse, error) {
 	if _, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindUser, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -303,10 +303,10 @@ func (s *Service) UpdateUser(ctx context.Context, req *userspb.UpdateUserRequest
 		return nil, trace.BadParameter("encountered unexpected user type")
 	}
 
-	return v2, nil
+	return &userspb.UpdateUserResponse{User: v2}, nil
 }
 
-func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest) (*types.UserV2, error) {
+func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest) (*userspb.UpsertUserResponse, error) {
 	authzCtx, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindUser, types.VerbCreate, types.VerbUpdate)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -362,7 +362,7 @@ func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest
 		return nil, trace.BadParameter("encountered unexpected user type")
 	}
 
-	return v2, nil
+	return &userspb.UpsertUserResponse{User: v2}, nil
 }
 
 func (s *Service) DeleteUser(ctx context.Context, req *userspb.DeleteUserRequest) (*emptypb.Empty, error) {

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -198,9 +198,9 @@ func TestCreateUser(t *testing.T) {
 	require.NoError(t, err, "creating user llama")
 
 	// Validate that the user now exists.
-	resp, err := env.GetUser(ctx, &userspb.GetUserRequest{Name: created.GetName()})
+	resp, err := env.GetUser(ctx, &userspb.GetUserRequest{Name: created.User.GetName()})
 	require.NoError(t, err, "failed getting created user")
-	require.Empty(t, cmp.Diff(created, resp, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.Empty(t, cmp.Diff(created.User, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	// Attempt to create a duplicate user
 	created2, err := env.CreateUser(ctx, &userspb.CreateUserRequest{User: llama.(*types.UserV2)})
@@ -232,7 +232,7 @@ func TestDeleteUser(t *testing.T) {
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
 
 	// Delete the user.
-	_, err = env.DeleteUser(ctx, &userspb.DeleteUserRequest{Name: created.GetName()})
+	_, err = env.DeleteUser(ctx, &userspb.DeleteUserRequest{Name: created.User.GetName()})
 	require.NoError(t, err)
 
 	event = <-env.emitter.C()
@@ -241,7 +241,7 @@ func TestDeleteUser(t *testing.T) {
 
 	// Attempt to delete the user again, this time deletion should fail because
 	// the user no longer exists.
-	_, err = env.DeleteUser(ctx, &userspb.DeleteUserRequest{Name: created.GetName()})
+	_, err = env.DeleteUser(ctx, &userspb.DeleteUserRequest{Name: created.User.GetName()})
 	assert.Error(t, err, "deleting nonexistent user succeeded")
 	require.True(t, trace.IsNotFound(err), "expected a not found error deleting nonexistent user got %T", err)
 }
@@ -277,10 +277,10 @@ func TestGetUser(t *testing.T) {
 
 	// Validate that the user now exists and that querying by name takes precedence over
 	// retrieving the current user.
-	resp, err = env.GetUser(ctx, &userspb.GetUserRequest{Name: created.GetName(), CurrentUser: true})
+	resp, err = env.GetUser(ctx, &userspb.GetUserRequest{Name: created.User.GetName(), CurrentUser: true})
 	assert.NoError(t, err, "failed getting created user")
-	assert.Empty(t, cmp.Diff(created, resp, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"), cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")))
-	assert.Nil(t, resp.GetLocalAuth(), "user secrets were provided when not requested")
+	assert.Empty(t, cmp.Diff(created.User, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"), cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")))
+	assert.Nil(t, resp.User.GetLocalAuth(), "user secrets were provided when not requested")
 
 	// Validate that getting the current user returns "alice" and not "llama".
 	resp, err = env.GetUser(authz.ContextWithUser(ctx, &authz.LocalUser{
@@ -290,16 +290,16 @@ func TestGetUser(t *testing.T) {
 		},
 	}), &userspb.GetUserRequest{CurrentUser: true})
 	assert.NoError(t, err, "failed getting created user")
-	assert.NotEmpty(t, cmp.Diff(created, resp, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-	assert.Equal(t, "alice", resp.GetName(), "expected current user to return alice")
-	assert.Nil(t, resp.GetLocalAuth(), "secrets returned with current user")
+	assert.NotEmpty(t, cmp.Diff(created.User, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	assert.Equal(t, "alice", resp.User.GetName(), "expected current user to return alice")
+	assert.Nil(t, resp.User.GetLocalAuth(), "secrets returned with current user")
 
 	// Validate that requesting a users secrets returns them.
-	resp, err = env.GetUser(ctx, &userspb.GetUserRequest{Name: created.GetName(), WithSecrets: true})
+	resp, err = env.GetUser(ctx, &userspb.GetUserRequest{Name: created.User.GetName(), WithSecrets: true})
 	assert.NoError(t, err, "failed getting created user")
-	assert.Empty(t, cmp.Diff(created, resp, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-	assert.NotNil(t, resp.GetLocalAuth(), "user secrets were not provided requested")
-	assert.Empty(t, cmp.Diff(llama.GetLocalAuth(), resp.GetLocalAuth()), "user secrets do not match")
+	assert.Empty(t, cmp.Diff(created.User, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	assert.NotNil(t, resp.User.GetLocalAuth(), "user secrets were not provided requested")
+	assert.Empty(t, cmp.Diff(llama.GetLocalAuth(), resp.User.GetLocalAuth()), "user secrets do not match")
 
 	// Validate that getting the current user never returns secrets
 	resp, err = env.GetUser(authz.ContextWithUser(ctx, &authz.LocalUser{
@@ -309,9 +309,9 @@ func TestGetUser(t *testing.T) {
 		},
 	}), &userspb.GetUserRequest{CurrentUser: true, WithSecrets: true})
 	assert.NoError(t, err, "failed getting created user")
-	assert.NotEmpty(t, cmp.Diff(created, resp, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-	assert.Equal(t, "alice", resp.GetName(), "expected current user to return alice")
-	assert.Nil(t, resp.GetLocalAuth(), "secrets returned with current user")
+	assert.NotEmpty(t, cmp.Diff(created.User, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	assert.Equal(t, "alice", resp.User.GetName(), "expected current user to return alice")
+	assert.Nil(t, resp.User.GetLocalAuth(), "secrets returned with current user")
 }
 
 func TestUpdateUser(t *testing.T) {
@@ -328,7 +328,7 @@ func TestUpdateUser(t *testing.T) {
 	updated, err := env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: llama.(*types.UserV2)})
 	assert.Error(t, err, "duplicate user was created successfully")
 	assert.Nil(t, updated, "received unexpected user")
-	require.True(t, trace.IsNotFound(err), "updated nonexistent user")
+	require.True(t, trace.IsCompareFailed(err), "updated nonexistent user")
 
 	// Create a new user.
 	created, err := env.CreateUser(ctx, &userspb.CreateUserRequest{User: llama.(*types.UserV2)})
@@ -339,11 +339,11 @@ func TestUpdateUser(t *testing.T) {
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
 
 	// Attempt to update the user again.
-	created.SetLogins([]string{"alpaca"})
-	updated, err = env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: created})
+	created.User.SetLogins([]string{"alpaca"})
+	updated, err = env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: created.User})
 	require.NoError(t, err, "failed updating user")
-	require.Empty(t, cmp.Diff(created, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-	require.Equal(t, []string{"alpaca"}, updated.GetLogins(), "logins were not updated")
+	require.Empty(t, cmp.Diff(created.User, updated.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.Equal(t, []string{"alpaca"}, updated.User.GetLogins(), "logins were not updated")
 
 	event = <-env.emitter.C()
 	assert.Equal(t, events.UserUpdatedEvent, event.GetType(), "unexpected event type")
@@ -375,11 +375,11 @@ func TestUpsertUser(t *testing.T) {
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
 
 	// Attempt to update the user again.
-	upserted.SetLogins([]string{"alpaca"})
-	updated, err := env.UpsertUser(ctx, &userspb.UpsertUserRequest{User: upserted})
+	upserted.User.SetLogins([]string{"alpaca"})
+	updated, err := env.UpsertUser(ctx, &userspb.UpsertUserRequest{User: upserted.User})
 	require.NoError(t, err, "failed upserting user")
-	require.Empty(t, cmp.Diff(upserted, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-	require.Equal(t, []string{"alpaca"}, updated.GetLogins(), "logins were not updated")
+	require.Empty(t, cmp.Diff(upserted.User, updated.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.Equal(t, []string{"alpaca"}, updated.User.GetLogins(), "logins were not updated")
 
 	event = <-env.emitter.C()
 	assert.Equal(t, events.UserCreateEvent, event.GetType(), "unexpected event type")
@@ -442,7 +442,7 @@ func TestRBAC(t *testing.T) {
 			f: func(t *testing.T, service *Service) {
 				user, err := service.GetUser(ctx, &userspb.GetUserRequest{CurrentUser: true})
 				assert.NoError(t, err, "expected RBAC to allow getting the current user")
-				assert.Empty(t, cmp.Diff(llama, user, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+				assert.Empty(t, cmp.Diff(llama, user.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -494,7 +494,7 @@ func TestRBAC(t *testing.T) {
 				u.SetName("alpaca")
 				created, err := service.CreateUser(ctx, &userspb.CreateUserRequest{User: u})
 				assert.NoError(t, err, "expected RBAC to allow creating user")
-				assert.Empty(t, cmp.Diff(u, created, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+				assert.Empty(t, cmp.Diff(u, created.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -533,7 +533,7 @@ func TestRBAC(t *testing.T) {
 				u.SetLogins([]string{"alpaca"})
 				updated, err := service.UpdateUser(ctx, &userspb.UpdateUserRequest{User: u})
 				assert.NoError(t, err, "expected RBAC to allow updating user")
-				assert.Empty(t, cmp.Diff(u, updated, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+				assert.Empty(t, cmp.Diff(u, updated.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -611,7 +611,7 @@ func TestRBAC(t *testing.T) {
 			f: func(t *testing.T, service *Service) {
 				upserted, err := service.UpsertUser(ctx, &userspb.UpsertUserRequest{User: llama.(*types.UserV2)})
 				assert.NoError(t, err, "expected RBAC to allow updating user")
-				assert.Empty(t, cmp.Diff(llama, upserted, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+				assert.Empty(t, cmp.Diff(llama, upserted.User, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -53,6 +53,10 @@ func TestEditResources(t *testing.T) {
 			kind: types.KindRole,
 			edit: testEditRole,
 		},
+		{
+			kind: types.KindUser,
+			edit: testEditUser,
+		},
 	}
 
 	for _, test := range tests {
@@ -60,7 +64,6 @@ func TestEditResources(t *testing.T) {
 			test.edit(t, fc, rootClient)
 		})
 	}
-
 }
 
 func testEditGithubConnector(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
@@ -110,6 +113,82 @@ func testEditGithubConnector(t *testing.T, fc *config.FileConfig, clt auth.Clien
 	// since the created revision is stale.
 	_, err = runEditCommand(t, fc, []string{"edit", "connector/github"}, withEditor(editor))
 	assert.Error(t, err, "stale connector was allowed to be updated")
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
+}
+
+func testEditRole(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
+	ctx := context.Background()
+
+	expected, err := types.NewRole("test-role", types.RoleSpecV6{})
+	require.NoError(t, err, "creating initial role resource")
+	created, err := clt.CreateRole(ctx, expected.(*types.RoleV6))
+	require.NoError(t, err, "persisting initial role resource")
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+
+		expected.SetRevision(created.GetRevision())
+		expected.SetLogins(types.Allow, []string{"abcdef"})
+
+		collection := &roleCollection{roles: []types.Role{expected}}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+
+	}
+
+	// Edit the role and validate that the expected field is updated.
+	_, err = runEditCommand(t, fc, []string{"edit", "role/test-role"}, withEditor(editor))
+	require.NoError(t, err, "expected editing role to succeed")
+
+	actual, err := clt.GetRole(ctx, expected.GetName())
+	require.NoError(t, err, "retrieving role after edit")
+	assert.NotEqual(t, created.GetLogins(types.Allow), actual.GetLogins(types.Allow), "logins should have been modified by edit")
+	require.Empty(t, cmp.Diff(expected, actual, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Try editing the role a second time. This time the revisions will not match
+	// since the created revision is stale.
+	_, err = runEditCommand(t, fc, []string{"edit", "role/test-role"}, withEditor(editor))
+	assert.Error(t, err, "stale role was allowed to be updated")
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
+}
+
+func testEditUser(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
+	ctx := context.Background()
+
+	expected, err := types.NewUser("llama")
+	require.NoError(t, err, "creating initial user resource")
+	created, err := clt.CreateUser(ctx, expected.(*types.UserV2))
+	require.NoError(t, err, "persisting initial user resource")
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+
+		expected.SetRevision(created.GetRevision())
+		expected.SetLogins([]string{"abcdef"})
+
+		collection := &userCollection{users: []types.User{expected}}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+
+	}
+
+	// Edit the user and validate that the expected field is updated.
+	_, err = runEditCommand(t, fc, []string{"edit", "user/llama"}, withEditor(editor))
+	require.NoError(t, err, "expected editing role to succeed")
+
+	actual, err := clt.GetUser(ctx, expected.GetName(), true)
+	require.NoError(t, err, "retrieving user after edit")
+	assert.NotEqual(t, created.GetLogins(), actual.GetLogins(), "logins should have been modified by edit")
+	require.Empty(t, cmp.Diff(expected, actual, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Try editing the user a second time. This time the revisions will not match
+	// since the created revision is stale.
+	_, err = runEditCommand(t, fc, []string{"edit", "user/llama"}, withEditor(editor))
+	assert.Error(t, err, "stale user was allowed to be updated")
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
@@ -270,43 +349,5 @@ func testEditSAMLConnector(t *testing.T, fc *config.FileConfig, clt auth.ClientI
 	// since the created revision is stale.
 	_, err = runEditCommand(t, fc, []string{"edit", "connector/saml"}, withEditor(editor))
 	assert.Error(t, err, "stale connector was allowed to be updated")
-	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
-}
-
-func testEditRole(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
-	ctx := context.Background()
-
-	expected, err := types.NewRole("test-role", types.RoleSpecV6{})
-	require.NoError(t, err, "creating initial role resource")
-	created, err := clt.CreateRole(ctx, expected.(*types.RoleV6))
-	require.NoError(t, err, "persisting initial role resource")
-
-	editor := func(name string) error {
-		f, err := os.Create(name)
-		if err != nil {
-			return trace.Wrap(err, "opening file to edit")
-		}
-
-		expected.SetRevision(created.GetRevision())
-		expected.SetLogins(types.Allow, []string{"abcdef"})
-
-		collection := &roleCollection{roles: []types.Role{expected}}
-		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
-	}
-
-	// Edit the connector and validate that the expected field is updated.
-	_, err = runEditCommand(t, fc, []string{"edit", "role/test-role"}, withEditor(editor))
-	require.NoError(t, err, "expected editing role to succeed")
-
-	actual, err := clt.GetRole(ctx, expected.GetName())
-	require.NoError(t, err, "retrieving role after edit")
-	assert.NotEqual(t, created.GetLogins(types.Allow), actual.GetLogins(types.Allow), "logins should have been modified by edit")
-	require.Empty(t, cmp.Diff(expected, actual, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-
-	// Try editing the connector a second time. This time the revisions will not match
-	// since the created revision is stale.
-	_, err = runEditCommand(t, fc, []string{"edit", "role/test-role"}, withEditor(editor))
-	assert.Error(t, err, "stale role was allowed to be updated")
 	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -515,7 +515,7 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client auth.ClientI, 
 		// This field should not be allowed to be overwritten.
 		user.SetCreatedBy(existingUser.GetCreatedBy())
 
-		if _, err := client.UpdateUser(ctx, user); err != nil {
+		if _, err := client.UpsertUser(ctx, user); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("user %q has been updated\n", userName)

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1364,6 +1364,10 @@ func TestCreateResources(t *testing.T) {
 			kind:   types.KindServerInfo,
 			create: testCreateServerInfo,
 		},
+		{
+			kind:   types.KindUser,
+			create: testCreateUser,
+		},
 	}
 
 	for _, test := range tests {
@@ -1430,6 +1434,193 @@ version: v3`
 	require.True(t, trace.IsAlreadyExists(err))
 
 	_, err = runResourceCommand(t, fc, []string{"create", "-f", connectorYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateRole(t *testing.T, fc *config.FileConfig) {
+	// Ensure that our test role does not exist
+	_, err := runResourceCommand(t, fc, []string{"get", types.KindRole + "/test-role", "--format=json"})
+	require.True(t, trace.IsNotFound(err), "expected test-role to not exist prior to being created")
+
+	const roleYAML = `kind: role
+metadata:
+  name: test-role
+spec:
+  allow:
+    app_labels:
+      '*': '*'
+    db_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+    kubernetes_resources:
+    - kind: pod
+      name: '*'
+      namespace: '*'
+    logins:
+    - test
+    node_labels:
+      '*': '*'
+  deny: {}
+  options:
+    cert_format: standard
+    create_db_user: false
+    create_desktop_user: false
+    desktop_clipboard: true
+    desktop_directory_sharing: true
+    enhanced_recording:
+    - command
+    - network
+    forward_agent: false
+    idp:
+      saml:
+        enabled: true
+    max_session_ttl: 30h0m0s
+    pin_source_ip: false
+    port_forwarding: true
+    record_session:
+      default: best_effort
+      desktop: true
+    ssh_file_copy: true
+version: v7
+`
+
+	// Create the role
+	roleYAMLPath := filepath.Join(t.TempDir(), "role.yaml")
+	require.NoError(t, os.WriteFile(roleYAMLPath, []byte(roleYAML), 0644))
+	_, err = runResourceCommand(t, fc, []string{"create", roleYAMLPath})
+	require.NoError(t, err)
+
+	// Fetch the role
+	buf, err := runResourceCommand(t, fc, []string{"get", types.KindRole + "/test-role", "--format=json"})
+	require.NoError(t, err)
+	roles := mustDecodeJSON[[]*types.RoleV6](t, buf)
+	require.Len(t, roles, 1)
+
+	var expected types.RoleV6
+	require.NoError(t, yaml.Unmarshal([]byte(roleYAML), &expected))
+
+	require.Empty(t, cmp.Diff(
+		[]*types.RoleV6{&expected},
+		roles,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+	))
+
+	// Explicitly change the revision and try creating the role with and without
+	// the force flag.
+	expected.SetRevision(uuid.NewString())
+	connectorBytes, err := services.MarshalRole(&expected, services.PreserveResourceID())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(roleYAMLPath, connectorBytes, 0644))
+
+	_, err = runResourceCommand(t, fc, []string{"create", roleYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err))
+
+	_, err = runResourceCommand(t, fc, []string{"create", "-f", roleYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateServerInfo(t *testing.T, fc *config.FileConfig) {
+	// Ensure that our test server info does not exist
+	_, err := runResourceCommand(t, fc, []string{"get", types.KindServerInfo + "/test-server-info", "--format=json"})
+	require.True(t, trace.IsNotFound(err), "expected test-role to not exist prior to being created")
+
+	const serverInfoYAML = `---
+kind: server_info
+sub_kind: cloud_info
+version: v1
+metadata:
+  name: test-server-info
+spec:
+  new_labels:
+    'a': '1'
+    'b': '2'
+`
+
+	// Create the server info
+	serverInfoYAMLPath := filepath.Join(t.TempDir(), "server-info.yaml")
+	err = os.WriteFile(serverInfoYAMLPath, []byte(serverInfoYAML), 0644)
+	require.NoError(t, err)
+	_, err = runResourceCommand(t, fc, []string{"create", serverInfoYAMLPath})
+	require.NoError(t, err)
+
+	// Fetch the server info
+	buf, err := runResourceCommand(t, fc, []string{"get", types.KindServerInfo + "/test-server-info", "--format=json"})
+	require.NoError(t, err)
+	serverInfos := mustDecodeJSON[[]*types.ServerInfoV1](t, buf)
+	require.Len(t, serverInfos, 1)
+
+	var expected types.ServerInfoV1
+	err = yaml.Unmarshal([]byte(serverInfoYAML), &expected)
+	require.NoError(t, err)
+
+	require.Empty(t, cmp.Diff(
+		[]*types.ServerInfoV1{&expected},
+		serverInfos,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+	))
+
+	// Explicitly change the revision and try creating the resource with and without
+	// the force flag.
+	expected.SetRevision(uuid.NewString())
+	newRevisionServerInfo, err := services.MarshalServerInfo(&expected, services.PreserveResourceID())
+	require.NoError(t, err)
+	err = os.WriteFile(serverInfoYAMLPath, newRevisionServerInfo, 0644)
+	require.NoError(t, err)
+
+	_, err = runResourceCommand(t, fc, []string{"create", serverInfoYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err))
+
+	_, err = runResourceCommand(t, fc, []string{"create", "-f", serverInfoYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateUser(t *testing.T, fc *config.FileConfig) {
+	// Ensure that our test user does not exist
+	_, err := runResourceCommand(t, fc, []string{"get", types.KindUser + "/llama", "--format=json"})
+	require.True(t, trace.IsNotFound(err), "expected llama user to not exist prior to being created")
+
+	const userYAML = `kind: user
+version: v2
+metadata:
+  name: llama
+spec:
+  roles: ["access"]
+`
+
+	// Create the user
+	userYAMLPath := filepath.Join(t.TempDir(), "user.yaml")
+	require.NoError(t, os.WriteFile(userYAMLPath, []byte(userYAML), 0644))
+	_, err = runResourceCommand(t, fc, []string{"create", userYAMLPath})
+	require.NoError(t, err)
+
+	// Fetch the user
+	buf, err := runResourceCommand(t, fc, []string{"get", types.KindUser + "/llama", "--format=json"})
+	require.NoError(t, err)
+	users := mustDecodeJSON[[]*types.UserV2](t, buf)
+	require.Len(t, users, 1)
+
+	var expected types.UserV2
+	require.NoError(t, yaml.Unmarshal([]byte(userYAML), &expected))
+
+	require.Empty(t, cmp.Diff(
+		[]*types.UserV2{&expected},
+		users,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+		cmpopts.IgnoreFields(types.UserSpecV2{}, "CreatedBy"),
+	))
+
+	// Explicitly change the revision and try creating the user with and without
+	// the force flag.
+	expected.SetRevision(uuid.NewString())
+	connectorBytes, err := services.MarshalUser(&expected, services.PreserveResourceID())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(userYAMLPath, connectorBytes, 0644))
+
+	_, err = runResourceCommand(t, fc, []string{"create", userYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err))
+
+	_, err = runResourceCommand(t, fc, []string{"create", "-f", userYAMLPath})
 	require.NoError(t, err)
 }
 
@@ -1602,143 +1793,5 @@ spec:
 	require.True(t, trace.IsAlreadyExists(err))
 
 	_, err = runResourceCommand(t, fc, []string{"create", "-f", connectorYAMLPath})
-	require.NoError(t, err)
-}
-
-func testCreateRole(t *testing.T, fc *config.FileConfig) {
-	// Ensure that our test role does not exist
-	_, err := runResourceCommand(t, fc, []string{"get", types.KindRole + "/test-role", "--format=json"})
-	require.True(t, trace.IsNotFound(err), "expected test-role to not exist prior to being created")
-
-	const roleYAML = `kind: role
-metadata:
-  name: test-role
-spec:
-  allow:
-    app_labels:
-      '*': '*'
-    db_labels:
-      '*': '*'
-    kubernetes_labels:
-      '*': '*'
-    kubernetes_resources:
-    - kind: pod
-      name: '*'
-      namespace: '*'
-    logins:
-    - test
-    node_labels:
-      '*': '*'
-  deny: {}
-  options:
-    cert_format: standard
-    create_db_user: false
-    create_desktop_user: false
-    desktop_clipboard: true
-    desktop_directory_sharing: true
-    enhanced_recording:
-    - command
-    - network
-    forward_agent: false
-    idp:
-      saml:
-        enabled: true
-    max_session_ttl: 30h0m0s
-    pin_source_ip: false
-    port_forwarding: true
-    record_session:
-      default: best_effort
-      desktop: true
-    ssh_file_copy: true
-version: v7
-`
-
-	// Create the connector
-	roleYAMLPath := filepath.Join(t.TempDir(), "role.yaml")
-	require.NoError(t, os.WriteFile(roleYAMLPath, []byte(roleYAML), 0644))
-	_, err = runResourceCommand(t, fc, []string{"create", roleYAMLPath})
-	require.NoError(t, err)
-
-	// Fetch the connector
-	buf, err := runResourceCommand(t, fc, []string{"get", types.KindRole + "/test-role", "--format=json"})
-	require.NoError(t, err)
-	roles := mustDecodeJSON[[]*types.RoleV6](t, buf)
-	require.Len(t, roles, 1)
-
-	var expected types.RoleV6
-	require.NoError(t, yaml.Unmarshal([]byte(roleYAML), &expected))
-
-	require.Empty(t, cmp.Diff(
-		[]*types.RoleV6{&expected},
-		roles,
-		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
-	))
-
-	// Explicitly change the revision and try creating the role with and without
-	// the force flag.
-	expected.SetRevision(uuid.NewString())
-	connectorBytes, err := services.MarshalRole(&expected, services.PreserveResourceID())
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(roleYAMLPath, connectorBytes, 0644))
-
-	_, err = runResourceCommand(t, fc, []string{"create", roleYAMLPath})
-	require.True(t, trace.IsAlreadyExists(err))
-
-	_, err = runResourceCommand(t, fc, []string{"create", "-f", roleYAMLPath})
-	require.NoError(t, err)
-}
-
-func testCreateServerInfo(t *testing.T, fc *config.FileConfig) {
-	// Ensure that our test server info does not exist
-	_, err := runResourceCommand(t, fc, []string{"get", types.KindServerInfo + "/test-server-info", "--format=json"})
-	require.True(t, trace.IsNotFound(err), "expected test-role to not exist prior to being created")
-
-	const serverInfoYAML = `---
-kind: server_info
-sub_kind: cloud_info
-version: v1
-metadata:
-  name: test-server-info
-spec:
-  new_labels:
-    'a': '1'
-    'b': '2'
-`
-
-	// Create the server info
-	serverInfoYAMLPath := filepath.Join(t.TempDir(), "server-info.yaml")
-	err = os.WriteFile(serverInfoYAMLPath, []byte(serverInfoYAML), 0644)
-	require.NoError(t, err)
-	_, err = runResourceCommand(t, fc, []string{"create", serverInfoYAMLPath})
-	require.NoError(t, err)
-
-	// Fetch the server info
-	buf, err := runResourceCommand(t, fc, []string{"get", types.KindServerInfo + "/test-server-info", "--format=json"})
-	require.NoError(t, err)
-	serverInfos := mustDecodeJSON[[]*types.ServerInfoV1](t, buf)
-	require.Len(t, serverInfos, 1)
-
-	var expected types.ServerInfoV1
-	err = yaml.Unmarshal([]byte(serverInfoYAML), &expected)
-	require.NoError(t, err)
-
-	require.Empty(t, cmp.Diff(
-		[]*types.ServerInfoV1{&expected},
-		serverInfos,
-		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
-	))
-
-	// Explicitly change the revision and try creating the resource with and without
-	// the force flag.
-	expected.SetRevision(uuid.NewString())
-	newRevisionServerInfo, err := services.MarshalServerInfo(&expected, services.PreserveResourceID())
-	require.NoError(t, err)
-	err = os.WriteFile(serverInfoYAMLPath, newRevisionServerInfo, 0644)
-	require.NoError(t, err)
-
-	_, err = runResourceCommand(t, fc, []string{"create", serverInfoYAMLPath})
-	require.True(t, trace.IsAlreadyExists(err))
-
-	_, err = runResourceCommand(t, fc, []string{"create", "-f", serverInfoYAMLPath})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Converts the auth client to use the new usersv1.Service instead of the auth.ProtoService to manage users. Since the new service leverages conditional updates this allows optimistic locking to now be used. The legacy RPC service now calls into the new users service to consolidate logic for all but the UpdateUser method, which was left alone to prevent altering the semantics of update for legacy clients. Additionally, the auth HTTP routes to get users were removed since they don't look to be consumed and have long been deprecated in favor of the gRPC API.