### PR TITLE
Add slog handlers to match existing logrus formatters

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -63,7 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 func TestGenerateUserCerts_MFAVerifiedFieldSet(t *testing.T) {
@@ -1325,7 +1325,7 @@ func BenchmarkListNodes(b *testing.B) {
 
 	logger := logrus.StandardLogger()
 	logger.ReplaceHooks(make(logrus.LevelHooks))
-	logrus.SetFormatter(utils.NewTestJSONFormatter())
+	logrus.SetFormatter(logutils.NewTestJSONFormatter())
 	logger.SetLevel(logrus.DebugLevel)
 	logger.SetOutput(io.Discard)
 
@@ -4623,7 +4623,7 @@ func BenchmarkListUnifiedResources(b *testing.B) {
 
 	logger := logrus.StandardLogger()
 	logger.ReplaceHooks(make(logrus.LevelHooks))
-	logrus.SetFormatter(utils.NewTestJSONFormatter())
+	logrus.SetFormatter(logutils.NewTestJSONFormatter())
 	logger.SetLevel(logrus.DebugLevel)
 	logger.SetOutput(io.Discard)
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // CommandLineFlags stores command line flag values, it's a much simplified subset
@@ -696,7 +697,7 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 	case "":
 		fallthrough // not set. defaults to 'text'
 	case "text":
-		formatter := &utils.TextFormatter{
+		formatter := &logutils.TextFormatter{
 			ExtraFields:  loggerConfig.Format.ExtraFields,
 			EnableColors: trace.IsTerminal(os.Stderr),
 		}
@@ -707,7 +708,7 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 
 		logger.SetFormatter(formatter)
 	case "json":
-		formatter := &utils.JSONFormatter{
+		formatter := &logutils.JSONFormatter{
 			ExtraFields: loggerConfig.Format.ExtraFields,
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type testConfigFiles struct {
@@ -2930,7 +2931,7 @@ func TestTextFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &utils.TextFormatter{
+			formatter := &logutils.TextFormatter{
 				ExtraFields: tt.formatConfig,
 			}
 			tt.assertErr(t, formatter.CheckAndSetDefaults())
@@ -2958,7 +2959,7 @@ func TestJSONFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &utils.JSONFormatter{
+			formatter := &logutils.JSONFormatter{
 				ExtraFields: tt.extraFields,
 			}
 			tt.assertErr(t, formatter.CheckAndSetDefaults())

--- a/lib/utils/log/buffer.go
+++ b/lib/utils/log/buffer.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import "sync"
+
+// buffer adapted from go/src/fmt/print.go
+type buffer []byte
+
+// Having an initial size gives a dramatic speedup.
+var bufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 1024)
+		return (*buffer)(&b)
+	},
+}
+
+func newBuffer() *buffer {
+	return bufPool.Get().(*buffer)
+}
+
+func (b *buffer) Free() {
+	// To reduce peak allocation, return only smaller buffers to the pool.
+	const maxBufferSize = 16 << 10
+	if cap(*b) <= maxBufferSize {
+		*b = (*b)[:0]
+		bufPool.Put(b)
+	}
+}
+
+func (b *buffer) Reset() {
+	*b = (*b)[:0]
+}
+
+func (b *buffer) Write(p []byte) (int, error) {
+	*b = append(*b, p...)
+	return len(p), nil
+}
+
+func (b *buffer) WriteString(s string) (int, error) {
+	*b = append(*b, s...)
+	return len(s), nil
+}
+
+func (b *buffer) WriteByte(c byte) error {
+	*b = append(*b, c)
+	return nil
+}
+
+func (b *buffer) WritePosInt(i int) {
+	b.WritePosIntWidth(i, 0)
+}
+
+// WritePosIntWidth writes non-negative integer i to the buffer, padded on the left
+// by zeroes to the given width. Use a width of 0 to omit padding.
+func (b *buffer) WritePosIntWidth(i, width int) {
+	// Cheap integer to fixed-width decimal ASCII.
+	// Copied from log/log.go.
+
+	if i < 0 {
+		panic("negative int")
+	}
+
+	// Assemble decimal in reverse order.
+	var bb [20]byte
+	bp := len(bb) - 1
+	for i >= 10 || width > 1 {
+		width--
+		q := i / 10
+		bb[bp] = byte('0' + i - q*10)
+		bp--
+		i = q
+	}
+	// i < 10
+	bb[bp] = byte('0' + i)
+	b.Write(bb[bp:])
+}
+
+func (b *buffer) String() string {
+	return string(*b)
+}

--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -1,0 +1,386 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const message = "Adding diagnostic debugging handlers.\t To connect with profiler, use `go tool pprof diag_addr`."
+
+var (
+	logErr = errors.New("the quick brown fox jumped really high")
+	addr   = fakeAddr{addr: "127.0.0.1:1234"}
+
+	fields = logrus.Fields{
+		"local":        &addr,
+		"remote":       &addr,
+		"login":        "llama",
+		"teleportUser": "user",
+		"id":           1234,
+	}
+)
+
+type fakeAddr struct {
+	addr string
+}
+
+func (a fakeAddr) Network() string {
+	return "tcp"
+}
+
+func (a fakeAddr) String() string {
+	return a.addr
+}
+
+func TestOutput(t *testing.T) {
+	// Set a specific time zone so that the regex doesn't have to match
+	// against any possible timezone. Note this mucks around with the global
+	// time zone which prevents running this test in parallel.
+	loc, err := time.LoadLocation("Africa/Cairo")
+	require.NoError(t, err, "failed getting timezone")
+	oldLoc := time.Local
+	time.Local = loc
+	t.Cleanup(func() {
+		time.Local = oldLoc
+	})
+
+	t.Run("text", func(t *testing.T) {
+		// fieldsRegex matches all the key value pairs emitted after the message and before the caller. All fields are
+		// in the following format key:value key2:value2 key3:value3.
+		fieldsRegex := regexp.MustCompile(`(\w+):((?:"[^"]*"|\[[^]]*]|\S+))\s*`)
+		// outputRegex groups the entire log output into 4 distinct matches. The regular expression is tailored toward
+		// the output emitted by the test and is not a general purpose match for all output emitted by the loggers.
+		// 1) the timestamp, component and level
+		// 2) the message
+		// 3) the fields
+		// 4) the caller
+		outputRegex := regexp.MustCompile("(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2})(\\s+.*)(\".*diag_addr`\\.\")(.*)(\\slog/formatter_test.go:\\d{3})")
+
+		tests := []struct {
+			name        string
+			logrusLevel logrus.Level
+			slogLevel   slog.Level
+		}{
+			{
+				name:        "trace",
+				logrusLevel: logrus.TraceLevel,
+				slogLevel:   TraceLevel,
+			},
+			{
+				name:        "debug",
+				logrusLevel: logrus.DebugLevel,
+				slogLevel:   slog.LevelDebug,
+			},
+			{
+				name:        "info",
+				logrusLevel: logrus.InfoLevel,
+				slogLevel:   slog.LevelInfo,
+			},
+			{
+				name:        "warn",
+				logrusLevel: logrus.WarnLevel,
+				slogLevel:   slog.LevelWarn,
+			},
+			{
+				name:        "error",
+				logrusLevel: logrus.ErrorLevel,
+				slogLevel:   slog.LevelError,
+			},
+			{
+				name:        "fatal",
+				logrusLevel: logrus.FatalLevel,
+				slogLevel:   slog.LevelError + 1,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				// Create a logrus logger using the custom formatter which outputs to a local buffer.
+				var logrusOutput bytes.Buffer
+				formatter := NewDefaultTextFormatter(true)
+				formatter.timestampEnabled = true
+				require.NoError(t, formatter.CheckAndSetDefaults())
+
+				logrusLogger := logrus.New()
+				logrusLogger.SetFormatter(formatter)
+				logrusLogger.SetOutput(&logrusOutput)
+				logrusLogger.ReplaceHooks(logrus.LevelHooks{})
+				logrusLogger.SetLevel(test.logrusLevel)
+				entry := logrusLogger.WithField(trace.Component, "test")
+
+				// Create a slog logger using the custom handler which outputs to a local buffer.
+				var slogOutput bytes.Buffer
+				slogConfig := &SlogTextHandlerConfig{
+					Level:        test.slogLevel,
+					EnableColors: true,
+					WithCaller:   true,
+				}
+				slogLogger := slog.New(NewSlogTextHandler(&slogOutput, slogConfig)).With(trace.Component, "test")
+
+				// Add some fields and output the message at the desired log level via logrus.
+				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
+				l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Log(test.logrusLevel, message)
+
+				// Add some fields and output the message at the desired log level via slog.
+				l2 := slogLogger.With("test", 123).With("animal", "llama\n").With("error", logErr)
+				l2.With(trace.ComponentFields, fields).Log(context.Background(), test.slogLevel, message, "diag_addr", &addr)
+
+				// Validate that both loggers produces the same output. The added complexity comes from the fact that
+				// our custom slog handler does NOT sort the additional fields like our logrus formatter does.
+				logrusMatches := outputRegex.FindStringSubmatch(logrusOutput.String())
+				require.NotEmpty(t, logrusMatches, "logrus output was in unexpected format: %s", logrusOutput.String())
+				slogMatches := outputRegex.FindStringSubmatch(slogOutput.String())
+				require.NotEmpty(t, slogMatches, "slog output was in unexpected format: %s", slogOutput.String())
+
+				// The first match is the timestamp: 2023-10-31T10:09:06+02:00
+				logrusTime, err := time.Parse(time.RFC3339, logrusMatches[1])
+				assert.NoError(t, err, "invalid logrus timestamp found %s", logrusMatches[1])
+
+				slogTime, err := time.Parse(time.RFC3339, slogMatches[1])
+				assert.NoError(t, err, "invalid slog timestamp found %s", slogMatches[1])
+
+				assert.InDelta(t, logrusTime.UnixNano(), slogTime.UnixNano(), 10)
+
+				// Match level, and component: DEBU [TEST]
+				assert.Empty(t, cmp.Diff(logrusMatches[2], slogMatches[2]), "level, and component to be identical")
+				// Match the log message: "Adding diagnostic debugging handlers.\t To connect with profiler, use `go tool pprof diag_addr`.\n"
+				assert.Empty(t, cmp.Diff(logrusMatches[3], slogMatches[3]), "expected output messages to be identical")
+				// The last matches are the caller information
+				assert.Equal(t, " log/formatter_test.go:151", logrusMatches[5])
+				assert.Equal(t, " log/formatter_test.go:155", slogMatches[5])
+
+				// The third matches are the fields which will be key value pairs(animal:llama) separated by a space. Since
+				// logrus sorts the fields and slog doesn't we can't just assert equality and instead build a map of the key
+				// value pairs to ensure they are all present and accounted for.
+				logrusFieldMatches := fieldsRegex.FindAllStringSubmatch(logrusMatches[4], -1)
+				slogFieldMatches := fieldsRegex.FindAllStringSubmatch(slogMatches[4], -1)
+
+				// The first match is the key, the second match is the value
+				logrusFields := map[string]string{}
+				for _, match := range logrusFieldMatches {
+					logrusFields[strings.TrimSpace(match[1])] = strings.TrimSpace(match[2])
+				}
+
+				slogFields := map[string]string{}
+				for _, match := range slogFieldMatches {
+					slogFields[strings.TrimSpace(match[1])] = strings.TrimSpace(match[2])
+				}
+
+				assert.Equal(t, slogFields, logrusFields)
+			})
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			logrusLevel logrus.Level
+			slogLevel   slog.Level
+		}{
+			{
+				name:        "trace",
+				logrusLevel: logrus.TraceLevel,
+				slogLevel:   TraceLevel,
+			},
+			{
+				name:        "debug",
+				logrusLevel: logrus.DebugLevel,
+				slogLevel:   slog.LevelDebug,
+			},
+			{
+				name:        "info",
+				logrusLevel: logrus.InfoLevel,
+				slogLevel:   slog.LevelInfo,
+			},
+			{
+				name:        "warn",
+				logrusLevel: logrus.WarnLevel,
+				slogLevel:   slog.LevelWarn,
+			},
+			{
+				name:        "error",
+				logrusLevel: logrus.ErrorLevel,
+				slogLevel:   slog.LevelError,
+			},
+			{
+				name:        "fatal",
+				logrusLevel: logrus.FatalLevel,
+				slogLevel:   slog.LevelError + 1,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				// Create a logrus logger using the custom formatter which outputs to a local buffer.
+				var logrusOut bytes.Buffer
+				formatter := &JSONFormatter{
+					ExtraFields:   nil,
+					callerEnabled: true,
+				}
+				require.NoError(t, formatter.CheckAndSetDefaults())
+
+				logrusLogger := logrus.New()
+				logrusLogger.SetFormatter(formatter)
+				logrusLogger.SetOutput(&logrusOut)
+				logrusLogger.ReplaceHooks(logrus.LevelHooks{})
+				logrusLogger.SetLevel(test.logrusLevel)
+				entry := logrusLogger.WithField(trace.Component, "test")
+
+				// Create a slog logger using the custom formatter which outputs to a local buffer.
+				var slogOutput bytes.Buffer
+				slogLogger := slog.New(NewSlogJSONHandler(&slogOutput, test.slogLevel)).With(trace.Component, "test")
+
+				// Add some fields and output the message at the desired log level via logrus.
+				l := entry.WithField("test", 123).WithField("animal", "llama").WithField("error", logErr)
+				l.WithField("diag_addr", &addr).Log(test.logrusLevel, message)
+
+				// Add some fields and output the message at the desired log level via slog.
+				l2 := slogLogger.With("test", 123).With("animal", "llama").With("error", logErr)
+				l2.Log(context.Background(), test.slogLevel, message, "diag_addr", &addr)
+
+				// The order of the fields emitted by the two loggers is different, so comparing the output directly
+				// for equality won't work. Instead, a map is built with all the key value pairs, excluding the caller
+				// and that map is compared to ensure all items are present and match.
+				var logrusData map[string]any
+				require.NoError(t, json.Unmarshal(logrusOut.Bytes(), &logrusData), "invalid logrus output format")
+
+				var slogData map[string]any
+				require.NoError(t, json.Unmarshal(slogOutput.Bytes(), &slogData), "invalid slog output format")
+
+				logrusCaller, ok := logrusData["caller"].(string)
+				delete(logrusData, "caller")
+				assert.True(t, ok, "caller was missing from logrus output")
+				assert.Equal(t, "log/formatter_test.go:264", logrusCaller)
+
+				slogCaller, ok := slogData["caller"].(string)
+				delete(slogData, "caller")
+				assert.True(t, ok, "caller was missing from slog output")
+				assert.Equal(t, "log/formatter_test.go:268", slogCaller)
+
+				require.Empty(t,
+					cmp.Diff(
+						logrusData,
+						slogData,
+						cmpopts.SortMaps(func(a, b string) bool { return a < b }),
+					),
+				)
+			})
+		}
+	})
+}
+
+func BenchmarkFormatter(b *testing.B) {
+	b.ReportAllocs()
+	b.Run("logrus", func(b *testing.B) {
+		b.Run("text", func(b *testing.B) {
+			formatter := NewDefaultTextFormatter(true)
+			require.NoError(b, formatter.CheckAndSetDefaults())
+			logger := logrus.New()
+			logger.SetFormatter(formatter)
+			logger.SetOutput(io.Discard)
+			logger.ReplaceHooks(logrus.LevelHooks{})
+			b.ResetTimer()
+
+			entry := logger.WithField(trace.Component, "test")
+			for i := 0; i < b.N; i++ {
+				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
+				l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Info(message)
+			}
+		})
+
+		b.Run("json", func(b *testing.B) {
+			formatter := &JSONFormatter{}
+			require.NoError(b, formatter.CheckAndSetDefaults())
+			logger := logrus.New()
+			logger.SetFormatter(formatter)
+			logger.SetOutput(io.Discard)
+			logger.ReplaceHooks(logrus.LevelHooks{})
+			b.ResetTimer()
+
+			entry := logger.WithField(trace.Component, "test")
+			for i := 0; i < b.N; i++ {
+				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
+				l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Info(message)
+			}
+		})
+	})
+
+	b.Run("slog", func(b *testing.B) {
+		b.Run("default_text", func(b *testing.B) {
+			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+				AddSource:   true,
+				Level:       slog.LevelDebug,
+				ReplaceAttr: nil,
+			})).With(trace.Component, "test")
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
+				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+			}
+		})
+
+		b.Run("text", func(b *testing.B) {
+			logger := slog.New(NewSlogTextHandler(io.Discard, &SlogTextHandlerConfig{Level: slog.LevelDebug, EnableColors: true})).With(trace.Component, "test")
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
+				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+			}
+		})
+
+		b.Run("default_json", func(b *testing.B) {
+			logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{
+				AddSource:   true,
+				Level:       slog.LevelDebug,
+				ReplaceAttr: nil,
+			})).With(trace.Component, "test")
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
+				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+			}
+		})
+
+		b.Run("json", func(b *testing.B) {
+			logger := slog.New(NewSlogJSONHandler(io.Discard, slog.LevelDebug)).With(trace.Component, "test")
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
+				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+			}
+		})
+	})
+}

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -1,0 +1,450 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// TraceLevel is the logging level when set to Trace verbosity.
+const TraceLevel = slog.LevelDebug - 1
+
+// SlogTextHandler is a [slog.Handler] that outputs messages in a textual
+// manner as configured by the Teleport configuration.
+type SlogTextHandler struct {
+	cfg       SlogTextHandlerConfig
+	component string
+	// preformatted data from previous calls to WithGroup and WithAttrs.
+	preformatted []byte
+	// groupPrefix is for the text handler only.
+	// It holds the prefix for groups that were already pre-formatted.
+	// A group will appear here when a call to WithGroup is followed by
+	// a call to WithAttrs.
+	groupPrefix buffer
+	// groups passed in via WithGroup and WithAttrs.
+	groups []string
+	// nOpenGroups the number of groups opened in preformatted.
+	nOpenGroups int
+
+	// mu protects out - it needs to be a pointer so that all cloned
+	// SlogTextHandler returned from WithAttrs and WithGroup share the
+	// same mutex. Otherwise, output may be garbled since each clone
+	// will use its own copy of the mutex to protect out. See
+	// https://github.com/golang/go/issues/61321 for more details.
+	mu  *sync.Mutex
+	out io.Writer
+}
+
+// SlogTextHandlerConfig allow the SlogTextHandler functionality
+// to be tweaked.
+type SlogTextHandlerConfig struct {
+	// Level is the minimum record level that will be logged.
+	Level slog.Leveler
+	// EnableColors allows the level to be printed in color.
+	EnableColors bool
+	// Padding to use for various components.
+	Padding int
+	// WithCaller indicates whether the source of the log should be
+	// included in output.
+	WithCaller bool
+	// ReplaceAttr is called to rewrite each non-group attribute before
+	// it is logged.
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+}
+
+// NewSlogTextHandler creates a SlogTextHandler that writes messages to w.
+func NewSlogTextHandler(w io.Writer, cfg *SlogTextHandlerConfig) *SlogTextHandler {
+	if cfg == nil {
+		cfg = &SlogTextHandlerConfig{}
+	}
+
+	if cfg.Padding == 0 {
+		cfg.Padding = trace.DefaultComponentPadding
+	}
+
+	return &SlogTextHandler{
+		cfg: *cfg,
+		out: w,
+		mu:  &sync.Mutex{},
+	}
+}
+
+// Enabled returns whether the provided level will be included in output.
+func (s *SlogTextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	minLevel := slog.LevelInfo
+	if s.cfg.Level != nil {
+		minLevel = s.cfg.Level.Level()
+	}
+	return level >= minLevel
+}
+
+func (s *SlogTextHandler) appendAttr(buf []byte, a slog.Attr) []byte {
+	if rep := s.cfg.ReplaceAttr; rep != nil && a.Value.Kind() != slog.KindGroup {
+		var gs []string
+		if s.groups != nil {
+			gs = s.groups
+		}
+		// Resolve before calling ReplaceAttr, so the user doesn't have to.
+		a.Value = a.Value.Resolve()
+		a = rep(gs, a)
+	}
+
+	// Resolve the Attr's value before doing anything else.
+	a.Value = a.Value.Resolve()
+	// Ignore empty Attrs.
+	if a.Equal(slog.Attr{}) {
+		return buf
+	}
+
+	switch a.Value.Kind() {
+	case slog.KindString:
+		value := a.Value.String()
+		if a.Key == slog.TimeKey {
+			buf = fmt.Append(buf, value)
+			break
+		}
+
+		if needsQuoting(value) {
+			if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == "caller" || a.Key == slog.MessageKey {
+				buf = fmt.Append(buf, " ")
+			} else {
+				buf = fmt.Appendf(buf, " %s%s:", s.groupPrefix, a.Key)
+			}
+			buf = strconv.AppendQuote(buf, value)
+			break
+		}
+
+		if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == "caller" || a.Key == slog.MessageKey {
+			buf = fmt.Appendf(buf, " %s", a.Value.String())
+			break
+		}
+
+		buf = fmt.Appendf(buf, " %s%s:%s", s.groupPrefix, a.Key, a.Value.String())
+	case slog.KindGroup:
+		attrs := a.Value.Group()
+		// Ignore empty groups.
+		if len(attrs) == 0 {
+			return buf
+		}
+		// If the key is non-empty, write it out and indent the rest of the attrs.
+		// Otherwise, inline the attrs.
+		if a.Key != "" {
+			s.groupPrefix = fmt.Append(s.groupPrefix, a.Key)
+			s.groupPrefix = fmt.Append(s.groupPrefix, ".")
+		}
+		for _, ga := range attrs {
+			buf = s.appendAttr(buf, ga)
+		}
+		if a.Key != "" {
+			s.groupPrefix = s.groupPrefix[:len(s.groupPrefix)-len(a.Key)-1 /* for keyComponentSep */]
+			if s.groups != nil {
+				s.groups = (s.groups)[:len(s.groups)-1]
+			}
+		}
+	default:
+		switch err := a.Value.Any().(type) {
+		case trace.Error:
+			buf = fmt.Appendf(buf, " error:[%v]", err.DebugReport())
+		case error:
+			buf = fmt.Appendf(buf, " error:[%v]", a.Value)
+		default:
+			buf = fmt.Appendf(buf, " %s:%s", a.Key, a.Value)
+		}
+	}
+	return buf
+}
+
+// writeTimeRFC3339 writes the time in [time.RFC3339Nano] to the buffer.
+// This takes half the time of [time.Time.AppendFormat]. Adapted from
+// go/src/log/slog/handler.go.
+func writeTimeRFC3339(buf *buffer, t time.Time) {
+	year, month, day := t.Date()
+	buf.WritePosIntWidth(year, 4)
+	buf.WriteByte('-')
+	buf.WritePosIntWidth(int(month), 2)
+	buf.WriteByte('-')
+	buf.WritePosIntWidth(day, 2)
+	buf.WriteByte('T')
+	hour, min, sec := t.Clock()
+	buf.WritePosIntWidth(hour, 2)
+	buf.WriteByte(':')
+	buf.WritePosIntWidth(min, 2)
+	buf.WriteByte(':')
+	buf.WritePosIntWidth(sec, 2)
+	_, offsetSeconds := t.Zone()
+	if offsetSeconds == 0 {
+		buf.WriteByte('Z')
+	} else {
+		offsetMinutes := offsetSeconds / 60
+		if offsetMinutes < 0 {
+			buf.WriteByte('-')
+			offsetMinutes = -offsetMinutes
+		} else {
+			buf.WriteByte('+')
+		}
+		buf.WritePosIntWidth(offsetMinutes/60, 2)
+		buf.WriteByte(':')
+		buf.WritePosIntWidth(offsetMinutes%60, 2)
+	}
+}
+
+// Handle formats the provided record and writes the output to the
+// destination.
+func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
+	buf := newBuffer()
+	defer buf.Free()
+
+	if !r.Time.IsZero() {
+		if s.cfg.ReplaceAttr != nil {
+			*buf = s.appendAttr(*buf, slog.Time(slog.TimeKey, r.Time))
+		} else {
+			writeTimeRFC3339(buf, r.Time)
+		}
+	}
+
+	var color int
+	var level string
+	switch r.Level {
+	case TraceLevel:
+		level = "TRACE"
+		color = gray
+	case slog.LevelDebug:
+		level = "DEBUG"
+		color = gray
+	case slog.LevelInfo:
+		level = "INFO"
+		color = blue
+	case slog.LevelWarn:
+		level = "WARN"
+		color = yellow
+	case slog.LevelError:
+		level = "ERROR"
+		color = red
+	case slog.LevelError + 1:
+		level = "FATAL"
+		color = red
+	default:
+		color = blue
+		level = r.Level.String()
+	}
+
+	if !s.cfg.EnableColors {
+		color = noColor
+	}
+
+	level = padMax(level, trace.DefaultLevelPadding)
+	if color == noColor {
+		*buf = s.appendAttr(*buf, slog.String(slog.LevelKey, level))
+	} else {
+		*buf = fmt.Appendf(*buf, " \u001B[%dm%s\u001B[0m", color, level)
+	}
+
+	*buf = s.appendAttr(*buf, slog.String(trace.Component, s.component))
+
+	*buf = s.appendAttr(*buf, slog.String(slog.MessageKey, r.Message))
+
+	// Insert preformatted attributes just after built-in ones.
+	*buf = append(*buf, s.preformatted...)
+	if r.NumAttrs() > 0 {
+		if len(s.groups) > 0 {
+			for _, n := range s.groups[s.nOpenGroups:] {
+				s.groupPrefix = fmt.Append(s.groupPrefix, n)
+				s.groupPrefix = fmt.Append(s.groupPrefix, ".")
+			}
+		}
+
+		r.Attrs(func(a slog.Attr) bool {
+			*buf = s.appendAttr(*buf, a)
+			return true
+		})
+	}
+
+	if r.PC != 0 && s.cfg.WithCaller {
+		fs := runtime.CallersFrames([]uintptr{r.PC})
+		f, _ := fs.Next()
+
+		src := &slog.Source{
+			Function: f.Function,
+			File:     f.File,
+			Line:     f.Line,
+		}
+
+		file, line := getCaller(slog.Attr{Key: slog.SourceKey, Value: slog.AnyValue(src)})
+		*buf = fmt.Appendf(*buf, " %s:%d", file, line)
+	}
+
+	buf.WriteByte('\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.out.Write(*buf)
+	return err
+}
+
+// WithAttrs clones the current handler with the provided attributes
+// added to any existing attributes. The values are preformatted here
+// so that they do not need to be formatted per call to Handle.
+func (s *SlogTextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return s
+	}
+	s2 := *s
+	// Force an append to copy the underlying arrays.
+	s2.preformatted = slices.Clip(s.preformatted)
+	s2.groups = slices.Clip(s.groups)
+
+	// Add all groups from WithGroup that haven't already been added to the prefix.
+	if len(s.groups) > 0 {
+		for _, n := range s.groups[s.nOpenGroups:] {
+			s2.groupPrefix = fmt.Append(s2.groupPrefix, n)
+			s2.groupPrefix = fmt.Append(s2.groupPrefix, ".")
+		}
+	}
+
+	// Now all groups have been opened.
+	s2.nOpenGroups = len(s2.groups)
+
+	component := s.component
+
+	// Pre-format the attributes.
+	for _, a := range attrs {
+		switch a.Key {
+		case trace.Component:
+			component = fmt.Sprintf("[%v]", a.Value.String())
+			component = strings.ToUpper(padMax(component, s.cfg.Padding))
+			if component[len(component)-1] != ' ' {
+				component = component[:len(component)-1] + "]"
+			}
+		case trace.ComponentFields:
+			switch fields := a.Value.Any().(type) {
+			case map[string]any:
+				for k, v := range fields {
+					s2.appendAttr(s2.preformatted, slog.Any(k, v))
+				}
+			case logrus.Fields:
+				for k, v := range fields {
+					s2.preformatted = s2.appendAttr(s2.preformatted, slog.Any(k, v))
+				}
+			}
+		default:
+			s2.preformatted = s2.appendAttr(s2.preformatted, a)
+		}
+	}
+
+	s2.component = component
+	// Remember how many opened groups are in preformattedAttrs,
+	// so we don't open them again when we handle a Record.
+	s2.nOpenGroups = len(s2.groups)
+	return &s2
+}
+
+// WithGroup opens a new group.
+func (s *SlogTextHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return s
+	}
+
+	s2 := *s
+	s2.groups = append(s2.groups, name)
+	return &s2
+}
+
+// SlogJSONHandler is a [slog.Handler] that outputs messages in a json
+// format per the config file.
+type SlogJSONHandler struct {
+	*slog.JSONHandler
+}
+
+// NewSlogJSONHandler creates a SlogJSONHandler that outputs to w.
+func NewSlogJSONHandler(w io.Writer, level slog.Leveler) *SlogJSONHandler {
+	return &SlogJSONHandler{
+		JSONHandler: slog.NewJSONHandler(w, &slog.HandlerOptions{
+			AddSource: true,
+			Level:     level,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				switch a.Key {
+				case trace.Component:
+					a.Key = "component"
+				case slog.LevelKey:
+					var level string
+					switch lvl := a.Value.Any().(slog.Level); lvl {
+					case TraceLevel:
+						level = "trace"
+					case slog.LevelDebug:
+						level = "debug"
+					case slog.LevelInfo:
+						level = "info"
+					case slog.LevelWarn:
+						level = "warning"
+					case slog.LevelError:
+						level = "error"
+					case slog.LevelError + 1:
+						level = "fatal"
+					default:
+						level = strings.ToLower(lvl.String())
+					}
+
+					a.Value = slog.StringValue(level)
+				case slog.TimeKey:
+					t := a.Value.Time()
+					if t.IsZero() {
+						return a
+					}
+
+					a.Key = "timestamp"
+					a.Value = slog.StringValue(t.Format(time.RFC3339))
+				case slog.MessageKey:
+					a.Key = "message"
+				case slog.SourceKey:
+					file, line := getCaller(a)
+					a = slog.String("caller", fmt.Sprintf("%s:%d", file, line))
+				}
+
+				return a
+			},
+		}),
+	}
+}
+
+// getCaller retrieves source information from the attribute
+// and returns the file and line of the caller. The file is
+// truncated from the absolute path to package/filename.
+func getCaller(a slog.Attr) (file string, line int) {
+	s := a.Value.Any().(*slog.Source)
+	count := 0
+	idx := strings.LastIndexFunc(s.File, func(r rune) bool {
+		if r == '/' {
+			count++
+		}
+
+		return count == 2
+	})
+	file = s.File[idx+1:]
+	line = s.Line
+
+	return file, line
+}

--- a/lib/utils/log/slog_handler_test.go
+++ b/lib/utils/log/slog_handler_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/slogtest"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlogTextHandler validates that the SlogTextHandler fulfills
+// the [slog.Handler] contract by exercising the handler with
+// various scenarios from [slogtest.TestHandler].
+func TestSlogTextHandler(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	now := clock.Now().UTC().Format(time.RFC3339)
+
+	// Create a handler that doesn't report the caller and automatically sets
+	// the time to whatever time the fake clock has in UTC time. Since the timestamp
+	// is not important for this test overriding, it allows the regex to be simpler.
+	var buf bytes.Buffer
+	h := NewSlogTextHandler(&buf, &SlogTextHandlerConfig{
+		WithCaller: false,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				a.Value = slog.StringValue(now)
+			}
+			return a
+		},
+	})
+
+	// The regular expression matches a line of text output by the handler and captures several
+	// groups to make interrogating the output simpler.
+	// Group 1: timestamp which should match the replaced time with our fake clock
+	// Group 2: verbosity level of output
+	// Group 3: message contents
+	// Group 4: additional attributes
+	regex := fmt.Sprintf("^(?:(%s)?)\\s([A-Z]{4})\\s+(\\w+)(?:\\s(.*))?$", now)
+	lineRegex := regexp.MustCompile(regex)
+
+	results := func() []map[string]any {
+		var ms []map[string]any
+		for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+			if len(line) == 0 {
+				continue
+			}
+
+			var m map[string]any
+			matches := lineRegex.FindSubmatch(line)
+			if len(matches) == 0 {
+				assert.Failf(t, "log output did not match regular expression", "regex: %s output: %s", regex, string(line))
+				continue
+			}
+
+			// Indexes mapped to the expected capture groups from the regular expression.
+			const (
+				timeMatch    = 1
+				levelMatch   = 2
+				messageMatch = 3
+				fieldsMatch  = 4
+			)
+
+			// Entries that should always be in the output.
+			m = map[string]any{
+				slog.LevelKey:   matches[levelMatch],
+				slog.MessageKey: string(matches[messageMatch]),
+			}
+
+			// The timestamp may be omitted if the record doesn't include a time.
+			if len(matches[timeMatch]) > 0 {
+				m[slog.TimeKey] = matches[timeMatch]
+			}
+
+			// Parse optional additional fields. Fields within a group will be in the form
+			// Group1.Group2.Group3.key:value. This converts keys into sub-maps for groups.
+			// The example group above would result in a map of Group1 -> Group2 -> Group3 -> key -> value
+			// instead of a flat map that had keys Group1, Group2, Group3, and key.
+			if len(matches[fieldsMatch]) > 0 {
+				s := string(bytes.TrimSpace(matches[fieldsMatch]))
+				for len(s) > 0 {
+					field, rest, _ := strings.Cut(s, " ")
+
+					k, value, found := strings.Cut(field, ":")
+					assert.True(t, found, "no ':' in %s", field)
+
+					keys := strings.Split(k, ".")
+					mm := m
+					for _, key := range keys[:len(keys)-1] {
+						x, ok := mm[key]
+						var m2 map[string]any
+						if !ok {
+							m2 = map[string]any{}
+							mm[key] = m2
+						} else {
+							m2, ok = x.(map[string]any)
+							if !ok {
+								t.Fatalf("value in composite key %q is not map[string]any", key)
+							}
+						}
+						mm = m2
+					}
+					mm[keys[len(keys)-1]] = value
+					s = rest
+				}
+			}
+
+			ms = append(ms, m)
+		}
+
+		return ms
+	}
+
+	require.NoError(t, slogtest.TestHandler(h, results))
+
+}
+
+// TestSlogJSONHandler validates that the SlogJSONHandler fulfills
+// the [slog.Handler] contract by exercising the handler with
+// various scenarios from [slogtest.TestHandler].
+func TestSlogJSONHandler(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	h := NewSlogJSONHandler(&buf, slog.LevelDebug)
+
+	results := func() []map[string]any {
+		var ms []map[string]any
+		for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+			if len(line) == 0 {
+				continue
+			}
+			var m map[string]any
+			assert.NoError(t, json.Unmarshal(line, &m), "unexpected non-json output: %s", line)
+
+			// The conformance test expects [slog.TimeKey] to be present, but
+			// because we convert that to "timestamp" to match the legacy output format,
+			// we need to convert it back to [slog.TimeKey] to satisfy the test.
+			if t, ok := m["timestamp"]; ok {
+				m[slog.TimeKey] = t
+				delete(m, "timestamp")
+			}
+
+			// The conformance test expects [slog.MessageKey] to be present, but
+			// because we convert that to "message" to match the legacy output format,
+			// we need to convert it back to [slog.MessageKey] to satisfy the test.
+			if msg, ok := m["message"]; ok {
+				m[slog.MessageKey] = msg
+				delete(m, "message")
+			}
+
+			ms = append(ms, m)
+		}
+		return ms
+	}
+	require.NoError(t, slogtest.TestHandler(h, results))
+}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -384,7 +385,7 @@ func setupLogger(debug bool, format string) error {
 
 	switch format {
 	case config.LogFormatJSON:
-		formatter := &utils.JSONFormatter{}
+		formatter := &logutils.JSONFormatter{}
 		logrus.SetFormatter(formatter)
 	case config.LogFormatText, "":
 	// Nothing to do, this is the default set up by utils.InitLogger

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // SSOConfigureCommand implements common.CLICommand interface
@@ -60,7 +60,7 @@ func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand stri
 			// the default tctl logging behavior is to ignore all logs, unless --debug is present.
 			// we want different behavior: log messages as normal, but with compact format (no time, no caller info).
 			if !cmd.Config.Debug {
-				formatter := utils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr))
+				formatter := logutils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr))
 				formatter.FormatCaller = func() (caller string) { return "" }
 				cmd.Logger.Logger.SetFormatter(formatter)
 				cmd.Logger.Logger.SetOutput(os.Stderr)


### PR DESCRIPTION
Implements two new `slog.Handlers` that attempt to output text in the same format as existing `logrus.TextFormatter` implementations. The most notable differences are that the order of fields in the json output does NOT match the logrus order and the additional items in text output are NOT sorted alphabetically like they are in logrus.

Tests added validate the output is equivalent when using slog or logrus taking into account the differences noted above . A benchmark test is also included to demonstrate the improvements slog offers over logrus. Some of the improvements made for the slog handlers were also able to be applied to the logrus formatters as well.