### PR TITLE
[docs] troubleshooting for AWS Access SSM sessions

### DIFF
--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -373,6 +373,31 @@ To log out of the AWS application and remove credentials:
 $ tsh apps logout awsconsole-test
 ```
 
+## Troubleshooting
+### `remote error: tls: bad certificate` error during SSM sessions
+
+You may encounter the `remote error: tls: bad certificate` error when starting
+System Session Manager (SSM) sessions using `tsh aws ssm start-session` or `tsh
+aws ecs execute-command` commands.
+
+The issue is that `tsh` cannot properly proxy WebSocket connections sent by
+SSM.
+
+Please upgrade to the latest version of `tsh` where workarounds have been
+implemented for [`tsh aws ssm
+start-session`](https://github.com/gravitational/teleport/pull/30510) and [`tsh
+aws ecs
+execute-command`](https://github.com/gravitational/teleport/pull/33705).
+
+If you are using `tsh proxy aws` or if your `tsh` version does not contain the
+above fixes, add the following domain to the `NO_PROXY` environment variable
+before running `tsh` commands to ensure the WebSocket connections bypass `tsh`:
+```bash
+export NO_PROXY=ssmmessages.us-west-1.amazonaws.com
+```
+
+Replace `us-west-1` with the AWS region you are accessing.
+
 ## Next steps
 
 - Take a closer look at [role-based access controls](../controls.mdx).

--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -377,17 +377,19 @@ $ tsh apps logout awsconsole-test
 ### `remote error: tls: bad certificate` error during SSM sessions
 
 You may encounter the `remote error: tls: bad certificate` error when starting
-System Session Manager (SSM) sessions using `tsh aws ssm start-session` or `tsh
-aws ecs execute-command` commands.
+System Session Manager (SSM) sessions using the `tsh aws ssm start-session` or
+`tsh aws ecs execute-command` commands.
 
 The issue is that `tsh` cannot properly proxy WebSocket connections sent by
 SSM.
 
 Please upgrade to the latest version of `tsh` where workarounds have been
-implemented for [`tsh aws ssm
-start-session`](https://github.com/gravitational/teleport/pull/30510) and [`tsh
-aws ecs
-execute-command`](https://github.com/gravitational/teleport/pull/33705).
+implemented for `tsh aws ssm start-session` and `tsh aws ecs execute-command`.
+For more information on the `tsh` workarounds, see the pull requests that
+introduced them:
+
+- [https://github.com/gravitational/teleport/pull/30510](https://github.com/gravitational/teleport/pull/30510)
+- [https://github.com/gravitational/teleport/pull/33705](https://github.com/gravitational/teleport/pull/33705)
 
 If you are using `tsh proxy aws` or if your `tsh` version does not contain the
 above fixes, add the following domain to the `NO_PROXY` environment variable


### PR DESCRIPTION
Related:
- https://github.com/gravitational/teleport/pull/30510
- https://github.com/gravitational/teleport/pull/33705

Add this troubleshooting section as this problem appears in both Zendesk and github issues.

Note that the above changes only fix `tsh aws xxx`. For `tsh proxy aws`, user still needs the workaround using `NO_PROXY`. 

Not sure if it's a good idea link github issues though.