### PR TITLE
[v14] Access Plugins: Support dynamic credential reloading

### DIFF
--- a/integrations/access/common/app.go
+++ b/integrations/access/common/app.go
@@ -36,8 +36,6 @@ import (
 const (
 	// minServerVersion is the minimal teleport version the plugin supports.
 	minServerVersion = "6.1.0-beta.1"
-	// grpcBackoffMaxDelay is a maximum time gRPC client waits before reconnection attempt.
-	grpcBackoffMaxDelay = time.Second * 2
 	// InitTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.

--- a/integrations/access/discord/config.go
+++ b/integrations/access/discord/config.go
@@ -82,7 +82,7 @@ func (c *Config) GetTeleportClient(ctx context.Context) (teleport.Client, error)
 	if c.Client != nil {
 		return c.Client, nil
 	}
-	return c.BaseConfig.GetTeleportClient(ctx)
+	return c.BaseConfig.Teleport.NewClient(ctx)
 }
 
 // NewBot initializes the new Discord message generator (DiscordBot)

--- a/integrations/access/jira/app.go
+++ b/integrations/access/jira/app.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -33,8 +36,6 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 const (

--- a/integrations/access/jira/app.go
+++ b/integrations/access/jira/app.go
@@ -42,8 +42,6 @@ const (
 	minServerVersion = "6.1.0"
 	// pluginName is used to tag PluginData and as a Delegator in Audit log.
 	pluginName = "jira"
-	// grpcBackoffMaxDelay is a maximum time gRPC client waits before reconnection attempt.
-	grpcBackoffMaxDelay = time.Second * 2
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -40,8 +40,6 @@ const (
 	pluginName = "opsgenie"
 	// minServerVersion is the minimal teleport version the plugin supports.
 	minServerVersion = "6.1.0"
-	// grpcBackoffMaxDelay is a maximum time gRPC client waits before reconnection attempt.
-	grpcBackoffMaxDelay = time.Second * 2
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
 	tp "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -31,8 +34,6 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 const (

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -68,13 +68,8 @@ type App struct {
 
 // NewOpsgenieApp initializes a new teleport-opsgenie app and returns it.
 func NewOpsgenieApp(ctx context.Context, conf *Config) (*App, error) {
-	teleportClient, err := conf.Teleport.NewClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	opsgenieApp := &App{
 		PluginName: pluginName,
-		teleport:   teleportClient,
 		conf:       *conf,
 	}
 	opsgenieApp.mainJob = lib.NewServiceJob(opsgenieApp.run)

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common"
@@ -31,8 +34,6 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 const (

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -40,8 +40,6 @@ const (
 	minServerVersion = "6.1.0"
 	// pluginName is used to tag PluginData and as a Delegator in Audit log.
 	pluginName = "pagerduty"
-	// grpcBackoffMaxDelay is a maximum time gRPC client waits before reconnection attempt.
-	grpcBackoffMaxDelay = time.Second * 2
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -23,21 +23,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"google.golang.org/grpc"
-	grpcbackoff "google.golang.org/grpc/backoff"
-
-	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/teleport/integrations/lib/credentials"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 const (
@@ -147,32 +142,13 @@ func (a *App) init(ctx context.Context) error {
 	defer cancel()
 	log := logger.Get(ctx)
 
-	if validCred, err := credentials.CheckIfExpired(a.conf.Teleport.Credentials()); err != nil {
-		log.Warn(err)
-		if !validCred {
-			return trace.BadParameter(
-				"No valid credentials found, this likely means credentials are expired. In this case, please sign new credentials and increase their TTL if needed.",
-			)
-		}
-		log.Info("At least one non-expired credential has been found, continuing startup")
-	}
-
 	var (
 		err  error
 		pong proto.PingResponse
 	)
 
 	if a.teleport == nil {
-		bk := grpcbackoff.DefaultConfig
-		bk.MaxDelay = grpcBackoffMaxDelay
-		if a.teleport, err = client.New(ctx, client.Config{
-			Addrs:       a.conf.Teleport.GetAddrs(),
-			Credentials: a.conf.Teleport.Credentials(),
-			DialOpts: []grpc.DialOption{
-				grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
-				grpc.WithReturnConnectionError(),
-			},
-		}); err != nil {
+		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -42,8 +42,6 @@ const (
 	pluginName = "servicenow"
 	// minServerVersion is the minimal teleport version the plugin supports.
 	minServerVersion = "13.0.0"
-	// grpcBackoffMaxDelay is a maximum time GRPC client waits before reconnection attempt.
-	grpcBackoffMaxDelay = time.Second * 2
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -24,22 +24,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"golang.org/x/exp/slices"
-	"google.golang.org/grpc"
-	grpcbackoff "google.golang.org/grpc/backoff"
-
 	tp "github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/teleport/integrations/lib/credentials"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -75,13 +70,8 @@ type App struct {
 
 // NewServicenowApp initializes a new teleport-servicenow app and returns it.
 func NewServiceNowApp(ctx context.Context, conf *Config) (*App, error) {
-	teleportClient, err := conf.GetTeleportClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	serviceNowApp := &App{
 		PluginName: pluginName,
-		teleport:   teleportClient,
 		conf:       *conf,
 	}
 	serviceNowApp.mainJob = lib.NewServiceJob(serviceNowApp.run)
@@ -147,31 +137,10 @@ func (a *App) run(ctx context.Context) error {
 func (a *App) init(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
-	log := logger.Get(ctx)
-
-	if validCred, err := credentials.CheckIfExpired(a.conf.Teleport.Credentials()); err != nil {
-		log.Warnf("Invalid Teleport credentials: %v", err)
-		if !validCred {
-			return trace.BadParameter(
-				"No valid credentials found, this likely means credentials are expired. In this case, please sign new credentials and increase their TTL if needed.",
-			)
-		}
-		log.Info("At least one non-expired credential has been found, continuing startup")
-	}
 
 	var err error
-
 	if a.teleport == nil {
-		bk := grpcbackoff.DefaultConfig
-		bk.MaxDelay = grpcBackoffMaxDelay
-		if a.teleport, err = client.New(ctx, client.Config{
-			Addrs:       a.conf.Teleport.GetAddrs(),
-			Credentials: a.conf.Teleport.Credentials(),
-			DialOpts: []grpc.DialOption{
-				grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
-				grpc.WithReturnConnectionError(),
-			},
-		}); err != nil {
+		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/exp/slices"
+
 	tp "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -32,9 +36,6 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -16,9 +16,6 @@ package lib
 
 import (
 	"context"
-	"github.com/gravitational/teleport/integrations/lib/credentials"
-	"google.golang.org/grpc"
-	grpcbackoff "google.golang.org/grpc/backoff"
 	"io"
 	"os"
 	"strings"
@@ -26,8 +23,11 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	grpcbackoff "google.golang.org/grpc/backoff"
 
 	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/integrations/lib/credentials"
 	"github.com/gravitational/teleport/integrations/lib/stringset"
 )
 

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -109,6 +109,11 @@ func (cfg *TeleportConfig) CheckTLSConfig() error {
 	return nil
 }
 
+// NewIdentityFileWatcher returns a credential compatible with the Teleport
+// client. This credential will reload from the identity file at the specified
+// path each time interval time passes. This function blocks until the initial
+// credential has been loaded and then returns, creating a goroutine in the
+// background to manage the reloading that will exit when ctx is cancelled.
 func NewIdentityFileWatcher(ctx context.Context, path string, interval time.Duration) (*client.DynamicIdentityFileCreds, error) {
 	dynamicCred, err := client.NewDynamicIdentityFileCreds(path)
 	if err != nil {

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -113,7 +113,7 @@ func (cfg *TeleportConfig) CheckTLSConfig() error {
 // client. This credential will reload from the identity file at the specified
 // path each time interval time passes. This function blocks until the initial
 // credential has been loaded and then returns, creating a goroutine in the
-// background to manage the reloading that will exit when ctx is cancelled.
+// background to manage the reloading that will exit when ctx is canceled.
 func NewIdentityFileWatcher(ctx context.Context, path string, interval time.Duration) (*client.DynamicIdentityFileCreds, error) {
 	dynamicCred, err := client.NewDynamicIdentityFileCreds(path)
 	if err != nil {

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -15,9 +15,14 @@
 package lib
 
 import (
+	"context"
+	"github.com/gravitational/teleport/integrations/lib/credentials"
+	"google.golang.org/grpc"
+	grpcbackoff "google.golang.org/grpc/backoff"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -26,40 +31,46 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/stringset"
 )
 
+const (
+	// grpcBackoffMaxDelay is a maximum time gRPC client waits before reconnection attempt.
+	grpcBackoffMaxDelay = time.Second * 2
+	// initTimeout is used to bound execution time of health check and teleport version check.
+	initTimeout = time.Second * 10
+)
+
 // TeleportConfig stores config options for where
 // the Teleport's Auth server is listening, and what certificates to
 // use to authenticate in it.
 type TeleportConfig struct {
+	// AuthServer specifies the address that the client should connect to.
+	// Deprecated: replaced by Addr
 	AuthServer string `toml:"auth_server"`
 	Addr       string `toml:"addr"`
-	Identity   string `toml:"identity"`
-	ClientKey  string `toml:"client_key"`
-	ClientCrt  string `toml:"client_crt"`
-	RootCAs    string `toml:"root_cas"`
-}
 
-func (cfg TeleportConfig) GetAddrs() []string {
-	if cfg.Addr != "" {
-		return []string{cfg.Addr}
-	} else if cfg.AuthServer != "" {
-		return []string{cfg.AuthServer}
-	}
-	return nil
+	ClientKey string `toml:"client_key"`
+	ClientCrt string `toml:"client_crt"`
+	RootCAs   string `toml:"root_cas"`
+
+	Identity                string        `toml:"identity"`
+	RefreshIdentity         bool          `toml:"refresh_identity"`
+	RefreshIdentityInterval time.Duration `toml:"refresh_identity_interval"`
 }
 
 func (cfg *TeleportConfig) CheckAndSetDefaults() error {
-	if cfg.Addr == "" && cfg.AuthServer == "" {
-		cfg.Addr = "localhost:3025"
-	} else if cfg.AuthServer != "" {
-		log.Warn("Configuration setting `auth_server` is deprecated, consider to change it to `addr`")
-	}
-
 	if err := cfg.CheckTLSConfig(); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if cfg.Identity != "" && cfg.ClientCrt != "" {
 		return trace.BadParameter("configuration setting `identity` is mutually exclusive with all the `client_crt`, `client_key` and `root_cas` settings")
+	}
+
+	// Default to refreshing identity minutely.
+	if cfg.RefreshIdentityInterval == 0 {
+		cfg.RefreshIdentityInterval = time.Minute
+	}
+	if cfg.RefreshIdentity && cfg.Identity == "" {
+		return trace.BadParameter("`refresh_identity` requires that `identity` be set")
 	}
 
 	return nil
@@ -98,31 +109,69 @@ func (cfg *TeleportConfig) CheckTLSConfig() error {
 	return nil
 }
 
-func (cfg TeleportConfig) Credentials() []client.Credentials {
-	switch true {
-	case cfg.Identity != "":
-		return []client.Credentials{client.LoadIdentityFile(cfg.Identity)}
-	case cfg.ClientCrt != "" && cfg.ClientKey != "" && cfg.RootCAs != "":
-		return []client.Credentials{client.LoadKeyPair(cfg.ClientCrt, cfg.ClientKey, cfg.RootCAs)}
-	default:
-		return nil
+func (cfg TeleportConfig) NewClient(ctx context.Context) (*client.Client, error) {
+	addr := "localhost:3025"
+	switch {
+	case cfg.Addr != "":
+		addr = cfg.Addr
+	case cfg.AuthServer != "":
+		log.Warn("Configuration setting `auth_server` is deprecated, consider to change it to `addr`")
+		addr = cfg.AuthServer
 	}
+
+	var creds []client.Credentials
+	switch {
+	case cfg.Identity != "":
+		creds = []client.Credentials{client.LoadIdentityFile(cfg.Identity)}
+	case cfg.ClientCrt != "" && cfg.ClientKey != "" && cfg.RootCAs != "":
+		creds = []client.Credentials{client.LoadKeyPair(cfg.ClientCrt, cfg.ClientKey, cfg.RootCAs)}
+	default:
+		return nil, trace.BadParameter("no credentials configured")
+	}
+
+	if validCred, err := credentials.CheckIfExpired(creds); err != nil {
+		log.Warn(err)
+		if !validCred {
+			return nil, trace.BadParameter(
+				"No valid credentials found, this likely means credentials are expired. In this case, please sign new credentials and increase their TTL if needed.",
+			)
+		}
+		log.Info("At least one non-expired credential has been found, continuing startup")
+	}
+
+	bk := grpcbackoff.DefaultConfig
+	bk.MaxDelay = grpcBackoffMaxDelay
+	clt, err := client.New(ctx, client.Config{
+		Addrs:       []string{addr},
+		Credentials: creds,
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return clt, nil
 }
 
 // ReadPassword reads password from file or env var, trims and returns
 func ReadPassword(filename string) (string, error) {
 	f, err := os.Open(filename)
-	if os.IsNotExist(err) {
-		return "", trace.BadParameter("Error reading password from %v", filename)
-	}
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", trace.BadParameter("Error reading password from %v", filename)
+		}
 		return "", trace.Wrap(err)
 	}
+
 	pass := make([]byte, 2000)
 	l, err := f.Read(pass)
 	if err != nil && err != io.EOF {
 		return "", err
 	}
+
 	pass = pass[:l] // truncate \0
 	return strings.TrimSpace(string(pass)), nil
 }

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -109,7 +109,7 @@ func (cfg *TeleportConfig) CheckTLSConfig() error {
 	return nil
 }
 
-func newIdentityFileWatcher(ctx context.Context, path string, interval time.Duration) (*client.DynamicIdentityFileCreds, error) {
+func NewIdentityFileWatcher(ctx context.Context, path string, interval time.Duration) (*client.DynamicIdentityFileCreds, error) {
 	dynamicCred, err := client.NewDynamicIdentityFileCreds(path)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating dynamic identity file watcher")
@@ -151,7 +151,7 @@ func (cfg TeleportConfig) NewClient(ctx context.Context) (*client.Client, error)
 	case cfg.Identity != "" && !cfg.RefreshIdentity:
 		creds = []client.Credentials{client.LoadIdentityFile(cfg.Identity)}
 	case cfg.Identity != "" && cfg.RefreshIdentity:
-		cred, err := newIdentityFileWatcher(ctx, cfg.Identity, cfg.RefreshIdentityInterval)
+		cred, err := NewIdentityFileWatcher(ctx, cfg.Identity, cfg.RefreshIdentityInterval)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
This PR:

- Refactors the access plugin's creation of the Teleport client to a single location rather than repeating this for each client. Adding new functionality would've involved me adding this at each of the client creation points and this seemed a bit silly to me.
- Adds a new configuration option to enable identity file reloading and to configure the interval

Before merging, wait for the Teleport Plugins PR: https://github.com/gravitational/teleport-plugins/pull/956

changelog: Introduces support for configuring Access Plugins to automatically refresh the identity file from disk. This improves compatibility with Machine ID as a credential source.

Backports #32974