### PR TITLE
Make cluster error states more pretty, add a reconnect button for leaf clusters

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -141,7 +141,7 @@ function LeafDisconnected(props: {
       clusterState="Trusted cluster is offline."
       action={{
         attempt: props.clusterSyncAttempt,
-        label: 'Reconnect',
+        label: 'Refresh cluster status',
         run: props.syncCluster,
       }}
     />
@@ -152,7 +152,7 @@ function NotFound(props: { clusterName: string }) {
   return (
     <PrintState
       clusterName={props.clusterName}
-      clusterState="Cluster is not found."
+      clusterState="Cluster not found."
     />
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -63,16 +63,14 @@ export default function DocumentCluster(props: {
 
   return (
     <Document visible={props.visible}>
-      <Layout>
-        <ClusterState
-          clusterName={clusterName}
-          clusterUri={clusterUri}
-          rootCluster={rootCluster}
-          cluster={cluster}
-          syncCluster={syncCluster}
-          clusterSyncAttempt={clusterSyncAttempt}
-        />
-      </Layout>
+      <ClusterState
+        clusterName={clusterName}
+        clusterUri={clusterUri}
+        rootCluster={rootCluster}
+        cluster={cluster}
+        syncCluster={syncCluster}
+        clusterSyncAttempt={clusterSyncAttempt}
+      />
     </Document>
   );
 }
@@ -109,7 +107,11 @@ function ClusterState(props: {
     );
   }
 
-  return <UnifiedResources clusterUri={props.clusterUri} />;
+  return (
+    <Layout>
+      <UnifiedResources clusterUri={props.clusterUri} />
+    </Layout>
+  );
 }
 
 function RequiresLogin(props: {
@@ -179,9 +181,7 @@ function PrintState(props: {
       <Text typography="h4" bold>
         {props.clusterName}
       </Text>
-      <Text as="span" typography="h5">
-        {props.clusterState}
-      </Text>
+      <Text>{props.clusterState}</Text>
       {props.action && (
         <ButtonPrimary
           mt={4}


### PR DESCRIPTION
While removing the cluster context I realized that the error states for the cluster look quite poor, unchanged from the alpha version.

I also fixed this issue https://github.com/gravitational/teleport.e/issues/863 (actually Reconnect syncs the entire cluster, but I think that's fine?)

Before 
<img width="1196" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/f236395b-6437-4894-b018-a1f91e766e64">


After
<img width="1196" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/18f90851-a710-4683-900c-4e338912bdb1">

The other error states look quite similar, so I didn't include screenshots for them.

Changelog: Fixed the formatting of errors displayed when cluster resources cannot be shown in Connect. Added a button to refresh a trusted cluster when it is offline.  
