### PR TITLE
Special case the subsystems handled by `teleport exec`

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -128,7 +128,7 @@ type ExecCommand struct {
 
 	// RequestType is the type of request: either "exec" or "shell". This will
 	// be used to control where to connect std{out,err} based on the request
-	// type: "exec" or "shell".
+	// type: "exec", "shell" or "subsystem".
 	RequestType string `json:"request_type"`
 
 	// PAMConfig is the configuration data that needs to be passed to the child and then to PAM modules.
@@ -743,6 +743,7 @@ func IsReexec() bool {
 // function is run by Teleport while it's re-executing.
 func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
+	isReexec := false // used for
 
 	// Get the login shell for the user (or fallback to the default).
 	shellPath, err := shell.GetLoginShell(c.Login)
@@ -754,9 +755,24 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 		shellPath = "/bin/sh"
 	}
 
-	// If no command was given, configure a shell to run in 'login' mode.
-	// Otherwise, execute a command through the shell.
-	if c.Command == "" {
+	// If a subsystem was requested, handle the known subsystems or error out;
+	// if it's a normal command execution, and if no command was given,
+	// configure a shell to run in 'login' mode. Otherwise, execute a command
+	// through the shell.
+	if c.RequestType == sshutils.SubsystemRequest {
+		switch c.Command {
+		case teleport.SFTPSubsystem:
+			executable, err := os.Executable()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			cmd.Path = executable
+			cmd.Args = []string{executable, teleport.SFTPSubCommand}
+			isReexec = true
+		default:
+			return nil, trace.BadParameter("unsupported subsystem execution request %q", c.Command)
+		}
+	} else if c.Command == "" {
 		// Set the path to the path of the shell.
 		cmd.Path = shellPath
 
@@ -881,7 +897,11 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 	}
 
 	// Perform OS-specific tweaks to the command.
-	userCommandOSTweaks(&cmd)
+	if isReexec {
+		reexecCommandOSTweaks(&cmd)
+	} else {
+		userCommandOSTweaks(&cmd)
+	}
 
 	return &cmd, nil
 }

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -743,7 +743,7 @@ func IsReexec() bool {
 // function is run by Teleport while it's re-executing.
 func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
-	isReexec := false // used for
+	isReexec := false
 
 	// Get the login shell for the user (or fallback to the default).
 	shellPath, err := shell.GetLoginShell(c.Login)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -95,7 +95,8 @@ func fdName(f FileFD) string {
 // construct and execute a shell.
 type ExecCommand struct {
 	// Command is the command to execute. If an interactive session is being
-	// requested, will be empty.
+	// requested, will be empty. If a subsystem is requested, it will contain
+	// the subsystem name.
 	Command string `json:"command"`
 
 	// DestinationAddress is the target address to dial to.

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -55,7 +55,9 @@ func newSFTPSubsys() (*sftpSubsys, error) {
 	}, nil
 }
 
-func (s *sftpSubsys) Start(ctx context.Context, serverConn *ssh.ServerConn, ch ssh.Channel, _ *ssh.Request,
+func (s *sftpSubsys) Start(ctx context.Context,
+	serverConn *ssh.ServerConn,
+	ch ssh.Channel, req *ssh.Request,
 	serverCtx *srv.ServerContext,
 ) error {
 	// Check that file copying is allowed Node-wide again here in case
@@ -88,15 +90,14 @@ func (s *sftpSubsys) Start(ctx context.Context, serverConn *ssh.ServerConn, ch s
 	defer auditPipeIn.Close()
 
 	// Create child process to handle SFTP connection
-	executable, err := os.Executable()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	execRequest, err := srv.NewExecRequest(serverCtx, executable+" sftp")
+	execRequest, err := srv.NewExecRequest(serverCtx, teleport.SFTPSubsystem)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if err := serverCtx.SetExecRequest(execRequest); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := serverCtx.SetSSHRequest(req); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -37,6 +37,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 )
@@ -252,7 +253,7 @@ func (c *Config) TransferFiles(ctx context.Context, sshClient *ssh.Client) error
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := s.RequestSubsystem("sftp"); err != nil {
+	if err := s.RequestSubsystem(teleport.SFTPSubsystem); err != nil {
 		// If the subsystem request failed and a generic error is
 		// returned, return the session's stderr as the error if it's
 		// non-empty, as the session's stderr may have a more useful

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -96,7 +96,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	join := app.Command("join", "Join a Teleport cluster without running the Teleport daemon.")
 	joinOpenSSH := join.Command("openssh", "Join an SSH server to a Teleport cluster.")
 	scpc := app.Command("scp", "Server-side implementation of SCP.").Hidden()
-	sftp := app.Command("sftp", "Server-side implementation of SFTP.").Hidden()
+	sftp := app.Command(teleport.SFTPSubCommand, "Server-side implementation of SFTP.").Hidden()
 	exec := app.Command(teleport.ExecSubCommand, "Used internally by Teleport to re-exec itself to run a command.").Hidden()
 	forward := app.Command(teleport.ForwardSubCommand, "Used internally by Teleport to re-exec itself to port forward.").Hidden()
 	checkHomeDir := app.Command(teleport.CheckHomeDirSubCommand, "Used internally by Teleport to re-exec itself to check access to a directory.").Hidden()


### PR DESCRIPTION
This only applies to `sftp`, and lets us do a real reexec where that's possible (i.e. launching `/proc/self/exe` on Linux), making sftp work even if Teleport has been replaced by some wrapper or has been deleted.