### PR TITLE
Add Access List owners to suggested reviewers.

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1033,7 +1033,7 @@ func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 
 			req := test.req.Copy()
 			updateAccessRequestWithAdditionalReviewers(ctx, req, accessLists, test.promotions)
-			require.Equal(t, test.expectedReviewers, req.GetSuggestedReviewers())
+			require.ElementsMatch(t, test.expectedReviewers, req.GetSuggestedReviewers())
 		})
 	}
 }

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,10 +34,14 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -931,4 +936,104 @@ func TestPromotedRequest(t *testing.T) {
 		require.Equal(t, "0000-00-00-0000", promotedRequest.GetPromotedAccessListName())
 		require.Equal(t, "ACL title", promotedRequest.GetPromotedAccessListTitle())
 	})
+}
+
+func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+
+	mustRequest := func(suggestedReviewers ...string) types.AccessRequest {
+		req, err := services.NewAccessRequest("test-user", "admins")
+		require.NoError(t, err)
+		req.SetSuggestedReviewers(suggestedReviewers)
+		return req
+	}
+
+	mustAccessList := func(name string, owners ...string) *accesslist.AccessList {
+		ownersSpec := make([]accesslist.Owner, len(owners))
+		for i, owner := range owners {
+			ownersSpec[i] = accesslist.Owner{
+				Name: owner,
+			}
+		}
+		accessList, err := accesslist.NewAccessList(header.Metadata{
+			Name: name,
+		}, accesslist.Spec{
+			Title: "simple",
+			Grants: accesslist.Grants{
+				Roles: []string{"grant-role"},
+			},
+			Audit: accesslist.Audit{
+				NextAuditDate: clock.Now().AddDate(1, 0, 0),
+			},
+			Owners: ownersSpec,
+		})
+		require.NoError(t, err)
+		return accessList
+	}
+
+	tests := []struct {
+		name              string
+		req               types.AccessRequest
+		accessLists       []*accesslist.AccessList
+		promotions        *types.AccessRequestAllowedPromotions
+		expectedReviewers []string
+	}{
+		{
+			name:              "nil promotions",
+			req:               mustRequest("rev1", "rev2"),
+			expectedReviewers: []string{"rev1", "rev2"},
+		},
+		{
+			name: "a few promotions",
+			req:  mustRequest("rev1", "rev2"),
+			accessLists: []*accesslist.AccessList{
+				mustAccessList("name1", "owner1", "owner2"),
+				mustAccessList("name2", "owner1", "owner3"),
+				mustAccessList("name3", "owner4", "owner5"),
+			},
+			promotions: &types.AccessRequestAllowedPromotions{
+				Promotions: []*types.AccessRequestAllowedPromotion{
+					{AccessListName: "name1"},
+					{AccessListName: "name2"},
+				},
+			},
+			expectedReviewers: []string{"rev1", "rev2", "owner1", "owner2", "owner3"},
+		},
+		{
+			name: "no promotions",
+			req:  mustRequest("rev1", "rev2"),
+			accessLists: []*accesslist.AccessList{
+				mustAccessList("name1", "owner1", "owner2"),
+				mustAccessList("name2", "owner1", "owner3"),
+				mustAccessList("name3", "owner4", "owner5"),
+			},
+			promotions: &types.AccessRequestAllowedPromotions{
+				Promotions: []*types.AccessRequestAllowedPromotion{},
+			},
+			expectedReviewers: []string{"rev1", "rev2"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mem, err := memory.New(memory.Config{})
+			require.NoError(t, err)
+			accessLists, err := local.NewAccessListService(mem, clock)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			for _, accessList := range test.accessLists {
+				_, err = accessLists.UpsertAccessList(ctx, accessList)
+				require.NoError(t, err)
+			}
+
+			req := test.req.Copy()
+			updateAccessRequestWithAdditionalReviewers(ctx, req, accessLists, test.promotions)
+			require.Equal(t, test.expectedReviewers, req.GetSuggestedReviewers())
+		})
+	}
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4325,7 +4325,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	if req.GetDryRun() {
-		_, promotions := a.getAccessRequestPromotions(ctx, req)
+		_, promotions := a.generateAccessRequestPromotions(ctx, req)
 		// update the request with additional reviewers if possible.
 		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
 		// Made it this far with no errors, return before creating the request
@@ -4363,7 +4363,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	// calculate the promotions
-	reqCopy, promotions := a.getAccessRequestPromotions(ctx, req)
+	reqCopy, promotions := a.generateAccessRequestPromotions(ctx, req)
 	if promotions != nil {
 		// Create the promotion entry even if the allowed promotion is empty. Otherwise, we won't
 		// be able to distinguish between an allowed empty set and generation failure.
@@ -4378,8 +4378,9 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	return req, nil
 }
 
-// getAccessRequestPromotions will return potential access list promotions for an access request.
-func (a *Server) getAccessRequestPromotions(ctx context.Context, req types.AccessRequest) (types.AccessRequest, *types.AccessRequestAllowedPromotions) {
+// generateAccessRequestPromotions will return potential access list promotions for an access request. On error, this function will log
+// the error and return whatever it has. The caller is expected to deal with the possibility of a nil promotions object.
+func (a *Server) generateAccessRequestPromotions(ctx context.Context, req types.AccessRequest) (types.AccessRequest, *types.AccessRequestAllowedPromotions) {
 	reqCopy := req.Copy()
 	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
 	if err != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4330,6 +4330,12 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		return req, nil
 	}
 
+	if err := a.verifyAccessRequestMonthlyLimit(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	log.Debugf("Creating Access Request %v with expiry %v.", req.GetName(), req.Expiry())
+
 	// calculate the promotions
 	reqCopy := req.Copy()
 	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
@@ -4341,12 +4347,6 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 
 	// update the request with additional reviewers if possible.
 	updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
-
-	if err := a.verifyAccessRequestMonthlyLimit(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	log.Debugf("Creating Access Request %v with expiry %v.", req.GetName(), req.Expiry())
 
 	if _, err := a.Services.CreateAccessRequestV2(ctx, req); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -51,6 +51,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -4392,7 +4393,7 @@ func updateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.A
 	}
 
 	// For promotions, add in access list owners as additional suggested reviewers
-	var additionalReviewers []string
+	additionalReviewers := map[string]struct{}{}
 
 	// Iterate through the promotions, adding the owners of the corresponding access lists as reviewers.
 	for _, promotion := range promotions.Promotions {
@@ -4403,19 +4404,13 @@ func updateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.A
 		}
 
 		for _, owner := range accessList.GetOwners() {
-			additionalReviewers = append(additionalReviewers, owner.Name)
+			additionalReviewers[owner.Name] = struct{}{}
 		}
 	}
 
 	// Only modify the original request if additional reviewers were found.
 	if len(additionalReviewers) > 0 {
-		originalNumSuggestedReviewers := len(req.GetSuggestedReviewers())
-		suggestedReviewers := make([]string, originalNumSuggestedReviewers+len(additionalReviewers))
-		copy(suggestedReviewers, req.GetSuggestedReviewers())
-		copy(suggestedReviewers[originalNumSuggestedReviewers:], additionalReviewers)
-
-		// Update the request, making sure we deduplicate if there are duplicate reviewers.
-		req.SetSuggestedReviewers(apiutils.Deduplicate(suggestedReviewers))
+		req.SetSuggestedReviewers(append(req.GetSuggestedReviewers(), maps.Keys(additionalReviewers)...))
 	}
 }
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4325,6 +4325,9 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	if req.GetDryRun() {
+		_, promotions := a.getAccessRequestPromotions(ctx, req)
+		// update the request with additional reviewers if possible.
+		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
 		// Made it this far with no errors, return before creating the request
 		// if this is a dry run.
 		return req, nil
@@ -4336,22 +4339,10 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 
 	log.Debugf("Creating Access Request %v with expiry %v.", req.GetName(), req.Expiry())
 
-	// calculate the promotions
-	reqCopy := req.Copy()
-	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
-	if err != nil {
-		// Do not fail the request if the promotions failed to generate.
-		// The request promotion will be blocked, but the request can still be approved.
-		log.WithError(err).Warn("Failed to generate access list promotions.")
-	}
-
-	// update the request with additional reviewers if possible.
-	updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
-
 	if _, err := a.Services.CreateAccessRequestV2(ctx, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
+	err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
 		Metadata: apievents.Metadata{
 			Type: events.AccessRequestCreateEvent,
 			Code: events.AccessRequestCreateCode,
@@ -4371,6 +4362,8 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		log.WithError(err).Warn("Failed to emit access request create event.")
 	}
 
+	// calculate the promotions
+	reqCopy, promotions := a.getAccessRequestPromotions(ctx, req)
 	if promotions != nil {
 		// Create the promotion entry even if the allowed promotion is empty. Otherwise, we won't
 		// be able to distinguish between an allowed empty set and generation failure.
@@ -4383,6 +4376,18 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		strconv.Itoa(len(req.GetRoles())),
 		strconv.Itoa(len(req.GetRequestedResourceIDs()))).Inc()
 	return req, nil
+}
+
+// getAccessRequestPromotions will return potential access list promotions for an access request.
+func (a *Server) getAccessRequestPromotions(ctx context.Context, req types.AccessRequest) (types.AccessRequest, *types.AccessRequestAllowedPromotions) {
+	reqCopy := req.Copy()
+	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
+	if err != nil {
+		// Do not fail the request if the promotions failed to generate.
+		// The request promotion will be blocked, but the request can still be approved.
+		log.WithError(err).Warn("Failed to generate access list promotions.")
+	}
+	return reqCopy, promotions
 }
 
 // updateAccessRequestWithAdditionalReviewers will update the given access request with additional reviewers given the promotions

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4329,6 +4329,18 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		return req, nil
 	}
 
+	// calculate the promotions
+	reqCopy := req.Copy()
+	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
+	if err != nil {
+		// Do not fail the request if the promotions failed to generate.
+		// The request promotion will be blocked, but the request can still be approved.
+		log.WithError(err).Warn("Failed to generate access list promotions.")
+	}
+
+	// update the request with additional reviewers if possible.
+	updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListClient(), promotions)
+
 	if err := a.verifyAccessRequestMonthlyLimit(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4338,7 +4350,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if _, err := a.Services.CreateAccessRequestV2(ctx, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
+	err = a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
 		Metadata: apievents.Metadata{
 			Type: events.AccessRequestCreateEvent,
 			Code: events.AccessRequestCreateCode,
@@ -4357,14 +4369,8 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if err != nil {
 		log.WithError(err).Warn("Failed to emit access request create event.")
 	}
-	// calculate the promotions
-	reqCopy := req.Copy()
-	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
-	if err != nil {
-		// Do not fail the request if the promotions failed to generate.
-		// The request promotion will be blocked, but the request can still be approved.
-		log.WithError(err).Warn("Failed to generate access list promotions.")
-	} else if promotions != nil {
+
+	if promotions != nil {
 		// Create the promotion entry even if the allowed promotion is empty. Otherwise, we won't
 		// be able to distinguish between an allowed empty set and generation failure.
 		if err := a.Services.CreateAccessRequestAllowedPromotions(ctx, reqCopy, promotions); err != nil {
@@ -4376,6 +4382,41 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 		strconv.Itoa(len(req.GetRoles())),
 		strconv.Itoa(len(req.GetRequestedResourceIDs()))).Inc()
 	return req, nil
+}
+
+// updateAccessRequestWithAdditionalReviewers will update the given access request with additional reviewers given the promotions
+// created for the access request.
+func updateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.AccessRequest, accessLists services.AccessListsGetter, promotions *types.AccessRequestAllowedPromotions) {
+	if promotions == nil {
+		return
+	}
+
+	// For promotions, add in access list owners as additional suggested reviewers
+	var additionalReviewers []string
+
+	// Iterate through the promotions, adding the owners of the corresponding access lists as reviewers.
+	for _, promotion := range promotions.Promotions {
+		accessList, err := accessLists.GetAccessList(ctx, promotion.AccessListName)
+		if err != nil {
+			log.WithError(err).Warn("Failed to get access list, skipping additional reviewers")
+			break
+		}
+
+		for _, owner := range accessList.GetOwners() {
+			additionalReviewers = append(additionalReviewers, owner.Name)
+		}
+	}
+
+	// Only modify the original request if additional reviewers were found.
+	if len(additionalReviewers) > 0 {
+		originalNumSuggestedReviewers := len(req.GetSuggestedReviewers())
+		suggestedReviewers := make([]string, originalNumSuggestedReviewers+len(additionalReviewers))
+		copy(suggestedReviewers, req.GetSuggestedReviewers())
+		copy(suggestedReviewers[originalNumSuggestedReviewers:], additionalReviewers)
+
+		// Update the request, making sure we deduplicate if there are duplicate reviewers.
+		req.SetSuggestedReviewers(apiutils.Deduplicate(suggestedReviewers))
+	}
 }
 
 func (a *Server) DeleteAccessRequest(ctx context.Context, name string) error {


### PR DESCRIPTION
When creating an access request, any owners of potential access list promotions will be added as suggested reviewers. These users will, in turn be notified through regular notification mechanisms.

changelog: Access List owners will be added as reviewers to promotable Access Requests if the Access Request targets resources that belong to an Access List. Reviewers will be notified via existing notification mechanisms.

Note: This has been adjusted so that it will only populated suggested reviewers when dry run is set. Dry run is used by the UI in order to populate access request defaults, so we'll latch into this mechanism for pre-populating suggested reviewers.