### PR TITLE
Fix links in the Predicate Language guide

### DIFF
--- a/docs/pages/reference/predicate-language.mdx
+++ b/docs/pages/reference/predicate-language.mdx
@@ -18,7 +18,7 @@ Some fields in Teleport's role resources use the predicate language to define
 the scope of a role's permissions:
 
 - [Dynamic Impersonation](../access-controls/guides/impersonation.mdx#filter-fields)
-- [RBAC for sessions](../access-controls/reference.mdx#filter-fields)
+- [RBAC for sessions](../access-controls/reference.mdx#rbac-for-sessions)
 
 When used in role resources, the predicate language supports the following operators:
 


### PR DESCRIPTION
Two links in the Predicate Language guide incorrectly point to the same heading. This change corrects the links.