### PR TITLE
Removes test `DeleteRole()` call from production `DeleteUser()`

### DIFF
--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -32,7 +32,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 )
 
@@ -223,19 +222,6 @@ func (a *Server) DeleteUser(ctx context.Context, user string) error {
 		log.WithError(err).Warn("Failed getting user during delete operation")
 		prevUser = nil
 		omitEditorEvent = true
-	}
-
-	role, err := a.Services.GetRole(ctx, services.RoleNameForUser(user))
-	if err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-	} else {
-		if err := a.DeleteRole(ctx, role.GetName()); err != nil {
-			if !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-		}
 	}
 
 	err = a.Services.DeleteUser(ctx, user)


### PR DESCRIPTION
Prior to this patch, the production `auth` server appears to be trying to delete
a user-specific role before deleting the user itself. This user-specific role appears
to be only created as part of some test harness setup, and the concept should never have
leaked into the production `auth` server.

The role-deletion code is also _wrong_; if such a user Role exists then `DeleteUser()`
attempts to delete that role while it is still in use - _by the very user that `DeleteUser()`
is trying to delete_ - causing the user deletion to fail.

This patch removes the code in question, but does not isolate the code that leaked in
to the production service. As the test code is used by multiple packages for their own
tests, any attempt to do so would trigger a large refactor, that would swamp this 
functional change.