### PR TITLE
Add AccessGraph service to user roles and ACLs

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -445,6 +445,9 @@ const (
 	// Teleport Assist resources.
 	KindAssistant = "assistant"
 
+	// KindAccessGraph is an access to access graph service.
+	KindAccessGraph = "access_graph"
+
 	// KindIntegration is a connection to a 3rd party system API.
 	KindIntegration = "integration"
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -166,7 +166,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindDiscoveryConfig, RW()),
 					types.NewRule(types.KindSecurityReport, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAuditQuery, append(RW(), types.VerbUse)),
-					types.NewRule(types.KindAccessGraph, append(RW(), types.VerbUse)),
+					types.NewRule(types.KindAccessGraph, RW()),
 				},
 			},
 		},

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -166,6 +166,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindDiscoveryConfig, RW()),
 					types.NewRule(types.KindSecurityReport, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAuditQuery, append(RW(), types.VerbUse)),
+					types.NewRule(types.KindAccessGraph, append(RW(), types.VerbUse)),
 				},
 			},
 		},

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -98,6 +98,8 @@ type UserACL struct {
 	AuditQuery ResourceAccess `json:"auditQuery"`
 	// SecurityReport defines access to security reports.
 	SecurityReport ResourceAccess `json:"securityReport"`
+	// AccessGraph defines access to access graph.
+	AccessGraph ResourceAccess `json:"accessGraph"`
 }
 
 func hasAccess(roleSet RoleSet, ctx *Context, kind string, verbs ...string) bool {
@@ -152,6 +154,9 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	if features.Cloud {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
 	}
+
+	//TODO(jakule): move later to the cloud section.
+	accessGraphAccess := newAccess(userRoles, ctx, types.KindAccessGraph)
 
 	var pluginsAccess ResourceAccess
 	if features.Plugins {
@@ -209,5 +214,6 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 		AccessList:              accessListAccess,
 		AuditQuery:              auditQuery,
 		SecurityReport:          securityReports,
+		AccessGraph:             accessGraphAccess,
 	}
 }

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -144,6 +144,7 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	desktopAccess := newAccess(userRoles, ctx, types.KindWindowsDesktop)
 	cnDiagnosticAccess := newAccess(userRoles, ctx, types.KindConnectionDiagnostic)
 	samlIdpServiceProviderAccess := newAccess(userRoles, ctx, types.KindSAMLIdPServiceProvider)
+	accessGraphAccess := newAccess(userRoles, ctx, types.KindAccessGraph)
 
 	var assistAccess ResourceAccess
 	if features.Assist {
@@ -154,9 +155,6 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	if features.Cloud {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
 	}
-
-	//TODO(jakule): move later to the cloud section.
-	accessGraphAccess := newAccess(userRoles, ctx, types.KindAccessGraph)
 
 	var pluginsAccess ResourceAccess
 	if features.Plugins {


### PR DESCRIPTION
This commit adds a new Service, AccessGraph, and integrates it into user roles and ACLs. It extends the rule set types to include the "access_graph" verb and adds AccessGraph as a new resource in userACL. This will allow users to gain authorized access to the AccessGraph service. A new constant, KindAccessGraph, is also defined for better identifiable.

Related https://github.com/gravitational/teleport.e/pull/2594