### PR TITLE
[TAG] Add localStorage value for enabling TAG & SQL editor

### DIFF
--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -279,6 +279,8 @@ const cfg = {
 
     // Assist needs some access request info to exist in OSS
     accessRequestPath: '/v1/enterprise/accessrequest/:requestId?',
+
+    accessGraphFeatures: '/v1/enterprise/accessgraph/static/features.json',
   },
 
   getUserClusterPreferencesUrl(clusterId: string) {
@@ -845,6 +847,10 @@ const cfg = {
 
   getAccessRequestRoute(requestId?: string) {
     return generatePath(cfg.routes.requests, { requestId });
+  },
+
+  getAccessGraphFeaturesUrl() {
+    return cfg.api.accessGraphFeatures;
   },
 
   getListEc2InstancesUrl(integrationName: string) {

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -243,6 +243,14 @@ const storage = {
     }
     return null;
   },
+
+  getAccessGraphEnabled(): boolean {
+    const item = window.localStorage.getItem(KeysEnum.ACCESS_GRAPH_ENABLED);
+    if (item) {
+      return JSON.parse(item);
+    }
+    return false;
+  },
 };
 
 export default storage;

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -251,6 +251,14 @@ const storage = {
     }
     return false;
   },
+
+  getAccessGraphSQLEnabled(): boolean {
+    const item = window.localStorage.getItem(KeysEnum.ACCESS_GRAPH_ENABLED);
+    if (item) {
+      return JSON.parse(item);
+    }
+    return false;
+  },
 };
 
 export default storage;

--- a/web/packages/teleport/src/services/localStorage/types.ts
+++ b/web/packages/teleport/src/services/localStorage/types.ts
@@ -32,6 +32,7 @@ export const KeysEnum = {
   CLOUD_USER_INVITES: 'grv_teleport_cloud_user_invites',
   ACCESS_GRAPH_SEARCH_MODE: 'grv_teleport_access_graph_search_mode',
   ACCESS_GRAPH_QUERY: 'grv_teleport_access_graph_query',
+  ACCESS_GRAPH_ENABLED: 'grv_teleport_access_graph_enabled',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/localStorage/types.ts
+++ b/web/packages/teleport/src/services/localStorage/types.ts
@@ -33,6 +33,7 @@ export const KeysEnum = {
   ACCESS_GRAPH_SEARCH_MODE: 'grv_teleport_access_graph_search_mode',
   ACCESS_GRAPH_QUERY: 'grv_teleport_access_graph_query',
   ACCESS_GRAPH_ENABLED: 'grv_teleport_access_graph_enabled',
+  ACCESS_GRAPH_SQL_ENABLED: 'grv_teleport_access_graph_sql_enabled',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -42,6 +42,10 @@ const service = {
       });
   },
 
+  fetchAccessGraphFeatures(): Promise<object> {
+    return api.get(cfg.getAccessGraphFeaturesUrl());
+  },
+
   fetchUser(username: string) {
     return api.get(cfg.getUserWithUsernameUrl(username)).then(makeUser);
   },

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -33,7 +33,6 @@ import desktopService from './services/desktops';
 import userGroupService from './services/userGroups';
 import MfaService from './services/mfa';
 import { agentService } from './services/agents';
-import localStorage from './services/localStorage';
 
 class TeleportContext implements types.Context {
   // stores
@@ -91,6 +90,21 @@ class TeleportContext implements types.Context {
       const hasResource =
         await userService.checkUserHasAccessToRegisteredResource();
       localStorage.setOnboardDiscover({ hasResource });
+    }
+
+    if (user.acl.accessGraph.list) {
+      // If access graph is enabled, check what features are enabled and store them in local storage.
+      try {
+        const accessGraphFeatures =
+          await userService.fetchAccessGraphFeatures();
+
+        for (let key in accessGraphFeatures) {
+          window.localStorage.setItem(key, accessGraphFeatures[key]);
+        }
+      } catch (e) {
+        // If we fail to fetch access graph features, log the error and continue.
+        console.error('Failed to fetch access graph features', e);
+      }
     }
   }
 


### PR DESCRIPTION
This adds a new key into the local storage enum for enabling/disabling TAG from showing up in the navigation, as well as enabling/disabling the manual SQL editor.