### PR TITLE
[TAG] Add access graph to the user ACL & feature flags

### DIFF
--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -68,6 +68,7 @@ export const allAccessAcl: Acl = {
   accessList: fullAccess,
   auditQuery: fullAccess,
   securityReport: fullAccess,
+  accessGraph: fullAccess,
 };
 
 export function getAcl(cfg?: { noAccess: boolean }) {

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -64,6 +64,7 @@ export function makeAcl(json): Acl {
   const securityReport = json.securityReport || defaultAccess;
 
   const samlIdpServiceProvider = json.samlIdpServiceProvider || defaultAccess;
+  const accessGraph = json.accessGraph || defaultAccess;
 
   return {
     accessList,
@@ -97,6 +98,7 @@ export function makeAcl(json): Acl {
     samlIdpServiceProvider,
     auditQuery,
     securityReport,
+    accessGraph,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -84,6 +84,7 @@ export interface Acl {
   accessList: Access;
   auditQuery: Access;
   securityReport: Access;
+  accessGraph: Access;
 }
 
 // AllTraits represent all the traits defined for a user.

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -248,6 +248,13 @@ test('undefined values in context response gives proper default values', async (
         create: false,
         remove: false,
       },
+      accessGraph: {
+        list: false,
+        read: false,
+        edit: false,
+        create: false,
+        remove: false,
+      },
       clipboardSharingEnabled: true,
       desktopSessionRecordingEnabled: true,
       directorySharingEnabled: true,

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -136,6 +136,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.accessRequests;
   }
 
+  getAccessGraphAccess() {
+    return this.state.acl.accessGraph;
+  }
+
   // hasPrereqAccessToAddAgents checks if user meets the prerequisite
   // access to add an agent:
   //  - user should be able to create provisioning tokens

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -173,6 +173,7 @@ class TeleportContext implements types.Context {
       assist: userContext.getAssistantAccess().list && this.assistEnabled,
       accessMonitoring: hasAccessMonitoringAccess(),
       managementSection: hasManagementSectionAccess(),
+      accessGraph: userContext.getAccessGraphAccess().list,
     };
   }
 }
@@ -205,6 +206,7 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   assist: false,
   managementSection: false,
   accessMonitoring: false,
+  accessGraph: false,
 };
 
 export default TeleportContext;

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -163,6 +163,7 @@ export interface FeatureFlags {
   accessMonitoring: boolean;
   // Whether or not the management section should be available.
   managementSection: boolean;
+  accessGraph: boolean;
 }
 
 // LockedFeatures are used for determining which features are disabled in the user's cluster.


### PR DESCRIPTION
This adds the `accessGraph` property added in https://github.com/gravitational/teleport/pull/34109 to the user ACL and creates an `accessGraph` feature flag (enabled if they have `list`)