### PR TITLE
Update "Allowed Users" in `tsh db ls" for databases with Automatic User Provisioning enabled

### DIFF
--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -4512,6 +4512,17 @@ func TestListDatabasesWithUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	dbWithAutoUser, err := types.NewDatabaseV3(types.Metadata{
+		Name: "auto-user",
+	}, types.DatabaseSpecV3{
+		Protocol: "postgres",
+		URI:      "localhost:5432",
+		AdminUser: &types.DatabaseAdminUser{
+			Name: "teleport-admin",
+		},
+	})
+	require.NoError(t, err)
+
 	roleDevStage := &types.RoleV6{
 		Metadata: types.Metadata{Name: "dev-stage", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
@@ -4596,6 +4607,12 @@ func TestListDatabasesWithUsers(t *testing.T) {
 			},
 			wantText: "[dev]",
 		},
+		{
+			name:      "database with automatic user provisioning",
+			database:  dbWithAutoUser,
+			wantUsers: &dbUsers{},
+			wantText:  "alice (+)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -4608,7 +4625,7 @@ func TestListDatabasesWithUsers(t *testing.T) {
 			gotUsers := getDBUsers(tt.database, accessChecker)
 			require.Equal(t, tt.wantUsers, gotUsers)
 
-			gotText := formatUsersForDB(tt.database, accessChecker)
+			gotText := formatUsersForDB("alice", tt.database, accessChecker)
 			require.Equal(t, tt.wantText, gotText)
 		})
 	}


### PR DESCRIPTION
Fixes #33942 

Example:

```bash
$ tsh db ls
Name                      Description                                      Allowed Users Labels                                                                                                                                     Connect 
------------------------- ------------------------------------------------ ------------- ------------------------------------------------------------------------------------------------------------------------------------------ ------- 
mongo-atlas                                                                [*]                                                                                                                                                              
self-hosted-mariadb                                                        [*]                                                                                                                                                              
self-hosted-mongo                                                          [*]                                                                                                                                                              
self-hosted-mysql                                                          [*]                                                                                                                                                              
self-hosted-redis                                                          [*]                                                                                                                                                              
self-hosted-redis-cluster                                                  [*]                                                                                                                                                              
steve-dynamodb                                                             [*]                                                                                                                                                              
steve-postgres            Aurora cluster in ca-central-1                   [STeve] [+]   Env=dev,Name=steve-postgres,Owner=STeve,account-id=1234567890123,endpoint-type=primary,engine-version=14.6,engine=aurora-postgresql,regi...         
steve-postgres-reader     Aurora cluster in ca-central-1 (reader endpoint) [STeve] [+]   Env=dev,Name=steve-postgres,Owner=STeve,account-id=1234567890123,endpoint-type=reader,engine-version=14.6,engine=aurora-postgresql,regio...         

[+] Automatic User Provisioning is enabled for the database. Only your username is allowed as --db-user. See https://goteleport.com/docs/database-access/architecture/ for more details.

```