### PR TITLE
[refactor] deprecate db/common/role.DatabaseRoleMatchers

### DIFF
--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -264,11 +264,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 	state := e.sessionCtx.GetAccessState(authPref)
 
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/clickhouse/engine.go
+++ b/lib/srv/db/clickhouse/engine.go
@@ -88,11 +88,11 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	}
 
 	state := sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database,
-		sessionCtx.DatabaseUser,
-		sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     sessionCtx.Database,
+		DatabaseUser: sessionCtx.DatabaseUser,
+		DatabaseName: sessionCtx.DatabaseName,
+	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
 		state,

--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -40,8 +40,8 @@ type RoleMatchersConfig struct {
 func GetDatabaseRoleMatchers(conf RoleMatchersConfig) (matchers services.RoleMatchers) {
 	// For automatic user provisioning, don't check against database users as
 	// users will be connecting as their own Teleport username.
-	disableDatabaseNameMatcher := conf.Database.SupportsAutoUsers() && conf.AutoCreateUser
-	if !disableDatabaseNameMatcher {
+	disableDatabaseUserMatcher := conf.Database.SupportsAutoUsers() && conf.AutoCreateUser
+	if !disableDatabaseUserMatcher {
 		matchers = append(matchers, services.NewDatabaseUserMatcher(conf.Database, conf.DatabaseUser))
 	}
 

--- a/lib/srv/db/common/role/role_test.go
+++ b/lib/srv/db/common/role/role_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestGetDatabaseRoleMatchers(t *testing.T) {
+	postgresDatabase, err := types.NewDatabaseV3(types.Metadata{
+		Name: "postgres",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+		AdminUser: types.DatabaseAdminUser{
+			Name: "teleport-admin",
+		},
+	})
+	require.NoError(t, err)
+
+	mysqlDatabase, err := types.NewDatabaseV3(types.Metadata{
+		Name: "mysql",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolMySQL,
+		URI:      "localhost:3306",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	tests := []struct {
+		name               string
+		inputConfig        RoleMatchersConfig
+		expectRoleMatchers services.RoleMatchers
+	}{
+		{
+			name: "database name matcher required",
+			inputConfig: RoleMatchersConfig{
+				Database:     postgresDatabase,
+				DatabaseUser: "alice",
+				DatabaseName: "db1",
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+				&services.DatabaseNameMatcher{Name: "db1"},
+			},
+		},
+		{
+			name: "database name matcher not required",
+			inputConfig: RoleMatchersConfig{
+				Database:     mysqlDatabase,
+				DatabaseUser: "alice",
+				DatabaseName: "db1",
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+			},
+		},
+		{
+			name: "AutoCreateUser",
+			inputConfig: RoleMatchersConfig{
+				Database:       postgresDatabase,
+				DatabaseUser:   "alice",
+				DatabaseName:   "db1",
+				AutoCreateUser: true,
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				&services.DatabaseNameMatcher{Name: "db1"},
+			},
+		},
+		{
+			name: "DisableDatabaseNameMatcher",
+			inputConfig: RoleMatchersConfig{
+				Database:                   postgresDatabase,
+				DatabaseUser:               "alice",
+				DatabaseName:               "db1",
+				DisableDatabaseNameMatcher: true,
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.EqualValues(t, test.expectRoleMatchers, GetDatabaseRoleMatchers(test.inputConfig))
+		})
+	}
+}

--- a/lib/srv/db/common/role/role_test.go
+++ b/lib/srv/db/common/role/role_test.go
@@ -32,7 +32,7 @@ func TestGetDatabaseRoleMatchers(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost:5432",
-		AdminUser: types.DatabaseAdminUser{
+		AdminUser: &types.DatabaseAdminUser{
 			Name: "teleport-admin",
 		},
 	})

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -299,11 +299,11 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	}
 
 	state := sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database,
-		sessionCtx.DatabaseUser,
-		sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     sessionCtx.Database,
+		DatabaseUser: sessionCtx.DatabaseUser,
+		DatabaseName: sessionCtx.DatabaseName,
+	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
 		state,

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -260,11 +260,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -209,13 +209,18 @@ func (e *Engine) authorizeConnection(ctx context.Context, sessionCtx *common.Ses
 	}
 
 	state := sessionCtx.GetAccessState(authPref)
-	// Only the username is checked upon initial connection. MongoDB sends
-	// database name with each protocol message (for query, update, etc.)
-	// so it is checked when we receive a message from client.
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     sessionCtx.Database,
+		DatabaseUser: sessionCtx.DatabaseUser,
+		// Only the username is checked upon initial connection. MongoDB sends
+		// database name with each protocol message (for query, update, etc.) so it
+		// is checked when we receive a message from client.
+		DisableDatabaseNameMatcher: true,
+	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
 		state,
-		services.NewDatabaseUserMatcher(sessionCtx.Database, sessionCtx.DatabaseUser),
+		dbRoleMatchers...,
 	)
 	if err != nil {
 		e.Audit.OnSessionStart(e.Context, sessionCtx, err)
@@ -260,13 +265,17 @@ func (e *Engine) checkClientMessage(sessionCtx *common.Session, message protocol
 	case "authenticate", "saslStart", "saslContinue", "logout":
 		return trace.AccessDenied("access denied")
 	}
+
 	// Otherwise authorize the command against allowed databases.
-	return sessionCtx.Checker.CheckAccess(sessionCtx.Database,
+	return sessionCtx.Checker.CheckAccess(
+		sessionCtx.Database,
 		services.AccessState{MFAVerified: true},
-		role.DatabaseRoleMatchers(
-			sessionCtx.Database,
-			sessionCtx.DatabaseUser,
-			database)...)
+		role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+			Database:     sessionCtx.Database,
+			DatabaseUser: sessionCtx.DatabaseUser,
+			DatabaseName: database,
+		})...,
+	)
 }
 
 func (e *Engine) replyError(clientConn net.Conn, replyTo protocol.Message, err error) {

--- a/lib/srv/db/opensearch/engine.go
+++ b/lib/srv/db/opensearch/engine.go
@@ -359,11 +359,11 @@ func (e *Engine) checkAccess(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -161,11 +161,11 @@ func fetchCredentialsOnConnect(closeCtx context.Context, sessionCtx *common.Sess
 	return func(ctx context.Context, conn *redis.Conn) error {
 		err := sessionCtx.Checker.CheckAccess(sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				sessionCtx.Database,
-				sessionCtx.DatabaseUser,
-				sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     sessionCtx.Database,
+				DatabaseUser: sessionCtx.DatabaseUser,
+				DatabaseName: sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/db/redis/cmds.go
+++ b/lib/srv/db/redis/cmds.go
@@ -175,11 +175,11 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				e.sessionCtx.Database,
-				e.sessionCtx.DatabaseUser,
-				e.sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     e.sessionCtx.Database,
+				DatabaseUser: e.sessionCtx.DatabaseUser,
+				DatabaseName: e.sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -222,11 +222,11 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				e.sessionCtx.Database,
-				e.sessionCtx.DatabaseUser,
-				e.sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     e.sessionCtx.Database,
+				DatabaseUser: e.sessionCtx.DatabaseUser,
+				DatabaseName: e.sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -99,11 +99,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -358,11 +358,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,


### PR DESCRIPTION
pre-req for MongoDB auto-user provisioning change #33717

Changes:
- Removed `role.DatabaseRoleMatchers`
- Added a new `DisableDatabaseNameMatcher` flag to  `role.RoleMatchersConfig`
- Refactored the logic of  `role.GetDatabaseRoleMatchers` a little bit and added UT

No backporting necessary. 