### PR TITLE
include state of access request after review in audit log description

### DIFF
--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -78,8 +78,10 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_REQUEST_REVIEWED]: {
     type: 'access_request.review',
     desc: 'Access Request Reviewed',
-    format: ({ id, reviewer, state }) =>
-      `User [${reviewer}] reviewed access request [${id}] and is ${state}`,
+    format: ({ id, reviewer, state }) => {
+      const stateLowerCase = state.toLowerCase();
+      return `User [${reviewer}] ${stateLowerCase} access request [${id}]`;
+    },
   },
   [eventCodes.ACCESS_REQUEST_DELETED]: {
     type: 'access_request.delete',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -79,8 +79,7 @@ export const formatters: Formatters = {
     type: 'access_request.review',
     desc: 'Access Request Reviewed',
     format: ({ id, reviewer, state }) => {
-      const stateLowerCase = state.toLowerCase();
-      return `User [${reviewer}] ${stateLowerCase} access request [${id}]`;
+      return `User [${reviewer}] ${state.toLowerCase()} access request [${id}]`;
     },
   },
   [eventCodes.ACCESS_REQUEST_DELETED]: {

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -78,8 +78,8 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_REQUEST_REVIEWED]: {
     type: 'access_request.review',
     desc: 'Access Request Reviewed',
-    format: ({ id, reviewer }) =>
-      `User [${reviewer}] reviewed access request [${id}]`,
+    format: ({ id, reviewer, state }) =>
+      `User [${reviewer}] reviewed access request [${id}] and is ${state}`,
   },
   [eventCodes.ACCESS_REQUEST_DELETED]: {
     type: 'access_request.delete',


### PR DESCRIPTION
Includes state of access request after approval. A user otherwise has to click into the details to get the state.

<img width="1276" alt="image" src="https://github.com/gravitational/teleport/assets/60704961/0e7de628-5f7a-41c7-aaca-42bbd4d6d212">

to

<img width="789" alt="image" src="https://github.com/gravitational/teleport/assets/60704961/b43a51af-54ec-4f0a-8950-f9b9ce9a705e">



changelog: include state of access request after review in audit log description