### PR TITLE
Discover Kube Agent: use automatic upgrades version

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -65,6 +65,10 @@ type WebConfig struct {
 	IsUsageBasedBilling bool `json:"isUsageBasedBilling,omitempty"`
 	// AutomaticUpgrades describes whether agents should automatically upgrade.
 	AutomaticUpgrades bool `json:"automaticUpgrades"`
+	// AutomaticUpgradesTargetVersion is the agents version (eg kube agent helm chart) that should be installed.
+	// Eg, v13.4.3
+	// Only present when AutomaticUpgrades are enabled.
+	AutomaticUpgradesTargetVersion string `json:"automaticUpgradesTargetVersion,omitempty"`
 	// AssistEnabled is true when Teleport Assist is enabled.
 	AssistEnabled bool `json:"assistEnabled"`
 	// HideInaccessibleFeatures is true when features should be undiscoverable to users without the necessary permissions.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -68,6 +68,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
+	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
@@ -279,6 +280,12 @@ type Config struct {
 	// PresenceChecker periodically runs the mfa ceremony for moderated
 	// sessions.
 	PresenceChecker PresenceChecker
+
+	// AutomaticUpgradesVersionURL is the URL which returns the target agent version.
+	// This URL must returns a valid version string.
+	// Eg, v13.4.3
+	// Optional: uses cloud/stable channel when omitted.
+	AutomaticUpgradesVersionURL string
 }
 
 // SetDefaults ensures proper default values are set if
@@ -1532,19 +1539,29 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		canJoinSessions = !services.IsRecordAtProxy(recCfg.GetMode())
 	}
 
+	automaticUpgradesEnabled := clusterFeatures.GetAutomaticUpgrades()
+	var automaticUpgradesTargetVersion string
+	if automaticUpgradesEnabled {
+		automaticUpgradesTargetVersion, err = automaticupgrades.Version(r.Context(), h.cfg.AutomaticUpgradesVersionURL)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	webCfg := webclient.WebConfig{
-		Auth:                     authSettings,
-		CanJoinSessions:          canJoinSessions,
-		IsCloud:                  clusterFeatures.GetCloud(),
-		TunnelPublicAddress:      tunnelPublicAddr,
-		RecoveryCodesEnabled:     clusterFeatures.GetRecoveryCodes(),
-		UI:                       h.getUIConfig(r.Context()),
-		IsDashboard:              isDashboard(clusterFeatures),
-		IsUsageBasedBilling:      clusterFeatures.GetIsUsageBased(),
-		AutomaticUpgrades:        clusterFeatures.GetAutomaticUpgrades(),
-		AssistEnabled:            assistEnabled,
-		HideInaccessibleFeatures: clusterFeatures.GetFeatureHiding(),
-		CustomTheme:              clusterFeatures.GetCustomTheme(),
+		Auth:                           authSettings,
+		CanJoinSessions:                canJoinSessions,
+		IsCloud:                        clusterFeatures.GetCloud(),
+		TunnelPublicAddress:            tunnelPublicAddr,
+		RecoveryCodesEnabled:           clusterFeatures.GetRecoveryCodes(),
+		UI:                             h.getUIConfig(r.Context()),
+		IsDashboard:                    isDashboard(clusterFeatures),
+		IsUsageBasedBilling:            clusterFeatures.GetIsUsageBased(),
+		AutomaticUpgrades:              automaticUpgradesEnabled,
+		AutomaticUpgradesTargetVersion: automaticUpgradesTargetVersion,
+		AssistEnabled:                  assistEnabled,
+		HideInaccessibleFeatures:       clusterFeatures.GetFeatureHiding(),
+		CustomTheme:                    clusterFeatures.GetCustomTheme(),
 	}
 
 	resource, err := h.cfg.ProxyClient.GetClusterName()

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4544,9 +4544,20 @@ func TestGetWebConfig(t *testing.T) {
 	}
 	env.proxies[0].handler.handler.cfg.ProxySettings = mockProxySetting
 
+	httpTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.URL.Path, "/v1/stable/cloud/version")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("v99.0.1"))
+	}))
+	defer httpTestServer.Close()
+	versionURL, err := url.JoinPath(httpTestServer.URL, "/v1/stable/cloud/version")
+	require.NoError(t, err)
+	env.proxies[0].handler.handler.cfg.AutomaticUpgradesVersionURL = versionURL
+
 	expectedCfg.IsCloud = true
 	expectedCfg.IsUsageBasedBilling = true
 	expectedCfg.AutomaticUpgrades = true
+	expectedCfg.AutomaticUpgradesTargetVersion = "v99.0.1"
 	expectedCfg.AssistEnabled = true
 
 	// request and verify enabled features are enabled.

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -38,6 +38,7 @@ const cfg = {
   isCloud: false,
   assistEnabled: false,
   automaticUpgrades: false,
+  automaticUpgradesTargetVersion: '',
   isDashboard: false,
   tunnelPublicAddress: '',
   recoveryCodesEnabled: false,

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -60,6 +60,7 @@ class TeleportContext implements types.Context {
   isEnterprise = cfg.isEnterprise;
   isCloud = cfg.isCloud;
   automaticUpgradesEnabled = cfg.automaticUpgrades;
+  automaticUpgradesTargetVersion = cfg.automaticUpgradesTargetVersion;
   assistEnabled = cfg.assistEnabled;
   agentService = agentService;
 


### PR DESCRIPTION
Fixes : https://github.com/gravitational/teleport/issues/34134

For clusters with auto upgrades enabled, the target version must be the one provided by the VersionURL endpoint.

Demo:
Without automatic upgrades
![image](https://github.com/gravitational/teleport/assets/689271/15808d0d-881a-4cc1-9896-19c8f4fe5f8e)

With automatic upgrades
![image](https://github.com/gravitational/teleport/assets/689271/1c9a8d59-ea18-4965-b93a-817242088c3d)

changelog: Kube Agent installation from Discover now uses the Automatic Upgrades version
