### PR TITLE
[v12] Installer Scripts: use bash instead of sh (#34039)

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -44,7 +44,7 @@ on_azure() {
     sudo apt-get install -y ${PACKAGE_LIST}
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
     if [ "$ID" = "rhel" ]; then
-      VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
+      VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"


### PR DESCRIPTION
Backport of #34039 to branch/v12