### PR TITLE
Fix headless login timing out prematurely

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5948,7 +5948,7 @@ func (a *Server) GetHeadlessAuthenticationFromWatcher(ctx context.Context, usern
 // that will expire after the standard callback timeout.
 func (a *Server) UpsertHeadlessAuthenticationStub(ctx context.Context, username string) error {
 	// Create the stub. If it already exists, update its expiration.
-	expires := a.clock.Now().Add(defaults.CallbackTimeout)
+	expires := a.clock.Now().Add(defaults.HeadlessLoginTimeout)
 	stub, err := types.NewHeadlessAuthentication(username, services.HeadlessAuthenticationUserStubID, expires)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1120,7 +1120,7 @@ func TestServer_Authenticate_headless(t *testing.T) {
 						RemoteAddr: "0.0.0.0",
 					},
 				},
-				TTL: defaults.CallbackTimeout,
+				TTL: defaults.HeadlessLoginTimeout,
 			})
 
 			// Use assert so that we also output any test failures below.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6957,7 +6957,7 @@ func (a *ServerWithRoles) MaintainHeadlessAuthenticationStub(ctx context.Context
 		return trace.Wrap(err)
 	}
 
-	ticker := time.NewTicker(defaults.CallbackTimeout)
+	ticker := time.NewTicker(defaults.HeadlessLoginTimeout)
 	defer ticker.Stop()
 
 	for {

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -194,6 +194,9 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 			ReadHeaderTimeout: defaults.ReadHeadersTimeout,
 			WriteTimeout:      apidefaults.DefaultIOTimeout,
 			IdleTimeout:       apidefaults.DefaultIdleTimeout,
+			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+				return authz.ContextWithConn(ctx, c)
+			},
 		},
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: cfg.Component,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1035,6 +1035,9 @@ const (
 
 	// contextClientDstAddr is a client destination address set in the context of the request
 	contextClientDstAddr contextKey = "teleport-client-dst-addr"
+
+	// contextConn is a connection in the context associated with the request
+	contextConn contextKey = "teleport-connection"
 )
 
 // WithDelegator alias for backwards compatibility
@@ -1393,6 +1396,24 @@ func ClientAddrsFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {
 	src, _ = ctx.Value(contextClientSrcAddr).(net.Addr)
 	dst, _ = ctx.Value(contextClientDstAddr).(net.Addr)
 	return
+}
+
+func ContextWithConn(ctx context.Context, conn net.Conn) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	return context.WithValue(ctx, contextConn, conn)
+}
+
+func ConnFromContext(ctx context.Context) (net.Conn, error) {
+	if ctx == nil {
+		return nil, trace.BadParameter("context is nil")
+	}
+	conn, ok := ctx.Value(contextConn).(net.Conn)
+	if !ok {
+		return nil, trace.NotFound("connection was not found in the context")
+	}
+	return conn, nil
 }
 
 // ContextWithUser returns the context with the user embedded.

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -433,8 +433,8 @@ func SSHAgentSSOLogin(ctx context.Context, login SSHLoginSSO, config *Redirector
 	case response := <-rd.ResponseC():
 		log.Debugf("Got response from browser.")
 		return response, nil
-	case <-time.After(defaults.CallbackTimeout):
-		log.Debugf("Timed out waiting for callback after %v.", defaults.CallbackTimeout)
+	case <-time.After(defaults.SSOCallbackTimeout):
+		log.Debugf("Timed out waiting for callback after %v.", defaults.SSOCallbackTimeout)
 		return nil, trace.Wrap(trace.Errorf("timed out waiting for callback"))
 	case <-rd.Done():
 		log.Debugf("Canceled by user.")
@@ -481,7 +481,7 @@ func SSHAgentHeadlessLogin(ctx context.Context, login SSHLoginHeadless) (*auth.S
 	}
 
 	// This request will block until the headless login is approved.
-	clt.Client.HTTPClient().Timeout = defaults.CallbackTimeout
+	clt.Client.HTTPClient().Timeout = defaults.HeadlessLoginTimeout
 
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
 		User:                     login.User,

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -261,9 +261,12 @@ const (
 	// refer to all addresses on the machine.
 	AnyAddress = "0.0.0.0"
 
-	// CallbackTimeout is how long to wait for a response from SSO provider
+	// SSOCallbackTimeout is how long to wait for a response from SSO provider
 	// before timeout.
-	CallbackTimeout = 180 * time.Second
+	SSOCallbackTimeout = 180 * time.Second
+
+	// HeadlessLoginTimeout is how long to wait for user to approve/reject headless login request.
+	HeadlessLoginTimeout = SSOCallbackTimeout
 
 	// NodeJoinTokenTTL is when a token for nodes expires.
 	NodeJoinTokenTTL = 4 * time.Hour

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4104,6 +4104,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),
 				ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+					ctx = authz.ContextWithConn(ctx, c)
 					return authz.ContextWithClientAddrs(ctx, c.RemoteAddr(), c.LocalAddr())
 				},
 			},

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -52,7 +52,7 @@ const certReissueClientWait = time.Second * 3
 
 // certReissueClientWaitHeadless is used when proxy works in headless mode - since user works in reexeced shell,
 // we give them longer time to perform the headless login flow.
-const certReissueClientWaitHeadless = defaults.CallbackTimeout
+const certReissueClientWaitHeadless = defaults.HeadlessLoginTimeout
 
 // KubeClientCerts is a map of Kubernetes client certs.
 type KubeClientCerts map[string]tls.Certificate

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -177,7 +177,7 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 
 				// headless authentication requests will timeout after 3 minutes, so we can close the
 				// Electron modal once this time is up.
-				sendCtx, cancelSend := context.WithTimeout(s.closeContext, defaults.CallbackTimeout)
+				sendCtx, cancelSend := context.WithTimeout(s.closeContext, defaults.HeadlessLoginTimeout)
 
 				// Add the pending request to the map so it is canceled early upon resolution.
 				addPendingRequest(ha.GetName(), cancelSend)


### PR DESCRIPTION
Headless login is supposed to be available for 3 minutes to allow/reject, but it was actually failing if user waited for more than 30 seconds. The reason is http server's write timeout is set to 30 seconds and after headless login flow unpaused and tried to write into connection it was timing out. In this PR we add request's connection to the context and override connection's `WriteDeadline` manually. Two http requests are involved in the headless login flow (one external by the user and one internal teleport), that's why we do it in two places.

Changelog: Fixed headless login not working after waiting for more than 30 seconds

Fixes #33982