### PR TITLE
Tidy up pointer/value receivers in tbot

### DIFF
--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -280,7 +280,7 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 			b := bytes.NewBuffer(nil)
 			encoder := yaml.NewEncoder(b)
 			encoder.SetIndent(2)
-			require.NoError(t, encoder.Encode(tt.in))
+			require.NoError(t, encoder.Encode(&tt.in))
 
 			if golden.ShouldSet() {
 				golden.Set(t, b.Bytes())

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -240,7 +240,7 @@ func (dd *DestinationDirectory) TryLock() (func() error, error) {
 	return unlock, trace.Wrap(err)
 }
 
-func (dm DestinationDirectory) MarshalYAML() (interface{}, error) {
+func (dm *DestinationDirectory) MarshalYAML() (interface{}, error) {
 	type raw DestinationDirectory
-	return withTypeHeader(raw(dm), DestinationDirectoryType)
+	return withTypeHeader((*raw)(dm), DestinationDirectoryType)
 }

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -91,7 +91,7 @@ func (dm *DestinationMemory) TryLock() (func() error, error) {
 	}, nil
 }
 
-func (dm DestinationMemory) MarshalYAML() (interface{}, error) {
+func (dm *DestinationMemory) MarshalYAML() (interface{}, error) {
 	type raw DestinationMemory
-	return withTypeHeader(raw(dm), DestinationMemoryType)
+	return withTypeHeader((*raw)(dm), DestinationMemoryType)
 }

--- a/lib/tbot/config/output_application.go
+++ b/lib/tbot/config/output_application.go
@@ -109,9 +109,9 @@ func (o *ApplicationOutput) Describe() []FileDescription {
 	return fds
 }
 
-func (o ApplicationOutput) MarshalYAML() (interface{}, error) {
+func (o *ApplicationOutput) MarshalYAML() (interface{}, error) {
 	type raw ApplicationOutput
-	return withTypeHeader(raw(o), ApplicationOutputType)
+	return withTypeHeader((*raw)(o), ApplicationOutputType)
 }
 
 func (o *ApplicationOutput) UnmarshalYAML(node *yaml.Node) error {

--- a/lib/tbot/config/output_database.go
+++ b/lib/tbot/config/output_database.go
@@ -160,9 +160,9 @@ func (o *DatabaseOutput) Describe() []FileDescription {
 	return fds
 }
 
-func (o DatabaseOutput) MarshalYAML() (interface{}, error) {
+func (o *DatabaseOutput) MarshalYAML() (interface{}, error) {
 	type raw DatabaseOutput
-	return withTypeHeader(raw(o), DatabaseOutputType)
+	return withTypeHeader((*raw)(o), DatabaseOutputType)
 }
 
 func (o *DatabaseOutput) UnmarshalYAML(node *yaml.Node) error {

--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -127,9 +127,9 @@ func (o *IdentityOutput) Describe() []FileDescription {
 	return fds
 }
 
-func (o IdentityOutput) MarshalYAML() (interface{}, error) {
+func (o *IdentityOutput) MarshalYAML() (interface{}, error) {
 	type raw IdentityOutput
-	return withTypeHeader(raw(o), IdentityOutputType)
+	return withTypeHeader((*raw)(o), IdentityOutputType)
 }
 
 func (o *IdentityOutput) UnmarshalYAML(node *yaml.Node) error {

--- a/lib/tbot/config/output_kubernetes.go
+++ b/lib/tbot/config/output_kubernetes.go
@@ -107,9 +107,9 @@ func (o *KubernetesOutput) Describe() []FileDescription {
 	return fds
 }
 
-func (o KubernetesOutput) MarshalYAML() (interface{}, error) {
+func (o *KubernetesOutput) MarshalYAML() (interface{}, error) {
 	type raw KubernetesOutput
-	return withTypeHeader(raw(o), KubernetesOutputType)
+	return withTypeHeader((*raw)(o), KubernetesOutputType)
 }
 
 func (o *KubernetesOutput) UnmarshalYAML(node *yaml.Node) error {

--- a/lib/tbot/config/output_ssh_host.go
+++ b/lib/tbot/config/output_ssh_host.go
@@ -97,9 +97,9 @@ func (o *SSHHostOutput) Describe() []FileDescription {
 	return fds
 }
 
-func (o SSHHostOutput) MarshalYAML() (interface{}, error) {
+func (o *SSHHostOutput) MarshalYAML() (interface{}, error) {
 	type raw SSHHostOutput
-	return withTypeHeader(raw(o), SSHHostOutputType)
+	return withTypeHeader((*raw)(o), SSHHostOutputType)
 }
 
 func (o *SSHHostOutput) UnmarshalYAML(node *yaml.Node) error {


### PR DESCRIPTION
These older methods were using a value receiver to workaround a slight issue with our yaml library, but we since found a better way around this, so these can be moved to use a pointer receiver, which makes dealing with things like mutexes easier (since we can't copy those).