### PR TITLE
Access list owners can promote access requests.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4514,8 +4514,8 @@ func (a *Server) submitAccessReview(
 		return nil, trace.Wrap(err)
 	}
 
-	// don't bother continuing if the author has no allow directives
-	if !checker.HasAllowDirectives() {
+	// don't bother continuing if the author has no allow directives and doesn't own any access lists
+	if !checker.HasAllowDirectives() && !checker.IsOwnerOfAccessLists() {
 		return nil, trace.AccessDenied("user %q cannot submit reviews", params.Review.Author)
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2547,11 +2547,11 @@ func (a *ServerWithRoles) GetAccessRequests(ctx context.Context, filter types.Ac
 			continue
 		}
 
-		ok, err := checker.CanReviewRequest(req)
+		canReview, err := checker.CanReviewRequest(req)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if ok {
+		if canReview == services.CanOnlyPromote || canReview == services.CanReview {
 			filtered = append(filtered, req)
 			continue
 		}

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -259,7 +259,7 @@ func TestIsAccessListOwner(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			accessList := newAccessList(t)
+			accessList := newAccessList(t, "test", ownerUser, []string{"grole1", "grole2"})
 			test.errAssertionFunc(t, IsAccessListOwner(test.identity, accessList))
 		})
 	}
@@ -396,7 +396,7 @@ func TestIsAccessListMember(t *testing.T) {
 
 			ctx := context.Background()
 
-			accessList := newAccessList(t)
+			accessList := newAccessList(t, "test", ownerUser, []string{"grole1", "grole2"})
 			members := newAccessListMembers(t)
 
 			memberMap := map[string]map[string]*accesslist.AccessListMember{}
@@ -458,7 +458,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			accessList := newAccessList(t)
+			accessList := newAccessList(t, "test", ownerUser, []string{"grole1", "grole2"})
 			accessList.Spec.Audit.NextAuditDate = test.currentReviewDate
 			accessList.Spec.Audit.Recurrence = accesslist.Recurrence{
 				Frequency:  test.frequency,
@@ -570,12 +570,12 @@ func TestAccessListReviewMarshal(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func newAccessList(t *testing.T) *accesslist.AccessList {
+func newAccessList(t *testing.T, name string, ownerUser string, grantedRoles []string) *accesslist.AccessList {
 	t.Helper()
 
 	accessList, err := accesslist.NewAccessList(
 		header.Metadata{
-			Name: "test",
+			Name: name,
 		},
 		accesslist.Spec{
 			Title:       "title",
@@ -612,7 +612,7 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 				},
 			},
 			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
+				Roles: grantedRoles,
 				Traits: map[string][]string{
 					"gtrait1": {"gvalue1", "gvalue2"},
 					"gtrait2": {"gvalue3", "gvalue4"},

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -812,6 +812,11 @@ func (c *ReviewPermissionChecker) HasAllowDirectives() bool {
 	return false
 }
 
+// IsOwnerOfAccessLists will return true if the user owns any access lists.
+func (c *ReviewPermissionChecker) IsOwnerOfAccessLists() bool {
+	return len(c.AccessListsToGrants) > 0
+}
+
 // CanReviewRequestResponse is the response to the can review request.
 type CanReviewRequestResponse int
 

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -163,7 +163,8 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 		}
 
 		// verify review permissions against request details
-		if ok, err := checker.CanReviewRequest(req); err != nil || !ok {
+		canReview, err := checker.CanReviewRequest(req)
+		if canReview == services.CantReview {
 			if err == nil {
 				err = trace.AccessDenied("user %q cannot review request %q", params.Review.Author, params.RequestID)
 			}
@@ -171,7 +172,7 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 		}
 
 		// run the application logic
-		if err := services.ApplyAccessReview(req, params.Review, checker.UserState); err != nil {
+		if err := services.ApplyAccessReview(req, params.Review, checker.UserState, canReview); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -279,9 +279,11 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) 
 		users := &struct {
 			auth.ClientI
 			services.UserLoginStatesGetter
+			services.AccessLists
 		}{
 			ClientI:               client,
 			UserLoginStatesGetter: client.UserLoginStateClient(),
+			AccessLists:           client.AccessListClient(),
 		}
 		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), users, req, tlsca.Identity{}, services.ExpandVars(true))
 		if err != nil {


### PR DESCRIPTION
Access list owners are now able to promote access requests provided they target the roles requested by the access request. For access list owners, users are *only* able to promote access requests and not make any reviews unless the user is otherwise able to review via the regular review thresholds and permissions.

changelog: Access list owners can now promote access requests that are targeting relevant roles.

Note: I'm working on actively testing this, but hopefully the idea is clear.