### PR TITLE
`tctl bots add` outputs ca pins

### DIFF
--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -79,7 +79,7 @@ func Run(args []string, stdout io.Writer) error {
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
 	startCmd.Flag("auth-server", "Address of the Teleport Auth Server or Proxy Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
 	startCmd.Flag("token", "A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
-	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
+	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server (can be repeated for multiple pins); used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
 	startCmd.Flag("destination-dir", "Directory to write short-lived machine certificates.").StringVar(&cf.DestinationDir)
 	startCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").DurationVar(&cf.CertificateTTL)
@@ -105,7 +105,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
 	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server (On-Prem installs) or Proxy Server (Cloud installs).").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
-	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
+	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server (can be repeated for multiple pins); used on first connect.").StringsVar(&cf.CAPins)
 	configureCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
 	configureCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
 	configureCmd.Flag("insecure", "Insecure configures the bot to trust the certificates from the Auth Server or Proxy on first connect without verification. Do not use in production.").BoolVar(&cf.Insecure)

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestBots(t *testing.T) {
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fc := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	authProc := makeAndRunTestAuthServer(t, withFileConfig(fc), withFileDescriptors(dynAddr.Descriptors))
+
+	// rotate HostCA so we get multiple CA pins.
+	err := authProc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        types.HostCA,
+		TargetPhase: types.RotationPhaseInit,
+		Mode:        types.RotationModeManual,
+	})
+	require.NoError(t, err)
+
+	resp, err := authProc.GetAuthServer().GetClusterCACert(ctx)
+	require.NoError(t, err)
+	caPins, err := tlsca.CalculatePins(resp.TLSCA)
+	require.NoError(t, err)
+	require.Len(t, caPins, 2)
+
+	roleYAMLPath := filepath.Join(t.TempDir(), "role.yaml")
+	require.NoError(t, os.WriteFile(roleYAMLPath, []byte(botRoleYAML), 0644))
+	_, err = runResourceCommand(t, fc, []string{"create", roleYAMLPath})
+	require.NoError(t, err)
+
+	buf, err := runBotsCommand(t, fc, []string{"add", "hal9000", "--roles", "robot"})
+	require.NoError(t, err)
+
+	wantOut := fmt.Sprintf(`--ca-pin="%s" \
+   --ca-pin="%s"`, caPins[0], caPins[1])
+	require.Contains(t, buf.String(), wantOut)
+}
+
+const botRoleYAML = `kind: role
+version: v7
+metadata:
+  name: robot
+spec:
+  allow:
+    db_labels:
+      '*': '*'
+    db_names: ["*"]
+    db_users: ["*"]`

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -159,6 +159,16 @@ func runTokensCommand(t *testing.T, fc *config.FileConfig, args []string, opts .
 	return &stdoutBuff, runCommand(t, fc, command, args, opts...)
 }
 
+func runBotsCommand(t *testing.T, fc *config.FileConfig, args []string, opts ...optionsFunc) (*bytes.Buffer, error) {
+	var stdoutBuff bytes.Buffer
+	command := &BotsCommand{
+		stdout: &stdoutBuff,
+	}
+
+	args = append([]string{"bots"}, args...)
+	return &stdoutBuff, runCommand(t, fc, command, args, opts...)
+}
+
 func runUserCommand(t *testing.T, fc *config.FileConfig, args []string, opts ...optionsFunc) error {
 	command := &UserCommand{}
 	args = append([]string{"users"}, args...)


### PR DESCRIPTION
This PR makes `tctl bots add` outpout CA pin(s) for the example command.

If `--ca-pin` isn't given, then `tbot start ...` prints a warning:

> WARN [AUTH]      Joining cluster without validating the identity of the Auth Server. This may open you up to a Man-In-The-Middle (MITM) attack if an attacker can gain privileged network access. To remedy this, use the CA pin value provided when join token was generated to validate the identity of the Auth Server or point to a valid Certificate via the CA Path option. auth/register.go:496

Our machine-id getting started guide also states:
> `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command.

## Example of new output
```diff
$ tctl bots add db-bot --roles=db-bot
The bot token: 0db5cc02a57a7f41f7dfff0a1d290bf7
This token will expire in 59 minutes.

Optionally, if running the bot under an isolated user account, first initialize
the data directory by running the following command as root:

 > tbot init \
   --destination-dir=./tbot-user \
   --bot-user=tbot \
   --reader-user=alice

... where "tbot" is the username of the bot's UNIX user, and "alice" is the
UNIX user that will be making use of the certificates.

Then, run this as the bot user to begin continuously fetching
certificates:

 > tbot start \
   --destination-dir=./tbot-user \
   --token=0db5cc02a57a7f41f7dfff0a1d290bf7 \
   --auth-server=mars.internal:3080 \
   --join-method=token \
+   --ca-pin="sha256:e9d1d784023a4adaeabd006f5ec6eafdb658115bb572d659c9ee4cb88e35d457" \
+   --ca-pin="sha256:82742a934a2c21b1490780ad783e15573ea162172e176e0b86f7c40f73e68bf3"
```

there's two pins because I ran the command during HostCA rotation. Otherwise, there's just the one.