### PR TITLE
list requestable roles with tsh request search

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1049,6 +1049,7 @@ var RequestableResourceKinds = []string{
 	KindKubeJob,
 	KindKubeCertificateSigningRequest,
 	KindKubeIngress,
+	KindRole,
 }
 
 // KubernetesResourcesKinds lists the supported Kubernetes resource kinds.

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1126,11 +1126,11 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 				// Roles are normally determined automatically for resource
 				// access requests, this role must have been explicitly
 				// requested, or a new deny rule has since been added.
-				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
+				return trace.BadParameter("user %q cannot search for resources as role %q", req.GetUser(), roleName)
 			}
 		} else {
 			if !m.CanRequestRole(roleName) {
-				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
+				return trace.BadParameter("user %q cannot request role %q", req.GetUser(), roleName)
 			}
 		}
 	}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -1090,7 +1090,7 @@ func TestRolesForResourceRequest(t *testing.T) {
 			currentRoles:       []string{"db-response-team"},
 			requestRoles:       []string{"db-admins"},
 			requestResourceIDs: nil,
-			expectError:        trace.BadParameter(`user "test-user" can not request role "db-admins"`),
+			expectError:        trace.BadParameter(`user "test-user" cannot request role "db-admins"`),
 		},
 		{
 			desc:               "deny search",
@@ -1128,7 +1128,7 @@ func TestRolesForResourceRequest(t *testing.T) {
 			currentRoles:       []string{"db-response-team"},
 			requestResourceIDs: resourceIDs,
 			requestRoles:       []string{"splunk-admins"},
-			expectError:        trace.BadParameter(`user "test-user" can not request role "splunk-admins"`),
+			expectError:        trace.BadParameter(`user "test-user" cannot request role "splunk-admins"`),
 		},
 		{
 			desc:               "no allowed roles",

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -539,8 +539,7 @@ func showRequestableRoles(w io.Writer, requestableRoles []string) error {
 	for _, r := range requestableRoles {
 		rows = append(rows, []string{r})
 	}
-	var table asciitable.Table
-	table = asciitable.MakeTable(tableColumns, rows...)
+	table := asciitable.MakeTable(tableColumns, rows...)
 	table.SortRowsBy([]int{0}, true)
 	if _, err := table.AsBuffer().WriteTo(w); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR is an attempt to address:
- https://github.com/gravitational/teleport/issues/7693

I'm leaving it as draft to get some feedback before I write any tests.

The changes improve error messages when a user can't request a role, or when they try to request a resource and specify a role at the same time.

I'm not 100% in favor of putting this behind `tsh request search --kind=role` since it's not a "resource" like every other `--kind`, but I also don't like `tsh request roles` for listing requestable roles since that sounds like a command for actually requesting roles instead of listing them.

The main reason I don't like putting it under `tsh request search --kind=role` is that most of the other search flags are irrelevant to it, e.g. the labels and query flags. I guess we could add support for those too, but I don't see the use-case for it.

I also decided not to list all requestable roles on an error in `tsh request create --roles=<some not allowed role>`, because I don't want to make that command automatically spam their screen with info every time. Instead, I just added a hint for how they can list their requestable roles.
Same reasoning for `tsh status`/`tsh login` - although I didn't add a hint there.

## Examples:
user "alice" has "requester" role, which has this spec:
```yaml
spec:
  allow:
    request:
      roles:
      - access
      - editor
      - auditor
      search_as_roles:
      - access-nodes
```

```
$ tsh request create --resource /mars.internal/node/7de365b5-1825-4436-ba6b-e0ae4f9ef2b1 --roles=access
Creating request...
ERROR: user "alice" cannot search for resources as role "access"
```
```
$ tsh request create --roles=admin
Creating request...
ERROR: user "alice" cannot request role "admin"

To see requestable roles, run
> tsh request search --kind=role
```
```
$ tsh request search --kind=role
Requestable Roles 
----------------- 
access            
auditor           
editor            

To request access, run
> tsh request create --roles=<role>
```

## TODO

1. If reviewers like this change I'll update the docs/references for `tsh request search` as well.
2. tests