### PR TITLE
[v13] oci: Parameterize Debian OCI Dockerfile for multiarch

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -1,12 +1,6 @@
 # Stage to build the image, without FIPS entrypoint argument
 FROM ubuntu:20.04 AS teleport
 
-# Copy the deb archive
-ARG DEB_PATH
-ARG DEB_BASE
-ARG TARGETARCH
-COPY ${DEB_PATH:-${DEB_BASE}_${TARGETARCH}.deb} /tmp/teleport.deb
-
 # Install dumb-init and ca-certificates. The dumb-init package is to ensure
 # signals and orphaned processes are are handled correctly. The ca-certificate
 # package is installed because the base Ubuntu image does not come with any
@@ -52,12 +46,25 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y net-tools iputils-ping inetutils-telnet netcat tcpdump busybox && \
     busybox --install -s && \
     update-ca-certificates && \
-    # Install Teleport
-    dpkg -i /tmp/teleport.deb && \
     # Cleanup
     apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/*
+    rm -rf /var/lib/apt/lists/*
+
+# DEB_PATH speficies the path to the Teleport .deb file under
+# the build context. If not specified, DEB_BASE specifies the path
+# prefix to the Teleport .deb file without the architecture and
+# `.deb` on the end. DEB_BASE is used for multi-architecture builds.
+# DEB_PATH is deprecated and will be removed.
+ARG DEB_PATH
+ARG DEB_BASE
+ARG TARGETARCH
+
+# Note --mount=target=/ctx which mounts the docker build context on /ctx
+# providing access to the .deb file to install without needing to COPY it
+# in, saving space in the image.
+RUN --mount=target=/ctx \
+    # Install Teleport
+    dpkg -i /ctx/${DEB_PATH:-${DEB_BASE}_${TARGETARCH}.deb}
 
 # Used to track whether a Teleport agent was installed using this method.
 ENV TELEPORT_INSTALL_METHOD_DOCKERFILE=true

--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -3,7 +3,9 @@ FROM ubuntu:20.04 AS teleport
 
 # Copy the deb archive
 ARG DEB_PATH
-COPY ${DEB_PATH?} /tmp/teleport.deb
+ARG DEB_BASE
+ARG TARGETARCH
+COPY ${DEB_PATH:-${DEB_BASE}_${TARGETARCH}.deb} /tmp/teleport.deb
 
 # Install dumb-init and ca-certificates. The dumb-init package is to ensure
 # signals and orphaned processes are are handled correctly. The ca-certificate


### PR DESCRIPTION
Parameterize the Debian OCI Dockerfile to take a `.deb` filename without
an architecture so we can use `${TARGETARCH}` in a multi-architecture
build. `${DEB_PATH}` still has precedence, but if not specified,
`${DEB_BASE}` can be provided to specify the `.deb` file to install into
the image without the architecture or `.deb` suffix.

This also fixes the `${DEB_PATH?}` expansion which is not a valid
expansion in a Dockerfile.

With this change, a multi-architecture image can be built with

    docker buildx build --platform p1,p2,p3 \
      --build-arg DEB_BASE=teleport-ent-v1.2.3 \
      ...

and docker will set `${TARGETARCH}` to the architecture of each of the
platforms `p1`, `p2` and `p3` as it builds each, having us install the
correct architecture of teleport `.deb` file.

Issue: https://github.com/gravitational/teleport/issues/20729
Backport: https://github.com/gravitational/teleport/pull/33949