### PR TITLE
[v14] Move bulk actions to Filter Panel

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { ButtonBorder, ButtonPrimary, ButtonSecondary } from 'design/Button';
 import { SortDir } from 'design/DataTable/types';
-import { Text, Flex } from 'design';
+import { Text, Flex, Box } from 'design';
 import Menu, { MenuItem } from 'design/Menu';
 import { StyledCheckbox } from 'design/Checkbox';
 import { ArrowUp, ArrowDown, ChevronDown } from 'design/Icon';
@@ -46,7 +46,7 @@ interface FilterPanelProps {
   setParams: (params: UnifiedResourcesQueryParams) => void;
   selectVisible: () => void;
   selected: boolean;
-  shouldUnpin: boolean;
+  BulkActions?: React.ReactElement;
 }
 
 export function FilterPanel({
@@ -55,7 +55,7 @@ export function FilterPanel({
   setParams,
   selectVisible,
   selected,
-  shouldUnpin,
+  BulkActions,
 }: FilterPanelProps) {
   const { sort, kinds } = params;
 
@@ -76,10 +76,16 @@ export function FilterPanel({
   };
 
   return (
-    <Flex mb={2} justifyContent="space-between">
+    // minHeight is set to 32px so there isn't layout shift when a bulk action button shows up
+    <Flex
+      mb={2}
+      justifyContent="space-between"
+      minHeight="32px"
+      alignItems="center"
+    >
       <Flex gap={2}>
         <HoverTooltip
-          tipContent={<>{shouldUnpin ? 'Deselect all' : 'Select all'}</>}
+          tipContent={<>{selected ? 'Deselect all' : 'Select all'}</>}
         >
           <StyledCheckbox checked={selected} onChange={selectVisible} />
         </HoverTooltip>
@@ -89,12 +95,15 @@ export function FilterPanel({
           kindsFromParams={kinds || []}
         />
       </Flex>
-      <SortMenu
-        onDirChange={onSortOrderButtonClicked}
-        onChange={onSortFieldChange}
-        sortType={activeSortFieldOption.label}
-        sortDir={sort.dir}
-      />
+      <Flex alignItems="center">
+        <Box mr={4}>{BulkActions}</Box>
+        <SortMenu
+          onDirChange={onSortOrderButtonClicked}
+          onChange={onSortFieldChange}
+          sortType={activeSortFieldOption.label}
+          sortDir={sort.dir}
+        />
+      </Flex>
     </Flex>
   );
 }

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import { ButtonBorder, Flex } from 'design';
+import { ButtonBorder } from 'design';
 
 import { apps } from 'teleport/Apps/fixtures';
 import { databases } from 'teleport/Databases/fixtures';
@@ -88,11 +88,6 @@ const story = ({
           'kube_cluster',
           'windows_desktop',
         ]}
-        Header={pinAllButton => (
-          <Flex justifyContent="end" height="50px">
-            {pinAllButton}
-          </Flex>
-        )}
         params={params}
         setParams={() => undefined}
         pinning={pinning}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -23,10 +23,10 @@ import {
   ButtonLink,
   ButtonSecondary,
   Text,
-  ButtonBorder,
   Popover,
+  ButtonBorder,
 } from 'design';
-import { Magnifier, PushPin } from 'design/Icon';
+import { Icon, Magnifier, PushPin } from 'design/Icon';
 import { Danger } from 'design/Alert';
 
 import './unifiedStyles.css';
@@ -100,14 +100,38 @@ export type UnifiedResourcesPinning =
       kind: 'hidden';
     };
 
+/*
+ * BulkAction describes a component that allows you to perform an action
+ * on multiple selected resources
+ */
+type BulkAction = {
+  /*
+   * key is an arbitrary name of what the bulk action is, as well
+   * as the key used when mapping our action components
+   */
+  key: string;
+  Icon: typeof Icon;
+  text: string;
+  disabled?: boolean;
+  /*
+   * a tooltip will be rendered when the action is hovered
+   * over if this prop is supplied
+   */
+  tooltip?: string;
+  action: (
+    selectedResources: {
+      unifiedResourceId: string;
+      resource: SharedUnifiedResource['resource'];
+    }[]
+  ) => void;
+};
+
 interface UnifiedResourcesProps {
   params: UnifiedResourcesQueryParams;
   resourcesFetchAttempt: Attempt;
   fetchResources(options?: { force?: boolean }): Promise<void>;
   resources: SharedUnifiedResource[];
-  //TODO(gzdunek): the pin button should be moved to some other place
-  //according to the new designs
-  Header(pinAllButton: React.ReactElement): React.ReactElement;
+  Header?: React.ReactElement;
   /**
    * Typically used to inform the user that there are no matching resources when
    * they want to list resources without filtering the list with a search query.
@@ -122,6 +146,8 @@ interface UnifiedResourcesProps {
   availableKinds: SharedUnifiedResource['resource']['kind'][];
   setParams(params: UnifiedResourcesQueryParams): void;
   onLabelClick(label: ResourceLabel): void;
+  /** A list of actions that can be performed on the selected items. */
+  bulkActions?: BulkAction[];
   updateUnifiedResourcesPreferences(
     preferences: UnifiedResourcePreferences
   ): void;
@@ -138,6 +164,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     availableKinds,
     pinning,
     updateUnifiedResourcesPreferences,
+    bulkActions = [],
   } = props;
 
   const { setTrigger } = useInfiniteScroll({
@@ -242,8 +269,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
 
   const allSelected =
     resources.length > 0 &&
-    resources.every(resource =>
-      selectedResources.includes(generateResourceKey(resource))
+    resources.every(({ resource }) =>
+      selectedResources.includes(generateUnifiedResourceKey(resource))
     );
 
   const toggleSelectVisible = () => {
@@ -252,7 +279,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
       return;
     }
     setSelectedResources(
-      resources.map(resource => generateResourceKey(resource))
+      resources.map(({ resource }) => generateUnifiedResourceKey(resource))
     );
   };
 
@@ -267,21 +294,39 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     updateUnifiedResourcesPreferences({ defaultTab: value });
   };
 
-  const $pinAllButton = (
-    <ButtonBorder
-      onClick={() => handlePinSelected(shouldUnpin)}
-      textTransform="none"
-      disabled={pinning.kind === 'not-supported'}
-      css={`
-        border: none;
-        color: ${props => props.theme.colors.brand};
-      `}
-    >
-      <PushPin color="brand" size={16} mr={2} />
-      {shouldUnpin ? 'Unpin ' : 'Pin '}
-      Selected
-    </ButtonBorder>
-  );
+  const getSelectedResources = () => {
+    return resources
+      .filter(({ resource }) =>
+        selectedResources.includes(generateUnifiedResourceKey(resource))
+      )
+      .map(({ resource }) => ({
+        resource: resource,
+        unifiedResourceId: generateUnifiedResourceKey(resource),
+      }));
+  };
+
+  const bulkActionsAndPinning = (): BulkAction[] => {
+    if (pinning.kind === 'hidden') {
+      return bulkActions;
+    }
+
+    return [
+      ...bulkActions,
+      {
+        key: 'pin_resource',
+        text: shouldUnpin ? 'Unpin Selected' : 'Pin Selected',
+        Icon: PushPin,
+        tooltip:
+          pinning.kind !== 'not-supported'
+            ? PINNING_NOT_SUPPORTED_MESSAGE
+            : null,
+        disabled:
+          pinning.kind === 'not-supported' ||
+          updatePinnedResourcesAttempt.status === 'processing',
+        action: () => handlePinSelected(shouldUnpin),
+      },
+    ];
+  };
 
   return (
     <div
@@ -317,26 +362,48 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
           <Danger>{updatePinnedResourcesAttempt.statusText}</Danger>
         </ErrorBox>
       )}
-      {props.Header(
-        <>
-          {selectedResources.length > 0 &&
-            pinning.kind !== 'hidden' &&
-            (pinning.kind === 'not-supported' ? (
-              <HoverTooltip tipContent={<>{PINNING_NOT_SUPPORTED_MESSAGE}</>}>
-                {$pinAllButton}
-              </HoverTooltip>
-            ) : (
-              $pinAllButton
-            ))}
-        </>
-      )}
+      {props.Header}
       <FilterPanel
         params={params}
         setParams={setParams}
         availableKinds={availableKinds}
         selectVisible={toggleSelectVisible}
         selected={allSelected}
-        shouldUnpin={shouldUnpin}
+        BulkActions={
+          <>
+            {selectedResources.length > 0 && (
+              <>
+                {bulkActionsAndPinning().map(
+                  ({ key, Icon, text, action, tooltip, disabled = false }) => {
+                    const $button = (
+                      <ButtonBorder
+                        key={key}
+                        textTransform="none"
+                        onClick={() => action(getSelectedResources())}
+                        disabled={disabled}
+                        css={`
+                          border: none;
+                          color: ${props => props.theme.colors.brand};
+                        `}
+                      >
+                        <Icon size="small" color="brand" mr={2} />
+                        {text}
+                      </ButtonBorder>
+                    );
+                    if (tooltip) {
+                      return (
+                        <HoverTooltip tipContent={<>{tooltip}</>}>
+                          {$button}
+                        </HoverTooltip>
+                      );
+                    }
+                    return $button;
+                  }
+                )}
+              </>
+            )}
+          </>
+        }
       />
       {pinning.kind !== 'hidden' && (
         <Flex gap={4} mb={3}>
@@ -365,7 +432,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
           {resources
             .map(unifiedResource => ({
               card: mapResourceToCard(unifiedResource),
-              key: generateResourceKey(unifiedResource),
+              key: generateUnifiedResourceKey(unifiedResource.resource),
             }))
             .map(({ card, key }) => (
               <ResourceCard
@@ -445,7 +512,9 @@ function getResourcePinningSupport(
   return PinningSupport.Supported;
 }
 
-function generateResourceKey({ resource }: SharedUnifiedResource): string {
+export function generateUnifiedResourceKey(
+  resource: SharedUnifiedResource['resource']
+): string {
   if (resource.kind === 'node') {
     return `${resource.hostname}/${resource.id}/node`.toLowerCase();
   }

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -112,6 +112,8 @@ export function TopBar({ hidePopup = false }: TopBarProps) {
     // When we switch clusters (to leaf or root), we remove the item and perform the check again by pushing
     // to the resource (new default view).
     window.localStorage.removeItem(KeysEnum.UNIFIED_RESOURCES_NOT_SUPPORTED);
+    // we also need to reset the pinned resources flag when we switch clusters to try again
+    window.localStorage.removeItem(KeysEnum.PINNED_RESOURCES_NOT_SUPPORTED);
     const legacyResourceRoutes = [
       cfg.getNodesRoute(clusterId),
       cfg.getAppsRoute(clusterId),

--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -54,6 +54,7 @@ export type ResourceFilter = {
   limit?: number;
   startKey?: string;
   pinnedOnly?: boolean;
+  searchAsRoles?: '' | 'yes';
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
 };

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -16,7 +16,6 @@
 
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
-import history from 'teleport/services/history';
 
 import { UnifiedResource, ResourcesResponse } from '../agents';
 import { KeysEnum } from '../localStorage';
@@ -60,7 +59,6 @@ class ResourceService {
             KeysEnum.UNIFIED_RESOURCES_NOT_SUPPORTED,
             'true'
           );
-          history.replace(cfg.getNodesRoute(clusterId));
         }
         throw res;
       });

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -461,5 +461,5 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
 }
 
 export type PendingAccessRequest = {
-  [k in ResourceKind]: Record<string, string>;
+  [k in Exclude<ResourceKind, 'resource'>]: Record<string, string>;
 };


### PR DESCRIPTION
Backport #34049 
Not a clean backport as I had to remove the changes made to `DocumentCluster` because Connect doesn't have the unified view in v14