### PR TITLE
Always prefer multiplex port if Kube Proxy endpoint is specified

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -858,7 +858,7 @@ func (c *Config) ParseProxyHost(proxyHost string) error {
 
 // KubeProxyHostPort returns the host and port of the Kubernetes proxy.
 func (c *Config) KubeProxyHostPort() (string, int) {
-	if c.KubeProxyAddr != "" {
+	if c.KubeProxyAddr != "" && !c.TLSRoutingEnabled {
 		addr, err := utils.ParseAddr(c.KubeProxyAddr)
 		if err == nil {
 			return addr.Host(), addr.Port(defaults.KubeListenPort)

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -501,8 +501,9 @@ func isKubectlConfigCommand(kubectlCommand *cobra.Command, args []string) bool {
 
 func kubeClusterAddrFromProfile(profile *profile.Profile) string {
 	partialClientConfig := client.Config{
-		WebProxyAddr:  profile.WebProxyAddr,
-		KubeProxyAddr: profile.KubeProxyAddr,
+		WebProxyAddr:      profile.WebProxyAddr,
+		KubeProxyAddr:     profile.KubeProxyAddr,
+		TLSRoutingEnabled: profile.TLSRoutingEnabled,
 	}
 	return partialClientConfig.KubeClusterAddr()
 }


### PR DESCRIPTION
This PR changes the default behavior of `tsh login -f kubeconfig -o ./kubeconfig --kube-cluster <kube_cluster>` to prefer the multiplex port instead of the Kubernetes public address if specified. 


Changelog: Always prefer multiplex port for Kubernetes Access