### PR TITLE
Enable testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    - testifylint
     - unconvert
     - unused
 
@@ -71,6 +72,18 @@ linters-settings:
     rules:
     - name: unused-parameter
       disabled: true
+  testifylint:
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - float-compare
+      - len
+      - suite-extra-assert-call
+      - suite-thelper
 
 output:
   uniq-by-line: false

--- a/api/client/alpn_conn_upgrade_test.go
+++ b/api/client/alpn_conn_upgrade_test.go
@@ -233,8 +233,8 @@ func mustReadConnData(t *testing.T, conn net.Conn, wantText string) {
 	data := make([]byte, len(wantText)*2)
 	n, err := conn.Read(data)
 	require.NoError(t, err)
-	require.Equal(t, len(wantText), n)
-	require.Equal(t, string(data[:n]), wantText)
+	require.Len(t, wantText, n)
+	require.Equal(t, wantText, string(data[:n]))
 }
 
 type mockALPNServer struct {

--- a/api/client/proxy/client_test.go
+++ b/api/client/proxy/client_test.go
@@ -397,12 +397,12 @@ func TestClient_DialHost(t *testing.T) {
 				msg := []byte("hello123")
 				n, err := conn.Write(msg)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 
 				out := make([]byte, len(msg))
 				n, err = conn.Read(out)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 				require.Equal(t, msg, out)
 
 				require.NoError(t, conn.Close())

--- a/api/client/proxy/transport/transportv1/client_test.go
+++ b/api/client/proxy/transport/transportv1/client_test.go
@@ -192,12 +192,12 @@ func TestClient_DialCluster(t *testing.T) {
 				msg := []byte("hello")
 				n, err := conn.Write(msg)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 
 				out := make([]byte, n)
 				n, err = conn.Read(out)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 				require.Equal(t, msg, out)
 
 				require.NoError(t, conn.Close())
@@ -407,7 +407,7 @@ func TestClient_DialHost(t *testing.T) {
 				msg := []byte("hello")
 				n, err := conn.Write(msg)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 
 				out := make([]byte, 10)
 				n, err = conn.Read(out)
@@ -428,12 +428,12 @@ func TestClient_DialHost(t *testing.T) {
 				msg := []byte("hello")
 				n, err := conn.Write(msg)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 
 				out := make([]byte, n)
 				n, err = conn.Read(out)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 				require.Equal(t, msg, out)
 
 				n, err = conn.Read(out)
@@ -457,13 +457,13 @@ func TestClient_DialHost(t *testing.T) {
 				msg := []byte("hello")
 				n, err := conn.Write(msg)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 
 				// read data via ssh frames
 				out := make([]byte, n)
 				n, err = conn.Read(out)
 				require.NoError(t, err)
-				require.Equal(t, len(msg), n)
+				require.Len(t, msg, n)
 				require.Equal(t, msg, out)
 
 				// get the keys from our local keyring
@@ -479,7 +479,7 @@ func TestClient_DialHost(t *testing.T) {
 				out = make([]byte, len(keys[0].Blob))
 				n, err = conn.Read(out)
 				require.NoError(t, err)
-				require.Equal(t, len(keys[0].Blob), n)
+				require.Len(t, keys[0].Blob, n)
 				require.Equal(t, keys[0].Blob, out)
 
 				// close the stream

--- a/api/internalutils/stream/stream_test.go
+++ b/api/internalutils/stream/stream_test.go
@@ -43,7 +43,7 @@ func TestSlice(t *testing.T) {
 	// nil slice
 	s, err = Collect(Slice[int](nil))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 }
 
 // TestFilterMap tests the FilterMap combinator.
@@ -75,12 +75,12 @@ func TestFilterMap(t *testing.T) {
 		return "", false
 	}))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// empty stream
 	s, err = Collect(FilterMap(Empty[int](), func(_ int) (string, bool) { panic("unreachable") }))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// failure
 	err = Drain(FilterMap(Fail[int](fmt.Errorf("unexpected error")), func(_ int) (string, bool) { panic("unreachable") }))
@@ -116,12 +116,12 @@ func TestMapWhile(t *testing.T) {
 		return "", false
 	}))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// empty stream
 	s, err = Collect(MapWhile(Empty[int](), func(_ int) (string, bool) { panic("unreachable") }))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// failure
 	err = Drain(MapWhile(Fail[int](fmt.Errorf("unexpected error")), func(_ int) (string, bool) { panic("unreachable") }))
@@ -161,7 +161,7 @@ func TestFunc(t *testing.T) {
 		return 0, io.EOF
 	}))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// immediate error
 	err = Drain(Func(func() (int, error) {
@@ -229,7 +229,7 @@ func TestPageFunc(t *testing.T) {
 		return nil, io.EOF
 	}))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// lots of empty pages
 	n = 0
@@ -262,7 +262,7 @@ func TestPageFunc(t *testing.T) {
 		return nil, nil
 	}))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// eventual failure
 	n = 0
@@ -290,17 +290,17 @@ func TestEmpty(t *testing.T) {
 	// empty case
 	s, err := Collect(Empty[int]())
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// normal error case
 	s, err = Collect(Fail[int](fmt.Errorf("unexpected error")))
 	require.Error(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 
 	// nil error case
 	s, err = Collect(Fail[int](nil))
 	require.NoError(t, err)
-	require.Len(t, s, 0)
+	require.Empty(t, s)
 }
 
 func TestCollectPages(t *testing.T) {
@@ -357,7 +357,7 @@ func TestCollectPages(t *testing.T) {
 				require.Error(t, err)
 			}
 			if len(tt.expect) == 0 {
-				require.Len(t, collected, 0)
+				require.Empty(t, collected)
 			} else {
 				require.Equal(t, tt.expect, collected)
 			}

--- a/api/types/cluster_alert_test.go
+++ b/api/types/cluster_alert_test.go
@@ -171,7 +171,7 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 			err := tc.ack.Check()
 
 			if tc.expectedErr == nil {
-				require.Equal(t, err, nil)
+				require.NoError(t, err)
 				return
 			}
 

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -153,6 +153,6 @@ func TestTrimN(t *testing.T) {
 
 	const maxLen = 20
 	for _, test := range tests {
-		require.Equal(t, trimN(test.have, maxLen), test.want)
+		require.Equal(t, test.want, trimN(test.have, maxLen))
 	}
 }

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -474,7 +474,7 @@ func TestResourcesWithLabels_ToMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.r.ToMap(), tt.want)
+			require.Equal(t, tt.want, tt.r.ToMap())
 		})
 	}
 }

--- a/api/types/saml_test.go
+++ b/api/types/saml_test.go
@@ -31,13 +31,13 @@ func TestSAMLSecretsStrip(t *testing.T) {
 		SigningKeyPair:           &AsymmetricKeyPair{PrivateKey: "test"},
 		EncryptionKeyPair:        &AsymmetricKeyPair{PrivateKey: "test"},
 	})
-	require.Nil(t, err)
-	require.Equal(t, connector.GetSigningKeyPair().PrivateKey, "test")
-	require.Equal(t, connector.GetEncryptionKeyPair().PrivateKey, "test")
+	require.NoError(t, err)
+	require.Equal(t, "test", connector.GetSigningKeyPair().PrivateKey)
+	require.Equal(t, "test", connector.GetEncryptionKeyPair().PrivateKey)
 
 	withoutSecrets := connector.WithoutSecrets().(*SAMLConnectorV2)
-	require.Equal(t, withoutSecrets.GetSigningKeyPair().PrivateKey, "")
-	require.Equal(t, withoutSecrets.GetEncryptionKeyPair().PrivateKey, "")
+	require.Empty(t, withoutSecrets.GetSigningKeyPair().PrivateKey)
+	require.Empty(t, withoutSecrets.GetEncryptionKeyPair().PrivateKey)
 }
 
 // TestSAMLAcsUriHasConnector tests that the ACS URI has the connector ID as the last part if IdP-initiated login is enabled.

--- a/api/types/userloginstate/convert/v1/user_login_state_test.go
+++ b/api/types/userloginstate/convert/v1/user_login_state_test.go
@@ -66,7 +66,7 @@ func TestFromProtoNils(t *testing.T) {
 
 	fromProto, err := FromProto(uls)
 	require.NoError(t, err)
-	require.Equal(t, fromProto.GetUserType(), types.UserTypeLocal)
+	require.Equal(t, types.UserTypeLocal, fromProto.GetUserType())
 }
 
 func newUserLoginState(t *testing.T, name string) *userloginstate.UserLoginState {

--- a/api/utils/aws/ec2_test.go
+++ b/api/utils/aws/ec2_test.go
@@ -58,7 +58,7 @@ func TestIsEC2NodeID(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, IsEC2NodeID(tc.id), tc.expected)
+			assert.Equal(t, tc.expected, IsEC2NodeID(tc.id))
 		})
 	}
 }

--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -449,7 +449,7 @@ func TestCassandraEndpointRegion(t *testing.T) {
 				require.False(t, IsKeyspacesEndpoint(test.inputURI))
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, got, test.wantRegion)
+				require.Equal(t, test.wantRegion, got)
 				require.True(t, IsKeyspacesEndpoint(test.inputURI))
 			}
 		})

--- a/api/utils/grpc/interceptors/errors_test.go
+++ b/api/utils/grpc/interceptors/errors_test.go
@@ -75,7 +75,7 @@ func TestGRPCErrorWrapping(t *testing.T) {
 		resp, err := client.Ping(context.Background(), &proto.PingRequest{})
 		require.Nil(t, resp)
 		require.True(t, trace.IsNotFound(err))
-		require.Equal(t, err.Error(), "not found")
+		require.Equal(t, "not found", err.Error())
 		_, ok := err.(*trace.TraceErr)
 		require.False(t, ok, "client error should not include traces originating in the middleware")
 	})
@@ -98,7 +98,7 @@ func TestGRPCErrorWrapping(t *testing.T) {
 
 		_, err = stream.Recv()
 		require.True(t, trace.IsAlreadyExists(err))
-		require.Equal(t, err.Error(), "already exists")
+		require.Equal(t, "already exists", err.Error())
 		_, ok := err.(*trace.TraceErr)
 		require.False(t, ok, "client error should not include traces originating in the middleware")
 	})

--- a/api/utils/grpc/stream/stream_test.go
+++ b/api/utils/grpc/stream/stream_test.go
@@ -79,14 +79,14 @@ func TestReadWriter_Write(t *testing.T) {
 		defer wg.Done()
 		n, err := streamConn.Write(data)
 		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
+		assert.Len(t, data, n)
 	}()
 	go func() {
 		defer wg.Done()
 		b := make([]byte, 2*MaxChunkSize)
 		n, err := local.Read(b)
 		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
+		assert.Len(t, data, n)
 		assert.Equal(t, data, b[:n])
 	}()
 
@@ -103,7 +103,7 @@ func TestReadWriter_WriteChunk(t *testing.T) {
 		defer wg.Done()
 		n, err := streamConn.Write(data)
 		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
+		assert.Len(t, data, n)
 	}()
 	go func() {
 		defer wg.Done()
@@ -133,14 +133,14 @@ func TestReadWriter_Read(t *testing.T) {
 		defer wg.Done()
 		n, err := streamConn.Read(b)
 		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
+		assert.Len(t, data, n)
 		assert.Equal(t, data, b[:n])
 	}()
 	go func() {
 		defer wg.Done()
 		n, err := local.Write(data)
 		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
+		assert.Len(t, data, n)
 	}()
 
 	wg.Wait()

--- a/api/utils/prompt/confirmation_test.go
+++ b/api/utils/prompt/confirmation_test.go
@@ -41,14 +41,14 @@ func TestInput(t *testing.T) {
 		go write(t, "hi")
 		got, err := Input(ctx, io.Discard, r, "")
 		require.NoError(t, err)
-		require.Equal(t, got, "hi")
+		require.Equal(t, "hi", got)
 	})
 
 	t.Run("with whitespace", func(t *testing.T) {
 		go write(t, "hey\n")
 		got, err := Input(ctx, io.Discard, r, "")
 		require.NoError(t, err)
-		require.Equal(t, got, "hey")
+		require.Equal(t, "hey", got)
 	})
 
 	t.Run("closed input", func(t *testing.T) {

--- a/api/utils/prompt/context_reader_test.go
+++ b/api/utils/prompt/context_reader_test.go
@@ -46,7 +46,7 @@ func TestContextReader(t *testing.T) {
 		go write(t, "hello")
 		buf, err := cr.ReadContext(ctx)
 		require.NoError(t, err)
-		require.Equal(t, string(buf), "hello")
+		require.Equal(t, "hello", string(buf))
 	})
 
 	t.Run("reclaim abandoned read", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestContextReader(t *testing.T) {
 		<-done // wait for write
 		buf, err = cr.ReadContext(ctx)
 		require.NoError(t, err)
-		require.Equal(t, string(buf), "after cancel")
+		require.Equal(t, "after cancel", string(buf))
 	})
 
 	t.Run("close ContextReader", func(t *testing.T) {
@@ -102,7 +102,7 @@ func TestContextReader(t *testing.T) {
 		// Read the last chunk of data successfully.
 		buf, err := cr.ReadContext(ctx)
 		require.NoError(t, err)
-		require.Equal(t, string(buf), "before close")
+		require.Equal(t, "before close", string(buf))
 
 		// Next read fails because underlying reader is closed.
 		buf, err = cr.ReadContext(ctx)

--- a/api/utils/retryutils/retry_test.go
+++ b/api/utils/retryutils/retry_test.go
@@ -47,17 +47,17 @@ func TestLinearV2(t *testing.T) {
 }
 
 func testLinear(t *testing.T, r Retry) {
-	require.Equal(t, r.Duration(), time.Duration(0))
+	require.Equal(t, time.Duration(0), r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), time.Second)
+	require.Equal(t, time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 2*time.Second)
+	require.Equal(t, 2*time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 3*time.Second)
+	require.Equal(t, 3*time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 3*time.Second)
+	require.Equal(t, 3*time.Second, r.Duration())
 	r.Reset()
-	require.Equal(t, r.Duration(), time.Duration(0))
+	require.Equal(t, time.Duration(0), r.Duration())
 }
 
 func TestExponential(t *testing.T) {
@@ -69,20 +69,20 @@ func TestExponential(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, r.Duration(), time.Duration(0))
+	require.Equal(t, time.Duration(0), r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), time.Second)
+	require.Equal(t, time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 2*time.Second)
+	require.Equal(t, 2*time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 4*time.Second)
+	require.Equal(t, 4*time.Second, r.Duration())
 	r.Inc()
-	require.Equal(t, r.Duration(), 8*time.Second)
+	require.Equal(t, 8*time.Second, r.Duration())
 	r.Inc()
 	// should hit configured maximum
-	require.Equal(t, r.Duration(), 12*time.Second)
+	require.Equal(t, 12*time.Second, r.Duration())
 	r.Reset()
-	require.Equal(t, r.Duration(), time.Duration(0))
+	require.Equal(t, time.Duration(0), r.Duration())
 
 	// verify that exponentiation is capped s.t. we don't wrap
 	for i := 0; i < 128; i++ {

--- a/api/utils/sshutils/conn_test.go
+++ b/api/utils/sshutils/conn_test.go
@@ -133,7 +133,7 @@ func TestTransportError(t *testing.T) {
 	t.Cleanup(func() { require.Error(t, sconn1.Close()) })
 
 	channel := <-nc
-	require.Equal(t, channel.ChannelType(), constants.ChanTransport)
+	require.Equal(t, constants.ChanTransport, channel.ChannelType())
 
 	sconn1.Close()
 	err := timeoutErrC(t, handlerErrC, time.Second*5)
@@ -143,7 +143,7 @@ func TestTransportError(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, sconn2.Close()) })
 
 	channel = <-nc
-	require.Equal(t, channel.ChannelType(), constants.ChanTransport)
+	require.Equal(t, constants.ChanTransport, channel.ChannelType())
 
 	err = channel.Reject(ssh.ConnectionFailed, "test reject")
 	require.NoError(t, err)

--- a/api/utils/user_test.go
+++ b/api/utils/user_test.go
@@ -33,7 +33,7 @@ func TestCurrentUser(t *testing.T) {
 		return nil, nil
 	}, 10*time.Millisecond)
 	require.Nil(t, u)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.True(t, trace.IsLimitExceeded(err))
 
 	u, err = currentUser(func() (*user.User, error) {

--- a/build.assets/tooling/cmd/difftest/ast_test.go
+++ b/build.assets/tooling/cmd/difftest/ast_test.go
@@ -64,10 +64,11 @@ func TestFindAllSuiteRunners(t *testing.T) {
 	runners, err := findAllSuiteRunners(".", []string{filepath.Join("testdata", "ast", "head", "testify_single_suite_b_test.go")})
 	require.NoError(t, err)
 
-	require.Equal(t, runners[filepath.Join("testdata", "ast", "head")], map[string]string{
+	expected := map[string]string{
 		"JiraSuite":   "TestJira",
 		"SingleSuite": "TestSingleSuite",
-	})
+	}
+	require.Equal(t, expected, runners[filepath.Join("testdata", "ast", "head")])
 }
 
 func TestParseASTTestifySuiteMulti(t *testing.T) {

--- a/build.assets/tooling/cmd/difftest/compare_test.go
+++ b/build.assets/tooling/cmd/difftest/compare_test.go
@@ -36,6 +36,6 @@ func TestChangedMethods(t *testing.T) {
 	assert.True(t, r.HasNew())
 	assert.True(t, r.HasChanged())
 
-	assert.Equal(t, r.New, []Method{{Name: "TestFourth", SHA1: "035a07a1e38e5387cd682b2c6b37114d187fa3d2", RefName: "TestFourth"}})
-	assert.Equal(t, r.Changed, []Method{{Name: "TestFirst", SHA1: "f045d205e581369b1c7c4148086c838c710f97c8", RefName: "TestFirst"}})
+	assert.Equal(t, []Method{{Name: "TestFourth", SHA1: "035a07a1e38e5387cd682b2c6b37114d187fa3d2", RefName: "TestFourth"}}, r.New)
+	assert.Equal(t, []Method{{Name: "TestFirst", SHA1: "f045d205e581369b1c7c4148086c838c710f97c8", RefName: "TestFirst"}}, r.Changed)
 }

--- a/e2e/aws/eks_test.go
+++ b/e2e/aws/eks_test.go
@@ -100,7 +100,7 @@ func awsEKSDiscoveryMatchedCluster(t *testing.T) {
 			return false
 		}
 		// Fail fast if the discovery service creates more than one cluster.
-		assert.Equal(t, 1, len(clusters))
+		assert.Len(t, clusters, 1)
 		// Fail fast if the discovery service creates a cluster with a different name.
 		assert.Equal(t, os.Getenv(eksClusterNameEnv), clusters[0].GetName())
 		return true

--- a/integration/agent_forwarding_test.go
+++ b/integration/agent_forwarding_test.go
@@ -55,7 +55,7 @@ func TestAgentSocketPermissions(t *testing.T) {
 			// Update uid to nonroot
 			_, _, serr := syscall.Syscall(syscall.SYS_SETUID, 1000, 0, 0)
 			require.Zero(t, serr)
-			require.True(t, !isRoot())
+			require.False(t, isRoot())
 
 			err := unix.Unlink(agentServer.Path)
 			require.Error(t, err)

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -396,19 +396,19 @@ func testRewriteHeadersRoot(p *Pack, t *testing.T) {
 	// Dumper app just dumps HTTP request so we should be able to read it back.
 	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(resp)))
 	require.NoError(t, err)
-	require.Equal(t, req.Host, "example.com")
-	require.Equal(t, req.Header.Get("X-Teleport-Cluster"), "root")
-	require.Equal(t, req.Header.Get("X-External-Env"), "production")
-	require.Equal(t, req.Header.Get("X-Existing"), "rewritten-existing-header")
+	require.Equal(t, "example.com", req.Host)
+	require.Equal(t, "root", req.Header.Get("X-Teleport-Cluster"))
+	require.Equal(t, "production", req.Header.Get("X-External-Env"))
+	require.Equal(t, "rewritten-existing-header", req.Header.Get("X-Existing"))
 
 	// verify these headers were not rewritten.
-	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
-	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedHost), "rewritten-x-forwarded-host-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedProto), "rewritten-x-forwarded-proto-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedServer), "rewritten-x-forwarded-server-header")
-	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
+	require.NotEqual(t, "rewritten-app-jwt-header", req.Header.Get(teleport.AppJWTHeader))
+	require.NotEqual(t, "rewritten-x-teleport-api-error", req.Header.Get(common.TeleportAPIErrorHeader))
+	require.NotEqual(t, "rewritten-x-forwarded-for-header", req.Header.Get(reverseproxy.XForwardedFor))
+	require.NotEqual(t, "rewritten-x-forwarded-host-header", req.Header.Get(reverseproxy.XForwardedHost))
+	require.NotEqual(t, "rewritten-x-forwarded-proto-header", req.Header.Get(reverseproxy.XForwardedProto))
+	require.NotEqual(t, "rewritten-x-forwarded-server-header", req.Header.Get(reverseproxy.XForwardedServer))
+	require.NotEqual(t, "rewritten-x-forwarded-ssl", req.Header.Get(common.XForwardedSSL))
 
 	// Verify JWT tokens.
 	for _, header := range []string{teleport.AppJWTHeader, "X-JWT"} {
@@ -432,20 +432,20 @@ func testRewriteHeadersLeaf(p *Pack, t *testing.T) {
 	// Dumper app just dumps HTTP request so we should be able to read it back.
 	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(resp)))
 	require.NoError(t, err)
-	require.Equal(t, req.Host, "example.com")
-	require.Equal(t, req.Header.Get("X-Teleport-Cluster"), "leaf")
+	require.Equal(t, "example.com", req.Host)
+	require.Equal(t, "leaf", req.Header.Get("X-Teleport-Cluster"))
 	require.ElementsMatch(t, []string{"root", "ubuntu", "-teleport-internal-join"}, req.Header.Values("X-Teleport-Login"))
-	require.Equal(t, req.Header.Get("X-External-Env"), "production")
-	require.Equal(t, req.Header.Get("X-Existing"), "rewritten-existing-header")
+	require.Equal(t, "production", req.Header.Get("X-External-Env"))
+	require.Equal(t, "rewritten-existing-header", req.Header.Get("X-Existing"))
 
 	// verify these headers were not rewritten.
-	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
-	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
-	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedHost), "rewritten-x-forwarded-host-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedProto), "rewritten-x-forwarded-proto-header")
-	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedServer), "rewritten-x-forwarded-server-header")
+	require.NotEqual(t, "rewritten-app-jwt-header", req.Header.Get(teleport.AppJWTHeader))
+	require.NotEqual(t, "rewritten-x-teleport-api-error", req.Header.Get(common.TeleportAPIErrorHeader))
+	require.NotEqual(t, "rewritten-x-forwarded-ssl", req.Header.Get(common.XForwardedSSL))
+	require.NotEqual(t, "rewritten-x-forwarded-for-header", req.Header.Get(reverseproxy.XForwardedFor))
+	require.NotEqual(t, "rewritten-x-forwarded-host-header", req.Header.Get(reverseproxy.XForwardedHost))
+	require.NotEqual(t, "rewritten-x-forwarded-proto-header", req.Header.Get(reverseproxy.XForwardedProto))
+	require.NotEqual(t, "rewritten-x-forwarded-server-header", req.Header.Get(reverseproxy.XForwardedServer))
 }
 
 // testLogout verifies the session is removed from the backend when the user logs out.
@@ -504,7 +504,7 @@ func testNoHeaderOverrides(p *Pack, t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
 	origHeaders := strings.Split(origHeaderResp, "\n")
-	require.Equal(t, len(origHeaders), len(forwardedHeaderNames)+1)
+	require.Len(t, origHeaders, len(forwardedHeaderNames)+1)
 
 	// Construct HTTP request with custom headers.
 	req, err := http.NewRequest(http.MethodGet, p.assembleRootProxyURL("/"), nil)
@@ -521,7 +521,7 @@ func testNoHeaderOverrides(p *Pack, t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
 	newHeaders := strings.Split(newHeaderResp, "\n")
-	require.Equal(t, len(newHeaders), len(forwardedHeaderNames)+1)
+	require.Len(t, newHeaders, len(forwardedHeaderNames)+1)
 
 	// Headers sent to the application should not be affected.
 	for i := range forwardedHeaderNames {

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -245,7 +245,7 @@ func (p *Pack) initWebSession(t *testing.T) {
 	// Extract session cookie and bearer token.
 	require.Len(t, resp.Cookies(), 1)
 	cookie := resp.Cookies()[0]
-	require.Equal(t, cookie.Name, websession.CookieName)
+	require.Equal(t, websession.CookieName, cookie.Name)
 
 	p.webCookie = cookie.Value
 	p.webToken = csResp.Token

--- a/integration/assist/command_test.go
+++ b/integration/assist/command_test.go
@@ -369,7 +369,7 @@ func registerMockSSHNode(t *testing.T, ctx context.Context, sshAddr, testDir str
 	require.Eventually(t, helpers.FindNodeWithLabel(t, ctx, rc.Process.GetAuthServer(), "hello", "true"), time.Second*2, time.Millisecond*50)
 	nodes, err := rc.Process.GetAuthServer().GetNodes(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(nodes))
+	require.Len(t, nodes, 1)
 	return nodes[0]
 }
 

--- a/integration/helpers/web.go
+++ b/integration/helpers/web.go
@@ -96,7 +96,7 @@ func LoginWebClient(t *testing.T, host, username, password string) *WebClientPac
 	// Extract session cookie and bearer token.
 	require.Len(t, resp.Cookies(), 1)
 	cookie := resp.Cookies()[0]
-	require.Equal(t, cookie.Name, websession.CookieName)
+	require.Equal(t, websession.CookieName, cookie.Name)
 
 	webClient := &WebClientPack{
 		clt:         client,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2184,7 +2184,7 @@ func testDisconnectScenarios(t *testing.T, suite *integrationTestSuite) {
 				ss, err := waitForSessionToBeEstablished(timeoutCtx, defaults.Namespace, site)
 				require.NoError(t, err)
 				require.Len(t, ss, 1)
-				require.Nil(t, teleport.StopAuth(false))
+				require.NoError(t, teleport.StopAuth(false))
 			},
 		},
 	}
@@ -4857,7 +4857,7 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 
 	// should have no sessions in it to start with
 	sessions, _ := site.GetActiveSessionTrackers(ctx)
-	require.Len(t, sessions, 0)
+	require.Empty(t, sessions)
 
 	beforeSession := time.Now()
 
@@ -6890,7 +6890,7 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 		if event.Type != types.OpInit {
 			t.Fatalf("Unexpected event type.")
 		}
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 	case <-watcher.Done():
 		t.Fatal(watcher.Error())
 	}
@@ -6933,14 +6933,14 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 	// Get session start event
 	sessionStart, err := findEventInLog(main, events.SessionStartEvent)
 	require.NoError(t, err)
-	require.Equal(t, sessionStart.GetCode(), events.SessionStartCode)
-	require.Equal(t, sessionStart.HasField(accessRequestsKey), true)
+	require.Equal(t, events.SessionStartCode, sessionStart.GetCode())
+	require.True(t, sessionStart.HasField(accessRequestsKey))
 
 	val, found := sessionStart[accessRequestsKey]
-	require.Equal(t, found, true)
+	require.True(t, found)
 
 	result := strings.Contains(fmt.Sprintf("%v", val), accessRequestID)
-	require.Equal(t, result, true)
+	require.True(t, result)
 }
 
 func WaitForResource(t *testing.T, watcher types.Watcher, kind, name string) {
@@ -7384,7 +7384,7 @@ func testSessionStreaming(t *testing.T, suite *integrationTestSuite) {
 
 	api := teleport.GetSiteAPI(helpers.Site)
 	uploadStream, err := api.CreateAuditStream(ctx, sessionID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	generatedSession := eventstest.GenerateTestSession(eventstest.SessionParams{
 		PrintEvents: 100,
@@ -7398,7 +7398,7 @@ func testSessionStreaming(t *testing.T, suite *integrationTestSuite) {
 	}
 
 	err = uploadStream.Complete(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	start := time.Now()
 
 	// retry in case of error
@@ -7419,9 +7419,9 @@ outer:
 
 				receivedSession = append(receivedSession, event)
 			case <-ctx.Done():
-				require.Nil(t, ctx.Err())
+				require.NoError(t, ctx.Err())
 			case err := <-e:
-				require.Nil(t, err)
+				require.NoError(t, err)
 			case <-time.After(time.Minute * 5):
 				t.FailNow()
 			}

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1290,8 +1290,8 @@ func testKubeTransportProtocol(t *testing.T, suite *KubeSuite) {
 	resp1, err := client.Get(u.String())
 	require.NoError(t, err)
 	defer resp1.Body.Close()
-	require.Equal(t, resp1.StatusCode, 200)
-	require.Equal(t, resp1.Proto, "HTTP/1.1")
+	require.Equal(t, 200, resp1.StatusCode)
+	require.Equal(t, "HTTP/1.1", resp1.Proto)
 
 	// call proxy with an HTTP2 client
 	err = http2.ConfigureTransport(trans)
@@ -1300,8 +1300,8 @@ func testKubeTransportProtocol(t *testing.T, suite *KubeSuite) {
 	resp2, err := client.Get(u.String())
 	require.NoError(t, err)
 	defer resp2.Body.Close()
-	require.Equal(t, resp2.StatusCode, 200)
-	require.Equal(t, resp2.Proto, "HTTP/2.0")
+	require.Equal(t, 200, resp2.StatusCode)
+	require.Equal(t, "HTTP/2.0", resp2.Proto)
 
 	// stream succeeds with an h1 transport
 	command := kubeExecArgs{
@@ -1789,7 +1789,7 @@ func kubeJoinObserverWithSNISet(t *testing.T, tc *client.TeleportClient, telepor
 
 	sessions, err := teleport.Process.GetAuthServer().GetActiveSessionTrackers(context.Background())
 	require.NoError(t, err)
-	require.Greater(t, len(sessions), 0)
+	require.NotEmpty(t, sessions)
 
 	stream, err := kubeJoin(kube.ProxyConfig{
 		T:                   teleport,

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -749,7 +749,7 @@ func mustGetKubePod(t *testing.T, client *kubernetes.Clientset) {
 
 	resp, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, len(resp.Items), 3)
+	require.Len(t, resp.Items, 3)
 }
 
 func mustGetProfileName(t *testing.T, webProxyAddr string) string {

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -386,7 +386,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 
 	resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
+	require.Len(t, resp.Items, 3, "pods item length mismatch")
 
 	// Simulate how tsh uses a kube local proxy to send kube requests to
 	// Teleport Proxy with a L7 LB in front.
@@ -658,7 +658,7 @@ func TestKubePROXYProtocol(t *testing.T) {
 
 			resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
-			require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
+			require.Len(t, resp.Items, 3, "pods item length mismatch")
 		})
 	}
 }
@@ -783,7 +783,7 @@ func TestKubeIPPinning(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
+			require.Len(t, resp.Items, 3, "pods item length mismatch")
 		})
 	}
 }
@@ -1201,7 +1201,7 @@ func TestALPNSNIProxyDatabaseAccess(t *testing.T) {
 		require.Error(t, err)
 		var x509Err x509.CertificateInvalidError
 		require.ErrorAs(t, err, &x509Err)
-		require.Equal(t, x509Err.Reason, x509.Expired)
+		require.Equal(t, x509.Expired, x509Err.Reason)
 		require.Contains(t, x509Err.Detail, "is after")
 
 		// Open a new connection

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -373,5 +373,5 @@ func checkKubeconfigPathInCommandEnv(t *testing.T, daemonService *daemon.Service
 
 	cmd, err := daemonService.GetGatewayCLICommand(gw)
 	require.NoError(t, err)
-	require.Equal(t, cmd.Env, []string{"KUBECONFIG=" + wantKubeconfigPath})
+	require.Equal(t, []string{"KUBECONFIG=" + wantKubeconfigPath}, cmd.Env)
 }

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -174,7 +174,7 @@ func testListRootClustersReturnsLoggedInUser(t *testing.T, pack *dbhelpers.Datab
 	response, err := handler.ListRootClusters(context.Background(), &api.ListClustersRequest{})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(response.Clusters))
+	require.Len(t, response.Clusters, 1)
 	require.Equal(t, pack.Root.User.GetName(), response.Clusters[0].LoggedInUser.Name)
 }
 
@@ -684,7 +684,7 @@ func testCreatingAndDeletingConnectMyComputerToken(t *testing.T, pack *dbhelpers
 		if event.Type != types.OpInit {
 			t.Fatalf("Unexpected event type.")
 		}
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 	case <-watcher.Done():
 		t.Fatal(watcher.Error())
 	}

--- a/integrations/access/discord/discord_test.go
+++ b/integrations/access/discord/discord_test.go
@@ -298,8 +298,8 @@ func (s *DiscordSuite) TestMessagePosting() {
 
 	t.Logf("%q", messages[0].Text)
 	matches := requestReasonRegexp.FindAllStringSubmatch(messages[0].Text, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "because of "+strings.Repeat("A", 489), matches[0][1])
 	assert.Equal(t, " (truncated)", matches[0][2])
 

--- a/integrations/access/jira/jira_test.go
+++ b/integrations/access/jira/jira_test.go
@@ -360,7 +360,7 @@ func (s *JiraSuite) TestIssueCreationWithLargeRequestReason() {
 		t.Error("reason not found in issue description")
 		return
 	}
-	require.Equal(t, jiraReasonLimit, len(match[1]))
+	require.Len(t, match[1], jiraReasonLimit)
 }
 
 func (s *JiraSuite) TestReviewComments() {

--- a/integrations/access/mattermost/mattermost_test.go
+++ b/integrations/access/mattermost/mattermost_test.go
@@ -320,8 +320,8 @@ func (s *MattermostSuite) TestMattermostMessagePosting() {
 	assert.Equal(t, s.userNames.requestor, username)
 
 	matches := requestReasonRegexp.FindAllStringSubmatch(post.Message, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "because of "+strings.Repeat("A", 489), matches[0][1])
 	assert.Equal(t, " (truncated)", matches[0][2])
 
@@ -357,8 +357,8 @@ func (s *MattermostSuite) TestApproval() {
 	assert.Equal(t, "✅ APPROVED", statusLine)
 
 	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "okay", matches[0][1])
 	assert.Equal(t, "", matches[0][2])
 }
@@ -390,8 +390,8 @@ func (s *MattermostSuite) TestDenial() {
 	assert.Equal(t, "❌ DENIED", statusLine)
 
 	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "not okay "+strings.Repeat("A", 491), matches[0][1])
 	assert.Equal(t, " (truncated)", matches[0][2])
 }
@@ -509,8 +509,8 @@ func (s *MattermostSuite) TestApprovalByReview() {
 	assert.Equal(t, "✅ APPROVED", statusLine)
 
 	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "finally okay", matches[0][1])
 	assert.Equal(t, "", matches[0][2])
 }
@@ -574,8 +574,8 @@ func (s *MattermostSuite) TestDenialByReview() {
 	assert.Equal(t, "❌ DENIED", statusLine)
 
 	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "finally not okay", matches[0][1])
 	assert.Equal(t, "", matches[0][2])
 }

--- a/integrations/access/pagerduty/pagerduty_test.go
+++ b/integrations/access/pagerduty/pagerduty_test.go
@@ -640,7 +640,7 @@ func (s *PagerdutySuite) assertReviewSubmitted() {
 	ev := s.assertNewEvent(watcher, types.OpPut, types.KindAccessRequest, reqID)
 	request, ok := ev.Resource.(types.AccessRequest)
 	require.True(t, ok)
-	assert.Len(t, request.GetReviews(), 0)
+	assert.Empty(t, request.GetReviews())
 	assert.Equal(t, types.RequestState_PENDING, request.GetState())
 
 	ev = s.assertNewEvent(watcher, types.OpPut, types.KindAccessRequest, reqID)
@@ -672,14 +672,14 @@ func (s *PagerdutySuite) assertNoReviewSubmitted() {
 	request, ok := ev.Resource.(types.AccessRequest)
 	require.True(t, ok)
 	assert.Equal(t, types.RequestState_PENDING, request.GetState())
-	assert.Len(t, request.GetReviews(), 0)
+	assert.Empty(t, request.GetReviews())
 
 	s.assertNoNewEvents(watcher)
 
 	request, err = s.ruler().GetAccessRequest(s.Context(), request.GetName())
 	require.NoError(t, err)
 	assert.Equal(t, types.RequestState_PENDING, request.GetState())
-	assert.Len(t, request.GetReviews(), 0)
+	assert.Empty(t, request.GetReviews())
 }
 
 func (s *PagerdutySuite) TestAutoApprovalWhenNotOnCall() {

--- a/integrations/access/servicenow/config_test.go
+++ b/integrations/access/servicenow/config_test.go
@@ -33,5 +33,5 @@ func TestNewBot(t *testing.T) {
 	}
 	_, err := conf.NewBot("someClusterName", "someWebProxyAddr")
 	require.NoError(t, err)
-	require.Equal(t, conf.WebProxyURL.Host, "someWebProxyAddr")
+	require.Equal(t, "someWebProxyAddr", conf.WebProxyURL.Host)
 }

--- a/integrations/access/servicenow/servicenow_test.go
+++ b/integrations/access/servicenow/servicenow_test.go
@@ -375,7 +375,7 @@ func (s *ServiceNowSuite) TestApproval() {
 	require.Contains(t, incident.Description, "submitted access request")
 	assert.Contains(t, incident.CloseNotes, "Access request has been resolved")
 	assert.Contains(t, incident.CloseNotes, "Reason: okay")
-	assert.Equal(t, incident.CloseCode, "resolved")
+	assert.Equal(t, "resolved", incident.CloseCode)
 }
 
 func (s *ServiceNowSuite) TestDenial() {

--- a/integrations/access/slack/slack_test.go
+++ b/integrations/access/slack/slack_test.go
@@ -309,8 +309,8 @@ func (s *SlackSuite) TestMessagePosting() {
 	require.True(t, ok)
 	t.Logf("%q", block.Text.GetText())
 	matches := requestReasonRegexp.FindAllStringSubmatch(block.Text.GetText(), -1)
-	require.Equal(t, 1, len(matches))
-	require.Equal(t, 3, len(matches[0]))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0], 3)
 	assert.Equal(t, "because of "+strings.Repeat("A", 489), matches[0][1])
 	assert.Equal(t, " (truncated)", matches[0][2])
 

--- a/integrations/kube-agent-updater/pkg/controller/updater_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/updater_test.go
@@ -169,7 +169,7 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 				require.Nil(t, image)
 			} else {
 				require.NotNil(t, image)
-				require.Equal(t, image.String(), tt.expectedImage)
+				require.Equal(t, tt.expectedImage, image.String())
 			}
 		})
 	}

--- a/integrations/lib/credentials/credentials_test.go
+++ b/integrations/lib/credentials/credentials_test.go
@@ -148,7 +148,7 @@ func TestCheckExpiredCredentials(t *testing.T) {
 				require.Error(t, err)
 				aggregate, ok := trace.Unwrap(err).(trace.Aggregate)
 				require.True(t, ok)
-				require.Equal(t, len(aggregate.Errors()), tc.expectNumErrors, "check number of errors reported")
+				require.Len(t, aggregate.Errors(), tc.expectNumErrors, "check number of errors reported")
 			}
 		})
 	}

--- a/integrations/lib/plugindata/access_request_test.go
+++ b/integrations/lib/plugindata/access_request_test.go
@@ -33,7 +33,7 @@ var sampleAccessRequestData = AccessRequestData{
 
 func TestEncodeAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(sampleAccessRequestData)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, dataMap, 8)
 	assert.Equal(t, "user-foo", dataMap["user"])
 	assert.Equal(t, "role-foo,role-bar", dataMap["roles"])
@@ -56,13 +56,13 @@ func TestDecodeAccessRequestData(t *testing.T) {
 		"resolve_reason":      "foo ok",
 		"suggested_reviewers": "[\"foouser\"]",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, sampleAccessRequestData, pluginData)
 }
 
 func TestEncodeEmptyAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(AccessRequestData{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, dataMap, 7)
 	for key, value := range dataMap {
 		assert.Emptyf(t, value, "value at key %q must be empty", key)
@@ -71,9 +71,9 @@ func TestEncodeEmptyAccessRequestData(t *testing.T) {
 
 func TestDecodeEmptyAccessRequestData(t *testing.T) {
 	decoded, err := DecodeAccessRequestData(nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, decoded)
 	decoded, err = DecodeAccessRequestData(make(map[string]string))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, decoded)
 }

--- a/integrations/lib/plugindata/cas_test.go
+++ b/integrations/lib/plugindata/cas_test.go
@@ -106,7 +106,7 @@ func TestModifyFailed(t *testing.T) {
 	})
 
 	require.Error(t, err, "fail")
-	require.Equal(t, r, mockData{})
+	require.Equal(t, mockData{}, r)
 }
 
 // We test cas is retrying modityT properly if modifyT returns a CompareFailedError during the first iteration.
@@ -130,7 +130,7 @@ func TestModifyCompareFailed(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, r)
-	require.Equal(t, r.Bar, "other value")
+	require.Equal(t, "other value", r.Bar)
 }
 
 func TestModifySuccess(t *testing.T) {
@@ -146,7 +146,7 @@ func TestModifySuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, r)
-	require.Equal(t, r.Foo, "other value")
+	require.Equal(t, "other value", r.Foo)
 }
 
 func TestBackoff(t *testing.T) {
@@ -162,7 +162,7 @@ func TestBackoff(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, r)
-	require.Equal(t, r.Foo, "yes")
+	require.Equal(t, "yes", r.Foo)
 }
 
 func TestWrongData(t *testing.T) {

--- a/integrations/operator/apis/resources/v3/oidcconnector_types_test.go
+++ b/integrations/operator/apis/resources/v3/oidcconnector_types_test.go
@@ -54,7 +54,7 @@ func TestTeleportOIDCConnectorSpec_MarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := json.Marshal(tc.spec)
 			require.NoError(t, err)
-			require.Equal(t, string(result), tc.expectedJSON)
+			require.Equal(t, tc.expectedJSON, string(result))
 		})
 	}
 }

--- a/integrations/operator/controllers/resources/provision_token_controller_test.go
+++ b/integrations/operator/controllers/resources/provision_token_controller_test.go
@@ -224,9 +224,9 @@ github:
 		}
 		require.NoError(t, err)
 
-		require.Equal(t, tToken.GetName(), tokenName)
+		require.Equal(t, tokenName, tToken.GetName())
 		require.Contains(t, tToken.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tToken.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tToken.GetMetadata().Labels[types.OriginLabel])
 		expectedToken := &types.ProvisionTokenV2{
 			Metadata: types.Metadata{},
 			Spec:     *expectedSpec,

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -56,9 +56,9 @@ func TestRoleCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// Role should have the same name, and have the Kubernetes origin label
-		require.Equal(t, tRole.GetName(), roleName)
+		require.Equal(t, roleName, tRole.GetName())
 		require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tRole.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})
@@ -225,9 +225,9 @@ allow:
 					}
 					require.NoError(t, err)
 
-					require.Equal(t, tRole.GetName(), roleName)
+					require.Equal(t, roleName, tRole.GetName())
 					require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-					require.Equal(t, tRole.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+					require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
 					expectedRole, _ := types.NewRole(roleName, *tc.expectedSpec)
 					compareRoleSpecs(t, expectedRole, tRole)
 
@@ -275,10 +275,10 @@ func TestRoleDeletionDrift(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		require.Equal(t, tRole.GetName(), roleName)
+		require.Equal(t, roleName, tRole.GetName())
 
 		require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tRole.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})
@@ -457,7 +457,7 @@ func TestAddTeleportResourceOriginRole(t *testing.T) {
 			r.AddTeleportResourceOrigin(tc.resource)
 			metadata := tc.resource.GetMetadata()
 			require.Contains(t, metadata.Labels, types.OriginLabel)
-			require.Equal(t, metadata.Labels[types.OriginLabel], types.OriginKubernetes)
+			require.Equal(t, types.OriginKubernetes, metadata.Labels[types.OriginLabel])
 		})
 	}
 }

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -65,7 +65,7 @@ func ResourceCreationTest[T resources.TeleportResource, K resources.TeleportKube
 		require.Equal(t, tResource.GetName(), resourceName)
 
 		require.Contains(t, tResource.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tResource.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tResource.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})
@@ -106,7 +106,7 @@ func ResourceDeletionDriftTest[T resources.TeleportResource, K resources.Telepor
 		require.Equal(t, tResource.GetName(), resourceName)
 
 		require.Contains(t, tResource.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tResource.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tResource.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -64,10 +64,10 @@ func TestUserCreation(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		require.Equal(t, tUser.GetName(), userName)
+		require.Equal(t, userName, tUser.GetName())
 
 		require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tUser.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})
@@ -193,9 +193,9 @@ traits:
 					}
 					require.NoError(t, err)
 
-					require.Equal(t, tUser.GetName(), userName)
+					require.Equal(t, userName, tUser.GetName())
 					require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-					require.Equal(t, tUser.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+					require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
 					require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name)
 					expectedUser := &types.UserV2{
 						Metadata: types.Metadata{},
@@ -256,10 +256,10 @@ func TestUserDeletionDrift(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		require.Equal(t, tUser.GetName(), userName)
+		require.Equal(t, userName, tUser.GetName())
 
 		require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, tUser.GetMetadata().Labels[types.OriginLabel], types.OriginKubernetes)
+		require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
 
 		return true
 	})
@@ -274,7 +274,7 @@ func TestUserDeletionDrift(t *testing.T) {
 		return trace.IsNotFound(err)
 	})
 
-	// We flag the role for deletion in Kubernetes (it won't be fully remopved until the operator has processed it and removed the finalizer)
+	// We flag the role for deletion in Kubernetes (it won't be fully removed until the operator has processed it and removed the finalizer)
 	k8sDeleteUser(ctx, t, setup.K8sClient, userName, setup.Namespace.Name)
 
 	// Test section: We resume the operator, it should reconcile and recover from the drift

--- a/integrations/operator/controllers/resources/utils_test.go
+++ b/integrations/operator/controllers/resources/utils_test.go
@@ -87,9 +87,9 @@ func TestCheckOwnership(t *testing.T) {
 			condition, isOwned := checkOwnership(tc.existingResource)
 
 			require.Equal(t, tc.isOwned, isOwned)
-			require.Equal(t, condition.Type, ConditionTypeTeleportResourceOwned)
-			require.Equal(t, condition.Status, tc.expectedConditionStatus)
-			require.Equal(t, condition.Reason, tc.expectedConditionReason)
+			require.Equal(t, ConditionTypeTeleportResourceOwned, condition.Type)
+			require.Equal(t, tc.expectedConditionStatus, condition.Status)
+			require.Equal(t, tc.expectedConditionReason, condition.Reason)
 		})
 	}
 }

--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -97,7 +97,7 @@ func TestChat_PromptTokens(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/event-stream")
 
-				require.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
+				require.NotEmpty(t, responses, "Unexpected request")
 				dataBytes := responses[0]
 				_, err := w.Write([]byte(dataBytes))
 				require.NoError(t, err, "Write error")
@@ -147,7 +147,7 @@ func TestChat_Complete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
-		require.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
+		require.NotEmpty(t, responses, "Unexpected request")
 		dataBytes := responses[0]
 
 		_, err := w.Write(dataBytes)

--- a/lib/ai/testutils/http.go
+++ b/lib/ai/testutils/http.go
@@ -50,7 +50,7 @@ func GetTestHandlerFn(t *testing.T, responses []string) http.HandlerFunc {
 func streamResponse(w http.ResponseWriter, t *testing.T, responses []string) []string {
 	w.Header().Set("Content-Type", "text/event-stream")
 
-	if !assert.GreaterOrEqual(t, len(responses), 1, "Unexpected request") {
+	if !assert.NotEmpty(t, responses, "Unexpected request") {
 		http.Error(w, "Unexpected request", http.StatusBadRequest)
 		return responses
 	}
@@ -95,7 +95,7 @@ func messageResponse(w http.ResponseWriter, r *http.Request, t *testing.T, respo
 	}
 
 	// Use assert as require doesn't work when called from a goroutine
-	if !assert.GreaterOrEqual(t, len(responses), 1, "Unexpected request") {
+	if !assert.NotEmpty(t, responses, "Unexpected request") {
 		http.Error(w, "Unexpected request", http.StatusBadRequest)
 		return responses
 	}

--- a/lib/assist/assist_test.go
+++ b/lib/assist/assist_test.go
@@ -104,7 +104,7 @@ func TestChatComplete(t *testing.T) {
 				return nil
 			}
 			require.Equal(t, MessageKindCommand, kind)
-			require.Equal(t, string(payload), `{"command":"df -h","nodes":["localhost"]}`)
+			require.Equal(t, `{"command":"df -h","nodes":["localhost"]}`, string(payload))
 			called = true
 			return nil
 		}, "Show free disk space on localhost")
@@ -150,19 +150,19 @@ func TestClassifyMessage(t *testing.T) {
 	t.Run("Valid class", func(t *testing.T) {
 		class, err := client.ClassifyMessage(ctx, "whatever", MessageClasses)
 		require.NoError(t, err)
-		require.Equal(t, class, "troubleshooting")
+		require.Equal(t, "troubleshooting", class)
 	})
 
 	t.Run("Valid class starting with upper-case", func(t *testing.T) {
 		class, err := client.ClassifyMessage(ctx, "whatever", MessageClasses)
 		require.NoError(t, err)
-		require.Equal(t, class, "troubleshooting")
+		require.Equal(t, "troubleshooting", class)
 	})
 
 	t.Run("Valid class starting with upper-case and ending with dot", func(t *testing.T) {
 		class, err := client.ClassifyMessage(ctx, "whatever", MessageClasses)
 		require.NoError(t, err)
-		require.Equal(t, class, "troubleshooting")
+		require.Equal(t, "troubleshooting", class)
 	})
 
 	t.Run("Model hallucinates", func(t *testing.T) {

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -47,14 +47,14 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 	// Creating a role should emit a RoleCreatedEvent.
 	role, err = p.a.CreateRole(ctx, role)
 	require.NoError(t, err)
-	require.Equal(t, p.mockEmitter.LastEvent().GetType(), events.RoleCreatedEvent)
+	require.Equal(t, events.RoleCreatedEvent, p.mockEmitter.LastEvent().GetType())
 	require.Equal(t, p.mockEmitter.LastEvent().(*apievents.RoleCreate).Name, role.GetName())
 	p.mockEmitter.Reset()
 
 	// Upserting a role should emit a RoleCreatedEvent.
 	role, err = p.a.UpsertRole(ctx, role)
 	require.NoError(t, err)
-	require.Equal(t, p.mockEmitter.LastEvent().GetType(), events.RoleCreatedEvent)
+	require.Equal(t, events.RoleCreatedEvent, p.mockEmitter.LastEvent().GetType())
 	require.Equal(t, p.mockEmitter.LastEvent().(*apievents.RoleCreate).Name, role.GetName())
 	p.mockEmitter.Reset()
 
@@ -62,14 +62,14 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 	role.SetLogins(types.Allow, []string{"llama"})
 	role, err = p.a.UpdateRole(ctx, role)
 	require.NoError(t, err)
-	require.Equal(t, p.mockEmitter.LastEvent().GetType(), events.RoleUpdatedEvent)
+	require.Equal(t, events.RoleUpdatedEvent, p.mockEmitter.LastEvent().GetType())
 	require.Equal(t, p.mockEmitter.LastEvent().(*apievents.RoleUpdate).Name, role.GetName())
 	p.mockEmitter.Reset()
 
 	// Deleting a role should emit a RoleDeletedEvent.
 	err = p.a.DeleteRole(ctx, role.GetName())
 	require.NoError(t, err)
-	require.Equal(t, p.mockEmitter.LastEvent().GetType(), events.RoleDeletedEvent)
+	require.Equal(t, events.RoleDeletedEvent, p.mockEmitter.LastEvent().GetType())
 	require.Equal(t, p.mockEmitter.LastEvent().(*apievents.RoleDelete).Name, role.GetName())
 	p.mockEmitter.Reset()
 

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -192,9 +192,9 @@ func TestStartAccountRecovery(t *testing.T) {
 
 			// Test events emitted.
 			event := mockEmitter.LastEvent()
-			require.Equal(t, event.GetType(), events.RecoveryTokenCreateEvent)
-			require.Equal(t, event.GetCode(), events.RecoveryTokenCreateCode)
-			require.Equal(t, event.(*apievents.UserTokenCreate).Name, u.username)
+			require.Equal(t, events.RecoveryTokenCreateEvent, event.GetType())
+			require.Equal(t, events.RecoveryTokenCreateCode, event.GetCode())
+			require.Equal(t, u.username, event.(*apievents.UserTokenCreate).Name)
 		})
 	}
 }
@@ -424,9 +424,9 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 
 			// Test events emitted.
 			event := mockEmitter.LastEvent()
-			require.Equal(t, event.GetType(), events.RecoveryTokenCreateEvent)
-			require.Equal(t, event.GetCode(), events.RecoveryTokenCreateCode)
-			require.Equal(t, event.(*apievents.UserTokenCreate).Name, u.username)
+			require.Equal(t, events.RecoveryTokenCreateEvent, event.GetType())
+			require.Equal(t, events.RecoveryTokenCreateCode, event.GetCode())
+			require.Equal(t, u.username, event.(*apievents.UserTokenCreate).Name)
 
 			// Test start token got deleted.
 			_, err = srv.Auth().GetUserToken(ctx, startToken.GetName())
@@ -440,7 +440,7 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 			// Test recovery attempts are deleted.
 			attempts, err = srv.Auth().GetUserRecoveryAttempts(ctx, u.username)
 			require.NoError(t, err)
-			require.Len(t, attempts, 0)
+			require.Empty(t, attempts)
 		})
 	}
 }
@@ -511,7 +511,7 @@ func TestVerifyAccountRecovery_WithLock(t *testing.T) {
 	// Test recovery attempts got reset.
 	attempts, err := srv.Auth().GetUserRecoveryAttempts(ctx, u.username)
 	require.NoError(t, err)
-	require.Len(t, attempts, 0)
+	require.Empty(t, attempts)
 }
 
 func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
@@ -651,7 +651,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	// Test login attempts are removed.
 	attempts, err := srv.Auth().GetUserLoginAttempts(u.username)
 	require.NoError(t, err)
-	require.Len(t, attempts, 0)
+	require.Empty(t, attempts)
 
 	// Test adding MFA devices.
 	approvedToken, err = srv.Auth().createRecoveryToken(ctx, u.username, UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
@@ -715,9 +715,9 @@ func TestCompleteAccountRecovery(t *testing.T) {
 
 			// Test events emitted.
 			event := mockEmitter.LastEvent()
-			require.Equal(t, event.GetType(), events.MFADeviceAddEvent)
-			require.Equal(t, event.GetCode(), events.MFADeviceAddEventCode)
-			require.Equal(t, event.(*apievents.MFADeviceAdd).UserMetadata.User, u.username)
+			require.Equal(t, events.MFADeviceAddEvent, event.GetType())
+			require.Equal(t, events.MFADeviceAddEventCode, event.GetCode())
+			require.Equal(t, u.username, event.(*apievents.MFADeviceAdd).UserMetadata.User)
 
 			// Test new device has been added.
 			mfas, err := srv.Auth().Services.GetMFADevices(ctx, u.username, false)
@@ -1323,9 +1323,9 @@ func triggerLoginLock(t *testing.T, srv *Server, username string) {
 
 		// Test last attempt returns locked error.
 		if i == defaults.MaxLoginAttempts {
-			require.Equal(t, err.Error(), MaxFailedAttemptsErrMsg)
+			require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
 		} else {
-			require.NotEqual(t, err.Error(), MaxFailedAttemptsErrMsg)
+			require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
 		}
 	}
 }

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -269,9 +269,9 @@ func TestCreateAuthenticateChallenge_WithUserCredentials_WithLock(t *testing.T) 
 
 		// Test last attempt returns locked error.
 		if i == defaults.MaxLoginAttempts {
-			require.Equal(t, err.Error(), MaxFailedAttemptsErrMsg)
+			require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
 		} else {
-			require.NotEqual(t, err.Error(), MaxFailedAttemptsErrMsg)
+			require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
 		}
 	}
 }
@@ -928,7 +928,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, attempts, "Login attempts not reset")
 
-			require.Equal(t, len(test.loginHooks), int(loginHookCounter.Load()))
+			require.Len(t, test.loginHooks, int(loginHookCounter.Load()))
 		})
 	}
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -300,14 +300,14 @@ func TestAuthenticateSSHUser(t *testing.T) {
 		RouteToCluster: s.clusterName.GetClusterName(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, resp.Username, user)
+	require.Equal(t, user, resp.Username)
 	// Verify the public key and principals in SSH cert.
 	inSSHPub, _, _, _, err := ssh.ParseAuthorizedKey(pub)
 	require.NoError(t, err)
 	gotSSHCert, err := sshutils.ParseCertificate(resp.Cert)
 	require.NoError(t, err)
-	require.Equal(t, gotSSHCert.Key, inSSHPub)
-	require.Equal(t, gotSSHCert.ValidPrincipals, []string{user, teleport.SSHSessionJoinPrincipal})
+	require.Equal(t, inSSHPub, gotSSHCert.Key)
+	require.Equal(t, []string{user, teleport.SSHSessionJoinPrincipal}, gotSSHCert.ValidPrincipals)
 	// Verify the public key and Subject in TLS cert.
 	inCryptoPub := inSSHPub.(ssh.CryptoPublicKey).CryptoPublicKey()
 	gotTLSCert, err := tlsca.ParseCertificatePEM(resp.TLSCert)
@@ -359,7 +359,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
-	require.Equal(t, *gotID, wantID)
+	require.Equal(t, wantID, *gotID)
 
 	// Register a kubernetes cluster to verify the defaulting logic in TLS cert
 	// generation.
@@ -405,7 +405,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
-	require.Equal(t, *gotID, wantID)
+	require.Equal(t, wantID, *gotID)
 
 	// Login without specifying kube cluster. A registered one should be picked
 	// automatically.
@@ -422,7 +422,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 		KubernetesCluster: "",
 	})
 	require.NoError(t, err)
-	require.Equal(t, resp.Username, user)
+	require.Equal(t, user, resp.Username)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
 	require.NoError(t, err)
 	wantID = tlsca.Identity{
@@ -439,7 +439,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
-	require.Equal(t, *gotID, wantID)
+	require.Equal(t, wantID, *gotID)
 
 	// Login specifying a valid kube cluster. It should appear in the TLS cert.
 	resp, err = s.a.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
@@ -453,7 +453,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 		KubernetesCluster: "root-kube-cluster",
 	})
 	require.NoError(t, err)
-	require.Equal(t, resp.Username, user)
+	require.Equal(t, user, resp.Username)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
 	require.NoError(t, err)
 	wantID = tlsca.Identity{
@@ -470,7 +470,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
-	require.Equal(t, *gotID, wantID)
+	require.Equal(t, wantID, *gotID)
 
 	// Login without specifying kube cluster. A registered one should be picked
 	// automatically.
@@ -487,7 +487,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 		KubernetesCluster: "",
 	})
 	require.NoError(t, err)
-	require.Equal(t, resp.Username, user)
+	require.Equal(t, user, resp.Username)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
 	require.NoError(t, err)
 	wantID = tlsca.Identity{
@@ -504,7 +504,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
-	require.Equal(t, *gotID, wantID)
+	require.Equal(t, wantID, *gotID)
 
 	// Login specifying an invalid kube cluster. This should fail.
 	_, err = s.a.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
@@ -703,7 +703,7 @@ func TestUpdateConfig(t *testing.T) {
 	require.Equal(t, cn.GetClusterName(), s.clusterName.GetClusterName())
 	st, err := s.a.GetStaticTokens()
 	require.NoError(t, err)
-	require.Equal(t, st.GetStaticTokens(), []types.ProvisionToken{})
+	require.Empty(t, st.GetStaticTokens())
 
 	// try and set cluster name, this should fail because you can only set the
 	// cluster name once
@@ -777,8 +777,8 @@ func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
 	})
 	user, err = s.a.CreateUser(ctx, user)
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserCreateEvent)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, "some-auth-user")
+	require.Equal(t, events.UserCreateEvent, s.mockEmitter.LastEvent().GetType())
+	require.Equal(t, "some-auth-user", s.mockEmitter.LastEvent().(*apievents.UserCreate).User)
 	s.mockEmitter.Reset()
 
 	// test create user with existing user
@@ -791,7 +791,7 @@ func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
 	require.NoError(t, err)
 	_, err = s.a.CreateUser(ctx, user2)
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, teleport.UserSystem)
+	require.Equal(t, teleport.UserSystem, s.mockEmitter.LastEvent().(*apievents.UserCreate).User)
 	s.mockEmitter.Reset()
 
 	// test update on non-existent user
@@ -804,8 +804,8 @@ func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
 	// test update user
 	_, err = s.a.UpdateUser(ctx, user)
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserUpdatedEvent)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserUpdate).User, teleport.UserSystem)
+	require.Equal(t, events.UserUpdatedEvent, s.mockEmitter.LastEvent().GetType())
+	require.Equal(t, teleport.UserSystem, s.mockEmitter.LastEvent().(*apievents.UserUpdate).User)
 }
 
 func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
@@ -839,7 +839,7 @@ func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 
 	_, err = s.a.UpsertTrustedCluster(ctx, tc)
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterCreateEvent)
+	require.Equal(t, events.TrustedClusterCreateEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test create event for switch case: when tc exists but enabled is true
@@ -847,13 +847,13 @@ func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 
 	_, err = s.a.UpsertTrustedCluster(ctx, tc)
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterCreateEvent)
+	require.Equal(t, events.TrustedClusterCreateEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test delete event
 	err = s.a.DeleteTrustedCluster(ctx, "test")
 	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterDeleteEvent)
+	require.Equal(t, events.TrustedClusterDeleteEvent, s.mockEmitter.LastEvent().GetType())
 }
 
 func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
@@ -875,7 +875,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	github, err = s.a.createGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
+	require.Equal(t, events.GithubConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test github update event
@@ -883,7 +883,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	github, err = s.a.updateGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorUpdate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorUpdatedEvent)
+	require.Equal(t, events.GithubConnectorUpdatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test github upsert event
@@ -891,14 +891,14 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	err = s.a.upsertGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
+	require.Equal(t, events.GithubConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test github delete event
 	err = s.a.deleteGithubConnector(ctx, "test")
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorDelete{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorDeletedEvent)
+	require.Equal(t, events.GithubConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())
 }
 
 func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
@@ -923,7 +923,7 @@ func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
 	oidc, err = s.a.CreateOIDCConnector(ctx, oidc)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
+	require.Equal(t, events.OIDCConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test oidc update event
@@ -931,7 +931,7 @@ func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
 	oidc, err = s.a.UpdateOIDCConnector(ctx, oidc)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorUpdate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorUpdatedEvent)
+	require.Equal(t, events.OIDCConnectorUpdatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test oidc upsert event
@@ -939,14 +939,14 @@ func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
 	err = s.a.UpsertOIDCConnector(ctx, oidc)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
+	require.Equal(t, events.OIDCConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test oidc delete event
 	err = s.a.DeleteOIDCConnector(ctx, "test")
 	require.NoError(t, err)
 	require.IsType(t, &apievents.OIDCConnectorDelete{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorDeletedEvent)
+	require.Equal(t, events.OIDCConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())
 }
 
 func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
@@ -995,7 +995,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 	saml, err = s.a.CreateSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
+	require.Equal(t, events.SAMLConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test saml update event
@@ -1003,7 +1003,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 	saml, err = s.a.UpdateSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorUpdate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorUpdatedEvent)
+	require.Equal(t, events.SAMLConnectorUpdatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test saml upsert event
@@ -1011,14 +1011,14 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 	err = s.a.UpsertSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
+	require.Equal(t, events.SAMLConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
 	s.mockEmitter.Reset()
 
 	// test saml delete event
 	err = s.a.DeleteSAMLConnector(ctx, "test")
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorDelete{}, s.mockEmitter.LastEvent())
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorDeletedEvent)
+	require.Equal(t, events.SAMLConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())
 }
 
 func TestEmitSSOLoginFailureEvent(t *testing.T) {
@@ -1026,7 +1026,7 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 
 	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), false)
 
-	require.Equal(t, mockE.LastEvent(), &apievents.UserLogin{
+	expectedLoginFailure := &apievents.UserLogin{
 		Metadata: apievents.Metadata{
 			Type: events.UserLoginEvent,
 			Code: events.UserSSOLoginFailureCode,
@@ -1037,11 +1037,12 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 			Error:       "some error",
 			UserMessage: "some error",
 		},
-	})
+	}
+	require.Equal(t, expectedLoginFailure, mockE.LastEvent())
 
 	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), true)
 
-	require.Equal(t, mockE.LastEvent(), &apievents.UserLogin{
+	expectedTestFailure := &apievents.UserLogin{
 		Metadata: apievents.Metadata{
 			Type: events.UserLoginEvent,
 			Code: events.UserSSOTestFlowLoginFailureCode,
@@ -1052,7 +1053,8 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 			Error:       "some error",
 			UserMessage: "some error",
 		},
-	})
+	}
+	require.Equal(t, expectedTestFailure, mockE.LastEvent())
 }
 
 func TestServer_AugmentContextUserCertificates(t *testing.T) {
@@ -1190,8 +1192,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 			newSSHCert, err := sshutils.ParseCertificate(certs.SSH)
 			require.NoError(t, err, "ParseCertificate failed")
 			test.assertSSHCert(t, newSSHCert)
-			assert.True(t,
-				uint64(validAfter.Unix()) < newSSHCert.ValidAfter,
+			assert.Less(t, uint64(validAfter.Unix()), newSSHCert.ValidAfter,
 				"got newSSHCert.ValidAfter = %v, want > %v", newSSHCert.ValidAfter, validAfter.Unix())
 			assert.Equal(t, uint64(xCert.NotAfter.Unix()), newSSHCert.ValidBefore, "newSSHCert.ValidBefore mismatch")
 		})
@@ -3275,7 +3276,7 @@ func TestGetLicense(t *testing.T) {
 
 	// GetLicense should return error if license is not set
 	_, err := s.a.GetLicense(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// GetLicense should return cert and key pem concatenated, when license is set
 	l := license.License{
@@ -3285,7 +3286,7 @@ func TestGetLicense(t *testing.T) {
 	s.a.SetLicense(&l)
 
 	actual, err := s.a.GetLicense(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s%s", l.CertPEM, l.KeyPEM), actual)
 }
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -719,7 +719,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 			require.NoError(t, err)
 			identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
 			require.NoError(t, err)
-			require.True(t, tt.expiration.Sub(identity.Expires).Abs() < 10*time.Second,
+			require.Less(t, tt.expiration.Sub(identity.Expires).Abs(), 10*time.Second,
 				"Identity expiration is out of expected boundaries")
 		})
 	}
@@ -1718,7 +1718,7 @@ func TestStreamSessionEvents_Builtin(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 0, len(searchEvents))
+	require.Empty(t, searchEvents)
 }
 
 // TestGetSessionEvents ensures that when a user streams a session's events, it emits an audit event.
@@ -2664,7 +2664,7 @@ func TestApps(t *testing.T) {
 	require.NoError(t, err)
 	apps, err = adminClt.GetApps(ctx)
 	require.NoError(t, err)
-	require.Len(t, apps, 0)
+	require.Empty(t, apps)
 }
 
 // TestReplaceRemoteLocksRBAC verifies that only a remote proxy may replace the
@@ -3076,7 +3076,7 @@ func TestGetAndList_KubernetesServers(t *testing.T) {
 	require.NoError(t, err)
 	servers, err = clt.GetKubernetesServers(ctx)
 	require.NoError(t, err)
-	require.Len(t, servers, 0)
+	require.Empty(t, servers)
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
 	require.Empty(t, resp.Resources)
@@ -3266,7 +3266,7 @@ func TestListResources_NeedTotalCountFlag(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Resources, 2)
 	require.NotEmpty(t, resp.NextKey)
-	require.Equal(t, len(testNodes), resp.TotalCount)
+	require.Len(t, testNodes, resp.TotalCount)
 
 	// No total.
 	resp, err = clt.ListResources(ctx, proto.ListResourcesRequest{
@@ -3651,7 +3651,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, res.NextKey)
 		require.Len(t, res.Resources, len(testNames))
-		require.Equal(t, res.TotalCount, len(testNames))
+		require.Len(t, testNames, res.TotalCount)
 
 		clusters, err := types.ResourcesWithLabels(res.Resources).AsKubeClusters()
 		require.NoError(t, err)
@@ -3792,7 +3792,7 @@ func TestListResources_KindUserGroup(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, res.NextKey)
 		require.Len(t, res.Resources, 3)
-		require.Equal(t, res.TotalCount, 3)
+		require.Equal(t, 3, res.TotalCount)
 
 		userGroups, err := types.ResourcesWithLabels(res.Resources).AsUserGroups()
 		require.NoError(t, err)
@@ -3917,7 +3917,7 @@ func TestDeleteUserAppSessions(t *testing.T) {
 	// No sessions left.
 	sessions, nextKey, err = srv.Auth().ListAppSessions(ctx, 10, "", "")
 	require.NoError(t, err)
-	require.Len(t, sessions, 0)
+	require.Empty(t, sessions)
 	require.Empty(t, nextKey)
 }
 
@@ -4039,7 +4039,7 @@ func TestListResources_SortAndDeduplicate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Len(t, resp.Resources, 2)
-			require.Equal(t, len(uniqueNames), resp.TotalCount)
+			require.Len(t, uniqueNames, resp.TotalCount)
 			fetchedResources = append(fetchedResources, resp.Resources...)
 
 			resp, err = clt.ListResources(ctx, proto.ListResourcesRequest{
@@ -4051,7 +4051,7 @@ func TestListResources_SortAndDeduplicate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Len(t, resp.Resources, 1)
-			require.Equal(t, len(uniqueNames), resp.TotalCount)
+			require.Len(t, uniqueNames, resp.TotalCount)
 			fetchedResources = append(fetchedResources, resp.Resources...)
 
 			r := types.ResourcesWithLabels(fetchedResources)
@@ -5128,7 +5128,7 @@ func TestListReleasesPermissions(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			role, err := CreateRole(ctx, srv.Auth(), "test-role", tc.Role)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			user, err := CreateUser(ctx, srv.Auth(), "test-user", role)
 			require.NoError(t, err)
@@ -5183,7 +5183,7 @@ func TestGetLicensePermissions(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			role, err := CreateRole(ctx, srv.Auth(), "test-role", tc.Role)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			user, err := CreateUser(ctx, srv.Auth(), "test-user", role)
 			require.NoError(t, err)
@@ -5696,7 +5696,7 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED,
 			assertError: require.NoError,
 			assertEvents: func(t *testing.T, emitter *eventstest.MockRecorderEmitter) {
-				require.Equal(t, 1, len(emitter.Events()))
+				require.Len(t, emitter.Events(), 1)
 				require.Equal(t, events.UserHeadlessLoginRejectedCode, emitter.LastEvent().GetCode())
 			},
 		}, {
@@ -5705,7 +5705,7 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 			withMFA:     true,
 			assertError: require.NoError,
 			assertEvents: func(t *testing.T, emitter *eventstest.MockRecorderEmitter) {
-				require.Equal(t, 1, len(emitter.Events()))
+				require.Len(t, emitter.Events(), 1)
 				require.Equal(t, events.UserHeadlessLoginApprovedCode, emitter.LastEvent().GetCode())
 			},
 		}, {
@@ -5714,7 +5714,7 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 			withMFA:     false,
 			assertError: assertAccessDenied,
 			assertEvents: func(t *testing.T, emitter *eventstest.MockRecorderEmitter) {
-				require.Equal(t, 1, len(emitter.Events()))
+				require.Len(t, emitter.Events(), 1)
 				require.Equal(t, events.UserHeadlessLoginApprovedFailureCode, emitter.LastEvent().GetCode())
 			},
 		}, {

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -130,7 +130,7 @@ func TestCreateGithubUser(t *testing.T) {
 		SessionTTL:    1 * time.Minute,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, user.GetName(), "foo@example.com")
+	require.Equal(t, "foo@example.com", user.GetName())
 
 	// Dry-run must not create a user.
 	_, err = tt.a.GetUser(ctx, "foo@example.com", false)
@@ -217,10 +217,10 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 		return auth, nil
 	}
 	_, _ = validateGithubAuthCallbackHelper(context.Background(), m, diagCtx, nil, tt.a.emitter)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetType(), events.UserLoginEvent)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetCode(), events.UserSSOLoginCode)
-	require.Equal(t, tt.mockEmitter.LastEvent().(*apievents.UserLogin).AppliedLoginRules, []string{"login-rule"})
-	require.Equal(t, ssoDiagInfoCalls, 0)
+	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
+	require.Equal(t, events.UserSSOLoginCode, tt.mockEmitter.LastEvent().GetCode())
+	require.Equal(t, []string{"login-rule"}, tt.mockEmitter.LastEvent().(*apievents.UserLogin).AppliedLoginRules)
+	require.Equal(t, 0, ssoDiagInfoCalls)
 	tt.mockEmitter.Reset()
 
 	// Test failure event, non-test-flow.
@@ -230,8 +230,8 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 		return auth, trace.BadParameter("")
 	}
 	_, _ = validateGithubAuthCallbackHelper(context.Background(), m, diagCtx, nil, tt.a.emitter)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetCode(), events.UserSSOLoginFailureCode)
-	require.Equal(t, ssoDiagInfoCalls, 0)
+	require.Equal(t, events.UserSSOLoginFailureCode, tt.mockEmitter.LastEvent().GetCode())
+	require.Equal(t, 0, ssoDiagInfoCalls)
 
 	// Test success event, test-flow.
 	diagCtx = ssoDiagContextFixture(true /* testFlow */)
@@ -240,9 +240,9 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 		return auth, nil
 	}
 	_, _ = validateGithubAuthCallbackHelper(context.Background(), m, diagCtx, nil, tt.a.emitter)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetType(), events.UserLoginEvent)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetCode(), events.UserSSOTestFlowLoginCode)
-	require.Equal(t, ssoDiagInfoCalls, 1)
+	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
+	require.Equal(t, events.UserSSOTestFlowLoginCode, tt.mockEmitter.LastEvent().GetCode())
+	require.Equal(t, 1, ssoDiagInfoCalls)
 	tt.mockEmitter.Reset()
 
 	// Test failure event, test-flow.
@@ -252,8 +252,8 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 		return auth, trace.BadParameter("")
 	}
 	_, _ = validateGithubAuthCallbackHelper(context.Background(), m, diagCtx, nil, tt.a.emitter)
-	require.Equal(t, tt.mockEmitter.LastEvent().GetCode(), events.UserSSOTestFlowLoginFailureCode)
-	require.Equal(t, ssoDiagInfoCalls, 2)
+	require.Equal(t, events.UserSSOTestFlowLoginFailureCode, tt.mockEmitter.LastEvent().GetCode())
+	require.Equal(t, 2, ssoDiagInfoCalls)
 }
 
 type mockedGithubManager struct {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -289,7 +289,7 @@ func TestMFADeviceManagement(t *testing.T) {
 		deviceIDs[dev.GetName()] = dev.Id
 	}
 	sort.Strings(deviceNames)
-	require.Equal(t, deviceNames, []string{pwdlessDevName, devs.TOTPName, devs.WebName, webDev2Name})
+	require.Equal(t, []string{pwdlessDevName, devs.TOTPName, devs.WebName, webDev2Name}, deviceNames)
 
 	// Delete several of the MFA devices.
 	deleteTests := []struct {
@@ -1191,7 +1191,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 					require.Equal(t, userCertExpires, identity.PreviousIdentityExpires)
 					require.True(t, net.ParseIP(identity.LoginIP).IsLoopback())
 					require.Equal(t, []string{teleport.UsageDatabaseOnly}, identity.Usage)
-					require.Equal(t, identity.RouteToDatabase.ServiceName, "db-a")
+					require.Equal(t, "db-a", identity.RouteToDatabase.ServiceName)
 				},
 			},
 		},
@@ -1230,7 +1230,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 					require.Equal(t, userCertExpires, identity.PreviousIdentityExpires)
 					require.True(t, net.ParseIP(identity.LoginIP).IsLoopback())
 					require.Equal(t, []string{teleport.UsageDatabaseOnly}, identity.Usage)
-					require.Equal(t, identity.RouteToDatabase.ServiceName, "db-a")
+					require.Equal(t, "db-a", identity.RouteToDatabase.ServiceName)
 				},
 			},
 		},
@@ -1267,7 +1267,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 					require.Equal(t, userCertExpires, identity.PreviousIdentityExpires)
 					require.True(t, net.ParseIP(identity.LoginIP).IsLoopback())
 					require.Equal(t, []string{teleport.UsageKubeOnly}, identity.Usage)
-					require.Equal(t, identity.KubernetesCluster, "kube-a")
+					require.Equal(t, "kube-a", identity.KubernetesCluster)
 				},
 			},
 		},
@@ -1558,7 +1558,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 					require.Equal(t, userCertExpires, identity.PreviousIdentityExpires)
 					require.True(t, net.ParseIP(identity.LoginIP).IsLoopback())
 					require.Equal(t, []string{teleport.UsageDatabaseOnly}, identity.Usage)
-					require.Equal(t, identity.RouteToDatabase.ServiceName, "db-b")
+					require.Equal(t, "db-b", identity.RouteToDatabase.ServiceName)
 				},
 			},
 		},
@@ -2031,7 +2031,7 @@ func testOriginDynamicStored(t *testing.T, setWithOrigin func(*Client, string) e
 
 			stored, err := getStored(srv.Auth())
 			require.NoError(t, err)
-			require.Equal(t, stored.Origin(), types.OriginDynamic)
+			require.Equal(t, types.OriginDynamic, stored.Origin())
 		})
 	}
 }
@@ -2227,7 +2227,7 @@ func TestGetSSHTargets(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rsp.Servers, 1)
-	require.Equal(t, rsp.Servers[0].GetHostname(), "foo")
+	require.Equal(t, "foo", rsp.Servers[0].GetHostname())
 
 	cnc := types.DefaultClusterNetworkingConfig()
 	cnc.SetCaseInsensitiveRouting(true)
@@ -2487,7 +2487,7 @@ func TestApplicationServersCRUD(t *testing.T) {
 	// Initially we expect no app servers.
 	out, err := clt.GetApplicationServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Register all app servers.
 	_, err = clt.UpsertApplicationServer(ctx, server1)
@@ -2528,7 +2528,7 @@ func TestApplicationServersCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = clt.GetApplicationServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 }
 
 // TestAppsCRUD tests application resource operations.
@@ -2559,7 +2559,7 @@ func TestAppsCRUD(t *testing.T) {
 	// Initially we expect no apps.
 	out, err := clt.GetApps(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both apps.
 	err = clt.CreateApp(ctx, app1)
@@ -2617,7 +2617,7 @@ func TestAppsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = clt.GetApps(ctx)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }
 
 // TestAppServersCRUD tests application server resource operations.
@@ -2748,7 +2748,7 @@ func TestDatabasesCRUD(t *testing.T) {
 	// Initially we expect no databases.
 	out, err := clt.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both databases.
 	err = clt.CreateDatabase(ctx, db1)
@@ -2806,7 +2806,7 @@ func TestDatabasesCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = clt.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }
 
 // TestDatabaseServicesCRUD tests DatabaseService resource operations.
@@ -3234,7 +3234,7 @@ func TestListResources(t *testing.T) {
 				Limit:        100,
 			})
 			require.NoError(t, err)
-			require.Len(t, resp.Resources, 0)
+			require.Empty(t, resp.Resources)
 			require.Empty(t, resp.NextKey)
 
 			// create two resources

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -75,10 +75,10 @@ func TestReadIdentity(t *testing.T) {
 
 	id, err := ReadSSHIdentityFromKeyPair(priv, cert)
 	require.NoError(t, err)
-	require.Equal(t, id.ClusterName, "example.com")
-	require.Equal(t, id.ID, IdentityID{HostUUID: "id1.example.com", Role: types.RoleNode})
-	require.Equal(t, id.CertBytes, cert)
-	require.Equal(t, id.KeyBytes, priv)
+	require.Equal(t, "example.com", id.ClusterName)
+	require.Equal(t, IdentityID{HostUUID: "id1.example.com", Role: types.RoleNode}, id.ID)
+	require.Equal(t, cert, id.CertBytes)
+	require.Equal(t, priv, id.KeyBytes)
 
 	// test TTL by converting the generated cert to text -> back and making sure ExpireAfter is valid
 	ttl := 10 * time.Second
@@ -409,7 +409,7 @@ func TestClusterID(t *testing.T) {
 	cc, err := authServer.GetClusterName()
 	require.NoError(t, err)
 	clusterID := cc.GetClusterID()
-	require.NotEqual(t, clusterID, "")
+	require.NotEmpty(t, clusterID)
 
 	// do it again and make sure cluster ID hasn't changed
 	authServer, err = Init(context.Background(), conf)
@@ -418,7 +418,7 @@ func TestClusterID(t *testing.T) {
 
 	cc, err = authServer.GetClusterName()
 	require.NoError(t, err)
-	require.Equal(t, cc.GetClusterID(), clusterID)
+	require.Equal(t, clusterID, cc.GetClusterID())
 }
 
 // TestClusterName ensures that a cluster can not be renamed.

--- a/lib/auth/keygen/keygen_test.go
+++ b/lib/auth/keygen/keygen_test.go
@@ -244,6 +244,6 @@ func TestUserCertCompatibility(t *testing.T) {
 
 		// Check if users custom extension was added.
 		extVal := userCertificate.Extensions["login@github.com"]
-		require.Equal(t, extVal, "hello")
+		require.Equal(t, "hello", extVal)
 	}
 }

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -33,7 +33,7 @@ var (
 	cacheMutex   sync.Mutex
 )
 
-// SetupSoftHSMToken is for use in tests only and creates a test SOFTHSM2
+// SetupSoftHSMTest is for use in tests only and creates a test SOFTHSM2
 // token.  This should be used for all tests which need to use SoftHSM because
 // the library can only be initialized once and SOFTHSM2_PATH and SOFTHSM2_CONF
 // cannot be changed. New tokens added after the library has been initialized
@@ -49,7 +49,7 @@ var (
 // many keys for a given token.
 func SetupSoftHSMTest(t *testing.T) Config {
 	path := os.Getenv("SOFTHSM2_PATH")
-	require.NotEqual(t, path, "")
+	require.NotEmpty(t, path, "SOFTHSM2_PATH must be provided to run soft hsm tests")
 
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()

--- a/lib/auth/kube_test.go
+++ b/lib/auth/kube_test.go
@@ -92,7 +92,7 @@ func TestProcessKubeCSR(t *testing.T) {
 	wantUserID := userID
 	// Auth server should overwrite the Usage field and enforce UsageKubeOnly.
 	wantUserID.Usage = []string{teleport.UsageKubeOnly}
-	require.Equal(t, *gotUserID, wantUserID)
+	require.Equal(t, wantUserID, *gotUserID)
 }
 
 // newTestCSR creates and PEM-encodes an x509 CSR with given subject.

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -40,5 +40,5 @@ func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
 	event := emitter.LastEvent()
 	loginEvent, ok := event.(*apievents.UserLogin)
 	require.True(t, ok)
-	require.True(t, len(loginEvent.UserAgent) <= maxUserAgentLen)
+	require.LessOrEqual(t, len(loginEvent.UserAgent), maxUserAgentLen)
 }

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -93,7 +93,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 
 			require.Equal(t, tt.expectEnrolled, periodic.TotalEnrolledInUpgrades(), "tt=%q", tt.desc)
 
-			require.Equal(t, len(tt.upgraders), periodic.TotalInstances(), "tt=%q", tt.desc)
+			require.Len(t, tt.upgraders, periodic.TotalInstances(), "tt=%q", tt.desc)
 		})
 	}
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -211,7 +211,7 @@ func TestRemoteRotation(t *testing.T) {
 	// remote cluster starts rotation
 	gracePeriod := time.Hour
 	remoteServer.AuthServer.privateKey, ok = fixtures.PEMBytes["rsa"]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	err = remoteServer.AuthServer.RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -345,7 +345,7 @@ func TestAutoRotation(t *testing.T) {
 
 	// starts rotation
 	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	gracePeriod := time.Hour
 	err = testSrv.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
@@ -364,7 +364,7 @@ func TestAutoRotation(t *testing.T) {
 		Type:       types.HostCA,
 	}, false)
 	require.NoError(t, err)
-	require.Equal(t, ca.GetRotation().Phase, types.RotationPhaseUpdateClients)
+	require.Equal(t, types.RotationPhaseUpdateClients, ca.GetRotation().Phase)
 
 	// old clients should work
 	_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
@@ -384,7 +384,7 @@ func TestAutoRotation(t *testing.T) {
 		Type:       types.HostCA,
 	}, false)
 	require.NoError(t, err)
-	require.Equal(t, ca.GetRotation().Phase, types.RotationPhaseUpdateServers)
+	require.Equal(t, types.RotationPhaseUpdateServers, ca.GetRotation().Phase)
 
 	// old clients should work
 	_, err = testSrv.CloneClient(t, proxy).GetNodes(ctx, apidefaults.Namespace)
@@ -406,7 +406,7 @@ func TestAutoRotation(t *testing.T) {
 		Type:       types.HostCA,
 	}, false)
 	require.NoError(t, err)
-	require.Equal(t, ca.GetRotation().Phase, types.RotationPhaseStandby)
+	require.Equal(t, types.RotationPhaseStandby, ca.GetRotation().Phase)
 	require.NoError(t, err)
 
 	// old clients should no longer work
@@ -446,7 +446,7 @@ func TestAutoFallback(t *testing.T) {
 
 	// starts rotation
 	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	gracePeriod := time.Hour
 	err = testSrv.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
@@ -465,8 +465,8 @@ func TestAutoFallback(t *testing.T) {
 		Type:       types.HostCA,
 	}, false)
 	require.NoError(t, err)
-	require.Equal(t, ca.GetRotation().Phase, types.RotationPhaseUpdateClients)
-	require.Equal(t, ca.GetRotation().Mode, types.RotationModeAuto)
+	require.Equal(t, types.RotationPhaseUpdateClients, ca.GetRotation().Phase)
+	require.Equal(t, types.RotationModeAuto, ca.GetRotation().Mode)
 
 	// rollback rotation
 	err = testSrv.Auth().RotateCertAuthority(ctx, RotateRequest{
@@ -482,8 +482,8 @@ func TestAutoFallback(t *testing.T) {
 		Type:       types.HostCA,
 	}, false)
 	require.NoError(t, err)
-	require.Equal(t, ca.GetRotation().Phase, types.RotationPhaseRollback)
-	require.Equal(t, ca.GetRotation().Mode, types.RotationModeManual)
+	require.Equal(t, types.RotationPhaseRollback, ca.GetRotation().Phase)
+	require.Equal(t, types.RotationModeManual, ca.GetRotation().Mode)
 }
 
 // TestManualRotation tests local manual rotation
@@ -507,7 +507,7 @@ func TestManualRotation(t *testing.T) {
 	// can't jump to mid-phase
 	gracePeriod := time.Hour
 	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	err = testSrv.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -617,7 +617,7 @@ func TestRollback(t *testing.T) {
 	// starts rotation
 	gracePeriod := time.Hour
 	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	err = testSrv.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -753,7 +753,7 @@ func TestAppTokenRotation(t *testing.T) {
 		Type:       types.JWTSigner,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, oldCA.GetRotation().Phase, types.RotationPhaseInit)
+	require.Equal(t, types.RotationPhaseInit, oldCA.GetRotation().Phase)
 	require.Len(t, oldCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Verify that the JWT token validates with the JWT authority.
@@ -791,7 +791,7 @@ func TestAppTokenRotation(t *testing.T) {
 		Type:       types.JWTSigner,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseUpdateClients)
+	require.Equal(t, types.RotationPhaseUpdateClients, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Both JWT should now validate.
@@ -815,7 +815,7 @@ func TestAppTokenRotation(t *testing.T) {
 		Type:       types.JWTSigner,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseUpdateServers)
+	require.Equal(t, types.RotationPhaseUpdateServers, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Both JWT should continue to validate.
@@ -839,7 +839,7 @@ func TestAppTokenRotation(t *testing.T) {
 		Type:       types.JWTSigner,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseStandby)
+	require.Equal(t, types.RotationPhaseStandby, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 1)
 
 	// Old token should no longer validate.
@@ -907,7 +907,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 		Type:       types.OIDCIdPCA,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, oldCA.GetRotation().Phase, types.RotationPhaseInit)
+	require.Equal(t, types.RotationPhaseInit, oldCA.GetRotation().Phase)
 	require.Len(t, oldCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Verify that the JWT token validates with the JWT authority.
@@ -938,7 +938,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 		Type:       types.OIDCIdPCA,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseUpdateClients)
+	require.Equal(t, types.RotationPhaseUpdateClients, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Both JWT should now validate.
@@ -962,7 +962,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 		Type:       types.OIDCIdPCA,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseUpdateServers)
+	require.Equal(t, types.RotationPhaseUpdateServers, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 2)
 
 	// Both JWT should continue to validate.
@@ -986,7 +986,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 		Type:       types.OIDCIdPCA,
 	}, true)
 	require.NoError(t, err)
-	require.Equal(t, newCA.GetRotation().Phase, types.RotationPhaseStandby)
+	require.Equal(t, types.RotationPhaseStandby, newCA.GetRotation().Phase)
 	require.Len(t, newCA.GetTrustedJWTKeyPairs(), 1)
 
 	// Old token should no longer validate.
@@ -1252,14 +1252,14 @@ func TestUsersCRUD(t *testing.T) {
 
 	users, err := clt.GetUsers(ctx, false)
 	require.NoError(t, err)
-	require.Equal(t, len(users), 1)
-	require.Equal(t, users[0].GetName(), "user1")
+	require.Len(t, users, 1)
+	require.Equal(t, "user1", users[0].GetName())
 
 	require.NoError(t, clt.DeleteUser(ctx, "user1"))
 
 	users, err = clt.GetUsers(ctx, false)
 	require.NoError(t, err)
-	require.Equal(t, len(users), 0)
+	require.Empty(t, users)
 }
 
 func TestPasswordGarbage(t *testing.T) {
@@ -1394,7 +1394,7 @@ func TestWebSessionWithoutAccessRequest(t *testing.T) {
 	// success with password set up
 	ws, err := proxy.AuthenticateWebUser(ctx, req)
 	require.NoError(t, err)
-	require.NotEqual(t, ws, "")
+	require.NotEmpty(t, ws)
 
 	web, err := testSrv.NewClientFromWebSession(ws)
 	require.NoError(t, err)
@@ -1720,10 +1720,10 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	}
 
 	_, hasRole := mappedRole[initialRole]
-	require.Equal(t, hasRole, true)
+	require.True(t, hasRole)
 
 	_, hasRole = mappedRole["test-request-role"]
-	require.Equal(t, hasRole, true)
+	require.True(t, hasRole)
 
 	// certRequests extracts the active requests from a PEM encoded TLS cert.
 	certRequests := func(tlsCert []byte) []string {
@@ -1755,7 +1755,7 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(roles, []string{initialRole}))
 
-	require.Len(t, certRequests(sess2.GetTLSCert()), 0)
+	require.Empty(t, certRequests(sess2.GetTLSCert()))
 }
 
 func TestExtendWebSessionWithReloadUser(t *testing.T) {
@@ -1816,8 +1816,8 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	require.NoError(t, err)
 	roles, err := services.ExtractRolesFromCert(sshcert)
 	require.NoError(t, err)
-	require.Equal(t, traits[constants.TraitLogins], []string{"apple", "banana"})
-	require.Equal(t, traits[constants.TraitDBUsers], []string{"llama", "alpaca"})
+	require.Equal(t, []string{"apple", "banana"}, traits[constants.TraitLogins])
+	require.Equal(t, []string{"llama", "alpaca"}, traits[constants.TraitDBUsers])
 	require.Contains(t, roles, newRoleName)
 }
 
@@ -2081,10 +2081,10 @@ func TestPluginData(t *testing.T) {
 		Resource: req.GetName(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, len(data), 1)
+	require.Len(t, data, 1)
 
 	entry, ok := data[0].Entries()[plugin]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	require.Empty(t, cmp.Diff(entry.Data, map[string]string{"foo": "bar"}))
 
 	err = pluginClient.UpdatePluginData(ctx, types.PluginDataUpdateParams{
@@ -2106,10 +2106,10 @@ func TestPluginData(t *testing.T) {
 		Resource: req.GetName(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, len(data), 1)
+	require.Len(t, data, 1)
 
 	entry, ok = data[0].Entries()[plugin]
-	require.Equal(t, ok, true)
+	require.True(t, ok)
 	require.Empty(t, cmp.Diff(entry.Data, map[string]string{"spam": "eggs"}))
 }
 
@@ -2576,7 +2576,7 @@ func TestGenerateAppToken(t *testing.T) {
 				URI:      "http://localhost:8080",
 			})
 			require.NoError(t, err, ts.inComment)
-			require.Equal(t, claims.Username, "foo@example.com", ts.inComment)
+			require.Equal(t, "foo@example.com", claims.Username, ts.inComment)
 			require.Empty(t, cmp.Diff(claims.Roles, []string{"bar", "baz"}), ts.inComment)
 			require.Empty(t, cmp.Diff(claims.Traits, wrappers.Traits{
 				"trait1": {"value1", "value2"},
@@ -2829,7 +2829,7 @@ func TestLoginAttempts(t *testing.T) {
 	// clears all failed attempts after success
 	loginAttempts, err = testSrv.Auth().GetUserLoginAttempts(user)
 	require.NoError(t, err)
-	require.Len(t, loginAttempts, 0)
+	require.Empty(t, loginAttempts)
 }
 
 func TestChangeUserAuthenticationSettings(t *testing.T) {
@@ -3262,7 +3262,7 @@ func TestClusterAlertAck(t *testing.T) {
 
 	require.Len(t, acks, 1)
 
-	require.Equal(t, acks[0].AlertID, "alert-1")
+	require.Equal(t, "alert-1", acks[0].AlertID)
 
 	clear := proto.ClearAlertAcksRequest{
 		AlertID: "alert-1",
@@ -3274,7 +3274,7 @@ func TestClusterAlertAck(t *testing.T) {
 	acks, err = adminClt.GetAlertAcks(ctx)
 	require.NoError(t, err)
 
-	require.Len(t, acks, 0)
+	require.Empty(t, acks)
 }
 
 func TestClusterAlertClearAckWildcard(t *testing.T) {
@@ -3318,8 +3318,8 @@ func TestClusterAlertClearAckWildcard(t *testing.T) {
 
 	require.Len(t, acks, 2)
 
-	require.Equal(t, acks[0].AlertID, "alert-1")
-	require.Equal(t, acks[1].AlertID, "alert-2")
+	require.Equal(t, "alert-1", acks[0].AlertID)
+	require.Equal(t, "alert-2", acks[1].AlertID)
 
 	clear := proto.ClearAlertAcksRequest{
 		AlertID: "*",
@@ -3331,7 +3331,7 @@ func TestClusterAlertClearAckWildcard(t *testing.T) {
 	acks, err = adminClt.GetAlertAcks(ctx)
 	require.NoError(t, err)
 
-	require.Len(t, acks, 0)
+	require.Empty(t, acks)
 }
 
 // TestClusterAlertAccessControls verifies expected behaviors of cluster alert
@@ -3558,7 +3558,7 @@ func TestEventsPermissions(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Timeout waiting for init event")
 	case event := <-w.Events():
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 	}
 
 	// start rotation
@@ -3726,7 +3726,7 @@ func TestEventsPermissionsPartialSuccess(t *testing.T) {
 			select {
 			case event := <-w.Events():
 				if len(tc.expectedConfirmedKinds) > 0 {
-					require.Equal(t, event.Type, types.OpInit)
+					require.Equal(t, types.OpInit, event.Type)
 					watchStatus, ok := event.Resource.(types.WatchStatus)
 					require.True(t, ok)
 					require.Equal(t, tc.expectedConfirmedKinds, watchStatus.GetKinds())
@@ -3791,7 +3791,7 @@ func TestEventsClusterConfig(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Timeout waiting for init event")
 	case event := <-w.Events():
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 	}
 
 	// start rotation

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -64,9 +64,9 @@ func TestCreateResetPasswordToken(t *testing.T) {
 	require.Equal(t, token.GetURL(), "https://<proxyhost>:3080/web/reset/"+token.GetName())
 
 	event := mockEmitter.LastEvent()
-	require.Equal(t, event.GetType(), events.ResetPasswordTokenCreateEvent)
-	require.Equal(t, event.(*apievents.UserTokenCreate).Name, username)
-	require.Equal(t, event.(*apievents.UserTokenCreate).User, teleport.UserSystem)
+	require.Equal(t, events.ResetPasswordTokenCreateEvent, event.GetType())
+	require.Equal(t, username, event.(*apievents.UserTokenCreate).Name)
+	require.Equal(t, teleport.UserSystem, event.(*apievents.UserTokenCreate).User)
 
 	// verify that user has no MFA devices
 	devs, err := srv.Auth().Services.GetMFADevices(ctx, username, false)
@@ -351,10 +351,10 @@ func TestCreatePrivilegeToken(t *testing.T) {
 
 			// Test events emitted.
 			event := mockEmitter.LastEvent()
-			require.Equal(t, event.GetType(), events.PrivilegeTokenCreateEvent)
-			require.Equal(t, event.GetCode(), events.PrivilegeTokenCreateCode)
-			require.Equal(t, event.(*apievents.UserTokenCreate).Name, username)
-			require.Equal(t, event.(*apievents.UserTokenCreate).User, username)
+			require.Equal(t, events.PrivilegeTokenCreateEvent, event.GetType())
+			require.Equal(t, events.PrivilegeTokenCreateCode, event.GetCode())
+			require.Equal(t, username, event.(*apievents.UserTokenCreate).Name)
+			require.Equal(t, username, event.(*apievents.UserTokenCreate).User)
 
 			// Test token expires after designated time.
 			fakeClock.Advance(defaults.PrivilegeTokenTTL)
@@ -426,9 +426,9 @@ func TestCreatePrivilegeToken_WithLock(t *testing.T) {
 
 				// Test last attempt returns locked error.
 				if i == defaults.MaxLoginAttempts {
-					require.Equal(t, err.Error(), MaxFailedAttemptsErrMsg)
+					require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
 				} else {
-					require.NotEqual(t, err.Error(), MaxFailedAttemptsErrMsg)
+					require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
 				}
 			}
 

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1699,7 +1699,7 @@ func TestFIDO2Register(t *testing.T) {
 			case test.wantErr != nil && err == nil:
 				t.Fatalf("FIDO2Register returned err = nil, wantErr %q", test.wantErr)
 			case test.wantErr != nil:
-				require.True(t, errors.Is(err, test.wantErr), "FIDO2Register returned err = %q, wantErr %q", err, test.wantErr)
+				require.ErrorIs(t, err, test.wantErr, "FIDO2Register returned err = %q, wantErr %q", err, test.wantErr)
 				return
 			default:
 				require.NoError(t, err, "FIDO2Register failed")

--- a/lib/auth/windows/windows_test.go
+++ b/lib/auth/windows/windows_test.go
@@ -118,15 +118,15 @@ func TestGenerateCredentials(t *testing.T) {
 					var san SubjectAltName[upn]
 					_, err = asn1.Unmarshal(extension.Value, &san)
 					require.NoError(t, err)
-					require.Equal(t, san.OtherName.OID, UPNOtherNameOID)
-					require.Equal(t, san.OtherName.Value.Value, user+"@"+domain)
+					require.Equal(t, UPNOtherNameOID, san.OtherName.OID)
+					require.Equal(t, user+"@"+domain, san.OtherName.Value.Value)
 				case extension.Id.Equal(ADUserMappingExtensionOID):
 					foundAdUserMapping = true
 					var adUserMapping SubjectAltName[adSid]
 					_, err = asn1.Unmarshal(extension.Value, &adUserMapping)
 					require.NoError(t, err)
-					require.Equal(t, adUserMapping.OtherName.OID, ADUserMappingInternalOID)
-					require.Equal(t, adUserMapping.OtherName.Value.Value, []byte(testSid))
+					require.Equal(t, ADUserMappingInternalOID, adUserMapping.OtherName.OID)
+					require.Equal(t, []byte(testSid), adUserMapping.OtherName.Value.Value)
 
 				}
 			}

--- a/lib/automaticupgrades/config_test.go
+++ b/lib/automaticupgrades/config_test.go
@@ -52,7 +52,7 @@ func TestIsEnabled(t *testing.T) {
 		t.Setenv(automaticUpgradesEnvar, "foo")
 		require.False(t, IsEnabled())
 
-		require.Equal(t, 1, len(hook.Entries))
+		require.Len(t, hook.Entries, 1)
 		require.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 		require.Equal(t, `unexpected value for ENV:TELEPORT_AUTOMATIC_UPGRADES: strconv.ParseBool: parsing "foo": invalid syntax`, hook.LastEntry().Message)
 	})

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -43,7 +43,7 @@ func TestWatcherSimple(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -52,7 +52,7 @@ func TestWatcherSimple(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Item.ID, int64(1))
+		require.Equal(t, int64(1), e.Item.ID)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -92,7 +92,7 @@ func TestWatcherCapacity(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	default:
 		t.Fatalf("Expected immediate OpInit.")
 	}
@@ -157,14 +157,14 @@ func TestWatcherClose(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	require.Equal(t, b.watchers.Len(), 1)
+	require.Equal(t, 1, b.watchers.Len())
 	w.(*BufferWatcher).closeAndRemove(removeSync)
-	require.Equal(t, b.watchers.Len(), 0)
+	require.Equal(t, 0, b.watchers.Len())
 }
 
 // TestRemoveRedundantPrefixes removes redundant prefixes
@@ -216,7 +216,7 @@ func TestWatcherMulti(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -225,13 +225,12 @@ func TestWatcherMulti(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Item.ID, int64(1))
+		require.Equal(t, int64(1), e.Item.ID)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
 
-	require.Equal(t, len(w.Events()), 0)
-
+	require.Empty(t, w.Events())
 }
 
 // TestWatcherReset tests scenarios with watchers and buffer resets
@@ -249,7 +248,7 @@ func TestWatcherReset(t *testing.T) {
 
 	select {
 	case e := <-w.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -270,7 +269,7 @@ func TestWatcherReset(t *testing.T) {
 
 	select {
 	case e := <-w2.Events():
-		require.Equal(t, e.Type, types.OpInit)
+		require.Equal(t, types.OpInit, e.Type)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -279,7 +278,7 @@ func TestWatcherReset(t *testing.T) {
 
 	select {
 	case e := <-w2.Events():
-		require.Equal(t, e.Item.ID, int64(2))
+		require.Equal(t, int64(2), e.Item.ID)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Timeout waiting for event.")
 	}
@@ -288,10 +287,10 @@ func TestWatcherReset(t *testing.T) {
 // TestWatcherTree tests buffer watcher tree
 func TestWatcherTree(t *testing.T) {
 	wt := newWatcherTree()
-	require.Equal(t, wt.rm(nil), false)
+	require.False(t, wt.rm(nil))
 
 	w1 := &BufferWatcher{Watch: Watch{Prefixes: [][]byte{[]byte("/a"), []byte("/a/a1"), []byte("/c")}}}
-	require.Equal(t, wt.rm(w1), false)
+	require.False(t, wt.rm(w1))
 
 	w2 := &BufferWatcher{Watch: Watch{Prefixes: [][]byte{[]byte("/a")}}}
 
@@ -319,8 +318,8 @@ func TestWatcherTree(t *testing.T) {
 	require.Equal(t, matched[0], w1)
 	require.Equal(t, matched[1], w2)
 
-	require.Equal(t, wt.rm(w1), true)
-	require.Equal(t, wt.rm(w1), false)
+	require.True(t, wt.rm(w1))
+	require.False(t, wt.rm(w1))
 
 	matched = nil
 	wt.walkPath("/a", func(w *BufferWatcher) {
@@ -329,5 +328,5 @@ func TestWatcherTree(t *testing.T) {
 	require.Len(t, matched, 1)
 	require.Equal(t, matched[0], w2)
 
-	require.Equal(t, wt.rm(w2), true)
+	require.True(t, wt.rm(w2))
 }

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -236,7 +236,7 @@ func TestLeaseBucketing(t *testing.T) {
 
 	// ensure that we averaged more than 1 item per lease, but
 	// also spanned more than one bucket.
-	require.Greater(t, len(leases), 1)
+	require.NotEmpty(t, leases)
 	require.Less(t, len(leases), count/2)
 }
 

--- a/lib/backend/kubernetes/kubernetes_test.go
+++ b/lib/backend/kubernetes/kubernetes_test.go
@@ -248,7 +248,7 @@ func TestBackend_Get(t *testing.T) {
 			} else if (err != nil) && trace.IsNotFound(err) && tt.wantNotFound {
 				return
 			}
-			require.Equal(t, got.Value, tt.want)
+			require.Equal(t, tt.want, got.Value)
 		})
 	}
 }
@@ -390,7 +390,7 @@ func TestBackend_Put(t *testing.T) {
 			// get secret loads the kubernetes secret to compare.
 			got, err := b.getSecret(context.TODO())
 			require.NoError(t, err)
-			require.Equal(t, got, tt.want)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -643,7 +643,7 @@ func testFetchLimit(t *testing.T, newBackend Constructor) {
 
 	result, err := uut.GetRange(ctx, prefix("/db"), backend.RangeEnd(prefix("/db")), backend.NoLimit)
 	require.NoError(t, err)
-	require.Equal(t, itemsCount, len(result.Items))
+	require.Len(t, result.Items, itemsCount)
 }
 
 // testLimit tests limit.
@@ -684,7 +684,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 
 	result, err := uut.GetRange(ctx, prefix("/db"), backend.RangeEnd(prefix("/db")), 2)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(result.Items))
+	require.Len(t, result.Items, 2)
 }
 
 // requireEvent asserts that a given event type with the given key is emitted

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2340,7 +2340,7 @@ func TestRelativeExpiry(t *testing.T) {
 
 	// make sure the event buffer is much larger than node count
 	// so that we can batch create nodes without waiting on each event
-	require.True(t, int(nodeCount*3) < eventBufferSize)
+	require.Less(t, int(nodeCount*3), eventBufferSize)
 
 	ctx := context.Background()
 
@@ -2404,7 +2404,7 @@ func TestRelativeExpiry(t *testing.T) {
 	// verify that sliding window has preserved most recent nodes
 	nodes, err = p.cache.GetNodes(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.True(t, len(nodes) > 0, "node_count=%d", len(nodes))
+	require.NotEmpty(t, nodes, "node_count=%d", len(nodes))
 }
 
 func TestRelativeExpiryLimit(t *testing.T) {
@@ -2416,7 +2416,7 @@ func TestRelativeExpiryLimit(t *testing.T) {
 
 	// make sure the event buffer is much larger than node count
 	// so that we can batch create nodes without waiting on each event
-	require.True(t, int(nodeCount*3) < eventBufferSize)
+	require.Less(t, int(nodeCount*3), eventBufferSize)
 
 	ctx := context.Background()
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -219,26 +219,26 @@ func TestParseLabels(t *testing.T) {
 	require.NotNil(t, m)
 	require.NoError(t, err)
 	require.Len(t, m, 3)
-	require.Equal(t, m["role"], "master")
-	require.Equal(t, m["type"], "database")
-	require.Equal(t, m["ver"], "mongoDB v1,2")
+	require.Equal(t, "master", m["role"])
+	require.Equal(t, "database", m["type"])
+	require.Equal(t, "mongoDB v1,2", m["ver"])
 
 	// multiple and unicode:
 	m, err = ParseLabelSpec(`服务器环境=测试,操作系统类别=Linux,机房=华北`)
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.Len(t, m, 3)
-	require.Equal(t, m["服务器环境"], "测试")
-	require.Equal(t, m["操作系统类别"], "Linux")
-	require.Equal(t, m["机房"], "华北")
+	require.Equal(t, "测试", m["服务器环境"])
+	require.Equal(t, "Linux", m["操作系统类别"])
+	require.Equal(t, "华北", m["机房"])
 
 	// invalid specs
 	m, err = ParseLabelSpec(`type="database,"role"=master,ver="mongoDB v1,2"`)
 	require.Nil(t, m)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	m, err = ParseLabelSpec(`type="database",role,master`)
 	require.Nil(t, m)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestPortsParsing(t *testing.T) {
@@ -374,7 +374,7 @@ func TestDynamicPortsParsing(t *testing.T) {
 	for _, tt := range dynamicPortForwardParsingTestCases {
 		specs, err := ParseDynamicPortForwardSpec(tt.spec)
 		if tt.isError {
-			require.NotNil(t, err)
+			require.Error(t, err)
 			continue
 		} else {
 			require.NoError(t, err)

--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -332,7 +332,7 @@ func TestProxySSHConfig(t *testing.T) {
 		// rejected and fail.
 		_, err = clt.NewSession()
 		require.Error(t, err)
-		require.Equal(t, int(called.Load()), 1)
+		require.Equal(t, 1, int(called.Load()))
 
 		_, spub, err := testauthority.New().GenerateKeyPair()
 		require.NoError(t, err)

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -39,9 +39,9 @@ import (
 )
 
 func TestHelperFunctions(t *testing.T) {
-	assert.Equal(t, nodeName(targetNode{addr: "one"}), "one")
-	assert.Equal(t, nodeName(targetNode{addr: "one:22"}), "one")
-	assert.Equal(t, nodeName(targetNode{addr: "one", hostname: "example.com"}), "example.com")
+	assert.Equal(t, "one", nodeName(targetNode{addr: "one"}))
+	assert.Equal(t, "one", nodeName(targetNode{addr: "one:22"}))
+	assert.Equal(t, "example.com", nodeName(targetNode{addr: "one", hostname: "example.com"}))
 }
 
 func TestNewSession(t *testing.T) {
@@ -55,12 +55,12 @@ func TestNewSession(t *testing.T) {
 	ses, err := newSession(ctx, nc, nil, nil, nil, nil, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, ses)
-	require.Equal(t, ses.NodeClient(), nc)
-	require.Equal(t, ses.namespace, nc.Namespace)
+	require.Equal(t, nc, ses.NodeClient())
+	require.Equal(t, nc.Namespace, ses.namespace)
 	require.NotNil(t, ses.env)
-	require.Equal(t, ses.terminal.Stderr(), os.Stderr)
-	require.Equal(t, ses.terminal.Stdout(), os.Stdout)
-	require.Equal(t, ses.terminal.Stdin(), os.Stdin)
+	require.Equal(t, os.Stderr, ses.terminal.Stderr())
+	require.Equal(t, os.Stdout, ses.terminal.Stdout())
+	require.Equal(t, os.Stdin, ses.terminal.Stdin())
 
 	// pass environ map
 	env := map[string]string{
@@ -71,7 +71,7 @@ func TestNewSession(t *testing.T) {
 	require.NotNil(t, ses)
 	require.Empty(t, cmp.Diff(ses.env, env))
 	// the session ID must be taken from tne environ map, if passed:
-	require.Equal(t, string(ses.id), "session-id")
+	require.Equal(t, "session-id", string(ses.id))
 }
 
 // TestProxyConnection verifies that client or server-side disconnect

--- a/lib/client/escape/reader_test.go
+++ b/lib/client/escape/reader_test.go
@@ -44,10 +44,10 @@ func runCase(t *testing.T, tc readerTestCase) {
 	})
 
 	_, err := io.Copy(out, r)
-	require.Equal(t, err, tc.wantReadErr)
-	require.Equal(t, disconnectErr, tc.wantDisconnectErr)
-	require.Equal(t, out.String(), tc.wantOut)
-	require.Equal(t, helpOut.String(), tc.wantHelp)
+	require.Equal(t, tc.wantReadErr, err)
+	require.Equal(t, tc.wantDisconnectErr, disconnectErr)
+	require.Equal(t, tc.wantOut, out.String())
+	require.Equal(t, tc.wantHelp, helpOut.String())
 }
 
 func TestNormalReads(t *testing.T) {

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -211,7 +211,7 @@ func TestWriteAllFormats(t *testing.T) {
 			for _, file := range files {
 				require.True(t, strings.HasPrefix(file, cfg.OutputPath))
 			}
-			require.True(t, len(files) > 0)
+			require.NotEmpty(t, files)
 		})
 	}
 }

--- a/lib/client/known_hosts_migrate_test.go
+++ b/lib/client/known_hosts_migrate_test.go
@@ -53,7 +53,7 @@ func generateHostCert(t *testing.T, s *knownHostsMigrateTest, clusterName string
 		ClusterName:   clusterName,
 		PublicHostKey: hostPub,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return cert
 }
@@ -63,7 +63,7 @@ func generateOldHostEntry(
 ) *knownHostEntry {
 	formatted := fmt.Sprintf("%s %s", clusterName, strings.TrimSpace(string(cert)))
 	entry, err := parseKnownHost(formatted)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, formatted, entry.raw)
 
 	return entry
@@ -77,7 +77,7 @@ func generateNewHostEntry(
 		proxyName, clusterName, clusterName, strings.TrimSpace(string(cert)),
 	)
 	entry, err := parseKnownHost(formatted)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, formatted, entry.raw)
 
 	return entry
@@ -94,7 +94,7 @@ func TestParseKnownHost(t *testing.T) {
 	require.Equal(t, []string{"example.com"}, oldEntry.hosts)
 
 	oldCertParsed, _, _, _, err := ssh.ParseAuthorizedKey(oldCert)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, bytes.Equal(oldCertParsed.Marshal(), oldEntry.pubKey.Marshal()))
 
 	newCert := generateHostCert(t, &s, "example.com")
@@ -105,7 +105,7 @@ func TestParseKnownHost(t *testing.T) {
 	require.Equal(t, "type=host", newEntry.comment)
 
 	newCertParsed, _, _, _, err := ssh.ParseAuthorizedKey(newCert)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, bytes.Equal(newCertParsed.Marshal(), newEntry.pubKey.Marshal()))
 }
 
@@ -125,13 +125,13 @@ func TestIsOldHostsEntry(t *testing.T) {
 	// In this case, multiple hosts should invalidate the key.
 	hostsEntryString := fmt.Sprintf("foo,bar %s", strings.TrimSpace(string(cert)))
 	hostsEntry, err := parseKnownHost(hostsEntryString)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, isOldStyleHostsEntry(hostsEntry))
 
 	// Additionally, any comment invalidates it.
 	commentEntryString := fmt.Sprintf("foo %s comment", strings.TrimSpace(string(cert)))
 	commentEntry, err := parseKnownHost(commentEntryString)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, isOldStyleHostsEntry(commentEntry))
 }
 

--- a/lib/client/tncon/buffer_test.go
+++ b/lib/client/tncon/buffer_test.go
@@ -167,7 +167,7 @@ func BenchmarkBufferedChannelPipe(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				written, err := buffer.Write(data)
 				require.NoError(b, err)
-				require.Equal(b, len(data), written)
+				require.Len(b, data, written)
 			}
 			require.NoError(b, <-errCh)
 			b.StopTimer()

--- a/lib/client/trusted_certs_store_test.go
+++ b/lib/client/trusted_certs_store_test.go
@@ -178,24 +178,24 @@ func TestAddTrustedHostKeys(t *testing.T) {
 		err = clientStore.AddTrustedHostKeys("leaf.example.com", "leaf", pub2)
 		require.NoError(t, err)
 		after, _ := clientStore.GetTrustedHostKeys()
-		require.Equal(t, len(before), len(after))
+		require.Len(t, before, len(after))
 
 		// check by hostname:
 		keys, _ = clientStore.GetTrustedHostKeys("nocluster")
-		require.Equal(t, len(keys), 0)
+		require.Empty(t, keys)
 		keys, _ = clientStore.GetTrustedHostKeys("leaf")
-		require.Equal(t, len(keys), 1)
+		require.Len(t, keys, 1)
 		require.True(t, apisshutils.KeysEqual(keys[0], pub2))
 
 		// check for proxy and wildcard as well:
 		keys, _ = clientStore.GetTrustedHostKeys("leaf.example.com")
-		require.Equal(t, 1, len(keys))
+		require.Len(t, keys, 1)
 		require.True(t, apisshutils.KeysEqual(keys[0], pub2))
 		keys, _ = clientStore.GetTrustedHostKeys("*.leaf")
-		require.Equal(t, 1, len(keys))
+		require.Len(t, keys, 1)
 		require.True(t, apisshutils.KeysEqual(keys[0], pub2))
 		keys, _ = clientStore.GetTrustedHostKeys("prefix.leaf")
-		require.Equal(t, 1, len(keys))
+		require.Len(t, keys, 1)
 		require.True(t, apisshutils.KeysEqual(keys[0], pub2))
 	})
 }

--- a/lib/cloud/azure/kubernetes_test.go
+++ b/lib/cloud/azure/kubernetes_test.go
@@ -87,7 +87,7 @@ func Test_aKSClient_ClusterCredentials(t *testing.T) {
 				},
 			},
 			validateRestConfig: func(t *testing.T, c *rest.Config) {
-				require.Equal(t, c.Username, "exp")
+				require.Equal(t, "exp", c.Username)
 			},
 		},
 		{

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -60,7 +60,7 @@ func TestGetVirtualMachine(t *testing.T) {
 				vm, ok := val.(*VirtualMachine)
 				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
 				require.Equal(t, vm.ID, validResourceID)
-				require.Equal(t, vm.Name, "name")
+				require.Equal(t, "name", vm.Name)
 				require.ElementsMatch(t, []Identity{
 					{ResourceID: "system assigned"},
 					{ResourceID: "identity1"},
@@ -83,7 +83,7 @@ func TestGetVirtualMachine(t *testing.T) {
 				vm, ok := val.(*VirtualMachine)
 				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
 				require.Equal(t, vm.ID, validResourceID)
-				require.Equal(t, vm.Name, "name")
+				require.Equal(t, "name", vm.Name)
 				require.Empty(t, vm.Identities)
 			},
 		},
@@ -108,7 +108,7 @@ func TestGetVirtualMachine(t *testing.T) {
 				vm, ok := val.(*VirtualMachine)
 				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
 				require.Equal(t, vm.ID, validResourceID)
-				require.Equal(t, vm.Name, "name")
+				require.Equal(t, "name", vm.Name)
 				require.ElementsMatch(t, []Identity{
 					{ResourceID: "identity1"},
 					{ResourceID: "identity2"},

--- a/lib/cloud/gcp/kubernetes_test.go
+++ b/lib/cloud/gcp/kubernetes_test.go
@@ -167,7 +167,7 @@ func Test_gcpGKEClient_ListClusters(t *testing.T) {
 				return got[i].Name < got[j].Name
 			})
 
-			require.Equal(t, got, tt.want)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"bytes"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -207,8 +206,8 @@ func TestSampleConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate a couple of values:
-			require.Equal(t, fc.Global.DataDir, defaults.DataDir)
-			require.Equal(t, fc.Logger.Severity, "INFO")
+			require.Equal(t, defaults.DataDir, fc.Global.DataDir)
+			require.Equal(t, "INFO", fc.Logger.Severity)
 			require.Equal(t, testCase.expectClusterName, fc.Auth.ClusterName)
 			require.Equal(t, testCase.expectLicenseFile, fc.Auth.LicenseFile)
 			require.Equal(t, testCase.expectProxyWebAddr, fc.Proxy.WebAddr)
@@ -592,7 +591,7 @@ func TestLabelParsing(t *testing.T) {
 	var err error
 	// empty spec. no errors, no labels
 	err = parseLabelsApply("", &conf)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, conf.CmdLabels)
 	require.Nil(t, conf.Labels)
 
@@ -600,7 +599,7 @@ func TestLabelParsing(t *testing.T) {
 	err = parseLabelsApply(`key=value,more="much better"`, &conf)
 	require.NoError(t, err)
 	require.NotNil(t, conf.CmdLabels)
-	require.Len(t, conf.CmdLabels, 0)
+	require.Empty(t, conf.CmdLabels)
 	require.Equal(t, map[string]string{
 		"key":  "value",
 		"more": "much better",
@@ -608,7 +607,7 @@ func TestLabelParsing(t *testing.T) {
 
 	// static labels + command labels
 	err = parseLabelsApply(`key=value,more="much better",arch=[5m2s:/bin/uname -m "p1 p2"]`, &conf)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, map[string]string{
 		"key":  "value",
 		"more": "much better",
@@ -758,7 +757,7 @@ func TestApplyConfig(t *testing.T) {
 	require.Equal(t, "tcp://mongo.example:27017", cfg.Proxy.MongoPublicAddrs[0].FullAddress())
 	require.Equal(t, "tcp://peerhost:1234", cfg.Proxy.PeerAddress.FullAddress())
 	require.Equal(t, "tcp://peer.example:1234", cfg.Proxy.PeerPublicAddr.FullAddress())
-	require.Equal(t, true, cfg.Proxy.IdP.SAMLIdP.Enabled)
+	require.True(t, cfg.Proxy.IdP.SAMLIdP.Enabled)
 	require.Equal(t, "", cfg.Proxy.IdP.SAMLIdP.BaseURL)
 
 	require.Equal(t, "tcp://127.0.0.1:3000", cfg.DiagnosticAddr.FullAddress())
@@ -880,7 +879,7 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 			},
 		},
 	))
-	require.Equal(t, cfg.Kube.KubeconfigPath, "/tmp/kubeconfig")
+	require.Equal(t, "/tmp/kubeconfig", cfg.Kube.KubeconfigPath)
 	require.Empty(t, cmp.Diff(cfg.Kube.StaticLabels,
 		map[string]string{
 			"testKey": "testValue",
@@ -888,22 +887,22 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 	))
 
 	require.True(t, cfg.Discovery.Enabled)
-	require.Equal(t, cfg.Discovery.AWSMatchers[0].Regions, []string{"eu-central-1"})
-	require.Equal(t, cfg.Discovery.AWSMatchers[0].Types, []string{"ec2"})
-	require.Equal(t, cfg.Discovery.AWSMatchers[0].AssumeRole.RoleARN, "arn:aws:iam::123456789012:role/DBDiscoverer")
-	require.Equal(t, cfg.Discovery.AWSMatchers[0].AssumeRole.ExternalID, "externalID123")
-	require.Equal(t, cfg.Discovery.AWSMatchers[0].Params, &types.InstallerParams{
+	require.Equal(t, []string{"eu-central-1"}, cfg.Discovery.AWSMatchers[0].Regions)
+	require.Equal(t, []string{"ec2"}, cfg.Discovery.AWSMatchers[0].Types)
+	require.Equal(t, "arn:aws:iam::123456789012:role/DBDiscoverer", cfg.Discovery.AWSMatchers[0].AssumeRole.RoleARN)
+	require.Equal(t, "externalID123", cfg.Discovery.AWSMatchers[0].AssumeRole.ExternalID)
+	require.Equal(t, &types.InstallerParams{
 		InstallTeleport: true,
 		JoinMethod:      "iam",
 		JoinToken:       types.IAMInviteTokenName,
 		ScriptName:      "default-installer",
 		SSHDConfig:      types.SSHDConfigPath,
-	})
+	}, cfg.Discovery.AWSMatchers[0].Params)
 
 	require.True(t, cfg.Okta.Enabled)
-	require.Equal(t, cfg.Okta.APIEndpoint, "https://some-endpoint")
-	require.Equal(t, cfg.Okta.APITokenPath, oktaAPITokenPath)
-	require.Equal(t, cfg.Okta.SyncPeriod, time.Second*300)
+	require.Equal(t, "https://some-endpoint", cfg.Okta.APIEndpoint)
+	require.Equal(t, oktaAPITokenPath, cfg.Okta.APITokenPath)
+	require.Equal(t, time.Second*300, cfg.Okta.SyncPeriod)
 }
 
 // TestApplyConfigNoneEnabled makes sure that if a section is not enabled,
@@ -1020,7 +1019,7 @@ func TestApplyCustomSessionRecordingConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, cfg.Auth.Enabled)
-	require.Equal(t, cfg.Auth.ClusterName.GetClusterName(), "example.com")
+	require.Equal(t, "example.com", cfg.Auth.ClusterName.GetClusterName())
 	require.Equal(t, types.OriginDefaults, cfg.Auth.Preference.Origin())
 	require.Equal(t, types.OriginDefaults, cfg.Auth.NetworkingConfig.Origin())
 	require.Equal(t, types.OriginConfigFile, cfg.Auth.SessionRecordingConfig.Origin())
@@ -1207,8 +1206,8 @@ func TestBackendDefaults(t *testing.T) {
        type: dir
        path: /var/lib/teleport/mybackend
 `)
-	require.Equal(t, cfg.Auth.StorageConfig.Type, lite.GetName())
-	require.Equal(t, cfg.Auth.StorageConfig.Params[defaults.BackendPath], "/var/lib/teleport/mybackend")
+	require.Equal(t, lite.GetName(), cfg.Auth.StorageConfig.Type)
+	require.Equal(t, "/var/lib/teleport/mybackend", cfg.Auth.StorageConfig.Params[defaults.BackendPath])
 
 	// Kubernetes proxy is disabled by default.
 	cfg = read(`teleport:
@@ -1323,9 +1322,9 @@ func TestParseCachePolicy(t *testing.T) {
 }
 
 func checkStaticConfig(t *testing.T, conf *FileConfig) {
-	require.Equal(t, conf.AuthToken, "xxxyyy")
-	require.Equal(t, conf.AdvertiseIP, "10.10.10.1:3022")
-	require.Equal(t, conf.PIDFile, "/var/run/teleport.pid")
+	require.Equal(t, "xxxyyy", conf.AuthToken)
+	require.Equal(t, "10.10.10.1:3022", conf.AdvertiseIP)
+	require.Equal(t, "/var/run/teleport.pid", conf.PIDFile)
 
 	require.Empty(t, cmp.Diff(conf.Limits, ConnectionLimits{
 		MaxConnections: 90,
@@ -2905,10 +2904,7 @@ func TestDatabaseCLIFlags(t *testing.T) {
 				require.Contains(t, err.Error(), tt.outError)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					config.Databases.Databases,
-					[]servicecfg.Database{tt.outDatabase},
-				)
+				require.Equal(t, []servicecfg.Database{tt.outDatabase}, config.Databases.Databases)
 			}
 		})
 	}
@@ -3574,7 +3570,7 @@ func TestAuthHostedPlugins(t *testing.T) {
 	}
 	notExist := func(t require.TestingT, err error, msgAndArgs ...interface{}) {
 		require.Error(t, err)
-		require.True(t, errors.Is(err, os.ErrNotExist), `expected "does not exist", but got %v`)
+		require.ErrorIs(t, err, os.ErrNotExist, `expected "does not exist", but got %v`, err)
 	}
 
 	tmpDir := t.TempDir()

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -514,7 +514,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 		t.Run("empty", func(t *testing.T) {
 			flags := DatabaseSampleFlags{}
 			databases := generateAndParseConfig(t, flags)
-			require.Len(t, databases.ResourceMatchers, 0)
+			require.Empty(t, databases.ResourceMatchers)
 		})
 
 		t.Run("multiple labels", func(t *testing.T) {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -521,7 +521,7 @@ func TestAuthenticationConfig_Parse_StaticToken(t *testing.T) {
 				Token:   tt.token,
 				Expires: provisionToken.Expires,
 			}
-			require.Equal(t, provisionToken, want)
+			require.Equal(t, want, provisionToken)
 		})
 	}
 }

--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -104,7 +104,7 @@ func TestSearchEvents(t *testing.T) {
 	}
 
 	wantCallsToAthena := func(t *testing.T, mock *mockAthenaExecutor, want int) {
-		require.Equal(t, want, len(mock.startQueryReqs))
+		require.Len(t, mock.startQueryReqs, want)
 	}
 	wantSingleCallToAthena := func(t *testing.T, mock *mockAthenaExecutor) {
 		wantCallsToAthena(t, mock, 1)

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -50,7 +50,7 @@ func TestStreams(t *testing.T) {
 	require.NoError(t, err)
 
 	handler, err := NewHandler(ctx, config)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("StreamManyParts", func(t *testing.T) {
 		test.StreamManyParts(t, handler)

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -81,11 +81,11 @@ func TestProtoStreamer(t *testing.T) {
 				Uploader:       uploader,
 				MinUploadBytes: tc.minUploadBytes,
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			sid := session.ID(fmt.Sprintf("test-%v", i))
 			stream, err := streamer.CreateAuditStream(ctx, sid)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			evts := tc.events
 			for _, event := range evts {
@@ -94,21 +94,21 @@ func TestProtoStreamer(t *testing.T) {
 					require.IsType(t, tc.err, err)
 					return
 				}
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 			err = stream.Complete(ctx)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			var outEvents []apievents.AuditEvent
 			uploads, err := uploader.ListUploads(ctx)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			parts, err := uploader.GetParts(uploads[0].ID)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			for _, part := range parts {
 				reader := events.NewProtoReader(bytes.NewReader(part))
 				out, err := reader.ReadAll(ctx)
-				require.Nil(t, err, "part crash %#v", part)
+				require.NoError(t, err, "part crash %#v", part)
 				outEvents = append(outEvents, out...)
 			}
 
@@ -205,7 +205,7 @@ func TestAsyncEmitter(t *testing.T) {
 
 		// context will not wait until all events have been submitted
 		emitter.Close()
-		require.True(t, int(counter.Count()) <= len(evts))
+		require.LessOrEqual(t, int(counter.Count()), len(evts))
 
 		// make sure all emit calls returned after context is done
 		for range evts {
@@ -272,5 +272,5 @@ func TestExport(t *testing.T) {
 		count++
 	}
 	require.NoError(t, snl.Err())
-	require.Equal(t, len(outEvents), count)
+	require.Len(t, outEvents, count)
 }

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -98,7 +98,7 @@ func TestFileLogPagination(t *testing.T) {
 		Order:    types.EventOrderAscending,
 		StartKey: checkpoint,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, eventArr, 1)
 	require.Empty(t, checkpoint)
 }
@@ -113,7 +113,7 @@ func TestSearchSessionEvents(t *testing.T) {
 		RotationPeriod: time.Hour * 24,
 		Clock:          clock,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	clock.Advance(1 * time.Minute)
 
 	require.NoError(t, log.EmitAuditEvent(ctx, &events.SessionEnd{
@@ -133,8 +133,8 @@ func TestSearchSessionEvents(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, result, 1)
-	require.Equal(t, result[0].GetType(), SessionEndEvent)
-	require.Equal(t, result[0].GetID(), "a")
+	require.Equal(t, SessionEndEvent, result[0].GetType())
+	require.Equal(t, "a", result[0].GetID())
 
 	// emit a non-session event, it should not show up in the next query
 	require.NoError(t, log.EmitAuditEvent(ctx, &events.SessionJoin{
@@ -154,8 +154,8 @@ func TestSearchSessionEvents(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, result, 1)
-	require.Equal(t, result[0].GetType(), SessionEndEvent)
-	require.Equal(t, result[0].GetID(), "a")
+	require.Equal(t, SessionEndEvent, result[0].GetType())
+	require.Equal(t, "a", result[0].GetID())
 
 	// emit a desktop session event, it should show up in the next query
 	require.NoError(t, log.EmitAuditEvent(ctx, &events.WindowsDesktopSessionEnd{
@@ -175,10 +175,10 @@ func TestSearchSessionEvents(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, result, 2)
-	require.Equal(t, result[0].GetType(), SessionEndEvent)
-	require.Equal(t, result[0].GetID(), "a")
-	require.Equal(t, result[1].GetType(), WindowsDesktopSessionEndEvent)
-	require.Equal(t, result[1].GetID(), "c")
+	require.Equal(t, SessionEndEvent, result[0].GetType())
+	require.Equal(t, "a", result[0].GetID())
+	require.Equal(t, WindowsDesktopSessionEndEvent, result[1].GetType())
+	require.Equal(t, "c", result[1].GetID())
 }
 
 // TestLargeEvent test fileLog behavior in case of large events.
@@ -188,7 +188,7 @@ func TestLargeEvent(t *testing.T) {
 
 	hasEventsLength := func(n int) check {
 		return func(t *testing.T, ee []events.AuditEvent) {
-			require.Equal(t, n, len(ee), "events length mismatch")
+			require.Len(t, ee, n, "events length mismatch")
 		}
 	}
 	hasEventsIDs := func(ids ...string) check {

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -43,7 +43,7 @@ func TestStreams(t *testing.T) {
 	handler, err := NewHandler(Config{
 		Directory: dir,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer handler.Close()
 
 	t.Run("Stream", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestStreams(t *testing.T) {
 				return nil
 			},
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer handler.Close()
 
 		test.StreamResumeManyParts(t, handler)

--- a/lib/events/gcssessions/gcshandler_test.go
+++ b/lib/events/gcssessions/gcshandler_test.go
@@ -46,7 +46,7 @@ func TestFakeStreams(t *testing.T) {
 		Endpoint: server.URL(),
 		Bucket:   fmt.Sprintf("teleport-test-%v", uuid.New().String()),
 	}, server.Client())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer handler.Close()
 
 	t.Run("UploadDownload", func(t *testing.T) {

--- a/lib/events/gcssessions/gcsstream_test.go
+++ b/lib/events/gcssessions/gcsstream_test.go
@@ -75,7 +75,7 @@ func TestStreams(t *testing.T) {
 			teleport.GCSTestURI)
 	}
 	u, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	config := Config{}
 	err = config.SetFromURL(u)

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -44,7 +44,7 @@ func TestStreams(t *testing.T) {
 		Path:   "/test/",
 		Bucket: fmt.Sprintf("teleport-unit-tests"),
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	defer handler.Close()
 
@@ -73,7 +73,7 @@ func TestACL(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			url, err := url.Parse(fmt.Sprintf("%s?acl=%s", baseUrl, tc.acl))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			conf := Config{}
 			err = conf.SetFromURL(url, "")
 			if tc.isError {

--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -49,7 +49,7 @@ func TestThirdpartyStreams(t *testing.T) {
 		Endpoint:                    server.URL,
 		DisableServerSideEncryption: true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	defer func() {
 		if err := handler.deleteBucket(context.Background()); err != nil {

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -61,7 +61,7 @@ func TestSessionWriter(t *testing.T) {
 		select {
 		case event := <-test.eventsCh:
 			require.Equal(t, string(test.sid), event.SessionID)
-			require.Nil(t, event.Error)
+			require.NoError(t, event.Error)
 		case <-test.ctx.Done():
 			t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 		}
@@ -75,7 +75,7 @@ func TestSessionWriter(t *testing.T) {
 		for _, part := range parts {
 			reader := events.NewProtoReader(bytes.NewReader(part))
 			out, err := reader.ReadAll(test.ctx)
-			require.Nil(t, err, "part crash %#v", part)
+			require.NoError(t, err, "part crash %#v", part)
 			outEvents = append(outEvents, out...)
 		}
 
@@ -256,7 +256,7 @@ func TestSessionWriter(t *testing.T) {
 		}
 		elapsedTime := time.Since(start)
 		log.Debugf("Emitted all events in %v.", elapsedTime)
-		require.True(t, elapsedTime < time.Second)
+		require.Less(t, elapsedTime, time.Second)
 		hangCancel()
 		err := test.writer.Complete(test.ctx)
 		require.NoError(t, err)
@@ -292,7 +292,7 @@ func TestSessionWriter(t *testing.T) {
 		test.Close(context.Background())
 		require.Equal(t, len(inEvents), len(emittedEvents))
 		for _, event := range emittedEvents {
-			require.Equal(t, event.GetClusterName(), "cluster")
+			require.Equal(t, "cluster", event.GetClusterName())
 		}
 	})
 
@@ -406,7 +406,7 @@ func (a *sessionWriterTest) collectEvents(t *testing.T) []apievents.AuditEvent {
 	case event := <-a.eventsCh:
 		log.Debugf("Got status update, upload %v in %v.", event.UploadID, time.Since(start))
 		require.Equal(t, string(a.sid), event.SessionID)
-		require.Nil(t, event.Error)
+		require.NoError(t, event.Error)
 		uploadID = event.UploadID
 	case <-a.ctx.Done():
 		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
@@ -421,7 +421,7 @@ func (a *sessionWriterTest) collectEvents(t *testing.T) []apievents.AuditEvent {
 	}
 	reader := events.NewProtoReader(io.MultiReader(readers...))
 	outEvents, err := reader.ReadAll(a.ctx)
-	require.Nil(t, err, "failed to read")
+	require.NoError(t, err, "failed to read")
 	log.WithFields(reader.GetStats().ToFields()).Debugf("Reader stats.")
 
 	return outEvents

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -42,21 +42,21 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	val := "hello, how is it going? this is the uploaded file"
 	id := session.NewID()
 	_, err := handler.Upload(context.TODO(), id, bytes.NewBuffer([]byte(val)))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	f, err := os.CreateTemp("", string(id))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()
 
 	err = handler.Download(context.TODO(), id, f)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = f.Seek(0, 0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, err := io.ReadAll(f)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, string(data), val)
 }
 
@@ -65,7 +65,7 @@ func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 	id := session.NewID()
 
 	f, err := os.CreateTemp("", string(id))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()
 
@@ -123,7 +123,7 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, arr, 4)
-	require.Equal(t, checkpoint, "")
+	require.Empty(t, checkpoint)
 
 	for _, name := range names {
 		arr, checkpoint, err = s.Log.SearchEvents(ctx, events.SearchEventsRequest{
@@ -148,9 +148,9 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 			StartKey: checkpoint,
 		})
 		require.NoError(t, err)
-		require.Len(t, arr, 0)
+		require.Empty(t, arr)
 	}
-	require.Equal(t, checkpoint, "")
+	require.Empty(t, checkpoint)
 
 	for _, i := range []int{0, 2} {
 		nameA := names[i]
@@ -180,9 +180,9 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 			StartKey: checkpoint,
 		})
 		require.NoError(t, err)
-		require.Len(t, arr, 0)
+		require.Empty(t, arr)
 	}
-	require.Equal(t, checkpoint, "")
+	require.Empty(t, checkpoint)
 
 	for i := len(names) - 1; i >= 0; i-- {
 		arr, checkpoint, err = s.Log.SearchEvents(ctx, events.SearchEventsRequest{
@@ -207,9 +207,9 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 			StartKey: checkpoint,
 		})
 		require.NoError(t, err)
-		require.Len(t, arr, 0)
+		require.Empty(t, arr)
 	}
-	require.Equal(t, checkpoint, "")
+	require.Empty(t, checkpoint)
 
 	// This serves no special purpose except to make querying easier.
 	baseTime2 := time.Now().UTC().AddDate(0, 0, -2)
@@ -351,8 +351,8 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, history, 3)
 
-	require.Equal(t, history[1].GetType(), events.SessionStartEvent)
-	require.Equal(t, history[2].GetType(), events.SessionEndEvent)
+	require.Equal(t, events.SessionStartEvent, history[1].GetType())
+	require.Equal(t, events.SessionEndEvent, history[2].GetType())
 
 	history, _, err = s.Log.SearchSessionEvents(ctx, events.SearchSessionEventsRequest{
 		From:  s.Clock.Now().UTC().Add(-1 * time.Hour),
@@ -388,7 +388,7 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 		Cond:  withParticipant("cecile"),
 	})
 	require.NoError(t, err)
-	require.Len(t, history, 0)
+	require.Empty(t, history)
 
 	history, _, err = s.Log.SearchSessionEvents(ctx, events.SearchSessionEventsRequest{
 		From:  s.Clock.Now().UTC().Add(-1 * time.Hour),
@@ -397,7 +397,7 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 		Order: types.EventOrderAscending,
 	})
 	require.NoError(t, err)
-	require.Len(t, history, 0)
+	require.Empty(t, history)
 }
 
 func (s *EventsSuite) SearchSessionEventsBySessionID(t *testing.T) {

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -205,7 +205,7 @@ func TestNormalizeECSResourceName(t *testing.T) {
 			require.True(t, validClusterName.Match([]byte(tt.input)))
 			require.True(t, validECSName.Match([]byte(tt.expected)))
 
-			require.Equal(t, normalizeECSResourceName(tt.input), tt.expected)
+			require.Equal(t, tt.expected, normalizeECSResourceName(tt.input))
 		})
 	}
 }

--- a/lib/integrations/awsoidc/list_ec2ice_test.go
+++ b/lib/integrations/awsoidc/list_ec2ice_test.go
@@ -105,7 +105,7 @@ func TestListEC2ICE(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.EC2ICEs, pageSize)
 		nextPageToken := resp.NextToken
-		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-0")
+		require.Equal(t, "subnet-0", resp.EC2ICEs[0].SubnetID)
 
 		// Second page must return pageSize number of Endpoints
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
@@ -117,7 +117,7 @@ func TestListEC2ICE(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.EC2ICEs, pageSize)
 		nextPageToken = resp.NextToken
-		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-100")
+		require.Equal(t, "subnet-100", resp.EC2ICEs[0].SubnetID)
 
 		// Third page must return only the remaining Endpoints and an empty nextToken
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
@@ -128,7 +128,7 @@ func TestListEC2ICE(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
 		require.Len(t, resp.EC2ICEs, 3)
-		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-200")
+		require.Equal(t, "subnet-200", resp.EC2ICEs[0].SubnetID)
 	})
 
 	for _, tt := range []struct {

--- a/lib/integrations/awsoidc/list_security_groups_test.go
+++ b/lib/integrations/awsoidc/list_security_groups_test.go
@@ -101,8 +101,8 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, pageSize)
 		nextPageToken := resp.NextToken
-		require.Equal(t, resp.SecurityGroups[0].ID, "sg-0")
-		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-0")
+		require.Equal(t, "sg-0", resp.SecurityGroups[0].ID)
+		require.Equal(t, "MySG-0", resp.SecurityGroups[0].Name)
 
 		// Second page must return pageSize number of Endpoints
 		resp, err = ListSecurityGroups(ctx, mockListClient, ListSecurityGroupsRequest{
@@ -113,8 +113,8 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, pageSize)
 		nextPageToken = resp.NextToken
-		require.Equal(t, resp.SecurityGroups[0].ID, "sg-100")
-		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-100")
+		require.Equal(t, "sg-100", resp.SecurityGroups[0].ID)
+		require.Equal(t, "MySG-100", resp.SecurityGroups[0].Name)
 
 		// Third page must return only the remaining Endpoints and an empty nextToken
 		resp, err = ListSecurityGroups(ctx, mockListClient, ListSecurityGroupsRequest{
@@ -124,8 +124,8 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, 3)
-		require.Equal(t, resp.SecurityGroups[0].ID, "sg-200")
-		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-200")
+		require.Equal(t, "sg-200", resp.SecurityGroups[0].ID)
+		require.Equal(t, "MySG-200", resp.SecurityGroups[0].Name)
 	})
 
 	for _, tt := range []struct {

--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -134,7 +134,7 @@ func TestListEC2(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.Servers, pageSize)
 		nextPageToken := resp.NextToken
-		require.Equal(t, resp.Servers[0].GetCloudMetadata().AWS.InstanceID, "i-0")
+		require.Equal(t, "i-0", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 
 		// Second page must return pageSize number of Servers
 		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
@@ -146,7 +146,7 @@ func TestListEC2(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.Servers, pageSize)
 		nextPageToken = resp.NextToken
-		require.Equal(t, resp.Servers[0].GetCloudMetadata().AWS.InstanceID, "i-100")
+		require.Equal(t, "i-100", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 
 		// Third page must return only the remaining Servers and an empty nextToken
 		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
@@ -157,7 +157,7 @@ func TestListEC2(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
 		require.Len(t, resp.Servers, 3)
-		require.Equal(t, resp.Servers[0].GetCloudMetadata().AWS.InstanceID, "i-200")
+		require.Equal(t, "i-200", resp.Servers[0].GetCloudMetadata().AWS.InstanceID)
 	})
 
 	for _, tt := range []struct {

--- a/lib/inventory/store_test.go
+++ b/lib/inventory/store_test.go
@@ -89,7 +89,7 @@ func BenchmarkStore(b *testing.B) {
 		wg.Wait()
 		failOnce.Do(func() {})
 		require.NoError(b, failErr)
-		require.True(b, store.Len() == uniqueServers)
+		require.Equal(b, uniqueServers, store.Len())
 	}
 }
 

--- a/lib/jwt/jwk_test.go
+++ b/lib/jwt/jwk_test.go
@@ -30,5 +30,5 @@ func TestMarshalJWK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Required for integrating with AWS OpenID Connect Identity Provider.
-	require.Equal(t, jwk.Use, "sig")
+	require.Equal(t, "sig", jwk.Use)
 }

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -62,8 +62,8 @@ func TestSignAndVerify(t *testing.T) {
 		URI:      "http://127.0.0.1:8080",
 	})
 	require.NoError(t, err)
-	require.Equal(t, claims.Username, "foo@example.com")
-	require.Equal(t, claims.Roles, []string{"foo", "bar"})
+	require.Equal(t, "foo@example.com", claims.Username)
+	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
 }
 
 // TestPublicOnlyVerifyAzure checks that a non-signing key used to validate a JWT
@@ -157,8 +157,8 @@ func TestPublicOnlyVerify(t *testing.T) {
 		RawToken: token,
 	})
 	require.NoError(t, err)
-	require.Equal(t, claims.Username, "foo@example.com")
-	require.Equal(t, claims.Roles, []string{"foo", "bar"})
+	require.Equal(t, "foo@example.com", claims.Username)
+	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
 
 	// Make sure this key returns an error when trying to sign.
 	_, err = key.Sign(SignParams{
@@ -345,9 +345,9 @@ func TestExpiry(t *testing.T) {
 		RawToken: token,
 	})
 	require.NoError(t, err)
-	require.Equal(t, claims.Username, "foo@example.com")
-	require.Equal(t, claims.Roles, []string{"foo", "bar"})
-	require.Equal(t, claims.IssuedAt, josejwt.NewNumericDate(clock.Now()))
+	require.Equal(t, "foo@example.com", claims.Username)
+	require.Equal(t, []string{"foo", "bar"}, claims.Roles)
+	require.Equal(t, josejwt.NewNumericDate(clock.Now()), claims.IssuedAt)
 
 	// Advance time by two minutes and verify the token is no longer valid.
 	clock.Advance(2 * time.Minute)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -780,7 +780,7 @@ func TestAuthenticate(t *testing.T) {
 			gotCtx, err := f.authenticate(req)
 			if tt.wantErr {
 				require.Error(t, err)
-				require.Equal(t, trace.IsAccessDenied(err), tt.wantAuthErr)
+				require.Equal(t, tt.wantAuthErr, trace.IsAccessDenied(err))
 				return
 			}
 			require.NoError(t, err)
@@ -1758,9 +1758,9 @@ func TestKubernetesLicenseEnforcement(t *testing.T) {
 				require.Error(tt, err)
 				var kubeErr *kubeerrors.StatusError
 				require.ErrorAs(tt, err, &kubeErr)
-				require.Equal(tt, kubeErr.ErrStatus.Code, int32(http.StatusForbidden))
-				require.Equal(tt, kubeErr.ErrStatus.Reason, metav1.StatusReasonForbidden)
-				require.Equal(tt, kubeErr.ErrStatus.Message, "Teleport cluster is not licensed for Kubernetes")
+				require.Equal(tt, int32(http.StatusForbidden), kubeErr.ErrStatus.Code)
+				require.Equal(tt, metav1.StatusReasonForbidden, kubeErr.ErrStatus.Reason)
+				require.Equal(tt, "Teleport cluster is not licensed for Kubernetes", kubeErr.ErrStatus.Message)
 			},
 		},
 	}

--- a/lib/kube/proxy/kube_creds_test.go
+++ b/lib/kube/proxy/kube_creds_test.go
@@ -316,7 +316,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				require.Equal(t, got.getKubeRestConfig().CAData, []byte(fixtures.TLSCACertPEM))
 				require.NoError(t, tt.args.validateBearerToken(got.getKubeRestConfig().BearerToken))
-				require.Equal(t, got.getTargetAddr(), tt.wantAddr)
+				require.Equal(t, tt.wantAddr, got.getTargetAddr())
 				fakeClock.BlockUntil(1)
 				fakeClock.Advance(ttl / 2)
 				// notify receives a signal when the cloud client is invoked.

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -109,7 +109,7 @@ func TestCheckOrSetKubeCluster(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			got, err := CheckOrSetKubeCluster(ctx, mockKubeServicesPresence(tt.services), tt.kubeCluster, tt.teleCluster)
 			tt.assertErr(t, err)
-			require.Equal(t, got, tt.want)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -113,7 +113,7 @@ func TestMux(t *testing.T) {
 		defer re.Body.Close()
 		bytes, err := io.ReadAll(re.Body)
 		require.NoError(t, err)
-		require.Equal(t, string(bytes), "backend 1")
+		require.Equal(t, "backend 1", string(bytes))
 
 		// Close mux, new requests should fail
 		mux.Close()
@@ -125,7 +125,7 @@ func TestMux(t *testing.T) {
 		if err == nil {
 			re.Body.Close()
 		}
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 	// ProxyLine tests proxy line protocol
 	t.Run("ProxyLines", func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestMux(t *testing.T) {
 
 		// make sure the TLS call failed
 		_, err = utils.RoundtripWithConn(tlsConn)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	// makes sure the connection gets dropped
@@ -295,7 +295,7 @@ func TestMux(t *testing.T) {
 
 		// make sure the TLS call failed
 		_, err = utils.RoundtripWithConn(tlsConn)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	// makes sure the connection get port set to 0
@@ -341,7 +341,7 @@ func TestMux(t *testing.T) {
 		defer tlsConn.Close()
 
 		res, err := utils.RoundtripWithConn(tlsConn)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// Make sure that server saw our connection with source port set to 0
 		require.Equal(t, "127.0.0.1:0", res)
@@ -388,7 +388,7 @@ func TestMux(t *testing.T) {
 
 		// roundtrip should fail on the timeout
 		_, err = utils.RoundtripWithConn(tlsConn)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	// UnknownProtocol make sure that multiplexer closes connection
@@ -447,7 +447,7 @@ func TestMux(t *testing.T) {
 			Timeout:         time.Second,
 			HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 		})
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		// TLS requests will succeed
 		client := testClient(backend1)
@@ -456,7 +456,7 @@ func TestMux(t *testing.T) {
 		defer re.Body.Close()
 		bytes, err := io.ReadAll(re.Body)
 		require.NoError(t, err)
-		require.Equal(t, string(bytes), "backend 1")
+		require.Equal(t, "backend 1", string(bytes))
 
 		// Close mux, new requests should fail
 		mux.Close()
@@ -468,7 +468,7 @@ func TestMux(t *testing.T) {
 		if err == nil {
 			re.Body.Close()
 		}
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	// TestDisableTLS tests scenario with disabled TLS
@@ -515,7 +515,7 @@ func TestMux(t *testing.T) {
 		if err == nil {
 			re.Body.Close()
 		}
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		// Close mux, new requests should fail
 		mux.Close()
@@ -579,7 +579,7 @@ func TestMux(t *testing.T) {
 		defer re.Body.Close()
 		bytes, err := io.ReadAll(re.Body)
 		require.NoError(t, err)
-		require.Equal(t, string(bytes), "http backend")
+		require.Equal(t, "http backend", string(bytes))
 
 		creds := credentials.NewClientTLSFromCert(cfg.CertPool, "")
 
@@ -592,7 +592,7 @@ func TestMux(t *testing.T) {
 
 		out, err := gclient.Ping(context.TODO(), &test.Request{})
 		require.NoError(t, err)
-		require.Equal(t, out.GetPayload(), "grpc backend")
+		require.Equal(t, "grpc backend", out.GetPayload())
 
 		// Close mux, new requests should fail
 		mux.Close()
@@ -604,7 +604,7 @@ func TestMux(t *testing.T) {
 		if err == nil {
 			re.Body.Close()
 		}
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		httpServer.Close()
 		s.Stop()

--- a/lib/multiplexer/proxyline_test.go
+++ b/lib/multiplexer/proxyline_test.go
@@ -118,7 +118,7 @@ func TestReadProxyLineV2(t *testing.T) {
 		require.Equal(t, "127.0.0.1:12345", pl.Source.String())
 		require.Equal(t, "127.0.0.2:42", pl.Destination.String())
 		require.NotNil(t, pl.TLVs)
-		require.Equal(t, 1, len(pl.TLVs))
+		require.Len(t, pl.TLVs, 1)
 		require.Equal(t, PP2TypeTeleport, pl.TLVs[0].Type)
 		require.Equal(t, []byte{0x01, 0x02, 0x03}, pl.TLVs[0].Value)
 
@@ -134,7 +134,7 @@ func TestReadProxyLineV2(t *testing.T) {
 		require.Equal(t, "127.0.0.1:12345", pl.Source.String())
 		require.Equal(t, "127.0.0.2:42", pl.Destination.String())
 		require.NotNil(t, pl.TLVs)
-		require.Equal(t, 1, len(pl.TLVs))
+		require.Len(t, pl.TLVs, 1)
 		require.Equal(t, PP2TypeTeleport, pl.TLVs[0].Type)
 		require.Equal(t, []byte{}, pl.TLVs[0].Value)
 
@@ -179,7 +179,7 @@ func TestProxyLine_Bytes(t *testing.T) {
 
 		b, err := pl.Bytes()
 		assert.NoError(t, err)
-		assert.Equal(t, 28, len(b))
+		assert.Len(t, b, 28)
 		assert.Equal(t, sampleProxyV2Line, b)
 
 		pl2, err := ReadProxyLineV2(bufio.NewReader(bytes.NewBuffer(b)))
@@ -187,7 +187,7 @@ func TestProxyLine_Bytes(t *testing.T) {
 		assert.Equal(t, TCP4, pl2.Protocol)
 		assert.Equal(t, "127.0.0.1:12345", pl2.Source.String())
 		assert.Equal(t, "127.0.0.2:42", pl2.Destination.String())
-		assert.Equal(t, 0, len(pl2.TLVs))
+		assert.Empty(t, pl2.TLVs)
 	})
 
 	t.Run("with TLV", func(t *testing.T) {
@@ -203,14 +203,14 @@ func TestProxyLine_Bytes(t *testing.T) {
 
 		b, err := pl.Bytes()
 		assert.NoError(t, err)
-		assert.Equal(t, 35, len(b))
+		assert.Len(t, b, 35)
 
 		pl2, err := ReadProxyLineV2(bufio.NewReader(bytes.NewBuffer(b)))
 		assert.NoError(t, err)
 		assert.Equal(t, TCP4, pl2.Protocol)
 		assert.Equal(t, "127.0.0.1:12345", pl2.Source.String())
 		assert.Equal(t, "127.0.0.2:42", pl2.Destination.String())
-		assert.Equal(t, 1, len(pl2.TLVs))
+		assert.Len(t, pl2.TLVs, 1)
 		assert.Equal(t, PP2TypeTeleport, pl2.TLVs[0].Type)
 		assert.Equal(t, []byte("0123"), pl2.TLVs[0].Value)
 	})

--- a/lib/release/release_test.go
+++ b/lib/release/release_test.go
@@ -33,20 +33,20 @@ import (
 func TestNewClient(t *testing.T) {
 	// should err when no TLS config is passed in
 	_, err := NewClient(ClientConfig{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// should err when no server addr is passed in
 	_, err = NewClient(ClientConfig{
 		TLSConfig: &tls.Config{},
 	})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// should not err when TLS config and server addr is passed in
 	_, err = NewClient(ClientConfig{
 		TLSConfig:         &tls.Config{},
 		ReleaseServerAddr: "server-addr",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestListReleases(t *testing.T) {
@@ -54,7 +54,7 @@ func TestListReleases(t *testing.T) {
 
 	// ListReleases should err if client is not initialized
 	_, err := mockClient.ListReleases(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	tt := []struct {
 		name               string
@@ -224,13 +224,13 @@ func TestListReleases(t *testing.T) {
 			}))
 
 			mockClient.client, err = roundtrip.NewClient(server.URL, "")
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			releases, err := mockClient.ListReleases(context.Background())
 			if tc.shouldErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.expected, releases)
 			}
 		})

--- a/lib/resourceusage/usage_test.go
+++ b/lib/resourceusage/usage_test.go
@@ -59,5 +59,5 @@ func TestGetAccessRequestMonthlyUsage(t *testing.T) {
 
 	result, err := GetAccessRequestMonthlyUsage(context.Background(), al, now)
 	require.NoError(t, err)
-	require.Equal(t, len(mockEvents), result)
+	require.Len(t, mockEvents, result)
 }

--- a/lib/reversetunnel/agent_proxy_test.go
+++ b/lib/reversetunnel/agent_proxy_test.go
@@ -27,12 +27,12 @@ func TestConnectedProxyGetter(t *testing.T) {
 
 	var expectIDs []string
 	ids := proxies.GetProxyIDs()
-	require.True(t, ids == nil)
+	require.Nil(t, ids)
 
 	expectIDs = []string{}
 	proxies.setProxyIDs(expectIDs)
 	ids = proxies.GetProxyIDs()
-	require.True(t, ids == nil)
+	require.Nil(t, ids)
 
 	expectIDs = []string{"test1", "test2"}
 	proxies.setProxyIDs(expectIDs)
@@ -42,5 +42,5 @@ func TestConnectedProxyGetter(t *testing.T) {
 	expectIDs = nil
 	proxies.setProxyIDs(expectIDs)
 	ids = proxies.GetProxyIDs()
-	require.True(t, ids == nil)
+	require.Nil(t, ids)
 }

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -285,13 +285,13 @@ func TestAgentStart(t *testing.T) {
 		<-waitForVersion
 
 		atomic.AddInt32(openChannels, 1)
-		assert.Equal(t, name, chanHeartbeat, "Unexpected channel opened during startup.")
+		assert.Equal(t, chanHeartbeat, name, "Unexpected channel opened during startup.")
 		return tracessh.NewTraceChannel(
 				&mockSSHChannel{
 					MockSendRequest: func(name string, wantReply bool, payload []byte) (bool, error) {
 						atomic.AddInt32(sentPings, 1)
 
-						assert.Equal(t, name, "ping", "Unexpected request name.")
+						assert.Equal(t, "ping", name, "Unexpected request name.")
 						assert.False(t, wantReply, "Expected no reply wanted.")
 						return true, nil
 					},

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -140,7 +140,7 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 	}, time.Second*5, time.Millisecond*10, "wait for agent pool")
 
 	require.Nil(t, pool.tracker.TryAcquire())
-	require.Equal(t, pool.Count(), 1)
+	require.Equal(t, 1, pool.Count())
 
 	pool, client = setupTestAgentPool(t)
 	client.mockGetClusterNetworkingConfig = func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
@@ -161,5 +161,5 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 	}, time.Second*5, time.Millisecond*10)
 
 	require.Nil(t, pool.tracker.TryAcquire())
-	require.Equal(t, pool.Count(), 3)
+	require.Equal(t, 3, pool.Count())
 }

--- a/lib/reversetunnel/localsite_test.go
+++ b/lib/reversetunnel/localsite_test.go
@@ -284,7 +284,7 @@ func TestProxyResync(t *testing.T) {
 	discoveryCh := make(chan *discoveryRequest)
 
 	reqHandler := func(name string, wantReply bool, payload []byte) (bool, error) {
-		assert.Equal(t, name, chanDiscoveryReq)
+		assert.Equal(t, chanDiscoveryReq, name)
 
 		var req discoveryRequest
 		assert.NoError(t, json.Unmarshal(payload, &req))
@@ -292,7 +292,7 @@ func TestProxyResync(t *testing.T) {
 		return true, nil
 	}
 	channelCreator := func(name string) ssh.Channel {
-		assert.Equal(t, name, chanDiscovery)
+		assert.Equal(t, chanDiscovery, name)
 		return &mockedSSHChannel{reqHandler: reqHandler}
 	}
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1474,8 +1474,8 @@ func TestSingleProcessModeResolver(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, mode, test.mode)
-			require.Equal(t, addr.FullAddress(), test.wantAddr)
+			require.Equal(t, test.mode, mode)
+			require.Equal(t, test.wantAddr, addr.FullAddress())
 		})
 	}
 }

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -78,25 +78,25 @@ func TestDefaultConfig(t *testing.T) {
 
 	// auth section
 	auth := config.Auth
-	require.Equal(t, auth.ListenAddr, localAuthAddr)
-	require.Equal(t, auth.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
-	require.Equal(t, auth.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
-	require.Equal(t, config.Auth.StorageConfig.Type, lite.GetName())
-	require.Equal(t, auth.StorageConfig.Params[defaults.BackendPath], filepath.Join(config.DataDir, defaults.BackendDir))
+	require.Equal(t, localAuthAddr, auth.ListenAddr)
+	require.Equal(t, int64(defaults.LimiterMaxConnections), auth.Limiter.MaxConnections)
+	require.Equal(t, defaults.LimiterMaxConcurrentUsers, auth.Limiter.MaxNumberOfUsers)
+	require.Equal(t, lite.GetName(), config.Auth.StorageConfig.Type)
+	require.Equal(t, filepath.Join(config.DataDir, defaults.BackendDir), auth.StorageConfig.Params[defaults.BackendPath])
 
 	// SSH section
 	ssh := config.SSH
-	require.Equal(t, ssh.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
-	require.Equal(t, ssh.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
-	require.Equal(t, ssh.AllowTCPForwarding, true)
+	require.Equal(t, int64(defaults.LimiterMaxConnections), ssh.Limiter.MaxConnections)
+	require.Equal(t, defaults.LimiterMaxConcurrentUsers, ssh.Limiter.MaxNumberOfUsers)
+	require.True(t, ssh.AllowTCPForwarding)
 
 	// proxy section
 	proxy := config.Proxy
-	require.Equal(t, proxy.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
-	require.Equal(t, proxy.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
+	require.Equal(t, int64(defaults.LimiterMaxConnections), proxy.Limiter.MaxConnections)
+	require.Equal(t, defaults.LimiterMaxConcurrentUsers, proxy.Limiter.MaxNumberOfUsers)
 
 	// Misc levers and dials
-	require.Equal(t, config.RotationConnectionInterval, defaults.HighResPollingPeriod)
+	require.Equal(t, defaults.HighResPollingPeriod, config.RotationConnectionInterval)
 }
 
 // TestCheckApp validates application configuration.

--- a/lib/service/state_test.go
+++ b/lib/service/state_test.go
@@ -82,7 +82,7 @@ func TestProcessStateGetState(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			ps := &processState{states: tt.states}
 			got := ps.getState()
-			require.Equal(t, got, tt.want)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2103,7 +2103,7 @@ func TestMaxDuration(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.desc, func(t *testing.T) {
-			require.GreaterOrEqual(t, len(tt.roles), 1, "at least one role must be specified")
+			require.NotEmpty(t, tt.roles, "at least one role must be specified")
 
 			// create a request for the specified author
 			req, err := types.NewAccessRequest("some-id", tt.requestor, tt.roles...)

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -202,7 +202,7 @@ func TestBuildAppURI(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		require.Equal(t, buildAppURI(tt.protocol, tt.serviceFQDN, tt.port), tt.expected)
+		require.Equal(t, tt.expected, buildAppURI(tt.protocol, tt.serviceFQDN, tt.port))
 	}
 }
 

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -2316,7 +2316,7 @@ func TestNewDatabaseFromAzureSQLServer(t *testing.T) {
 				db, ok := i.(types.Database)
 				require.True(t, ok, "expected types.Database, got %T", i)
 
-				require.Equal(t, db.GetProtocol(), defaults.ProtocolSQLServer)
+				require.Equal(t, defaults.ProtocolSQLServer, db.GetProtocol())
 				require.Equal(t, "sqlserver", db.GetName())
 				require.Equal(t, "sqlserver.database.windows.net:1433", db.GetURI())
 				require.Equal(t, "sqlserver", db.GetAzure().Name)
@@ -2371,7 +2371,7 @@ func TestNewDatabaseFromAzureManagedSQLServer(t *testing.T) {
 				db, ok := i.(types.Database)
 				require.True(t, ok, "expected types.Database, got %T", i)
 
-				require.Equal(t, db.GetProtocol(), defaults.ProtocolSQLServer)
+				require.Equal(t, defaults.ProtocolSQLServer, db.GetProtocol())
 				require.Equal(t, "sqlserver", db.GetName())
 				require.Equal(t, "sqlserver.database.windows.net:1433", db.GetURI())
 				require.Equal(t, "sqlserver", db.GetAzure().Name)

--- a/lib/services/fanout_test.go
+++ b/lib/services/fanout_test.go
@@ -36,7 +36,7 @@ func TestFanoutWatcherClose(t *testing.T) {
 	w, err := f.NewWatcher(ctx,
 		types.Watch{Name: "test", Kinds: []types.WatchKind{{Name: "test"}}})
 	require.NoError(t, err)
-	require.Equal(t, f.Len(), 1)
+	require.Equal(t, 1, f.Len())
 
 	err = w.Close()
 	select {
@@ -45,7 +45,7 @@ func TestFanoutWatcherClose(t *testing.T) {
 		t.Fatalf("Timeout waiting for event")
 	}
 	require.NoError(t, err)
-	require.Equal(t, f.Len(), 0)
+	require.Equal(t, 0, f.Len())
 }
 
 // TestFanoutInit verifies that Init event is sent exactly once.

--- a/lib/services/local/apps_test.go
+++ b/lib/services/local/apps_test.go
@@ -59,7 +59,7 @@ func TestAppsCRUD(t *testing.T) {
 	// Initially we expect no apps.
 	out, err := service.GetApps(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both apps.
 	err = service.CreateApp(ctx, app1)
@@ -117,5 +117,5 @@ func TestAppsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = service.GetApps(ctx)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -126,11 +126,11 @@ func TestSessionRecording(t *testing.T) {
 	// default is to record at the node
 	recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{})
 	require.NoError(t, err)
-	require.Equal(t, recConfig.GetMode(), types.RecordAtNode)
+	require.Equal(t, types.RecordAtNode, recConfig.GetMode())
 
 	// update sessions to be recorded at the proxy and check again
 	recConfig.SetMode(types.RecordAtProxy)
-	require.Equal(t, recConfig.GetMode(), types.RecordAtProxy)
+	require.Equal(t, types.RecordAtProxy, recConfig.GetMode())
 }
 
 func TestAuditConfig(t *testing.T) {

--- a/lib/services/local/databases_test.go
+++ b/lib/services/local/databases_test.go
@@ -62,7 +62,7 @@ func TestDatabasesCRUD(t *testing.T) {
 	// Initially we expect no databases.
 	out, err := service.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both databases.
 	err = service.CreateDatabase(ctx, db1)
@@ -130,5 +130,5 @@ func TestDatabasesCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = service.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }

--- a/lib/services/local/kube_test.go
+++ b/lib/services/local/kube_test.go
@@ -55,7 +55,7 @@ func TestKubernetesCRUD(t *testing.T) {
 	// Initially we expect no Kubernetess.
 	out, err := service.GetKubernetesClusters(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both Kubernetess.
 	err = service.CreateKubernetesCluster(ctx, kubeCluster1)
@@ -113,5 +113,5 @@ func TestKubernetesCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = service.GetKubernetesClusters(ctx)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }

--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -127,5 +127,5 @@ func benchmarkGetNodes(ctx context.Context, b *testing.B, svc services.Presence,
 	// do *something* with the loop result.  probably unnecessary since the loop
 	// contains I/O, but I don't know enough about the optimizer to be 100% certain
 	// about that.
-	require.Equal(b, nodeCount, len(nodes))
+	require.Len(b, nodes, nodeCount)
 }

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -64,7 +64,7 @@ func TestPluginsCRUD(t *testing.T) {
 	// Initially we expect no items.
 	out, err := service.GetPlugins(ctx, false)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create both plugins.
 	err = service.CreatePlugin(ctx, plugin1)
@@ -136,7 +136,7 @@ func TestPluginsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = service.GetPlugins(ctx, true)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }
 
 func TestListPlugins(t *testing.T) {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -236,7 +236,7 @@ func TestApplicationServersCRUD(t *testing.T) {
 	// No app servers should be registered initially
 	out, err := presence.GetApplicationServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Create app servers.
 	lease, err := presence.UpsertApplicationServer(ctx, serverA)
@@ -327,7 +327,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	// Initially expect not to be returned any servers.
 	out, err := presence.GetDatabaseServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Upsert server.
 	lease, err := presence.UpsertDatabaseServer(ctx, server)
@@ -357,7 +357,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	// Now expect no servers to be returned.
 	out, err = presence.GetDatabaseServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 
 	// Upsert server with TTL.
 	server.SetExpiry(clock.Now().UTC().Add(time.Hour))
@@ -384,7 +384,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	// Now expect no servers to be returned.
 	out, err = presence.GetDatabaseServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 }
 
 func TestNodeCRUD(t *testing.T) {
@@ -405,7 +405,7 @@ func TestNodeCRUD(t *testing.T) {
 		// Initially expect no nodes to be returned.
 		nodes, err := presence.GetNodes(ctx, apidefaults.Namespace)
 		require.NoError(t, err)
-		require.Equal(t, 0, len(nodes))
+		require.Empty(t, nodes)
 
 		// Create nodes
 		_, err = presence.UpsertNode(ctx, node1)
@@ -465,7 +465,7 @@ func TestNodeCRUD(t *testing.T) {
 		// Now expect no nodes to be returned.
 		nodes, err := presence.GetNodes(ctx, apidefaults.Namespace)
 		require.NoError(t, err)
-		require.Equal(t, 0, len(nodes))
+		require.Empty(t, nodes)
 	})
 }
 
@@ -1094,7 +1094,7 @@ func TestFakePaginate_TotalCount(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, resp.Resources, tc.limit)
 				require.Equal(t, resources[0:tc.limit], resp.Resources)
-				require.Equal(t, len(nodes), resp.TotalCount)
+				require.Len(t, nodes, resp.TotalCount)
 
 				// Next fetch should return same amount of totals.
 				if tc.limit != len(nodes) {
@@ -1105,11 +1105,11 @@ func TestFakePaginate_TotalCount(t *testing.T) {
 					require.NoError(t, err)
 					require.Len(t, resp.Resources, tc.limit)
 					require.Equal(t, resources[tc.limit:tc.limit*2], resp.Resources)
-					require.Equal(t, len(nodes), resp.TotalCount)
+					require.Len(t, nodes, resp.TotalCount)
 				} else {
 					require.Empty(t, resp.NextKey)
 					require.Equal(t, resources, resp.Resources)
-					require.Equal(t, len(nodes), resp.TotalCount)
+					require.Len(t, nodes, resp.TotalCount)
 				}
 			})
 		}

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -86,16 +86,16 @@ func runUserResourceTest(
 	s := NewIdentityService(tt.bk)
 	b, err := s.GetUser(ctx, "bob", withSecrets)
 	require.NoError(t, err)
-	require.Equal(t, services.UsersEquals(bob, b), true, "dynamically inserted user does not match")
+	require.True(t, services.UsersEquals(bob, b), "dynamically inserted user does not match")
 	allUsers, err := s.GetUsers(ctx, withSecrets)
 	require.NoError(t, err)
-	require.Equal(t, len(allUsers), 2, "expected exactly two users")
+	require.Len(t, allUsers, 2, "expected exactly two users")
 	for _, user := range allUsers {
 		switch user.GetName() {
 		case "alice":
-			require.Equal(t, services.UsersEquals(alice, user), true, "alice does not match")
+			require.True(t, services.UsersEquals(alice, user), "alice does not match")
 		case "bob":
-			require.Equal(t, services.UsersEquals(bob, user), true, "bob does not match")
+			require.True(t, services.UsersEquals(bob, user), "bob does not match")
 		default:
 			t.Errorf("Unexpected user %q", user.GetName())
 		}
@@ -105,7 +105,7 @@ func runUserResourceTest(
 	tt.bk.Clock().(clockwork.FakeClock).Advance(2 * time.Minute)
 	allUsers, err = s.GetUsers(ctx, withSecrets)
 	require.NoError(t, err)
-	require.Equal(t, len(allUsers), 0, "expected all users to expire")
+	require.Empty(t, allUsers, "expected all users to expire")
 }
 
 func TestCertAuthorityResource(t *testing.T) {

--- a/lib/services/local/session_test.go
+++ b/lib/services/local/session_test.go
@@ -76,7 +76,7 @@ func TestDeleteUserAppSessions(t *testing.T) {
 
 	sessions, nextKey, err = identity.ListAppSessions(ctx, 10, "", "")
 	require.NoError(t, err)
-	require.Len(t, sessions, 0)
+	require.Empty(t, sessions)
 	require.Empty(t, nextKey)
 }
 
@@ -215,7 +215,7 @@ func TestDeleteUserSAMLIdPSessions(t *testing.T) {
 
 	sessions, nextKey, err = identity.ListSAMLIdPSessions(ctx, 10, "", "")
 	require.NoError(t, err)
-	require.Len(t, sessions, 0)
+	require.Empty(t, sessions)
 	require.Empty(t, nextKey)
 }
 

--- a/lib/services/local/sessiontracker_test.go
+++ b/lib/services/local/sessiontracker_test.go
@@ -98,7 +98,7 @@ func TestSessionTrackerStorage(t *testing.T) {
 		Kind: types.KindWindowsDesktop,
 	})
 	require.NoError(t, err)
-	require.Len(t, sessions, 0)
+	require.Empty(t, sessions)
 	sessions, err = srv.GetActiveSessionTrackersWithFilter(ctx, &types.SessionTrackerFilter{
 		Kind: types.KindSSHSession,
 	})

--- a/lib/services/local/status_test.go
+++ b/lib/services/local/status_test.go
@@ -115,7 +115,7 @@ func TestClusterAlerts(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, alerts, 0)
+	require.Empty(t, alerts)
 
 	// empty query returns all alerts
 	alerts, err = status.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{})
@@ -126,5 +126,5 @@ func TestClusterAlerts(t *testing.T) {
 	clock.Advance(time.Hour * 24)
 	alerts, err = status.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{})
 	require.NoError(t, err)
-	require.Len(t, alerts, 0)
+	require.Empty(t, alerts)
 }

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -247,7 +247,7 @@ func TestRecoveryAttemptsCRUD(t *testing.T) {
 		require.NoError(t, err)
 		attempts, err = identity.GetUserRecoveryAttempts(ctx, username)
 		require.NoError(t, err)
-		require.Len(t, attempts, 0)
+		require.Empty(t, attempts)
 	})
 
 	t.Run("deleting user deletes recovery attempts", func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestRecoveryAttemptsCRUD(t *testing.T) {
 		require.NoError(t, err)
 		attempts, err = identity.GetUserRecoveryAttempts(ctx, username)
 		require.NoError(t, err)
-		require.Len(t, attempts, 0)
+		require.Empty(t, attempts)
 	})
 }
 
@@ -469,7 +469,7 @@ func TestIdentityService_UpsertMFADevice_errors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := identity.UpsertMFADevice(ctx, user, test.createDev())
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Contains(t, err.Error(), test.wantErr)
 		})
 	}

--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -65,14 +65,15 @@ func TestRoleParsing(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		comment := fmt.Sprintf("test case '%v'", i)
-		_, err := parseRoleMap(tc.roleMap)
-		if tc.err != nil {
-			require.NotNilf(t, err, comment)
-			require.IsTypef(t, err, tc.err, comment)
-		} else {
-			require.NoError(t, err)
-		}
+		t.Run(fmt.Sprintf("test case '%v'", i), func(t *testing.T) {
+			_, err := parseRoleMap(tc.roleMap)
+			if tc.err != nil {
+				require.Error(t, err)
+				require.IsType(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -186,14 +187,16 @@ func TestRoleMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		comment := fmt.Sprintf("test case '%v'", tc.name)
-		local, err := MapRoles(tc.roleMap, tc.remote)
-		if tc.err != nil {
-			require.NotNilf(t, err, comment)
-			require.IsTypef(t, err, tc.err, comment)
-		} else {
-			require.NoError(t, err, comment)
-			require.Empty(t, cmp.Diff(local, tc.local), comment)
-		}
+		t.Run(fmt.Sprintf("test case '%v'", tc.name), func(t *testing.T) {
+
+			local, err := MapRoles(tc.roleMap, tc.remote)
+			if tc.err != nil {
+				require.Error(t, err)
+				require.IsType(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(local, tc.local))
+			}
+		})
 	}
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -43,12 +42,12 @@ func TestParseFromMetadata(t *testing.T) {
 
 	oc, err := UnmarshalSAMLConnector(raw.Raw)
 	require.NoError(t, err)
-	require.Equal(t, oc.GetIssuer(), "http://www.okta.com/exkafftca6RqPVgyZ0h7")
-	require.Equal(t, oc.GetSSO(), "https://dev-813354.oktapreview.com/app/gravitationaldev813354_teleportsaml_1/exkafftca6RqPVgyZ0h7/sso/saml")
-	require.Equal(t, oc.GetAssertionConsumerService(), "https://localhost:3080/v1/webapi/saml/acs")
-	require.Equal(t, oc.GetAudience(), "https://localhost:3080/v1/webapi/saml/acs")
+	require.Equal(t, "http://www.okta.com/exkafftca6RqPVgyZ0h7", oc.GetIssuer())
+	require.Equal(t, "https://dev-813354.oktapreview.com/app/gravitationaldev813354_teleportsaml_1/exkafftca6RqPVgyZ0h7/sso/saml", oc.GetSSO())
+	require.Equal(t, "https://localhost:3080/v1/webapi/saml/acs", oc.GetAssertionConsumerService())
+	require.Equal(t, "https://localhost:3080/v1/webapi/saml/acs", oc.GetAudience())
 	require.NotNil(t, oc.GetSigningKeyPair())
-	require.Empty(t, cmp.Diff(oc.GetAttributes(), []string{"groups"}))
+	require.Equal(t, []string{"groups"}, oc.GetAttributes())
 }
 
 func TestCheckSAMLEntityDescriptor(t *testing.T) {

--- a/lib/services/semaphore_test.go
+++ b/lib/services/semaphore_test.go
@@ -33,23 +33,23 @@ func TestAcquireSemaphoreRequest(t *testing.T) {
 		Expires:       time.Now(),
 	}
 	ok2 := ok
-	require.Nil(t, ok.Check())
-	require.Nil(t, ok2.Check())
+	require.NoError(t, ok.Check())
+	require.NoError(t, ok2.Check())
 
 	// Check that all the required fields have their
 	// zero values rejected.
 	bad := ok
 	bad.SemaphoreKind = ""
-	require.NotNil(t, bad.Check())
+	require.Error(t, bad.Check())
 	bad = ok
 	bad.SemaphoreName = ""
-	require.NotNil(t, bad.Check())
+	require.Error(t, bad.Check())
 	bad = ok
 	bad.MaxLeases = 0
-	require.NotNil(t, bad.Check())
+	require.Error(t, bad.Check())
 	bad = ok
 	bad.Expires = time.Time{}
-	require.NotNil(t, bad.Check())
+	require.Error(t, bad.Check())
 
 	// ensure that well formed acquire params can configure
 	// a well formed semaphore.
@@ -66,9 +66,9 @@ func TestAcquireSemaphoreRequest(t *testing.T) {
 	// semaphore expiry.
 	newLease := *lease
 	newLease.Expires = sem.Expiry().Add(time.Second)
-	require.Nil(t, sem.KeepAlive(newLease))
+	require.NoError(t, sem.KeepAlive(newLease))
 	require.Equal(t, newLease.Expires, sem.Expiry())
 
-	require.Nil(t, sem.Cancel(newLease))
+	require.NoError(t, sem.Cancel(newLease))
 	require.False(t, sem.Contains(newLease))
 }

--- a/lib/services/servers_test.go
+++ b/lib/services/servers_test.go
@@ -50,42 +50,42 @@ func TestServersCompare(t *testing.T) {
 		}
 		node.SetExpiry(time.Date(2018, 1, 2, 3, 4, 5, 6, time.UTC))
 		// Server is equal to itself
-		require.Equal(t, CompareServers(node, node), Equal)
+		require.Equal(t, Equal, CompareServers(node, node))
 
 		// Only timestamps are different
 		node2 := *node
 		node2.SetExpiry(time.Date(2018, 1, 2, 3, 4, 5, 8, time.UTC))
-		require.Equal(t, CompareServers(node, &node2), OnlyTimestampsDifferent)
+		require.Equal(t, OnlyTimestampsDifferent, CompareServers(node, &node2))
 
 		// Labels are different
 		node2 = *node
 		node2.Metadata.Labels = map[string]string{"a": "d"}
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Command labels are different
 		node2 = *node
 		node2.Spec.CmdLabels = map[string]types.CommandLabelV2{"a": {Period: types.Duration(time.Minute), Command: []string{"ls", "-lR"}}}
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Address has changed
 		node2 = *node
 		node2.Spec.Addr = "localhost:3033"
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Proxy addr has changed
 		node2 = *node
 		node2.Spec.PublicAddrs = []string{"localhost:3033"}
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Hostname has changed
 		node2 = *node
 		node2.Spec.Hostname = "luna2"
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// TeleportVersion has changed
 		node2 = *node
 		node2.Spec.Version = "5.0.0"
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Rotation has changed
 		node2 = *node
@@ -102,7 +102,7 @@ func TestServersCompare(t *testing.T) {
 				Standby:       time.Date(2018, 3, 4, 5, 6, 13, 8, time.UTC),
 			},
 		}
-		require.Equal(t, CompareServers(node, &node2), Different)
+		require.Equal(t, Different, CompareServers(node, &node2))
 	})
 
 	t.Run("compare DatabaseServices", func(t *testing.T) {
@@ -122,19 +122,19 @@ func TestServersCompare(t *testing.T) {
 		service.SetExpiry(time.Date(2018, 1, 2, 3, 4, 5, 6, time.UTC))
 
 		// DatabaseService is equal to itself
-		require.Equal(t, CompareServers(service, service), Equal)
+		require.Equal(t, Equal, CompareServers(service, service))
 
 		// Only timestamps are different
 		service2 := *service
 		service2.SetExpiry(time.Date(2018, 1, 2, 3, 4, 5, 8, time.UTC))
-		require.Equal(t, CompareServers(service, &service2), OnlyTimestampsDifferent)
+		require.Equal(t, OnlyTimestampsDifferent, CompareServers(service, &service2))
 
 		// Resource Matcher has changed
 		service2 = *service
 		service2.Spec.ResourceMatchers = []*types.DatabaseResourceMatcher{
 			{Labels: &types.Labels{"env": []string{"stg", "qa"}}},
 		}
-		require.Equal(t, CompareServers(service, &service2), Different)
+		require.Equal(t, Different, CompareServers(service, &service2))
 	})
 }
 
@@ -145,8 +145,8 @@ func TestGuessProxyHostAndVersion(t *testing.T) {
 
 	// No proxies passed in.
 	host, version, err := GuessProxyHostAndVersion(nil)
-	require.Equal(t, host, "")
-	require.Equal(t, version, "")
+	require.Empty(t, host)
+	require.Empty(t, version)
 	require.True(t, trace.IsNotFound(err))
 
 	// No proxies have public address set.

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -40,13 +40,13 @@ func TestOptions(t *testing.T) {
 
 	// test empty scenario
 	out := AddOptions(nil)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 
 	// make sure original option list is not affected
 	var in []MarshalOption
 	out = AddOptions(in, WithResourceID(1), WithRevision("abc"))
 	require.Len(t, out, 2)
-	require.Len(t, in, 0)
+	require.Empty(t, in)
 	cfg, err := CollectOptions(out)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), cfg.ID)
@@ -55,7 +55,7 @@ func TestOptions(t *testing.T) {
 	// Add a couple of other parameters
 	out = AddOptions(in, WithResourceID(2), WithVersion(types.V2), WithRevision("xyz"))
 	require.Len(t, out, 3)
-	require.Len(t, in, 0)
+	require.Empty(t, in)
 	cfg, err = CollectOptions(out)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), cfg.ID)
@@ -69,7 +69,7 @@ func TestCommandLabels(t *testing.T) {
 
 	var l CommandLabels
 	out := l.Clone()
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 
 	label := &types.CommandLabelV2{Command: []string{"ls", "-l"}, Period: types.Duration(time.Second)}
 	l = CommandLabels{"a": label}

--- a/lib/services/suite/presence_test.go
+++ b/lib/services/suite/presence_test.go
@@ -32,8 +32,8 @@ func TestServerLabels(t *testing.T) {
 	server := &types.ServerV2{}
 	require.Empty(t, cmp.Diff(server.GetAllLabels(), emptyLabels))
 	require.Empty(t, server.GetAllLabels())
-	require.Equal(t, types.MatchLabels(server, emptyLabels), true)
-	require.Equal(t, types.MatchLabels(server, map[string]string{"a": "b"}), false)
+	require.True(t, types.MatchLabels(server, emptyLabels))
+	require.False(t, types.MatchLabels(server, map[string]string{"a": "b"}))
 
 	// more complex
 	server = &types.ServerV2{
@@ -58,9 +58,9 @@ func TestServerLabels(t *testing.T) {
 		"time": "now",
 	}))
 
-	require.Equal(t, types.MatchLabels(server, emptyLabels), true)
-	require.Equal(t, types.MatchLabels(server, map[string]string{"a": "b"}), false)
-	require.Equal(t, types.MatchLabels(server, map[string]string{"role": "database"}), true)
-	require.Equal(t, types.MatchLabels(server, map[string]string{"time": "now"}), true)
-	require.Equal(t, types.MatchLabels(server, map[string]string{"time": "now", "role": "database"}), true)
+	require.True(t, types.MatchLabels(server, emptyLabels))
+	require.False(t, types.MatchLabels(server, map[string]string{"a": "b"}))
+	require.True(t, types.MatchLabels(server, map[string]string{"role": "database"}))
+	require.True(t, types.MatchLabels(server, map[string]string{"time": "now"}))
+	require.True(t, types.MatchLabels(server, map[string]string{"time": "now", "role": "database"}))
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -213,7 +213,7 @@ func (s *ServicesTestSuite) UsersCRUD(t *testing.T) {
 
 	u, err := s.WebS.GetUsers(ctx, false)
 	require.NoError(t, err)
-	require.Equal(t, len(u), 0)
+	require.Empty(t, u)
 
 	require.NoError(t, s.WebS.UpsertPasswordHash("user1", []byte("hash")))
 	require.NoError(t, s.WebS.UpsertPasswordHash("user2", []byte("hash2")))
@@ -271,7 +271,7 @@ func (s *ServicesTestSuite) UsersExpiry(t *testing.T) {
 	// Make sure the user exists.
 	u, err := s.WebS.GetUser(ctx, "foo", false)
 	require.NoError(t, err)
-	require.Equal(t, u.GetName(), "foo")
+	require.Equal(t, "foo", u.GetName())
 
 	s.Clock.Advance(2 * time.Minute)
 
@@ -289,7 +289,7 @@ func (s *ServicesTestSuite) LoginAttempts(t *testing.T) {
 
 	attempts, err := s.WebS.GetUserLoginAttempts(user.GetName())
 	require.NoError(t, err)
-	require.Equal(t, len(attempts), 0)
+	require.Empty(t, attempts)
 
 	clock := clockwork.NewFakeClock()
 	attempt1 := services.LoginAttempt{Time: clock.Now().UTC(), Success: false}
@@ -303,8 +303,8 @@ func (s *ServicesTestSuite) LoginAttempts(t *testing.T) {
 	attempts, err = s.WebS.GetUserLoginAttempts(user.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(attempts, []services.LoginAttempt{attempt1, attempt2}))
-	require.Equal(t, services.LastFailed(3, attempts), false)
-	require.Equal(t, services.LastFailed(2, attempts), true)
+	require.False(t, services.LastFailed(3, attempts))
+	require.True(t, services.LastFailed(2, attempts))
 }
 
 func (s *ServicesTestSuite) CertAuthCRUD(t *testing.T) {
@@ -377,7 +377,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	// SSH service.
 	out, err := s.PresenceS.GetNodes(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	srv := NewServer(types.KindNode, "srv1", "127.0.0.1:2022", apidefaults.Namespace)
 	_, err = s.PresenceS.UpsertNode(ctx, srv)
@@ -397,12 +397,12 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetNodes(ctx, srv.Metadata.Namespace)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 
 	// Proxy service.
 	out, err = s.PresenceS.GetProxies()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	proxy := NewServer(types.KindProxy, "proxy1", "127.0.0.1:2023", apidefaults.Namespace)
 	require.NoError(t, s.PresenceS.UpsertProxy(ctx, proxy))
@@ -417,12 +417,12 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetProxies()
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 
 	// Auth service.
 	out, err = s.PresenceS.GetAuthServers()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	auth := NewServer(types.KindAuthServer, "auth1", "127.0.0.1:2025", apidefaults.Namespace)
 	require.NoError(t, s.PresenceS.UpsertAuthServer(ctx, auth))
@@ -440,7 +440,7 @@ func (s *ServicesTestSuite) AppServerCRUD(t *testing.T) {
 	// Expect not to be returned any applications and trace.NotFound.
 	out, err := s.PresenceS.GetApplicationServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	// Make an app and an app server.
 	app, err := types.NewAppV3(types.Metadata{Name: "foo"},
@@ -473,7 +473,7 @@ func (s *ServicesTestSuite) AppServerCRUD(t *testing.T) {
 	// Now expect no applications to be returned.
 	out, err = s.PresenceS.GetApplicationServers(ctx, server.Metadata.Namespace)
 	require.NoError(t, err)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 }
 
 func newReverseTunnel(clusterName string, dialAddrs []string) *types.ReverseTunnelV2 {
@@ -494,7 +494,7 @@ func newReverseTunnel(clusterName string, dialAddrs []string) *types.ReverseTunn
 func (s *ServicesTestSuite) ReverseTunnelsCRUD(t *testing.T) {
 	out, err := s.PresenceS.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	tunnel := newReverseTunnel("example.com", []string{"example.com:2023"})
 	require.NoError(t, s.PresenceS.UpsertReverseTunnel(tunnel))
@@ -509,7 +509,7 @@ func (s *ServicesTestSuite) ReverseTunnelsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	err = s.PresenceS.UpsertReverseTunnel(newReverseTunnel("", []string{"127.0.0.1:1234"}))
 	require.True(t, trace.IsBadParameter(err))
@@ -523,7 +523,7 @@ func (s *ServicesTestSuite) ReverseTunnelsCRUD(t *testing.T) {
 
 func (s *ServicesTestSuite) PasswordHashCRUD(t *testing.T) {
 	_, err := s.WebS.GetPasswordHash("user1")
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("%#v", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("%#v", err))
 
 	err = s.WebS.UpsertPasswordHash("user1", []byte("hello123"))
 	require.NoError(t, err)
@@ -544,7 +544,7 @@ func (s *ServicesTestSuite) WebSessionCRUD(t *testing.T) {
 	ctx := context.Background()
 	req := types.GetWebSessionRequest{User: "user1", SessionID: "sid1"}
 	_, err := s.WebS.WebSessions().Get(ctx, req)
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("%#v", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("%#v", err))
 
 	dt := s.Clock.Now().Add(1 * time.Minute)
 	ws, err := types.NewWebSession("sid1", types.KindWebSession,
@@ -600,9 +600,9 @@ func (s *ServicesTestSuite) TokenCRUD(t *testing.T) {
 
 	token, err := s.ProvisioningS.GetToken(ctx, "token")
 	require.NoError(t, err)
-	require.Equal(t, token.GetRoles().Include(types.RoleAuth), true)
-	require.Equal(t, token.GetRoles().Include(types.RoleNode), true)
-	require.Equal(t, token.GetRoles().Include(types.RoleProxy), false)
+	require.True(t, token.GetRoles().Include(types.RoleAuth))
+	require.True(t, token.GetRoles().Include(types.RoleNode))
+	require.False(t, token.GetRoles().Include(types.RoleProxy))
 	require.Equal(t, time.Time{}, token.Expiry())
 
 	require.NoError(t, s.ProvisioningS.DeleteToken(ctx, "token"))
@@ -651,7 +651,7 @@ func (s *ServicesTestSuite) TokenCRUD(t *testing.T) {
 
 	tokens, err = s.ProvisioningS.GetTokens(ctx)
 	require.NoError(t, err)
-	require.Len(t, tokens, 0)
+	require.Empty(t, tokens)
 }
 
 func (s *ServicesTestSuite) RolesCRUD(t *testing.T) {
@@ -659,7 +659,7 @@ func (s *ServicesTestSuite) RolesCRUD(t *testing.T) {
 
 	out, err := s.Access.GetRoles(ctx)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	role := types.RoleV6{
 		Kind:    types.KindRole,
@@ -715,7 +715,7 @@ func (s *ServicesTestSuite) RolesCRUD(t *testing.T) {
 func (s *ServicesTestSuite) NamespacesCRUD(t *testing.T) {
 	out, err := s.PresenceS.GetNamespaces()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	ns := types.Namespace{
 		Kind:    types.KindNamespace,
@@ -790,10 +790,10 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	err = s.WebS.DeleteSAMLConnector(ctx, connector.GetName())
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	_, err = s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	created, err := s.WebS.CreateSAMLConnector(ctx, connector)
 	require.NoError(t, err)
@@ -878,10 +878,10 @@ func (s *ServicesTestSuite) OIDCCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	err = s.WebS.DeleteOIDCConnector(ctx, connector.GetName())
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	_, err = s.WebS.GetOIDCConnector(ctx, connector.GetName(), true)
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	created, err := s.WebS.CreateOIDCConnector(ctx, connector)
 	require.NoError(t, err)
@@ -921,7 +921,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	clusterName := "example.com"
 	out, err := s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	dt := s.Clock.Now()
 	conn, err := types.NewTunnelConnection("conn1", types.TunnelConnectionSpecV2{
@@ -936,12 +936,12 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	out, err = s.PresenceS.GetAllTunnelConnections()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	dt = dt.Add(time.Hour)
@@ -952,7 +952,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.PresenceS.DeleteAllTunnelConnections()
@@ -960,7 +960,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	err = s.PresenceS.DeleteAllTunnelConnections()
 	require.NoError(t, err)
@@ -971,7 +971,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.PresenceS.DeleteTunnelConnection(clusterName, conn.GetName())
@@ -979,7 +979,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 }
 
 func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
@@ -1031,10 +1031,10 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	err = s.WebS.DeleteGithubConnector(ctx, connector.GetName())
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	_, err = s.WebS.GetGithubConnector(ctx, connector.GetName(), true)
-	require.Equal(t, trace.IsNotFound(err), true, fmt.Sprintf("expected not found, got %T", err))
+	require.True(t, trace.IsNotFound(err), fmt.Sprintf("expected not found, got %T", err))
 
 	created, err := s.WebS.CreateGithubConnector(ctx, connector)
 	require.NoError(t, err)
@@ -1076,7 +1076,7 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 	clusterName := "example.com"
 	out, err := s.PresenceS.GetRemoteClusters()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	rc, err := types.NewRemoteCluster(clusterName)
 	require.NoError(t, err)
@@ -1091,7 +1091,7 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetRemoteClusters()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.PresenceS.DeleteAllRemoteClusters()
@@ -1099,7 +1099,7 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetRemoteClusters()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 0)
+	require.Empty(t, out)
 
 	// test delete individual connection
 	err = s.PresenceS.CreateRemoteCluster(rc)
@@ -1107,7 +1107,7 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 
 	out, err = s.PresenceS.GetRemoteClusters()
 	require.NoError(t, err)
-	require.Equal(t, len(out), 1)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	err = s.PresenceS.DeleteRemoteCluster(ctx, clusterName)
@@ -1133,9 +1133,9 @@ func (s *ServicesTestSuite) AuthPreference(t *testing.T) {
 	gotAP, err := s.ConfigS.GetAuthPreference(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, gotAP.GetType(), "local")
-	require.Equal(t, gotAP.GetSecondFactor(), constants.SecondFactorOTP)
-	require.Equal(t, gotAP.GetDisconnectExpiredCert(), true)
+	require.Equal(t, "local", gotAP.GetType())
+	require.Equal(t, constants.SecondFactorOTP, gotAP.GetSecondFactor())
+	require.True(t, gotAP.GetDisconnectExpiredCert())
 }
 
 // SessionRecordingConfig tests session recording configuration.
@@ -1152,7 +1152,7 @@ func (s *ServicesTestSuite) SessionRecordingConfig(t *testing.T) {
 	gotrecConfig, err := s.ConfigS.GetSessionRecordingConfig(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, gotrecConfig.GetMode(), types.RecordAtProxy)
+	require.Equal(t, types.RecordAtProxy, gotrecConfig.GetMode())
 }
 
 func (s *ServicesTestSuite) StaticTokens(t *testing.T) {
@@ -1250,8 +1250,8 @@ func (s *ServicesTestSuite) ClusterNetworkingConfig(t *testing.T) {
 	gotNetConfig, err := s.ConfigS.GetClusterNetworkingConfig(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, gotNetConfig.GetClientIdleTimeout(), 17*time.Second)
-	require.Equal(t, gotNetConfig.GetKeepAliveCountMax(), int64(3000))
+	require.Equal(t, 17*time.Second, gotNetConfig.GetClientIdleTimeout())
+	require.Equal(t, int64(3000), gotNetConfig.GetKeepAliveCountMax())
 }
 
 // sem wrapper is a helper for overriding the keepalive
@@ -1392,8 +1392,8 @@ func (s *ServicesTestSuite) SemaphoreConcurrency(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	require.Equal(t, atomic.LoadInt64(&success), maxLeases)
-	require.Equal(t, atomic.LoadInt64(&failure), attempts-maxLeases)
+	require.Equal(t, maxLeases, atomic.LoadInt64(&success))
+	require.Equal(t, attempts-maxLeases, atomic.LoadInt64(&failure))
 }
 
 // SemaphoreLock verifies correct functionality of the basic
@@ -1930,7 +1930,7 @@ func (s *ServicesTestSuite) runEventsTests(t *testing.T, testCases []eventTest, 
 
 	select {
 	case event := <-w.Events():
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 		watchStatus, ok := event.Resource.(types.WatchStatus)
 		require.True(t, ok)
 		expectedKinds := eventsTestKinds(testCases)

--- a/lib/services/useracl_test.go
+++ b/lib/services/useracl_test.go
@@ -94,8 +94,8 @@ func TestNewUserACL(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.Desktops, allowedRW))
 
 	require.Empty(t, cmp.Diff(userContext.Billing, denied))
-	require.Equal(t, userContext.Clipboard, true)
-	require.Equal(t, userContext.DesktopSessionRecording, true)
+	require.True(t, userContext.Clipboard)
+	require.True(t, userContext.DesktopSessionRecording)
 	require.Empty(t, cmp.Diff(userContext.License, denied))
 	require.Empty(t, cmp.Diff(userContext.Download, denied))
 
@@ -107,7 +107,7 @@ func TestNewUserACL(t *testing.T) {
 
 	// test that desktopRecordingEnabled being false overrides the roleSet.RecordDesktopSession() returning true
 	userContext = NewUserACL(user, roleSet, proto.Features{}, false, false)
-	require.Equal(t, userContext.DesktopSessionRecording, false)
+	require.False(t, userContext.DesktopSessionRecording)
 }
 
 func TestNewUserACLCloud(t *testing.T) {
@@ -149,8 +149,8 @@ func TestNewUserACLCloud(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.AccessRequests, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.DiscoveryConfig, allowedRW))
 
-	require.Equal(t, userContext.Clipboard, true)
-	require.Equal(t, userContext.DesktopSessionRecording, true)
+	require.True(t, userContext.Clipboard)
+	require.True(t, userContext.DesktopSessionRecording)
 
 	// cloud-specific asserts
 	require.Empty(t, cmp.Diff(userContext.Billing, allowedRW))

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -564,7 +564,7 @@ func TestDatabaseWatcher(t *testing.T) {
 	// Initially there are no databases so watcher should send an empty list.
 	select {
 	case changeset := <-w.DatabasesC:
-		require.Len(t, changeset, 0)
+		require.Empty(t, changeset)
 	case <-w.Done():
 		t.Fatal("Watcher has unexpectedly exited.")
 	case <-time.After(2 * time.Second):
@@ -663,7 +663,7 @@ func TestAppWatcher(t *testing.T) {
 	// Initially there are no apps so watcher should send an empty list.
 	select {
 	case changeset := <-w.AppsC:
-		require.Len(t, changeset, 0)
+		require.Empty(t, changeset)
 	case <-w.Done():
 		t.Fatal("Watcher has unexpectedly exited.")
 	case <-time.After(2 * time.Second):
@@ -922,9 +922,9 @@ func TestNodeWatcherFallback(t *testing.T) {
 	got := w.GetNodes(ctx, func(n services.Node) bool {
 		return true
 	})
-	require.Equal(t, len(nodes), len(got))
+	require.Len(t, nodes, len(got))
 
-	require.Equal(t, len(nodes), w.NodeCount())
+	require.Len(t, nodes, w.NodeCount())
 	require.False(t, w.IsInitialized())
 }
 
@@ -1139,7 +1139,7 @@ func TestAccessRequestWatcher(t *testing.T) {
 	// Initially there are no access requests so watcher should send an empty list.
 	select {
 	case changeset := <-w.AccessRequestsC:
-		require.Len(t, changeset, 0)
+		require.Empty(t, changeset)
 	case <-w.Done():
 		t.Fatal("Watcher has unexpectedly exited.")
 	case <-time.After(2 * time.Second):
@@ -1253,7 +1253,7 @@ func TestOktaAssignmentWatcher(t *testing.T) {
 	// Initially there are no assignments so watcher should send an empty list.
 	select {
 	case changeset := <-w.CollectorChan():
-		require.Len(t, changeset, 0, "initial assignment list should be empty")
+		require.Empty(t, changeset, "initial assignment list should be empty")
 	case <-w.Done():
 		t.Fatal("Watcher has unexpectedly exited.")
 	case <-time.After(2 * time.Second):

--- a/lib/shell/shell_test.go
+++ b/lib/shell/shell_test.go
@@ -29,7 +29,7 @@ func TestGetShell(t *testing.T) {
 
 	shell, err = GetLoginShell("non-existent-user")
 	require.NoError(t, err)
-	require.Equal(t, shell, DefaultShell)
+	require.Equal(t, DefaultShell, shell)
 
 	shell, err = GetLoginShell("nobody")
 	require.NoError(t, err)

--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -220,7 +220,7 @@ func mustReadFromConnection(t *testing.T, conn net.Conn, want string) {
 	buff, err := io.ReadAll(conn)
 	require.NoError(t, err)
 	require.NoError(t, conn.SetReadDeadline(time.Time{}))
-	require.Equal(t, string(buff), want)
+	require.Equal(t, want, string(buff))
 }
 
 func mustCloseConnection(t *testing.T, conn net.Conn) {

--- a/lib/srv/alpnproxy/local_proxy_config_opt_test.go
+++ b/lib/srv/alpnproxy/local_proxy_config_opt_test.go
@@ -30,7 +30,7 @@ func TestWithDatabaseProtocol(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var config LocalProxyConfig
 		require.NoError(t, WithDatabaseProtocol(defaults.ProtocolRedis)(&config))
-		require.Equal(t, config.Protocols, []common.Protocol{common.ProtocolRedisDB})
+		require.Equal(t, []common.Protocol{common.ProtocolRedisDB}, config.Protocols)
 	})
 	t.Run("fail", func(t *testing.T) {
 		var config LocalProxyConfig

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -568,7 +568,7 @@ func TestKubeMiddleware(t *testing.T) {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, 1, len(certs))
+				require.Len(t, certs, 1)
 				require.Equal(t, tt.overwrittenCert, certs[0])
 			}
 		})
@@ -606,7 +606,7 @@ func requireExpiredCertErr(t require.TestingT, err error, _ ...interface{}) {
 	require.Error(t, err)
 	var certErr x509.CertificateInvalidError
 	require.ErrorAs(t, err, &certErr)
-	require.Equal(t, certErr.Reason, x509.Expired)
+	require.Equal(t, x509.Expired, certErr.Reason)
 }
 
 func requireCertSubjectUserErr(t require.TestingT, err error, _ ...interface{}) {

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -415,7 +415,7 @@ func TestAWSSignerHandler(t *testing.T) {
 					require.FailNow(t, "wrong event type", "unexpected event type: wanted %T but got %T", tc.wantEventType, appSessionEvent)
 				}
 			} else {
-				require.Len(t, suite.recorder.C(), 0)
+				require.Empty(t, suite.recorder.C())
 			}
 		})
 	}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -663,10 +663,10 @@ func TestHandleConnection(t *testing.T) {
 		},
 	})
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
-		require.Equal(t, resp.StatusCode, http.StatusOK)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		buf, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(string(buf)), s.message)
+		require.Equal(t, s.message, strings.TrimSpace(string(buf)))
 	})
 }
 
@@ -711,10 +711,10 @@ func TestHandleConnectionHTTP2WS(t *testing.T) {
 
 	// First, make the request. This will be using HTTP2.
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
-		require.Equal(t, resp.StatusCode, http.StatusOK)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		buf, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(string(buf)), s.message)
+		require.Equal(t, s.message, strings.TrimSpace(string(buf)))
 	})
 
 	// Second, make the WebSocket connection. This will be using HTTP/1.1
@@ -793,10 +793,10 @@ func TestRewriteJWT(t *testing.T) {
 					Login: login,
 				})
 			s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
-				require.Equal(t, resp.StatusCode, http.StatusOK)
+				require.Equal(t, http.StatusOK, resp.StatusCode)
 				buf, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
-				require.Equal(t, strings.TrimSpace(string(buf)), s.message)
+				require.Equal(t, s.message, strings.TrimSpace(string(buf)))
 			})
 		})
 	}
@@ -888,10 +888,10 @@ func TestAuthorizeWithLocks(t *testing.T) {
 	}()
 
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
-		require.Equal(t, resp.StatusCode, http.StatusForbidden)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 		buf, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(string(buf)), "Forbidden")
+		require.Equal(t, "Forbidden", strings.TrimSpace(string(buf)))
 	})
 }
 
@@ -926,7 +926,7 @@ func TestAWSConsoleRedirect(t *testing.T) {
 		require.Equal(t, http.StatusFound, resp.StatusCode)
 		location, err := resp.Location()
 		require.NoError(t, err)
-		require.Equal(t, location.String(), "https://signin.aws.amazon.com")
+		require.Equal(t, "https://signin.aws.amazon.com", location.String())
 	})
 }
 
@@ -1150,7 +1150,7 @@ func (s *Suite) checkWSResponse(t *testing.T, clientCert tls.Certificate, checkM
 	require.NoError(t, err)
 
 	// Check response.
-	require.Equal(t, resp.StatusCode, http.StatusSwitchingProtocols)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
 	// Read websocket message

--- a/lib/srv/app/session_test.go
+++ b/lib/srv/app/session_test.go
@@ -74,7 +74,7 @@ func TestSessionChunkCloseTimeout(t *testing.T) {
 	}
 
 	elapsed := time.Since(start)
-	require.True(t, elapsed > timeout, "expected to wait at least %s before closing, waited only %s", timeout, elapsed)
+	require.Greater(t, elapsed, timeout, "expected to wait at least %s before closing, waited only %s", timeout, elapsed)
 }
 
 func TestSessionChunkCannotAcquireAfterClosing(t *testing.T) {

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1084,7 +1084,7 @@ func TestRedisGetSet(t *testing.T) {
 
 	getResult := redisClient.Get(ctx, "key1")
 	require.NoError(t, getResult.Err())
-	require.Equal(t, getResult.Val(), "123")
+	require.Equal(t, "123", getResult.Val())
 
 	// Disconnect.
 	err = redisClient.Close()

--- a/lib/srv/db/cloud/users/helpers_test.go
+++ b/lib/srv/db/cloud/users/helpers_test.go
@@ -42,7 +42,7 @@ func TestLookupMap(t *testing.T) {
 		lookup.setDatabaseUsers(db3, []User{user3})
 
 		require.Equal(t, []string{"user1", "user2"}, db1.GetManagedUsers())
-		require.Len(t, db2.GetManagedUsers(), 0)
+		require.Empty(t, db2.GetManagedUsers())
 		require.Equal(t, []string{"user3"}, db3.GetManagedUsers())
 	})
 

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -65,7 +65,7 @@ func TestLocalProxyPostgres(t *testing.T) {
 	var pgErr *pgconn.PgError
 	require.ErrorAs(t, err, &pgErr)
 	require.Equal(t, pgerrcode.QueryCanceled, pgErr.Code)
-	require.Len(t, results, 0)
+	require.Empty(t, results)
 }
 
 // TestLocalProxyMySQL verifies connecting to a MySQL database

--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -221,7 +221,7 @@ func TestProxyProtocolPostgresStartup(t *testing.T) {
 					payload := task.sendMsg.Encode(nil)
 					nWritten, err := conn.Write(payload)
 					require.NoError(t, err)
-					require.Equal(t, len(payload), nWritten, "failed to fully write payload")
+					require.Len(t, payload, nWritten, "failed to fully write payload")
 
 					var checkResponse responseChecker
 					var needsTLSUpgrade bool

--- a/lib/srv/db/proxyserver_test.go
+++ b/lib/srv/db/proxyserver_test.go
@@ -107,7 +107,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 			// When a connection is released a new can be established
 			t.Run("reconnect one", func(t *testing.T) {
 				// Get one open connection.
-				require.GreaterOrEqual(t, len(connsClosers), 1)
+				require.NotEmpty(t, connsClosers)
 				oneConn := connsClosers[len(connsClosers)-1]
 				connsClosers = connsClosers[:len(connsClosers)-1]
 

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -337,7 +337,7 @@ func TestShutdown(t *testing.T) {
 			})
 
 			// Validate that the server is proxying db0 after start.
-			require.Equal(t, server.getProxiedDatabases(), types.Databases{db0})
+			require.Equal(t, types.Databases{db0}, server.getProxiedDatabases())
 
 			// Validate heartbeat is present after start.
 			server.ForceHeartbeat()

--- a/lib/srv/db/snowflake_test.go
+++ b/lib/srv/db/snowflake_test.go
@@ -349,7 +349,7 @@ func TestTokenSession(t *testing.T) {
 	err = json.Unmarshal(respBody, &jsonMap)
 	require.NoError(t, err)
 
-	require.Equal(t, jsonMap.Data.Rowset[0][0], "42")
+	require.Equal(t, "42", jsonMap.Data.Rowset[0][0])
 }
 
 func withSnowflake(name string, opts ...snowflake.TestServerOption) withDatabaseOption {

--- a/lib/srv/db/sqlserver/protocol/fuzz_test.go
+++ b/lib/srv/db/sqlserver/protocol/fuzz_test.go
@@ -47,7 +47,7 @@ func FuzzRPCClientPartialLength(f *testing.F) {
 	f.Fuzz(func(t *testing.T, length uint64, chunks uint64) {
 		packet, err := ReadPacket(bytes.NewReader(fixtures.RPCClientPartiallyLength("foo3", length, chunks)))
 		require.NoError(t, err)
-		require.Equal(t, packet.Type(), PacketTypeRPCRequest)
+		require.Equal(t, PacketTypeRPCRequest, packet.Type())
 
 		// Given that `ToSQLPacket` recovers from panics when reading the packet,
 		// we just need to ensure the function doesn't return error.

--- a/lib/srv/db/sqlserver/protocol/protocol_test.go
+++ b/lib/srv/db/sqlserver/protocol/protocol_test.go
@@ -66,7 +66,7 @@ func TestSQLBatch(t *testing.T) {
 	require.NoError(t, err)
 	r, err := ToSQLPacket(packet)
 	require.NoError(t, err)
-	require.Equal(t, r.Type(), PacketTypeSQLBatch)
+	require.Equal(t, PacketTypeSQLBatch, r.Type())
 	p, ok := r.(*SQLBatch)
 	require.True(t, ok)
 	require.Equal(t, "\nselect 'foo' as 'bar'\n        ", p.SQLText)
@@ -76,7 +76,7 @@ func TestSQLBatch(t *testing.T) {
 func TestRPCClientRequestParam(t *testing.T) {
 	packet, err := ReadPacket(bytes.NewReader(fixtures.GenerateExecuteSQLRPCPacket("select @@version")))
 	require.NoError(t, err)
-	require.Equal(t, packet.Type(), PacketTypeRPCRequest)
+	require.Equal(t, PacketTypeRPCRequest, packet.Type())
 	r, err := ToSQLPacket(packet)
 	require.NoError(t, err)
 	p, ok := r.(*RPCRequest)
@@ -88,7 +88,7 @@ func TestRPCClientRequestParam(t *testing.T) {
 func TestRPCClientRequest(t *testing.T) {
 	packet, err := ReadPacket(bytes.NewReader(fixtures.GenerateCustomRPCCallPacket("foo3")))
 	require.NoError(t, err)
-	require.Equal(t, packet.Type(), PacketTypeRPCRequest)
+	require.Equal(t, PacketTypeRPCRequest, packet.Type())
 	r, err := ToSQLPacket(packet)
 	require.NoError(t, err)
 	p, ok := r.(*RPCRequest)
@@ -99,7 +99,7 @@ func TestRPCClientRequest(t *testing.T) {
 func TestRPCClientRequestPartialLength(t *testing.T) {
 	packet, err := ReadPacket(bytes.NewReader(fixtures.RPCClientPartiallyLength("foo3", 32, 4)))
 	require.NoError(t, err)
-	require.Equal(t, packet.Type(), PacketTypeRPCRequest)
+	require.Equal(t, PacketTypeRPCRequest, packet.Type())
 
 	r, err := ToSQLPacket(packet)
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestRPCClientRequestParamNTEXT(t *testing.T) {
 
 	packet, err := ReadPacket(bytes.NewReader(fixtures.GenerateExecuteSQLRPCPacketNTEXT("select @@version")))
 	require.NoError(t, err)
-	require.Equal(t, packet.Type(), PacketTypeRPCRequest)
+	require.Equal(t, PacketTypeRPCRequest, packet.Type())
 	r, err := ToSQLPacket(packet)
 	require.NoError(t, err)
 	p, ok := r.(*RPCRequest)

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -91,17 +91,17 @@ func TestAppliesLDAPLabels(t *testing.T) {
 	s.applyLabelsFromLDAP(entry, l)
 
 	// check default labels
-	require.Equal(t, l[types.OriginLabel], types.OriginDynamic)
-	require.Equal(t, l[types.DiscoveryLabelWindowsDNSHostName], "foo.example.com")
-	require.Equal(t, l[types.DiscoveryLabelWindowsComputerName], "foo")
-	require.Equal(t, l[types.DiscoveryLabelWindowsOS], "Windows Server")
-	require.Equal(t, l[types.DiscoveryLabelWindowsOSVersion], "6.1")
+	require.Equal(t, types.OriginDynamic, l[types.OriginLabel])
+	require.Equal(t, "foo.example.com", l[types.DiscoveryLabelWindowsDNSHostName])
+	require.Equal(t, "foo", l[types.DiscoveryLabelWindowsComputerName])
+	require.Equal(t, "Windows Server", l[types.DiscoveryLabelWindowsOS])
+	require.Equal(t, "6.1", l[types.DiscoveryLabelWindowsOSVersion])
 
 	// check OU label
-	require.Equal(t, l[types.DiscoveryLabelWindowsOU], "OU=IT,DC=goteleport,DC=com")
+	require.Equal(t, "OU=IT,DC=goteleport,DC=com", l[types.DiscoveryLabelWindowsOU])
 
 	// check custom labels
-	require.Equal(t, l["ldap/bar"], "baz")
+	require.Equal(t, "baz", l["ldap/bar"])
 	require.Empty(t, l["ldap/quux"])
 }
 

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -270,35 +270,35 @@ func TestHeartbeatAnnounce(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			require.Equal(t, hb.state, HeartbeatStateInit)
+			require.Equal(t, HeartbeatStateInit, hb.state)
 
 			// on the first run, heartbeat will move to announce state,
 			// will call announce right away
 			err = hb.fetch()
 			require.NoError(t, err)
-			require.Equal(t, hb.state, HeartbeatStateAnnounce)
+			require.Equal(t, HeartbeatStateAnnounce, hb.state)
 
 			err = hb.announce()
 			require.NoError(t, err)
-			require.Equal(t, announcer.upsertCalls[hb.Mode], 1)
-			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
-			require.Equal(t, hb.nextAnnounce, clock.Now().UTC().Add(hb.AnnouncePeriod))
+			require.Equal(t, 1, announcer.upsertCalls[hb.Mode])
+			require.Equal(t, HeartbeatStateAnnounceWait, hb.state)
+			require.Equal(t, clock.Now().UTC().Add(hb.AnnouncePeriod), hb.nextAnnounce)
 
 			// next call will not move to announce, because time is not up yet
 			err = hb.fetchAndAnnounce()
 			require.NoError(t, err)
-			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
+			require.Equal(t, HeartbeatStateAnnounceWait, hb.state)
 
 			// advance time, and heartbeat will move to announce
 			clock.Advance(hb.AnnouncePeriod + time.Second)
 			err = hb.fetch()
 			require.NoError(t, err)
-			require.Equal(t, hb.state, HeartbeatStateAnnounce)
+			require.Equal(t, HeartbeatStateAnnounce, hb.state)
 			err = hb.announce()
 			require.NoError(t, err)
-			require.Equal(t, announcer.upsertCalls[hb.Mode], 2)
-			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
-			require.Equal(t, hb.nextAnnounce, clock.Now().UTC().Add(hb.AnnouncePeriod))
+			require.Equal(t, 2, announcer.upsertCalls[hb.Mode])
+			require.Equal(t, HeartbeatStateAnnounceWait, hb.state)
+			require.Equal(t, clock.Now().UTC().Add(hb.AnnouncePeriod), hb.nextAnnounce)
 
 			// in case of error, system will move to announce wait state,
 			// with next attempt scheduled on the next keep alive period
@@ -307,18 +307,18 @@ func TestHeartbeatAnnounce(t *testing.T) {
 			err = hb.fetchAndAnnounce()
 			require.Error(t, err)
 			require.True(t, trace.IsConnectionProblem(err))
-			require.Equal(t, announcer.upsertCalls[hb.Mode], 3)
-			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
-			require.Equal(t, hb.nextAnnounce, clock.Now().UTC().Add(hb.KeepAlivePeriod))
+			require.Equal(t, 3, announcer.upsertCalls[hb.Mode])
+			require.Equal(t, HeartbeatStateAnnounceWait, hb.state)
+			require.Equal(t, clock.Now().UTC().Add(hb.KeepAlivePeriod), hb.nextAnnounce)
 
 			// once announce is successful, next announce is set on schedule
 			announcer.err = nil
 			clock.Advance(hb.KeepAlivePeriod + time.Second)
 			err = hb.fetchAndAnnounce()
 			require.NoError(t, err)
-			require.Equal(t, announcer.upsertCalls[hb.Mode], 4)
-			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
-			require.Equal(t, hb.nextAnnounce, clock.Now().UTC().Add(hb.AnnouncePeriod))
+			require.Equal(t, 4, announcer.upsertCalls[hb.Mode])
+			require.Equal(t, HeartbeatStateAnnounceWait, hb.state)
+			require.Equal(t, clock.Now().UTC().Add(hb.AnnouncePeriod), hb.nextAnnounce)
 		})
 	}
 }

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -105,7 +105,7 @@ func TestConnectionMonitorLockInForce(t *testing.T) {
 		tconn := &mockTrackingConn{closedC: make(chan struct{})}
 		monitorCtx, _, err := monitor.MonitorConn(ctx, authzCtx, tconn)
 		require.NoError(t, err)
-		require.Nil(t, monitorCtx.Err())
+		require.NoError(t, monitorCtx.Err())
 
 		// Create a lock targeting the user that was connected above.
 		require.NoError(t, asrv.AuthServer.UpsertLock(ctx, lock))

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -129,7 +129,7 @@ func TestStartNewParker(t *testing.T) {
 						CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
 							require.NotNil(t, ctx)
 							require.Len(t, arg, 1)
-							require.Equal(t, arg[0], teleport.ParkSubCommand)
+							require.Equal(t, teleport.ParkSubCommand, arg[0])
 							parkerStarted = true
 							return exec.CommandContext(ctx, name, arg...)
 						},

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -552,11 +552,11 @@ func TestParties(t *testing.T) {
 
 	// Create a session with 3 parties
 	sess, _ := testOpenSession(t, reg, nil)
-	require.Equal(t, 1, len(sess.getParties()))
+	require.Len(t, sess.getParties(), 1)
 	testJoinSession(t, reg, sess)
-	require.Equal(t, 2, len(sess.getParties()))
+	require.Len(t, sess.getParties(), 2)
 	testJoinSession(t, reg, sess)
-	require.Equal(t, 3, len(sess.getParties()))
+	require.Len(t, sess.getParties(), 3)
 
 	// If a party leaves, the session should remove the party and continue.
 	p := sess.getParties()[0]
@@ -590,7 +590,7 @@ func TestParties(t *testing.T) {
 
 	// If a party connects to the lingering session, it will continue.
 	testJoinSession(t, reg, sess)
-	require.Equal(t, 1, len(sess.getParties()))
+	require.Len(t, sess.getParties(), 1)
 
 	// advance clock and give lingerAndDie goroutine a second to complete.
 	regClock.Advance(defaults.SessionIdlePeriod)

--- a/lib/srv/termmanager_test.go
+++ b/lib/srv/termmanager_test.go
@@ -65,7 +65,7 @@ func TestHistoryKept(t *testing.T) {
 	data := make([]byte, 10000)
 	n, err := rand.Read(data)
 	require.NoError(t, err)
-	require.Equal(t, len(data), n)
+	require.Len(t, data, n)
 
 	n, err = m.Write(data[:len(data)/2])
 	require.NoError(t, err)
@@ -87,11 +87,11 @@ func TestBufferedKept(t *testing.T) {
 	data := make([]byte, 20000)
 	n, err := rand.Read(data)
 	require.NoError(t, err)
-	require.Equal(t, len(data), n)
+	require.Len(t, data, n)
 
 	n, err = m.Write(data)
 	require.NoError(t, err)
-	require.Equal(t, len(data), n)
+	require.Len(t, data, n)
 
 	kept := data[len(data)-maxPausedHistoryBytes:]
 	require.Equal(t, m.buffer, kept)
@@ -174,7 +174,7 @@ func TestTermManagerRead(t *testing.T) {
 			},
 			readAssertion: func(n int, err error, d []byte) {
 				assert.NoError(t, err)
-				assert.Equal(t, n, len(data))
+				assert.Len(t, data, n)
 				assert.Equal(t, data, d)
 			},
 		},
@@ -270,7 +270,7 @@ func TestTermManagerRead(t *testing.T) {
 			},
 			readAssertion: func(n int, err error, d []byte) {
 				assert.NoError(t, err)
-				assert.Equal(t, n, len(data))
+				assert.Len(t, data, n)
 				assert.Equal(t, data, d)
 			},
 		},
@@ -317,7 +317,7 @@ func TestTermManagerRead(t *testing.T) {
 			},
 			readAssertion: func(n int, err error, d []byte) {
 				assert.NoError(t, err)
-				assert.Equal(t, n, len(data))
+				assert.Len(t, data, n)
 				assert.Equal(t, data, d)
 			},
 		},

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -19,7 +19,6 @@ package sftp
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -328,7 +327,7 @@ func TestUpload(t *testing.T) {
 				"idontexist",
 			},
 			errCheck: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, errors.Is(err, os.ErrNotExist))
+				require.ErrorIs(t, err, os.ErrNotExist)
 			},
 		},
 	}
@@ -508,7 +507,7 @@ func TestDownload(t *testing.T) {
 			name:    "non-existent src file",
 			srcPath: "idontexist",
 			errCheck: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, errors.Is(err, os.ErrNotExist))
+				require.ErrorIs(t, err, os.ErrNotExist)
 			},
 		},
 	}

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -119,7 +119,7 @@ func TestLoadTokenFromFile(t *testing.T) {
 
 	token, err := cfg.Onboarding.Token()
 	require.NoError(t, err)
-	require.Equal(t, token, "xxxyyy")
+	require.Equal(t, "xxxyyy", token)
 }
 
 const exampleConfigFile = `

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -135,7 +135,7 @@ func TestGatewayCRUD(t *testing.T) {
 					gatewayURIs[gateway.URI()] = struct{}{}
 				}
 
-				require.Equal(t, 2, len(gateways))
+				require.Len(t, gateways, 2)
 				require.Contains(t, gatewayURIs, c.nameToGateway["gateway1"].URI())
 				require.Contains(t, gatewayURIs, c.nameToGateway["gateway2"].URI())
 			},

--- a/lib/teleterm/gateway/kube_test.go
+++ b/lib/teleterm/gateway/kube_test.go
@@ -119,7 +119,7 @@ func sendRequestToKubeLocalProxyAndSucceed(t *testing.T, client *kubernetes.Clie
 	t.Helper()
 	resp, err := client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, len(resp.Items), 1)
+	require.Len(t, resp.Items, 1)
 	require.Equal(t, "kube-pod-name", resp.Items[0].GetName())
 }
 func sendRequestToKubeLocalProxyAndFail(t *testing.T, client *kubernetes.Clientset) {

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -33,20 +32,20 @@ func TestParseHostPort(t *testing.T) {
 	// success
 	addr, err := ParseHostPortAddr("localhost:22", -1)
 	require.NoError(t, err)
-	require.Equal(t, addr.AddrNetwork, "tcp")
-	require.Equal(t, addr.Addr, "localhost:22")
+	require.Equal(t, "tcp", addr.AddrNetwork)
+	require.Equal(t, "localhost:22", addr.Addr)
 
 	// scheme + existing port
 	addr, err = ParseHostPortAddr("https://localhost", 443)
 	require.NoError(t, err)
-	require.Equal(t, addr.AddrNetwork, "https")
-	require.Equal(t, addr.Addr, "localhost:443")
+	require.Equal(t, "https", addr.AddrNetwork)
+	require.Equal(t, "localhost:443", addr.Addr)
 
 	// success
 	addr, err = ParseHostPortAddr("localhost", 1111)
 	require.NoError(t, err)
-	require.Equal(t, addr.AddrNetwork, "tcp")
-	require.Equal(t, addr.Addr, "localhost:1111")
+	require.Equal(t, "tcp", addr.AddrNetwork)
+	require.Equal(t, "localhost:1111", addr.Addr)
 
 	// missing port
 	addr, err = ParseHostPortAddr("localhost", -1)
@@ -55,14 +54,14 @@ func TestParseHostPort(t *testing.T) {
 
 	// scheme + missing port
 	_, err = ParseHostPortAddr("https://localhost", -1)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 
 	var a NetAddr
-	require.Equal(t, a.IsEmpty(), true)
+	require.True(t, a.IsEmpty())
 }
 
 func TestParse(t *testing.T) {
@@ -71,12 +70,12 @@ func TestParse(t *testing.T) {
 	addr, err := ParseAddr("tcp://one:25/path")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "one:25")
-	require.Equal(t, addr.Path, "/path")
-	require.Equal(t, addr.FullAddress(), "tcp://one:25")
-	require.Equal(t, addr.IsEmpty(), false)
-	require.Equal(t, addr.Host(), "one")
-	require.Equal(t, addr.Port(0), 25)
+	require.Equal(t, "one:25", addr.Addr)
+	require.Equal(t, "/path", addr.Path)
+	require.Equal(t, "tcp://one:25", addr.FullAddress())
+	require.False(t, addr.IsEmpty())
+	require.Equal(t, "one", addr.Host())
+	require.Equal(t, 25, addr.Port(0))
 }
 
 func TestParseIPV6(t *testing.T) {
@@ -85,19 +84,19 @@ func TestParseIPV6(t *testing.T) {
 	addr, err := ParseAddr("[::1]:49870")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "[::1]:49870")
-	require.Equal(t, addr.Path, "")
-	require.Equal(t, addr.FullAddress(), "tcp://[::1]:49870")
-	require.Equal(t, addr.IsEmpty(), false)
-	require.Equal(t, addr.Host(), "::1")
-	require.Equal(t, addr.Port(0), 49870)
+	require.Equal(t, "[::1]:49870", addr.Addr)
+	require.Empty(t, addr.Path)
+	require.Equal(t, "tcp://[::1]:49870", addr.FullAddress())
+	require.False(t, addr.IsEmpty())
+	require.Equal(t, "::1", addr.Host())
+	require.Equal(t, 49870, addr.Port(0))
 
 	// Just square brackets is also valid
 	addr, err = ParseAddr("[::1]")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "[::1]")
-	require.Equal(t, addr.Host(), "::1")
+	require.Equal(t, "[::1]", addr.Addr)
+	require.Equal(t, "::1", addr.Host())
 }
 
 func TestParseEmptyPort(t *testing.T) {
@@ -106,12 +105,12 @@ func TestParseEmptyPort(t *testing.T) {
 	addr, err := ParseAddr("one")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "one")
-	require.Equal(t, addr.Path, "")
-	require.Equal(t, addr.FullAddress(), "tcp://one")
-	require.Equal(t, addr.IsEmpty(), false)
-	require.Equal(t, addr.Host(), "one")
-	require.Equal(t, addr.Port(443), 443)
+	require.Equal(t, "one", addr.Addr)
+	require.Empty(t, addr.Path)
+	require.Equal(t, "tcp://one", addr.FullAddress())
+	require.False(t, addr.IsEmpty())
+	require.Equal(t, "one", addr.Host())
+	require.Equal(t, 443, addr.Port(443))
 }
 
 func TestParseHTTP(t *testing.T) {
@@ -120,10 +119,10 @@ func TestParseHTTP(t *testing.T) {
 	addr, err := ParseAddr("http://one:25/path")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "one:25")
-	require.Equal(t, addr.Path, "/path")
-	require.Equal(t, addr.FullAddress(), "http://one:25")
-	require.Equal(t, addr.IsEmpty(), false)
+	require.Equal(t, "one:25", addr.Addr)
+	require.Equal(t, "/path", addr.Path)
+	require.Equal(t, "http://one:25", addr.FullAddress())
+	require.False(t, addr.IsEmpty())
 }
 
 func TestParseDefaults(t *testing.T) {
@@ -132,9 +131,9 @@ func TestParseDefaults(t *testing.T) {
 	addr, err := ParseAddr("host:25")
 	require.NoError(t, err)
 	require.NotNil(t, addr)
-	require.Equal(t, addr.Addr, "host:25")
-	require.Equal(t, addr.FullAddress(), "tcp://host:25")
-	require.Equal(t, addr.IsEmpty(), false)
+	require.Equal(t, "host:25", addr.Addr)
+	require.Equal(t, "tcp://host:25", addr.FullAddress())
+	require.False(t, addr.IsEmpty())
 }
 
 func TestReplaceLocalhost(t *testing.T) {
@@ -142,17 +141,17 @@ func TestReplaceLocalhost(t *testing.T) {
 
 	var result string
 	result = ReplaceLocalhost("10.10.1.1", "192.168.1.100:399")
-	require.Equal(t, result, "10.10.1.1")
+	require.Equal(t, "10.10.1.1", result)
 	result = ReplaceLocalhost("10.10.1.1:22", "192.168.1.100:399")
-	require.Equal(t, result, "10.10.1.1:22")
+	require.Equal(t, "10.10.1.1:22", result)
 	result = ReplaceLocalhost("127.0.0.1:22", "192.168.1.100:399")
-	require.Equal(t, result, "192.168.1.100:22")
+	require.Equal(t, "192.168.1.100:22", result)
 	result = ReplaceLocalhost("0.0.0.0:22", "192.168.1.100:399")
-	require.Equal(t, result, "192.168.1.100:22")
+	require.Equal(t, "192.168.1.100:22", result)
 	result = ReplaceLocalhost("[::]:22", "192.168.1.100:399")
-	require.Equal(t, result, "192.168.1.100:22")
+	require.Equal(t, "192.168.1.100:22", result)
 	result = ReplaceLocalhost("[::]:22", "[1::1]:399")
-	require.Equal(t, result, "[1::1]:22")
+	require.Equal(t, "[1::1]:22", result)
 }
 
 func TestLocalAddrs(t *testing.T) {
@@ -172,8 +171,7 @@ func TestLocalAddrs(t *testing.T) {
 	for i, testCase := range testCases {
 		addr, err := ParseAddr(testCase.in)
 		require.NoError(t, err)
-		require.Equalf(t, addr.IsLocal(), testCase.expected,
-			fmt.Sprintf("test case %v, %v should be local(%v)", i, testCase.in, testCase.expected))
+		require.Equal(t, testCase.expected, addr.IsLocal(), "test case %v, %v should be local(%v)", i, testCase.in, testCase.expected)
 	}
 }
 
@@ -250,8 +248,10 @@ func TestGuessesIPAddress(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		ip := guessHostIP(testCase.addrs)
-		require.Empty(t, cmp.Diff(ip, testCase.expected), fmt.Sprintf(testCase.comment))
+		t.Run(testCase.comment, func(t *testing.T) {
+			ip := guessHostIP(testCase.addrs)
+			require.Empty(t, cmp.Diff(ip, testCase.expected))
+		})
 	}
 }
 
@@ -271,8 +271,7 @@ func TestMarshal(t *testing.T) {
 	for i, testCase := range testCases {
 		bytes, err := yaml.Marshal(testCase.in)
 		require.NoError(t, err)
-		require.Equalf(t, strings.TrimSpace(string(bytes)), testCase.expected,
-			fmt.Sprintf("test case %v, %v should be marshaled to: %v", i, testCase.in, testCase.expected))
+		require.Equal(t, testCase.expected, strings.TrimSpace(string(bytes)), "test case %v, %v should be marshaled to: %v", i, testCase.in, testCase.expected)
 	}
 }
 
@@ -292,8 +291,7 @@ func TestUnmarshal(t *testing.T) {
 		addr := &NetAddr{}
 		err := yaml.Unmarshal([]byte(testCase.in), addr)
 		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(addr, testCase.expected),
-			fmt.Sprintf("test case %v, %v should be unmarshalled to: %v", i, testCase.in, testCase.expected))
+		require.Empty(t, cmp.Diff(addr, testCase.expected), "test case %v, %v should be unmarshalled to: %v", i, testCase.in, testCase.expected)
 
 	}
 }

--- a/lib/utils/anonymizer_test.go
+++ b/lib/utils/anonymizer_test.go
@@ -36,6 +36,6 @@ func TestHMACAnonymizer(t *testing.T) {
 
 	data := "secret"
 	result := a.Anonymize([]byte(data))
-	require.NotEqual(t, result, "")
+	require.NotEmpty(t, result)
 	require.NotEqual(t, result, data)
 }

--- a/lib/utils/fncache_test.go
+++ b/lib/utils/fncache_test.go
@@ -84,7 +84,7 @@ func TestFnCacheGet(t *testing.T) {
 		return value.(int), nil
 	})
 	require.NoError(t, err)
-	require.Equal(t, value2, 123)
+	require.Equal(t, 123, value2)
 
 	value3, err := FnCacheGet(context.Background(), cache, "test", func(ctx context.Context) (string, error) {
 		return "123", nil

--- a/lib/utils/interval/multi_test.go
+++ b/lib/utils/interval/multi_test.go
@@ -108,7 +108,7 @@ func TestMultiIntervalBasics(t *testing.T) {
 	var prevT time.Time
 	for i := 0; i < 60; i++ {
 		tick := <-interval.Next()
-		require.True(t, !tick.Time.IsZero())
+		require.False(t, tick.Time.IsZero())
 		require.True(t, tick.Time.After(prevT) || tick.Time == prevT)
 		prevT = tick.Time
 		switch tick.Key {

--- a/lib/utils/jsontools_test.go
+++ b/lib/utils/jsontools_test.go
@@ -108,7 +108,7 @@ func TestStreamJSONArray(t *testing.T) {
 		require.NoError(t, err)
 
 		if len(iterative) == 0 {
-			require.Len(t, iterOut, 0)
+			require.Empty(t, iterOut)
 		} else {
 			require.Equal(t, iterative, iterOut)
 		}

--- a/lib/utils/kernel_test.go
+++ b/lib/utils/kernel_test.go
@@ -91,8 +91,8 @@ func TestKernelVersion(t *testing.T) {
 			require.NoError(t, err)
 			max, err := semver.NewVersion(tt.inMax)
 			require.NoError(t, err)
-			require.Equal(t, version.LessThan(*max), true)
-			require.Equal(t, version.LessThan(*min), false)
+			require.True(t, version.LessThan(*max))
+			require.False(t, version.LessThan(*min))
 		})
 	}
 

--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -48,7 +48,7 @@ func TestSingleBackendLB(t *testing.T) {
 
 	out, err := Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 }
 
 func TestTwoBackendsLB(t *testing.T) {
@@ -76,17 +76,17 @@ func TestTwoBackendsLB(t *testing.T) {
 
 	// no endpoints
 	_, err = Roundtrip(lb.Addr().String())
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	lb.AddBackend(backend1Addr)
 	out, err := Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 
 	lb.AddBackend(backend2Addr)
 	out, err = Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 2")
+	require.Equal(t, "backend 2", out)
 }
 
 func TestOneFailingBackend(t *testing.T) {
@@ -117,14 +117,14 @@ func TestOneFailingBackend(t *testing.T) {
 
 	out, err := Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 
 	_, err = Roundtrip(lb.Addr().String())
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	out, err = Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 }
 
 func TestClose(t *testing.T) {
@@ -145,7 +145,7 @@ func TestClose(t *testing.T) {
 
 	out, err := Roundtrip(lb.Addr().String())
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 
 	lb.Close()
 	// second close works
@@ -155,7 +155,7 @@ func TestClose(t *testing.T) {
 
 	// requests are failing
 	out, err = Roundtrip(lb.Addr().String())
-	require.NotNilf(t, err, fmt.Sprintf("output: %s, err: %v", out, err))
+	require.Error(t, err, "output: %s, err: %v", out, err)
 }
 
 func TestDropConnections(t *testing.T) {
@@ -181,18 +181,18 @@ func TestDropConnections(t *testing.T) {
 
 	out, err := RoundtripWithConn(conn)
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 
 	// to make sure multiple requests work on the same wire
 	out, err = RoundtripWithConn(conn)
 	require.NoError(t, err)
-	require.Equal(t, out, "backend 1")
+	require.Equal(t, "backend 1", out)
 
 	// removing backend results in dropped connection to this backend
 	err = lb.RemoveBackend(backendAddr)
 	require.NoError(t, err)
 	_, err = RoundtripWithConn(conn)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func urlToNetAddr(u string) NetAddr {

--- a/lib/utils/roles_test.go
+++ b/lib/utils/roles_test.go
@@ -40,8 +40,8 @@ func TestParsing(t *testing.T) {
 	require.NoError(t, roles[1].Check())
 	require.NoError(t, roles[2].Check())
 	require.NoError(t, roles.Check())
-	require.Equal(t, roles.String(), "Auth,Proxy,Node")
-	require.Equal(t, roles[0].String(), "Auth")
+	require.Equal(t, "Auth,Proxy,Node", roles.String())
+	require.Equal(t, "Auth", roles[0].String())
 }
 
 func TestBadRoles(t *testing.T) {
@@ -68,10 +68,8 @@ func TestEquivalence(t *testing.T) {
 		types.RoleAuth,
 	}
 
-	require.Equal(t, authRole.Include(types.RoleAdmin), true)
-	require.Equal(t, authRole.Include(types.RoleProxy), false)
-	require.Equal(t, authRole.Equals(nodeProxyRole), false)
-	require.Equal(t, authRole.Equals(types.SystemRoles{types.RoleAuth, types.RoleAdmin}),
-		true)
-
+	require.True(t, authRole.Include(types.RoleAdmin))
+	require.False(t, authRole.Include(types.RoleProxy))
+	require.False(t, authRole.Equals(nodeProxyRole))
+	require.True(t, authRole.Equals(types.SystemRoles{types.RoleAuth, types.RoleAdmin}))
 }

--- a/lib/utils/typical/parser_test.go
+++ b/lib/utils/typical/parser_test.go
@@ -427,7 +427,7 @@ func TestUnknownIdentifier(t *testing.T) {
 	_, err = parser.Parse("unknown")
 
 	var u typical.UnknownIdentifierError
-	require.True(t, errors.As(err, &u))
-	require.True(t, errors.As(trace.Wrap(err), &u))
+	require.ErrorAs(t, err, &u)
+	require.ErrorAs(t, trace.Wrap(err), &u)
 	require.Equal(t, "unknown", u.Identifier())
 }

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -58,7 +58,7 @@ func TestHostUUIDBadLocation(t *testing.T) {
 
 	// call with a read-only dir, make sure to get an error
 	id, err := ReadOrMakeHostUUID("/bad-location")
-	require.Equal(t, id, "")
+	require.Empty(t, id)
 	require.Error(t, err)
 	require.Regexp(t, "^.*no such file or directory.*$", err.Error())
 }
@@ -105,8 +105,8 @@ func TestRandomDuration(t *testing.T) {
 	expectedMax := time.Second * 10
 	for i := 0; i < 50; i++ {
 		dur := RandomDuration(expectedMax)
-		require.True(t, dur >= expectedMin)
-		require.True(t, dur < expectedMax)
+		require.GreaterOrEqual(t, dur, expectedMin)
+		require.Less(t, dur, expectedMax)
 	}
 }
 
@@ -555,7 +555,7 @@ func TestStringsSet(t *testing.T) {
 	t.Parallel()
 
 	out := StringsSet(nil)
-	require.Len(t, out, 0)
+	require.Empty(t, out)
 	require.NotNil(t, out)
 }
 
@@ -667,7 +667,7 @@ func TestByteCount(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, ByteCount(tc.size), tc.expected)
+			assert.Equal(t, tc.expected, ByteCount(tc.size))
 		})
 	}
 }

--- a/lib/versioncontrol/upgradewindow/upgradewindow_test.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow_test.go
@@ -122,7 +122,7 @@ func TestSystemdUnitDriver(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, driver.Kind(), "unit")
+	require.Equal(t, "unit", driver.Kind())
 
 	// verify basic schedule creation
 	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{

--- a/lib/web/assistant_test.go
+++ b/lib/web/assistant_test.go
@@ -77,7 +77,7 @@ func Test_runAssistant(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, assist.MessageKindError, msg.Type)
-		require.Equal(t, msg.Payload, "You have reached the rate limit. Please try again later.")
+		require.Equal(t, "You have reached the rate limit. Please try again later.", msg.Payload)
 	}
 
 	testCases := []struct {
@@ -113,7 +113,7 @@ func Test_runAssistant(t *testing.T) {
 			setup: func(t *testing.T, s *WebSuite) {
 				// Assert that rate limiter is set up when Cloud feature is active,
 				// before replacing with a lower capacity rate-limiter for test purposes
-				require.Equal(t, assistantLimiterRate, s.webHandler.handler.assistantLimiter.Limit())
+				require.InEpsilon(t, float64(assistantLimiterRate), float64(s.webHandler.handler.assistantLimiter.Limit()), 0.0)
 
 				// 101 token capacity (lookaheadTokens+1) and a slow replenish rate
 				// to let the first completion request succeed, but not the second one

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -47,7 +47,7 @@ func TestWriteUpgradeResponse(t *testing.T) {
 	io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 
-	require.Equal(t, resp.StatusCode, http.StatusSwitchingProtocols)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 	require.Equal(t, "custom", resp.Header.Get("Upgrade"))
 }
 
@@ -68,7 +68,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 
 			n, err := conn.Write([]byte(expectedPayload))
 			require.NoError(t, err)
-			require.Equal(t, len(expectedPayload), n)
+			require.Len(t, expectedPayload, n)
 		}()
 		return nil
 	}

--- a/lib/web/discoveryconfig_test.go
+++ b/lib/web/discoveryconfig_test.go
@@ -210,7 +210,7 @@ func TestDiscoveryConfig(t *testing.T) {
 			require.NotEmpty(t, listResponse.NextKey)
 			startKey = listResponse.NextKey
 		}
-		require.Equal(t, listTestCount, len(uniqDC))
+		require.Len(t, uniqDC, listTestCount)
 		require.Zero(t, iterationsCount, "invalid number of iterations")
 	})
 }

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -633,8 +633,8 @@ func TestGetAppJoinScript(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			script, err = getJoinScript(context.Background(), tc.settings, m)
 			if tc.shouldError {
-				require.NotNil(t, err)
-				require.Equal(t, script, "")
+				require.Error(t, err)
+				require.Empty(t, script)
 			} else {
 				require.NoError(t, err)
 				for _, output := range tc.outputs {
@@ -937,7 +937,7 @@ func TestJoinScript(t *testing.T) {
 			currentStableCloudVersion := "v99.1.1"
 
 			httpTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/v1/stable/cloud/version")
+				assert.Equal(t, "/v1/stable/cloud/version", r.URL.Path)
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(currentStableCloudVersion))
 			}))

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -67,9 +67,9 @@ func TestOIDCIdPPublicEndpoints(t *testing.T) {
 
 	require.NotEmpty(t, jwksKeys.Keys)
 	key := jwksKeys.Keys[0]
-	require.Equal(t, key.Use, "sig")
-	require.Equal(t, key.KeyType, "RSA")
-	require.Equal(t, key.Alg, "RS256")
+	require.Equal(t, "sig", key.Use)
+	require.Equal(t, "RSA", key.KeyType)
+	require.Equal(t, "RS256", key.Alg)
 	require.NotNil(t, key.KeyID) // AWS requires this to be present (even if empty string).
 }
 

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -51,7 +51,7 @@ spec:
     - testing
 version: v3`
 	extractedResource, err := ExtractResourceAndValidate(goodContent)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, extractedResource)
 
 	// Test missing name.
@@ -283,10 +283,10 @@ spec:
 version: v2
 `
 	cluster, err := types.NewTrustedCluster("tcName", types.TrustedClusterSpecV2{})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	item, err := ui.NewResourceItem(cluster)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, item, &ui.ResourceItem{
 		ID:      "trusted_cluster:tcName",
 		Kind:    types.KindTrustedCluster,
@@ -304,14 +304,14 @@ func TestGetRoles(t *testing.T) {
 				Logins: []string{"test"},
 			},
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		return []types.Role{role}, nil
 	}
 
 	// Test response is converted to ui objects.
 	roles, err := getRoles(m)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, roles, 1)
 	require.Contains(t, roles[0].Content, "name: test")
 }
@@ -433,7 +433,7 @@ func TestGetGithubConnectors(t *testing.T) {
 
 	// Test response is converted to ui objects.
 	connectors, err := getGithubConnectors(ctx, m)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, connectors, 1)
 	require.Contains(t, connectors[0].Content, "name: test")
 }
@@ -444,14 +444,14 @@ func TestGetTrustedClusters(t *testing.T) {
 
 	m.mockGetTrustedClusters = func(ctx context.Context) ([]types.TrustedCluster, error) {
 		cluster, err := types.NewTrustedCluster("test", types.TrustedClusterSpecV2{})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		return []types.TrustedCluster{cluster}, nil
 	}
 
 	// Test response is converted to ui objects.
 	tcs, err := getTrustedClusters(ctx, m)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, tcs, 1)
 	require.Contains(t, tcs[0].Content, "name: test")
 }

--- a/lib/web/servers_test.go
+++ b/lib/web/servers_test.go
@@ -144,7 +144,7 @@ func TestCreateNode(t *testing.T) {
 			resp, err := pack.clt.PostJSON(ctx, createNodeEndpoint, tt.req)
 			tt.errAssert(t, err)
 
-			require.Equal(t, resp.Code(), tt.expectedStatus, "invalid status code received")
+			require.Equal(t, tt.expectedStatus, resp.Code(), "invalid status code received")
 
 			if err != nil {
 				continue

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -48,20 +48,20 @@ func TestNewUserContext(t *testing.T) {
 	require.NoError(t, err)
 
 	// test user name
-	require.Equal(t, userContext.Name, "root")
+	require.Equal(t, "root", userContext.Name)
 	require.Empty(t, cmp.Diff(userContext.AccessStrategy, accessStrategy{
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",
 	}))
 
 	// test local auth type
-	require.Equal(t, userContext.AuthType, authLocal)
+	require.Equal(t, authLocal, userContext.AuthType)
 
 	// test sso auth type
 	user.Spec.GithubIdentities = []types.ExternalIdentity{{ConnectorID: "foo", Username: "bar"}}
 	userContext, err = NewUserContext(user, roleSet, proto.Features{}, true, false)
 	require.NoError(t, err)
-	require.Equal(t, userContext.AuthType, authSSO)
+	require.Equal(t, authSSO, userContext.AuthType)
 }
 
 func TestNewUserContextCloud(t *testing.T) {
@@ -81,7 +81,7 @@ func TestNewUserContextCloud(t *testing.T) {
 	userContext, err := NewUserContext(user, roleSet, proto.Features{Cloud: true}, true, false)
 	require.NoError(t, err)
 
-	require.Equal(t, userContext.Name, "root")
+	require.Equal(t, "root", userContext.Name)
 	require.Empty(t, cmp.Diff(userContext.AccessStrategy, accessStrategy{
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -58,7 +58,7 @@ func TestRequestParameters(t *testing.T) {
 		Roles:  []string{"testrole"},
 		Traits: userTraits{},
 	}
-	require.Nil(t, r.checkAndSetDefaults())
+	require.NoError(t, r.checkAndSetDefaults())
 }
 
 func TestCRUDs(t *testing.T) {
@@ -92,7 +92,7 @@ func TestCRUDs(t *testing.T) {
 
 	// test create
 	user, err := createUser(newRequest(t, u), m, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "testname", user.Name)
 	require.Equal(t, "local", user.AuthType)
 	require.Contains(t, user.Roles, "testrole")
@@ -100,22 +100,22 @@ func TestCRUDs(t *testing.T) {
 	// test update
 	u.Roles = []string{"newrole"}
 	user, err = updateUser(newRequest(t, u), m, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Contains(t, user.Roles, "newrole")
 
 	// test list
 	users, err := getUsers(context.Background(), m)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, users, 1)
 	require.Equal(t, "testname", users[0].Name)
 
 	// test delete
 	param := httprouter.Params{httprouter.Param{Key: "username", Value: "testname"}}
 	req, err := http.NewRequest("", "/:username", nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = deleteUser(req, param, m, "self")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestUpdateUser_setTraits(t *testing.T) {
@@ -311,7 +311,7 @@ func TestCRUDErrors(t *testing.T) {
 	// delete errors
 	param := httprouter.Params{httprouter.Param{Key: "username", Value: "testname"}}
 	req, err := http.NewRequest("", "/:username", nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = deleteUser(req, param, m, "self")
 	require.True(t, trace.IsNotFound(err))
@@ -319,7 +319,7 @@ func TestCRUDErrors(t *testing.T) {
 	// deleting self error
 	param = httprouter.Params{httprouter.Param{Key: "username", Value: "self"}}
 	req, err = http.NewRequest("", "/:username", nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = deleteUser(req, param, m, "self")
 	require.True(t, trace.IsBadParameter(err))
@@ -328,10 +328,10 @@ func TestCRUDErrors(t *testing.T) {
 // newRequest creates http request with given body
 func newRequest(t *testing.T, body interface{}) *http.Request {
 	reqBody, err := json.Marshal(body)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest("", "", bytes.NewBuffer(reqBody))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	req.Header.Add("Content-Type", "application/json")
 
 	return req

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -165,7 +165,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
 				require.Error(t, err)
-				require.Equal(t, err.Error(), "expected --proxy URL with http or https scheme")
+				require.Equal(t, "expected --proxy URL with http or https scheme", err.Error())
 			},
 		},
 		{
@@ -279,7 +279,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
 				require.Error(t, err)
-				require.Equal(t, err.Error(), "couldn't find leaf cluster named \"doesnotexist.example.com\"")
+				require.Equal(t, `couldn't find leaf cluster named "doesnotexist.example.com"`, err.Error())
 			},
 		},
 		{

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -54,7 +54,7 @@ func TestDatabaseResourceMatchersToString(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, databaseResourceMatchersToString(resMatch), "(Labels: x=[y])")
+	require.Equal(t, "(Labels: x=[y])", databaseResourceMatchersToString(resMatch))
 }
 
 type writeTextTest struct {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1029,7 +1029,7 @@ func (test *dynamicResourceTest[T]) run(t *testing.T) {
 	buf, err := runResourceCommand(t, fileConfig, []string{"get", test.kind, "--format=json"})
 	require.NoError(t, err)
 	resources := mustDecodeJSON[[]T](t, buf)
-	require.Len(t, resources, 0)
+	require.Empty(t, resources)
 
 	// Create the resources.
 	yamlPath := filepath.Join(t.TempDir(), "resources.yaml")

--- a/tool/tctl/common/tarwriter_test.go
+++ b/tool/tctl/common/tarwriter_test.go
@@ -95,7 +95,7 @@ func TestTarWriterFileWrite(t *testing.T) {
 
 		require.Equal(t, testContent[i].filename, header.Name)
 		require.Equal(t, testContent[i].filemode, header.Mode)
-		require.Equal(t, len(testContent[i].content), int(header.Size))
+		require.Len(t, testContent[i].content, int(header.Size))
 		require.Equal(t, expectedTime, header.ModTime)
 
 		actualContent := make([]byte, header.Size)
@@ -109,5 +109,5 @@ func TestTarWriterFileWrite(t *testing.T) {
 		i++
 	}
 
-	require.Equal(t, i, len(testContent))
+	require.Len(t, testContent, i)
 }

--- a/tool/tctl/common/token_command_test.go
+++ b/tool/tctl/common/token_command_test.go
@@ -85,7 +85,7 @@ func TestTokens(t *testing.T) {
 
 		buf, err = runTokensCommand(t, fileConfig, []string{"add", "--type=node,app", "--format", teleport.Text})
 		require.NoError(t, err)
-		require.Equal(t, strings.Count(buf.String(), "\n"), 1)
+		require.Equal(t, 1, strings.Count(buf.String(), "\n"))
 
 		buf, err = runTokensCommand(t, fileConfig, []string{"add", "--type=node,app", "--format", teleport.JSON})
 		require.NoError(t, err)

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -60,7 +60,7 @@ func TestTrimDurationSuffix(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.comment, func(t *testing.T) {
 			fmt := trimDurationZeroSuffix(tt.ts)
-			require.Equal(t, fmt, tt.wantFmt)
+			require.Equal(t, tt.wantFmt, fmt)
 		})
 	}
 }

--- a/tool/tctl/sso/configure/teams_to_roles_test.go
+++ b/tool/tctl/sso/configure/teams_to_roles_test.go
@@ -82,7 +82,7 @@ func Test_teamsToRolesParser_Set(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.parser, tt.wantParser)
+				require.Equal(t, tt.wantParser, tt.parser)
 			}
 		})
 	}

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -261,8 +261,8 @@ func testDatabaseLogin(t *testing.T) {
 			// grab the certs using the actual database name to verify certs.
 			certs, keys, err := decodePEM(profile.DatabaseCertPathForCluster("", test.databaseName))
 			require.NoError(t, err)
-			require.Equal(t, test.expectCertsLen, len(certs)) // don't use require.Len, because it spams PEM bytes on fail.
-			require.Equal(t, test.expectKeysLen, len(keys))   // don't use require.Len, because it spams PEM bytes on fail.
+			require.Len(t, certs, test.expectCertsLen)
+			require.Len(t, keys, test.expectKeysLen)
 
 			t.Run("print info", func(t *testing.T) {
 				// organize these as parallel subtests in a group, so we can run

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -146,8 +146,8 @@ func sendRequestToKubeLocalProxy(t *testing.T, config *clientcmdapi.Config, tele
 	require.NoError(t, err)
 
 	resp, err := client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
-	require.Nil(t, err)
-	require.GreaterOrEqual(t, len(resp.Items), 1)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Items)
 
 	runKubectlExec(t, restConfig)
 }

--- a/tool/tsh/common/options_test.go
+++ b/tool/tsh/common/options_test.go
@@ -47,7 +47,7 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"AddKeysToAgent yes"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, true, opts.AddKeysToAgent)
+				require.True(t, opts.AddKeysToAgent)
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"AddKeysToAgent=yes"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, true, opts.AddKeysToAgent)
+				require.True(t, opts.AddKeysToAgent)
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"ForwardX11 yes"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, true, opts.ForwardX11)
-				require.Equal(t, true, *opts.ForwardX11Trusted)
+				require.True(t, opts.ForwardX11)
+				require.True(t, *opts.ForwardX11Trusted)
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"ForwardX11Trusted yes"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, true, *opts.ForwardX11Trusted)
+				require.True(t, *opts.ForwardX11Trusted)
 			},
 		},
 		{
@@ -137,7 +137,7 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"ForwardX11Trusted no"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, false, *opts.ForwardX11Trusted)
+				require.False(t, *opts.ForwardX11Trusted)
 			},
 		},
 		{
@@ -145,8 +145,8 @@ func TestOptions(t *testing.T) {
 			inOptions:   []string{"ForwardX11 yes", "ForwardX11Trusted no"},
 			assertError: require.NoError,
 			assertOptions: func(t *testing.T, opts Options) {
-				require.Equal(t, true, opts.ForwardX11)
-				require.Equal(t, false, *opts.ForwardX11Trusted)
+				require.True(t, opts.ForwardX11)
+				require.False(t, *opts.ForwardX11Trusted)
 			},
 		},
 		{

--- a/tool/tsh/common/tctl_test.go
+++ b/tool/tsh/common/tctl_test.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 
@@ -79,14 +78,14 @@ func TestLoadConfigFromProfile(t *testing.T) {
 			cfg: &servicecfg.Config{
 				TeleportHome: "some/dir/that/does/not/exist",
 			},
-			want: trace.NotFound("profile is not found"),
+			want: trace.NotFound("current-profile is not set"),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := common.LoadConfigFromProfile(tc.ccf, tc.cfg)
 			if tc.want != nil {
-				require.Error(t, err, tc.want)
+				require.ErrorIs(t, err, tc.want)
 				return
 			}
 			require.NoError(t, err)
@@ -148,7 +147,7 @@ func TestRemoteTctlWithProfile(t *testing.T) {
 			err := common.TryRun(tt.commands, tt.args)
 			if tt.wantErrContains != "" {
 				var exitError *toolcommon.ExitCodeError
-				require.True(t, errors.As(err, &exitError))
+				require.ErrorAs(t, err, &exitError)
 				require.ErrorContains(t, err, tt.wantErrContains)
 				return
 			}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -439,7 +439,7 @@ func TestOIDCLogin(t *testing.T) {
 	// goroutine (ensures watcher init does not race with request creation).
 	select {
 	case event := <-watcher.Events():
-		require.Equal(t, event.Type, types.OpInit)
+		require.Equal(t, types.OpInit, event.Type)
 	case <-watcher.Done():
 		require.FailNow(t, "watcher closed unexpected", "err: %v", watcher.Error())
 	}
@@ -994,7 +994,7 @@ func TestMakeClient(t *testing.T) {
 	// forwarding is required for proxy recording mode.
 	agentKeys, err := tc.LocalAgent().ExtendedAgent.List()
 	require.NoError(t, err)
-	require.Greater(t, len(agentKeys), 0)
+	require.NotEmpty(t, agentKeys)
 	require.Equal(t, keys.PrivateKeyPolicyNone, tc.PrivateKeyPolicy,
 		"private key policy should be configured from the identity file temp profile")
 }


### PR DESCRIPTION
Updates our golangci-lint configuration to enable [testifylint](https://github.com/Antonboom/testifylint) and fixes all issues found.

Companion in e: https://github.com/gravitational/teleport.e/pull/2567