### PR TITLE
Prevent duplicate node entries in the unified cache

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -128,8 +128,26 @@ func (c *UnifiedResourceCache) put(ctx context.Context, resource resource) error
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	key := resourceKey(resource)
-	c.resources[key] = resource
 	sortKey := makeResourceSortKey(resource)
+	oldResource, exists := c.resources[key]
+	if exists {
+		// If the resource has changed in such a way that the sort keys
+		// for the nameTree or typeTree change, remove the old entries
+		// from those trees before adding a new one. This can happen
+		// when a node's hostname changes
+		oldSortKey := makeResourceSortKey(oldResource)
+		if string(oldSortKey.byName) != string(sortKey.byName) {
+			if _, ok := c.nameTree.Delete(&item{Key: oldSortKey.byName}); !ok {
+				return trace.NotFound("key %q is not found in unified cache name sort tree", string(sortKey.byName))
+			}
+		}
+		if string(oldSortKey.byType) != string(sortKey.byType) {
+			if _, ok := c.typeTree.Delete(&item{Key: oldSortKey.byType}); !ok {
+				return trace.NotFound("key %q is not found in unified cache type sort tree", string(sortKey.byType))
+			}
+		}
+	}
+	c.resources[key] = resource
 	c.nameTree.ReplaceOrInsert(&item{Key: sortKey.byName, Value: key})
 	c.typeTree.ReplaceOrInsert(&item{Key: sortKey.byType, Value: key})
 	return nil

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -62,7 +62,7 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		Events:                  local.NewEventsService(bk),
 	}
 	// Add node to the backend.
-	node := newNodeServer(t, "node1", "127.0.0.1:22", false /*tunnel*/)
+	node := newNodeServer(t, "node1", "hostname1", "127.0.0.1:22", false /*tunnel*/)
 	_, err = clt.UpsertNode(ctx, node)
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	))
 
 	// // Update and remove some resources.
-	nodeUpdated := newNodeServer(t, "node1", "192.168.0.1:22", false /*tunnel*/)
+	nodeUpdated := newNodeServer(t, "node1", "hostname1", "192.168.0.1:22", false /*tunnel*/)
 	_, err = clt.UpsertNode(ctx, nodeUpdated)
 	require.NoError(t, err)
 	err = clt.DeleteApplicationServer(ctx, defaults.Namespace, "app1-host-id", "app1")
@@ -179,6 +179,62 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		// Ignore order.
 		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
 	))
+}
+
+func TestUnifiedResourceWatcher_PreventDuplicates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	type client struct {
+		services.Presence
+		services.WindowsDesktops
+		services.SAMLIdPServiceProviders
+		types.Events
+	}
+
+	samlService, err := local.NewSAMLIdPServiceProviderService(bk)
+	require.NoError(t, err)
+
+	clt := &client{
+		Presence:                local.NewPresenceService(bk),
+		WindowsDesktops:         local.NewWindowsDesktopService(bk),
+		SAMLIdPServiceProviders: samlService,
+		Events:                  local.NewEventsService(bk),
+	}
+	w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentUnifiedResource,
+			Client:    clt,
+		},
+		ResourceGetter: clt,
+	})
+	require.NoError(t, err)
+
+	// add a node
+	node := newNodeServer(t, "node1", "hostname1", "127.0.0.1:22", false /*tunnel*/)
+	_, err = clt.UpsertNode(ctx, node)
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		res, _ := w.GetUnifiedResources(ctx)
+		return len(res) == 1
+	}, 5*time.Second, 10*time.Millisecond, "Timed out waiting for unified resources to be added")
+
+	// update a node
+	updatedNode := newNodeServer(t, "node1", "hostname2", "127.0.0.1:22", false /*tunnel*/)
+	_, err = clt.UpsertNode(ctx, updatedNode)
+	require.NoError(t, err)
+
+	// only one resource should still exists with the name "node1" (with hostname updated)
+	assert.Eventually(t, func() bool {
+		res, _ := w.GetUnifiedResources(ctx)
+		return len(res) == 1
+	}, 5*time.Second, 10*time.Millisecond, "Timed out waiting for unified resources to be added")
+
 }
 
 func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
@@ -215,7 +271,7 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	// add a node
-	node := newNodeServer(t, "node1", "127.0.0.1:22", false /*tunnel*/)
+	node := newNodeServer(t, "node1", "hostname1", "127.0.0.1:22", false /*tunnel*/)
 	_, err = clt.UpsertNode(ctx, node)
 	require.NoError(t, err)
 

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -910,7 +910,7 @@ func TestNodeWatcherFallback(t *testing.T) {
 	// Add some servers.
 	nodes := make([]types.Server, 0, 5)
 	for i := 0; i < 5; i++ {
-		node := newNodeServer(t, fmt.Sprintf("node%d", i), "127.0.0.1:2023", i%2 == 0)
+		node := newNodeServer(t, fmt.Sprintf("node%d", i), fmt.Sprintf("hostname%d", i), "127.0.0.1:2023", i%2 == 0)
 		_, err = presence.UpsertNode(ctx, node)
 		require.NoError(t, err)
 		nodes = append(nodes, node)
@@ -962,7 +962,7 @@ func TestNodeWatcher(t *testing.T) {
 	// Add some node servers.
 	nodes := make([]types.Server, 0, 5)
 	for i := 0; i < 5; i++ {
-		node := newNodeServer(t, fmt.Sprintf("node%d", i), "127.0.0.1:2023", i%2 == 0)
+		node := newNodeServer(t, fmt.Sprintf("node%d", i), fmt.Sprintf("hostname%d", i), "127.0.0.1:2023", i%2 == 0)
 		_, err = presence.UpsertNode(ctx, node)
 		require.NoError(t, err)
 		nodes = append(nodes, node)
@@ -989,10 +989,11 @@ func TestNodeWatcher(t *testing.T) {
 	require.Empty(t, w.GetNodes(ctx, func(n services.Node) bool { return n.GetName() == nodes[0].GetName() }))
 }
 
-func newNodeServer(t *testing.T, name, addr string, tunnel bool) types.Server {
+func newNodeServer(t *testing.T, name, hostname, addr string, tunnel bool) types.Server {
 	s, err := types.NewServer(name, types.KindNode, types.ServerSpecV2{
 		Addr:      addr,
 		UseTunnel: tunnel,
+		Hostname:  hostname,
 	})
 	require.NoError(t, err)
 	return s


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/34236

This change will prevent duplicate nodes from being added to the cache when changing the `nodename` in `teleport.yaml`. 

The `hostname` of the node doesn't update until the heartbeat and will be initialized with the "old" value. The resource map doesn't include a duplicate because we store _every_ resource by `name/type`. But the sort trees store nodes specifically with a key like `hostname/name/type`, meaning the "old" initialized value AND the "new" value that gets processed will have different sort keys (with the new hostname but same UUID). These two entries point to the same resource in resource map. 

To prevent this, if the node exists with a different hostname, we delete the entries from the sort trees before re-adding with the new name to ensure the resource isn't mapped to multiple times.

changelog: Fixed duplicate entries in resources view when updating nodename