### PR TITLE
Link to version-specific docs pages from the support page

### DIFF
--- a/web/packages/teleport/src/Support/Support.story.tsx
+++ b/web/packages/teleport/src/Support/Support.story.tsx
@@ -66,7 +66,7 @@ const ctx = createTeleportContext();
 
 const props: Props = {
   clusterId: 'test',
-  authVersion: '4.4.0-dev',
+  authVersion: '13.4.0-dev',
   publicURL: 'localhost:3080',
   isEnterprise: false,
   isCloud: false,

--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -93,9 +93,9 @@ export const Support = ({
           </Box>
           <Box>
             <Header title="Resources" icon={<Icons.BookOpenText />} />
-            <SupportLink title="Quickstart Guide" url={docs.quickstart} />
-            <SupportLink title="tsh User Guide" url={docs.userManual} />
-            <SupportLink title="Admin Guide" url={docs.adminGuide} />
+            <SupportLink title="Get Started" url={docs.getStarted} />
+            <SupportLink title="tsh User Guide" url={docs.tshGuide} />
+            <SupportLink title="Admin Guides" url={docs.adminGuide} />
             <SupportLink
               title="Download Page"
               url={getDownloadLink(isCloud, isEnterprise)}
@@ -168,19 +168,23 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
   const withUTM = (url = '', anchorHash = '') =>
     `${url}?product=teleport&version=${verPrefix}_${version}${anchorHash}`;
 
-  let docVer = ''
+  let docVer = '';
   if (version && version.length > 0) {
     const major = version.split('.')[0];
-    docVer = `/ver/${major}.x`
+    docVer = `/ver/${major}.x`;
   }
 
   return {
-    quickstart: withUTM(`https://goteleport.com/docs${docVer}/getting-started`),
-    userManual: withUTM(`https://goteleport.com/docs${docVer}/server-access/guides/tsh`),
-    adminGuide: withUTM(`https://goteleport.com/docs${docVer}/setup/admin`),
+    getStarted: withUTM(`https://goteleport.com/docs${docVer}/getting-started`),
+    tshGuide: withUTM(
+      `https://goteleport.com/docs${docVer}/server-access/guides/tsh`
+    ),
+    adminGuide: withUTM(
+      `https://goteleport.com/docs${docVer}/management/admin/`
+    ),
     faq: withUTM(`https://goteleport.com${docVer}/docs/faq`),
     troubleshooting: withUTM(
-      `https://goteleport.com/docs${docVer}/setup/admin/troubleshooting`
+      `https://goteleport.com/docs${docVer}/management/admin/troubleshooting/`
     ),
 
     // there isn't a version-specific changelog page

--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -168,15 +168,23 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
   const withUTM = (url = '', anchorHash = '') =>
     `${url}?product=teleport&version=${verPrefix}_${version}${anchorHash}`;
 
+  let docVer = ''
+  if (version && version.length > 0) {
+    const major = version.split('.')[0];
+    docVer = `/ver/${major}.x`
+  }
+
   return {
-    quickstart: withUTM('https://goteleport.com/docs/getting-started'),
-    userManual: withUTM('https://goteleport.com/docs/server-access/guides/tsh'),
-    adminGuide: withUTM('https://goteleport.com/docs/setup/admin'),
-    changeLog: withUTM('https://goteleport.com/docs/changelog'),
+    quickstart: withUTM(`https://goteleport.com/docs${docVer}/getting-started`),
+    userManual: withUTM(`https://goteleport.com/docs${docVer}/server-access/guides/tsh`),
+    adminGuide: withUTM(`https://goteleport.com/docs${docVer}/setup/admin`),
+    faq: withUTM(`https://goteleport.com${docVer}/docs/faq`),
     troubleshooting: withUTM(
-      'https://goteleport.com/docs/setup/admin/troubleshooting'
+      `https://goteleport.com/docs${docVer}/setup/admin/troubleshooting`
     ),
-    faq: withUTM('https://goteleport.com/docs/faq'),
+
+    // there isn't a version-specific changelog page
+    changeLog: withUTM('https://goteleport.com/docs/changelog'),
   };
 };
 

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/getting-started?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -237,7 +237,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/server-access/guides/tsh?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -245,7 +245,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -261,7 +261,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/faq?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -297,7 +297,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin/troubleshooting?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -341,7 +341,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -396,7 +396,7 @@ exports[`support Cloud 1`] = `
       <div
         class="c12"
       >
-        4.4.0-dev
+        13.4.0-dev
       </div>
     </div>
     <div
@@ -656,7 +656,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/getting-started?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -664,7 +664,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/server-access/guides/tsh?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -672,7 +672,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -688,7 +688,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/faq?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -724,7 +724,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin/troubleshooting?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -768,7 +768,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/changelog?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/changelog?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -823,7 +823,7 @@ exports[`support Enterprise 1`] = `
       <div
         class="c12"
       >
-        4.4.0-dev
+        13.4.0-dev
       </div>
     </div>
     <div
@@ -1164,7 +1164,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/getting-started?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1172,7 +1172,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/server-access/guides/tsh?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1180,7 +1180,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1196,7 +1196,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/faq?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1232,7 +1232,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin/troubleshooting?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1276,7 +1276,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/changelog?product=teleport&version=e_4.4.0-dev"
+          href="https://goteleport.com/docs/changelog?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1331,7 +1331,7 @@ exports[`support Enterprise with CTA 1`] = `
       <div
         class="c15"
       >
-        4.4.0-dev
+        13.4.0-dev
       </div>
     </div>
     <div
@@ -1583,7 +1583,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/getting-started?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1591,7 +1591,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/server-access/guides/tsh?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1599,7 +1599,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1615,7 +1615,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/faq?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1651,7 +1651,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin/troubleshooting?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1695,7 +1695,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1750,7 +1750,7 @@ exports[`support OSS 1`] = `
       <div
         class="c12"
       >
-        4.4.0-dev
+        13.4.0-dev
       </div>
     </div>
     <div
@@ -2091,7 +2091,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/getting-started?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/getting-started?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2099,7 +2099,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/server-access/guides/tsh?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/server-access/guides/tsh?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2107,7 +2107,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2123,7 +2123,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/faq?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2159,7 +2159,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/setup/admin/troubleshooting?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2203,7 +2203,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_4.4.0-dev"
+          href="https://goteleport.com/docs/changelog?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2258,7 +2258,7 @@ exports[`support OSSWithCTA 1`] = `
       <div
         class="c15"
       >
-        4.4.0-dev
+        13.4.0-dev
       </div>
     </div>
     <div

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`support Cloud 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Quickstart Guide
+          Get Started
         </a>
         <a
           class="c7"
@@ -245,11 +245,11 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
-          Admin Guide
+          Admin Guides
         </a>
         <a
           class="c7"
@@ -297,7 +297,7 @@ exports[`support Cloud 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -660,7 +660,7 @@ exports[`support Enterprise 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Quickstart Guide
+          Get Started
         </a>
         <a
           class="c7"
@@ -672,11 +672,11 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
-          Admin Guide
+          Admin Guides
         </a>
         <a
           class="c7"
@@ -724,7 +724,7 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1168,7 +1168,7 @@ exports[`support Enterprise with CTA 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Quickstart Guide
+          Get Started
         </a>
         <a
           class="c7"
@@ -1180,11 +1180,11 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
-          Admin Guide
+          Admin Guides
         </a>
         <a
           class="c7"
@@ -1232,7 +1232,7 @@ exports[`support Enterprise with CTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1587,7 +1587,7 @@ exports[`support OSS 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Quickstart Guide
+          Get Started
         </a>
         <a
           class="c7"
@@ -1599,11 +1599,11 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
-          Admin Guide
+          Admin Guides
         </a>
         <a
           class="c7"
@@ -1651,7 +1651,7 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2095,7 +2095,7 @@ exports[`support OSSWithCTA 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Quickstart Guide
+          Get Started
         </a>
         <a
           class="c7"
@@ -2107,11 +2107,11 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
-          Admin Guide
+          Admin Guides
         </a>
         <a
           class="c7"
@@ -2159,7 +2159,7 @@ exports[`support OSSWithCTA 1`] = `
         </div>
         <a
           class="c7"
-          href="https://goteleport.com/docs/ver/13.x/setup/admin/troubleshooting?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/management/admin/troubleshooting/?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
Fixes #34148
Fixes #34149

changelog: Link to version-specific docs pages from the web UI.