### PR TITLE
Add a Usage Reporting and Billing page

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -20,6 +20,11 @@
           "title": "FAQ",
           "slug": "/faq/"
         },
+	{
+	  "title": "Usage Reporting and Billing",
+	  "slug": "/usage-billing/",
+	  "forScopes": ["cloud", "team", "enterprise"]
+	},
         {
           "title": "Upcoming Releases",
           "slug": "/upcoming-releases/"

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Usage Reporting and Billing
-description: Provides a detaield breakdown of Teleport usage reporting and billing.
+description: Provides a detailed breakdown of Teleport usage reporting and billing.
 ---
 
 Commercial editions of Teleport send anonymized usage data to Teleport so we can

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -3,19 +3,23 @@ title: Usage Reporting and Billing
 description: Provides a detaield breakdown of Teleport usage reporting and billing.
 ---
 
-Teleport Team, Teleport Enterprise Cloud, and Teleport Enterprise send
-anonymized usage data to Teleport so we can calculate billing metrics. This
-guide describes the anonymized usage data and the billing metrics we calculate.
+Commercial editions of Teleport send anonymized usage data to Teleport so we can
+calculate billing metrics. This guide describes the anonymized usage data and
+the billing metrics we calculate.
 
 ## Anonymized usage data
 
 The commercial editions of Teleport send anonymized information to Teleport's
 cloud infrastructure. This information contains the following:
 
--   Teleport license identifier
--   Anonymized cluster name and Teleport Auth Service host ID
--   For each Teleport user, the anonymized user name and a count of interactions
-    with infrastructure resources enrolled in your Teleport cluster.
+- Teleport license identifier.
+- Anonymized cluster name and Teleport Auth Service host ID.
+- For each Teleport user, the anonymized user name and a count of interactions
+  with infrastructure resources enrolled in your Teleport cluster. 
+
+Self-hosted Teleport deployments aggregate interaction data before it reaches
+Teleport Cloud. Teleport Cloud accounts provide this information as an
+anonymized log, which Teleport aggregates over the billing period.  
 
 The count of interactions includes the following:
 

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -1,0 +1,88 @@
+---
+title: Usage Reporting and Billing
+description: Provides a detaield breakdown of Teleport usage reporting and billing.
+---
+
+Teleport Team, Teleport Enterprise Cloud, and Teleport Enterprise send
+anonymized usage data to Teleport so we can calculate billing metrics. This
+guide describes the anonymized usage data and the billing metrics we calculate.
+
+## Anonymized usage data
+
+The commercial editions of Teleport send anonymized information to Teleport's
+cloud infrastructure. This information contains the following:
+
+-   Teleport license identifier
+-   Anonymized cluster name and Teleport Auth Service host ID
+-   For each Teleport user, the anonymized user name and a count of interactions
+    with infrastructure resources enrolled in your Teleport cluster.
+
+The count of interactions includes the following:
+
+- Teleport logins
+- SSH and Kubernetes exec sessions
+- Web sessions with registered HTTP applications
+- Connections with registered TCP applications
+- SSH port forwards
+- Kubernetes API requests
+- SFTP actions
+
+The anonymization is done by passing names and IDs through HMAC-SHA-256, with an
+HMAC key that's randomly generated when the Teleport cluster is initialized and
+is never shared with us. This makes it infeasible for anyone without access to
+the cluster to deanonymize the data we store.
+
+The code that aggregates and anonymizes this data can be found in our [GitHub
+repository](https://github.com/gravitational/teleport/tree/master/lib/usagereporter/teleport/aggregating).
+
+## Billing metrics
+
+Teleport uses the anonymized usage data described in the previous section to
+calculate three types of billing metrics:
+
+- Monthly Active Users
+- Teleport Protected Resources
+- Teleport Identity Authorizations
+
+### Monthly Active Users 
+
+Monthly Active Users (MAU) are calculated as the aggregate number of unique
+active users (as defined in the Services Agreement and aggregated over each
+monthly period starting on the Subscription Start Date and ending on each
+monthly anniversary thereafter) accessing Teleport. 
+
+"Active" means a user having performed any auditable activity in a resource
+(e.g., an action that would appear in an audit log such as logging into a
+resource via the Web UI or via `tsh login`, submitting an Access Request, etc.).
+The MAU calculation does not include automated actions, such as the modification
+of a user's role by an administrator or the automatic creation of a user
+automatically through an identity provider.
+
+### Teleport Protected Resources
+
+The Teleport Protected Resources (TPR) metric is calculated as the aggregate
+number of unique resources (aggregated over each monthly period starting on the
+Subscription Start Date and ending on each monthly anniversary thereafter)
+connected to Teleport. A "resource" means any unique endpoint such as a
+Kubernetes cluster, SSH server, database instance or serverless endpoint, that
+is registered itself with the Teleport cluster and is protected by Teleport.
+
+### Teleport Identity Authorizations
+
+Teleport Identity Authorizations (TIA) are calculated as the aggregate number of
+Authorization Requests (aggregated over each monthly period starting on the
+Subscription Start Date and ending on each monthly anniversary thereafter)
+processed by Teleport. An Authorization Request is the authorization by Teleport
+of a client connection, API request, SSH session, or any other activity related
+to a user.
+
+## Usage measurement for billing
+
+The counts of the billing metrics are aggregated on a monthly basis starting on
+the Subscription Start Date and ending on each monthly anniversary thereafter.
+The amount of usage purchased by a Teleport customer is based on the maximum
+aggregate amount of a billing metric in a given month during the term of the
+Subscription (also known as a high water mark calculation).
+
+Reach out to sales@goteleport.com if you have questions about the
+commercial editions of Teleport.


### PR DESCRIPTION
Closes #34220

Add a docs page to the Home section that describes the way we calculate customer usage data and billing for commercial editions of Teleport.