### PR TITLE
Temporarily disable conditional updates for users

### DIFF
--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -328,7 +328,7 @@ func TestUpdateUser(t *testing.T) {
 	updated, err := env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: llama.(*types.UserV2)})
 	assert.Error(t, err, "duplicate user was created successfully")
 	assert.Nil(t, updated, "received unexpected user")
-	require.True(t, trace.IsCompareFailed(err), "updated nonexistent user")
+	require.True(t, trace.IsNotFound(err), "updated nonexistent user")
 
 	// Create a new user.
 	created, err := env.CreateUser(ctx, &userspb.CreateUserRequest{User: llama.(*types.UserV2)})

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -360,7 +360,7 @@ func (s *IdentityService) UpdateUser(ctx context.Context, user types.User) (type
 		ID:       user.GetResourceID(),
 		Revision: rev,
 	}
-	lease, err := s.Backend.ConditionalUpdate(ctx, item)
+	lease, err := s.Backend.Update(ctx, item)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -188,8 +188,10 @@ func testEditUser(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
 	// Try editing the user a second time. This time the revisions will not match
 	// since the created revision is stale.
 	_, err = runEditCommand(t, fc, []string{"edit", "user/llama"}, withEditor(editor))
-	assert.Error(t, err, "stale user was allowed to be updated")
-	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
+	// TODO(tross) remove and uncomment lines below once conditional update support for users lands
+	require.NoError(t, err)
+	//assert.Error(t, err, "stale user was allowed to be updated")
+	//require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
 // TestEditEnterpriseResources asserts that tctl edit


### PR DESCRIPTION
The operator is not handling revisions which causes TestUsersUpdate in users_controller_test.go to fail. Rolling back the user service backend to use update until the operator is updated to unblock CI.