### PR TITLE
integrations/operator: propagate revision + fix tests

### DIFF
--- a/integrations/operator/apis/resources/v1/loginrule_types.go
+++ b/integrations/operator/apis/resources/v1/loginrule_types.go
@@ -112,3 +112,11 @@ func (l *LoginRuleResource) SetOrigin(origin string) {
 func (l *LoginRuleResource) GetMetadata() types.Metadata {
 	return *l.LoginRule.Metadata
 }
+
+func (l *LoginRuleResource) GetRevision() string {
+	return l.LoginRule.Metadata.GetRevision()
+}
+
+func (l *LoginRuleResource) SetRevision(rev string) {
+	l.LoginRule.Metadata.SetRevision(rev)
+}

--- a/integrations/operator/controllers/resources/role_controller.go
+++ b/integrations/operator/controllers/resources/role_controller.go
@@ -171,6 +171,9 @@ func (r *RoleReconciler) Upsert(ctx context.Context, obj kclient.Object) error {
 		}
 	}
 
+	if existingResource != nil {
+		teleportResource.SetRevision(existingResource.GetRevision())
+	}
 	r.AddTeleportResourceOrigin(teleportResource)
 
 	// If an error happens we want to put it in status.conditions before returning.

--- a/integrations/operator/controllers/resources/teleport_reconciler.go
+++ b/integrations/operator/controllers/resources/teleport_reconciler.go
@@ -35,6 +35,8 @@ type TeleportResource interface {
 	GetName() string
 	SetOrigin(string)
 	GetMetadata() types.Metadata
+	GetRevision() string
+	SetRevision(string)
 }
 
 // TeleportKubernetesResource is a Kubernetes resource representing a Teleport resource
@@ -132,6 +134,11 @@ func (r TeleportResourceReconciler[T, K]) Upsert(ctx context.Context, obj kclien
 	}
 
 	teleportResource.SetOrigin(types.OriginKubernetes)
+
+	// Propagate revision as required by opportunistic locking
+	if exists {
+		teleportResource.SetRevision(existingResource.GetRevision())
+	}
 
 	// We apply resource-specific mutations.
 	if mutator, ok := r.resourceClient.(TeleportResourceMutator[T]); ok {

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -18,12 +18,13 @@ package resources_test
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -347,7 +348,7 @@ func TestUserUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		// TeleportUser was updated with new roles
-		return assert.ElementsMatch(t, tUser.GetRoles(), []string{"x", "z"})
+		return compareRoles([]string{"x", "z"}, tUser.GetRoles())
 	})
 
 	// Updating the user in K8S
@@ -373,7 +374,7 @@ func TestUserUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		// TeleportUser updated with new roles
-		return assert.ElementsMatch(t, tUser.GetRoles(), []string{"x", "z", "y"})
+		return compareRoles([]string{"x", "y", "z"}, tUser.GetRoles())
 	})
 	require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name, "createdBy has not been erased")
 }
@@ -418,4 +419,12 @@ func getUserStatusConditionError(object map[string]interface{}) []metav1.Conditi
 		}
 	}
 	return conditionsWithError
+}
+
+func compareRoles(expected, actual []string) bool {
+	return cmp.Diff(
+		expected,
+		actual,
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	) == ""
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -18,11 +18,11 @@ package resources_test
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/34263

This PR does two things:
- ensure revision is properly propagated (this is required in v15, tests will fail if it is not. No additional coverage required, this will be covered when we'll revert https://github.com/gravitational/teleport/pull/34255)
- fix tests causing definitive failures instead of temporary ones (failing instead of returning false in `Eventually`)