### PR TITLE
Limit access list creation to 1 without IGS flag

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1114,9 +1114,13 @@ func TestPromotedRequest(t *testing.T) {
 }
 
 func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
-	t.Parallel()
-
 	clock := clockwork.NewFakeClock()
+
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			IdentityGovernance: true,
+		},
+	})
 
 	mustRequest := func(suggestedReviewers ...string) types.AccessRequest {
 		req, err := services.NewAccessRequest("test-user", "admins")

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1118,7 +1118,7 @@ func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			IdentityGovernance: true,
+			IdentityGovernanceSecurity: true,
 		},
 	})
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -281,8 +281,8 @@ func TestAccessLists(t *testing.T) {
 			modules.SetTestModules(t, &modules.TestModules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
-					Cloud:              test.cloud,
-					IdentityGovernance: true,
+					Cloud:                      test.cloud,
+					IdentityGovernanceSecurity: true,
 				},
 			})
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -281,7 +281,8 @@ func TestAccessLists(t *testing.T) {
 			modules.SetTestModules(t, &modules.TestModules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
-					Cloud: test.cloud,
+					Cloud:              test.cloud,
+					IdentityGovernance: true,
 				},
 			})
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -152,21 +152,19 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 		})
 	}
 
-	var completeUpsertFn func() error
+	var err error
 	if feature := modules.GetModules().Features(); !feature.IGSEnabled() {
-		completeUpsertFn = func() error {
-			return a.service.RunWhileLocked(ctx, "createAccessListLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-				if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
-					return trace.Wrap(err)
-				}
-				return trace.Wrap(upsertWithLockFn())
-			})
-		}
+		err = a.service.RunWhileLocked(ctx, "createAccessListLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Wrap(upsertWithLockFn())
+		})
 	} else {
-		completeUpsertFn = upsertWithLockFn
+		err = upsertWithLockFn()
 	}
 
-	if err := completeUpsertFn(); err != nil {
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -342,21 +340,19 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 		})
 	}
 
-	var completeUpsertFn func() error
+	var err error
 	if feature := modules.GetModules().Features(); !feature.IGSEnabled() {
-		completeUpsertFn = func() error {
-			return a.service.RunWhileLocked(ctx, "createAccessListWithMembersLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-				if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
-					return trace.Wrap(err)
-				}
-				return trace.Wrap(upsertWithLockFn())
-			})
-		}
+		err = a.service.RunWhileLocked(ctx, "createAccessListWithMembersLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Wrap(upsertWithLockFn())
+		})
 	} else {
-		completeUpsertFn = upsertWithLockFn
+		err = upsertWithLockFn()
 	}
 
-	if err := completeUpsertFn(); err != nil {
+	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -153,7 +153,7 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 	}
 
 	var completeUpsertFn func() error
-	if feature := modules.GetModules().Features(); !feature.IdentityGovernance {
+	if feature := modules.GetModules().Features(); !feature.IGSEnabled() {
 		completeUpsertFn = func() error {
 			return a.service.RunWhileLocked(ctx, "createAccessListLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 				if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
@@ -343,7 +343,7 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 	}
 
 	var completeUpsertFn func() error
-	if feature := modules.GetModules().Features(); !feature.IdentityGovernance {
+	if feature := modules.GetModules().Features(); !feature.IGSEnabled() {
 		completeUpsertFn = func() error {
 			return a.service.RunWhileLocked(ctx, "createAccessListWithMembersLimitLock", accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 				if err := a.VerifyAccessListCreateLimit(ctx, accessList.GetName()); err != nil {
@@ -528,7 +528,7 @@ func lockName(accessListName string) string {
 // Returns error if limit has been reached.
 func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, targetAccessListName string) error {
 	feature := modules.GetModules().Features()
-	if feature.IdentityGovernance {
+	if feature.IGSEnabled() {
 		return nil // unlimited
 	}
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -538,11 +538,15 @@ func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, tar
 	}
 
 	// Iterate through fetched lists, to check if the request was
-	// an update.
+	// an update, which is allowed.
 	for _, list := range lists {
 		if list.GetName() == targetAccessListName {
 			return nil
 		}
+	}
+
+	if len(lists) < feature.AccessList.CreateLimit {
+		return nil
 	}
 
 	const limitReachedMessage = "cluster has reached its limit for creating access lists, please contact the cluster administrator"

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -522,7 +522,10 @@ func lockName(accessListName string) string {
 	return strings.Join([]string{"access_list", accessListName}, string(backend.Separator))
 }
 
-// VerifyAccessListCreateLimit ensures
+// VerifyAccessListCreateLimit ensures creating access list is limited to no more than 1 (updating is allowed).
+// It differentiates request for `creating` and `updating` by checking to see if the request
+// access list name matches the ones we retrieved.
+// Returns error if limit has been reached.
 func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, targetAccessListName string) error {
 	feature := modules.GetModules().Features()
 	if feature.IdentityGovernance {
@@ -539,7 +542,7 @@ func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, tar
 	}
 
 	// Iterate through fetched lists, to check if the request was
-	// an update. It's an update if target is within these lists.
+	// an update.
 	for _, list := range lists {
 		if list.GetName() == targetAccessListName {
 			return nil

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.
@@ -276,13 +275,13 @@ func TestAccessListCreate_UpsertAccessListWithMembers_WithLimit(t *testing.T) {
 	out, err := service.GetAccessLists(ctx)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
-	require.Equal(t, out[0].Metadata.Name, "accessList1")
+	require.Equal(t, "accessList1", out[0].Metadata.Name)
 
 	// Double check only one member exists.
 	members, _, err := service.ListAccessListMembers(ctx, accessList1.GetName(), 0 /* default size*/, "")
 	require.NoError(t, err)
 	require.Len(t, members, 1)
-	require.Equal(t, members[0].Metadata.Name, "alice")
+	require.Equal(t, "alice", members[0].Metadata.Name)
 
 	// Updating existing access list should be allowed.
 	accessList1.Spec.Description = "changing description"
@@ -619,8 +618,7 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var service services.AccessLists
-	service = newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -48,7 +48,7 @@ func TestAccessListCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -148,16 +148,7 @@ func TestAccessListCreate_UpsertAccessList_WithoutLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
-
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: true,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
-			},
-		},
-	})
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -190,16 +181,7 @@ func TestAccessListCreate_UpsertAccessList_WithLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
-
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: false,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
-			},
-		},
-	})
+	service := newAccessListService(t, mem, clock, false /* igsEnabled */)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -245,16 +227,7 @@ func TestAccessListCreate_UpsertAccessListWithMembers_WithLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
-
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: false,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
-			},
-		},
-	})
+	service := newAccessListService(t, mem, clock, false /* igsEnabled */)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -309,16 +282,7 @@ func TestAccessListCreate_UpsertAccessListWithMembers_WithoutLimit(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
-
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: true,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
-			},
-		},
-	})
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -351,7 +315,7 @@ func TestAccessListDedupeOwnersBackwardsCompat(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	// Put an unduplicated owners access list in the backend.
 	accessListDuplicateOwners := newAccessList(t, "accessListDuplicateOwners", clock)
@@ -379,7 +343,7 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -454,7 +418,7 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -618,7 +582,7 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock)
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -1032,12 +996,15 @@ func newAccessListReview(t *testing.T, accessList, name string) *accesslist.Revi
 	return review
 }
 
-func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Clock) *AccessListService {
+func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Clock, igsEnabled bool) *AccessListService {
 	t.Helper()
 
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: true,
+			IdentityGovernanceSecurity: igsEnabled,
+			AccessList: modules.AccessListFeature{
+				CreateLimit: 1,
+			},
 		},
 	})
 

--- a/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
+++ b/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
@@ -56,7 +56,7 @@ export function ButtonLockedFeature({
     return (
       <Link
         target="blank"
-        href={getSalesURL(version, isEnterprise, isUsageBased, event)}
+        href={getSalesURL(version, cfg.isEnterprise, event)}
         onClick={handleClick}
         {...rest}
       >

--- a/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
+++ b/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { ButtonPrimary } from 'design/Button';
+import { ButtonPrimary, Link } from 'design';
 import { Unlock } from 'design/Icon';
 import Flex from 'design/Flex';
 
@@ -32,6 +32,7 @@ export type Props = {
   children: React.ReactNode;
   noIcon?: boolean;
   event?: CtaEvent;
+  textLink?: boolean;
   [index: string]: any;
 };
 
@@ -39,6 +40,7 @@ export function ButtonLockedFeature({
   children,
   noIcon = false,
   event,
+  textLink = false,
   ...rest
 }: Props) {
   const ctx = useTeleport();
@@ -48,6 +50,19 @@ export function ButtonLockedFeature({
     if (cfg.isEnterprise) {
       userEventService.captureCtaEvent(event);
     }
+  }
+
+  if (textLink) {
+    return (
+      <Link
+        target="blank"
+        href={getSalesURL(version, isEnterprise, isUsageBased, event)}
+        onClick={handleClick}
+        {...rest}
+      >
+        {children}
+      </Link>
+    );
   }
 
   return (


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/2317

No logic for creating access list changed. I just introduce verifying the limite with its own verifying lock

Without IGS flag:
- limited to 1 access list
- unlimited edits
- deleting frees up limit

With IGS flag, everything unlimited.