### PR TITLE
integrations/operator: remove require checks from Eventually funcs

### DIFF
--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -334,7 +334,7 @@ func TestRoleUpdate(t *testing.T) {
 		// TeleportRole updated with new logins
 		logins := tRole.GetLogins(types.Allow)
 		sort.Strings(logins)
-		require.ElementsMatch(c, logins, []string{"x", "z"})
+		assert.ElementsMatch(c, logins, []string{"x", "z"})
 	})
 
 	// Updating the role in K8S
@@ -362,7 +362,7 @@ func TestRoleUpdate(t *testing.T) {
 		// TeleportRole updated with new logins
 		logins := tRole.GetLogins(types.Allow)
 		sort.Strings(logins)
-		require.ElementsMatch(c, logins, []string{"admin", "root", "x", "z"})
+		assert.ElementsMatch(c, logins, []string{"admin", "root", "x", "z"})
 	})
 }
 

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -18,12 +18,12 @@ package resources_test
 
 import (
 	"context"
-	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/gravitational/trace"
 	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -340,14 +340,14 @@ func TestRoleUpdate(t *testing.T) {
 	k8sCreateRole(ctx, t, setup.K8sClient, &k8sRole)
 
 	// The role is updated in Teleport
-	fastEventually(t, func() bool {
+	fastEventuallyWithT(t, func(c *assert.CollectT) {
 		tRole, err := setup.TeleportClient.GetRole(ctx, roleName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		// TeleportRole updated with new logins
 		logins := tRole.GetLogins(types.Allow)
 		sort.Strings(logins)
-		return reflect.DeepEqual(logins, []string{"x", "z"})
+		require.ElementsMatch(c, logins, []string{"x", "z"})
 	})
 
 	// Updating the role in K8S
@@ -368,14 +368,14 @@ func TestRoleUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Updates the role in Teleport
-	fastEventually(t, func() bool {
+	fastEventuallyWithT(t, func(c *assert.CollectT) {
 		tRole, err := setup.TeleportClient.GetRole(ctx, roleName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		// TeleportRole updated with new logins
 		logins := tRole.GetLogins(types.Allow)
 		sort.Strings(logins)
-		return reflect.DeepEqual(logins, []string{"admin", "root", "x", "z"})
+		require.ElementsMatch(c, logins, []string{"admin", "root", "x", "z"})
 	})
 }
 

--- a/integrations/operator/controllers/resources/suite_test.go
+++ b/integrations/operator/controllers/resources/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
@@ -40,6 +41,9 @@ func setupTestEnv(t *testing.T, opts ...testlib.TestOption) *testlib.TestSetup {
 }
 func validRandomResourceName(prefix string) string       { return testlib.ValidRandomResourceName(prefix) }
 func fastEventually(t *testing.T, condition func() bool) { testlib.FastEventually(t, condition) }
+func fastEventuallyWithT(t *testing.T, condition func(*assert.CollectT)) {
+	testlib.FastEventuallyWithT(t, condition)
+}
 
 func teleportCreateDummyRole(ctx context.Context, roleName string, tClient *client.Client) error {
 	// The role is created in Teleport

--- a/integrations/operator/controllers/resources/teleport_reconciler.go
+++ b/integrations/operator/controllers/resources/teleport_reconciler.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"context"
 	"reflect"
+	"slices"
 
 	"github.com/gravitational/trace"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +27,6 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"slices"
 
 	"github.com/gravitational/teleport/api/types"
 )

--- a/integrations/operator/controllers/resources/teleport_reconciler.go
+++ b/integrations/operator/controllers/resources/teleport_reconciler.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"context"
 	"reflect"
-	"slices"
 
 	"github.com/gravitational/trace"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +26,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"slices"
 
 	"github.com/gravitational/teleport/api/types"
 )

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -140,6 +140,10 @@ func FastEventually(t *testing.T, condition func() bool) {
 	require.Eventually(t, condition, time.Second, 100*time.Millisecond)
 }
 
+func FastEventuallyWithT(t *testing.T, condition func(collectT *assert.CollectT)) {
+	require.EventuallyWithT(t, condition, time.Second, 100*time.Millisecond)
+}
+
 func clientForTeleport(t *testing.T, teleportServer *helpers.TeleInstance, userName string) *client.Client {
 	identityFilePath := helpers.MustCreateUserIdentityFile(t, teleportServer, userName, time.Hour)
 	creds := client.LoadIdentityFile(identityFilePath)

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
@@ -153,19 +154,19 @@ func ResourceUpdateTest[T resources.TeleportResource, K resources.TeleportKubern
 	require.NoError(t, err)
 
 	// Check the resource was updated in Teleport
-	FastEventually(t, func() bool {
+	FastEventuallyWithT(t, func(c *assert.CollectT) {
 		tResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		// Kubernetes and Teleport resources are in-sync
 		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
 		if !equal {
 			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		}
-		return equal
+		require.True(c, equal)
 	})
 
 	// Updating the resource in Kubernetes
@@ -176,19 +177,19 @@ func ResourceUpdateTest[T resources.TeleportResource, K resources.TeleportKubern
 	require.NoError(t, err)
 
 	// Check the resource was updated in Teleport
-	FastEventually(t, func() bool {
+	FastEventuallyWithT(t, func(c *assert.CollectT) {
 		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		tResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		// Kubernetes and Teleport resources are in-sync
 		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
 		if !equal {
 			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		}
-		return equal
+		require.True(c, equal)
 	})
 
 	// Delete the resource to avoid leftover state.

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -154,7 +154,7 @@ func ResourceUpdateTest[T resources.TeleportResource, K resources.TeleportKubern
 		if !equal {
 			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		}
-		require.True(c, equal)
+		assert.True(c, equal)
 	})
 
 	// Updating the resource in Kubernetes
@@ -177,7 +177,7 @@ func ResourceUpdateTest[T resources.TeleportResource, K resources.TeleportKubern
 		if !equal {
 			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		}
-		require.True(c, equal)
+		assert.True(c, equal)
 	})
 
 	// Delete the resource to avoid leftover state.

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -59,20 +59,16 @@ func TestUserCreation(t *testing.T) {
 	// The user is created in K8S
 	k8sCreateDummyUser(ctx, t, setup.K8sClient, setup.Namespace.Name, userName)
 
+	var tUser types.User
+	var err error
 	fastEventually(t, func() bool {
-		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		if trace.IsNotFound(err) {
-			return false
-		}
-		require.NoError(t, err)
-
-		require.Equal(t, userName, tUser.GetName())
-
-		require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
-
-		return true
+		tUser, err = setup.TeleportClient.GetUser(ctx, userName, false)
+		return !trace.IsNotFound(err)
 	})
+	require.NoError(t, err)
+	require.Equal(t, userName, tUser.GetName())
+	require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
+	require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
 
 	// The user is deleted in K8S
 	k8sDeleteUser(ctx, t, setup.K8sClient, userName, setup.Namespace.Name)
@@ -177,37 +173,29 @@ traits:
 					}, obj)
 					errorConditions := getUserStatusConditionError(obj.Object)
 					// If there's no error condition, reconciliation has not happened yet
-					if len(errorConditions) == 0 {
-						return false
-					}
-
-					_, err := setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
-					require.True(t, trace.IsNotFound(err), "The user should not be created in Teleport")
-					return true
+					return len(errorConditions) != 0
 				})
+				_, err = setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
+				require.True(t, trace.IsNotFound(err), "The user should not be created in Teleport")
 			} else {
 				// We wait for Teleport resource creation
+				var tUser types.User
 				fastEventually(t, func() bool {
-					tUser, err := setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
+					tUser, err = setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
 					// If the resource creation should succeed we check the resource was found and validate ownership labels
-					if trace.IsNotFound(err) {
-						return false
-					}
-					require.NoError(t, err)
-
-					require.Equal(t, userName, tUser.GetName())
-					require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-					require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
-					require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name)
-					expectedUser := &types.UserV2{
-						Metadata: types.Metadata{},
-						Spec:     *tc.expectedSpec,
-					}
-					_ = expectedUser.CheckAndSetDefaults()
-					compareUserSpecs(t, expectedUser, tUser)
-
-					return true
+					return !trace.IsNotFound(err)
 				})
+				require.NoError(t, err)
+				require.Equal(t, userName, tUser.GetName())
+				require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
+				require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
+				require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name)
+				expectedUser := &types.UserV2{
+					Metadata: types.Metadata{},
+					Spec:     *tc.expectedSpec,
+				}
+				_ = expectedUser.CheckAndSetDefaults()
+				compareUserSpecs(t, expectedUser, tUser)
 			}
 			// Teardown
 
@@ -251,25 +239,22 @@ func TestUserDeletionDrift(t *testing.T) {
 	// The user is created in K8S
 	k8sCreateDummyUser(ctx, t, setup.K8sClient, setup.Namespace.Name, userName)
 
+	var tUser types.User
+	var err error
 	fastEventually(t, func() bool {
-		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		if trace.IsNotFound(err) {
-			return false
-		}
-		require.NoError(t, err)
-
-		require.Equal(t, userName, tUser.GetName())
-
-		require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-		require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
-
-		return true
+		tUser, err = setup.TeleportClient.GetUser(ctx, userName, false)
+		return !trace.IsNotFound(err)
 	})
+	require.NoError(t, err)
+	require.Equal(t, userName, tUser.GetName())
+	require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
+	require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
+
 	// We cause a drift by altering the Teleport resource.
 	// To make sure the operator does not reconcile while we're finished we suspend the operator
 	setup.StopKubernetesOperator()
 
-	err := setup.TeleportClient.DeleteUser(ctx, userName)
+	err = setup.TeleportClient.DeleteUser(ctx, userName)
 	require.NoError(t, err)
 	fastEventually(t, func() bool {
 		_, err := setup.TeleportClient.GetUser(ctx, userName, false)
@@ -346,7 +331,7 @@ func TestUserUpdate(t *testing.T) {
 	// The user is updated in Teleport
 	fastEventually(t, func() bool {
 		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		// TeleportUser was updated with new roles
 		return compareRoles([]string{"x", "z"}, tUser.GetRoles())

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -369,12 +370,12 @@ func TestUserUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Updates the user in Teleport
-	fastEventually(t, func() bool {
+	fastEventuallyWithT(t, func(c *assert.CollectT) {
 		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		// TeleportUser updated with new roles
-		return compareRoles([]string{"x", "y", "z"}, tUser.GetRoles())
+		require.ElementsMatch(c, tUser.GetRoles(), []string{"x", "z", "y"})
 	})
 	require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name, "createdBy has not been erased")
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -360,7 +360,7 @@ func TestUserUpdate(t *testing.T) {
 		require.NoError(c, err)
 
 		// TeleportUser updated with new roles
-		require.ElementsMatch(c, tUser.GetRoles(), []string{"x", "z", "y"})
+		assert.ElementsMatch(c, tUser.GetRoles(), []string{"x", "z", "y"})
 	})
 	require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name, "createdBy has not been erased")
 }


### PR DESCRIPTION
This PR cleans a lot of `require.X(t)` statements that were happening inside `require.Eventually()`. Most eventual checks are here to wait for the reconciliation. Once we know the reconciliation happened, we can perform validations out of the `Eventually` block.

The few `Eventually` blocks that actually needed to perform checks got converted to `EventuallyWithT`.