### PR TITLE
Add first step of guided flow for Connect My Computer in Discover

### DIFF
--- a/web/packages/design/src/Card/Card.jsx
+++ b/web/packages/design/src/Card/Card.jsx
@@ -21,7 +21,7 @@ import { darkTheme } from './../theme';
 
 const Card = styled(Box)`
   box-shadow: ${props => props.theme.boxShadow[2]};
-  border-radius: 8px;
+  border-radius: ${props => props.theme.radii[3]}px;
   background-color: ${props => props.theme.colors.levels.surface};
 `;
 

--- a/web/packages/design/src/Card/Card.story.tsx
+++ b/web/packages/design/src/Card/Card.story.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { Flex, Text } from '..';
+
+import Card from '.';
+
+export default {
+  title: 'Design/Card',
+};
+
+export const Story = () => (
+  <Card p={2}>
+    <Text as="h1" typography="h1">
+      Curabitur ullamcorper diam sed ante gravida imperdiet
+    </Text>
+    <Text>{loremIpsum}</Text>
+  </Card>
+);
+
+export const AsFlex = () => (
+  <Card p={8} as={Flex} gap={4} flexWrap="wrap">
+    {Array(12)
+      .fill(undefined)
+      .map((_, i) => (
+        <Card
+          p={2}
+          flex={i % 2 === 0 ? 3 : 1}
+          css={`
+            min-width: 20ch;
+          `}
+        >
+          <Text>{loremIpsum}</Text>
+        </Card>
+      ))}
+  </Card>
+);
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ligula leo, dictum ac bibendum ut, dapibus sed ex. Morbi eget posuere arcu. Duis consectetur felis sed consequat dignissim. In id semper arcu, vitae fringilla lacus. Donec justo justo, feugiat eget lobortis eu, venenatis eu nulla. Morbi scelerisque vitae tortor quis tempus. Integer a nulla pellentesque, pellentesque nisl eleifend, dapibus quam. Donec eget odio vel justo efficitur commodo.';

--- a/web/packages/design/src/CardError/CardError.story.jsx
+++ b/web/packages/design/src/CardError/CardError.story.jsx
@@ -21,7 +21,7 @@ import * as CardError from './CardError';
 const message = 'some error message';
 
 export default {
-  title: 'Design/CardError',
+  title: 'Design/Card/CardError',
 };
 
 export const Cards = () => (

--- a/web/packages/design/src/CardSuccess/CardSuccess.story.jsx
+++ b/web/packages/design/src/CardSuccess/CardSuccess.story.jsx
@@ -19,7 +19,7 @@ import React from 'react';
 import CardSuccess, { CardSuccessLogin } from './index';
 
 export default {
-  title: 'Design/CardSuccess',
+  title: 'Design/Card/Success',
 };
 
 export const Cards = () => (

--- a/web/packages/design/src/buttons.story.jsx
+++ b/web/packages/design/src/buttons.story.jsx
@@ -62,6 +62,15 @@ export const Buttons = () => (
     </Flex>
 
     <Flex gap={3}>
+      <Button as="a" href="https://example.com" target="_blank">
+        Link as button
+      </Button>
+      <ButtonSecondary as="a" href="https://example.com" target="_blank">
+        Link as button
+      </ButtonSecondary>
+    </Flex>
+
+    <Flex gap={3}>
       <ButtonLink href="">Button Link</ButtonLink>
       <ButtonText>Button Text</ButtonText>
     </Flex>

--- a/web/packages/shared/components/MenuAction/MenuActionButton.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionButton.tsx
@@ -21,6 +21,13 @@ import { ChevronDown } from 'design/Icon';
 
 import { MenuProps, AnchorProps } from './types';
 
+type Props = MenuProps & {
+  defaultOpen?: boolean;
+  buttonProps?: AnchorProps;
+  buttonText?: string;
+  menuProps?: MenuProps;
+};
+
 export default class MenuActionIcon extends React.Component<Props> {
   anchorEl = null;
 
@@ -54,7 +61,7 @@ export default class MenuActionIcon extends React.Component<Props> {
           onClick={this.onOpen}
           {...buttonProps}
         >
-          OPTIONS
+          {this.props.buttonText || 'OPTIONS'}
           <ChevronDown ml={2} mr={-2} size="small" color="text.slightlyMuted" />
         </ButtonBorder>
         <Menu
@@ -102,9 +109,3 @@ export default class MenuActionIcon extends React.Component<Props> {
 const menuListCss = () => `
   min-width: 100px;
 `;
-
-type Props = MenuProps & {
-  defaultOpen?: boolean;
-  buttonProps?: AnchorProps;
-  menuProps?: MenuProps;
-};

--- a/web/packages/shared/components/OverrideUserAgent/index.tsx
+++ b/web/packages/shared/components/OverrideUserAgent/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useRef } from 'react';
+
+export enum UserAgent {
+  Windows = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/118.0.2088.88',
+  macOS = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15',
+  Linux = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0',
+}
+
+/**
+ * OverrideUserAgent overrides window.navigator.userAgent. It's reserved for use only at the top
+ * level in stories. Useful for creating stories for components which return different results based
+ * on the return value of getPlatform.
+ */
+export const OverrideUserAgent: React.FC<{ userAgent: UserAgent }> = ({
+  userAgent,
+  children,
+}) => {
+  const originalUserAgentRef = useRef<string>(window.navigator.userAgent);
+
+  if (window.navigator.userAgent !== userAgent) {
+    // Unfortunately, we cannot do this from useEffect as it needs to happen before children are
+    // rendered. Otherwise they'd render with the user agent set to the original value.
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+  }
+
+  useEffect(() => {
+    return () => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        get: () => originalUserAgentRef.current,
+        configurable: true,
+      });
+    };
+  }, []);
+
+  return <>{children}</>;
+};

--- a/web/packages/shared/components/OverrideUserAgent/index.tsx
+++ b/web/packages/shared/components/OverrideUserAgent/index.tsx
@@ -43,6 +43,12 @@ export const OverrideUserAgent: React.FC<{ userAgent: UserAgent }> = ({
   }
 
   useEffect(() => {
+    if (!process.env.STORYBOOK) {
+      throw new Error(
+        'OverrideUserAgent is meant to be run only from within stories'
+      );
+    }
+
     return () => {
       Object.defineProperty(window.navigator, 'userAgent', {
         get: () => originalUserAgentRef.current,

--- a/web/packages/shared/deepLinks.ts
+++ b/web/packages/shared/deepLinks.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file does not import whatwg-url and thus does not perform any parsing on purpose. whatwg-url
+ * provides uniform parsing across browser implementations but it weights a ton [1], so we should
+ * avoid pulling it into the deps of Web UI.
+ *
+ * [1] https://bundlephobia.com/package/whatwg-url@13.0.0
+ */
+
+// We're able to get away with defining the path like this only because we don't use matchPath from
+// React Router v5 like teleterm/src/ui/uri.ts does. Once we get to more complex use cases that will
+// use matchPath, we'll likely have to sacrifice some type safety.
+// The underscore was chosen as a separator since resource kinds on the backend already use
+// underscores.
+export enum Path {
+  ConnectMyComputer = 'connect_my_computer',
+}
+
+export const CUSTOM_PROTOCOL = 'teleport' as const;
+
+/**
+ * makeDeepLinkWithSafeInput creates a deep link by interpolating passed arguments.
+ *
+ * Important: This function does not perform any validation or parsing. It must not be called with
+ * user-generated content.
+ */
+export function makeDeepLinkWithSafeInput(args: {
+  /**
+   * proxyHost is the address and an optional port number of the proxy, e.g.
+   * "bigco.cloud.gravitational.io" or "teleport-local.dev:3080". In the Web UI proxyHost is
+   * commonly referred to as publicURL.
+   */
+  proxyHost: string;
+  path: Path;
+  username: string | undefined;
+}): string {
+  // The username in a URL should be percend-encoded. [1]
+  //
+  // What's more, Chrome 119, unlike Firefox and Safari, won't even trigger a custom protocol prompt
+  // when clicking on a link that includes a username with an @ symbol that is not percent-encoded,
+  // e.g. teleport://alice@example.com@example.com/connect_my_computer.
+  //
+  // [1] https://url.spec.whatwg.org/#set-the-username
+  const encodedUsername = args.username
+    ? encodeURIComponent(args.username) + '@'
+    : '';
+
+  return `${CUSTOM_PROTOCOL}://${encodedUsername}${args.proxyHost}/${args.path}`;
+}

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  OverrideUserAgent,
+  UserAgent,
+} from 'shared/components/OverrideUserAgent';
+
+import { ContextProvider } from 'teleport';
+import { UserContext } from 'teleport/User/UserContext';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+
+import { SetupConnect } from './SetupConnect';
+
+export default {
+  title: 'Teleport/Discover/ConnectMyComputer/SetupConnect',
+};
+
+export const macOS = () => (
+  <OverrideUserAgent userAgent={UserAgent.macOS}>
+    <Provider>
+      <SetupConnect prevStep={() => {}} />
+    </Provider>
+  </OverrideUserAgent>
+);
+
+export const Linux = () => (
+  <OverrideUserAgent userAgent={UserAgent.Linux}>
+    <Provider>
+      <SetupConnect prevStep={() => {}} />
+    </Provider>
+  </OverrideUserAgent>
+);
+
+const Provider = ({ children }) => {
+  const ctx = createTeleportContext();
+  ctx.storeUser.state.cluster.proxyVersion = '14.1.0';
+
+  const preferences = makeDefaultUserPreferences();
+  const updatePreferences = () => Promise.resolve();
+  const getClusterPinnedResources = () => Promise.resolve([]);
+  const updateClusterPinnedResources = () => Promise.resolve();
+
+  return (
+    <UserContext.Provider
+      value={{
+        preferences,
+        updatePreferences,
+        getClusterPinnedResources,
+        updateClusterPinnedResources,
+      }}
+    >
+      <ContextProvider ctx={ctx}>{children}</ContextProvider>
+    </UserContext.Provider>
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ButtonSecondary } from 'design/Button';
+import { Platform, getPlatform } from 'design/platform';
+import { Text, Flex } from 'design';
+import { MenuButton, MenuItem } from 'shared/components/MenuAction';
+import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
+
+import useTeleport from 'teleport/useTeleport';
+
+import { ActionButtons, Header, StyledBox } from 'teleport/Discover/Shared';
+
+import type { AgentStepProps } from '../../types';
+
+export function SetupConnect(props: AgentStepProps) {
+  const ctx = useTeleport();
+  const { cluster, username } = ctx.storeUser.state;
+  const platform = getPlatform();
+  const downloadLinks = getConnectDownloadLinks(platform, cluster.proxyVersion);
+  const connectMyComputerDeepLink = makeDeepLinkWithSafeInput({
+    proxyHost: cluster.publicURL,
+    username,
+    path: Path.ConnectMyComputer,
+  });
+
+  return (
+    <Flex flexDirection="column" alignItems="flex-start" mb={2} gap={4}>
+      <Header>Set Up Teleport Connect</Header>
+
+      <StyledBox>
+        <Text bold>Step 1: Download and Install Teleport Connect</Text>
+
+        <Text typography="subtitle1" mb={2}>
+          Teleport Connect is a native desktop application for browsing and
+          accessing your resources. It can also connect your computer as an SSH
+          resource and scope access to a unique role so it is not automatically
+          shared with anyone else in the cluster.
+          <br />
+          <br />
+          Once you’ve downloaded Teleport Connect, run the installer to add it
+          to your computer’s applications.
+        </Text>
+
+        <Flex flexWrap="wrap" alignItems="baseline" gap={2}>
+          <DownloadConnect downloadLinks={downloadLinks} />
+          <Text typography="subtitle1">
+            Already have Teleport Connect? Skip to the next step.
+          </Text>
+        </Flex>
+      </StyledBox>
+
+      <StyledBox>
+        <Text bold>Step 2: Sign In and Connect My Computer</Text>
+
+        <Text typography="subtitle1" mb={2}>
+          The button below will open Teleport Connect and once you are logged
+          in, it will prompt you to connect your computer. From there, follow
+          the instructions in Teleport Connect, and this page will update when
+          your computer is detected in the cluster.
+        </Text>
+
+        <ButtonSecondary as="a" href={connectMyComputerDeepLink}>
+          Sign In & Connect My Computer
+        </ButtonSecondary>
+      </StyledBox>
+
+      <ActionButtons
+        onProceed={() => {}}
+        disableProceed={true}
+        onPrev={props.prevStep}
+      />
+    </Flex>
+  );
+}
+
+type DownloadLink = { text: string; url: string };
+
+const DownloadConnect = (props: { downloadLinks: Array<DownloadLink> }) => {
+  if (props.downloadLinks.length === 1) {
+    const downloadLink = props.downloadLinks[0];
+    return (
+      <ButtonSecondary as="a" href={downloadLink.url}>
+        Download Teleport Connect
+      </ButtonSecondary>
+    );
+  }
+
+  return (
+    <MenuButton buttonText="Download Teleport Connect">
+      {props.downloadLinks.map(link => (
+        <MenuItem as="a" href={link.url}>
+          {link.text}
+        </MenuItem>
+      ))}
+    </MenuButton>
+  );
+};
+
+function getConnectDownloadLinks(
+  platform: Platform,
+  proxyVersion: string
+): Array<DownloadLink> {
+  switch (platform) {
+    case Platform.Windows:
+      return [
+        {
+          text: 'Teleport Connect',
+          url: `https://cdn.teleport.dev/Teleport Connect Setup-${proxyVersion}.exe`,
+        },
+      ];
+    case Platform.macOS:
+      return [
+        {
+          text: 'Teleport Connect',
+          url: `https://cdn.teleport.dev/Teleport Connect-${proxyVersion}.dmg`,
+        },
+      ];
+    case Platform.Linux:
+      return [
+        {
+          text: 'DEB',
+          url: `https://cdn.teleport.dev/teleport-connect_${proxyVersion}_amd64.deb`,
+        },
+        {
+          text: 'RPM',
+          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}.x86_64.rpm`,
+        },
+
+        {
+          text: 'tar.gz',
+          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}-x64.tar.gz`,
+        },
+      ];
+  }
+}

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -104,7 +104,7 @@ const DownloadConnect = (props: { downloadLinks: Array<DownloadLink> }) => {
   return (
     <MenuButton buttonText="Download Teleport Connect">
       {props.downloadLinks.map(link => (
-        <MenuItem as="a" href={link.url}>
+        <MenuItem key={link.url} as="a" href={link.url}>
           {link.text}
         </MenuItem>
       ))}

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { SetupConnect } from './SetupConnect';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ResourceViewConfig } from 'teleport/Discover/flow';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import { DiscoverEvent } from 'teleport/services/userEvent';
+
+import { ResourceSpec } from '../SelectResource';
+
+import { SetupConnect } from './SetupConnect';
+
+export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
+  kind: ResourceKind.ConnectMyComputer,
+  views: [
+    {
+      title: 'Set Up Teleport Connect',
+      component: SetupConnect,
+      eventName: DiscoverEvent.DeployService,
+    },
+    {
+      title: 'Test Connection',
+      component: () => <div>WIP</div>,
+      eventName: DiscoverEvent.TestConnection,
+      // TODO(ravicious): Manually emit success event on test connection success.
+      // manuallyEmitSuccessEvent: true,
+    },
+  ],
+};

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { Text, Box, Flex, Link } from 'design';
 import { Danger } from 'design/Alert';
 import { Info } from 'design/Icon';
@@ -27,7 +26,13 @@ import useTeleport from 'teleport/useTeleport';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Tabs } from 'teleport/components/Tabs';
 
-import { HeaderSubtitle, ActionButtons, Mark, Header } from '../../Shared';
+import {
+  HeaderSubtitle,
+  ActionButtons,
+  Mark,
+  Header,
+  StyledBox,
+} from '../../Shared';
 import { dbCU } from '../../yamlTemplates';
 import { DatabaseEngine } from '../../SelectResource';
 
@@ -292,10 +297,3 @@ function DbEngineInstructions({ dbEngine }: { dbEngine: DatabaseEngine }) {
     );
   }
 }
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;

--- a/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
 import { Box, Text, Flex, Link } from 'design';
 import { Info as InfoIcon } from 'design/Icon';
 
@@ -27,7 +26,7 @@ import {
   useUserTraits,
   SetupAccessWrapper,
 } from 'teleport/Discover/Shared/SetupAccess';
-import { Mark } from 'teleport/Discover/Shared';
+import { Mark, StyledBox } from 'teleport/Discover/Shared';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { DbMeta } from 'teleport/Discover/useDiscover';
 
@@ -381,10 +380,3 @@ function DbEngineInstructions({
 
   return null;
 }
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { Text, Box, LabelInput } from 'design';
 
 import Select, { Option } from 'shared/components/Select';
@@ -29,6 +28,7 @@ import {
   HeaderSubtitle,
   Header,
   ConnectionDiagnosticResult,
+  StyledBox,
 } from '../../Shared';
 import { DatabaseEngine } from '../../SelectResource';
 
@@ -165,10 +165,3 @@ export function TestConnectionView({
     </Box>
   );
 }
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;

--- a/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { Text, Box } from 'design';
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';
@@ -32,6 +31,7 @@ import {
   HeaderSubtitle,
   Header,
   ConnectionDiagnosticResult,
+  StyledBox,
 } from '../../Shared';
 
 import { useTestConnection, State } from './useTestConnection';
@@ -204,10 +204,3 @@ export function TestConnection({
     </Validation>
   );
 }
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;

--- a/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { ButtonSecondary, Text, Box, LabelInput } from 'design';
 import Select from 'shared/components/Select';
 
@@ -26,6 +25,7 @@ import {
   ActionButtons,
   HeaderSubtitle,
   ConnectionDiagnosticResult,
+  StyledBox,
 } from '../../Shared';
 
 import { useTestConnection, State } from './useTestConnection';
@@ -110,10 +110,3 @@ export function TestConnection({
     </Box>
   );
 }
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -21,7 +21,7 @@ import * as Icons from 'design/Icon';
 
 import { YamlReader } from 'teleport/Discover/Shared/SetupAccess/AccessInfo';
 
-import { TextIcon, Mark } from '..';
+import { StyledBox, TextIcon, Mark } from '..';
 
 import type { Attempt } from 'shared/hooks/useAttemptNext';
 import type { ConnectionDiagnostic } from 'teleport/services/agents';
@@ -155,13 +155,6 @@ const ErrorWithDetails = ({
     </TextIcon>
   );
 };
-
-const StyledBox = styled(Box)`
-  max-width: 800px;
-  background-color: ${props => props.theme.colors.spotBackground[0]};
-  border-radius: 8px;
-  padding: 20px;
-`;
 
 const ButtonShowMore = styled(ButtonText)`
   min-height: auto;

--- a/web/packages/teleport/src/Discover/Shared/StyledBox.ts
+++ b/web/packages/teleport/src/Discover/Shared/StyledBox.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+import { Box } from 'design';
+
+export const StyledBox = styled(Box).attrs({
+  p: 4,
+  borderRadius: 3,
+  maxWidth: '800px',
+})`
+  background-color: ${props => props.theme.colors.spotBackground[0]};
+`;

--- a/web/packages/teleport/src/Discover/Shared/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/index.ts
@@ -34,5 +34,6 @@ export { SecurityGroupPicker } from './SecurityGroupPicker';
 export type { ViewRulesSelection } from './SecurityGroupPicker';
 export { AwsAccount } from './AwsAccount';
 export { DisableableCell, Labels, labelMatcher, RadioCell } from './Aws';
+export { StyledBox } from './StyledBox';
 
 export type { DiscoverLabel } from './LabelsCreater';

--- a/web/packages/teleport/src/Discover/flow.tsx
+++ b/web/packages/teleport/src/Discover/flow.tsx
@@ -26,23 +26,27 @@ type ViewFunction<T> = (t: T) => View[];
 
 export interface ResourceViewConfig<T = any> {
   kind: ResourceKind;
-  // views contain all the possible views for a resource kind.
-  // Resources with no sub types will have views defined
-  // in a simple View list (eg. kubernetes and servers).
-  // ViewFunction is defined instead if a resource can have
-  // varying views depending on the resource "sub-type". For
-  // example, a database resource can have many sub-types.
-  // A aws postgres will contain different views versus a
-  // self-hosted postgres.
+  /**
+   * views contain all the possible views for a resource kind.
+   * Resources with no sub types will have views defined
+   * in a simple View list (eg. kubernetes and servers).
+   * ViewFunction is defined instead if a resource can have
+   * varying views depending on the resource "sub-type". For
+   * example, a database resource can have many sub-types.
+   * A aws postgres will contain different views versus a
+   * self-hosted postgres.
+   */
   views: View[] | ViewFunction<T>;
   wrapper?: (component: React.ReactNode) => React.ReactNode;
-  // shouldPrompt is an optional function that determines if the
-  // react-router-dom's Prompt should be invocated on exit or
-  // changing route. We can control when to show the prompt
-  // depending on what step in the flow a user is in (indicated
-  // by "currentStep" param).
-  // Not supplying a function is equivalent to always prompting
-  // on exit or changing route.
+  /**
+   * shouldPrompt is an optional function that determines if the
+   * react-router-dom's Prompt should be invocated on exit or
+   * changing route. We can control when to show the prompt
+   * depending on what step in the flow a user is in (indicated
+   * by "currentStep" param).
+   * Not supplying a function is equivalent to always prompting
+   * on exit or changing route.
+   */
   shouldPrompt?: (currentStep: number, resourceSpec: ResourceSpec) => boolean;
 }
 
@@ -53,16 +57,20 @@ export interface View {
   index?: number;
   views?: View[];
   eventName?: DiscoverEvent;
-  // manuallyEmitSuccessEvent is a flag that when true
-  // means success events will be sent by the children
-  // (current view component) instead of the default
-  // which is sent by the parent context.
+  /**
+   * manuallyEmitSuccessEvent is a flag that when true
+   * means success events will be sent by the children
+   * (current view component) instead of the default
+   * which is sent by the parent context.
+   */
   manuallyEmitSuccessEvent?: boolean;
 }
 
-// computeViewChildrenSize calculates how many children a view has, without counting the first
-// child. This is because the first child shares the same index with its parent, so we don't
-// need to count it as it's not taking up a new index
+/**
+ * computeViewChildrenSize calculates how many children a view has, without counting the first
+ * child. This is because the first child shares the same index with its parent, so we don't
+ * need to count it as it's not taking up a new index
+ */
 export function computeViewChildrenSize(views: View[]) {
   let size = 0;
   for (const view of views) {
@@ -76,9 +84,11 @@ export function computeViewChildrenSize(views: View[]) {
   return size;
 }
 
-// addIndexToViews will recursively loop over the given views, adding an index value to each one
-// The first child shares its index with the parent, as we effectively ignore the fact the parent
-// exists when trying to find the active view by the current step index.
+/**
+ * addIndexToViews will recursively loop over the given views, adding an index value to each one
+ * The first child shares its index with the parent, as we effectively ignore the fact the parent
+ * exists when trying to find the active view by the current step index.
+ */
 export function addIndexToViews(views: View[], index = 0): View[] {
   const result: View[] = [];
 
@@ -103,8 +113,10 @@ export function addIndexToViews(views: View[], index = 0): View[] {
   return result;
 }
 
-// findViewAtIndex will recursively loop views and their children in order to find the deepest
-// match at that index.
+/**
+ * findViewAtIndex will recursively loop views and their children in order to find the deepest
+ * match at that index.
+ */
 export function findViewAtIndex(
   views: View[],
   currentStep: number
@@ -124,9 +136,11 @@ export function findViewAtIndex(
   }
 }
 
-// hasActiveChildren will recursively loop through views and their children in order to find
-// out if there is a view with a matching index to the given `currentStep` value
-// This is because a parent is active as long as its children are active
+/**
+ * hasActiveChildren will recursively loop through views and their children in order to find
+ * out if there is a view with a matching index to the given `currentStep` value
+ * This is because a parent is active as long as its children are active
+ */
 export function hasActiveChildren(views: View[], currentStep: number) {
   for (const view of views) {
     if (view.index === currentStep) {

--- a/web/packages/teleport/src/Discover/resourceViewConfigs.ts
+++ b/web/packages/teleport/src/Discover/resourceViewConfigs.ts
@@ -18,6 +18,7 @@ import { ServerResource } from 'teleport/Discover/Server';
 import { DatabaseResource } from 'teleport/Discover/Database';
 import { KubernetesResource } from 'teleport/Discover/Kubernetes';
 import { DesktopResource } from 'teleport/Discover/Desktop';
+import { ConnectMyComputerResource } from 'teleport/Discover/ConnectMyComputer';
 
 import { ResourceViewConfig } from './flow';
 
@@ -26,4 +27,5 @@ export const viewConfigs: ResourceViewConfig[] = [
   DatabaseResource,
   KubernetesResource,
   DesktopResource,
+  ConnectMyComputerResource,
 ];

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -20,6 +20,8 @@ import path from 'node:path';
 
 import { app, globalShortcut, shell, nativeTheme } from 'electron';
 
+import { CUSTOM_PROTOCOL } from 'shared/deepLinks';
+
 import MainProcess from 'teleterm/mainProcess';
 import { getRuntimeSettings } from 'teleterm/mainProcess/runtimeSettings';
 import { enableWebHandlersProtection } from 'teleterm/mainProcess/protocolHandler';
@@ -32,7 +34,7 @@ import {
 } from 'teleterm/services/config';
 import { createFileStorage } from 'teleterm/services/fileStorage';
 import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
-import { CUSTOM_PROTOCOL, parseDeepLink } from 'teleterm/deepLinks';
+import { parseDeepLink } from 'teleterm/deepLinks';
 import { assertUnreachable } from 'teleterm/ui/utils';
 
 // Set the app as a default protocol client only if it wasn't started through `electron .`.


### PR DESCRIPTION
Part of #32185.

[Figma](https://www.figma.com/file/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?type=design&node-id=1375-23952&mode=design&t=VtkFrynloY0xx89n-4) – Kenny prepared the designs using a different look compared to other guided flows. I asked him about it and [Kenny said](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1698944223316569?thread_ts=1698937267.944029&cid=C02DQ1C2BMW) to make the guided flow for Connect My Computer match the other flows for now.

This PR implements the first step without polling. Polling will be implemented in a subsequent PR. Connection test is coming in about 2-3 weeks, so when I'll get around to implementing the UI for polling, I'll have to figure out what to show as step two.

The code for the guided flow itself is quite small, but I had to address a couple of things to make it possible. I had to move some of the code related to the deep links to the shared package so that the Web UI can create deep links to Connect.

To test the deep link integration, you need to build and package Connect, either from this branch or master.

```
yarn build-term && CONNECT_TSH_BIN_PATH=$PWD/build/tsh yarn package-term
```

![first step of guided flow](https://github.com/gravitational/teleport/assets/27113/bd0093b6-2b6d-4f41-b98a-ecb73349d96e)
