### PR TITLE
Update bloat check cache key

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -43,13 +43,21 @@ jobs:
           path: .github/shared-workflows
           ref: main
 
+      # The cache action was not evaluating ${{ github.event.push.before }} when used directly in the
+      # key. Output the correct base sha in an output so that the cache action can consume that instead.
+      - name: Compute base sha
+        id: base_sha
+        run: |
+          echo "Base SHA = ${{ github.event.push.before || github.event.pull_request.base.sha }}"
+          echo "sha=${{ github.event.push.before || github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+
       - name: Setup base cache
         uses: actions/cache/restore@v3
         id: cache-build-restore
         with:
           path: |
             ~/teleport_base_build_stats
-          key: ${{ runner.os }}-${{ github.event.push.before }}
+          key: ${{ github.job }}-${{ runner.os }}-${{ steps.base_sha.outputs.sha }}
 
       - name: Generate GitHub Token
         id: generate_token
@@ -66,6 +74,7 @@ jobs:
           cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"  >> ~/teleport_base_build_stats
           echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
           echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
+
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Save base build
         id: base-build-save
@@ -73,7 +82,7 @@ jobs:
         with:
           path: |
             ${{ steps.build_base.outputs.base_stats_file }}
-          key: ${{ runner.os }}-${{ github.event.push.before }}
+          key: ${{ github.job }}-${{ runner.os }}-${{ steps.base_sha.outputs.sha }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit == 'true' }}
         name: Restore base stats
@@ -98,6 +107,7 @@ jobs:
         id: build_branch
         run: |
           BUILD_SECRET=FAKE_SECRET make WEBASSETS_SKIP_BUILD=1 binaries
+
       - name: Check for Environment Leak
         id: check_branch_env_leak
         run: |
@@ -107,6 +117,7 @@ jobs:
               exit 1; \
             fi; \
           done
+          
       - name: Check for bloat
         id: check_branch_bloat
         run: |


### PR DESCRIPTION
The old key was not correctly evaluating the sha of the before
commit resulting in reusing the action cache key "Linux-" for all
builds. This resulted in continual failures in the event that the
previous build was larger than the current build until the cache
was manually cleared. The key also did not include the job name
which makes it harder to distinguish what action is consuming
the cache.

The new key references the bloat check job name and attempts to
ensure the cache key include the previous commit sha by expanding
the value and outputting it in a separate step.



Results from a bloat check run that was triggered off this branch: https://github.com/gravitational/teleport/actions/runs/6787619637