### PR TITLE
[Docs] Add necessary permission for using auto-provisioned user deletion on MariaDB guide

### DIFF
--- a/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
@@ -51,6 +51,7 @@ CREATE USER 'teleport-admin' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
 GRANT PROCESS, CREATE USER ON *.* TO 'teleport-admin';
 GRANT SELECT ON mysql.roles_mapping TO 'teleport-admin';
 GRANT UPDATE ON mysql.* TO 'teleport-admin'; -- For SET DEFAULT ROLE FOR
+GRANT SELECT ON *.* TO 'teleport-admin'; -- For checking if users own resources before dropping them.
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
 GRANT ALL ON `teleport`.* TO 'teleport-admin' WITH GRANT OPTION;

--- a/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
@@ -86,6 +86,7 @@ CREATE USER 'teleport-admin' REQUIRE SUBJECT '/CN=teleport-admin';
 GRANT PROCESS, CREATE USER ON *.* TO 'teleport-admin';
 GRANT SELECT ON mysql.roles_mapping TO 'teleport-admin';
 GRANT UPDATE ON mysql.* TO 'teleport-admin'; -- For SET DEFAULT ROLE FOR
+GRANT SELECT ON *.* TO 'teleport-admin'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
 GRANT ALL ON `teleport`.* TO 'teleport-admin' WITH GRANT OPTION;

--- a/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
@@ -51,7 +51,7 @@ CREATE USER 'teleport-admin' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
 GRANT PROCESS, CREATE USER ON *.* TO 'teleport-admin';
 GRANT SELECT ON mysql.roles_mapping TO 'teleport-admin';
 GRANT UPDATE ON mysql.* TO 'teleport-admin'; -- For SET DEFAULT ROLE FOR
-GRANT SELECT ON *.* TO 'teleport-admin'; -- For checking if users own resources before dropping them.
+GRANT SELECT ON *.* TO 'teleport-admin'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
 GRANT ALL ON `teleport`.* TO 'teleport-admin' WITH GRANT OPTION;

--- a/docs/pages/includes/database-access/auto-user-provisioning/common-teleport-role.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/common-teleport-role.mdx
@@ -33,6 +33,7 @@ The available provisioning modes are:
 * `keep`: Enables user provisioning and disables users at session end. The user
   will be stripped of all roles and the user account will be locked.
 
-* `best_effort_drop`: Enables user provisioning and tries to drop user
-  at session end. If the drop fails, fallback to disabling them (same as `keep`
-  mode).
+* `best_effort_drop`: Enables user provisioning and, when the session ends,
+  drops the user if no resources depend on it. In cases where any resource
+  depends on the user, it falls back to disabling the user, mirroring the
+  behavior of `keep` mode.


### PR DESCRIPTION
The auto-provisioned user deletion procedure requires an additional `SELECT` permission to execute properly ([more info here](https://github.com/gravitational/teleport/pull/33938)).