### PR TITLE
[v14]  Fix an issue MySQL auto-user deletion fails on usernames that require quotes

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -523,7 +523,7 @@ func getCreateProcedureCommand(conn *clientConn, procedureName string) (string, 
 const (
 	// procedureVersion is a hard-coded string that is set as procedure
 	// comments to indicate the procedure version.
-	procedureVersion = "teleport-auto-user-v2"
+	procedureVersion = "teleport-auto-user-v3"
 
 	// mysqlMaxUsernameLength is the maximum username/role length for MySQL.
 	//

--- a/lib/srv/db/mysql/sql/mariadb_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mariadb_delete_user.sql
@@ -22,7 +22,12 @@ BEGIN
             CALL teleport_deactivate_user(username);
         ELSE
             SET state = 'TP003';
-            SET @sql := CONCAT('DROP USER ', username);
+            SET @sql := CONCAT('DROP ROLE ', QUOTE(CONCAT("tp-role-", username)));
+            PREPARE stmt FROM @sql;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+
+            SET @sql := CONCAT('DROP USER ', QUOTE(username));
             PREPARE stmt FROM @sql;
             EXECUTE stmt;
             DEALLOCATE PREPARE stmt;

--- a/lib/srv/db/mysql/sql/mysql_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mysql_delete_user.sql
@@ -16,7 +16,7 @@ BEGIN
         -- Throw a custom error code when user is still active from other sessions.
         SIGNAL SQLSTATE 'TP000' SET MESSAGE_TEXT = 'User has active connections';
     ELSE
-        SET @sql := CONCAT('DROP USER ', username);
+        SET @sql := CONCAT('DROP USER ', QUOTE(username));
         PREPARE stmt FROM @sql;
         EXECUTE stmt;
         DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
backport of #34258 to branch/v14

no cherry-pick conflict on top of #34256 

changelog: Fix an issue MySQL auto-user deletion fails on usernames that require quotes