### PR TITLE
Enable conditional updates for users

### DIFF
--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -336,7 +336,7 @@ func TestUpdateUser(t *testing.T) {
 	updated, err := env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: llama.(*types.UserV2)})
 	assert.Error(t, err, "duplicate user was created successfully")
 	assert.Nil(t, updated, "received unexpected user")
-	require.True(t, trace.IsNotFound(err), "updated nonexistent user")
+	require.True(t, trace.IsCompareFailed(err), "updated nonexistent user")
 
 	// Create a new user.
 	created, err := env.CreateUser(ctx, &userspb.CreateUserRequest{User: llama.(*types.UserV2)})

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -360,7 +360,7 @@ func (s *IdentityService) UpdateUser(ctx context.Context, user types.User) (type
 		ID:       user.GetResourceID(),
 		Revision: rev,
 	}
-	lease, err := s.Backend.Update(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -188,10 +188,8 @@ func testEditUser(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
 	// Try editing the user a second time. This time the revisions will not match
 	// since the created revision is stale.
 	_, err = runEditCommand(t, fc, []string{"edit", "user/llama"}, withEditor(editor))
-	// TODO(tross) remove and uncomment lines below once conditional update support for users lands
-	require.NoError(t, err)
-	//assert.Error(t, err, "stale user was allowed to be updated")
-	//require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
+	assert.Error(t, err, "stale user was allowed to be updated")
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision, "expected an incorrect revision error, got %T", err)
 }
 
 // TestEditEnterpriseResources asserts that tctl edit


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/34255 temporarily reverted users to blind update since the operator didn't handle revisions properly. Now that https://github.com/gravitational/teleport/pull/34265 has been merged to update the operator to support revisions, the conditional updates for users can be restored.