### PR TITLE
Use correct commit hashes in bloat action

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
-          ref: ${{ github.event.push.before }}
+          ref: ${{ github.event.before }}
 
       - name: Prepare workspace
         uses: ./.github/actions/prepare-workspace
@@ -43,21 +43,13 @@ jobs:
           path: .github/shared-workflows
           ref: main
 
-      # The cache action was not evaluating ${{ github.event.push.before }} when used directly in the
-      # key. Output the correct base sha in an output so that the cache action can consume that instead.
-      - name: Compute base sha
-        id: base_sha
-        run: |
-          echo "Base SHA = ${{ github.event.push.before || github.event.pull_request.base.sha }}"
-          echo "sha=${{ github.event.push.before || github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
-
       - name: Setup base cache
         uses: actions/cache/restore@v3
         id: cache-build-restore
         with:
           path: |
             ~/teleport_base_build_stats
-          key: ${{ github.job }}-${{ runner.os }}-${{ steps.base_sha.outputs.sha }}
+          key: ${{ github.job }}-${{ runner.os }}-${{ github.event.before }}
 
       - name: Generate GitHub Token
         id: generate_token
@@ -94,7 +86,7 @@ jobs:
         uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
           clean: false
-          ref: ${{ github.event.push.after }}
+          ref: ${{ github.event.after }}
 
       - name: Checkout shared-workflow
         uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility


### PR DESCRIPTION
The `github.event` is the `push` event payload, `github.event.push` does not exist. Update the bloat action to pull the before/after commit hashes from the correct object.


https://docs.github.com/en/actions/learn-github-actions/contexts#github-context


Property name | Type | Description
--------------- | ------- | -----------
github.event	   |  object | The full event webhook payload. You can access individual properties of the event using this context. This object is identical to the webhook payload of the event that triggered the workflow run, and is different for each event. The webhooks for each GitHub Actions event is linked in "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)." For example, for a workflow run triggered by the [push event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push), this object contains the contents of the [push webhook payload](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push).
