### PR TITLE
Fix PROXY protocol handling of dedicated kube listener with TLS routing

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -583,6 +583,7 @@ func TestKubePROXYProtocol(t *testing.T) {
 				Log:         utils.NewLoggerForTests(),
 			}
 			tconf := servicecfg.MakeDefaultConfig()
+			tconf.Proxy.Kube.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyKube, &cfg.Fds))
 			if tt.proxyListenerMode == types.ProxyListenerMode_Multiplex {
 				cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 				tconf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
@@ -590,7 +591,6 @@ func TestKubePROXYProtocol(t *testing.T) {
 				cfg.Listeners = helpers.StandardListenerSetup(t, &cfg.Fds)
 				tconf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
 				tconf.Proxy.DisableALPNSNIListener = true
-				tconf.Proxy.Kube.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyKube, &cfg.Fds))
 			}
 
 			testCluster := helpers.NewInstance(t, cfg)
@@ -624,41 +624,43 @@ func TestKubePROXYProtocol(t *testing.T) {
 				require.NoError(t, testCluster.StopAll())
 			})
 
-			targetAddr := testCluster.Config.Proxy.WebAddr
-			if tt.proxyListenerMode == types.ProxyListenerMode_Separate {
-				targetAddr = testCluster.Config.Proxy.Kube.ListenAddr
+			checkForTargetAddr := func(targetAddr utils.NetAddr) {
+				// If PROXY protocol is required, create load balancer in front of Teleport cluster
+				if tt.proxyProtocolMode == multiplexer.PROXYProtocolOn {
+					frontend := *utils.MustParseAddr("127.0.0.1:0")
+					lb, err := utils.NewLoadBalancer(context.Background(), frontend)
+					require.NoError(t, err)
+					lb.PROXYHeader = []byte("PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n") // Send fake PROXY header
+					lb.AddBackend(targetAddr)
+					err = lb.Listen()
+					require.NoError(t, err)
+
+					go lb.Serve()
+					t.Cleanup(func() { require.NoError(t, lb.Close()) })
+					targetAddr = *utils.MustParseAddr(lb.Addr().String())
+				}
+
+				// Create kube client that we'll use to test that connection is working correctly.
+				k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
+					T:                   testCluster,
+					Username:            kubeRoleSpec.Allow.Logins[0],
+					KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
+					KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+					CustomTLSServerName: kubeCluster,
+					TargetAddress:       targetAddr,
+					RouteToCluster:      testCluster.Secrets.SiteName,
+				})
+				require.NoError(t, err)
+
+				resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Len(t, resp.Items, 3, "pods item length mismatch")
 			}
 
-			// If PROXY protocol is required, create load balancer in front of Teleport cluster
-			if tt.proxyProtocolMode == multiplexer.PROXYProtocolOn {
-				frontend := *utils.MustParseAddr("127.0.0.1:0")
-				lb, err := utils.NewLoadBalancer(context.Background(), frontend)
-				require.NoError(t, err)
-				lb.PROXYHeader = []byte("PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n") // Send fake PROXY header
-				lb.AddBackend(targetAddr)
-				err = lb.Listen()
-				require.NoError(t, err)
-
-				go lb.Serve()
-				t.Cleanup(func() { require.NoError(t, lb.Close()) })
-				targetAddr = *utils.MustParseAddr(lb.Addr().String())
+			checkForTargetAddr(testCluster.Config.Proxy.Kube.ListenAddr)
+			if tt.proxyListenerMode == types.ProxyListenerMode_Multiplex {
+				checkForTargetAddr(testCluster.Config.Proxy.WebAddr)
 			}
-
-			// Create kube client that we'll use to test that connection is working correctly.
-			k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
-				T:                   testCluster,
-				Username:            kubeRoleSpec.Allow.Logins[0],
-				KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
-				KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
-				CustomTLSServerName: kubeCluster,
-				TargetAddress:       targetAddr,
-				RouteToCluster:      testCluster.Secrets.SiteName,
-			})
-			require.NoError(t, err)
-
-			resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
-			require.NoError(t, err)
-			require.Len(t, resp.Items, 3, "pods item length mismatch")
 		})
 	}
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4410,16 +4410,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
-		proxyProtocol := cfg.Proxy.PROXYProtocolMode
-		if clusterNetworkConfig.GetProxyListenerMode() == types.ProxyListenerMode_Multiplex {
-			// If ProxyListenerMode is MULTIPLEX it means that the ALPN listener handles the PROXY line
-			// and sends the connection to the Proxy Kube listener. When it does, it uses the same net.Conn
-			// and doesn't dial so the PROXY Protocol cannot be present. Under those circumstances,
-			// ProxyProtocol for Proxy Kube listener must be off.
-
-			proxyProtocol = multiplexer.PROXYProtocolOff
-		}
-
 		kubeServer, err = kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 			ForwarderConfig: kubeproxy.ForwarderConfig{
 				Namespace:                     apidefaults.Namespace,
@@ -4455,7 +4445,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Log:                      log,
 			IngressReporter:          ingressReporter,
 			KubernetesServersWatcher: kubeServerWatcher,
-			PROXYProtocolMode:        proxyProtocol,
+			PROXYProtocolMode:        cfg.Proxy.PROXYProtocolMode,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
In multiplexed mode alpn proxy passes connection to the Kube listener directly. If PROXY protocol mode is "on" Kube listener in that case would not get PROXY line that was already handled by the alpn listener and fail. In https://github.com/gravitational/teleport/pull/32893 we made Kube listener to always have PROXY protocol mode "off" in multiplexed proxy listening mode, but that lead to a problem that now users couldn't use dedicated Kube listener directly, since PROXY line was rejected. 

This PR changes how we handle it - now we don't switch off PROXY protocol mode for the Kube listener in multiplexed mode, instead in the multiplexer listener we check if accepted connection is itself multiplexer connection (or wrapped at some level) - that means it's coming from alpn proxy and PROXY protocol line requirement was already handled, so we don't check it second time.

Changelog: Fix accessing dedicated Proxy Kube port when TLS routing is enabled.

Closes https://github.com/gravitational/teleport/issues/34178