### PR TITLE
[v14] chore: Bump golangci-lint to v1.55.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport14
 
     env:
-      GOLANGCI_LINT_VERSION: v1.55.1
+      GOLANGCI_LINT_VERSION: v1.55.2
 
     steps:
       - name: Checkout

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -309,7 +309,7 @@ RUN go install github.com/daixiang0/gci@v0.11.0
 RUN go install gotest.tools/gotestsum@v1.10.1
 
 # Install golangci-lint.
-RUN VERSION='v1.55.1'; \
+RUN VERSION='v1.55.2'; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 


### PR DESCRIPTION
Backport #34313 to branch/v14.

Update to the latest patch.

* https://github.com/golangci/golangci-lint/releases/tag/v1.55.2
