### PR TITLE
Allow leaf logins to be shown when accessing via a root cluster

### DIFF
--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -142,7 +142,7 @@ func NewSessionController(cfg SessionControllerConfig) (*SessionController, erro
 // WebSessionContext contains information associated with a session
 // established via the web ui.
 type WebSessionContext interface {
-	GetUserAccessChecker() (services.AccessChecker, error)
+	GetAccessChecker() (services.AccessChecker, error)
 	GetSSHCertificate() (*ssh.Certificate, error)
 	GetUser() string
 }
@@ -152,7 +152,7 @@ type WebSessionContext interface {
 // This allows `lib/web` to not depend on `lib/srv`.
 func WebSessionController(controller *SessionController) func(ctx context.Context, sctx WebSessionContext, login, localAddr, remoteAddr string) (context.Context, error) {
 	return func(ctx context.Context, sctx WebSessionContext, login, localAddr, remoteAddr string) (context.Context, error) {
-		accessChecker, err := sctx.GetUserAccessChecker()
+		accessChecker, err := sctx.GetAccessChecker()
 		if err != nil {
 			return ctx, trace.Wrap(err)
 		}

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -613,7 +613,7 @@ func (h *Handler) assistGenSSHCommandLoop(ctx context.Context, assistClient *ass
 func (h *Handler) assistChatLoop(ctx context.Context, assistClient *assist.Assist, authClient auth.ClientI,
 	conversationID string, sctx *SessionContext, ws *websocket.Conn,
 ) error {
-	ac, err := sctx.GetUserAccessChecker()
+	ac, err := sctx.GetAccessChecker()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -115,7 +115,7 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -293,7 +293,7 @@ func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -47,7 +47,7 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -102,7 +102,7 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 		databases = append(databases, server.GetDatabase())
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -136,7 +136,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -190,7 +190,7 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -251,7 +251,7 @@ func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.NotFound("expected at least 1 desktop, got 0")
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -422,7 +422,7 @@ func (h *Handler) handleNodeCreate(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := sctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -594,7 +594,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws WSConn, tc *clien
 	ctx, span := t.tracer.Start(ctx, "terminal/connectToHost")
 	defer span.End()
 
-	accessChecker, err := t.ctx.GetUserAccessChecker()
+	accessChecker, err := t.ctx.GetAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
The `services.AccessChecker` used to populate logins for resources is constructed based on the cluster that the target resource is a member of. This allows the role mapping to be considered when populating available logins for a given resource.

Fixes #5041.

changelog: Update the web UI to show leaf resource logins when accessing them via the root cluster.