### PR TITLE
Fix custom client `PivSlot` overridden by server settings

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2729,7 +2729,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 	}
 
 	if tc.SSHLogDir != "" {
-		if err := os.MkdirAll(tc.SSHLogDir, 0700); err != nil {
+		if err := os.MkdirAll(tc.SSHLogDir, 0o700); err != nil {
 			return trace.ConvertSystemError(err)
 		}
 	}
@@ -4578,7 +4578,11 @@ func (tc *TeleportClient) applyProxySettings(proxySettings webclient.ProxySettin
 // authentication settings, overriding existing fields in tc.
 func (tc *TeleportClient) applyAuthSettings(authSettings webclient.AuthenticationSettings) {
 	tc.LoadAllCAs = authSettings.LoadAllCAs
-	tc.PIVSlot = authSettings.PIVSlot
+
+	// If PIVSlot is not already set, default to the server setting.
+	if tc.PIVSlot == "" {
+		tc.PIVSlot = authSettings.PIVSlot
+	}
 
 	// Update the private key policy from auth settings if it is stricter than the saved setting.
 	if authSettings.PrivateKeyPolicy != "" && !authSettings.PrivateKeyPolicy.IsSatisfiedBy(tc.PrivateKeyPolicy) {

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -544,6 +544,51 @@ func TestApplyProxySettings(t *testing.T) {
 	}
 }
 
+func TestApplyAuthSettings(t *testing.T) {
+	tests := []struct {
+		desc        string
+		settingsIn  webclient.AuthenticationSettings
+		tcConfigIn  Config
+		tcConfigOut Config
+	}{
+		{
+			desc: "PIV slot set by server",
+			settingsIn: webclient.AuthenticationSettings{
+				PIVSlot: "9c",
+			},
+			tcConfigOut: Config{
+				PIVSlot: "9c",
+			},
+		}, {
+			desc: "PIV slot set by client",
+			tcConfigIn: Config{
+				PIVSlot: "9a",
+			},
+			tcConfigOut: Config{
+				PIVSlot: "9a",
+			},
+		}, {
+			desc: "PIV slot set on server and client, client takes precedence",
+			settingsIn: webclient.AuthenticationSettings{
+				PIVSlot: "9c",
+			},
+			tcConfigIn: Config{
+				PIVSlot: "9a",
+			},
+			tcConfigOut: Config{
+				PIVSlot: "9a",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			tc := &TeleportClient{Config: test.tcConfigIn}
+			tc.applyAuthSettings(test.settingsIn)
+			require.EqualValues(t, test.tcConfigOut, tc.Config)
+		})
+	}
+}
+
 type mockAgent struct {
 	// Agent is embedded to avoid redeclaring all interface methods.
 	// Only the Signers method is implemented by testAgent.


### PR DESCRIPTION
`tsh --piv-slot` was always ignored in favor of the `cap.piv_slot`, even when empty.

Changelog: Fix `tsh --piv-slot` custom PIV slot setting for Hardware Key Support