### PR TITLE
Fix default piv key slot to match comments and docs

### DIFF
--- a/api/utils/keys/yubikey.go
+++ b/api/utils/keys/yubikey.go
@@ -142,12 +142,12 @@ func GetDefaultKeySlot(policy PrivateKeyPolicy) (piv.Slot, error) {
 	case PrivateKeyPolicyHardwareKeyTouch:
 		// private_key_policy: hardware_key_touch -> 9c
 		return piv.SlotSignature, nil
-	case PrivateKeyPolicyHardwareKeyPIN:
-		// private_key_policy: hardware_key_pin -> 9d
-		return piv.SlotCardAuthentication, nil
 	case PrivateKeyPolicyHardwareKeyTouchAndPIN:
-		// private_key_policy: hardware_key_touch_and_pin -> 9e
+		// private_key_policy: hardware_key_touch_and_pin -> 9d
 		return piv.SlotKeyManagement, nil
+	case PrivateKeyPolicyHardwareKeyPIN:
+		// private_key_policy: hardware_key_pin -> 9e
+		return piv.SlotCardAuthentication, nil
 	default:
 		return piv.Slot{}, trace.BadParameter("unexpected private key policy %v", policy)
 	}
@@ -715,10 +715,10 @@ func parsePIVSlot(slotKey uint32) (piv.Slot, error) {
 		return piv.SlotAuthentication, nil
 	case piv.SlotSignature.Key:
 		return piv.SlotSignature, nil
-	case piv.SlotCardAuthentication.Key:
-		return piv.SlotCardAuthentication, nil
 	case piv.SlotKeyManagement.Key:
 		return piv.SlotKeyManagement, nil
+	case piv.SlotCardAuthentication.Key:
+		return piv.SlotCardAuthentication, nil
 	default:
 		retiredSlot, ok := piv.RetiredKeyManagementSlot(slotKey)
 		if !ok {

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -210,8 +210,8 @@ $ tsh clusters
 By default, Teleport clients use the following PIV slots for each option:
   - `hardware_key`: slot `9a`
   - `hardware_key_touch`: slot `9c`
-  - `hardware_key_pin`: slot `9d`
-  - `hardware_key_and_pin`: slot `9e`
+  - `hardware_key_touch_and_pin`: slot `9d`
+  - `hardware_key_pin`: slot `9e`
 
 If you are using any other PIV applications, you might need to specify a different slot.
 For example, `yubikey-agent` uses slot `9a`. To avoid overwriting the `yubikey-agent` key and certificate,

--- a/rfd/0080-hardware-key-support.md
+++ b/rfd/0080-hardware-key-support.md
@@ -342,7 +342,7 @@ If a hardware key policy is required, then a private key will be generated direc
 
 #### PIV slot logic
 
-PIV provides us with up to 24 different slots. Each slot has a different intended purpose, but functionally they are the same. We will use the first four slots (`9a`, `9c`, `9d`, `9e`) to support each of the 4 hardware key policy requirements (`hardware_key`, `hardware_key_touch`, `hardware_key_pin`, `hardware_key_touch_and_pin` respectively).
+PIV provides us with up to 24 different slots. Each slot has a different intended purpose, but functionally they are the same. We will use the first four slots (`9a`, `9c`, `9d`, `9e`) to support each of the 4 hardware key policy requirements (`hardware_key`, `hardware_key_touch`, `hardware_key_touch_and_pin`, `hardware_key_pin` respectively).
 
 Each of these keys will be generated for the first time when a Teleport client is required to meet its respective private key policy. Once a key is generated, it will be reused by any other Teleport client required to meet the same private key policy.
 


### PR DESCRIPTION
I mixed up the order because they are out of order in the piv-go library

```go
        SlotAuthentication     = Slot{0x9a, 0x5fc105}
        SlotSignature          = Slot{0x9c, 0x5fc10a}
        SlotCardAuthentication = Slot{0x9e, 0x5fc101}
        SlotKeyManagement      = Slot{0x9d, 0x5fc10b}
```

I updated the comments/docs to match the released functionality.