### PR TITLE
Allow user locks to affect access list membership.

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -34,13 +34,19 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+// AccessListsAndLockGetter is an interface for retrieving access lists and locks.
+type AccessListsAndLockGetter interface {
+	services.AccessListsGetter
+	services.LockGetter
+}
+
 // GeneratorConfig is the configuration for the user login state generator.
 type GeneratorConfig struct {
 	// Log is a logger to use for the generator.
 	Log *logrus.Entry
 
-	// AccessLists is a service for retrieving access lists from the backend.
-	AccessLists services.AccessListsGetter
+	// AccessLists is a service for retrieving access lists and locks from the backend.
+	AccessLists AccessListsAndLockGetter
 
 	// Access is a service that will be used for retrieving roles from the backend.
 	Access services.Access
@@ -89,7 +95,7 @@ func (g *GeneratorConfig) CheckAndSetDefaults() error {
 // Generator will generate a user login state from a user.
 type Generator struct {
 	log         *logrus.Entry
-	accessLists services.AccessListsGetter
+	accessLists AccessListsAndLockGetter
 	access      services.Access
 	usageEvents UsageEventsClient
 	clock       clockwork.Clock

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -94,11 +94,12 @@ func (g *GeneratorConfig) CheckAndSetDefaults() error {
 
 // Generator will generate a user login state from a user.
 type Generator struct {
-	log         *logrus.Entry
-	accessLists AccessListsAndLockGetter
-	access      services.Access
-	usageEvents UsageEventsClient
-	clock       clockwork.Clock
+	log           *logrus.Entry
+	accessLists   AccessListsAndLockGetter
+	access        services.Access
+	usageEvents   UsageEventsClient
+	memberChecker *services.AccessListMembershipChecker
+	clock         clockwork.Clock
 }
 
 // NewGenerator creates a new user login state generator.
@@ -108,11 +109,12 @@ func NewGenerator(config GeneratorConfig) (*Generator, error) {
 	}
 
 	return &Generator{
-		log:         config.Log,
-		accessLists: config.AccessLists,
-		access:      config.Access,
-		usageEvents: config.UsageEvents,
-		clock:       config.Clock,
+		log:           config.Log,
+		accessLists:   config.AccessLists,
+		access:        config.Access,
+		usageEvents:   config.UsageEvents,
+		memberChecker: services.NewAccessListMembershipChecker(config.Clock, config.AccessLists, config.Access),
+		clock:         config.Clock,
 	}, nil
 }
 
@@ -177,7 +179,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 
 	for _, accessList := range accessLists {
 		// Check that the user meets the access list requirements.
-		if err := services.IsAccessListMember(ctx, identity, g.clock, accessList, g.accessLists); err != nil {
+		if err := g.memberChecker.IsAccessListMember(ctx, identity, accessList); err != nil {
 			continue
 		}
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -58,6 +58,7 @@ func TestAccessLists(t *testing.T) {
 		cloud              bool
 		accessLists        []*accesslist.AccessList
 		members            []*accesslist.AccessListMember
+		locks              []types.Lock
 		roles              []string
 		expected           *userloginstate.UserLoginState
 		expectedRoleCount  int
@@ -96,6 +97,33 @@ func TestAccessLists(t *testing.T) {
 				trait.Traits{"otrait1": {"value1", "value2"}, "trait1": {"value1", "value2"}, "trait2": {"value3"}}),
 			expectedRoleCount:  2,
 			expectedTraitCount: 3,
+		},
+		{
+			name:  "lock prevents adding roles and traits",
+			user:  user,
+			cloud: true,
+			accessLists: []*accesslist.AccessList{
+				newAccessList(t, clock, "1", []string{"role1"}, trait.Traits{
+					"trait1": []string{"value1"},
+				}),
+				newAccessList(t, clock, "2", []string{"role2"}, trait.Traits{
+					"trait1": []string{"value2"},
+					"trait2": []string{"value3"},
+				}),
+			},
+			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
+			locks: []types.Lock{
+				newUserLock(t, "test-lock", user.GetName()),
+			},
+			roles: []string{"orole1", "role1", "role2"},
+			expected: newUserLoginState(t, "user",
+				[]string{
+					"orole1",
+				}, trait.Traits{
+					"otrait1": []string{"value1", "value2"},
+				}),
+			expectedRoleCount:  0,
+			expectedTraitCount: 0,
 		},
 		{
 			name:  "access lists add roles and traits (cloud disabled)",
@@ -268,6 +296,10 @@ func TestAccessLists(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			for _, lock := range test.locks {
+				require.NoError(t, backendSvc.UpsertLock(ctx, lock))
+			}
+
 			state, err := svc.Generate(ctx, test.user)
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(test.expected, state,
@@ -278,6 +310,7 @@ func TestAccessLists(t *testing.T) {
 			if test.expectedRoleCount == 0 && test.expectedTraitCount == 0 {
 				require.Nil(t, backendSvc.event)
 			} else {
+				require.NotNil(t, backendSvc.event)
 				require.IsType(t, &usageeventsv1.UsageEventOneOf_AccessListGrantsToUser{}, backendSvc.event.Event)
 				event := (backendSvc.event.Event).(*usageeventsv1.UsageEventOneOf_AccessListGrantsToUser)
 
@@ -394,4 +427,17 @@ func newUserLoginState(t *testing.T, name string, originalRoles, roles []string,
 	require.NoError(t, err)
 
 	return uls
+}
+
+func newUserLock(t *testing.T, name string, username string) types.Lock {
+	t.Helper()
+
+	lock, err := types.NewLock(name, types.LockSpecV2{
+		Target: types.LockTarget{
+			User: username,
+		},
+	})
+	require.NoError(t, err)
+
+	return lock
 }

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -117,11 +117,9 @@ func TestAccessLists(t *testing.T) {
 			},
 			roles: []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
-				[]string{
-					"orole1",
-				}, trait.Traits{
-					"otrait1": []string{"value1", "value2"},
-				}),
+				[]string{"orole1"},
+				[]string{"orole1"},
+				trait.Traits{"otrait1": []string{"value1", "value2"}}),
 			expectedRoleCount:  0,
 			expectedTraitCount: 0,
 		},

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -148,6 +148,9 @@ type AccessResourcesGetter interface {
 
 	GetUser(ctx context.Context, userName string, withSecrets bool) (types.User, error)
 	GetRole(ctx context.Context, name string) (types.Role, error)
+
+	GetLock(ctx context.Context, name string) (types.Lock, error)
+	GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error)
 }
 
 // Modules defines interface that external libraries can implement customizing

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -211,28 +211,42 @@ func IsAccessListOwner(identity tlsca.Identity, accessList *accesslist.AccessLis
 	return nil
 }
 
-// AccessListMemberAndLocker is an interface that allows getting access list members and detecting if they're locked.
-type AccessListMemberAndLockGetter interface {
-	AccessListMembersGetter
-	LockGetter
+// AccessListMembershipChecker will check if users are members of an access list and
+// makes sure the user is not locked and meets membership requirements.
+type AccessListMembershipChecker struct {
+	members AccessListMembersGetter
+	locks   LockGetter
+	clock   clockwork.Clock
+}
+
+// NewAccessListMembershipChecker will create a new access list membership checker.
+func NewAccessListMembershipChecker(clock clockwork.Clock, members AccessListMembersGetter, locks LockGetter) *AccessListMembershipChecker {
+	return &AccessListMembershipChecker{
+		members: members,
+		locks:   locks,
+		clock:   clock,
+	}
 }
 
 // IsAccessListMember will return true if the user is a member for the current list.
-func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock clockwork.Clock, accessList *accesslist.AccessList, getter AccessListMemberAndLockGetter) error {
+func (a AccessListMembershipChecker) IsAccessListMember(ctx context.Context, identity tlsca.Identity, accessList *accesslist.AccessList) error {
 	username := identity.Username
 
-	locks, err := getter.GetLocks(ctx, true, types.LockTarget{
-		User: username,
-	})
-	if err != nil {
-		return trace.Wrap(err)
+	// Allow for nil locks while we transition away from using `IsAccessListMember` outside of this struct.
+	if a.locks != nil {
+		locks, err := a.locks.GetLocks(ctx, true, types.LockTarget{
+			User: username,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if len(locks) > 0 {
+			return trace.AccessDenied("user %s is currently locked", username)
+		}
 	}
 
-	if len(locks) > 0 {
-		return trace.AccessDenied("user %s is currently locked", username)
-	}
-
-	member, err := getter.GetAccessListMember(ctx, accessList.GetName(), username)
+	member, err := a.members.GetAccessListMember(ctx, accessList.GetName(), username)
 	if trace.IsNotFound(err) {
 		// The member has not been found, so we know they're not a member of this list.
 		return trace.NotFound("user %s is not a member of the access list", username)
@@ -246,7 +260,7 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 		return nil
 	}
 
-	if !clock.Now().Before(expires) {
+	if !a.clock.Now().Before(expires) {
 		return trace.AccessDenied("user %s's membership has expired in the access list", username)
 	}
 
@@ -254,6 +268,17 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 		return trace.AccessDenied("user %s is a member, but does not have the roles or traits required to be a member of this list", username)
 	}
 	return nil
+}
+
+// TODO(mdwn): Remove this in favor of using the access list membership checker.
+func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock clockwork.Clock, accessList *accesslist.AccessList, members AccessListMembersGetter) error {
+	// See if the member getter also implements lock getter. If so, use it. Otherwise, nil is fine.
+	lockGetter, _ := members.(LockGetter)
+	return AccessListMembershipChecker{
+		members: members,
+		locks:   lockGetter,
+		clock:   clock,
+	}.IsAccessListMember(ctx, identity, accessList)
 }
 
 // UserMeetsRequirements will return true if the user meets the requirements for the access list.


### PR DESCRIPTION
Access list membership will now be impacted by active user locks. If a user is locked, they will not be considered a part of an access list. This, in turn will be used for things like Okta assignments to ensure that Okta access can be rescinded while a lock is active.

changelog: Access lists now respect user locking.