### PR TITLE
[v13] MemoryDB IAM auth support

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -247,6 +247,8 @@ var (
 			"memorydb:UpdateUser",
 		},
 		requireSecretsManager: true,
+		authBoundary:          []string{"memorydb:Connect"},
+		requireIAMEdit:        true,
 	}
 	// awsKeyspacesActions contains IAM actions for static AWS Keyspaces databases.
 	awsKeyspacesActions = databaseActions{

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -432,6 +432,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
@@ -440,6 +443,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"memorydb:DescribeSubnetGroups",
 					"memorydb:DescribeUsers",
 					"memorydb:UpdateUser",
+					"memorydb:Connect",
 				}},
 				{
 					Effect: awslib.EffectAllow,
@@ -451,6 +455,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 		},
 		"MemoryDB static database": {
@@ -506,6 +513,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
@@ -514,6 +524,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"memorydb:DescribeSubnetGroups",
 					"memorydb:DescribeUsers",
 					"memorydb:UpdateUser",
+					"memorydb:Connect",
 				}},
 				{
 					Effect: "Allow",
@@ -535,6 +546,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 		},
 		"AutoDiscovery EC2": {
@@ -1339,12 +1353,17 @@ func TestAWSIAMDocuments(t *testing.T) {
 						},
 						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 					},
+					{
+						Effect:    awslib.EffectAllow,
+						Resources: []string{roleTarget.String()},
+						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
+					},
 				},
 				boundaryStatements: []*awslib.Statement{
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: []string{"*"},
-						Actions:   []string{"memorydb:DescribeClusters", "memorydb:DescribeUsers", "memorydb:UpdateUser"},
+						Actions:   []string{"memorydb:DescribeClusters", "memorydb:DescribeUsers", "memorydb:UpdateUser", "memorydb:Connect"},
 					},
 					{
 						Effect: awslib.EffectAllow,
@@ -1355,6 +1374,11 @@ func TestAWSIAMDocuments(t *testing.T) {
 							"secretsmanager:TagResource",
 						},
 						Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
+					},
+					{
+						Effect:    awslib.EffectAllow,
+						Resources: []string{roleTarget.String()},
+						Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
 					},
 				},
 			},

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2808,7 +2808,7 @@ func withElastiCacheRedis(name string, token, engineVersion string) withDatabase
 }
 
 func withMemoryDBRedis(name string, token, engineVersion string) withDatabaseOption {
-	return func(t testing.TB, ctx context.Context, testCtx *testContext) types.Database {
+	return func(t *testing.T, ctx context.Context, testCtx *testContext) types.Database {
 		redisServer, err := redis.NewTestServer(t, common.TestServerConfig{
 			Name:       name,
 			AuthClient: testCtx.authClient,

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2167,6 +2167,8 @@ type agentParams struct {
 	GCPSQL *mocks.GCPSQLAdminClientMock
 	// ElastiCache defines the AWS ElastiCache mock to use for ElastiCache API calls.
 	ElastiCache *mocks.ElastiCacheMock
+	// MemoryDB defines the AWS MemoryDB mock to use for MemoryDB API calls.
+	MemoryDB *mocks.MemoryDBMock
 	// OnHeartbeat defines a heartbeat function that generates heartbeat events.
 	OnHeartbeat func(error)
 	// CADownloader defines the CA downloader.
@@ -2200,6 +2202,9 @@ func (p *agentParams) setDefaults(c *testContext) {
 	if p.ElastiCache == nil {
 		p.ElastiCache = &mocks.ElastiCacheMock{}
 	}
+	if p.MemoryDB == nil {
+		p.MemoryDB = &mocks.MemoryDBMock{}
+	}
 	if p.CADownloader == nil {
 		p.CADownloader = &fakeDownloader{
 			cert: []byte(fixtures.TLSCACertPEM),
@@ -2213,7 +2218,7 @@ func (p *agentParams) setDefaults(c *testContext) {
 			Redshift:           &mocks.RedshiftMock{},
 			RedshiftServerless: &mocks.RedshiftServerlessMock{},
 			ElastiCache:        p.ElastiCache,
-			MemoryDB:           &mocks.MemoryDBMock{},
+			MemoryDB:           p.MemoryDB,
 			SecretsManager:     secrets.NewMockSecretsManagerClient(secrets.MockSecretsManagerClientConfig{}),
 			IAM:                &mocks.IAMMock{},
 			GCPSQL:             p.GCPSQL,
@@ -2786,6 +2791,43 @@ func withElastiCacheRedis(name string, token, engineVersion string) withDatabase
 				Region: "us-west-1",
 				ElastiCache: types.ElastiCache{
 					ReplicationGroupID: "example-cluster",
+				},
+			},
+			// Set CA cert to pass cert validation.
+			TLS: types.DatabaseTLS{
+				CACert: string(testCtx.databaseCA.GetActiveKeys().TLS[0].Cert),
+			},
+		})
+		require.NoError(t, err)
+		testCtx.redis[name] = testRedis{
+			db:       redisServer,
+			resource: database,
+		}
+		return database
+	}
+}
+
+func withMemoryDBRedis(name string, token, engineVersion string) withDatabaseOption {
+	return func(t testing.TB, ctx context.Context, testCtx *testContext) types.Database {
+		redisServer, err := redis.NewTestServer(t, common.TestServerConfig{
+			Name:       name,
+			AuthClient: testCtx.authClient,
+		}, redis.TestServerPassword(token))
+		require.NoError(t, err)
+
+		database, err := types.NewDatabaseV3(types.Metadata{
+			Name: name,
+			Labels: map[string]string{
+				"engine-version": engineVersion,
+			},
+		}, types.DatabaseSpecV3{
+			Protocol:      defaults.ProtocolRedis,
+			URI:           fmt.Sprintf("rediss://%s", net.JoinHostPort("localhost", redisServer.Port())),
+			DynamicLabels: dynamicLabels,
+			AWS: types.AWS{
+				Region: "us-west-1",
+				MemoryDB: types.MemoryDB{
+					ClusterName: "example-cluster",
 				},
 			},
 			// Set CA cert to pass cert validation.

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -198,6 +198,14 @@ func (c *IAM) isSetupRequiredForDatabase(database types.Database) bool {
 			return true
 		}
 		return ok
+	case types.DatabaseTypeMemoryDB:
+		ok, err := iam.CheckMemoryDBSupportsIAMAuth(database)
+		if err != nil {
+			c.log.WithError(err).Debugf("Assuming database %s supports IAM auth.",
+				database.GetName())
+			return true
+		}
+		return ok
 	default:
 		return false
 	}

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -129,6 +129,22 @@ func TestAWSIAM(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	memorydb, err := types.NewDatabaseV3(types.Metadata{
+		Name: "aws-memorydb",
+	}, types.DatabaseSpecV3{
+		Protocol: "redis",
+		URI:      "clustercfg.my-memorydb.xxxxxx.memorydb.us-east-1.amazonaws.com:6379",
+		AWS: types.AWS{
+			AccountID: "123456789012",
+			MemoryDB: types.MemoryDB{
+				ClusterName:  "my-memorydb",
+				TLSEnabled:   true,
+				EndpointType: "cluster",
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	// Make configurator.
 	taskChan := make(chan struct{})
 	waitForTaskProcessed := func(t *testing.T) {
@@ -205,6 +221,13 @@ func TestAWSIAM(t *testing.T) {
 			wantPolicyContains: elasticache.GetAWS().ElastiCache.ReplicationGroupID,
 			getIAMAuthEnabled: func() bool {
 				return true // it always is for ElastiCache.
+			},
+		},
+		"MemoryDB": {
+			database:           memorydb,
+			wantPolicyContains: memorydb.GetAWS().MemoryDB.ClusterName,
+			getIAMAuthEnabled: func() bool {
+				return true // it always is for MemoryDB.
 			},
 		},
 	}

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/rds/rdsutils"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
@@ -74,6 +75,8 @@ type Auth interface {
 	GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error)
 	// GetElastiCacheRedisToken generates an ElastiCache Redis auth token.
 	GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Session) (string, error)
+	// GetMemoryDBToken generates a MemoryDB auth token.
+	GetMemoryDBToken(ctx context.Context, sessionCtx *Session) (string, error)
 	// GetCloudSQLAuthToken generates Cloud SQL auth token.
 	GetCloudSQLAuthToken(ctx context.Context, sessionCtx *Session) (string, error)
 	// GetCloudSQLPassword generates password for a Cloud SQL database user.
@@ -415,14 +418,35 @@ func (a *dbAuth) GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Sessi
 		return "", trace.Wrap(err)
 	}
 	a.cfg.Log.Debugf("Generating ElastiCache Redis auth token for %s.", sessionCtx)
-	tokenReq := &elastiCacheRedisIAMTokenRequest{
+	tokenReq := &awsRedisIAMTokenRequest{
 		// For IAM-enabled ElastiCache users, the username and user id properties must be identical.
 		// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
-		userID:             sessionCtx.DatabaseUser,
-		replicationGroupId: meta.ElastiCache.ReplicationGroupID,
-		region:             meta.Region,
-		credentials:        awsSession.Config.Credentials,
-		clock:              a.cfg.Clock,
+		userID:      sessionCtx.DatabaseUser,
+		targetID:    meta.ElastiCache.ReplicationGroupID,
+		serviceName: elasticache.ServiceName,
+		region:      meta.Region,
+		credentials: awsSession.Config.Credentials,
+		clock:       a.cfg.Clock,
+	}
+	token, err := tokenReq.toSignedRequestURI()
+	return token, trace.Wrap(err)
+}
+
+// GetMemoryDBToken generates a MemoryDB auth token.
+func (a *dbAuth) GetMemoryDBToken(ctx context.Context, sessionCtx *Session) (string, error) {
+	meta := sessionCtx.Database.GetAWS()
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	a.cfg.Log.Debugf("Generating MemoryDB auth token for %s.", sessionCtx)
+	tokenReq := &awsRedisIAMTokenRequest{
+		userID:      sessionCtx.DatabaseUser,
+		targetID:    meta.MemoryDB.ClusterName,
+		serviceName: strings.ToLower(memorydb.ServiceName),
+		region:      meta.Region,
+		credentials: awsSession.Config.Credentials,
+		clock:       a.cfg.Clock,
 	}
 	token, err := tokenReq.toSignedRequestURI()
 	return token, trace.Wrap(err)
@@ -944,36 +968,42 @@ func redshiftServerlessUsernameToRoleARN(aws types.AWS, username string) (string
 	return awsutils.BuildRoleARN(username, aws.Region, aws.AccountID)
 }
 
-// elastiCacheRedisIAMTokenRequest builds an AWS IAM auth token for ElastiCache
-// Redis.
-// Implemented following the AWS example:
+// awsRedisIAMTokenRequest builds an AWS IAM auth token for ElastiCache
+// Redis and MemoryDB.
+// Implemented following the AWS examples:
 // https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-Connecting
-type elastiCacheRedisIAMTokenRequest struct {
+// https://docs.aws.amazon.com/memorydb/latest/devguide/auth-iam.html#auth-iam-Connecting
+type awsRedisIAMTokenRequest struct {
 	// userID is the ElastiCache user ID.
 	userID string
-	// replicationGroupId is the ElastiCache replication group ID.
-	replicationGroupId string
+	// targetID is the ElastiCache replication group ID or the MemoryDB cluster name.
+	targetID string
 	// region is the AWS region.
 	region string
 	// credentials are used to presign with AWS SigV4.
 	credentials *credentials.Credentials
 	// clock is the clock implementation.
 	clock clockwork.Clock
+	// serviceName is the AWS service name used for signing.
+	serviceName string
 }
 
 // checkAndSetDefaults validates config and sets defaults.
-func (r *elastiCacheRedisIAMTokenRequest) checkAndSetDefaults() error {
+func (r *awsRedisIAMTokenRequest) checkAndSetDefaults() error {
 	if r.userID == "" {
 		return trace.BadParameter("missing user ID")
 	}
-	if r.replicationGroupId == "" {
-		return trace.BadParameter("missing replication group ID")
+	if r.targetID == "" {
+		return trace.BadParameter("missing target ID for signing")
 	}
 	if r.region == "" {
 		return trace.BadParameter("missing region")
 	}
 	if r.credentials == nil {
 		return trace.BadParameter("missing credentials")
+	}
+	if r.serviceName == "" {
+		return trace.BadParameter("missing service name")
 	}
 	if r.clock == nil {
 		r.clock = clockwork.NewRealClock()
@@ -983,8 +1013,8 @@ func (r *elastiCacheRedisIAMTokenRequest) checkAndSetDefaults() error {
 
 // toSignedRequestURI creates a new AWS SigV4 pre-signed request URI.
 // This pre-signed request URI can then be used to authenticate as an
-// ElastiCache Redis user.
-func (r *elastiCacheRedisIAMTokenRequest) toSignedRequestURI() (string, error) {
+// ElastiCache Redis or MemoryDB user.
+func (r *awsRedisIAMTokenRequest) toSignedRequestURI() (string, error) {
 	if err := r.checkAndSetDefaults(); err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -993,7 +1023,7 @@ func (r *elastiCacheRedisIAMTokenRequest) toSignedRequestURI() (string, error) {
 		return "", trace.Wrap(err)
 	}
 	s := v4.NewSigner(r.credentials)
-	_, err = s.Presign(req, nil, elasticache.ServiceName, r.region, time.Minute*15, r.clock.Now())
+	_, err = s.Presign(req, nil, r.serviceName, r.region, time.Minute*15, r.clock.Now())
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -1006,14 +1036,14 @@ func (r *elastiCacheRedisIAMTokenRequest) toSignedRequestURI() (string, error) {
 }
 
 // getSignableRequest creates a new request suitable for pre-signing with SigV4.
-func (r *elastiCacheRedisIAMTokenRequest) getSignableRequest() (*http.Request, error) {
+func (r *awsRedisIAMTokenRequest) getSignableRequest() (*http.Request, error) {
 	query := url.Values{
 		"Action": {"connect"},
 		"User":   {r.userID},
 	}
 	reqURI := url.URL{
 		Scheme:   "http",
-		Host:     r.replicationGroupId,
+		Host:     r.targetID,
 		Path:     "/",
 		RawQuery: query.Encode(),
 	}

--- a/lib/srv/db/common/iam/aws.go
+++ b/lib/srv/db/common/iam/aws.go
@@ -38,6 +38,8 @@ func GetAWSPolicyDocument(db types.Database) (*awslib.PolicyDocument, Placeholde
 		return getRedshiftPolicyDocument(db)
 	case types.DatabaseTypeElastiCache:
 		return getElastiCachePolicyDocument(db)
+	case types.DatabaseTypeMemoryDB:
+		return getMemoryDBPolicyDocument(db)
 	default:
 		return nil, nil, trace.BadParameter("GetAWSPolicyDocument is not supported for database type %s", db.GetType())
 	}
@@ -89,11 +91,31 @@ func CheckElastiCacheSupportsIAMAuth(database types.Database) (bool, error) {
 	if !ok {
 		return false, trace.NotFound("database missing engine-version label")
 	}
+	return checkRedisEngineVersionSupportsIAMAuth(version)
+}
+
+func checkRedisEngineVersionSupportsIAMAuth(version string) (bool, error) {
 	v, err := semver.NewVersion(strings.TrimPrefix(version, "v"))
 	if err != nil {
 		return false, trace.Wrap(err, "failed to parse engine-version")
 	}
 	return v.Major >= 7, nil
+}
+
+// CheckMemoryDBSupportsIAMAuth returns whether the given MemoryDB database
+// supports IAM auth.
+// AWS MemoryDB supports IAM auth for redis version 7+.
+func CheckMemoryDBSupportsIAMAuth(database types.Database) (bool, error) {
+	version, ok := database.GetLabel("engine-version")
+	if !ok {
+		return false, trace.NotFound("database missing engine-version label")
+	}
+
+	// MemoryDB version may not have patch version (e.g. "7.0")
+	if strings.Count(version, ".") == 1 {
+		version = version + ".0"
+	}
+	return checkRedisEngineVersionSupportsIAMAuth(version)
 }
 
 func getRDSPolicyDocument(db types.Database) (*awslib.PolicyDocument, Placeholders, error) {
@@ -206,6 +228,37 @@ func getElastiCachePolicyDocument(db types.Database) (*awslib.PolicyDocument, Pl
 		Resources: awslib.SliceOrString{
 			fmt.Sprintf("arn:%v:elasticache:%v:%v:replicationgroup:%v", partition, region, accountID, replicationGroupID),
 			fmt.Sprintf("arn:%v:elasticache:%v:%v:user:*", partition, region, accountID),
+		},
+	})
+	return policyDoc, placeholders, nil
+}
+
+// getMemoryDBPolicyDocument returns the policy document used for MemoryDB
+// databases.
+//
+// https://docs.aws.amazon.com/memorydb/latest/devguide/auth-iam.html
+func getMemoryDBPolicyDocument(db types.Database) (*awslib.PolicyDocument, Placeholders, error) {
+	meta := db.GetAWS()
+	partition := awsutils.GetPartitionFromRegion(meta.Region)
+	region := meta.Region
+	accountID := meta.AccountID
+	clusterName := meta.MemoryDB.ClusterName
+
+	placeholders := Placeholders(nil).
+		setPlaceholderIfEmpty(&region, "{region}").
+		setPlaceholderIfEmpty(&partition, "{partition}").
+		setPlaceholderIfEmpty(&accountID, "{account_id}").
+		setPlaceholderIfEmpty(&clusterName, "{cluster_name}")
+
+	policyDoc := awslib.NewPolicyDocument(&awslib.Statement{
+		Effect:  awslib.EffectAllow,
+		Actions: awslib.SliceOrString{"memorydb:Connect"},
+		Resources: awslib.SliceOrString{
+			// Note that MemoryDB requires `/` to divide resources like
+			// `cluster/<cluster_name>`, whereas ElastiCache requires `:` like
+			// `replicationgroup:<id>`.
+			fmt.Sprintf("arn:%v:memorydb:%v:%v:cluster/%v", partition, region, accountID, clusterName),
+			fmt.Sprintf("arn:%v:memorydb:%v:%v:user/*", partition, region, accountID),
 		},
 	})
 	return policyDoc, placeholders, nil

--- a/lib/srv/db/common/iam/aws_test.go
+++ b/lib/srv/db/common/iam/aws_test.go
@@ -76,6 +76,22 @@ func TestGetAWSPolicyDocument(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	memorydb, err := types.NewDatabaseV3(types.Metadata{
+		Name: "aws-memorydb",
+	}, types.DatabaseSpecV3{
+		Protocol: "redis",
+		URI:      "clustercfg.my-memorydb.xxxxxx.memorydb.us-east-1.amazonaws.com:6379",
+		AWS: types.AWS{
+			AccountID: "123456789012",
+			MemoryDB: types.MemoryDB{
+				ClusterName:  "my-memorydb",
+				TLSEnabled:   true,
+				EndpointType: "cluster",
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		inputDatabase        types.Database
 		expectPolicyDocument string
@@ -137,6 +153,22 @@ func TestGetAWSPolicyDocument(t *testing.T) {
             "Resource": [
                 "arn:aws:elasticache:ca-central-1:123456789012:replicationgroup:some-group",
                 "arn:aws:elasticache:ca-central-1:123456789012:user:*"
+            ]
+        }
+    ]
+}`,
+		},
+		{
+			inputDatabase: memorydb,
+			expectPolicyDocument: `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "memorydb:Connect",
+            "Resource": [
+                "arn:aws:memorydb:us-east-1:123456789012:cluster/my-memorydb",
+                "arn:aws:memorydb:us-east-1:123456789012:user/*"
             ]
         }
     ]

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-redis/redis/v9"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
@@ -143,6 +144,10 @@ type onClientConnectFunc func(context.Context, *redis.Conn) error
 // fetchCredentialsFunc fetches credentials for a new connection.
 type fetchCredentialsFunc func(ctx context.Context) (username, password string, err error)
 
+func noopOnConnect(context.Context, *redis.Conn) error {
+	return nil
+}
+
 // authWithPasswordOnConnect returns an onClientConnectFunc that sends "auth"
 // with provided username and password.
 func authWithPasswordOnConnect(username, password string) onClientConnectFunc {
@@ -223,6 +228,31 @@ func elasticacheIAMTokenFetchFunc(sessionCtx *common.Session, auth common.Auth) 
 				sessionCtx.DatabaseUser, err)
 		}
 		return sessionCtx.DatabaseUser, password, nil
+	}
+}
+
+// memorydbIAMTokenFetchFunc fetches an AWS MemoryDB IAM auth token.
+func memorydbIAMTokenFetchFunc(sessionCtx *common.Session, auth common.Auth) fetchCredentialsFunc {
+	return func(ctx context.Context) (string, string, error) {
+		password, err := auth.GetMemoryDBToken(ctx, sessionCtx)
+		if err != nil {
+			return "", "", trace.AccessDenied(
+				"failed to get AWS MemoryDB IAM auth token for %v: %v",
+				sessionCtx.DatabaseUser, err)
+		}
+		return sessionCtx.DatabaseUser, password, nil
+	}
+}
+
+func awsIAMTokenFetchFunc(sessionCtx *common.Session, auth common.Auth) (fetchCredentialsFunc, error) {
+	switch sessionCtx.Database.GetType() {
+	case types.DatabaseTypeElastiCache:
+		return elasticacheIAMTokenFetchFunc(sessionCtx, auth), nil
+	case types.DatabaseTypeMemoryDB:
+		return memorydbIAMTokenFetchFunc(sessionCtx, auth), nil
+	default:
+		// If this happens it means something wrong with our implementation.
+		return nil, trace.BadParameter("database type %q not supported for AWS IAM Auth", sessionCtx.Database.GetType())
 	}
 }
 

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/go-redis/redis/v9"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
@@ -32,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/cloud"
+	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -239,7 +241,10 @@ func (e *Engine) getNewClientFn(ctx context.Context, sessionCtx *common.Session)
 	}
 
 	return func(username, password string) (redis.UniversalClient, error) {
-		onConnect := e.createOnClientConnectFunc(ctx, sessionCtx, username, password)
+		onConnect, err := e.createOnClientConnectFunc(ctx, sessionCtx, username, password)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
 		redisClient, err := newClient(ctx, connectionOptions, tlsConfig, onConnect)
 		if err != nil {
@@ -252,16 +257,16 @@ func (e *Engine) getNewClientFn(ctx context.Context, sessionCtx *common.Session)
 
 // createOnClientConnectFunc creates a callback function that is called after a
 // successful client connection with the Redis server.
-func (e *Engine) createOnClientConnectFunc(ctx context.Context, sessionCtx *common.Session, username, password string) onClientConnectFunc {
+func (e *Engine) createOnClientConnectFunc(ctx context.Context, sessionCtx *common.Session, username, password string) (onClientConnectFunc, error) {
 	switch {
 	// If password is provided by client.
 	case password != "":
-		return authWithPasswordOnConnect(username, password)
+		return authWithPasswordOnConnect(username, password), nil
 
 	// Azure databases authenticate via access keys.
 	case sessionCtx.Database.IsAzure():
 		credFetchFn := azureAccessKeyFetchFunc(sessionCtx, e.Auth)
-		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn), nil
 
 	// If database user is one of managed users (AWS only).
 	//
@@ -271,18 +276,22 @@ func (e *Engine) createOnClientConnectFunc(ctx context.Context, sessionCtx *comm
 	// Redis is in cluster mode.
 	case slices.Contains(sessionCtx.Database.GetManagedUsers(), sessionCtx.DatabaseUser):
 		credFetchFn := managedUserCredFetchFunc(sessionCtx, e.Auth, e.Users)
-		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn), nil
 
 	// AWS ElastiCache has limited support for IAM authentication.
 	// See: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
 	// So we must check that the database supports IAM auth and that the
 	// ElastiCache user has IAM auth enabled.
+	// Same applies for AWS MemoryDB.
 	case e.isAWSIAMAuthSupported(ctx, sessionCtx):
-		credFetchFn := elasticacheIAMTokenFetchFunc(sessionCtx, e.Auth)
-		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
+		credFetchFn, err := awsIAMTokenFetchFunc(sessionCtx, e.Auth)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn), nil
 
 	default:
-		return nil
+		return noopOnConnect, nil
 	}
 }
 
@@ -295,6 +304,9 @@ func (e *Engine) isAWSIAMAuthSupported(ctx context.Context, sessionCtx *common.S
 	defer func() {
 		// cache result to avoid API calls on each new instance connection.
 		e.awsIAMAuthSupported = &res
+		if res {
+			e.Log.Debugf("IAM Auth is enabled for user %q in database %q.", sessionCtx.DatabaseUser, sessionCtx.Database.GetName())
+		}
 	}()
 	// check if the db supports IAM auth. If we get an error, assume the db does
 	// support IAM auth. False positives just incur an extra API call.
@@ -304,9 +316,8 @@ func (e *Engine) isAWSIAMAuthSupported(ctx context.Context, sessionCtx *common.S
 	} else if !ok {
 		return false
 	}
-	awsMeta := sessionCtx.Database.GetAWS()
 	dbUser := sessionCtx.DatabaseUser
-	ok, err := checkUserIAMAuthIsEnabled(ctx, e.CloudClients, awsMeta, dbUser)
+	ok, err := checkUserIAMAuthIsEnabled(ctx, sessionCtx, e.CloudClients, dbUser)
 	if err != nil {
 		e.Log.WithError(err).Debugf("Assuming IAM auth is not enabled for user %s.",
 			dbUser)
@@ -316,18 +327,33 @@ func (e *Engine) isAWSIAMAuthSupported(ctx context.Context, sessionCtx *common.S
 }
 
 // checkDBSupportsIAMAuth returns whether the given database is an ElastiCache
-// database that supports IAM auth.
-// AWS ElastiCache Redis supports IAM auth for redis version 7+.
+// or MemoryDB database that supports IAM auth.
+// AWS ElastiCache Redis/MemoryDB supports IAM auth for redis version 7+.
 func checkDBSupportsIAMAuth(database types.Database) (bool, error) {
-	if !database.IsElastiCache() {
+	switch database.GetType() {
+	case types.DatabaseTypeElastiCache:
+		return iam.CheckElastiCacheSupportsIAMAuth(database)
+	case types.DatabaseTypeMemoryDB:
+		return iam.CheckMemoryDBSupportsIAMAuth(database)
+	default:
 		return false, nil
 	}
-	return iam.CheckElastiCacheSupportsIAMAuth(database)
 }
 
-// checkUserIAMAuthIsEnabled returns whether a given ElastiCache user has IAM auth
-// enabled.
-func checkUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
+// checkUserIAMAuthIsEnabled returns whether a given ElastiCache or MemoryDB
+// user has IAM auth enabled.
+func checkUserIAMAuthIsEnabled(ctx context.Context, sessionCtx *common.Session, clients cloud.Clients, username string) (bool, error) {
+	switch sessionCtx.Database.GetType() {
+	case types.DatabaseTypeElastiCache:
+		return checkElastiCacheUserIAMAuthIsEnabled(ctx, clients, sessionCtx.Database.GetAWS(), username)
+	case types.DatabaseTypeMemoryDB:
+		return checkMemoryDBUserIAMAuthIsEnabled(ctx, clients, sessionCtx.Database.GetAWS(), username)
+	default:
+		return false, nil
+	}
+}
+
+func checkElastiCacheUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
 	client, err := clients.GetAWSElastiCacheClient(ctx, awsMeta.Region,
 		cloud.WithAssumeRoleFromAWSMeta(awsMeta))
 	if err != nil {
@@ -339,7 +365,25 @@ func checkUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMe
 	input := elasticache.DescribeUsersInput{UserId: aws.String(username)}
 	out, err := client.DescribeUsersWithContext(ctx, &input)
 	if err != nil {
+		return false, trace.Wrap(libaws.ConvertRequestFailureError(err))
+	}
+	if len(out.Users) < 1 || out.Users[0].Authentication == nil {
+		return false, nil
+	}
+	authType := aws.StringValue(out.Users[0].Authentication.Type)
+	return elasticache.AuthenticationTypeIam == authType, nil
+}
+
+func checkMemoryDBUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
+	client, err := clients.GetAWSMemoryDBClient(ctx, awsMeta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(awsMeta))
+	if err != nil {
 		return false, trace.Wrap(err)
+	}
+	input := memorydb.DescribeUsersInput{UserName: aws.String(username)}
+	out, err := client.DescribeUsersWithContext(ctx, &input)
+	if err != nil {
+		return false, trace.Wrap(libaws.ConvertRequestFailureError(err))
 	}
 	if len(out.Users) < 1 || out.Users[0].Authentication == nil {
 		return false, nil

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -388,8 +388,11 @@ func checkMemoryDBUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Client
 	if len(out.Users) < 1 || out.Users[0].Authentication == nil {
 		return false, nil
 	}
+
+	// memorydb.AuthenticationTypeIam is not available in this version of the
+	// SDK yet. Using "iam" instead.
 	authType := aws.StringValue(out.Users[0].Authentication.Type)
-	return elasticache.AuthenticationTypeIam == authType, nil
+	return "iam" == authType, nil
 }
 
 // reconnect closes the current Redis server connection and creates a new one pre-authenticated


### PR DESCRIPTION
Backport #33937 to branch/v13

changelog: Added IAM Authentication support for Amazon MemoryDB Access

Replaced `memorydb.AuthenticationTypeIam == authType` with `"iam"`, as the AWS SDK is not updated with the new type. However, manually tested EVERYTHING WORKS without upgrading AWS SDK.