### PR TITLE
Fix floating error box in Unified View

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -87,7 +87,11 @@ export function FilterPanel({
         <HoverTooltip
           tipContent={<>{selected ? 'Deselect all' : 'Select all'}</>}
         >
-          <StyledCheckbox checked={selected} onChange={selectVisible} />
+          <StyledCheckbox
+            checked={selected}
+            onChange={selectVisible}
+            data-testid="select_all"
+          />
         </HoverTooltip>
         <FilterTypesMenu
           onChange={onKindsChanged}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -339,7 +339,13 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     >
       {resourcesFetchAttempt.status === 'failed' && (
         <ErrorBox>
-          <ErrorBoxInternal>
+          {/* If pinning is hidden, we hide the different tabs to select a view (All resources, pinning).
+              This causes this error box to cover the search bar. If pinning isn't supported, we push down the
+              error by 60px to not hide the search bar.
+          */}
+          <ErrorBoxInternal
+            topPadding={pinning.kind === 'hidden' ? '60px' : '0px'}
+          >
             <Danger>
               {resourcesFetchAttempt.statusText}
               {/* we don't want them to try another request with BAD REQUEST, it will just fail again. */}
@@ -585,6 +591,7 @@ const ErrorBoxInternal = styled(Box)`
   position: absolute;
   left: 0;
   right: 0;
+  top: ${props => props.topPadding};
   margin: ${props => props.theme.space[1]}px 10% 0 10%;
 `;
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -378,6 +378,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                     const $button = (
                       <ButtonBorder
                         key={key}
+                        data-testid={key}
                         textTransform="none"
                         onClick={() => action(getSelectedResources())}
                         disabled={disabled}


### PR DESCRIPTION
[this comment](https://github.com/gravitational/teleport.e/pull/2514#pullrequestreview-1703605740) pointed out that when the "tabs" in the unified resource view are hidden (when pinning is hidden) the error box will cover the search.

This will add small conditional to throw some absolute top padding to push the error down and not obscure the search panel. This is a sticky error so I had to push "down" otherwise if the error happened when scrolled farther down, pushing UP would have hidden the error all together
old:
![Screenshot 2023-11-08 at 5 37 38 PM](https://github.com/gravitational/teleport/assets/5201977/f7371610-999c-4834-bdb8-6b403ac0e0bd)

new:
![Screenshot 2023-11-08 at 5 39 23 PM](https://github.com/gravitational/teleport/assets/5201977/d5469202-9425-430a-80c1-a33f7da8ed28)



Also, I added some test IDs to help with some tests in https://github.com/gravitational/teleport.e/pull/2514