### PR TITLE
Expose AccessGraphEnabled setting in the REST API

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -316,6 +316,8 @@ type ProxySettings struct {
 	TLSRoutingEnabled bool `json:"tls_routing_enabled"`
 	// AssistEnabled is true when Teleport Assist is enabled.
 	AssistEnabled bool `json:"assist_enabled"`
+	// AccessGraphEnabled is true when Access Graph is enabled.
+	AccessGraphEnabled bool `json:"access_graph_enabled"`
 }
 
 // KubeProxySettings is kubernetes proxy settings

--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -77,6 +77,8 @@ type WebConfig struct {
 	HideInaccessibleFeatures bool `json:"hideInaccessibleFeatures"`
 	// CustomTheme is a string that represents the name of the custom theme that the WebUI should use.
 	CustomTheme string `json:"customTheme"`
+	// AccessGraphEnabled is true when the access graph feature is enabled.
+	AccessGraphEnabled bool `json:"accessGraphEnabled"`
 }
 
 // UIConfig provides config options for the web UI served by the proxy service.

--- a/lib/service/proxy_settings.go
+++ b/lib/service/proxy_settings.go
@@ -73,8 +73,9 @@ func (p *proxySettings) GetProxySettings(ctx context.Context) (*webclient.ProxyS
 // where incoming connections are routed to the proper proxy service based on TLS SNI ALPN routing information.
 func (p *proxySettings) buildProxySettings(proxyListenerMode types.ProxyListenerMode) *webclient.ProxySettings {
 	proxySettings := webclient.ProxySettings{
-		TLSRoutingEnabled: proxyListenerMode == types.ProxyListenerMode_Multiplex,
-		AssistEnabled:     p.cfg.Proxy.AssistAPIKey != "",
+		TLSRoutingEnabled:  proxyListenerMode == types.ProxyListenerMode_Multiplex,
+		AssistEnabled:      p.cfg.Proxy.AssistAPIKey != "",
+		AccessGraphEnabled: p.cfg.AccessGraph.Enabled,
 		Kube: webclient.KubeProxySettings{
 			Enabled: p.cfg.Proxy.Kube.Enabled,
 		},

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1520,6 +1520,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	// get tunnel address to display on cloud instances
 	tunnelPublicAddr := ""
 	assistEnabled := false // TODO(jakule) remove when plugins are implemented
+	accessGraphEnabled := false
 	proxyConfig, err := h.cfg.ProxySettings.GetProxySettings(r.Context())
 	if err != nil {
 		h.log.WithError(err).Warn("Cannot retrieve ProxySettings, tunnel address won't be set in Web UI.")
@@ -1537,6 +1538,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 			// disable if auth doesn't support assist
 			assistEnabled = enabled.Enabled
 		}
+		accessGraphEnabled = proxyConfig.AccessGraphEnabled
 	}
 
 	// disable joining sessions if proxy session recording is enabled
@@ -1569,6 +1571,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		AutomaticUpgrades:              automaticUpgradesEnabled,
 		AutomaticUpgradesTargetVersion: automaticUpgradesTargetVersion,
 		AssistEnabled:                  assistEnabled,
+		AccessGraphEnabled:             accessGraphEnabled,
 		HideInaccessibleFeatures:       clusterFeatures.GetFeatureHiding(),
 		CustomTheme:                    clusterFeatures.GetCustomTheme(),
 	}


### PR DESCRIPTION
This commit introduces an AccessGraphEnabled flag in the Web UI settings. It can be used to display/hide access graph elements in the Web UI.

Closes: https://github.com/gravitational/access-graph/issues/186