### PR TITLE
Unified resources view improvements 

### DIFF
--- a/web/packages/design/src/ShimmerBox/ShimmerBox.tsx
+++ b/web/packages/design/src/ShimmerBox/ShimmerBox.tsx
@@ -32,7 +32,7 @@ const ShimmerWrapper = styled.div`
   width: 100%;
   height: 100%;
   background-color: ${props => props.theme.colors.levels.surface};
-  border-radius: ${props => props.theme.radii[3]}px;
+  border-radius: ${props => props.theme.radii[2]}px;
   overflow: hidden;
   position: relative;
 `;

--- a/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Flex, Box } from 'design';
+import { ShimmerBox } from 'design/ShimmerBox';
+
+type LoadingCardProps = {
+  delay?: 'none' | 'short' | 'long';
+};
+
+export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
+  const [canDisplay, setCanDisplay] = useState(false);
+
+  useEffect(() => {
+    const displayTimeout = setTimeout(() => {
+      setCanDisplay(true);
+    }, DelayValueMap[delay]);
+    return () => {
+      clearTimeout(displayTimeout);
+    };
+  }, []);
+
+  if (!canDisplay) {
+    return null;
+  }
+
+  return (
+    <Flex gap={2} alignItems="start" height="106px" p={3}>
+      {/* Checkbox */}
+      <ShimmerBox height="16px" width="16px" />
+      {/* Image */}
+      <ShimmerBox height="45px" width="45px" />
+      <Box flex={1}>
+        <Flex gap={2} mb={2} justifyContent="space-between">
+          {/* Name */}
+          <ShimmerBox
+            height="24px"
+            css={`
+              flex-basis: ${randomNum(100, 30)}%;
+            `}
+          />
+          {/* Action button */}
+          <ShimmerBox height="24px" width="90px" />
+        </Flex>
+        {/* Description */}
+        <ShimmerBox height="16px" width={`${randomNum(90, 40)}%`} mb={2} />
+        {/* Labels */}
+        <Flex gap={2}>
+          {new Array(randomNum(4, 0)).fill(null).map((_, i) => (
+            <ShimmerBox key={i} height="16px" width="60px" />
+          ))}
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}
+
+const DelayValueMap = {
+  none: 0,
+  short: 400, // 0.4s;
+  long: 600, // 0.6s;
+};
+
+function randomNum(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
@@ -18,7 +18,7 @@ import React, { useState, useEffect } from 'react';
 import { Flex, Box } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 
-const DISPLAY_SKELETON_AFTER = 400; // 400 ms
+const DISPLAY_SKELETON_AFTER_MS = 150;
 
 export function CardsLoadingSkeleton(props: { count: number }) {
   const [canDisplay, setCanDisplay] = useState(false);
@@ -26,7 +26,7 @@ export function CardsLoadingSkeleton(props: { count: number }) {
   useEffect(() => {
     const displayTimeout = setTimeout(() => {
       setCanDisplay(true);
-    }, DISPLAY_SKELETON_AFTER);
+    }, DISPLAY_SKELETON_AFTER_MS);
     return () => {
       clearTimeout(displayTimeout);
     };

--- a/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsLoadingSkeleton.tsx
@@ -18,17 +18,15 @@ import React, { useState, useEffect } from 'react';
 import { Flex, Box } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 
-type LoadingCardProps = {
-  delay?: 'none' | 'short' | 'long';
-};
+const DISPLAY_SKELETON_AFTER = 400; // 400 ms
 
-export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
+export function CardsLoadingSkeleton(props: { count: number }) {
   const [canDisplay, setCanDisplay] = useState(false);
 
   useEffect(() => {
     const displayTimeout = setTimeout(() => {
       setCanDisplay(true);
-    }, DelayValueMap[delay]);
+    }, DISPLAY_SKELETON_AFTER);
     return () => {
       clearTimeout(displayTimeout);
     };
@@ -38,6 +36,17 @@ export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
     return null;
   }
 
+  return (
+    <>
+      {new Array(props.count).fill(undefined).map((_, i) => (
+        // Using index as key here is ok because these elements never change order
+        <LoadingCard key={i} />
+      ))}
+    </>
+  );
+}
+
+function LoadingCard() {
   return (
     <Flex gap={2} alignItems="start" height="106px" p={3}>
       {/* Checkbox */}
@@ -68,12 +77,6 @@ export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
     </Flex>
   );
 }
-
-const DelayValueMap = {
-  none: 0,
-  short: 400, // 0.4s;
-  long: 600, // 0.6s;
-};
 
 function randomNum(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -146,6 +146,7 @@ const FilterTypesMenu = ({
   // we have a separate state in the filter so we can select a few different things and then click "apply"
   const [kinds, setKinds] = useState<string[]>(kindsFromParams || []);
   const handleOpen = event => {
+    setKinds(kindsFromParams);
     setAnchorEl(event.currentTarget);
   };
 

--- a/web/packages/shared/components/UnifiedResources/LoadingCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/LoadingCard.tsx
@@ -14,39 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Flex, Box } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 
-const DISPLAY_SKELETON_AFTER_MS = 150;
-
-export function CardsLoadingSkeleton(props: { count: number }) {
-  const [canDisplay, setCanDisplay] = useState(false);
-
-  useEffect(() => {
-    const displayTimeout = setTimeout(() => {
-      setCanDisplay(true);
-    }, DISPLAY_SKELETON_AFTER_MS);
-    return () => {
-      clearTimeout(displayTimeout);
-    };
-  }, []);
-
-  if (!canDisplay) {
-    return null;
-  }
-
-  return (
-    <>
-      {new Array(props.count).fill(undefined).map((_, i) => (
-        // Using index as key here is ok because these elements never change order
-        <LoadingCard key={i} />
-      ))}
-    </>
-  );
-}
-
-function LoadingCard() {
+export function LoadingCard() {
   return (
     <Flex gap={2} alignItems="start" height="106px" p={3}>
       {/* Checkbox */}

--- a/web/packages/shared/components/UnifiedResources/LoadingSkeleton.tsx
+++ b/web/packages/shared/components/UnifiedResources/LoadingSkeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect, Fragment, ReactElement } from 'react';
+
+const DISPLAY_SKELETON_AFTER_MS = 150;
+
+export function LoadingSkeleton(props: {
+  count: number;
+  /* Single skeleton item. */
+  Element: ReactElement;
+}) {
+  const [canDisplay, setCanDisplay] = useState(false);
+
+  useEffect(() => {
+    const displayTimeout = setTimeout(() => {
+      setCanDisplay(true);
+    }, DISPLAY_SKELETON_AFTER_MS);
+    return () => {
+      clearTimeout(displayTimeout);
+    };
+  }, []);
+
+  if (!canDisplay) {
+    return null;
+  }
+
+  return (
+    <>
+      {new Array(props.count).fill(undefined).map((_, i) => (
+        // Using index as key here is ok because these elements never change order
+        <Fragment key={i}>{props.Element}</Fragment>
+      ))}
+    </>
+  );
+}

--- a/web/packages/shared/components/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/ResourceCard.tsx
@@ -333,32 +333,33 @@ export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
   }
 
   return (
-    <LoadingCardWrapper p={3}>
-      <Flex gap={2} alignItems="start">
-        {/* Image */}
-        <ShimmerBox height="45px" width="45px" />
-        {/* Name and action button */}
-        <Box flex={1}>
-          <Flex gap={2} mb={2} justifyContent="space-between">
-            <ShimmerBox
-              height="24px"
-              css={`
-                flex-basis: ${randomNum(100, 30)}%;
-              `}
-            />
-            <ShimmerBox height="24px" width="90px" />
-          </Flex>
-          <ShimmerBox height="16px" width={`${randomNum(90, 40)}%`} mb={2} />
-          <Box>
-            <Flex gap={2}>
-              {new Array(randomNum(4, 0)).fill(null).map((_, i) => (
-                <ShimmerBox key={i} height="16px" width="60px" />
-              ))}
-            </Flex>
-          </Box>
-        </Box>
-      </Flex>
-    </LoadingCardWrapper>
+    <Flex gap={2} alignItems="start" height="106px" p={3}>
+      {/* Checkbox */}
+      <ShimmerBox height="16px" width="16px" />
+      {/* Image */}
+      <ShimmerBox height="45px" width="45px" />
+      <Box flex={1}>
+        <Flex gap={2} mb={2} justifyContent="space-between">
+          {/* Name */}
+          <ShimmerBox
+            height="24px"
+            css={`
+              flex-basis: ${randomNum(100, 30)}%;
+            `}
+          />
+          {/* Action button */}
+          <ShimmerBox height="24px" width="90px" />
+        </Flex>
+        {/* Description */}
+        <ShimmerBox height="16px" width={`${randomNum(90, 40)}%`} mb={2} />
+        {/* Labels */}
+        <Flex gap={2}>
+          {new Array(randomNum(4, 0)).fill(null).map((_, i) => (
+            <ShimmerBox key={i} height="16px" width="60px" />
+          ))}
+        </Flex>
+      </Box>
+    </Flex>
   );
 }
 
@@ -505,13 +506,6 @@ const MoreLabelsButton = styled(ButtonLink)`
 
   transition: visibility 0s;
   transition: background 150ms;
-`;
-
-const LoadingCardWrapper = styled(Box)`
-  height: 100px;
-  border: ${props => props.theme.borders[2]}
-    ${props => props.theme.colors.spotBackground[0]};
-  border-radius: ${props => props.theme.radii[3]}px;
 `;
 
 function PinButton({

--- a/web/packages/shared/components/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/ResourceCard.tsx
@@ -27,7 +27,6 @@ import { Box, ButtonIcon, ButtonLink, Flex, Label, Text } from 'design';
 import copyToClipboard from 'design/utils/copyToClipboard';
 import { StyledCheckbox } from 'design/Checkbox';
 
-import { ShimmerBox } from 'design/ShimmerBox';
 import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
 import { Icon, Copy, Check, PushPinFilled, PushPin } from 'design/Icon';
 
@@ -299,67 +298,6 @@ export function ResourceCard({
         </CardInnerContainer>
       </CardOuterContainer>
     </CardContainer>
-  );
-}
-
-type LoadingCardProps = {
-  delay?: 'none' | 'short' | 'long';
-};
-
-const DelayValueMap = {
-  none: 0,
-  short: 400, // 0.4s;
-  long: 600, // 0.6s;
-};
-
-function randomNum(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-export function LoadingCard({ delay = 'none' }: LoadingCardProps) {
-  const [canDisplay, setCanDisplay] = useState(false);
-
-  useEffect(() => {
-    const displayTimeout = setTimeout(() => {
-      setCanDisplay(true);
-    }, DelayValueMap[delay]);
-    return () => {
-      clearTimeout(displayTimeout);
-    };
-  }, []);
-
-  if (!canDisplay) {
-    return null;
-  }
-
-  return (
-    <Flex gap={2} alignItems="start" height="106px" p={3}>
-      {/* Checkbox */}
-      <ShimmerBox height="16px" width="16px" />
-      {/* Image */}
-      <ShimmerBox height="45px" width="45px" />
-      <Box flex={1}>
-        <Flex gap={2} mb={2} justifyContent="space-between">
-          {/* Name */}
-          <ShimmerBox
-            height="24px"
-            css={`
-              flex-basis: ${randomNum(100, 30)}%;
-            `}
-          />
-          {/* Action button */}
-          <ShimmerBox height="24px" width="90px" />
-        </Flex>
-        {/* Description */}
-        <ShimmerBox height="16px" width={`${randomNum(90, 40)}%`} mb={2} />
-        {/* Labels */}
-        <Flex gap={2}>
-          {new Array(randomNum(4, 0)).fill(null).map((_, i) => (
-            <ShimmerBox key={i} height="16px" width="60px" />
-          ))}
-        </Flex>
-      </Box>
-    </Flex>
   );
 }
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -32,7 +32,7 @@ import {
   UnifiedResourcesPinning,
   useUnifiedResourcesFetch,
 } from './UnifiedResources';
-import { SharedUnifiedResource } from './types';
+import { SharedUnifiedResource, UnifiedResourcesQueryParams } from './types';
 
 export default {
   title: 'Shared/UnifiedResources',
@@ -67,14 +67,24 @@ const story = ({
     getClusterPinnedResources: async () => [],
     updateClusterPinnedResources: async () => undefined,
   },
+  params,
 }: {
   fetchFunc: (
     params: UrlResourcesParams,
     signal: AbortSignal
   ) => Promise<ResourcesResponse<SharedUnifiedResource['resource']>>;
   pinning?: UnifiedResourcesPinning;
+  params?: Partial<UnifiedResourcesQueryParams>;
 }) => {
-  const params = { sort: { dir: 'ASC', fieldName: 'name' } } as const;
+  const mergedParams: UnifiedResourcesQueryParams = {
+    ...{
+      sort: {
+        dir: 'ASC',
+        fieldName: 'name',
+      },
+    },
+    ...params,
+  };
   return () => {
     const { fetch, attempt, resources } = useUnifiedResourcesFetch({
       fetchFunc,
@@ -88,7 +98,7 @@ const story = ({
           'kube_cluster',
           'windows_desktop',
         ]}
-        params={params}
+        params={mergedParams}
         setParams={() => undefined}
         pinning={pinning}
         updateUnifiedResourcesPreferences={() => undefined}
@@ -115,6 +125,13 @@ export const List = story({
   fetchFunc: async () => ({
     agents: allResources,
   }),
+});
+
+export const NoResults = story({
+  fetchFunc: async () => ({
+    agents: [],
+  }),
+  params: { search: 'my super long search query' },
 });
 
 export const Loading = story({

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -63,14 +63,12 @@ import {
 import { ResourceTab } from './ResourceTab';
 import { ResourceCard, PinningSupport } from './ResourceCard';
 import { FilterPanel } from './FilterPanel';
-import { LoadingCard } from './CardsLoadingSkeleton';
+import { CardsLoadingSkeleton } from './CardsLoadingSkeleton';
 
 // get 48 resources to start
 const INITIAL_FETCH_SIZE = 48;
 // increment by 24 every fetch
 const FETCH_MORE_SIZE = 24;
-
-const loadingCardArray = new Array(FETCH_MORE_SIZE).fill(undefined);
 
 export const PINNING_NOT_SUPPORTED_MESSAGE =
   'This cluster does not support pinning resources. To enable, upgrade to 14.1 or newer.';
@@ -463,10 +461,9 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
             ))}
           {/* Using index as key here is ok because these elements never change order */}
           {(resourcesFetchAttempt.status === 'processing' ||
-            getPinnedResourcesAttempt.status === 'processing') &&
-            loadingCardArray.map((_, i) => (
-              <LoadingCard delay="short" key={i} />
-            ))}
+            getPinnedResourcesAttempt.status === 'processing') && (
+            <CardsLoadingSkeleton count={FETCH_MORE_SIZE} />
+          )}
         </ResourcesContainer>
       )}
       <div ref={setTrigger} />

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -32,7 +32,6 @@ import { Danger } from 'design/Alert';
 import './unifiedStyles.css';
 
 import { ResourcesResponse, ResourceLabel } from 'teleport/services/agents';
-import { TextIcon } from 'teleport/Discover/Shared';
 import {
   UnifiedTabPreference,
   UnifiedResourcePreferences,
@@ -551,28 +550,37 @@ function NoResults({
   query: string;
   isPinnedTab: boolean;
 }) {
-  // Prevent `No resources were found for ""` flicker.
   if (query) {
     return (
-      <Box p={8} mt={3} mx="auto" maxWidth="720px" textAlign="center">
-        <TextIcon typography="h3">
-          <Magnifier />
-          No {isPinnedTab ? 'pinned ' : ''}resources were found for&nbsp;
-          <Text
-            as="span"
-            bold
-            css={`
-              max-width: 270px;
-              overflow: hidden;
-              text-overflow: ellipsis;
-            `}
-          >
-            {query}
-          </Text>
-        </TextIcon>
-      </Box>
+      <Text
+        typography="h3"
+        mt={9}
+        mx="auto"
+        justifyContent="center"
+        alignItems="center"
+        css={`
+          white-space: nowrap;
+        `}
+        as={Flex}
+      >
+        <Magnifier mr={2} />
+        No {isPinnedTab ? 'pinned ' : ''}resources were found for&nbsp;
+        <Text
+          as="span"
+          bold
+          css={`
+            max-width: 270px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          `}
+        >
+          {query}
+        </Text>
+      </Text>
     );
   }
+
   return null;
 }
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -61,8 +61,9 @@ import {
 } from './cards';
 
 import { ResourceTab } from './ResourceTab';
-import { ResourceCard, LoadingCard, PinningSupport } from './ResourceCard';
+import { ResourceCard, PinningSupport } from './ResourceCard';
 import { FilterPanel } from './FilterPanel';
+import { LoadingCard } from './CardsLoadingSkeleton';
 
 // get 48 resources to start
 const INITIAL_FETCH_SIZE = 48;

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -63,7 +63,8 @@ import {
 import { ResourceTab } from './ResourceTab';
 import { ResourceCard, PinningSupport } from './ResourceCard';
 import { FilterPanel } from './FilterPanel';
-import { CardsLoadingSkeleton } from './CardsLoadingSkeleton';
+import { LoadingSkeleton } from './LoadingSkeleton';
+import { LoadingCard } from './LoadingCard';
 
 // get 48 resources to start
 const INITIAL_FETCH_SIZE = 48;
@@ -462,7 +463,10 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
           {/* Using index as key here is ok because these elements never change order */}
           {(resourcesFetchAttempt.status === 'processing' ||
             getPinnedResourcesAttempt.status === 'processing') && (
-            <CardsLoadingSkeleton count={FETCH_MORE_SIZE} />
+            <LoadingSkeleton
+              count={FETCH_MORE_SIZE}
+              Element={<LoadingCard />}
+            />
           )}
         </ResourcesContainer>
       )}


### PR DESCRIPTION
This PR addresses some minor issues in the `UnifiedResources` that were found during the work on integrated search bar in Connect.
I also changed the loading cards styling a bit ([this was feedback from Kenny](https://gravitational.slack.com/archives/C03FJA391M3/p1699461029937179?thread_ts=1699019207.545239&cid=C03FJA391M3))
Before:
<img width="926" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/0e5e24a0-3d9a-4042-9bc6-78b2e0b45c4f">

After:
<img width="926" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/c127fedd-a9e7-4113-8385-b9b4f4d723d3">

While I was on it, I refactored it slightly. There is no need in setting up `setTimeout` 24 times if we can do this once.
