### PR TITLE
Allow using cluster_networking_config and auth_pref with --bootstrap

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -595,6 +595,42 @@ func init() {
 		}
 		return lock, nil
 	})
+	RegisterResourceMarshaler(types.KindClusterNetworkingConfig, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		cnc, ok := resource.(types.ClusterNetworkingConfig)
+		if !ok {
+			return nil, trace.BadParameter("expected cluster_networking_config go %T", resource)
+		}
+		bytes, err := MarshalClusterNetworkingConfig(cnc, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindClusterNetworkingConfig, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		cnc, err := UnmarshalClusterNetworkingConfig(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return cnc, nil
+	})
+	RegisterResourceMarshaler(types.KindClusterAuthPreference, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		ap, ok := resource.(types.AuthPreference)
+		if !ok {
+			return nil, trace.BadParameter("expected cluster_auth_preference go %T", resource)
+		}
+		bytes, err := MarshalAuthPreference(ap, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindClusterAuthPreference, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		ap, err := UnmarshalAuthPreference(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return ap, nil
+	})
 }
 
 // MarshalResource attempts to marshal a resource dynamically, returning NotImplementedError


### PR DESCRIPTION
Part of https://github.com/gravitational/cloud/pull/6204

changelog: Allow configuring cluster_networking_config and cluster_auth_preference via `--bootstrap`