### PR TITLE
Enable the sloglint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - misspell
     - nolintlint
     - revive
+    - sloglint
     - staticcheck
     - testifylint
     - unconvert
@@ -72,6 +73,10 @@ linters-settings:
     rules:
     - name: unused-parameter
       disabled: true
+  sloglint:
+    context-only: true
+    key-naming-case: snake
+    static-msg: true
   testifylint:
     enable:
       - bool-compare


### PR DESCRIPTION
Updates the golangci-lint configuration to enable sloglint and configure it as per [RFD 0154](https://github.com/gravitational/teleport/blob/master/rfd/0154-logging-guidelines.md).

The current version of golangci-lint includes an older version of sloglint which does not yet support the linter-settings specified. So at present, this configuration will not actually catch any problems. However, we aren't actively using slog yet and golangci-lint has already pulled in the latest version of sloglint, so the next release will be capable of handling the settings.