### PR TITLE
Poll for Connect My Computer node in the Discover flow

### DIFF
--- a/web/packages/shared/constants.ts
+++ b/web/packages/shared/constants.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Be wary that this file is being loaded by both Node.js and browser environments, so keep the
+ * definitions simple and do not put environment-specific code here.
+ *
+ * If it turns out that the design package needs to depend on a constant from here, move this file
+ * to the design package or just its own package. This avoids cyclic dependencies as the shared
+ * package depends on the design package.
+ */
+
+/**
+ * TeleportNamespace is used as the namespace prefix for labels defined by Teleport which can
+ * carry metadata such as cloud AWS account or instance. Those labels can be used for RBAC.
+ *
+ * If a label with this prefix is used in a config file, the associated feature must take into
+ * account that the label might be removed, modified or could have been set by the user.
+ *
+ * See also teleport.internal and teleport.hidden.
+ */
+export const TeleportNamespace = 'teleport.dev' as const;
+
+/**
+ * ConnectMyComputerNodeOwnerLabel is a label used to control access to the node managed by
+ * Teleport Connect as part of Connect My Computer.
+ */
+export const ConnectMyComputerNodeOwnerLabel =
+  `${TeleportNamespace}/connect-my-computer/owner` as const;

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-
+import { MemoryRouter } from 'react-router';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { rest } from 'msw';
 
@@ -135,15 +135,17 @@ const Provider = ({ children }) => {
   const updateClusterPinnedResources = () => Promise.resolve();
 
   return (
-    <UserContext.Provider
-      value={{
-        preferences,
-        updatePreferences,
-        getClusterPinnedResources,
-        updateClusterPinnedResources,
-      }}
-    >
-      <ContextProvider ctx={ctx}>{children}</ContextProvider>
-    </UserContext.Provider>
+    <MemoryRouter>
+      <UserContext.Provider
+        value={{
+          preferences,
+          updatePreferences,
+          getClusterPinnedResources,
+          updateClusterPinnedResources,
+        }}
+      >
+        <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      </UserContext.Provider>
+    </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.test.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import * as useTeleport from 'teleport/useTeleport';
+import NodeService from 'teleport/services/nodes/nodes';
+import TeleportContext from 'teleport/teleportContext';
+
+import { nodes } from 'teleport/Nodes/fixtures';
+
+import { Node } from 'teleport/services/nodes';
+
+import { usePollForConnectMyComputerNode } from './SetupConnect';
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('usePollForConnectMyComputerNode', () => {
+  const tests: Array<{
+    name: string;
+    initialNodes: Node[];
+  }> = [
+    {
+      name: 'returns the correct node if the first polling request returns no nodes',
+      initialNodes: [],
+    },
+    {
+      name: 'returns the correct node if the first polling request returns some nodes',
+      initialNodes: [nodes[1], nodes[2]],
+    },
+  ];
+
+  test.each(tests)('$name', async ({ initialNodes }) => {
+    const expectedNode = nodes[0];
+
+    const nodeService = {
+      fetchNodes: jest.fn(),
+    } as Partial<NodeService> as NodeService;
+
+    jest
+      .mocked(nodeService)
+      .fetchNodes.mockResolvedValue({ agents: [...initialNodes, expectedNode] })
+      .mockResolvedValueOnce({ agents: initialNodes });
+
+    jest
+      .spyOn(useTeleport, 'default')
+      .mockReturnValue({ nodeService } as TeleportContext);
+
+    const { result, waitForValueToChange } = renderHook(() =>
+      usePollForConnectMyComputerNode({
+        username: 'alice',
+        clusterId: 'foo',
+        pingInterval: 1,
+      })
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.current.node).toBeFalsy();
+    expect(result.current.isPolling).toBe(true);
+
+    await waitForValueToChange(() => result.current.node, { interval: 3 });
+
+    expect(result.current.node).toEqual(expectedNode);
+    expect(result.current.isPolling).toBe(false);
+  });
+});

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -77,9 +77,9 @@ export function SetupConnect(
     }
   }, [isPolling, showHintTimeout]);
 
-  let hint: JSX.Element;
+  let pollingStatus: JSX.Element;
   if (showHint && !node) {
-    hint = (
+    pollingStatus = (
       // Override max-width to match StyledBox's max-width.
       <HintBox header="We're still looking for your computer" maxWidth="800px">
         <Flex flexDirection="column" gap={3}>
@@ -122,7 +122,7 @@ export function SetupConnect(
       </HintBox>
     );
   } else if (node) {
-    hint = (
+    pollingStatus = (
       <SuccessBox>
         <Text>
           Your computer, <strong>{node.hostname}</strong>, has been detected!
@@ -130,7 +130,7 @@ export function SetupConnect(
       </SuccessBox>
     );
   } else {
-    hint = (
+    pollingStatus = (
       <WaitingInfo>
         <TextIcon
           css={`
@@ -186,7 +186,7 @@ export function SetupConnect(
         </ButtonSecondary>
       </StyledBox>
 
-      {hint}
+      {pollingStatus}
 
       <ActionButtons
         onProceed={props.nextStep}

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useCallback, useState, useRef } from 'react';
+import { Link } from 'react-router-dom';
 
 import { ButtonSecondary } from 'design/Button';
 import { Platform, getPlatform } from 'design/platform';
@@ -24,6 +25,7 @@ import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 import * as constants from 'shared/constants';
 
+import cfg from 'teleport/config';
 import useTeleport from 'teleport/useTeleport';
 import { Node } from 'teleport/services/nodes';
 
@@ -109,7 +111,12 @@ export function SetupConnect(
             <li>
               <Text>
                 The computer you are trying to add has already joined the
-                Teleport cluster before you entered this page.
+                Teleport cluster before you entered this page. If that's the
+                case, you can go back to{' '}
+                <Link to={cfg.getUnifiedResourcesRoute(clusterId)}>
+                  the resources
+                </Link>{' '}
+                and connect to it.
               </Text>
             </li>
           </ul>

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -212,6 +212,9 @@ export function SetupConnect(
  * check the returned nodes against this set. The hook stops polling as soon as a node that is not
  * in the set was found.
  *
+ * There can be multiple nodes matching the search criteria and we want the one that was added only
+ * after the user has started the guided flow, hence why we need to keep track of the IDs in a set.
+ *
  * Unlike the DownloadScript step responsible for adding a server, we don't have a unique ID that
  * identifies the node that the user added after following the steps from the guided flow. In
  * theory, we could make the deep link button pass such ID to Connect, but the user would still be
@@ -236,8 +239,8 @@ export const usePollForConnectMyComputerNode = (args: {
       async signal => {
         const request = {
           query: `labels["${constants.ConnectMyComputerNodeOwnerLabel}"] == "${args.username}"`,
-          // An arbitrary limit where we bank on the fact that no one is going to have 50 Connect My Computer
-          // nodes assigned to them running at the same time.
+          // An arbitrary limit where we bank on the fact that no one is going to have 50 Connect My
+          // Computer nodes assigned to them running at the same time.
           limit: 50,
         };
 

--- a/web/packages/teleport/src/Discover/Shared/HintBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/HintBox.tsx
@@ -23,8 +23,9 @@ import * as Icons from 'design/Icon';
 
 import { TextIcon } from 'teleport/Discover/Shared/Text';
 
-const HintBoxContainer = styled(Box)`
-  max-width: 1000px;
+const HintBoxContainer = styled(Box).attrs(props => ({
+  maxWidth: props.maxWidth,
+}))`
   background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
@@ -53,11 +54,12 @@ export const SuccessInfo = styled(Box)`
 
 interface HintBoxProps {
   header: string;
+  maxWidth?: string;
 }
 
 export function HintBox(props: React.PropsWithChildren<HintBoxProps>) {
   return (
-    <HintBoxContainer>
+    <HintBoxContainer maxWidth={props.maxWidth || '1000px'}>
       <Text color="warning.main">
         <Flex alignItems="center" mb={2}>
           <TextIcon

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -19,6 +19,8 @@ import { execFile } from 'node:child_process';
 import { access, rm } from 'node:fs/promises';
 import path from 'node:path';
 
+import * as constants from 'shared/constants';
+
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
 
@@ -49,8 +51,7 @@ export async function createAgentConfigFile(
   }
 
   const labels = Object.entries({
-    // TODO(ravicious): Move this to a JavaScript version of constants.go.
-    'teleport.dev/connect-my-computer/owner': args.username,
+    [constants.ConnectMyComputerNodeOwnerLabel]: args.username,
   })
     .map(keyAndValue => keyAndValue.join('='))
     .join(',');


### PR DESCRIPTION
Part of #32192.

[Figma](https://www.figma.com/file/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?type=design&node-id=1373-15152&mode=design&t=RsXxwZpyTdBHW1jq-4)

This PR implements the happy path for polling for a node during the Connect My Computer flow in Discover. It does not implement the second step, it also doesn't handle an edge case where for certain role setups the user needs to refresh the role list to be able to even see the node. Those cases will be addressed by another PR.

The video looping video shown in the Figma designs is yet to be recorded. I'm going to reorganize the setup of Connect My Computer in Connect soon so I want to avoid having to record the video twice.

## The original idea for polling

Originally the idea was to make it so that Connect configures the agent with a hidden label that contains the timestamp at which the agent was configured. Then when the guided flow gets opened, the Web UI would capture a timestamp and poll for nodes created only after the flow was started.

However, there are two problems with that:

1. Hidden labels are not sent to the Web UI so they cannot be used to implement this logic, not without rewriting how we handle hidden labels in the Web UI.
2. Fetching nodes where some timestamp in a label is greater than X is possible but not natively supported by our backend. So in the end we'd still need to fetch all nodes with that particular label and filter that on the frontend.

## What actually got implemented

Instead, we just poll for nodes labeled with `teleport.dev/connect-my-computer/owner: <current-username>`. The first response fills out a set with node IDs. Subsequent requests compare the received nodes against this set and return the first node not found in the set.

The end result for the most part is the same: the guided flow will detect a Connect My Computer node that has joined the cluster after the flow has started.

[The comment for `usePollForConnectMyComputerNode`](https://github.com/gravitational/teleport/blob/dc115892c8eaea3890dc1b5c82ec6db69b3e2bf2/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx#L204-L218) explains why we cannot do the polling the same way as when adding a regular SSH node through discover.