### PR TITLE
[v14] Introduce scaffolding for access list Slack notification.

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesslist
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/integrations/access/common"
+	"github.com/gravitational/teleport/integrations/access/common/teleport"
+	"github.com/gravitational/teleport/integrations/lib"
+	"github.com/gravitational/teleport/integrations/lib/logger"
+	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/interval"
+)
+
+func init() {
+	common.RegisterAppCreator("accesslist", NewApp)
+}
+
+const (
+	// oneWeek is the number of hours in a week.
+	oneWeek = 24 * time.Hour * 7
+)
+
+// App is the access list application for plugins. This will notify access list owners
+// when they need to review an access list.
+type App struct {
+	pluginName string
+	apiClient  teleport.Client
+	pluginData *pd.CompareAndSwap[pd.AccessListNotificationData]
+	bot        MessagingBot
+	job        lib.ServiceJob
+	clock      clockwork.Clock
+}
+
+// NewApp will create a new access list application.
+func NewApp(bot common.MessagingBot) (common.App, error) {
+	if _, ok := bot.(MessagingBot); !ok {
+		return nil, trace.BadParameter("bot does not support this app")
+	}
+	app := &App{}
+	app.job = lib.NewServiceJob(app.run)
+	return app, nil
+}
+
+// Init will initialize the application.
+func (a *App) Init(baseApp *common.BaseApp) error {
+	a.pluginName = baseApp.PluginName
+	a.apiClient = baseApp.APIClient
+	a.pluginData = pd.NewCAS(
+		a.apiClient,
+		a.pluginName,
+		types.KindAccessList,
+		pd.EncodeAccessListNotificationData,
+		pd.DecodeAccessListNotificationData,
+	)
+
+	var ok bool
+	a.bot, ok = baseApp.Bot.(MessagingBot)
+	if !ok {
+		return trace.BadParameter("bot does not implement access list bot methods")
+	}
+
+	a.clock = baseApp.Clock
+
+	return nil
+}
+
+// Start will start the application.
+func (a *App) Start(process *lib.Process) {
+	process.SpawnCriticalJob(a.job)
+}
+
+// WaitReady will block until the job is ready.
+func (a *App) WaitReady(ctx context.Context) (bool, error) {
+	return a.job.WaitReady(ctx)
+}
+
+// WaitForDone will wait until the job has completed.
+func (a *App) WaitForDone() {
+	<-a.job.Done()
+}
+
+// Err will return the error associated with the underlying job.
+func (a *App) Err() error {
+	return a.job.Err()
+}
+
+// run will monitor access lists and post review reminders.
+func (a *App) run(ctx context.Context) error {
+	process := lib.MustGetProcess(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+
+	// On process termination, explicitly cancel the context
+	process.OnTerminate(func(ctx context.Context) error {
+		cancel()
+		return nil
+	})
+
+	remindInterval := interval.New(interval.Config{
+		Duration:      time.Hour * 3,
+		FirstDuration: utils.FullJitter(time.Second * 30),
+		Jitter:        retryutils.NewSeventhJitter(),
+		Clock:         a.clock,
+	})
+	defer remindInterval.Stop()
+	log := logger.Get(ctx)
+
+	log.Info("Access list monitor is running")
+
+	a.job.SetReady(true)
+	for {
+		select {
+		case <-remindInterval.Next():
+			log.Info("Looking for Access List Review reminders")
+
+			var nextToken string
+			var err error
+			for {
+				var accessLists []*accesslist.AccessList
+				accessLists, nextToken, err = a.apiClient.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
+				if err != nil {
+					log.Errorf("error listing access lists: %v", err)
+					continue
+				}
+
+				for _, accessList := range accessLists {
+					if err := a.notifyForAccessListReviews(ctx, accessList); err != nil {
+						log.WithError(err).Warn("Error notifying for access list reviews")
+					}
+				}
+
+				if nextToken == "" {
+					break
+				}
+			}
+		case <-ctx.Done():
+			log.Info("Access list monitor is finished")
+			return nil
+		}
+	}
+}
+
+// notifyForAccessListReviews will notify if access list review dates are getting close. At the moment, this
+// only supports notifying owners.
+func (a *App) notifyForAccessListReviews(ctx context.Context, accessList *accesslist.AccessList) error {
+	// Find the current notification window.
+	now := a.clock.Now()
+	notificationStart := accessList.Spec.Audit.NextAuditDate.Add(-accessList.Spec.Audit.Notifications.Start)
+
+	allRecipients := a.fetchRecipients(ctx, accessList, now, notificationStart)
+	if len(allRecipients) == 0 {
+		return trace.NotFound("no recipients could be fetched for access list %s", accessList.GetName())
+	}
+
+	// Try to create base notification data with a zero notification date. If these objects already
+	// exist, that's okay.
+	userNotifications := map[string]time.Time{}
+	for _, recipient := range allRecipients {
+		userNotifications[recipient.Name] = time.Time{}
+	}
+	_, err := a.pluginData.Create(ctx, accessList.GetName(), pd.AccessListNotificationData{
+		UserNotifications: userNotifications,
+	})
+
+	// Error is okay so long as it's already exists.
+	if err != nil && !trace.IsAlreadyExists(err) {
+		return trace.Wrap(err, "during create")
+	}
+
+	return trace.Wrap(a.sendMessages(ctx, accessList, allRecipients, now, notificationStart))
+}
+
+// fetchRecipients will return all recipients.
+func (a *App) fetchRecipients(ctx context.Context, accessList *accesslist.AccessList, now, notificationStart time.Time) map[string]common.Recipient {
+	log := logger.Get(ctx)
+
+	allRecipients := make(map[string]common.Recipient, len(accessList.Spec.Owners))
+
+	// If the current time before the notification start time, skip notifications.
+	if now.Before(notificationStart) {
+		log.Debugf("Access list %s is not ready for notifications, notifications start at %s", accessList.GetName(), notificationStart.Format(time.RFC3339))
+		return nil
+	}
+
+	// Get the owners from the bot as recipients.
+	for _, owner := range accessList.Spec.Owners {
+		recipient, err := a.bot.FetchRecipient(ctx, owner.Name)
+		if err != nil {
+			log.Debugf("error getting recipient %s", owner.Name)
+			continue
+		}
+		allRecipients[owner.Name] = *recipient
+	}
+
+	return allRecipients
+}
+
+// sendMessages will send review notifications to owners and update the plugin data.
+func (a *App) sendMessages(ctx context.Context, accessList *accesslist.AccessList, allRecipients map[string]common.Recipient, now, notificationStart time.Time) error {
+	log := logger.Get(ctx)
+
+	// Calculate weeks from start.
+	weeksFromStart := now.Sub(notificationStart) / oneWeek
+	windowStart := notificationStart.Add(weeksFromStart * oneWeek)
+
+	recipients := []common.Recipient{}
+	_, err := a.pluginData.Update(ctx, accessList.GetName(), func(data pd.AccessListNotificationData) (pd.AccessListNotificationData, error) {
+		userNotifications := map[string]time.Time{}
+		for _, recipient := range allRecipients {
+			lastNotification := data.UserNotifications[recipient.Name]
+
+			// If the notification window is before the last notification date, then this user doesn't need a notification.
+			if !windowStart.After(lastNotification) {
+				log.Debugf("User %s has already been notified", recipient.Name)
+				userNotifications[recipient.Name] = lastNotification
+				continue
+			}
+
+			recipients = append(recipients, recipient)
+			userNotifications[recipient.Name] = now
+		}
+		if len(recipients) == 0 {
+			return pd.AccessListNotificationData{}, trace.NotFound("nobody to notify for access list %s", accessList.GetName())
+		}
+
+		if err := a.bot.SendReviewReminders(ctx, recipients, accessList); err != nil {
+			return pd.AccessListNotificationData{}, trace.Wrap(err)
+		}
+
+		return pd.AccessListNotificationData{UserNotifications: userNotifications}, nil
+	})
+	return trace.Wrap(err)
+}

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesslist
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/integrations/access/common"
+	"github.com/gravitational/teleport/integrations/access/common/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type mockMessagingBot struct {
+	lastReminderRecipients []common.Recipient
+	recipients             map[string]*common.Recipient
+}
+
+func (m *mockMessagingBot) CheckHealth(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	m.lastReminderRecipients = recipients
+	return nil
+}
+
+func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
+	fetchedRecipient, ok := m.recipients[recipient]
+	if !ok {
+		return nil, trace.NotFound("recipient %s not found", recipient)
+	}
+
+	return fetchedRecipient, nil
+}
+
+type mockPluginConfig struct {
+	as  *auth.Server
+	bot *mockMessagingBot
+}
+
+func (m *mockPluginConfig) GetTeleportClient(ctx context.Context) (teleport.Client, error) {
+	return m.as, nil
+}
+
+func (m *mockPluginConfig) GetRecipients() common.RawRecipientsMap {
+	return nil
+}
+
+func (m *mockPluginConfig) NewBot(clusterName string, webProxyAddr string) (common.MessagingBot, error) {
+	return m.bot, nil
+}
+
+func (m *mockPluginConfig) GetPluginType() types.PluginType {
+	return types.PluginTypeSlack
+}
+
+func TestAccessListReminders(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	server, err := auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			Dir:   t.TempDir(),
+			Clock: clock,
+		},
+	})
+	require.NoError(t, err)
+	as := server.Auth()
+
+	bot := &mockMessagingBot{
+		recipients: map[string]*common.Recipient{
+			"owner1": {Name: "owner1"},
+			"owner2": {Name: "owner2"},
+		},
+	}
+	app := common.NewApp(&mockPluginConfig{as: as, bot: bot}, "test-plugin")
+	app.Clock = clock
+	ctx := context.Background()
+	go func() {
+		require.NoError(t, app.Run(ctx))
+	}()
+
+	ready, err := app.WaitReady(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	t.Cleanup(func() {
+		app.Terminate()
+		<-app.Done()
+		require.NoError(t, app.Err())
+	})
+
+	accessList, err := accesslist.NewAccessList(header.Metadata{
+		Name: "test-access-list",
+	}, accesslist.Spec{
+		Title:  "test access list",
+		Owners: []accesslist.Owner{{Name: "owner1"}, {Name: "not-found"}},
+		Grants: accesslist.Grants{
+			Roles: []string{"role"},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: clock.Now().Add(28 * 24 * time.Hour), // Four weeks out from today
+			Notifications: accesslist.Notifications{
+				Start: time.Hour * 24 * 14, // Start alerting at two weeks before audit date
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// No notifications for today
+	advanceAndLookForRecipients(t, bot, as, clock, 0, accessList)
+
+	// Advance by one week, expect no notifications.
+	advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList)
+
+	// Advance by one week, expect a notification. "not-found" will be missing as a recipient.
+	advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList, "owner1")
+
+	// Add a new owner.
+	accessList.Spec.Owners = append(accessList.Spec.Owners, accesslist.Owner{Name: "owner2"})
+
+	// Advance by one day, expect a notification only to the new owner.
+	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList, "owner2")
+
+	// Advance by one day, expect no notifications.
+	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+
+	// Advance by five more days, to the next week, expect two notifications
+	advanceAndLookForRecipients(t, bot, as, clock, 24*5*time.Hour, accessList, "owner1", "owner2")
+
+	// Advance by one day, expect no notifications
+	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+
+	// Advance by one day, expect no notifications
+	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+
+	// Advance by five more days, to the next week, expect two notifications
+	advanceAndLookForRecipients(t, bot, as, clock, 24*5*time.Hour, accessList, "owner1", "owner2")
+
+	// Advance by one year a week at a time, expect two notifications each time.
+	for i := 0; i < 52; i++ {
+		advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList, "owner1", "owner2")
+	}
+}
+
+func advanceAndLookForRecipients(t *testing.T,
+	bot *mockMessagingBot,
+	alSvc services.AccessLists,
+	clock clockwork.FakeClock,
+	advance time.Duration,
+	accessList *accesslist.AccessList,
+	recipients ...string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := alSvc.UpsertAccessList(ctx, accessList)
+	require.NoError(t, err)
+
+	bot.lastReminderRecipients = nil
+
+	var expectedRecipients []common.Recipient
+	if len(recipients) > 0 {
+		expectedRecipients = make([]common.Recipient, len(recipients))
+		for i, r := range recipients {
+			expectedRecipients[i] = common.Recipient{Name: r}
+		}
+	}
+	clock.Advance(advance)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
+	}, 5*time.Second, 250*time.Millisecond)
+}

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesslist
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/integrations/access/common"
+)
+
+type MessagingBot interface {
+	common.MessagingBot
+
+	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
+	SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error
+}

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accessrequest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/accessrequest"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
+	"github.com/gravitational/teleport/integrations/access/common/teleport"
+	"github.com/gravitational/teleport/integrations/lib"
+	"github.com/gravitational/teleport/integrations/lib/logger"
+	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
+	"github.com/gravitational/teleport/integrations/lib/watcherjob"
+)
+
+func init() {
+	common.RegisterAppCreator("accessrequest", NewApp)
+}
+
+const (
+	// handlerTimeout is used to bound the execution time of watcher event handler.
+	handlerTimeout = time.Second * 5
+)
+
+// App is the access request application for plugins. This will notify when access requests
+// are created and reviewed.
+type App struct {
+	pluginName string
+	pluginType string
+	apiClient  teleport.Client
+	recipients common.RawRecipientsMap
+	pluginData *pd.CompareAndSwap[PluginData]
+	bot        MessagingBot
+	job        lib.ServiceJob
+}
+
+// NewApp will create a new access request application.
+func NewApp(bot common.MessagingBot) (common.App, error) {
+	if _, ok := bot.(MessagingBot); !ok {
+		return nil, trace.BadParameter("bot does not support this app")
+	}
+	app := &App{}
+	app.job = lib.NewServiceJob(app.run)
+	return app, nil
+}
+
+func (a *App) Init(baseApp *common.BaseApp) error {
+	a.pluginName = baseApp.PluginName
+	a.pluginType = string(baseApp.Conf.GetPluginType())
+	a.apiClient = baseApp.APIClient
+	a.recipients = baseApp.Conf.GetRecipients()
+	a.pluginData = pd.NewCAS(
+		a.apiClient,
+		a.pluginName,
+		types.KindAccessRequest,
+		EncodePluginData,
+		DecodePluginData,
+	)
+
+	var ok bool
+	a.bot, ok = baseApp.Bot.(MessagingBot)
+	if !ok {
+		return trace.BadParameter("bot does not implement access request bot methods")
+	}
+
+	return nil
+}
+
+// Start will start the application.
+func (a *App) Start(process *lib.Process) {
+	process.SpawnCriticalJob(a.job)
+}
+
+// WaitReady will block until the job is ready.
+func (a *App) WaitReady(ctx context.Context) (bool, error) {
+	return a.job.WaitReady(ctx)
+}
+
+// WaitForDone will wait until the job has completed.
+func (a *App) WaitForDone() {
+	<-a.job.Done()
+}
+
+// Err will return the error associated with the underlying job.
+func (a *App) Err() error {
+	if a.job != nil {
+		return a.job.Err()
+	}
+
+	return nil
+}
+
+func (a *App) run(ctx context.Context) error {
+	process := lib.MustGetProcess(ctx)
+
+	job, err := watcherjob.NewJob(
+		a.apiClient,
+		watcherjob.Config{
+			Watch:            types.Watch{Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}}},
+			EventFuncTimeout: handlerTimeout,
+		},
+		a.onWatcherEvent,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	process.SpawnCriticalJob(job)
+
+	ok, err := job.WaitReady(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	a.job.SetReady(ok)
+	if !ok {
+		return trace.BadParameter("job not ready")
+	}
+
+	<-job.Done()
+	return nil
+}
+
+// onWatcherEvent is called for every cluster Event. It will filter out non-access-request events and
+// call onPendingRequest, onResolvedRequest and on DeletedRequest depending on the event.
+func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
+	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
+		return trace.Errorf("unexpected kind %s", kind)
+	}
+	op := event.Type
+	reqID := event.Resource.GetName()
+	ctx, _ = logger.WithField(ctx, "request_id", reqID)
+
+	switch op {
+	case types.OpPut:
+		ctx, _ = logger.WithField(ctx, "request_op", "put")
+		req, ok := event.Resource.(types.AccessRequest)
+		if !ok {
+			return trace.Errorf("unexpected resource type %T", event.Resource)
+		}
+		ctx, log := logger.WithField(ctx, "request_state", req.GetState().String())
+
+		var err error
+		switch {
+		case req.GetState().IsPending():
+			err = a.onPendingRequest(ctx, req)
+		case req.GetState().IsResolved():
+			err = a.onResolvedRequest(ctx, req)
+		default:
+			log.WithField("event", event).Warn("Unknown request state")
+			return nil
+		}
+
+		if err != nil {
+			log.WithError(err).Errorf("Failed to process request")
+			return trace.Wrap(err)
+		}
+
+		return nil
+	case types.OpDelete:
+		ctx, log := logger.WithField(ctx, "request_op", "delete")
+
+		if err := a.onDeletedRequest(ctx, reqID); err != nil {
+			log.WithError(err).Errorf("Failed to process deleted request")
+			return trace.Wrap(err)
+		}
+		return nil
+	default:
+		return trace.BadParameter("unexpected event operation %s", op)
+	}
+}
+
+func (a *App) onPendingRequest(ctx context.Context, req types.AccessRequest) error {
+	log := logger.Get(ctx)
+
+	reqID := req.GetName()
+
+	resourceNames, err := a.getResourceNames(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	reqData := pd.AccessRequestData{
+		User:              req.GetUser(),
+		Roles:             req.GetRoles(),
+		RequestReason:     req.GetRequestReason(),
+		SystemAnnotations: req.GetSystemAnnotations(),
+		Resources:         resourceNames,
+	}
+
+	_, err = a.pluginData.Create(ctx, reqID, PluginData{AccessRequestData: reqData})
+	switch {
+	case err == nil:
+		// This is a new access-request, we have to broadcast it first.
+		if recipients := a.getMessageRecipients(ctx, req); len(recipients) > 0 {
+			if err := a.broadcastAccessRequestMessages(ctx, recipients, reqID, reqData); err != nil {
+				return trace.Wrap(err)
+			}
+		} else {
+			log.Warning("No channel to post")
+		}
+	case trace.IsAlreadyExists(err):
+		// The messages were already sent, nothing to do, we can update the reviews
+	default:
+		// This is an unexpected error, returning
+		return trace.Wrap(err)
+	}
+
+	// This is an already existing access request, we post reviews and update its status
+	if reqReviews := req.GetReviews(); len(reqReviews) > 0 {
+		if err := a.postReviewReplies(ctx, reqID, reqReviews); err != nil {
+			return trace.Wrap(err)
+		}
+
+		err := a.updateMessages(ctx, reqID, pd.Unresolved, "", reqReviews)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (a *App) onResolvedRequest(ctx context.Context, req types.AccessRequest) error {
+	// We always post review replies in thread. If the messaging service does not support
+	// threading this will do nothing
+	replyErr := a.postReviewReplies(ctx, req.GetName(), req.GetReviews())
+
+	reason := req.GetResolveReason()
+	state := req.GetState()
+	var tag pd.ResolutionTag
+
+	switch state {
+	case types.RequestState_APPROVED:
+		tag = pd.ResolvedApproved
+	case types.RequestState_DENIED:
+		tag = pd.ResolvedDenied
+	case types.RequestState_PROMOTED:
+		tag = pd.ResolvedPromoted
+	default:
+		logger.Get(ctx).Warningf("Unknown state %v (%s)", state, state.String())
+		return replyErr
+	}
+	err := trace.Wrap(a.updateMessages(ctx, req.GetName(), tag, reason, req.GetReviews()))
+	return trace.NewAggregate(replyErr, err)
+}
+
+func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
+	return a.updateMessages(ctx, reqID, pd.ResolvedExpired, "", nil)
+}
+
+// broadcastAccessRequestMessages sends nessages to each recipient for an access-request.
+// This method is only called when for new access-requests.
+func (a *App) broadcastAccessRequestMessages(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) error {
+	sentMessages, err := a.bot.BroadcastAccessRequestMessage(ctx, recipients, reqID, reqData)
+	if len(sentMessages) == 0 && err != nil {
+		return trace.Wrap(err)
+	}
+	for _, data := range sentMessages {
+		logger.Get(ctx).WithFields(logger.Fields{
+			"channel_id": data.ChannelID,
+			"message_id": data.MessageID,
+		}).Info("Successfully posted messages")
+	}
+	if err != nil {
+		logger.Get(ctx).WithError(err).Error("Failed to post one or more messages")
+	}
+
+	_, err = a.pluginData.Update(ctx, reqID, func(existing PluginData) (PluginData, error) {
+		existing.SentMessages = sentMessages
+		return existing, nil
+	})
+
+	return trace.Wrap(err)
+}
+
+// postReviewReplies lists and updates existing messages belonging to an access request.
+// Posting reviews is done both by updating the original message and by replying in thread if possible.
+func (a *App) postReviewReplies(ctx context.Context, reqID string, reqReviews []types.AccessReview) error {
+	var oldCount int
+
+	pd, err := a.pluginData.Update(ctx, reqID, func(existing PluginData) (PluginData, error) {
+		sentMessages := existing.SentMessages
+		if len(sentMessages) == 0 {
+			// wait for the plugin data to be updated with SentMessages
+			return PluginData{}, trace.CompareFailed("existing sentMessages is empty")
+		}
+
+		count := len(reqReviews)
+		oldCount = existing.ReviewsCount
+		if oldCount >= count {
+			return PluginData{}, trace.AlreadyExists("reviews are sent already")
+		}
+
+		existing.ReviewsCount = count
+		return existing, nil
+	})
+	if trace.IsAlreadyExists(err) {
+		logger.Get(ctx).Debug("Failed to post reply: replies are already sent")
+		return nil
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	slice := reqReviews[oldCount:]
+	if len(slice) == 0 {
+		return nil
+	}
+
+	errors := make([]error, 0, len(slice))
+	for _, data := range pd.SentMessages {
+		ctx, _ = logger.WithFields(ctx, logger.Fields{"channel_id": data.ChannelID, "message_id": data.MessageID})
+		for _, review := range slice {
+			if err := a.bot.PostReviewReply(ctx, data.ChannelID, data.MessageID, review); err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// getMessageRecipients takes an access request and returns a list of channelIDs that should be messaged.
+// channelIDs can represent any communication channel depending on the MessagingBot implementation:
+// a public channel, a private one, or a user direct message channel.
+func (a *App) getMessageRecipients(ctx context.Context, req types.AccessRequest) []common.Recipient {
+	log := logger.Get(ctx)
+
+	// We receive a set from GetRawRecipientsFor but we still might end up with duplicate channel names.
+	// This can happen if this set contains the channel `C` and the email for channel `C`.
+	recipientSet := common.NewRecipientSet()
+
+	switch a.pluginType {
+	case types.PluginTypeServiceNow:
+		// The ServiceNow plugin does not use recipients currently and create incidents in the incident table directly.
+		// Recipients just needs to be non empty.
+		recipientSet.Add(common.Recipient{})
+		return recipientSet.ToSlice()
+	case types.PluginTypeOpsgenie:
+		if recipients, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationSchedulesLabel]; ok {
+			for _, recipient := range recipients {
+				rec, err := a.bot.FetchRecipient(ctx, recipient)
+				if err != nil {
+					log.Warning(err)
+				}
+				recipientSet.Add(*rec)
+			}
+			return recipientSet.ToSlice()
+		}
+	}
+
+	validEmailSuggReviewers := []string{}
+	for _, reviewer := range req.GetSuggestedReviewers() {
+		if !lib.IsEmail(reviewer) {
+			log.Warningf("Failed to notify a suggested reviewer: %q does not look like a valid email", reviewer)
+			continue
+		}
+
+		validEmailSuggReviewers = append(validEmailSuggReviewers, reviewer)
+	}
+	rawRecipients := a.recipients.GetRawRecipientsFor(req.GetRoles(), validEmailSuggReviewers)
+	for _, rawRecipient := range rawRecipients {
+		recipient, err := a.bot.FetchRecipient(ctx, rawRecipient)
+		if err != nil {
+			log.WithError(err).Warn("Failure when fetching recipient, continuing anyway")
+		} else {
+			recipientSet.Add(*recipient)
+		}
+	}
+
+	return recipientSet.ToSlice()
+}
+
+// updateMessages updates the messages status and adds the resolve reason.
+func (a *App) updateMessages(ctx context.Context, reqID string, tag pd.ResolutionTag, reason string, reviews []types.AccessReview) error {
+	log := logger.Get(ctx)
+
+	pluginData, err := a.pluginData.Update(ctx, reqID, func(existing PluginData) (PluginData, error) {
+		if len(existing.SentMessages) == 0 {
+			return PluginData{}, trace.NotFound("plugin data not found")
+		}
+
+		// If resolution field is not empty then we already resolved the incident before. In this case we just quit.
+		if existing.AccessRequestData.ResolutionTag != pd.Unresolved {
+			return PluginData{}, trace.AlreadyExists("request is already resolved")
+		}
+
+		// Mark plugin data as resolved.
+		existing.ResolutionTag = tag
+		existing.ResolutionReason = reason
+
+		return existing, nil
+	})
+	if trace.IsNotFound(err) {
+		log.Debug("Failed to update messages: plugin data is missing")
+		return nil
+	}
+	if trace.IsAlreadyExists(err) {
+		if tag != pluginData.ResolutionTag {
+			return trace.WrapWithMessage(err,
+				"cannot change the resolution tag of an already resolved request, existing: %s, event: %s",
+				pluginData.ResolutionTag, tag)
+		}
+		log.Debug("Request is already resolved, ignoring event")
+		return nil
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	reqData, sentMessages := pluginData.AccessRequestData, pluginData.SentMessages
+	if err := a.bot.UpdateMessages(ctx, reqID, reqData, sentMessages, reviews); err != nil {
+		return trace.Wrap(err)
+	}
+
+	log.Infof("Successfully marked request as %s in all messages", tag)
+
+	return nil
+}
+
+func (a *App) getResourceNames(ctx context.Context, req types.AccessRequest) ([]string, error) {
+	resourceNames := make([]string, 0, len(req.GetRequestedResourceIDs()))
+	resourcesByCluster := accessrequest.GetResourceIDsByCluster(req)
+
+	for cluster, resources := range resourcesByCluster {
+		resourceDetails, err := accessrequest.GetResourceDetails(ctx, cluster, a.apiClient, resources)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, resource := range resources {
+			resourceName := types.ResourceIDToString(resource)
+			if details, ok := resourceDetails[resourceName]; ok && details.FriendlyName != "" {
+				resourceName = fmt.Sprintf("%s/%s", resource.Kind, details.FriendlyName)
+			}
+			resourceNames = append(resourceNames, resourceName)
+		}
+	}
+	return resourceNames, nil
+}

--- a/integrations/access/accessrequest/bot.go
+++ b/integrations/access/accessrequest/bot.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accessrequest
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
+	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
+)
+
+type MessagingBot interface {
+	common.MessagingBot
+
+	// BroadcastAccessRequestMessage sends an access request message to a list of Recipient
+	BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data SentMessages, err error)
+	// PostReviewReply posts in thread an access request review. This does nothing if the messaging service
+	// does not support threaded replies.
+	PostReviewReply(ctx context.Context, channelID string, threadID string, review types.AccessReview) error
+	// UpdateMessages updates access request messages that were previously sent via Broadcast
+	// This is used to change the access-request status and number of required approval remaining
+	UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, messageData SentMessages, reviews []types.AccessReview) error
+}

--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package accessrequest
 
 import (
 	"fmt"

--- a/integrations/access/accessrequest/plugindata.go
+++ b/integrations/access/accessrequest/plugindata.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package accessrequest
 
 import (
 	"fmt"
@@ -25,8 +25,8 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
 )
 
-// GenericPluginData is a data associated with access request that we store in Teleport using UpdatePluginData API.
-type GenericPluginData struct {
+// PluginData is a data associated with access request that we store in Teleport using UpdatePluginData API.
+type PluginData struct {
 	plugindata.AccessRequestData
 	SentMessages
 }
@@ -42,14 +42,14 @@ type MessageData struct {
 
 type SentMessages []MessageData
 
-// DecodePluginData deserializes a string map to GenericPluginData struct.
-func DecodePluginData(dataMap map[string]string) (GenericPluginData, error) {
-	data := GenericPluginData{}
+// DecodePluginData deserializes a string map to PluginData struct.
+func DecodePluginData(dataMap map[string]string) (PluginData, error) {
+	data := PluginData{}
 
 	var err error
 	data.AccessRequestData, err = plugindata.DecodeAccessRequestData(dataMap)
 	if err != nil {
-		return GenericPluginData{}, trace.Wrap(err)
+		return PluginData{}, trace.Wrap(err)
 	}
 
 	if channelID, timestamp := dataMap["channel_id"], dataMap["timestamp"]; channelID != "" && timestamp != "" {
@@ -66,8 +66,8 @@ func DecodePluginData(dataMap map[string]string) (GenericPluginData, error) {
 	return data, nil
 }
 
-// EncodePluginData serializes a GenericPluginData struct into a string map.
-func EncodePluginData(data GenericPluginData) (map[string]string, error) {
+// EncodePluginData serializes a PluginData struct into a string map.
+func EncodePluginData(data PluginData) (map[string]string, error) {
 	result, err := plugindata.EncodeAccessRequestData(data.AccessRequestData)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/integrations/access/accessrequest/plugindata_test.go
+++ b/integrations/access/accessrequest/plugindata_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package accessrequest
 
 import (
 	"testing"
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
 )
 
-var samplePluginData = GenericPluginData{
+var samplePluginData = PluginData{
 	AccessRequestData: plugindata.AccessRequestData{
 		User:             "user-foo",
 		Roles:            []string{"role-foo", "role-bar"},
@@ -68,7 +68,7 @@ func TestDecodePluginData(t *testing.T) {
 }
 
 func TestEncodeEmptyPluginData(t *testing.T) {
-	dataMap, err := EncodePluginData(GenericPluginData{})
+	dataMap, err := EncodePluginData(PluginData{})
 	assert.NoError(t, err)
 	assert.Len(t, dataMap, 8)
 	for key, value := range dataMap {

--- a/integrations/access/common/app.go
+++ b/integrations/access/common/app.go
@@ -19,18 +19,16 @@ package common
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
-	"github.com/gravitational/teleport/api/accessrequest"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
-	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
-	"github.com/gravitational/teleport/integrations/lib/watcherjob"
 )
 
 const (
@@ -38,33 +36,54 @@ const (
 	minServerVersion = "6.1.0-beta.1"
 	// InitTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
-	// handlerTimeout is used to bound the execution time of watcher event handler.
-	handlerTimeout = time.Second * 5
 )
 
-// BaseApp is responsible for handling all the access-request logic.
+var (
+	appCreatorRegistry   = map[string]AppCreator{}
+	appCreatorRegistryMu sync.Mutex
+)
+
+// AppCreator will create an application for use by the plugin.
+type AppCreator func(bot MessagingBot) (App, error)
+
+// RegisterApp will register the app creator function.
+func RegisterAppCreator(name string, fn AppCreator) {
+	appCreatorRegistryMu.Lock()
+	defer appCreatorRegistryMu.Unlock()
+
+	if _, ok := appCreatorRegistry[name]; ok {
+		panic(fmt.Sprintf("duplicate plugin application %s", name))
+	}
+
+	appCreatorRegistry[name] = fn
+}
+
+// BaseApp is responsible for handling the common features for a plugin.
 // It will start a Teleport client, listen for events and treat them.
 // It also handles signals and watches its thread.
 // To instantiate a new BaseApp, use NewApp()
 type BaseApp struct {
 	PluginName string
-	apiClient  teleport.Client
-	bot        MessagingBot
-	mainJob    lib.ServiceJob
-	pluginData *pd.CompareAndSwap[GenericPluginData]
+	APIClient  teleport.Client
 	Conf       PluginConfiguration
+	Bot        MessagingBot
+	Clock      clockwork.Clock
+
+	apps    []App
+	mainJob lib.ServiceJob
 
 	*lib.Process
 }
 
 // NewApp creates a new BaseApp and initialize its main job
 func NewApp(conf PluginConfiguration, pluginName string) *BaseApp {
-	app := BaseApp{
+	baseApp := BaseApp{
 		PluginName: pluginName,
 		Conf:       conf,
 	}
-	app.mainJob = lib.NewServiceJob(app.run)
-	return &app
+	baseApp.mainJob = lib.NewServiceJob(baseApp.run)
+
+	return &baseApp
 }
 
 // Run initializes and runs a watcher and a callback server
@@ -90,7 +109,7 @@ func (a *BaseApp) checkTeleportVersion(ctx context.Context) (proto.PingResponse,
 	log := logger.Get(ctx)
 	log.Debug("Checking Teleport server version")
 
-	pong, err := a.apiClient.Ping(ctx)
+	pong, err := a.APIClient.Ping(ctx)
 	if err != nil {
 		if trace.IsNotImplemented(err) {
 			return pong, trace.Wrap(err, "server version must be at least %s", minServerVersion)
@@ -108,7 +127,7 @@ func (a *BaseApp) initTeleport(ctx context.Context, conf PluginConfiguration) (c
 		return "", "", trace.Wrap(err)
 	}
 
-	a.apiClient = clt
+	a.APIClient = clt
 	pong, err := a.checkTeleportVersion(ctx)
 	if err != nil {
 		return "", "", trace.Wrap(err)
@@ -121,53 +140,12 @@ func (a *BaseApp) initTeleport(ctx context.Context, conf PluginConfiguration) (c
 	return pong.ClusterName, webProxyAddr, nil
 }
 
-// onWatcherEvent is called for every cluster Event. It will filter out non-access-request events and
-// call onPendingRequest, onResolvedRequest and on DeletedRequest depending on the event.
-func (a *BaseApp) onWatcherEvent(ctx context.Context, event types.Event) error {
-	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %s", kind)
-	}
-	op := event.Type
-	reqID := event.Resource.GetName()
-	ctx, _ = logger.WithField(ctx, "request_id", reqID)
-
-	switch op {
-	case types.OpPut:
-		ctx, _ = logger.WithField(ctx, "request_op", "put")
-		req, ok := event.Resource.(types.AccessRequest)
-		if !ok {
-			return trace.Errorf("unexpected resource type %T", event.Resource)
-		}
-		ctx, log := logger.WithField(ctx, "request_state", req.GetState().String())
-
-		var err error
-		switch {
-		case req.GetState().IsPending():
-			err = a.onPendingRequest(ctx, req)
-		case req.GetState().IsResolved():
-			err = a.onResolvedRequest(ctx, req)
-		default:
-			log.WithField("event", event).Warn("Unknown request state")
-			return nil
-		}
-
-		if err != nil {
-			log.WithError(err).Errorf("Failed to process request")
-			return trace.Wrap(err)
-		}
-
-		return nil
-	case types.OpDelete:
-		ctx, log := logger.WithField(ctx, "request_op", "delete")
-
-		if err := a.onDeletedRequest(ctx, reqID); err != nil {
-			log.WithError(err).Errorf("Failed to process deleted request")
-			return trace.Wrap(err)
-		}
-		return nil
-	default:
-		return trace.BadParameter("unexpected event operation %s", op)
-	}
+type App interface {
+	Init(baseApp *BaseApp) error
+	Start(process *lib.Process)
+	WaitReady(ctx context.Context) (bool, error)
+	WaitForDone()
+	Err() error
 }
 
 // run starts the event watcher job and blocks utils it stops
@@ -177,33 +155,40 @@ func (a *BaseApp) run(ctx context.Context) error {
 	if err := a.init(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	watcherJob, err := watcherjob.NewJob(
-		a.apiClient,
-		watcherjob.Config{
-			Watch:            types.Watch{Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}}},
-			EventFuncTimeout: handlerTimeout,
-		},
-		a.onWatcherEvent,
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	a.SpawnCriticalJob(watcherJob)
-	ok, err := watcherJob.WaitReady(ctx)
-	if err != nil {
-		return trace.Wrap(err)
+
+	for _, app := range a.apps {
+		app.Start(a.Process)
 	}
 
-	a.mainJob.SetReady(ok)
-	if ok {
+	allOK := true
+	for _, app := range a.apps {
+		ok, err := app.WaitReady(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		allOK = allOK && ok
+		if !allOK {
+			break
+		}
+	}
+
+	a.mainJob.SetReady(allOK)
+	if allOK {
 		log.Info("Plugin is ready")
 	} else {
 		log.Error("Plugin is not ready")
 	}
 
-	<-watcherJob.Done()
+	for _, app := range a.apps {
+		app.WaitForDone()
+	}
 
-	return trace.Wrap(watcherJob.Err())
+	var allErrs []error
+	for _, app := range a.apps {
+		allErrs = append(allErrs, app.Err())
+	}
+	return trace.NewAggregate(allErrs...)
 }
 
 func (a *BaseApp) init(ctx context.Context) error {
@@ -216,295 +201,38 @@ func (a *BaseApp) init(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	a.bot, err = a.Conf.NewBot(clusterName, webProxyAddr)
+	a.Bot, err = a.Conf.NewBot(clusterName, webProxyAddr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	a.pluginData = pd.NewCAS(
-		a.apiClient,
-		a.PluginName,
-		types.KindAccessRequest,
-		EncodePluginData,
-		DecodePluginData,
-	)
+	appCreatorRegistryMu.Lock()
+	for appName, appCreatorFn := range appCreatorRegistry {
+		app, err := appCreatorFn(a.Bot)
+		if err != nil {
+			log.Debugf("Plugin %s does not support app %s", a.PluginName, appName)
+			continue
+		}
+
+		a.apps = append(a.apps, app)
+	}
+	appCreatorRegistryMu.Unlock()
+
+	if len(a.apps) == 0 {
+		return trace.BadParameter("no apps supported for this plugin")
+	}
+
+	for _, app := range a.apps {
+		if err := app.Init(a); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 
 	log.Debug("Starting API health check...")
-	if err = a.bot.CheckHealth(ctx); err != nil {
+	if err = a.Bot.CheckHealth(ctx); err != nil {
 		return trace.Wrap(err, "API health check failed")
 	}
 
 	log.Debug("API health check finished ok")
 	return nil
-}
-
-func (a *BaseApp) onPendingRequest(ctx context.Context, req types.AccessRequest) error {
-	log := logger.Get(ctx)
-
-	reqID := req.GetName()
-
-	resourceNames, err := a.getResourceNames(ctx, req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	reqData := pd.AccessRequestData{
-		User:               req.GetUser(),
-		Roles:              req.GetRoles(),
-		RequestReason:      req.GetRequestReason(),
-		SystemAnnotations:  req.GetSystemAnnotations(),
-		Resources:          resourceNames,
-		SuggestedReviewers: req.GetSuggestedReviewers(),
-	}
-
-	_, err = a.pluginData.Create(ctx, reqID, GenericPluginData{AccessRequestData: reqData})
-	switch {
-	case err == nil:
-		// This is a new access-request, we have to broadcast it first.
-		if recipients := a.getMessageRecipients(ctx, req); len(recipients) > 0 {
-			if err := a.broadcastMessages(ctx, recipients, reqID, reqData); err != nil {
-				return trace.Wrap(err)
-			}
-		} else {
-			log.Warning("No channel to post")
-		}
-	case trace.IsAlreadyExists(err):
-		// The messages were already sent, nothing to do, we can update the reviews
-	default:
-		// This is an unexpected error, returning
-		return trace.Wrap(err)
-	}
-
-	// This is an already existing access request, we post reviews and update its status
-	if reqReviews := req.GetReviews(); len(reqReviews) > 0 {
-		if err := a.postReviewReplies(ctx, reqID, reqReviews); err != nil {
-			return trace.Wrap(err)
-		}
-
-		err := a.updateMessages(ctx, reqID, pd.Unresolved, "", reqReviews)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	return nil
-}
-
-func (a *BaseApp) onResolvedRequest(ctx context.Context, req types.AccessRequest) error {
-	// We always post review replies in thread. If the messaging service does not support
-	// threading this will do nothing
-	replyErr := a.postReviewReplies(ctx, req.GetName(), req.GetReviews())
-
-	reason := req.GetResolveReason()
-	state := req.GetState()
-	var tag pd.ResolutionTag
-
-	switch state {
-	case types.RequestState_APPROVED:
-		tag = pd.ResolvedApproved
-	case types.RequestState_DENIED:
-		tag = pd.ResolvedDenied
-	case types.RequestState_PROMOTED:
-		tag = pd.ResolvedPromoted
-	default:
-		logger.Get(ctx).Warningf("Unknown state %v (%s)", state, state.String())
-		return replyErr
-	}
-	err := trace.Wrap(a.updateMessages(ctx, req.GetName(), tag, reason, req.GetReviews()))
-	return trace.NewAggregate(replyErr, err)
-}
-
-func (a *BaseApp) onDeletedRequest(ctx context.Context, reqID string) error {
-	return a.updateMessages(ctx, reqID, pd.ResolvedExpired, "", nil)
-}
-
-// broadcastMessages sends nessages to each recipient for an access-request.
-// This method is only called when for new access-requests.
-func (a *BaseApp) broadcastMessages(ctx context.Context, recipients []Recipient, reqID string, reqData pd.AccessRequestData) error {
-	sentMessages, err := a.bot.Broadcast(ctx, recipients, reqID, reqData)
-	if len(sentMessages) == 0 && err != nil {
-		return trace.Wrap(err)
-	}
-	for _, data := range sentMessages {
-		logger.Get(ctx).WithFields(logger.Fields{
-			"channel_id": data.ChannelID,
-			"message_id": data.MessageID,
-		}).Info("Successfully posted messages")
-	}
-	if err != nil {
-		logger.Get(ctx).WithError(err).Error("Failed to post one or more messages")
-	}
-
-	_, err = a.pluginData.Update(ctx, reqID, func(existing GenericPluginData) (GenericPluginData, error) {
-		existing.SentMessages = sentMessages
-		return existing, nil
-	})
-
-	return trace.Wrap(err)
-}
-
-// postReviewReplies lists and updates existing messages belonging to an access request.
-// Posting reviews is done both by updating the original message and by replying in thread if possible.
-func (a *BaseApp) postReviewReplies(ctx context.Context, reqID string, reqReviews []types.AccessReview) error {
-	var oldCount int
-
-	pd, err := a.pluginData.Update(ctx, reqID, func(existing GenericPluginData) (GenericPluginData, error) {
-		sentMessages := existing.SentMessages
-		if len(sentMessages) == 0 {
-			// wait for the plugin data to be updated with SentMessages
-			return GenericPluginData{}, trace.CompareFailed("existing sentMessages is empty")
-		}
-
-		count := len(reqReviews)
-		oldCount = existing.ReviewsCount
-		if oldCount >= count {
-			return GenericPluginData{}, trace.AlreadyExists("reviews are sent already")
-		}
-
-		existing.ReviewsCount = count
-		return existing, nil
-	})
-	if trace.IsAlreadyExists(err) {
-		logger.Get(ctx).Debug("Failed to post reply: replies are already sent")
-		return nil
-	}
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	slice := reqReviews[oldCount:]
-	if len(slice) == 0 {
-		return nil
-	}
-
-	errors := make([]error, 0, len(slice))
-	for _, data := range pd.SentMessages {
-		ctx, _ = logger.WithFields(ctx, logger.Fields{"channel_id": data.ChannelID, "message_id": data.MessageID})
-		for _, review := range slice {
-			if err := a.bot.PostReviewReply(ctx, data.ChannelID, data.MessageID, review); err != nil {
-				errors = append(errors, err)
-			}
-		}
-	}
-	return trace.NewAggregate(errors...)
-}
-
-// getMessageRecipients takes an access request and returns a list of channelIDs that should be messaged.
-// channelIDs can represent any communication channel depending on the MessagingBot implementation:
-// a public channel, a private one, or a user direct message channel.
-func (a *BaseApp) getMessageRecipients(ctx context.Context, req types.AccessRequest) []Recipient {
-	log := logger.Get(ctx)
-
-	// We receive a set from GetRawRecipientsFor but we still might end up with duplicate channel names.
-	// This can happen if this set contains the channel `C` and the email for channel `C`.
-	recipientSet := NewRecipientSet()
-
-	switch a.Conf.GetPluginType() {
-	case types.PluginTypeServiceNow:
-		// The ServiceNow plugin does not use recipients currently and create incidents in the incident table directly.
-		// Recipients just needs to be non empty.
-		recipientSet.Add(Recipient{})
-		return recipientSet.ToSlice()
-	case types.PluginTypeOpsgenie:
-		if recipients, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationSchedulesLabel]; ok {
-			for _, recipient := range recipients {
-				rec, err := a.bot.FetchRecipient(ctx, recipient)
-				if err != nil {
-					log.Warning(err)
-				}
-				recipientSet.Add(*rec)
-			}
-			return recipientSet.ToSlice()
-		}
-	}
-
-	validEmailSuggReviewers := []string{}
-	for _, reviewer := range req.GetSuggestedReviewers() {
-		if !lib.IsEmail(reviewer) {
-			log.Warningf("Failed to notify a suggested reviewer: %q does not look like a valid email", reviewer)
-			continue
-		}
-
-		validEmailSuggReviewers = append(validEmailSuggReviewers, reviewer)
-	}
-	rawRecipients := a.Conf.GetRecipients().GetRawRecipientsFor(req.GetRoles(), validEmailSuggReviewers)
-	for _, rawRecipient := range rawRecipients {
-		recipient, err := a.bot.FetchRecipient(ctx, rawRecipient)
-		if err != nil {
-			// Something wrong happened, we log the error and continue to treat valid rawRecipients
-			log.Warning(err)
-		} else {
-			recipientSet.Add(*recipient)
-		}
-	}
-
-	return recipientSet.ToSlice()
-}
-
-// updateMessages updates the messages status and adds the resolve reason.
-func (a *BaseApp) updateMessages(ctx context.Context, reqID string, tag pd.ResolutionTag, reason string, reviews []types.AccessReview) error {
-	log := logger.Get(ctx)
-
-	pluginData, err := a.pluginData.Update(ctx, reqID, func(existing GenericPluginData) (GenericPluginData, error) {
-		if len(existing.SentMessages) == 0 {
-			return GenericPluginData{}, trace.NotFound("plugin data not found")
-		}
-
-		// If resolution field is not empty then we already resolved the incident before. In this case we just quit.
-		if existing.AccessRequestData.ResolutionTag != pd.Unresolved {
-			return GenericPluginData{}, trace.AlreadyExists("request is already resolved")
-		}
-
-		// Mark plugin data as resolved.
-		existing.ResolutionTag = tag
-		existing.ResolutionReason = reason
-
-		return existing, nil
-	})
-	if trace.IsNotFound(err) {
-		log.Debug("Failed to update messages: plugin data is missing")
-		return nil
-	}
-	if trace.IsAlreadyExists(err) {
-		if tag != pluginData.ResolutionTag {
-			return trace.WrapWithMessage(err,
-				"cannot change the resolution tag of an already resolved request, existing: %s, event: %s",
-				pluginData.ResolutionTag, tag)
-		}
-		log.Debug("Request is already resolved, ignoring event")
-		return nil
-	}
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	reqData, sentMessages := pluginData.AccessRequestData, pluginData.SentMessages
-	if err := a.bot.UpdateMessages(ctx, reqID, reqData, sentMessages, reviews); err != nil {
-		return trace.Wrap(err)
-	}
-
-	log.Infof("Successfully marked request as %s in all messages", tag)
-
-	return nil
-}
-
-func (a *BaseApp) getResourceNames(ctx context.Context, req types.AccessRequest) ([]string, error) {
-	resourceNames := make([]string, 0, len(req.GetRequestedResourceIDs()))
-	resourcesByCluster := accessrequest.GetResourceIDsByCluster(req)
-
-	for cluster, resources := range resourcesByCluster {
-		resourceDetails, err := accessrequest.GetResourceDetails(ctx, cluster, a.apiClient, resources)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		for _, resource := range resources {
-			resourceName := types.ResourceIDToString(resource)
-			if details, ok := resourceDetails[resourceName]; ok && details.FriendlyName != "" {
-				resourceName = fmt.Sprintf("%s/%s", resource.Kind, details.FriendlyName)
-			}
-			resourceNames = append(resourceNames, resourceName)
-		}
-	}
-	return resourceNames, nil
 }

--- a/integrations/access/common/bot.go
+++ b/integrations/access/common/bot.go
@@ -17,10 +17,7 @@ limitations under the License.
 package common
 
 import (
-	"golang.org/x/net/context"
-
-	"github.com/gravitational/teleport/api/types"
-	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
+	"context"
 )
 
 // MessagingBot is a generic interface with all methods required to send notifications through a messaging service.
@@ -29,14 +26,6 @@ import (
 type MessagingBot interface {
 	// CheckHealth checks if the bot can connect to its messaging service
 	CheckHealth(ctx context.Context) error
-	// Broadcast sends an access request message to a list of Recipient
-	Broadcast(ctx context.Context, recipients []Recipient, reqID string, reqData pd.AccessRequestData) (data SentMessages, err error)
-	// PostReviewReply posts in thread an access request review. This does nothing if the messaging service
-	// does not support threaded replies.
-	PostReviewReply(ctx context.Context, channelID string, threadID string, review types.AccessReview) error
-	// UpdateMessages updates access request messages that were previously sent via Broadcast
-	// This is used to change the access-request status and number of required approval remaining
-	UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, messageData SentMessages, reviews []types.AccessReview) error
 	// FetchRecipient fetches recipient data from the messaging service API. It can also be used to check and initialize
 	// a communication channel (e.g. MsTeams needs to install the app for the user before being able to send
 	// notifications)

--- a/integrations/access/common/teleport/client.go
+++ b/integrations/access/common/teleport/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Client aggregates the parts of Teleport API client interface
@@ -33,4 +34,5 @@ type Client interface {
 	SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error)
 	SetAccessRequestState(ctx context.Context, params types.AccessRequestUpdate) error
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
+	AccessListClient() services.AccessLists
 }

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -106,9 +108,14 @@ func (b DiscordBot) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
-// Broadcast posts request info to Discord.
-func (b DiscordBot) Broadcast(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (common.SentMessages, error) {
-	var data common.SentMessages
+// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
+func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list review reminder is not yet implemented")
+}
+
+// BroadcastAccessRequestMessage posts request info to Discord.
+func (b DiscordBot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
+	var data accessrequest.SentMessages
 	var errors []error
 
 	for _, recipient := range recipients {
@@ -125,7 +132,7 @@ func (b DiscordBot) Broadcast(ctx context.Context, recipients []common.Recipient
 			errors = append(errors, trace.Wrap(err))
 			continue
 		}
-		data = append(data, common.MessageData{ChannelID: recipient.ID, MessageID: result.DiscordID})
+		data = append(data, accessrequest.MessageData{ChannelID: recipient.ID, MessageID: result.DiscordID})
 
 	}
 
@@ -138,7 +145,7 @@ func (b DiscordBot) PostReviewReply(ctx context.Context, channelID, timestamp st
 }
 
 // UpdateMessages updates already posted Discord messages
-func (b DiscordBot) UpdateMessages(ctx context.Context, reqID string, reqData pd.AccessRequestData, messagingData common.SentMessages, reviews []types.AccessReview) error {
+func (b DiscordBot) UpdateMessages(ctx context.Context, reqID string, reqData pd.AccessRequestData, messagingData accessrequest.SentMessages, reviews []types.AccessReview) error {
 	var errors []error
 	for _, msg := range messagingData {
 		_, err := b.client.NewRequest().
@@ -161,7 +168,7 @@ func (b DiscordBot) discordEmbeds(reviews []types.AccessReview) []DiscordEmbed {
 	reviewEmbeds := make([]DiscordEmbed, len(reviews))
 	for i, review := range reviews {
 		if review.Reason != "" {
-			review.Reason = lib.MarkdownEscape(review.Reason, common.ReviewReasonLimit)
+			review.Reason = lib.MarkdownEscape(review.Reason, accessrequest.ReviewReasonLimit)
 		}
 
 		var color int
@@ -194,18 +201,18 @@ func (b DiscordBot) discordEmbeds(reviews []types.AccessReview) []DiscordEmbed {
 
 func (b DiscordBot) discordMsgText(reqID string, reqData pd.AccessRequestData) string {
 	return "You have a new Role Request:\n" +
-		common.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL) +
-		common.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
+		accessrequest.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL) +
+		accessrequest.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
 }
 
-func (b DiscordBot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
+func (b DiscordBot) FetchRecipient(ctx context.Context, name string) (*common.Recipient, error) {
 	// Discord does not support resolving email addresses with bot permissions
 	// This bot does not implement channel name resolving yet, this is doable but will require caching
 	// as the endpoint returns all channels at the same time and is rate-limited.
 	// FetchRecipient currently only supports creating recipients from ChannelIDs.
 	return &common.Recipient{
-		Name: recipient,
-		ID:   recipient,
+		Name: name,
+		ID:   name,
 		Kind: "Channel",
 		Data: nil,
 	}, nil

--- a/integrations/access/discord/config.go
+++ b/integrations/access/discord/config.go
@@ -82,7 +82,7 @@ func (c *Config) GetTeleportClient(ctx context.Context) (teleport.Client, error)
 	if c.Client != nil {
 		return c.Client, nil
 	}
-	return c.BaseConfig.Teleport.NewClient(ctx)
+	return c.BaseConfig.GetTeleportClient(ctx)
 }
 
 // NewBot initializes the new Discord message generator (DiscordBot)

--- a/integrations/access/discord/discord_test.go
+++ b/integrations/access/discord/discord_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -240,14 +241,14 @@ func (s *DiscordSuite) createAccessRequest() types.AccessRequest {
 	return out
 }
 
-func (s *DiscordSuite) checkPluginData(reqID string, cond func(common.GenericPluginData) bool) common.GenericPluginData {
+func (s *DiscordSuite) checkPluginData(reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
 	t := s.T()
 	t.Helper()
 
 	for {
 		rawData, err := s.ruler().PollAccessRequestPluginData(s.Context(), "discord", reqID)
 		require.NoError(t, err)
-		data, err := common.DecodePluginData(rawData)
+		data, err := accessrequest.DecodePluginData(rawData)
 		require.NoError(t, err)
 		if cond(data) {
 			return data
@@ -269,7 +270,7 @@ func (s *DiscordSuite) TestMessagePosting() {
 	s.startApp()
 	request := s.createAccessRequest()
 
-	pluginData := s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	pluginData := s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 	assert.Len(t, pluginData.SentMessages, 2)
@@ -279,7 +280,7 @@ func (s *DiscordSuite) TestMessagePosting() {
 	for i := 0; i < 2; i++ {
 		msg, err := s.fakeDiscord.CheckNewMessage(s.Context())
 		require.NoError(t, err)
-		messageSet.Add(common.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID})
+		messageSet.Add(accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID})
 		messages = append(messages, msg)
 	}
 
@@ -387,7 +388,7 @@ func (s *DiscordSuite) TestReviewUpdates() {
 
 	request := s.createAccessRequest()
 
-	s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
@@ -446,7 +447,7 @@ func (s *DiscordSuite) TestApprovalByReview() {
 
 	request := s.createAccessRequest()
 
-	s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
@@ -504,7 +505,7 @@ func (s *DiscordSuite) TestDenialByReview() {
 
 	request := s.createAccessRequest()
 
-	s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
@@ -558,7 +559,7 @@ func (s *DiscordSuite) TestExpiration() {
 
 	request := s.createAccessRequest()
 
-	s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
@@ -566,7 +567,7 @@ func (s *DiscordSuite) TestExpiration() {
 	require.NoError(t, err)
 	assert.Equal(t, s.appConfig.Recipients["editor"][0], msg.Channel)
 
-	s.checkPluginData(request.GetName(), func(data common.GenericPluginData) bool {
+	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
@@ -641,7 +642,7 @@ func (s *DiscordSuite) TestRace() {
 				return setRaceErr(trace.Wrap(err))
 			}
 
-			threadMsgKey := common.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID}
+			threadMsgKey := accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID}
 			if _, loaded := threadMsgIDs.LoadOrStore(threadMsgKey, struct{}{}); loaded {
 				return setRaceErr(trace.Errorf("thread %v already stored", threadMsgKey))
 			}
@@ -682,7 +683,7 @@ func (s *DiscordSuite) TestRace() {
 				return setRaceErr(trace.Wrap(err))
 			}
 
-			threadMsgKey := common.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID}
+			threadMsgKey := accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.DiscordID}
 			var newCounter int32
 			val, _ := msgUpdateCounters.LoadOrStore(threadMsgKey, &newCounter)
 			counterPtr := val.(*int32)

--- a/integrations/access/discord/helpers_test.go
+++ b/integrations/access/discord/helpers_test.go
@@ -14,10 +14,12 @@
 
 package discord
 
-import "github.com/gravitational/teleport/integrations/access/common"
+import (
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
+)
 
 type MessageSlice []DiscordMsg
-type MessageSet map[common.MessageData]struct{}
+type MessageSet map[accessrequest.MessageData]struct{}
 
 func (slice MessageSlice) Len() int {
 	return len(slice)
@@ -34,11 +36,11 @@ func (slice MessageSlice) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func (set MessageSet) Add(msg common.MessageData) {
+func (set MessageSet) Add(msg accessrequest.MessageData) {
 	set[msg] = struct{}{}
 }
 
-func (set MessageSet) Contains(msg common.MessageData) bool {
+func (set MessageSet) Contains(msg accessrequest.MessageData) bool {
 	_, ok := set[msg]
 	return ok
 }

--- a/integrations/access/jira/app.go
+++ b/integrations/access/jira/app.go
@@ -132,7 +132,7 @@ func (a *App) run(ctx context.Context) error {
 	watcherJob, err := watcherjob.NewJob(
 		a.teleport,
 		watcherjob.Config{
-			Watch:            types.Watch{Kinds: []types.WatchKind{types.WatchKind{Kind: types.KindAccessRequest}}},
+			Watch:            types.Watch{Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}}},
 			EventFuncTimeout: handlerTimeout,
 		},
 		a.onWatcherEvent,
@@ -170,7 +170,7 @@ func (a *App) init(ctx context.Context) error {
 
 	var err error
 	if a.teleport == nil {
-		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
+		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -29,6 +29,8 @@ import (
 	"github.com/mailgun/holster/v3/collections"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -228,14 +230,19 @@ func (b Bot) GetMe(ctx context.Context) (User, error) {
 	return userResult(resp)
 }
 
-// Broadcast posts request info to Mattermost.
-func (b Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (common.SentMessages, error) {
+// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list review reminder is not yet implemented")
+}
+
+// BroadcastAccessRequestMessage posts request info to Mattermost.
+func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (accessrequest.SentMessages, error) {
 	text, err := b.buildPostText(reqID, reqData)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var data common.SentMessages
+	var data accessrequest.SentMessages
 	var errors []error
 
 	for _, recipient := range recipients {
@@ -253,7 +260,7 @@ func (b Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqID
 			continue
 		}
 
-		data = append(data, common.MessageData{ChannelID: post.ChannelID, MessageID: post.ID})
+		data = append(data, accessrequest.MessageData{ChannelID: post.ChannelID, MessageID: post.ID})
 	}
 
 	return data, trace.NewAggregate(errors...)
@@ -355,7 +362,7 @@ func (b Bot) LookupDirectChannel(ctx context.Context, email string) (string, err
 	return channel.ID, nil
 }
 
-func (b Bot) UpdateMessages(ctx context.Context, reqID string, reqData pd.AccessRequestData, mmData common.SentMessages, reviews []types.AccessReview) error {
+func (b Bot) UpdateMessages(ctx context.Context, reqID string, reqData pd.AccessRequestData, mmData accessrequest.SentMessages, reviews []types.AccessReview) error {
 	text, err := b.buildPostText(reqID, reqData)
 	if err != nil {
 		return trace.Wrap(err)
@@ -469,26 +476,26 @@ func (b Bot) tryLookupChannel(ctx context.Context, team, name string) string {
 }
 
 // FetchRecipient returns the recipient for the given raw recipient.
-func (b Bot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
+func (b Bot) FetchRecipient(ctx context.Context, name string) (*common.Recipient, error) {
 	var channel string
 	kind := "Channel"
 
 	// Recipients from config file could contain either email or team and
 	// channel names separated by '/' symbol. It's up to user what format to use.
-	if lib.IsEmail(recipient) {
-		channel = b.tryLookupDirectChannel(ctx, recipient)
+	if lib.IsEmail(name) {
+		channel = b.tryLookupDirectChannel(ctx, name)
 		kind = "Email"
 	} else {
-		parts := strings.Split(recipient, "/")
+		parts := strings.Split(name, "/")
 		if len(parts) == 2 {
 			channel = b.tryLookupChannel(ctx, parts[0], parts[1])
 		} else {
-			return nil, trace.BadParameter("Recipient must be either a user email or a channel in the format \"team/channel\" but got %q", recipient)
+			return nil, trace.BadParameter("Recipient must be either a user email or a channel in the format \"team/channel\" but got %q", name)
 		}
 	}
 
 	return &common.Recipient{
-		Name: recipient,
+		Name: name,
 		ID:   channel,
 		Kind: kind,
 		Data: nil,

--- a/integrations/access/mattermost/config.go
+++ b/integrations/access/mattermost/config.go
@@ -92,7 +92,7 @@ func (c *Config) CheckAndSetDefaults() error {
 func (c *Config) NewBot(clusterName, webProxyAddr string) (common.MessagingBot, error) {
 	bot, err := NewBot(*c, clusterName, webProxyAddr)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return Bot{}, trace.Wrap(err)
 	}
 	return bot, nil
 }

--- a/integrations/access/mattermost/helper_test.go
+++ b/integrations/access/mattermost/helper_test.go
@@ -21,11 +21,11 @@ import (
 	"sync/atomic"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/access/common"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 )
 
 type MattermostPostSlice []Post
-type MattermostDataPostSet map[common.MessageData]struct{}
+type MattermostDataPostSet map[accessrequest.MessageData]struct{}
 
 func (slice MattermostPostSlice) Len() int {
 	return len(slice)
@@ -42,11 +42,11 @@ func (slice MattermostPostSlice) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func (set MattermostDataPostSet) Add(msg common.MessageData) {
+func (set MattermostDataPostSet) Add(msg accessrequest.MessageData) {
 	set[msg] = struct{}{}
 }
 
-func (set MattermostDataPostSet) Contains(msg common.MessageData) bool {
+func (set MattermostDataPostSet) Contains(msg accessrequest.MessageData) bool {
 	_, ok := set[msg]
 	return ok
 }

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -29,6 +29,7 @@ import (
 	tp "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
@@ -139,7 +140,7 @@ func (a *App) init(ctx context.Context) error {
 
 	var err error
 	if a.teleport == nil {
-		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
+		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
 )
@@ -43,8 +45,13 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 	return trace.Wrap(b.client.CheckHealth(ctx))
 }
 
-// Broadcast creates an alert for the provided recipients (schedules)
-func (b *Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data common.SentMessages, err error) {
+// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list review reminder is not yet implemented")
+}
+
+// BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)
+func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	schedules := []string{}
 	for _, recipient := range recipients {
 		schedules = append(schedules, recipient.Name)
@@ -70,7 +77,7 @@ func (b *Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqI
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	data = common.SentMessages{{
+	data = accessrequest.SentMessages{{
 		ChannelID: opsgenieData.ServiceID,
 		MessageID: opsgenieData.AlertID,
 	}}
@@ -86,7 +93,7 @@ func (b *Bot) PostReviewReply(ctx context.Context, _ string, alertID string, rev
 
 // UpdateMessages add notes to the alert containing updates to status.
 // This will also resolve alerts based on the resolution tag.
-func (b *Bot) UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, alertData common.SentMessages, reviews []types.AccessReview) error {
+func (b *Bot) UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, alertData accessrequest.SentMessages, reviews []types.AccessReview) error {
 	var errs []error
 	for _, alert := range alertData {
 		resolution := Resolution{
@@ -102,10 +109,10 @@ func (b *Bot) UpdateMessages(ctx context.Context, reqID string, data pd.AccessRe
 }
 
 // FetchRecipient returns the recipient for the given raw recipient.
-func (b *Bot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
+func (b *Bot) FetchRecipient(ctx context.Context, name string) (*common.Recipient, error) {
 	return &common.Recipient{
-		Name: recipient,
-		ID:   recipient,
+		Name: name,
+		ID:   name,
 		Kind: common.RecipientKindSchedule,
 	}, nil
 }

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -110,7 +110,7 @@ func (a *App) run(ctx context.Context) error {
 	watcherJob, err := watcherjob.NewJob(
 		a.teleport,
 		watcherjob.Config{
-			Watch:            types.Watch{Kinds: []types.WatchKind{types.WatchKind{Kind: types.KindAccessRequest}}},
+			Watch:            types.Watch{Kinds: []types.WatchKind{{Kind: types.KindAccessRequest}}},
 			EventFuncTimeout: handlerTimeout,
 		},
 		a.onWatcherEvent,
@@ -147,7 +147,7 @@ func (a *App) init(ctx context.Context) error {
 	)
 
 	if a.teleport == nil {
-		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
+		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -31,6 +31,7 @@ import (
 	tp "github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
@@ -139,7 +140,7 @@ func (a *App) init(ctx context.Context) error {
 
 	var err error
 	if a.teleport == nil {
-		if a.teleport, err = a.conf.Teleport.NewClient(ctx); err != nil {
+		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
 )
@@ -42,8 +44,13 @@ func (b *Bot) CheckHealth(ctx context.Context) error {
 	return trace.Wrap(b.client.CheckHealth(ctx))
 }
 
-// Broadcast creates a ServiceNow incident.
-func (b *Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data common.SentMessages, err error) {
+// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
+func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
+	return trace.NotImplemented("access list review reminder is not yet implemented")
+}
+
+// BroadcastAccessRequestMessage creates a ServiceNow incident.
+func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
 	serviceNowReqData := RequestData{
 		User:               reqData.User,
 		Roles:              reqData.Roles,
@@ -57,7 +64,7 @@ func (b *Bot) Broadcast(ctx context.Context, recipients []common.Recipient, reqI
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	data = common.SentMessages{{
+	data = accessrequest.SentMessages{{
 		MessageID: serviceNowData.IncidentID,
 	}}
 
@@ -71,7 +78,7 @@ func (b *Bot) PostReviewReply(ctx context.Context, _ string, incidentID string, 
 
 // UpdateMessages add notes to the incident containing updates to status.
 // This will also resolve incidents based on the resolution tag.
-func (b *Bot) UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, incidentData common.SentMessages, reviews []types.AccessReview) error {
+func (b *Bot) UpdateMessages(ctx context.Context, reqID string, data pd.AccessRequestData, incidentData accessrequest.SentMessages, reviews []types.AccessReview) error {
 	var errs []error
 
 	var state string

--- a/integrations/access/slack/helpers_test.go
+++ b/integrations/access/slack/helpers_test.go
@@ -19,11 +19,11 @@ import (
 	"sync/atomic"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/access/common"
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
 )
 
 type SlackMessageSlice []Message
-type SlackDataMessageSet map[common.MessageData]struct{}
+type SlackDataMessageSet map[accessrequest.MessageData]struct{}
 
 func (slice SlackMessageSlice) Len() int {
 	return len(slice)
@@ -40,11 +40,11 @@ func (slice SlackMessageSlice) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func (set SlackDataMessageSet) Add(msg common.MessageData) {
+func (set SlackDataMessageSet) Add(msg accessrequest.MessageData) {
 	set[msg] = struct{}{}
 }
 
-func (set SlackDataMessageSet) Contains(msg common.MessageData) bool {
+func (set SlackDataMessageSet) Contains(msg accessrequest.MessageData) bool {
 	_, ok := set[msg]
 	return ok
 }

--- a/integrations/lib/plugindata/access_list.go
+++ b/integrations/lib/plugindata/access_list.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugindata
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+// AccessListNotificationData represents generic plugin data required for access list notifications
+type AccessListNotificationData struct {
+	UserNotifications map[string]time.Time
+}
+
+// DecodeAccessListNotificationData deserializes a string map to PluginData struct.
+func DecodeAccessListNotificationData(dataMap map[string]string) (data AccessListNotificationData, err error) {
+	userNotificationsData := dataMap["user_notifications"]
+	if userNotificationsData != "" {
+		if err := json.Unmarshal([]byte(userNotificationsData), &data.UserNotifications); err != nil {
+			return data, trace.Wrap(err)
+		}
+	}
+
+	return data, nil
+}
+
+// EncodeAccessListNotificationData deserializes a string map to PluginData struct.
+func EncodeAccessListNotificationData(data AccessListNotificationData) (map[string]string, error) {
+	result := make(map[string]string)
+
+	result["user_notifications"] = ""
+
+	if len(data.UserNotifications) > 0 {
+		userNotificationsData, err := json.Marshal(data.UserNotifications)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		result["user_notifications"] = string(userNotificationsData)
+	}
+
+	return result, nil
+}

--- a/integrations/lib/plugindata/access_list_test.go
+++ b/integrations/lib/plugindata/access_list_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugindata
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sampleAccessListNotificationData = AccessListNotificationData{
+	UserNotifications: map[string]time.Time{
+		"user-foo":   time.Now().UTC(),
+		"user-foo-2": time.Now().UTC(),
+	},
+}
+
+func TestEncodeAccessListNotificationData(t *testing.T) {
+	dataMap, err := EncodeAccessListNotificationData(sampleAccessListNotificationData)
+	assert.NoError(t, err)
+	assert.Len(t, dataMap, 1)
+
+	userNotificationsData, err := json.Marshal(sampleAccessListNotificationData.UserNotifications)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"user_notifications": string(userNotificationsData),
+	}, dataMap)
+}
+
+func TestDecodeAccessListNotificationData(t *testing.T) {
+	userNotificationsData, err := json.Marshal(sampleAccessListNotificationData.UserNotifications)
+	require.NoError(t, err)
+	pluginData, err := DecodeAccessListNotificationData(map[string]string{
+		"user_notifications": string(userNotificationsData),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, sampleAccessListNotificationData, pluginData)
+}
+
+func TestEncodeEmptyAccessListNotificationtData(t *testing.T) {
+	dataMap, err := EncodeAccessListNotificationData(AccessListNotificationData{})
+	assert.NoError(t, err)
+	assert.Len(t, dataMap, 1)
+	assert.Empty(t, dataMap["userNotifications"])
+}
+
+func TestDecodeEmptyAccessListNotificationtData(t *testing.T) {
+	decoded, err := DecodeAccessListNotificationData(nil)
+	assert.NoError(t, err)
+	assert.Empty(t, decoded)
+	decoded, err = DecodeAccessListNotificationData(make(map[string]string))
+	assert.NoError(t, err)
+	assert.Empty(t, decoded)
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -257,6 +257,9 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
+	if cfg.PluginData == nil {
+		cfg.PluginData = local.NewPluginData(cfg.Backend, cfg.DynamicAccessExt)
+	}
 	if cfg.Integrations == nil {
 		cfg.Integrations, err = local.NewIntegrationsService(cfg.Backend)
 		if err != nil {
@@ -340,6 +343,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		UsageReporter:           cfg.UsageReporter,
 		Assistant:               cfg.Assist,
 		UserPreferences:         cfg.UserPreferences,
+		PluginData:              cfg.PluginData,
 	}
 
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
@@ -480,6 +484,7 @@ type Services struct {
 	services.Assistant
 	services.Embeddings
 	services.UserPreferences
+	services.PluginData
 	usagereporter.UsageReporter
 	types.Events
 	events.AuditLogSessionStreamer

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2773,15 +2773,15 @@ func (a *ServerWithRoles) GetAccessCapabilities(ctx context.Context, req types.A
 // GetPluginData loads all plugin data matching the supplied filter.
 func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
 	switch filter.Kind {
-	case types.KindAccessRequest:
-		// for backwards compatibility, we allow list/read against access requests to also grant list/read for
+	case types.KindAccessRequest, types.KindAccessList:
+		// for backwards compatibility, we allow list/read against kinds to also grant list/read for
 		// access request related plugin data.
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, types.KindAccessRequest, types.VerbList) != nil {
+		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, filter.Kind, types.VerbList) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbList); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, types.KindAccessRequest, types.VerbRead) != nil {
+		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, filter.Kind, types.VerbRead) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbRead); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2795,10 +2795,10 @@ func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter types.Plugin
 // UpdatePluginData updates a per-resource PluginData entry.
 func (a *ServerWithRoles) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
 	switch params.Kind {
-	case types.KindAccessRequest:
+	case types.KindAccessRequest, types.KindAccessList:
 		// for backwards compatibility, we allow update against access requests to also grant update for
 		// access request related plugin data.
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, types.KindAccessRequest, types.VerbUpdate) != nil {
+		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, params.Kind, types.VerbUpdate) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbUpdate); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -248,6 +248,9 @@ type InitConfig struct {
 	// SecReports is a service that manages security reports.
 	SecReports services.SecReports
 
+	// PluginData is a service that manages plugin data.
+	PluginData services.PluginData
+
 	// Clock is the clock instance auth uses. Typically you'd only want to set
 	// this during testing.
 	Clock clockwork.Clock

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -160,8 +160,6 @@ func (r *RequestIDs) IsEmpty() bool {
 type AccessRequestGetter interface {
 	// GetAccessRequests gets all currently active access requests.
 	GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error)
-	// GetPluginData loads all plugin data matching the supplied filter.
-	GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error)
 }
 
 // DynamicAccessCore is the core functionality common to all DynamicAccess implementations.
@@ -171,8 +169,6 @@ type DynamicAccessCore interface {
 	CreateAccessRequestV2(ctx context.Context, req types.AccessRequest) (types.AccessRequest, error)
 	// DeleteAccessRequest deletes an access request.
 	DeleteAccessRequest(ctx context.Context, reqID string) error
-	// UpdatePluginData updates a per-resource PluginData entry.
-	UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error
 }
 
 // DynamicAccess is a service which manages dynamic RBAC.  Specifically, this is the
@@ -693,7 +689,7 @@ ProcessReviews:
 }
 
 // GetAccessRequest is a helper function assists with loading a specific request by ID.
-func GetAccessRequest(ctx context.Context, acc DynamicAccess, reqID string) (types.AccessRequest, error) {
+func GetAccessRequest(ctx context.Context, acc DynamicAccessCore, reqID string) (types.AccessRequest, error) {
 	reqs, err := acc.GetAccessRequests(ctx, types.AccessRequestFilter{
 		ID: reqID,
 	})

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -71,7 +70,6 @@ func (s *DynamicAccessService) SetAccessRequestState(ctx context.Context, params
 	if err := params.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	retryPeriod := retryPeriodMs * time.Millisecond
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
 		Step: retryPeriod / 7,
 		Max:  retryPeriod,
@@ -140,7 +138,6 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 	if err := params.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	retryPeriod := retryPeriodMs * time.Millisecond
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
 		Step: retryPeriod / 7,
 		Max:  retryPeriod,
@@ -232,7 +229,9 @@ func (s *DynamicAccessService) GetAccessRequests(ctx context.Context, filter typ
 		}
 		return []types.AccessRequest{req}, nil
 	}
-	result, err := s.GetRange(ctx, backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix)), backend.NoLimit)
+	startKey := backend.ExactKey(accessRequestsPrefix)
+	endKey := backend.RangeEnd(startKey)
+	result, err := s.GetRange(ctx, startKey, endKey, backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -268,7 +267,9 @@ func (s *DynamicAccessService) DeleteAccessRequest(ctx context.Context, name str
 }
 
 func (s *DynamicAccessService) DeleteAllAccessRequests(ctx context.Context) error {
-	return trace.Wrap(s.DeleteRange(ctx, backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix))))
+	startKey := backend.ExactKey(accessRequestsPrefix)
+	endKey := backend.RangeEnd(startKey)
+	return trace.Wrap(s.DeleteRange(ctx, startKey, endKey))
 }
 
 func (s *DynamicAccessService) UpsertAccessRequest(ctx context.Context, req types.AccessRequest) error {
@@ -322,160 +323,6 @@ func (s *DynamicAccessService) GetAccessRequestAllowedPromotions(ctx context.Con
 	return promotions, nil
 }
 
-// GetPluginData loads all plugin data matching the supplied filter.
-func (s *DynamicAccessService) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	switch filter.Kind {
-	case types.KindAccessRequest:
-		data, err := s.getAccessRequestPluginData(ctx, filter)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return data, nil
-	default:
-		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
-	}
-}
-
-func (s *DynamicAccessService) getAccessRequestPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	// Filters which specify Resource are a special case since they will match exactly zero or one
-	// possible PluginData instances.
-	if filter.Resource != "" {
-		item, err := s.Get(ctx, pluginDataKey(types.KindAccessRequest, filter.Resource))
-		if err != nil {
-			// A filter with zero matches is still a success, it just
-			// happens to return an empty slice.
-			if trace.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, trace.Wrap(err)
-		}
-		data, err := itemToPluginData(*item)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !filter.Match(data) {
-			// A filter with zero matches is still a success, it just
-			// happens to return an empty slice.
-			return nil, nil
-		}
-		return []types.PluginData{data}, nil
-	}
-	prefix := backend.Key(pluginDataPrefix, types.KindAccessRequest)
-	result, err := s.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var matches []types.PluginData
-	for _, item := range result.Items {
-		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
-			// Item represents a different resource type in the
-			// same namespace.
-			continue
-		}
-		data, err := itemToPluginData(item)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !filter.Match(data) {
-			continue
-		}
-		matches = append(matches, data)
-	}
-	return matches, nil
-}
-
-// UpdatePluginData updates a per-resource PluginData entry.
-func (s *DynamicAccessService) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	switch params.Kind {
-	case types.KindAccessRequest:
-		return trace.Wrap(s.updateAccessRequestPluginData(ctx, params))
-	default:
-		return trace.BadParameter("unsupported resource kind %q", params.Kind)
-	}
-}
-
-func (s *DynamicAccessService) updateAccessRequestPluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	retryPeriod := retryPeriodMs * time.Millisecond
-	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		Step: retryPeriod / 7,
-		Max:  retryPeriod,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// Update is attempted multiple times in the event of concurrent writes.
-	for i := 0; i < maxCmpAttempts; i++ {
-		var create bool
-		var data types.PluginData
-		item, err := s.Get(ctx, pluginDataKey(types.KindAccessRequest, params.Resource))
-		if err == nil {
-			data, err = itemToPluginData(*item)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			create = false
-		} else {
-			if !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-			// In order to prevent orphaned plugin data, we automatically
-			// configure new instances to expire shortly after the AccessRequest
-			// to which they are associated.  This discrepency in expiry gives
-			// plugins the ability to use stored data when handling an expiry
-			// (OpDelete) event.
-			req, err := s.GetAccessRequest(ctx, params.Resource)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			data, err = types.NewPluginData(params.Resource, types.KindAccessRequest)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			data.SetExpiry(req.GetAccessExpiry().Add(time.Hour))
-			create = true
-		}
-		if err := data.Update(params); err != nil {
-			return trace.Wrap(err)
-		}
-		if err := data.CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-		newItem, err := itemFromPluginData(data)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if create {
-			if _, err := s.Create(ctx, newItem); err != nil {
-				if trace.IsAlreadyExists(err) {
-					select {
-					case <-retry.After():
-						retry.Inc()
-						continue
-					case <-ctx.Done():
-						return trace.Wrap(ctx.Err())
-					}
-				}
-				return trace.Wrap(err)
-			}
-		} else {
-			if _, err := s.CompareAndSwap(ctx, *item, newItem); err != nil {
-				if trace.IsCompareFailed(err) {
-					select {
-					case <-retry.After():
-						retry.Inc()
-						continue
-					case <-ctx.Done():
-						return trace.Wrap(ctx.Err())
-					}
-				}
-				return trace.Wrap(err)
-			}
-		}
-		return nil
-	}
-	return trace.CompareFailed("too many concurrent writes to plugin data %s", params.Resource)
-}
-
 func itemFromAccessRequest(req types.AccessRequest) (backend.Item, error) {
 	rev := req.GetRevision()
 	value, err := services.MarshalAccessRequest(req)
@@ -522,39 +369,6 @@ func itemToAccessRequest(item backend.Item, opts ...services.MarshalOption) (typ
 	return req, nil
 }
 
-func itemFromPluginData(data types.PluginData) (backend.Item, error) {
-	rev := data.GetRevision()
-	value, err := services.MarshalPluginData(data)
-	if err != nil {
-		return backend.Item{}, trace.Wrap(err)
-	}
-	// enforce explicit limit on resource size in order to prevent PluginData from
-	// growing uncontrollably.
-	if len(value) > teleport.MaxResourceSize {
-		return backend.Item{}, trace.BadParameter("plugin data size limit exceeded")
-	}
-	return backend.Item{
-		Key:      pluginDataKey(data.GetSubKind(), data.GetName()),
-		Value:    value,
-		Expires:  data.Expiry(),
-		ID:       data.GetResourceID(),
-		Revision: rev,
-	}, nil
-}
-
-func itemToPluginData(item backend.Item) (types.PluginData, error) {
-	data, err := services.UnmarshalPluginData(
-		item.Value,
-		services.WithResourceID(item.ID),
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
-}
-
 func accessRequestKey(name string) []byte {
 	return backend.Key(accessRequestsPrefix, name, paramsPrefix)
 }
@@ -563,14 +377,9 @@ func AccessRequestAllowedPromotionKey(name string) []byte {
 	return backend.Key(accessRequestPromotionPrefix, name, paramsPrefix)
 }
 
-func pluginDataKey(kind string, name string) []byte {
-	return backend.Key(pluginDataPrefix, kind, name, paramsPrefix)
-}
-
 const (
 	accessRequestsPrefix         = "access_requests"
 	accessRequestPromotionPrefix = "access_request_promotions"
-	pluginDataPrefix             = "plugin_data"
 	maxCmpAttempts               = 7
-	retryPeriodMs                = 2048
+	retryPeriod                  = 2048 * time.Millisecond
 )

--- a/lib/services/local/plugin_data.go
+++ b/lib/services/local/plugin_data.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const (
+	twoWeeks = 24 * 14 * time.Hour
+)
+
+// PluginDataService is the backend service for plugin data.
+type PluginDataService struct {
+	backend.Backend
+
+	dynamicAccess services.DynamicAccessCore
+}
+
+// NewPluginData creates a new plugin data service.
+func NewPluginData(backend backend.Backend, dynamicAccess services.DynamicAccessCore) *PluginDataService {
+	return &PluginDataService{
+		Backend:       backend,
+		dynamicAccess: dynamicAccess,
+	}
+}
+
+// GetPluginData loads all plugin data matching the supplied filter.
+func (p *PluginDataService) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
+	switch filter.Kind {
+	case types.KindAccessRequest, types.KindAccessList:
+		data, err := p.getPluginData(ctx, filter)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return data, nil
+	default:
+		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
+	}
+}
+
+func (p *PluginDataService) getPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
+	// Filters which specify Resource are a special case since they will match exactly zero or one
+	// possible PluginData instances.
+	if filter.Resource != "" {
+		item, err := p.Get(ctx, pluginDataKey(filter.Kind, filter.Resource))
+		if err != nil {
+			// A filter with zero matches is still a success, it just
+			// happens to return an empty slice.
+			if trace.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, trace.Wrap(err)
+		}
+		data, err := itemToPluginData(*item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !filter.Match(data) {
+			// A filter with zero matches is still a success, it just
+			// happens to return an empty slice.
+			return nil, nil
+		}
+		return []types.PluginData{data}, nil
+	}
+	prefix := backend.ExactKey(pluginDataPrefix, filter.Kind)
+	result, err := p.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var matches []types.PluginData
+	for _, item := range result.Items {
+		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
+			// Item represents a different resource type in the
+			// same namespace.
+			continue
+		}
+		data, err := itemToPluginData(item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !filter.Match(data) {
+			continue
+		}
+		matches = append(matches, data)
+	}
+	return matches, nil
+}
+
+// UpdatePluginData updates a per-resource PluginData entry.
+func (p *PluginDataService) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
+	switch params.Kind {
+	case types.KindAccessRequest, types.KindAccessList:
+	default:
+		return trace.BadParameter("unsupported resource kind %q", params.Kind)
+	}
+
+	return trace.Wrap(p.updatePluginData(ctx, params))
+}
+
+func (p *PluginDataService) updatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		Step: retryPeriod / 7,
+		Max:  retryPeriod,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Update is attempted multiple times in the event of concurrent writes.
+	for i := 0; i < maxCmpAttempts; i++ {
+		var create bool
+		var data types.PluginData
+		item, err := p.Get(ctx, pluginDataKey(params.Kind, params.Resource))
+		if err == nil {
+			data, err = itemToPluginData(*item)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			create = false
+		} else {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+
+			data, err = types.NewPluginData(params.Resource, params.Kind)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			create = true
+
+			if params.Kind == types.KindAccessRequest {
+				// In order to prevent orphaned plugin data, we automatically
+				// configure new instances to expire shortly after the AccessRequest
+				// to which they are associated.  This discrepency in expiry gives
+				// plugins the ability to use stored data when handling an expiry
+				// (OpDelete) event.
+				req, err := services.GetAccessRequest(ctx, p.dynamicAccess, params.Resource)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				data.SetExpiry(req.GetAccessExpiry().Add(time.Hour))
+			}
+		}
+
+		if params.Kind == types.KindAccessList {
+			// Expire access list data two weeks from now for every update, which will
+			// make sure that at some point it will get cleaned up if an access list no
+			// longer needs notifications.
+			data.SetExpiry(p.Clock().Now().Add(twoWeeks))
+		}
+
+		if err := data.Update(params); err != nil {
+			return trace.Wrap(err)
+		}
+		if err := data.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+		newItem, err := itemFromPluginData(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if create {
+			if _, err := p.Create(ctx, newItem); err != nil {
+				if trace.IsAlreadyExists(err) {
+					select {
+					case <-retry.After():
+						retry.Inc()
+						continue
+					case <-ctx.Done():
+						return trace.Wrap(ctx.Err())
+					}
+				}
+				return trace.Wrap(err)
+			}
+		} else {
+			if _, err := p.CompareAndSwap(ctx, *item, newItem); err != nil {
+				if trace.IsCompareFailed(err) {
+					select {
+					case <-retry.After():
+						retry.Inc()
+						continue
+					case <-ctx.Done():
+						return trace.Wrap(ctx.Err())
+					}
+				}
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}
+	return trace.CompareFailed("too many concurrent writes to plugin data %s", params.Resource)
+}
+
+func itemFromPluginData(data types.PluginData) (backend.Item, error) {
+	rev := data.GetRevision()
+	value, err := services.MarshalPluginData(data)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	// enforce explicit limit on resource size in order to prevent PluginData from
+	// growing uncontrollably.
+	if len(value) > teleport.MaxResourceSize {
+		return backend.Item{}, trace.BadParameter("plugin data size limit exceeded")
+	}
+	return backend.Item{
+		Key:      pluginDataKey(data.GetSubKind(), data.GetName()),
+		Value:    value,
+		Expires:  data.Expiry(),
+		ID:       data.GetResourceID(),
+		Revision: rev,
+	}, nil
+}
+
+func itemToPluginData(item backend.Item) (types.PluginData, error) {
+	data, err := services.UnmarshalPluginData(
+		item.Value,
+		services.WithResourceID(item.ID),
+		services.WithExpires(item.Expires),
+		services.WithRevision(item.Revision),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return data, nil
+}
+
+func pluginDataKey(kind string, name string) []byte {
+	return backend.Key(pluginDataPrefix, kind, name, paramsPrefix)
+}
+
+const (
+	pluginDataPrefix = "plugin_data"
+)

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -17,11 +17,27 @@ limitations under the License.
 package services
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+// PluginDataGetter defines the interface for getting plugin data.
+type PluginDataGetter interface {
+	// GetPluginData loads all plugin data matching the supplied filter.
+	GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error)
+}
+
+// PluginData defines the interface for managing plugin data.
+type PluginData interface {
+	PluginDataGetter
+
+	// UpdatePluginData updates a per-resource PluginData entry.
+	UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error
+}
 
 // MarshalPluginData marshals the PluginData resource to JSON.
 func MarshalPluginData(pluginData types.PluginData, opts ...MarshalOption) ([]byte, error) {


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/33415 to branch/v14.

Note: This backport is manual due to a conflict in `dynamic_access.go` in the deleted functions. I elected to go with master's copy here since these were all removed. This pulled in a few unrelated, but benign changes.