### PR TITLE
[v12] Hardcode the v12 plugin version

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -150,7 +150,7 @@ $ teleport-jira start
 ```code
 $ helm install teleport-plugin-jira teleport/teleport-plugin-jira \
   --values teleport-jira-helm.yaml \
-  --version (=teleport.plugin.version=)
+  --version 12.3.1
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -413,7 +413,7 @@ $ teleport-msteams validate <email of your teams account>
 If everything works fine, the log output should look like this:
 
 ```text
-teleport-msteams v(=teleport.plugin.version=) go(=teleport.golang=)
+teleport-msteams v12.3.1 go(=teleport.golang=)
 
  - Checking application xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx status...
  - Application found in the team app store (internal ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
@@ -446,7 +446,7 @@ and your Teleport cluster:
 ```code
 $ teleport-msteams start -d
 DEBU   DEBUG logging enabled msteams/main.go:120
-INFO   Starting Teleport MS Teams Plugin (=teleport.plugin.version=): msteams/app.go:74
+INFO   Starting Teleport MS Teams Plugin 12.3.1: msteams/app.go:74
 DEBU   Attempting GET teleport.example.com:443/webapi/find webclient/webclient.go:129
 DEBU   Checking Teleport server version msteams/app.go:242
 INFO   MS Teams app found in org app store id:292e2881-38ab-7777-8aa7-cefed1404a63 name:TeleBot msteams/app.go:179

--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -29,7 +29,7 @@ Service or Proxy Service:
 
 ```code
 $ TELEPORT_CLUSTER_ADDRESS=mytenant.teleport.sh:443
-$ docker run -v `pwd`:/opt/teleport-plugin -w /opt/teleport-plugin public.ecr.aws/gravitational/teleport-plugin-event-handler:(=teleport.plugin.version=) configure . ${TELEPORT_CLUSTER_ADDRESS?}
+$ docker run -v `pwd`:/opt/teleport-plugin -w /opt/teleport-plugin public.ecr.aws/gravitational/teleport-plugin-event-handler:12.3.1 configure . ${TELEPORT_CLUSTER_ADDRESS?}
 ```
 
 In order to export audit events, you'll need to have the root certificate and the

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -2,8 +2,8 @@
 <TabItem label="Linux">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-event-handler-v12.3.1-linux-amd64-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v12.3.1-linux-amd64-bin.tar.gz
 ```
 
 We currently only build the Event Handler plugin for amd64 machines. For ARM
@@ -14,8 +14,8 @@ architecture, you can build from source.
 <TabItem label="macOS">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-event-handler-v12.3.1-darwin-amd64-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v12.3.1-darwin-amd64-bin.tar.gz
 ```
 
 We currently only build the event handler plugin for amd64 machines. If your
@@ -29,7 +29,7 @@ event handler plugin. You can also build from source.
 Ensure that you have Docker installed and running.
 
 ```code
-$ docker pull public.ecr.aws/gravitational/teleport-plugin-event-handler:(=teleport.plugin.version=)
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-event-handler:12.3.1
 ```
 
 </TabItem>

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -6,8 +6,8 @@ plugins from source. You can run the plugin from a remote host or your local
 development machine.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v12.3.1-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-{{ name }}-v12.3.1-linux-amd64-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install
 ```
@@ -16,7 +16,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v12.3.1 git:teleport-{{ name }}-v12.3.1-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>
@@ -26,14 +26,14 @@ We currently only provide Docker images for `linux-amd64`.
 Pull the Docker image for the latest access request plugin by running the following command:
 
 ```code
-$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=)
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:12.3.1
 ```
 
 Make sure the plugin is installed by running the following command:
 
 ```code
-$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=) version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)--fffffffff (=teleport.golang=)
+$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:12.3.1 version
+teleport-{{ name }} v12.3.1 git:teleport-{{ name }}-v12.3.1--fffffffff (=teleport.golang=)
 ```
 
 For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }}).
@@ -55,7 +55,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v12.3.1 git:teleport-{{ name }}-v12.3.1-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>

--- a/docs/pages/management/export-audit-events/datadog.mdx
+++ b/docs/pages/management/export-audit-events/datadog.mdx
@@ -302,7 +302,7 @@ To start the event handler in Kubernetes, run the following command:
 ```code
 $ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
   --values teleport-plugin-event-handler-values.yaml \
-  --version (=teleport.plugin.version=)
+  --version 12.3.1
 ```
 
 </TabItem>

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -320,7 +320,7 @@ To start the event handler in Kubernetes, run the following command:
 ```code
 $ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
   --values teleport-plugin-event-handler-values.yaml \
-  --version (=teleport.plugin.version=)
+  --version 12.3.1
 ```
 
 </TabItem>


### PR DESCRIPTION
Closes #33930

Hardcode the plugin version as 13.3.8, the latest `teleport-plugins` release, since we are no longer publishing new v13 releases.