### PR TITLE
Clarify the relationship between Kubernetes docs

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments.mdx
@@ -4,6 +4,19 @@ description: How to install and configure Teleport in Kubernetes using Helm
 layout: tocless-doc
 ---
 
+The `teleport-cluster` Helm chart enables you deploy and manage a self-hosted,
+high-availability Teleport cluster. This chart launches the Teleport Auth
+Service, Teleport Proxy Service, and the Kubernetes infrastructure required to
+support these services. The guides in this section show you how to use the
+`teleport-cluster` Helm chart in your environment.
+
+You do not need to deploy the Auth Service and Proxy Service on Kubernetes in
+order to protect a Kubernetes cluster with Teleport, and it is possible to
+enroll a Kubernetes cluster on Teleport Cloud or by running the Teleport
+Kubernetes Service on a Linux server. For instructions on enrolling a Kubernetes
+cluster with Teleport, read the [Kubernetes
+Access](../kubernetes-access/introduction.mdx) documentation.
+
 ## Helm deployment guides
 
 These guides show you how to set up a full self-hosted Teleport deployment using

--- a/docs/pages/deploy-a-cluster/introduction.mdx
+++ b/docs/pages/deploy-a-cluster/introduction.mdx
@@ -3,7 +3,8 @@ title: "Running a Production Teleport Cluster"
 description: "Guides to running Teleport in production."
 ---
 
-These guides show you how to run a Teleport cluster in production.
+These guides show you how to run a self-hosted Teleport Enterprise or Teleport
+Community Edition cluster in production.
 
 Read our [High Availability Guide](./high-availability.mdx) for the general
 principles behind deploying a scalable, fault-tolerant Teleport cluster. Once

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -12,6 +12,11 @@ Teleport provides secure access to Kubernetes clusters:
   cluster.
 - Organizations can achieve compliance by recording `kubectl` sessions.
 
+The guides in this section show you how to protect Kubernetes clusters with
+Teleport. For instructions on self-hosting Teleport Community Edition or
+Teleport Enterprise on Kubernetes, see the [Kubernetes Deployment
+Guides](../deploy-a-cluster/helm-deployments.mdx).
+
 Here is an example of using Teleport to access a Kubernetes cluster, execute
 commands, and view your `kubectl`  activity in Teleport's audit log:
 


### PR DESCRIPTION
Closes #19192

Add introductory language to the Helm Deployments and Kubernetes Access section introductions to clarify the relationship of these docs sections to one another. The intention is to help newcomers to Teleport understand when they need to read the Kubernetes Access docs and when it is more appropriate to the read the Helm Deployments docs.