### PR TITLE
Remove version warnings in Details boxes

### DIFF
--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -11,17 +11,6 @@ This guide will help you understand how to set up and use Teleport Assist, an
 AI-powered assistant that helps you run commands, debug issues and navigate your
 infrastructure.
 
-<Details
-  title="Version warning"
-  opened={true}
-  min="12.0"
->
-
-Teleport Assist is available starting from Teleport `v12.4` for Teleport
-Community Edition.
-
-</Details>
-
 ### Architecture diagram
 
 ![Teleport Assist Architecture](../img/assist/architecture-diagram.png)
@@ -34,8 +23,8 @@ Community Edition.
 
 Before you get started with Teleport Assist, make sure you have the following:
 
-- A running Teleport Community Edition cluster. For details on how to set this
-  up, see our [Getting Started](./index.mdx) guide.
+- A running Teleport Community Edition cluster, v12.4 or higher. For details on
+  how to set this up, see our [Getting Started](./index.mdx) guide.
 - **OpenAI Account**: You will need an active OpenAI account with GPT-4 API
   access as Teleport Assist relies on OpenAI services.
 

--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -3,17 +3,6 @@ title: TLS Routing
 description: How Teleport implements a single-port setup with TLS routing
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="13.0"
->
-  Support for TLS Routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
-  proxies is available starting from Teleport `13.0`.
-</Details>
-
 In TLS routing mode [Teleport proxy](./proxy.mdx) multiplexes all client
 connections on a single TLS port.
 
@@ -25,6 +14,9 @@ network such as SSH.
 To implement TLS routing, Teleport uses SNI ([Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication))
 and ALPN ([Application-Level Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation))
 TLS extensions.
+
+Support for TLS Routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
+proxies is available starting from Teleport `13.0`.
 
 ## How it works
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -8,18 +8,6 @@ This guide will show you how to set up your Teleport Cluster to use the Google
 Cloud Key Management Service (KMS) to store and handle the CA private key
 material used to sign all certificates issued by your Teleport cluster.
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["enterprise"]}
-  scopeOnly={true}
-  min="11.1.0"
->
-
-The features documented on this page are available in Teleport `11.1.0` and higher.
-
-</Details>
-
 Teleport generates private key material for its internal Certificate Authorities
 (CAs) during the first Auth Server's initial startup.
 These CAs are used to sign all certificates issued to clients and hosts in the
@@ -41,6 +29,9 @@ learn more.
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
 ## Prerequisites
+
+The features documented on this page are available in Teleport `11.1.0` and
+higher.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 

--- a/docs/pages/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -3,22 +3,12 @@ title: AWS Redshift Automatic User Provisioning
 description: Configure automatic user provisioning for AWS Redshift.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="14.2"
->
-  Automatic user provisioning for AWS Redshift is available starting from
-  Teleport 14.2.
-</Details>
-
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
 
 ## Prerequisites
 
-- Teleport cluster with a configured [AWS Redshift](../guides/postgres-redshift.mdx) database.
+- Teleport cluster v14.2 or higher with a configured [AWS
+  Redshift](../guides/postgres-redshift.mdx) database.
 - Ability to connect to and create user accounts in the target database.
 
 <Admonition type="note" title="Supported services">

--- a/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mariadb.mdx
@@ -3,23 +3,13 @@ title: MariaDB Automatic User Provisioning
 description: Configure automatic user provisioning for MariaDB.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="14.2"
->
-  Automatic user provisioning for MariaDB is available starting from Teleport
-  14.2.
-</Details>
-
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
 
 ## Prerequisites
 
-- Teleport cluster with a configured [self-hosted MariaDB](../guides/mysql-self-hosted.mdx)
-  or [RDS MariaDB](../guides/rds.mdx) database.
+- Teleport cluster v14.2 or higher with a configured [self-hosted
+  MariaDB](../guides/mysql-self-hosted.mdx) or [RDS MariaDB](../guides/rds.mdx)
+  database.
 - Ability to connect to and create user accounts in the target database.
 
 <Admonition type="note" title="Supported versions">

--- a/docs/pages/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mysql.mdx
@@ -3,21 +3,11 @@ title: MySQL Automatic User Provisioning
 description: Configure automatic user provisioning for MySQL.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="14.1"
->
-  Automatic user provisioning for MySQL is available starting from Teleport
-  14.1.
-</Details>
-
 ## Prerequisites
 
-- Teleport cluster with a configured [self-hosted MySQL](../guides/mysql-self-hosted.mdx)
-  or [RDS MySQL](../guides/rds.mdx) database.
+- Teleport cluster v14.1 or higher with a configured [self-hosted
+  MySQL](../guides/mysql-self-hosted.mdx) or [RDS MySQL](../guides/rds.mdx)
+  database.
 - Ability to connect to and create user accounts in the target database.
 
 <Admonition type="note" title="Supported versions">

--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -3,23 +3,13 @@ title: PostgreSQL Automatic User Provisioning
 description: Configure automatic user provisioning for PostgreSQL.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="13.1"
->
-  Automatic user provisioning for PostgreSQL is available starting from
-  Teleport 13.1.
-</Details>
-
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
 
 ## Prerequisites
 
-- Teleport cluster with a configured [self-hosted PostgreSQL](../guides/postgres-self-hosted.mdx)
-  or [RDS PostgreSQL](../guides/rds.mdx) database.
+- Teleport cluster v13.1 or above with a configured [self-hosted
+  PostgreSQL](../guides/postgres-self-hosted.mdx) or [RDS
+  PostgreSQL](../guides/rds.mdx) database.
 - Ability to connect to and create user accounts in the target database.
 
 ## Step 1/3. Configure database admin

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -3,16 +3,6 @@ title: Database Access with AWS Keyspaces (Apache Cassandra)
 description: How to configure Teleport database access with AWS Keyspaces (Apache Cassandra)
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="11.0"
->
-  Database access for AWS Keyspaces (Apache Cassandra) is available starting from Teleport `v11.0`.
-</Details>
-
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS Keyspaces (Apache Cassandra)" dbConfigure="AWS Keyspaces database with IAM authentication" dbName="AWS Keyspaces" !)
 
 <Tabs>
@@ -26,6 +16,9 @@ description: How to configure Teleport database access with AWS Keyspaces (Apach
 </Tabs>
 
 ## Prerequisites
+
+Database access for AWS Keyspaces (Apache Cassandra) is available starting from
+Teleport `v11.0`.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 

--- a/docs/pages/database-access/guides/aws-cross-account.mdx
+++ b/docs/pages/database-access/guides/aws-cross-account.mdx
@@ -3,19 +3,11 @@ title: AWS Cross-Account Database Access
 description: How to connect AWS databases in external AWS accounts to Teleport.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="13.0"
->
-  AWS cross-account database access is available starting from Teleport `13.0`.
-</Details>
-
 You can deploy the Teleport Database Service with AWS IAM credentials in one
 AWS account and use an AWS IAM role to grant Teleport access to databases in
 another AWS account.
+
+AWS cross-account database access is available starting from Teleport `13.0`.
 
 When the Teleport Database Service needs to discover, configure, or retrieve
 short-lived authentication tokens for AWS databases, it uses credentials for an

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -3,17 +3,6 @@ title: Database Access with SQL Server on Azure
 description: How to configure Teleport database access with Azure SQL Server using Azure Active Directory authentication.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="11.0"
->
-  Database access for Azure SQL Server with Azure Active Directory authentication
-  is available starting from Teleport `11.0`.
-</Details>
-
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure SQL Server" dbConfigure="Azure SQL Server using Azure Active Directory authentication" dbName="Azure SQL Server" !)
 
 <Tabs>
@@ -27,6 +16,9 @@ description: How to configure Teleport database access with Azure SQL Server usi
 </Tabs>
 
 ## Prerequisites
+
+Database access for Azure SQL Server with Azure Active Directory authentication
+is available starting from Teleport `11.0`.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -3,16 +3,6 @@ title: Database Access with Cassandra and ScyllaDB
 description: How to configure Teleport database access with Cassandra and ScyllaDB.
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="11.0"
->
-  Database access for Cassandra & ScyllaDB is available starting from Teleport `v11.0`.
-</Details>
-
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Cassandra or ScyllaDB" dbConfigure="Cassandra or ScyllaDB with mutual TLS authentication" dbName="Cassandra or ScyllaDB" !)
 
 <Tabs>
@@ -26,6 +16,9 @@ description: How to configure Teleport database access with Cassandra and Scylla
 </Tabs>
 
 ## Prerequisites
+
+Database access for Cassandra & ScyllaDB is available starting from Teleport
+`v11.0`.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 

--- a/docs/pages/includes/machine-id/v2-config-warning.mdx
+++ b/docs/pages/includes/machine-id/v2-config-warning.mdx
@@ -1,9 +1,3 @@
-<Details
-  title="Version warning"
-  opened={true}
-  min="14.0"
->
-  This version of the guide uses the v2 `tbot` configuration. This version is only
-  supported by Teleport 14 and beyond. Change the selected version of the
-  documentation to view the guide for previous Teleport versions.
-</Details>
+This version of the guide uses the v2 `tbot` configuration. This version is only
+supported by Teleport 14 and beyond. Change the selected version of the
+documentation to view the guide for previous Teleport versions.

--- a/docs/pages/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-id/deployment/gitlab.mdx
@@ -3,16 +3,6 @@ title: Deploying Machine ID on GitLab CI
 description: How to install and configure Machine ID on GitLab CI
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="12.2"
->
-  Machine ID for GitLab is available starting from Teleport `v12.2`.
-</Details>
-
 In this guide, you will use Teleport Machine ID to allow a GitLab pipeline to
 securely connect to a Teleport SSH node without the need for long-lived secrets.
 
@@ -26,6 +16,8 @@ the other benefits of Teleport such as auditing and finely-grained access
 control.
 
 ## Prerequisites
+
+Machine ID for GitLab is available starting from Teleport `v12.2`.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 

--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -3,14 +3,6 @@ title: Enroll an agent into automatic updates
 description: How to enroll an agent into automatic updates
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  min="13.0"
->
-  Automatic agent update is available starting from Teleport `13.0`.
-</Details>
-
 Teleport supports automatic agent updates for
 systemd-based Linux distributions using `apt`, `yum`, or `zypper` package
 managers, and Kubernetes clusters. The [automatic updates architecture
@@ -21,6 +13,8 @@ This guide explains how to enroll an existing Teleport agent into automatic
 updates.
 
 ## Requirements
+
+Automatic agent update is available starting from Teleport `13.0`.
 
 <Tabs>
 <TabItem label="Self-hosted" scope="enterprise">

--- a/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
@@ -3,16 +3,6 @@ title: Setting up self-hosted automatic agent updates
 description: How to setup automatic agent update for self-hosted Teleport
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["enterprise"]}
-  scopeOnly={true}
-  min="13.0"
->
-  Automatic agent update is available starting from Teleport `13.0`.
-</Details>
-
 Teleport supports automatic agent updates for
 systemd-based Linux distributions using `apt`, `yum`, and `zypper` package managers,
 and Kubernetes clusters. The [automatic updates architecture 
@@ -35,7 +25,7 @@ Teleport v13.3.2 forward, including future major releases.
 
 ## Requirements
 
-- Self-hosted Teleport cluster running.
+- Self-hosted Teleport cluster v13.0 or higher.
 - `tctl` execution on the auth machine or a role allowing verbs `create`, `read`,
   `update`, `delete` on the resource `cluster_maintenance_config`.
 - Either:

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -3,17 +3,6 @@ title: TLS Routing Migration
 description: How to upgrade an existing Teleport cluster to single-port TLS routing mode
 ---
 
-<Details
-  title="Version warning"
-  opened={true}
-  scope={["oss", "enterprise"]}
-  scopeOnly={true}
-  min="13.0"
->
-  Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
-  proxies is available starting from Teleport `13.0`.
-</Details>
-
 In TLS routing mode, all Teleport client connections are wrapped in TLS and
 multiplexed on one Teleport Proxy Service port.
 
@@ -31,21 +20,22 @@ Upgrading Teleport will not enable TLS routing by default and the cluster will
 keep working in backwards-compatibility mode. Follow this guide to migrate your
 Teleport installation to TLS routing.
 
-<Notice type="tip">
-
-Teleport Team manages the Proxy Service's networking configuration for you.
-Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
+Teleport Team manages the Proxy Service's networking configuration for you. Get
+started with a [free trial](https://goteleport.com/signup?t_source=docs) of
 Teleport Team.
 
-To see which ports and networking settings the Proxy Service is configured to
-use in your Teleport Cloud tenant, run the following command, replacing
-`mytenant.teleport.sh` with your tenant address:
+## Prerequisites
+
+Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
+proxies is available starting from Teleport `13.0`.
+
+If you use Teleport Cloud, see which ports and networking settings the Proxy
+Service is configured to use in your Teleport Cloud tenant. Run the following
+command, replacing `mytenant.teleport.sh` with your tenant address:
 
 ```code
 $ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
 ```
-
-</Notice>
 
 ## Step 1/7. Upgrade Teleport
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -174,13 +174,8 @@ teleport:
 
 ## PostgreSQL
 
-<Details
-  title="Version warning"
-  opened={true}
-  min="13.3"
->
-  The PostgreSQL cluster state and audit log storage is available starting from Teleport `13.3`.
-</Details>
+PostgreSQL cluster state and audit log storage is available starting from
+Teleport `13.3`.
 
 <Admonition
   type="tip"
@@ -1374,13 +1369,8 @@ teleport:
 
 ## Azure Blob Storage
 
-<Details
-  title="Version warning"
-  opened={true}
-  min="13.3"
->
-  Azure Blob Storage for session storage is available starting from Teleport `13.3`.
-</Details>
+Azure Blob Storage for session storage is available starting from Teleport
+`13.3`.
 
 <Admonition
   type="tip"


### PR DESCRIPTION
Fixes #29913

The `Details` box is the wrong component for a version warning, since this box is meant for users to expand and collapse, and there is no benefit of expanding and collapsing a version warning. Depending on the guide, this change either:

- Integrates the version warning into the Prerequisites section of a how-to guide
- Makes the version warning regular text within the introductory section