### PR TITLE
Improve `utils.FatalError` error formatting

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -178,19 +178,13 @@ func UserMessageFromError(err error) string {
 // The error message is escaped if necessary. A newline is added if the error text
 // does not end with a newline.
 func FormatErrorWithNewline(err error) string {
-	message := formatError(err)
+	var buf bytes.Buffer
+	formatErrorWriter(err, &buf)
+	message := buf.String()
 	if !strings.HasSuffix(message, "\n") {
 		message = message + "\n"
 	}
 	return message
-}
-
-// formatError returns user friendly error message from error.
-// The error message is escaped if necessary
-func formatError(err error) string {
-	var buf bytes.Buffer
-	formatErrorWriter(err, &buf)
-	return buf.String()
 }
 
 // formatErrorWriter formats the specified error into the provided writer.
@@ -211,7 +205,7 @@ func formatErrorWriter(err error, w io.Writer) {
 		return
 	}
 
-	fmt.Fprintln(w, AllowWhitespace(err.Error()))
+	fmt.Fprintln(w, AllowWhitespace(msg))
 }
 
 func formatCertError(err error) string {

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -203,22 +203,15 @@ func formatErrorWriter(err error, w io.Writer) {
 		fmt.Fprintln(w, certErr)
 		return
 	}
-	// If the error is a trace error, check if it has a user message embedded in
-	// it, if it does, print it, otherwise escape and print the original error.
-	if traceErr, ok := err.(*trace.TraceErr); ok {
-		for _, message := range traceErr.Messages {
-			fmt.Fprintln(w, AllowWhitespace(message))
-		}
-		fmt.Fprintln(w, AllowWhitespace(trace.Unwrap(traceErr).Error()))
+
+	msg := trace.UserMessage(err)
+	// Error can be of type trace.proxyError where error message didn't get captured.
+	if msg == "" {
+		fmt.Fprintln(w, "please check Teleport's log for more details")
 		return
 	}
-	strErr := err.Error()
-	// Error can be of type trace.proxyError where error message didn't get captured.
-	if strErr == "" {
-		fmt.Fprintln(w, "please check Teleport's log for more details")
-	} else {
-		fmt.Fprintln(w, AllowWhitespace(err.Error()))
-	}
+
+	fmt.Fprintln(w, AllowWhitespace(err.Error()))
 }
 
 func formatCertError(err error) string {

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -19,15 +19,15 @@ package utils
 import (
 	"crypto/x509"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUserMessageFromError(t *testing.T) {
-	// Behaviour is different in debug
+	// Behavior is different in debug
 	priorLevel := logrus.GetLevel()
 	logrus.SetLevel(logrus.InfoLevel)
 	t.Cleanup(func() {


### PR DESCRIPTION
I've noticed the past few months a number of cases where users reporting an issue with `tbot` were confused by the error message output by `tbot`.

A contributing factor to this is that they appear "scrambled". This scrambling appears to be caused by `utils.formatErrorWriter` which prints the Messages from deepest to shallowest, and then prints the underlying error. But - this makes no sense - the underlying error is the deepest element. You can see an example of this below.

I noticed that when `-d` was provided, a different implementation was used to print the error. This implementation is within our `trace` package, and correctly shows the messages from shallowest to deepest - and also indents each message. This helps distinguish each message and is especially important when printing a stack including an aggregate error. So - I figured it made sense to reuse that implementation.

Example Code:

```go
package main

import (
	"github.com/gravitational/teleport/lib/utils"
	"github.com/gravitational/trace"
)

func chargeCapacitors() error {
	return trace.BadParameter("capacitor bank exploded")
}

func prepareEnergySubsystem() error {
	return trace.Wrap(chargeCapacitors(), "charging capacitors")
}

func jumpToLightspeed() error {
	return trace.Wrap(prepareEnergySubsystem(), "preparing energy subsystem")
}

func main() {
	err := trace.Wrap(jumpToLightspeed(), "jumping to lightspeed")
	utils.FatalError(err)
}

```

Prior to this PR:
```
noah@Noahs-MBP teleport % go run ./example   
ERROR: charging capacitors
preparing energy subsystem
jumping to lightspeed
capacitor exploded

exit status 1
```

After this PR:
```
noah@Noahs-MBP teleport % go run ./example 
ERROR: jumping to lightspeed
        preparing energy subsystem
                charging capacitors
                        capacitor exploded

exit status 1
```

If we feel the risk this change is too wide for `utils.FatalError`, I'm more than happy to isolate this fix to `tbot`.

nb: I'm also currently investigating an issue within `trace` when pretty printing aggregate errors. I hope to raise a PR for that soonish as part of a general effort to improve `tbot`'s error output.