### PR TITLE
[v14] integrations/operator: re-use the teleport client instead of creating a new one

### DIFF
--- a/integrations/operator/controllers/resources/github_connector_controller.go
+++ b/integrations/operator/controllers/resources/github_connector_controller.go
@@ -38,6 +38,8 @@ func (r githubConnectorClient) Get(ctx context.Context, name string) (types.Gith
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	github, err := teleportClient.GetGithubConnector(ctx, name, false /* with secrets*/)
 	return github, trace.Wrap(err)
@@ -49,6 +51,8 @@ func (r githubConnectorClient) Create(ctx context.Context, github types.GithubCo
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
@@ -59,6 +63,8 @@ func (r githubConnectorClient) Update(ctx context.Context, github types.GithubCo
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
@@ -69,6 +75,8 @@ func (r githubConnectorClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteGithubConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/github_connector_controller.go
+++ b/integrations/operator/controllers/resources/github_connector_controller.go
@@ -34,12 +34,11 @@ type githubConnectorClient struct {
 
 // Get gets the Teleport github_connector of a given name
 func (r githubConnectorClient) Get(ctx context.Context, name string) (types.GithubConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	github, err := teleportClient.GetGithubConnector(ctx, name, false /* with secrets*/)
 	return github, trace.Wrap(err)
@@ -47,36 +46,33 @@ func (r githubConnectorClient) Get(ctx context.Context, name string) (types.Gith
 
 // Create creates a Teleport github_connector
 func (r githubConnectorClient) Create(ctx context.Context, github types.GithubConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
 
 // Update updates a Teleport github_connector
 func (r githubConnectorClient) Update(ctx context.Context, github types.GithubConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
 
 // Delete deletes a Teleport github_connector
 func (r githubConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteGithubConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/login_rule_controller.go
+++ b/integrations/operator/controllers/resources/login_rule_controller.go
@@ -33,12 +33,11 @@ type loginRuleClient struct {
 
 // Get gets the Teleport login_rule of a given name
 func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.LoginRuleResource, error) {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	loginRule, err := teleportClient.GetLoginRule(ctx, name)
 	if err != nil {
@@ -50,12 +49,11 @@ func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.Log
 
 // Create creates a Teleport login_rule
 func (l loginRuleClient) Create(ctx context.Context, resource *resourcesv1.LoginRuleResource) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	_, err = teleportClient.CreateLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -63,12 +61,11 @@ func (l loginRuleClient) Create(ctx context.Context, resource *resourcesv1.Login
 
 // Update updates a Teleport login_rule
 func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.LoginRuleResource) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	_, err = teleportClient.UpsertLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -76,12 +73,11 @@ func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.Login
 
 // Delete deletes a Teleport login_rule
 func (l loginRuleClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteLoginRule(ctx, name))
 }

--- a/integrations/operator/controllers/resources/login_rule_controller.go
+++ b/integrations/operator/controllers/resources/login_rule_controller.go
@@ -37,6 +37,8 @@ func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.Log
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	loginRule, err := teleportClient.GetLoginRule(ctx, name)
 	if err != nil {
@@ -52,6 +54,8 @@ func (l loginRuleClient) Create(ctx context.Context, resource *resourcesv1.Login
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	_, err = teleportClient.CreateLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -63,6 +67,8 @@ func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.Login
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	_, err = teleportClient.UpsertLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -74,6 +80,8 @@ func (l loginRuleClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteLoginRule(ctx, name))
 }

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -38,6 +38,8 @@ func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCCo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	oidc, err := teleportClient.GetOIDCConnector(ctx, name, false /* with secrets*/)
 	return oidc, trace.Wrap(err)
@@ -49,6 +51,8 @@ func (r oidcConnectorClient) Create(ctx context.Context, oidc types.OIDCConnecto
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
@@ -59,6 +63,8 @@ func (r oidcConnectorClient) Update(ctx context.Context, oidc types.OIDCConnecto
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
@@ -69,6 +75,8 @@ func (r oidcConnectorClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteOIDCConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -34,12 +34,11 @@ type oidcConnectorClient struct {
 
 // Get gets the Teleport oidc_connector of a given name
 func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	oidc, err := teleportClient.GetOIDCConnector(ctx, name, false /* with secrets*/)
 	return oidc, trace.Wrap(err)
@@ -47,36 +46,33 @@ func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCCo
 
 // Create creates a Teleport oidc_connector
 func (r oidcConnectorClient) Create(ctx context.Context, oidc types.OIDCConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
 
 // Update updates a Teleport oidc_connector
 func (r oidcConnectorClient) Update(ctx context.Context, oidc types.OIDCConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
 
 // Delete deletes a Teleport oidc_connector
 func (r oidcConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteOIDCConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/okta_import_rule_controller.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller.go
@@ -38,6 +38,8 @@ func (r oktaImportRuleClient) Get(ctx context.Context, name string) (types.OktaI
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	importRule, err := teleportClient.OktaClient().GetOktaImportRule(ctx, name)
 	return importRule, trace.Wrap(err)
@@ -49,6 +51,8 @@ func (r oktaImportRuleClient) Create(ctx context.Context, importRule types.OktaI
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	_, err = teleportClient.OktaClient().CreateOktaImportRule(ctx, importRule)
 	return trace.Wrap(err)
@@ -60,6 +64,8 @@ func (r oktaImportRuleClient) Update(ctx context.Context, importRule types.OktaI
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	_, err = teleportClient.OktaClient().UpdateOktaImportRule(ctx, importRule)
 	return trace.Wrap(err)
@@ -71,6 +77,8 @@ func (r oktaImportRuleClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.OktaClient().DeleteOktaImportRule(ctx, name))
 }

--- a/integrations/operator/controllers/resources/okta_import_rule_controller.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller.go
@@ -34,12 +34,11 @@ type oktaImportRuleClient struct {
 
 // Get gets the Teleport okta_import_rule of a given name
 func (r oktaImportRuleClient) Get(ctx context.Context, name string) (types.OktaImportRule, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	importRule, err := teleportClient.OktaClient().GetOktaImportRule(ctx, name)
 	return importRule, trace.Wrap(err)
@@ -47,12 +46,11 @@ func (r oktaImportRuleClient) Get(ctx context.Context, name string) (types.OktaI
 
 // Create creates a Teleport okta_import_rule
 func (r oktaImportRuleClient) Create(ctx context.Context, importRule types.OktaImportRule) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	_, err = teleportClient.OktaClient().CreateOktaImportRule(ctx, importRule)
 	return trace.Wrap(err)
@@ -60,12 +58,11 @@ func (r oktaImportRuleClient) Create(ctx context.Context, importRule types.OktaI
 
 // Update updates a Teleport okta_import_rule
 func (r oktaImportRuleClient) Update(ctx context.Context, importRule types.OktaImportRule) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	_, err = teleportClient.OktaClient().UpdateOktaImportRule(ctx, importRule)
 	return trace.Wrap(err)
@@ -73,12 +70,11 @@ func (r oktaImportRuleClient) Update(ctx context.Context, importRule types.OktaI
 
 // Delete deletes a Teleport okta_import_rule
 func (r oktaImportRuleClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.OktaClient().DeleteOktaImportRule(ctx, name))
 }

--- a/integrations/operator/controllers/resources/provision_token_controller.go
+++ b/integrations/operator/controllers/resources/provision_token_controller.go
@@ -35,6 +35,8 @@ func (r provisionTokenClient) Get(ctx context.Context, name string) (types.Provi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	token, err := teleportClient.GetToken(ctx, name)
 	return token, trace.Wrap(err)
@@ -46,6 +48,8 @@ func (r provisionTokenClient) Create(ctx context.Context, token types.ProvisionT
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertToken(ctx, token))
 }
@@ -56,6 +60,8 @@ func (r provisionTokenClient) Update(ctx context.Context, token types.ProvisionT
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertToken(ctx, token))
 }
@@ -66,6 +72,8 @@ func (r provisionTokenClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteToken(ctx, name))
 }

--- a/integrations/operator/controllers/resources/provision_token_controller.go
+++ b/integrations/operator/controllers/resources/provision_token_controller.go
@@ -31,12 +31,11 @@ type provisionTokenClient struct {
 
 // Get gets the Teleport provision token of a given name
 func (r provisionTokenClient) Get(ctx context.Context, name string) (types.ProvisionToken, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	token, err := teleportClient.GetToken(ctx, name)
 	return token, trace.Wrap(err)
@@ -44,36 +43,33 @@ func (r provisionTokenClient) Get(ctx context.Context, name string) (types.Provi
 
 // Create creates a Teleport provision token
 func (r provisionTokenClient) Create(ctx context.Context, token types.ProvisionToken) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertToken(ctx, token))
 }
 
 // Update updates a Teleport provision token
 func (r provisionTokenClient) Update(ctx context.Context, token types.ProvisionToken) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertToken(ctx, token))
 }
 
 // Delete deletes a Teleport provision token
 func (r provisionTokenClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteToken(ctx, name))
 }

--- a/integrations/operator/controllers/resources/role_controller.go
+++ b/integrations/operator/controllers/resources/role_controller.go
@@ -95,6 +95,9 @@ func (r *RoleReconciler) Delete(ctx context.Context, obj kclient.Object) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
+
 	return teleportClient.DeleteRole(ctx, obj.GetName())
 }
 
@@ -133,6 +136,8 @@ func (r *RoleReconciler) Upsert(ctx context.Context, obj kclient.Object) error {
 	if err != nil || updateErr != nil {
 		return trace.NewAggregate(err, updateErr)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	existingResource, err := teleportClient.GetRole(ctx, teleportResource.GetName())
 	updateErr = updateStatus(updateStatusConfig{

--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -38,6 +38,8 @@ func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLCo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	saml, err := teleportClient.GetSAMLConnector(ctx, name, false /* with secrets*/)
 	return saml, trace.Wrap(err)
@@ -49,6 +51,8 @@ func (r samlConnectorClient) Create(ctx context.Context, saml types.SAMLConnecto
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
@@ -59,6 +63,8 @@ func (r samlConnectorClient) Update(ctx context.Context, saml types.SAMLConnecto
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
@@ -69,6 +75,8 @@ func (r samlConnectorClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteSAMLConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -34,12 +34,11 @@ type samlConnectorClient struct {
 
 // Get gets the Teleport saml_connector of a given name
 func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	saml, err := teleportClient.GetSAMLConnector(ctx, name, false /* with secrets*/)
 	return saml, trace.Wrap(err)
@@ -47,36 +46,33 @@ func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLCo
 
 // Create creates a Teleport saml_connector
 func (r samlConnectorClient) Create(ctx context.Context, saml types.SAMLConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
 
 // Update updates a Teleport saml_connector
 func (r samlConnectorClient) Update(ctx context.Context, saml types.SAMLConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
 
 // Delete deletes a Teleport saml_connector
 func (r samlConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteSAMLConnector(ctx, name))
 }

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -45,6 +45,7 @@ import (
 	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
 	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/integrations/operator/sidecar"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
@@ -173,8 +174,8 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	// We have to create a new Manager on each start because the Manager does not support to be restarted
-	clientAccessor := func(ctx context.Context) (*client.Client, error) {
-		return s.TeleportClient, nil
+	clientAccessor := func(ctx context.Context) (*sidecar.SyncClient, error) {
+		return sidecar.NewSyncClient(s.TeleportClient), nil
 	}
 
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -174,8 +174,8 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	// We have to create a new Manager on each start because the Manager does not support to be restarted
-	clientAccessor := func(ctx context.Context) (*sidecar.SyncClient, error) {
-		return sidecar.NewSyncClient(s.TeleportClient), nil
+	clientAccessor := func(ctx context.Context) (*sidecar.SyncClient, func(), error) {
+		return sidecar.NewSyncClient(s.TeleportClient), func() {}, nil
 	}
 
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -38,6 +38,8 @@ func (r userClient) Get(ctx context.Context, name string) (types.User, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	user, err := teleportClient.GetUser(name, false /* with secrets*/)
 	return user, trace.Wrap(err)
@@ -49,6 +51,8 @@ func (r userClient) Create(ctx context.Context, user types.User) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.CreateUser(ctx, user))
 }
@@ -59,6 +63,8 @@ func (r userClient) Update(ctx context.Context, user types.User) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.UpdateUser(ctx, user))
 }
@@ -69,6 +75,8 @@ func (r userClient) Delete(ctx context.Context, name string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	teleportClient.RLock()
+	defer teleportClient.RUnlock()
 
 	return trace.Wrap(teleportClient.DeleteUser(ctx, name))
 }

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -34,12 +34,11 @@ type userClient struct {
 
 // Get gets the Teleport user of a given name
 func (r userClient) Get(ctx context.Context, name string) (types.User, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	user, err := teleportClient.GetUser(name, false /* with secrets*/)
 	return user, trace.Wrap(err)
@@ -47,36 +46,33 @@ func (r userClient) Get(ctx context.Context, name string) (types.User, error) {
 
 // Create creates a Teleport user
 func (r userClient) Create(ctx context.Context, user types.User) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.CreateUser(ctx, user))
 }
 
 // Update updates a Teleport user
 func (r userClient) Update(ctx context.Context, user types.User) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.UpdateUser(ctx, user))
 }
 
 // Delete deletes a Teleport user
 func (r userClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportClient.RLock()
-	defer teleportClient.RUnlock()
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteUser(ctx, name))
 }

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -140,26 +140,26 @@ func main() {
 	if err = (&resources.RoleReconciler{
 		Client:                 mgr.GetClient(),
 		Scheme:                 mgr.GetScheme(),
-		TeleportClientAccessor: bot.GetClient,
+		TeleportClientAccessor: bot.GetSyncClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportRole")
 		os.Exit(1)
 	}
 
-	if err = resources.NewUserReconciler(mgr.GetClient(), bot.GetClient).
+	if err = resources.NewUserReconciler(mgr.GetClient(), bot.GetSyncClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportUser")
 		os.Exit(1)
 	}
 
-	if err = resources.NewGithubConnectorReconciler(mgr.GetClient(), bot.GetClient).
+	if err = resources.NewGithubConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportGithubConnector")
 		os.Exit(1)
 	}
 
 	if features.OIDC {
-		if err = resources.NewOIDCConnectorReconciler(mgr.GetClient(), bot.GetClient).
+		if err = resources.NewOIDCConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportOIDCConnector")
 			os.Exit(1)
@@ -169,7 +169,7 @@ func main() {
 	}
 
 	if features.SAML {
-		if err = resources.NewSAMLConnectorReconciler(mgr.GetClient(), bot.GetClient).
+		if err = resources.NewSAMLConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportSAMLConnector")
 			os.Exit(1)
@@ -180,7 +180,7 @@ func main() {
 
 	// Login Rules are enterprise-only but there is no specific feature flag for them.
 	if features.OIDC || features.SAML {
-		if err := resources.NewLoginRuleReconciler(mgr.GetClient(), bot.GetClient).SetupWithManager(mgr); err != nil {
+		if err := resources.NewLoginRuleReconciler(mgr.GetClient(), bot.GetSyncClient).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportLoginRule")
 			os.Exit(1)
 		}
@@ -188,13 +188,13 @@ func main() {
 		setupLog.Info("Login Rules are only available in Teleport Enterprise edition. TeleportLoginRule resources won't be reconciled")
 	}
 
-	if err = resources.NewProvisionTokenReconciler(mgr.GetClient(), bot.GetClient).
+	if err = resources.NewProvisionTokenReconciler(mgr.GetClient(), bot.GetSyncClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportProvisionToken")
 		os.Exit(1)
 	}
 
-	if err = resources.NewOktaImportRuleReconciler(mgr.GetClient(), bot.GetClient).
+	if err = resources.NewOktaImportRuleReconciler(mgr.GetClient(), bot.GetSyncClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportOktaImportRule")
 		os.Exit(1)

--- a/integrations/operator/sidecar/syncclient.go
+++ b/integrations/operator/sidecar/syncclient.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"context"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/client"
+)
+
+// Note: this whole part of the code handles client reloading.
+// In the next versions, tbot will be able to issue Client with automatically
+// refreshed certificates. We will be able to remove this whole section and
+// pass a plain client to the controllers.
+
+// ClientAccessor is a function that returns a SyncClient to be used in a
+// reconciliation loop. As we need a new client each time tbot renews
+// certificate, we cannot pass the client directly to the controllers.
+// Controllers are given a ClientAccessor and are responsible for calling
+// RLock() / RUnlock() on the SyncClient.
+type ClientAccessor func(ctx context.Context) (*SyncClient, error)
+
+// SyncClient is a wrapper around client.Client that embeds an RWMutex to
+// keep track of client usage and know when/if we can call client.Close().
+type SyncClient struct {
+	*sync.RWMutex
+	*client.Client
+}
+
+// RetireClient waits for all SyncClient users to RUnlock(), then it closes the
+// client. This function can be run asynchronously. If we can't close the
+// client we're leaking goroutines and memory anyway.
+func (tc *SyncClient) RetireClient() {
+	if tc.Client == nil {
+		return
+	}
+	log.Debug("Waiting for client users to exit")
+	tc.Lock()
+	defer tc.Unlock()
+
+	log.Debug("Closing teleport client")
+	err := tc.Close()
+	if err != nil {
+		log.Warnf("Failed to close teleport client: %s", err)
+	}
+}
+
+// NewSyncClient wraps an existing client.Client into a SyncClient.
+func NewSyncClient(teleportClient *client.Client) *SyncClient {
+	return &SyncClient{
+		RWMutex: &sync.RWMutex{},
+		Client:  teleportClient,
+	}
+}

--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -17,9 +17,11 @@ limitations under the License.
 package sidecar
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -43,10 +45,6 @@ const (
 	DefaultRenewalInterval = 30 * time.Minute
 )
 
-// ClientAccessor returns a working teleport api client when invoked.
-// Client users should always call this function on a regular basis to ensure certs are always valid.
-type ClientAccessor func(ctx context.Context) (*client.Client, error)
-
 // Bot is a wrapper around an embedded tbot.
 // It implements sigs.k8s.io/controller-runtime/manager.Runnable and
 // sigs.k8s.io/controller-runtime/manager.LeaderElectionRunnable so it can be added to a controllerruntime.Manager.
@@ -55,6 +53,14 @@ type Bot struct {
 	running    bool
 	rootClient auth.ClientI
 	opts       Options
+
+	// mutex protects cachedCert and cachedClient
+	mutex        sync.Mutex
+	cachedCert   []byte
+	cachedClient *SyncClient
+
+	// clientBuilder is used for testing purposes. Outside of tests, its value should always be buildClient.
+	clientBuilder ClientAccessor
 }
 
 func (b *Bot) initializeConfig(ctx context.Context) {
@@ -97,20 +103,11 @@ func (b *Bot) initializeConfig(ctx context.Context) {
 
 }
 
-func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
-	if !b.running {
-		return nil, trace.Errorf("bot not started yet")
-	}
-	// If the bot has not joined the cluster yet or not generated client certs we bail out
-	// This is either temporary or the bot is dead and the manager will shut down everything.
+// buildClient reads tbot's memory disttination, retrieves the certificates
+// and builds a new Teleport client using those certs.
+func (b *Bot) buildClient(ctx context.Context) (*SyncClient, error) {
+	log.Infof("Building a new client to connect to %s", b.cfg.AuthServer)
 	storageDestination := b.cfg.Storage.Destination
-	if botCert, err := storageDestination.Read(ctx, identity.TLSCertKey); err != nil || len(botCert) == 0 {
-		return nil, trace.Retry(err, "bot cert not yet present")
-	}
-	if cert, err := b.cfg.Outputs[0].GetDestination().Read(ctx, identity.TLSCertKey); err != nil || len(cert) == 0 {
-		return nil, trace.Retry(err, "cert not yet present")
-	}
-
 	// Hack to be able to reuse LoadIdentity functions from tbot
 	// LoadIdentity expects to have all the artifacts required for a bot
 	// We loop over missing artifacts and are loading them from the bot storage to the destination
@@ -136,7 +133,50 @@ func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
 		Addrs:       []string{b.cfg.AuthServer},
 		Credentials: []client.Credentials{clientCredentials{id}},
 	})
-	return c, trace.Wrap(err)
+	return NewSyncClient(c), trace.Wrap(err)
+}
+
+// GetSyncClient gets a client authenticated as the bot. To avoid rebuilding a
+// client for each call, this function caches the client and creates a new one
+// only when the client certs changed (tbot renewed them).
+func (b *Bot) GetSyncClient(ctx context.Context) (*SyncClient, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if !b.running {
+		return nil, trace.Errorf("bot not started yet")
+	}
+	// If the bot has not joined the cluster yet or not generated client certs we bail out
+	// This is either temporary or the bot is dead and the manager will shut down everything.
+	storageDestination := b.cfg.Storage.Destination
+	if botCert, err := storageDestination.Read(ctx, identity.TLSCertKey); err != nil || len(botCert) == 0 {
+		return nil, trace.Retry(err, "bot cert not yet present")
+	}
+
+	cert, err := b.cfg.Outputs[0].GetDestination().Read(ctx, identity.TLSCertKey)
+	if err != nil || len(cert) == 0 {
+		return nil, trace.Retry(err, "cert not yet present")
+	}
+
+	// This is where caching happens. We don't know when tbot renews the certificates, so we need to check
+	// if the current certificate stored in memory changed since last time. If it did not and we already built a
+	// working client, then we hit the cache. Else we build a new client, replace the cached client with the new one,
+	// and fire a separate goroutine to close the previous client.
+	if b.cachedClient != nil && bytes.Equal(cert, b.cachedCert) {
+		return b.cachedClient, nil
+	}
+
+	oldClient := b.cachedClient
+	freshClient, err := b.clientBuilder(ctx)
+	if err == nil {
+		b.cachedCert = cert
+		b.cachedClient = freshClient
+	}
+
+	if oldClient != nil {
+		go oldClient.RetireClient()
+	}
+	return b.cachedClient, trace.Wrap(err)
 }
 
 type clientCredentials struct {
@@ -228,7 +268,9 @@ func CreateAndBootstrapBot(ctx context.Context, opts Options) (*Bot, *proto.Feat
 		opts:       opts,
 	}
 
+	bot.clientBuilder = bot.buildClient
 	bot.initializeConfig(ctx)
+
 	return bot, ping.ServerFeatures, nil
 }
 

--- a/integrations/operator/sidecar/tbot_test.go
+++ b/integrations/operator/sidecar/tbot_test.go
@@ -125,7 +125,7 @@ func TestBot_GetClient(t *testing.T) {
 				cachedClient:  tt.cachedClient,
 				clientBuilder: mock.buildClient,
 			}
-			_, err := b.GetSyncClient(ctx)
+			_, _, err := b.GetSyncClient(ctx)
 			tt.assertError(t, err)
 			tt.expectNewClientBuild(t, mock.countClientBuild() != 0)
 		})

--- a/integrations/operator/sidecar/tbot_test.go
+++ b/integrations/operator/sidecar/tbot_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+)
+
+type mockClientBuilder struct {
+	counter atomic.Int32
+}
+
+func (m *mockClientBuilder) buildClient(_ context.Context) (*SyncClient, error) {
+	m.counter.Add(1)
+	return NewSyncClient(nil), nil
+}
+
+func (m *mockClientBuilder) countClientBuild() int {
+	count := m.counter.Load()
+	count32 := int(count)
+	return count32
+}
+
+func TestBot_GetClient(t *testing.T) {
+	ctx := context.Background()
+
+	cert1 := []byte("cert1")
+	cert2 := []byte("cert2")
+
+	tests := []struct {
+		name                 string
+		running              bool
+		currentCert          []byte
+		cachedCert           []byte
+		cachedClient         *SyncClient
+		expectNewClientBuild require.BoolAssertionFunc
+		assertError          require.ErrorAssertionFunc
+	}{
+		{
+			name:                 "not started",
+			running:              false,
+			currentCert:          nil,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.False,
+			assertError:          require.Error,
+		},
+		{
+			name:                 "no cert yet",
+			running:              true,
+			currentCert:          nil,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.False,
+			assertError:          require.Error,
+		},
+		{
+			name:                 "cert but no cache",
+			running:              true,
+			currentCert:          cert1,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.True,
+			assertError:          require.NoError,
+		},
+		{
+			name:                 "cert and fresh cache",
+			running:              true,
+			currentCert:          cert1,
+			cachedCert:           cert1,
+			cachedClient:         NewSyncClient(nil),
+			expectNewClientBuild: require.False,
+			assertError:          require.NoError,
+		},
+		{
+			name:                 "cert and stale cache",
+			running:              true,
+			currentCert:          cert2,
+			cachedCert:           cert1,
+			cachedClient:         NewSyncClient(nil),
+			expectNewClientBuild: require.True,
+			assertError:          require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockClientBuilder{}
+			destination := &config.DestinationMemory{}
+			require.NoError(t, destination.CheckAndSetDefaults())
+			require.NoError(t, destination.Write(ctx, identity.TLSCertKey, tt.currentCert))
+			b := &Bot{
+				cfg: &config.BotConfig{
+					Storage: &config.StorageConfig{
+						Destination: destination,
+					},
+					Outputs: []config.Output{
+						&config.IdentityOutput{
+							Destination: destination,
+						},
+					},
+				},
+				running:       tt.running,
+				cachedCert:    tt.cachedCert,
+				cachedClient:  tt.cachedClient,
+				clientBuilder: mock.buildClient,
+			}
+			_, err := b.GetSyncClient(ctx)
+			tt.assertError(t, err)
+			tt.expectNewClientBuild(t, mock.countClientBuild() != 0)
+		})
+	}
+}


### PR DESCRIPTION
Backport #34050 to branch/v14