### PR TITLE
Link to the Usage/Billing page in the FAQ

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -178,6 +178,9 @@ The code that aggregates and anonymizes this data can be found [in our
 repository on
 GitHub](https://github.com/gravitational/teleport/tree/master/lib/usagereporter/teleport/aggregating).
 
+For more details, see the [Usage Reporting and Billing](./usage-billing.mdx)
+guide.
+
 Reach out to `sales@goteleport.com` if you have questions about the commercial
 editions of Teleport.
 


### PR DESCRIPTION
Ensure that users who start to learn about usage reporting and billing from the FAQ know that there is a dedicated page for this information.