### PR TITLE
Stop using shared buffer in logrus text formatter

### DIFF
--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -21,14 +21,17 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,16 +65,10 @@ func (a fakeAddr) String() string {
 }
 
 func TestOutput(t *testing.T) {
-	// Set a specific time zone so that the regex doesn't have to match
-	// against any possible timezone. Note this mucks around with the global
-	// time zone which prevents running this test in parallel.
 	loc, err := time.LoadLocation("Africa/Cairo")
 	require.NoError(t, err, "failed getting timezone")
-	oldLoc := time.Local
-	time.Local = loc
-	t.Cleanup(func() {
-		time.Local = oldLoc
-	})
+	clock := clockwork.NewFakeClockAt(time.Now().In(loc))
+	formattedNow := clock.Now().UTC().Format(time.RFC3339)
 
 	t.Run("text", func(t *testing.T) {
 		// fieldsRegex matches all the key value pairs emitted after the message and before the caller. All fields are
@@ -83,7 +80,7 @@ func TestOutput(t *testing.T) {
 		// 2) the message
 		// 3) the fields
 		// 4) the caller
-		outputRegex := regexp.MustCompile("(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2})(\\s+.*)(\".*diag_addr`\\.\")(.*)(\\slog/formatter_test.go:\\d{3})")
+		outputRegex := regexp.MustCompile("(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)(\\s+.*)(\".*diag_addr`\\.\")(.*)(\\slog/formatter_test.go:\\d{3})")
 
 		tests := []struct {
 			name        string
@@ -135,7 +132,7 @@ func TestOutput(t *testing.T) {
 				logrusLogger.SetOutput(&logrusOutput)
 				logrusLogger.ReplaceHooks(logrus.LevelHooks{})
 				logrusLogger.SetLevel(test.logrusLevel)
-				entry := logrusLogger.WithField(trace.Component, "test")
+				entry := logrusLogger.WithField(trace.Component, "test").WithTime(clock.Now().UTC())
 
 				// Create a slog logger using the custom handler which outputs to a local buffer.
 				var slogOutput bytes.Buffer
@@ -143,6 +140,12 @@ func TestOutput(t *testing.T) {
 					Level:        test.slogLevel,
 					EnableColors: true,
 					WithCaller:   true,
+					ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+						if a.Key == slog.TimeKey {
+							a.Value = slog.StringValue(formattedNow)
+						}
+						return a
+					},
 				}
 				slogLogger := slog.New(NewSlogTextHandler(&slogOutput, slogConfig)).With(trace.Component, "test")
 
@@ -175,8 +178,8 @@ func TestOutput(t *testing.T) {
 				// Match the log message: "Adding diagnostic debugging handlers.\t To connect with profiler, use `go tool pprof diag_addr`.\n"
 				assert.Empty(t, cmp.Diff(logrusMatches[3], slogMatches[3]), "expected output messages to be identical")
 				// The last matches are the caller information
-				assert.Equal(t, " log/formatter_test.go:151", logrusMatches[5])
-				assert.Equal(t, " log/formatter_test.go:155", slogMatches[5])
+				assert.Equal(t, " log/formatter_test.go:154", logrusMatches[5])
+				assert.Equal(t, " log/formatter_test.go:158", slogMatches[5])
 
 				// The third matches are the fields which will be key value pairs(animal:llama) separated by a space. Since
 				// logrus sorts the fields and slog doesn't we can't just assert equality and instead build a map of the key
@@ -279,12 +282,12 @@ func TestOutput(t *testing.T) {
 				logrusCaller, ok := logrusData["caller"].(string)
 				delete(logrusData, "caller")
 				assert.True(t, ok, "caller was missing from logrus output")
-				assert.Equal(t, "log/formatter_test.go:264", logrusCaller)
+				assert.Equal(t, "log/formatter_test.go:267", logrusCaller)
 
 				slogCaller, ok := slogData["caller"].(string)
 				delete(slogData, "caller")
 				assert.True(t, ok, "caller was missing from slog output")
-				assert.Equal(t, "log/formatter_test.go:268", slogCaller)
+				assert.Equal(t, "log/formatter_test.go:271", slogCaller)
 
 				require.Empty(t,
 					cmp.Diff(
@@ -299,6 +302,7 @@ func TestOutput(t *testing.T) {
 }
 
 func BenchmarkFormatter(b *testing.B) {
+	ctx := context.Background()
 	b.ReportAllocs()
 	b.Run("logrus", func(b *testing.B) {
 		b.Run("text", func(b *testing.B) {
@@ -307,7 +311,6 @@ func BenchmarkFormatter(b *testing.B) {
 			logger := logrus.New()
 			logger.SetFormatter(formatter)
 			logger.SetOutput(io.Discard)
-			logger.ReplaceHooks(logrus.LevelHooks{})
 			b.ResetTimer()
 
 			entry := logger.WithField(trace.Component, "test")
@@ -337,15 +340,14 @@ func BenchmarkFormatter(b *testing.B) {
 	b.Run("slog", func(b *testing.B) {
 		b.Run("default_text", func(b *testing.B) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
-				AddSource:   true,
-				Level:       slog.LevelDebug,
-				ReplaceAttr: nil,
+				AddSource: true,
+				Level:     slog.LevelDebug,
 			})).With(trace.Component, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
@@ -355,21 +357,20 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
 		b.Run("default_json", func(b *testing.B) {
 			logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{
-				AddSource:   true,
-				Level:       slog.LevelDebug,
-				ReplaceAttr: nil,
+				AddSource: true,
+				Level:     slog.LevelDebug,
 			})).With(trace.Component, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
@@ -379,8 +380,47 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).Info(message, "diag_addr", &addr)
+				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
+	})
+}
+
+func TestConcurrentOutput(t *testing.T) {
+	t.Run("logrus", func(t *testing.T) {
+		debugFormatter := NewDefaultTextFormatter(true)
+		require.NoError(t, debugFormatter.CheckAndSetDefaults())
+		logrus.SetFormatter(debugFormatter)
+		logrus.SetOutput(os.Stdout)
+
+		logger := logrus.WithField(trace.Component, "test")
+
+		var wg sync.WaitGroup
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				logger.Infof("Detected Teleport component %d is running in a degraded state.", i)
+			}(i)
+		}
+		wg.Wait()
+	})
+
+	t.Run("slog", func(t *testing.T) {
+		logger := slog.New(NewSlogTextHandler(os.Stdout, &SlogTextHandlerConfig{
+			EnableColors: true,
+			WithCaller:   true,
+		})).With(trace.Component, "test")
+
+		var wg sync.WaitGroup
+		ctx := context.Background()
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				logger.InfoContext(ctx, "Teleport component entered degraded state", "component", i)
+			}(i)
+		}
+		wg.Wait()
 	})
 }

--- a/lib/utils/log/logrus_formatter.go
+++ b/lib/utils/log/logrus_formatter.go
@@ -53,11 +53,7 @@ type writer struct {
 }
 
 func newWriter() *writer {
-	return &writer{b: newBuffer()}
-}
-
-func (w *writer) Free() {
-	w.b.Free()
+	return &writer{b: &buffer{}}
 }
 
 func (w *writer) Len() int {
@@ -140,7 +136,6 @@ func (tf *TextFormatter) CheckAndSetDefaults() error {
 func (tf *TextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	caller := tf.FormatCaller()
 	w := newWriter()
-	defer w.Free()
 
 	// write timestamp first if enabled
 	if tf.timestampEnabled {


### PR DESCRIPTION
Since the formatter does not directly write the output it creates and instead returns it to later be written we cannot reuse the buffer in a pool without potential races. This reverts the behavior of the formatter to create a new buffer instead of pulling one from a pool of buffers during formatting.


Fixes https://github.com/gravitational/teleport/issues/34426 and https://github.com/gravitational/teleport/issues/34410.