### PR TITLE
[v12] integrations/operator: re-use the teleport client instead of creating a new one

### DIFF
--- a/operator/controllers/resources/github_connector_controller.go
+++ b/operator/controllers/resources/github_connector_controller.go
@@ -34,10 +34,11 @@ type githubConnectorClient struct {
 
 // Get gets the Teleport github_connector of a given name
 func (r githubConnectorClient) Get(ctx context.Context, name string) (types.GithubConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer release()
 
 	github, err := teleportClient.GetGithubConnector(ctx, name, false /* with secrets*/)
 	return github, trace.Wrap(err)
@@ -45,30 +46,33 @@ func (r githubConnectorClient) Get(ctx context.Context, name string) (types.Gith
 
 // Create creates a Teleport github_connector
 func (r githubConnectorClient) Create(ctx context.Context, github types.GithubConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
 
 // Update updates a Teleport github_connector
 func (r githubConnectorClient) Update(ctx context.Context, github types.GithubConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertGithubConnector(ctx, github))
 }
 
 // Delete deletes a Teleport github_connector
 func (r githubConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteGithubConnector(ctx, name))
 }

--- a/operator/controllers/resources/login_rule_controller.go
+++ b/operator/controllers/resources/login_rule_controller.go
@@ -33,10 +33,11 @@ type loginRuleClient struct {
 
 // Get gets the Teleport login_rule of a given name
 func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.LoginRuleResource, error) {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer release()
 
 	loginRule, err := teleportClient.GetLoginRule(ctx, name)
 	if err != nil {
@@ -48,10 +49,11 @@ func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.Log
 
 // Create creates a Teleport login_rule
 func (l loginRuleClient) Create(ctx context.Context, resource *resourcesv1.LoginRuleResource) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	_, err = teleportClient.CreateLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -59,10 +61,11 @@ func (l loginRuleClient) Create(ctx context.Context, resource *resourcesv1.Login
 
 // Update updates a Teleport login_rule
 func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.LoginRuleResource) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	_, err = teleportClient.UpsertLoginRule(ctx, resource.LoginRule)
 	return trace.Wrap(err)
@@ -70,10 +73,11 @@ func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.Login
 
 // Delete deletes a Teleport login_rule
 func (l loginRuleClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := l.TeleportClientAccessor(ctx)
+	teleportClient, release, err := l.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteLoginRule(ctx, name))
 }

--- a/operator/controllers/resources/oidc_connector_controller.go
+++ b/operator/controllers/resources/oidc_connector_controller.go
@@ -34,10 +34,11 @@ type oidcConnectorClient struct {
 
 // Get gets the Teleport oidc_connector of a given name
 func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer release()
 
 	oidc, err := teleportClient.GetOIDCConnector(ctx, name, false /* with secrets*/)
 	return oidc, trace.Wrap(err)
@@ -45,30 +46,33 @@ func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCCo
 
 // Create creates a Teleport oidc_connector
 func (r oidcConnectorClient) Create(ctx context.Context, oidc types.OIDCConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
 
 // Update updates a Teleport oidc_connector
 func (r oidcConnectorClient) Update(ctx context.Context, oidc types.OIDCConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertOIDCConnector(ctx, oidc))
 }
 
 // Delete deletes a Teleport oidc_connector
 func (r oidcConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteOIDCConnector(ctx, name))
 }

--- a/operator/controllers/resources/role_controller.go
+++ b/operator/controllers/resources/role_controller.go
@@ -91,10 +91,11 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *RoleReconciler) Delete(ctx context.Context, obj kclient.Object) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 	return teleportClient.DeleteRole(ctx, obj.GetName())
 }
 
@@ -123,7 +124,10 @@ func (r *RoleReconciler) Upsert(ctx context.Context, obj kclient.Object) error {
 
 	// Converting the Kubernetes resource into a Teleport one, checking potential ownership issues.
 	teleportResource := k8sResource.ToTeleport()
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
+	if err == nil {
+		defer release()
+	}
 	updateErr = updateStatus(updateStatusConfig{
 		ctx:         ctx,
 		client:      r.Client,

--- a/operator/controllers/resources/saml_connector_controller.go
+++ b/operator/controllers/resources/saml_connector_controller.go
@@ -34,10 +34,11 @@ type samlConnectorClient struct {
 
 // Get gets the Teleport saml_connector of a given name
 func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLConnector, error) {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer release()
 
 	saml, err := teleportClient.GetSAMLConnector(ctx, name, false /* with secrets*/)
 	return saml, trace.Wrap(err)
@@ -45,30 +46,33 @@ func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLCo
 
 // Create creates a Teleport saml_connector
 func (r samlConnectorClient) Create(ctx context.Context, saml types.SAMLConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
 
 // Update updates a Teleport saml_connector
 func (r samlConnectorClient) Update(ctx context.Context, saml types.SAMLConnector) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.UpsertSAMLConnector(ctx, saml))
 }
 
 // Delete deletes a Teleport saml_connector
 func (r samlConnectorClient) Delete(ctx context.Context, name string) error {
-	teleportClient, err := r.TeleportClientAccessor(ctx)
+	teleportClient, release, err := r.TeleportClientAccessor(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer release()
 
 	return trace.Wrap(teleportClient.DeleteSAMLConnector(ctx, name))
 }

--- a/operator/controllers/resources/testlib/env.go
+++ b/operator/controllers/resources/testlib/env.go
@@ -48,6 +48,7 @@ import (
 	resourcesv3 "github.com/gravitational/teleport/operator/apis/resources/v3"
 	resourcesv5 "github.com/gravitational/teleport/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/operator/controllers/resources"
+	"github.com/gravitational/teleport/operator/sidecar"
 )
 
 // scheme is our own test-specific scheme to avoid using the global
@@ -172,8 +173,8 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	// We have to create a new Manager on each start because the Manager does not support to be restarted
-	clientAccessor := func(ctx context.Context) (*client.Client, error) {
-		return s.TeleportClient, nil
+	clientAccessor := func(ctx context.Context) (*sidecar.SyncClient, func(), error) {
+		return sidecar.NewSyncClient(s.TeleportClient), func() {}, nil
 	}
 
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{

--- a/operator/main.go
+++ b/operator/main.go
@@ -138,7 +138,7 @@ func main() {
 	if err = (&resourcescontrollers.RoleReconciler{
 		Client:                 mgr.GetClient(),
 		Scheme:                 mgr.GetScheme(),
-		TeleportClientAccessor: bot.GetClient,
+		TeleportClientAccessor: bot.GetSyncClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportRole")
 		os.Exit(1)
@@ -147,20 +147,20 @@ func main() {
 	if err = (&resourcescontrollers.UserReconciler{
 		Client:                 mgr.GetClient(),
 		Scheme:                 mgr.GetScheme(),
-		TeleportClientAccessor: bot.GetClient,
+		TeleportClientAccessor: bot.GetSyncClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportUser")
 		os.Exit(1)
 	}
 
-	if err = resourcescontrollers.NewGithubConnectorReconciler(mgr.GetClient(), bot.GetClient).
+	if err = resourcescontrollers.NewGithubConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TeleportGithubConnector")
 		os.Exit(1)
 	}
 
 	if features.OIDC {
-		if err = resourcescontrollers.NewOIDCConnectorReconciler(mgr.GetClient(), bot.GetClient).
+		if err = resourcescontrollers.NewOIDCConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportOIDCConnector")
 			os.Exit(1)
@@ -170,7 +170,7 @@ func main() {
 	}
 
 	if features.SAML {
-		if err = resourcescontrollers.NewSAMLConnectorReconciler(mgr.GetClient(), bot.GetClient).
+		if err = resourcescontrollers.NewSAMLConnectorReconciler(mgr.GetClient(), bot.GetSyncClient).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportSAMLConnector")
 			os.Exit(1)
@@ -181,7 +181,7 @@ func main() {
 
 	// Login Rules are enterprise-only but there is no specific feature flag for them.
 	if features.OIDC || features.SAML {
-		if err := resourcescontrollers.NewLoginRuleReconciler(mgr.GetClient(), bot.GetClient).SetupWithManager(mgr); err != nil {
+		if err := resourcescontrollers.NewLoginRuleReconciler(mgr.GetClient(), bot.GetSyncClient).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TeleportLoginRule")
 			os.Exit(1)
 		}

--- a/operator/sidecar/syncclient.go
+++ b/operator/sidecar/syncclient.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"context"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/client"
+)
+
+// Note: this whole part of the code handles client reloading.
+// In the next versions, tbot will be able to issue Client with automatically
+// refreshed certificates. We will be able to remove this whole section and
+// pass a plain client to the controllers.
+
+// ClientAccessor is a function that returns a SyncClient to be used in a
+// reconciliation loop. As we need a new client each time tbot renews
+// certificate, we cannot pass the client directly to the controllers.
+// Controllers are given a ClientAccessor and are responsible for calling
+// RLock() / RUnlock() on the SyncClient.
+type ClientAccessor func(ctx context.Context) (*SyncClient, func(), error)
+
+// SyncClient is a wrapper around client.Client that embeds a WaitGroup to
+// keep track of client usage and know when/if we can call client.Close().
+type SyncClient struct {
+	useCounter *sync.WaitGroup
+	*client.Client
+}
+
+// RetireClient waits for all SyncClient users to RUnlock(), then it closes the
+// client. This function can be run asynchronously. If we can't close the
+// client we're leaking goroutines and memory anyway.
+func (tc *SyncClient) RetireClient() {
+	if tc.Client == nil {
+		return
+	}
+	log.Debug("Waiting for client users to exit")
+	tc.useCounter.Wait()
+
+	log.Debug("Closing teleport client")
+	err := tc.Close()
+	if err != nil {
+		log.Warnf("Failed to close teleport client: %s", err)
+	}
+}
+
+// LockClient registers that the caller is using the client and
+// prevents client deletion. It returns a function that must be called to
+// release the client once the reconciliation is done.
+func (tc *SyncClient) LockClient() func() {
+	tc.useCounter.Add(1)
+	return func() {
+		tc.useCounter.Done()
+	}
+}
+
+// NewSyncClient wraps an existing client.Client into a SyncClient.
+func NewSyncClient(teleportClient *client.Client) *SyncClient {
+	return &SyncClient{
+		useCounter: &sync.WaitGroup{},
+		Client:     teleportClient,
+	}
+}

--- a/operator/sidecar/tbot.go
+++ b/operator/sidecar/tbot.go
@@ -17,9 +17,11 @@ limitations under the License.
 package sidecar
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -43,10 +45,6 @@ const (
 	DefaultRenewalInterval = 30 * time.Minute
 )
 
-// ClientAccessor returns a working teleport api client when invoked.
-// Client users should always call this function on a regular basis to ensure certs are always valid.
-type ClientAccessor func(ctx context.Context) (*client.Client, error)
-
 // Bot is a wrapper around an embedded tbot.
 // It implements sigs.k8s.io/controller-runtime/manager.Runnable and
 // sigs.k8s.io/controller-runtime/manager.LeaderElectionRunnable so it can be added to a controllerruntime.Manager.
@@ -55,6 +53,14 @@ type Bot struct {
 	running    bool
 	rootClient auth.ClientI
 	opts       Options
+
+	// mutex protects cachedCert and cachedClient
+	mutex        sync.Mutex
+	cachedCert   []byte
+	cachedClient *SyncClient
+
+	// clientBuilder is used for testing purposes. Outside of tests, its value should always be buildClient.
+	clientBuilder func(ctx context.Context) (*SyncClient, error)
 }
 
 func (b *Bot) initializeConfig() {
@@ -101,19 +107,10 @@ func (b *Bot) initializeConfig() {
 
 }
 
-func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
-	if !b.running {
-		return nil, trace.Errorf("bot not started yet")
-	}
-	// If the bot has not joined the cluster yet or not generated client certs we bail out
-	// This is either temporary or the bot is dead and the manager will shut down everything.
-	if botCert, err := b.cfg.Storage.Memory.Read(identity.TLSCertKey); err != nil || len(botCert) == 0 {
-		return nil, trace.Retry(err, "bot cert not yet present")
-	}
-	if cert, err := b.cfg.Destinations[0].Memory.Read(identity.TLSCertKey); err != nil || len(cert) == 0 {
-		return nil, trace.Retry(err, "cert not yet present")
-	}
-
+// buildClient reads tbot's memory disttination, retrieves the certificates
+// and builds a new Teleport client using those certs.
+func (b *Bot) buildClient(ctx context.Context) (*SyncClient, error) {
+	log.Infof("Building a new client to connect to %s", b.cfg.AuthServer)
 	// Hack to be able to reuse LoadIdentity functions from tbot
 	// LoadIdentity expects to have all the artifacts required for a bot
 	// We loop over missing artifacts and are loading them from the bot storage to the destination
@@ -139,7 +136,54 @@ func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
 		Addrs:       []string{b.cfg.AuthServer},
 		Credentials: []client.Credentials{clientCredentials{id}},
 	})
-	return c, trace.Wrap(err)
+	return NewSyncClient(c), trace.Wrap(err)
+}
+
+// GetSyncClient gets a client authenticated as the bot. To avoid rebuilding a
+// client for each call, this function caches the client and creates a new one
+// only when the client certs changed (tbot renewed them).
+func (b *Bot) GetSyncClient(ctx context.Context) (*SyncClient, func(), error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if !b.running {
+		return nil, nil, trace.Errorf("bot not started yet")
+	}
+	// If the bot has not joined the cluster yet or not generated client certs we bail out
+	// This is either temporary or the bot is dead and the manager will shut down everything.
+	storageDestination := b.cfg.Storage.Memory
+	if botCert, err := storageDestination.Read(identity.TLSCertKey); err != nil || len(botCert) == 0 {
+		return nil, nil, trace.Retry(err, "bot cert not yet present")
+	}
+
+	cert, err := b.cfg.Destinations[0].Memory.Read(identity.TLSCertKey)
+	if err != nil || len(cert) == 0 {
+		return nil, nil, trace.Retry(err, "cert not yet present")
+	}
+
+	// This is where caching happens. We don't know when tbot renews the certificates, so we need to check
+	// if the current certificate stored in memory changed since last time. If it did not and we already built a
+	// working client, then we hit the cache. Else we build a new client, replace the cached client with the new one,
+	// and fire a separate goroutine to close the previous client.
+	if b.cachedClient != nil && bytes.Equal(cert, b.cachedCert) {
+		return b.cachedClient, b.cachedClient.LockClient(), nil
+	}
+
+	oldClient := b.cachedClient
+	freshClient, err := b.clientBuilder(ctx)
+
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	b.cachedCert = cert
+	b.cachedClient = freshClient
+
+	if oldClient != nil {
+		go oldClient.RetireClient()
+	}
+
+	return b.cachedClient, b.cachedClient.LockClient(), nil
 }
 
 type clientCredentials struct {
@@ -232,7 +276,9 @@ func CreateAndBootstrapBot(ctx context.Context, opts Options) (*Bot, *proto.Feat
 		opts:       opts,
 	}
 
+	bot.clientBuilder = bot.buildClient
 	bot.initializeConfig()
+
 	return bot, ping.ServerFeatures, nil
 }
 

--- a/operator/sidecar/tbot_test.go
+++ b/operator/sidecar/tbot_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+)
+
+type mockClientBuilder struct {
+	counter atomic.Int32
+}
+
+func (m *mockClientBuilder) buildClient(_ context.Context) (*SyncClient, error) {
+	m.counter.Add(1)
+	return NewSyncClient(nil), nil
+}
+
+func (m *mockClientBuilder) countClientBuild() int {
+	count := m.counter.Load()
+	count32 := int(count)
+	return count32
+}
+
+func TestBot_GetClient(t *testing.T) {
+	ctx := context.Background()
+
+	cert1 := []byte("cert1")
+	cert2 := []byte("cert2")
+
+	tests := []struct {
+		name                 string
+		running              bool
+		currentCert          []byte
+		cachedCert           []byte
+		cachedClient         *SyncClient
+		expectNewClientBuild require.BoolAssertionFunc
+		assertError          require.ErrorAssertionFunc
+	}{
+		{
+			name:                 "not started",
+			running:              false,
+			currentCert:          nil,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.False,
+			assertError:          require.Error,
+		},
+		{
+			name:                 "no cert yet",
+			running:              true,
+			currentCert:          nil,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.False,
+			assertError:          require.Error,
+		},
+		{
+			name:                 "cert but no cache",
+			running:              true,
+			currentCert:          cert1,
+			cachedCert:           nil,
+			cachedClient:         nil,
+			expectNewClientBuild: require.True,
+			assertError:          require.NoError,
+		},
+		{
+			name:                 "cert and fresh cache",
+			running:              true,
+			currentCert:          cert1,
+			cachedCert:           cert1,
+			cachedClient:         NewSyncClient(nil),
+			expectNewClientBuild: require.False,
+			assertError:          require.NoError,
+		},
+		{
+			name:                 "cert and stale cache",
+			running:              true,
+			currentCert:          cert2,
+			cachedCert:           cert1,
+			cachedClient:         NewSyncClient(nil),
+			expectNewClientBuild: require.True,
+			assertError:          require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockClientBuilder{}
+			destination := &config.DestinationMemory{}
+			require.NoError(t, destination.CheckAndSetDefaults())
+			require.NoError(t, destination.Write(identity.TLSCertKey, tt.currentCert))
+			b := &Bot{
+				cfg: &config.BotConfig{
+					Storage: &config.StorageConfig{DestinationMixin: config.DestinationMixin{Memory: destination}},
+					Destinations: []*config.DestinationConfig{
+						{DestinationMixin: config.DestinationMixin{Memory: destination}},
+					},
+				},
+				running:       tt.running,
+				cachedCert:    tt.cachedCert,
+				cachedClient:  tt.cachedClient,
+				clientBuilder: mock.buildClient,
+			}
+			_, _, err := b.GetSyncClient(ctx)
+			tt.assertError(t, err)
+			tt.expectNewClientBuild(t, mock.countClientBuild() != 0)
+		})
+	}
+}


### PR DESCRIPTION
Manual backport of #34050 to branch/v12