### PR TITLE
Implement temporary last step of Connect My Computer flow in Discover

### DIFF
--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -120,7 +120,12 @@ export const HintTimeout = () => (
 
 HintTimeout.parameters = {
   msw: {
-    handlers: [noNodesHandler],
+    handlers: [
+      noNodesHandler,
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+    ],
   },
 };
 

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -37,6 +37,7 @@ const oneDay = 1000 * 60 * 60 * 24;
 const setupConnectProps = {
   prevStep: () => {},
   nextStep: () => {},
+  updateAgentMeta: () => {},
   // Set high default intervals and timeouts so that stories don't poll for no reason.
   pingInterval: oneDay,
   showHintTimeout: oneDay,

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.test.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.test.ts
@@ -122,6 +122,7 @@ describe('usePollForConnectMyComputerNode', () => {
     await waitFor(() => {
       expect(nodeService.fetchNodes).toHaveBeenCalled();
     });
+    expect(userService.reloadUser).not.toHaveBeenCalled();
 
     rerender({
       reloadUser: true,

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -86,6 +86,23 @@ export function SetupConnect(
     reloadUser: showHint,
   });
 
+  const { agentMeta, updateAgentMeta, nextStep } = props;
+  const handleNextStep = useCallback(() => {
+    if (!node) {
+      return;
+    }
+
+    updateAgentMeta({
+      ...agentMeta,
+      // Node is an oddity in that the hostname is the more
+      // user identifiable resource name and what user expects
+      // as the resource name.
+      resourceName: node.hostname,
+      node,
+    });
+    nextStep();
+  }, [node, updateAgentMeta, agentMeta, nextStep]);
+
   useEffect(() => {
     if (isPolling) {
       const id = window.setTimeout(() => setShowHint(true), showHintTimeout);
@@ -211,7 +228,7 @@ export function SetupConnect(
       {pollingStatus}
 
       <ActionButtons
-        onProceed={props.nextStep}
+        onProceed={handleNextStep}
         disableProceed={!node}
         onPrev={props.prevStep}
       />

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -86,8 +86,9 @@ export function SetupConnect(
     reloadUser: showHint,
   });
 
+  // TODO(ravicious): Take these from the context rather than from props.
   const { agentMeta, updateAgentMeta, nextStep } = props;
-  const handleNextStep = useCallback(() => {
+  const handleNextStep = () => {
     if (!node) {
       return;
     }
@@ -101,7 +102,7 @@ export function SetupConnect(
       node,
     });
     nextStep();
-  }, [node, updateAgentMeta, agentMeta, nextStep]);
+  };
 
   useEffect(() => {
     if (isPolling) {

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 
 import { nodes } from 'teleport/Nodes/fixtures';
 
@@ -28,10 +29,16 @@ const node = nodes[0];
 
 export const Story = () => {
   return (
-    <TestConnection
-      prevStep={() => {}}
-      nextStep={() => {}}
-      agentMeta={{ resourceName: node.hostname, node, agentMatcherLabels: [] }}
-    />
+    <MemoryRouter>
+      <TestConnection
+        prevStep={() => {}}
+        nextStep={() => {}}
+        agentMeta={{
+          resourceName: node.hostname,
+          node,
+          agentMatcherLabels: [],
+        }}
+      />
+    </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -16,29 +16,119 @@
 
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+import { rest } from 'msw';
 
 import { nodes } from 'teleport/Nodes/fixtures';
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { UserContext } from 'teleport/User/UserContext';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 
 import { TestConnection } from './TestConnection';
 
 export default {
   title: 'Teleport/Discover/ConnectMyComputer/TestConnection',
+  loaders: [mswLoader],
 };
+
+initialize();
 
 const node = nodes[0];
 
+const agentStepProps = {
+  prevStep: () => {},
+  nextStep: () => {},
+  agentMeta: { resourceName: node.hostname, node, agentMatcherLabels: [] },
+};
+
 export const Story = () => {
   return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+Story.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+    ],
+  },
+};
+
+export const ReloadUserProcessing = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+ReloadUserProcessing.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.delay('infinite'))
+      ),
+    ],
+  },
+};
+
+export const ReloadUserError = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+ReloadUserError.parameters = {
+  msw: {
+    handlers: [
+      // The first handler returns an error immediately. Subsequent requests return after a delay so
+      // that we can show a spinner after clicking on "Retry".
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res.once(
+          ctx.status(500),
+          ctx.json({ message: 'Could not renew session' })
+        )
+      ),
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(
+          ctx.delay(1000),
+          ctx.status(500),
+          ctx.json({ message: 'Could not renew session' })
+        )
+      ),
+    ],
+  },
+};
+
+const Provider = ({ children }) => {
+  const ctx = createTeleportContext();
+
+  const preferences = makeDefaultUserPreferences();
+  const updatePreferences = () => Promise.resolve();
+  const getClusterPinnedResources = () => Promise.resolve([]);
+  const updateClusterPinnedResources = () => Promise.resolve();
+
+  return (
     <MemoryRouter>
-      <TestConnection
-        prevStep={() => {}}
-        nextStep={() => {}}
-        agentMeta={{
-          resourceName: node.hostname,
-          node,
-          agentMatcherLabels: [],
+      <UserContext.Provider
+        value={{
+          preferences,
+          updatePreferences,
+          getClusterPinnedResources,
+          updateClusterPinnedResources,
         }}
-      />
+      >
+        <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      </UserContext.Provider>
     </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -57,6 +57,9 @@ Story.parameters = {
       rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
         res(ctx.json({}))
       ),
+      rest.get(cfg.api.nodesPath, (req, res, ctx) =>
+        res(ctx.json({ items: [node] }))
+      ),
     ],
   },
 };

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { nodes } from 'teleport/Nodes/fixtures';
+
+import { TestConnection } from './TestConnection';
+
+export default {
+  title: 'Teleport/Discover/ConnectMyComputer/TestConnection',
+};
+
+const node = nodes[0];
+
+export const Story = () => {
+  return (
+    <TestConnection
+      prevStep={() => {}}
+      nextStep={() => {}}
+      agentMeta={{ resourceName: node.hostname, node, agentMatcherLabels: [] }}
+    />
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -16,9 +16,10 @@
 
 import React from 'react';
 
-import { ButtonSecondary, Flex, Text } from 'design';
+import { Flex, Text } from 'design';
 
 import { ActionButtons, StyledBox, Header } from 'teleport/Discover/Shared';
+import { NodeConnect } from 'teleport/UnifiedResources/ResourceActionButton';
 
 import { NodeMeta } from '../../useDiscover';
 
@@ -39,7 +40,7 @@ export const TestConnection = (props: AgentStepProps) => {
           Optionally verify that you can connect to &ldquo;{meta.resourceName}
           &rdquo; by starting a session.
         </Text>
-        <ButtonSecondary>Start a Session</ButtonSecondary>
+        <NodeConnect node={meta.node} textTransform="uppercase" />
       </StyledBox>
 
       <ActionButtons

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ButtonSecondary, Flex, Text } from 'design';
+
+import { ActionButtons, StyledBox, Header } from 'teleport/Discover/Shared';
+
+import { NodeMeta } from '../../useDiscover';
+
+import type { AgentStepProps } from '../../types';
+
+export const TestConnection = (props: AgentStepProps) => {
+  const meta = props.agentMeta as NodeMeta;
+
+  return (
+    <Flex flexDirection="column" alignItems="flex-start" mb={2} gap={4}>
+      <div>
+        <Header>Start a Session</Header>
+      </div>
+
+      <StyledBox>
+        <Text bold>Step 1: Connect to Your Computer</Text>
+        <Text typography="subtitle1" mb={2}>
+          Optionally verify that you can connect to &ldquo;{meta.resourceName}
+          &rdquo; by starting a session.
+        </Text>
+        <ButtonSecondary>Start a Session</ButtonSecondary>
+      </StyledBox>
+
+      <ActionButtons
+        onProceed={props.nextStep}
+        lastStep={true}
+        onPrev={props.prevStep}
+      />
+    </Flex>
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -125,7 +125,9 @@ export const TestConnection = (props: AgentStepProps) => {
         onProceed={props.nextStep}
         disableProceed={refetchNodeAttempt.status !== 'success'}
         lastStep={true}
-        onPrev={props.prevStep}
+        // onPrev is not passed on purpose to disable the back button. The flow would go back to
+        // polling which wouldn't make sense as the user has already connected their computer so the
+        // step would poll forever, unless the user removed the agent and configured it again.
       />
     </Flex>
   );

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TestConnection } from './TestConnection';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
 import { ResourceViewConfig } from 'teleport/Discover/flow';
-import { ResourceKind } from 'teleport/Discover/Shared';
+import { Finished, ResourceKind } from 'teleport/Discover/Shared';
 import { DiscoverEvent } from 'teleport/services/userEvent';
 
 import { ResourceSpec } from '../SelectResource';
 
 import { SetupConnect } from './SetupConnect';
+import { TestConnection } from './TestConnection';
 
 export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.ConnectMyComputer,
@@ -33,11 +32,18 @@ export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
       eventName: DiscoverEvent.DeployService,
     },
     {
-      title: 'Test Connection',
-      component: () => <div>WIP</div>,
+      // TODO(ravicious): Rename this to "Test Connection" after implementing the connection test.
+      title: 'Start a Session',
+      component: TestConnection,
       eventName: DiscoverEvent.TestConnection,
       // TODO(ravicious): Manually emit success event on test connection success.
-      // manuallyEmitSuccessEvent: true,
+      manuallyEmitSuccessEvent: true,
+    },
+    {
+      title: 'Finished',
+      component: Finished,
+      hide: true,
+      eventName: DiscoverEvent.Completed,
     },
   ],
 };

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
@@ -40,7 +40,7 @@ describe('onProceed correctly deduplicates, removes static traits, updates meta,
   const ctx = createTeleportContext();
   jest.spyOn(ctx.userService, 'fetchUser').mockResolvedValue(getMockUser());
   jest.spyOn(ctx.userService, 'updateUser').mockResolvedValue(null);
-  jest.spyOn(ctx.userService, 'applyUserTraits').mockResolvedValue(null);
+  jest.spyOn(ctx.userService, 'reloadUser').mockResolvedValue(null);
   jest
     .spyOn(userEventService, 'captureDiscoverEvent')
     .mockResolvedValue(null as never); // return value does not matter but required by ts
@@ -120,7 +120,7 @@ describe('onProceed correctly deduplicates, removes static traits, updates meta,
     });
 
     await waitFor(() => {
-      expect(ctx.userService.applyUserTraits).toHaveBeenCalledTimes(1);
+      expect(ctx.userService.reloadUser).toHaveBeenCalledTimes(1);
     });
 
     // Test that we are updating the user with the correct traits.
@@ -199,7 +199,7 @@ describe('onProceed correctly deduplicates, removes static traits, updates meta,
     });
 
     await waitFor(() => {
-      expect(ctx.userService.applyUserTraits).toHaveBeenCalledTimes(1);
+      expect(ctx.userService.reloadUser).toHaveBeenCalledTimes(1);
     });
 
     // Test that we are updating the user with the correct traits.
@@ -270,7 +270,7 @@ describe('onProceed correctly deduplicates, removes static traits, updates meta,
     });
 
     await waitFor(() => {
-      expect(ctx.userService.applyUserTraits).toHaveBeenCalledTimes(1);
+      expect(ctx.userService.reloadUser).toHaveBeenCalledTimes(1);
     });
 
     // Test that we are updating the user with the correct traits.

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
@@ -248,7 +248,7 @@ export function useUserTraits(props: AgentStepProps) {
           throw error;
         });
 
-      await ctx.userService.applyUserTraits().catch((error: Error) => {
+      await ctx.userService.reloadUser().catch((error: Error) => {
         emitErrorEvent(`error applying new user traits: ${error.message}`);
         throw error;
       });

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -54,7 +54,13 @@ export const ResourceActionButton = ({ resource }: Props) => {
   }
 };
 
-const NodeConnect = ({ node }: { node: Node }) => {
+export const NodeConnect = ({
+  node,
+  textTransform,
+}: {
+  node: Node;
+  textTransform?: string;
+}) => {
   const { clusterId } = useStickyClusterId();
   const startSshSession = (login: string, serverId: string) => {
     const url = cfg.getSshConnectRoute({
@@ -78,7 +84,7 @@ const NodeConnect = ({ node }: { node: Node }) => {
   return (
     <MenuLogin
       width="90px"
-      textTransform="none"
+      textTransform={textTransform || 'none'}
       alignButtonWidthToMenu
       getLoginItems={handleOnOpen}
       onSelect={handleOnSelect}

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -68,8 +68,8 @@ const service = {
     return api.delete(cfg.getUserWithUsernameUrl(name));
   },
 
-  async reloadUser() {
-    await session.renewSession({ reloadUser: true });
+  async reloadUser(signal?: AbortSignal) {
+    await session.renewSession({ reloadUser: true }, signal);
   },
 
   checkUserHasAccessToRegisteredResource(): Promise<boolean> {

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -68,8 +68,8 @@ const service = {
     return api.delete(cfg.getUserWithUsernameUrl(name));
   },
 
-  applyUserTraits() {
-    return session.renewSession({ reloadUser: true });
+  async reloadUser() {
+    await session.renewSession({ reloadUser: true });
   },
 
   checkUserHasAccessToRegisteredResource(): Promise<boolean> {

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -71,8 +71,8 @@ const session = {
 
   // renewSession renews session and returns the
   // absolute time the new session expires.
-  renewSession(req: RenewSessionRequest): Promise<Date> {
-    return this._renewToken(req).then(token => token.sessionExpires);
+  renewSession(req: RenewSessionRequest, signal?: AbortSignal): Promise<Date> {
+    return this._renewToken(req, signal).then(token => token.sessionExpires);
   },
 
   /**
@@ -133,10 +133,10 @@ const session = {
     return this._timeLeft() < RENEW_TOKEN_TIME;
   },
 
-  _renewToken(req: RenewSessionRequest = {}) {
+  _renewToken(req: RenewSessionRequest = {}, signal?: AbortSignal) {
     this._setAndBroadcastIsRenewing(true);
     return api
-      .post(cfg.getRenewTokenUrl(), req)
+      .post(cfg.getRenewTokenUrl(), req, signal)
       .then(json => {
         const token = makeBearerToken(json);
         localStorage.setBearerToken(token);


### PR DESCRIPTION
Closes #32192.

[Figma](https://www.figma.com/file/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?type=design&node-id=1386-30152&mode=dev)

This PR implements the last step of the Connect My Computer flom in Discover. It's a temporary version of it – after next week I'm going to work on adding an actual connection test.

### Shortcuts taken in the last step

Connect My Computer creates a special role for each user (`connect-my-computer-<username>`) which contains a valid login for the device where Connect My Computer was set up on. If the user set up Connect My Computer on multiple devices which use different system usernames, this role is going to contain multiple valid logins.

Originally the idea was to read the logins from that role and show only them in MenuLogin – or not even show MenuLogin at all if there's only a single valid role.

However, I assumed that there exists a way to read the details of a role in the Web UI. There's no such API today, the only way to achieve that is to read the YAML from the role which we don't want to do. idk why I assumed that, Connect doesn't have such an API on the frontend as well!

Once I get around to adding an actual connection test, I'm going to add an endpoint which reads the logins from the Connect My Computer role. In the meantime, I'm just going to show all usable logins.

### Reloading user in polling

This PR also addresses an edge case I described in #34401. If polling in the previous step reaches a "timeout" where we show the hint, we should reload the user session. If they finished the setup in Connect, the new role in their role list might allow them to see the newly added node which they would not be able to see otherwise.

---

For the deep link to work, you need to compile master Connect locally:

```
yarn build-term && CONNECT_TSH_BIN_PATH=$PWD/build/tsh CSC_IDENTITY_AUTO_DISCOVERY=false yarn package-term -c.extraMetadata.version=14.1.1
```

But you can also just download the current v14 of Connect, open the app manually and then open Connect My Computer through the top left icon.