### PR TITLE
Initialize slog logger alongside logrus logger

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
-	stdlog "log"
+	"log/slog"
 	"maps"
 	"net"
 	"net/url"
@@ -666,59 +666,84 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *servicecfg.Config) error {
 func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 	logger := log.StandardLogger()
 
+	var w io.Writer
 	switch loggerConfig.Output {
 	case "":
-		break // not set
+		w = os.Stderr
 	case "stderr", "error", "2":
-		logger.SetOutput(os.Stderr)
+		w = os.Stderr
 		cfg.Console = io.Discard // disable console printing
 	case "stdout", "out", "1":
-		logger.SetOutput(os.Stdout)
+		w = os.Stdout
 		cfg.Console = io.Discard // disable console printing
 	case teleport.Syslog:
-		err := utils.SwitchLoggerToSyslog(logger)
+		// TODO(tross): add slog support for syslog.
+		hook, err := utils.CreateSyslogHook()
 		if err != nil {
-			// this error will go to stderr
-			log.Errorf("Failed to switch logging to syslog: %v.", err)
+			// syslog is not available
+			logger.Errorf("Failed to switch logging to syslog: %v.", err)
+			w = os.Stderr
+			break
 		}
+		logger.ReplaceHooks(make(log.LevelHooks))
+		logger.AddHook(hook)
+		// ... and disable stderr:
+		w = io.Discard
 	default:
 		// assume it's a file path:
 		logFile, err := os.Create(loggerConfig.Output)
 		if err != nil {
 			return trace.Wrap(err, "failed to create the log file")
 		}
-		logger.SetOutput(logFile)
+		w = logFile
 	}
 
+	var level slog.Level
 	switch strings.ToLower(loggerConfig.Severity) {
 	case "", "info":
 		logger.SetLevel(log.InfoLevel)
+		level = slog.LevelInfo
 	case "err", "error":
 		logger.SetLevel(log.ErrorLevel)
+		level = slog.LevelError
 	case teleport.DebugLevel:
 		logger.SetLevel(log.DebugLevel)
+		level = slog.LevelDebug
 	case "warn", "warning":
 		logger.SetLevel(log.WarnLevel)
+		level = slog.LevelWarn
 	case "trace":
 		logger.SetLevel(log.TraceLevel)
+		level = logutils.TraceLevel
 	default:
 		return trace.BadParameter("unsupported logger severity: %q", loggerConfig.Severity)
 	}
 
+	sharedWriter := logutils.NewSharedWriter(w)
+	var slogLogger *slog.Logger
 	switch strings.ToLower(loggerConfig.Format.Output) {
 	case "":
 		fallthrough // not set. defaults to 'text'
 	case "text":
+		enableColors := trace.IsTerminal(os.Stderr)
 		formatter := &logutils.TextFormatter{
 			ExtraFields:  loggerConfig.Format.ExtraFields,
-			EnableColors: trace.IsTerminal(os.Stderr),
+			EnableColors: enableColors,
 		}
 
 		if err := formatter.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 
+		logger.SetOutput(sharedWriter)
 		logger.SetFormatter(formatter)
+
+		slogLogger = slog.New(logutils.NewSlogTextHandler(sharedWriter, &logutils.SlogTextHandlerConfig{
+			Level:        level,
+			EnableColors: enableColors,
+			WithCaller:   true,
+		}))
+		slog.SetDefault(slogLogger)
 	case "json":
 		formatter := &logutils.JSONFormatter{
 			ExtraFields: loggerConfig.Format.ExtraFields,
@@ -729,13 +754,16 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 		}
 
 		logger.SetFormatter(formatter)
-		stdlog.SetOutput(io.Discard) // disable the standard logger used by external dependencies
-		stdlog.SetFlags(0)
+		logger.SetOutput(sharedWriter)
+
+		slogLogger = slog.New(logutils.NewSlogJSONHandler(sharedWriter, level))
+		slog.SetDefault(slogLogger)
 	default:
 		return trace.BadParameter("unsupported log output format : %q", loggerConfig.Format.Output)
 	}
 
 	cfg.Log = logger
+	cfg.Logger = slogLogger
 	return nil
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -394,8 +395,11 @@ type TeleportProcess struct {
 	// during in-process reloads.
 	id string
 
-	// log is a process-local log entry.
+	// log is a process-local logrus.Entry.
+	// Deprecated: use logger instead.
 	log logrus.FieldLogger
+	// logger is a process-local slog.Logger.
+	logger *slog.Logger
 
 	// keyPairs holds private/public key pairs used
 	// to get signed host certificates from auth server
@@ -805,6 +809,10 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		trace.Component: teleport.Component(teleport.ComponentProcess, processID),
 		"pid":           fmt.Sprintf("%v.%v", os.Getpid(), processID),
 	}))
+	cfg.Logger = cfg.Logger.With(
+		trace.Component, teleport.Component(teleport.ComponentProcess, processID),
+		"pid", fmt.Sprintf("%v.%v", os.Getpid(), processID),
+	)
 
 	// If FIPS mode was requested make sure binary is build against BoringCrypto.
 	if cfg.FIPS {
@@ -940,16 +948,13 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		storage:                storage,
 		id:                     processID,
 		log:                    cfg.Log,
+		logger:                 cfg.Logger,
 		keyPairs:               make(map[keyPairKey]KeyPair),
 		cloudLabels:            cloudLabels,
 		TracingProvider:        tracing.NoopProvider(),
 	}
 
 	process.registerExpectedServices(cfg)
-
-	process.log = cfg.Log.WithFields(logrus.Fields{
-		trace.Component: teleport.Component(teleport.ComponentProcess, process.id),
-	})
 
 	// if user started auth and another service (without providing the auth address for
 	// that service, the address of the in-process auth will be used

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package servicecfg contains the runtime configuration for Teleport services
+// Package servicecfg contains the runtime configuration for Teleport services
 package servicecfg
 
 import (
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -210,8 +211,12 @@ type Config struct {
 	// Kube is a Kubernetes API gateway using Teleport client identities.
 	Kube KubeConfig
 
-	// Log optionally specifies the logger
+	// Log optionally specifies the logger.
+	// Deprecated: use Logger instead.
 	Log utils.Logger
+	// Logger outputs messages using slog. The underlying handler respects
+	// the user supplied logging config.
+	Logger *slog.Logger
 
 	// PluginRegistry allows adding enterprise logic to Teleport services
 	PluginRegistry plugin.Registry
@@ -500,6 +505,10 @@ func ApplyDefaults(cfg *Config) {
 
 	if cfg.Log == nil {
 		cfg.Log = utils.NewLogger()
+	}
+
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
 	}
 
 	// Remove insecure and (borderline insecure) cryptographic primitives from

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -82,11 +82,6 @@ func RemainingArgs(s kingpin.Settings) (target *[]string) {
 	return
 }
 
-const (
-	LogFormatJSON = "json"
-	LogFormatText = "text"
-)
-
 // CLIConf is configuration from the CLI.
 type CLIConf struct {
 	ConfigPath string

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -18,16 +18,19 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	stdlog "log"
+	"log/slog"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"unicode"
 
@@ -41,73 +44,149 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
+// LoggingPurpose specifies which kind of application logging is
+// to be configured for.
 type LoggingPurpose int
 
 const (
+	// LoggingForDaemon configures logging for non-user interactive applications (teleport, tbot, tsh deamon).
 	LoggingForDaemon LoggingPurpose = iota
+	// LoggingForCLI configures logging for user face utilities (tctl, tsh).
 	LoggingForCLI
 )
 
+// LoggingFormat defines the possible logging output formats.
+type LoggingFormat = string
+
+const (
+	// LogFormatJSON configures logs to be emitted in json.
+	LogFormatJSON LoggingFormat = "json"
+	// LogFormatText configures logs to be emitted in a human readable text format.
+	LogFormatText LoggingFormat = "text"
+)
+
+type logOpts struct {
+	format LoggingFormat
+}
+
+// LoggerOption enables customizing the global logger.
+type LoggerOption func(opts *logOpts)
+
+// WithLogFormat initializes the default logger with the provided format.
+func WithLogFormat(format LoggingFormat) LoggerOption {
+	return func(opts *logOpts) {
+		opts.format = format
+	}
+}
+
 // InitLogger configures the global logger for a given purpose / verbosity level
-func InitLogger(purpose LoggingPurpose, level logrus.Level) {
+func InitLogger(purpose LoggingPurpose, level slog.Level, opts ...LoggerOption) {
+	var o logOpts
+
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
-	logrus.SetLevel(level)
+	logrus.SetLevel(logutils.SlogLevelToLogrusLevel(level))
+
+	var (
+		w            io.Writer
+		enableColors bool
+	)
 	switch purpose {
 	case LoggingForCLI:
 		// If debug logging was asked for on the CLI, then write logs to stderr.
 		// Otherwise, discard all logs.
-		if level == logrus.DebugLevel {
-			debugFormatter := logutils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr))
-			_ = debugFormatter.CheckAndSetDefaults()
-			logrus.SetFormatter(debugFormatter)
-			logrus.SetOutput(os.Stderr)
+		if level == slog.LevelDebug {
+			enableColors = trace.IsTerminal(os.Stderr)
+			w = logutils.NewSharedWriter(os.Stderr)
 		} else {
-			logrus.SetOutput(io.Discard)
+			w = io.Discard
+			enableColors = false
 		}
 	case LoggingForDaemon:
-		logrus.SetFormatter(logutils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
-		logrus.SetOutput(os.Stderr)
+		enableColors = trace.IsTerminal(os.Stderr)
+		w = logutils.NewSharedWriter(os.Stderr)
 	}
+
+	var (
+		formatter logrus.Formatter
+		handler   slog.Handler
+	)
+	switch o.format {
+	case LogFormatText, "":
+		textFormatter := logutils.NewDefaultTextFormatter(enableColors)
+
+		// Calling CheckAndSetDefaults enables the timestamp field to
+		// be included in the output. The error returned is ignored
+		// because the default formatter cannot be invalid.
+		if purpose == LoggingForCLI && level == slog.LevelDebug {
+			_ = textFormatter.CheckAndSetDefaults()
+		}
+
+		formatter = textFormatter
+		handler = logutils.NewSlogTextHandler(w, &logutils.SlogTextHandlerConfig{
+			Level:        level,
+			EnableColors: enableColors,
+			WithCaller:   true,
+		})
+	case LogFormatJSON:
+		formatter = &logutils.JSONFormatter{}
+		handler = logutils.NewSlogJSONHandler(w, level)
+	}
+
+	logrus.SetFormatter(formatter)
+	logrus.SetOutput(w)
+	slog.SetDefault(slog.New(handler))
 }
+
+var initTestLoggerOnce = sync.Once{}
 
 // InitLoggerForTests initializes the standard logger for tests.
 func InitLoggerForTests() {
-	// Parse flags to check testing.Verbose().
-	flag.Parse()
+	initTestLoggerOnce.Do(func() {
+		// Parse flags to check testing.Verbose().
+		flag.Parse()
 
-	logger := logrus.StandardLogger()
-	logger.ReplaceHooks(make(logrus.LevelHooks))
-	logrus.SetFormatter(logutils.NewTestJSONFormatter())
-	logger.SetLevel(logrus.DebugLevel)
-	logger.SetOutput(os.Stderr)
-	if testing.Verbose() {
-		return
-	}
-	logger.SetLevel(logrus.WarnLevel)
-	logger.SetOutput(io.Discard)
+		level := slog.LevelWarn
+		w := io.Discard
+		if testing.Verbose() {
+			level = slog.LevelDebug
+			w = os.Stderr
+		}
+
+		logger := logrus.StandardLogger()
+		logger.SetFormatter(logutils.NewTestJSONFormatter())
+		logger.SetLevel(logutils.SlogLevelToLogrusLevel(level))
+
+		output := logutils.NewSharedWriter(w)
+		logger.SetOutput(output)
+		slog.SetDefault(slog.New(logutils.NewSlogJSONHandler(output, level)))
+	})
 }
 
-// NewLoggerForTests creates a new logger for test environment
+// NewLoggerForTests creates a new logrus logger for test environments.
 func NewLoggerForTests() *logrus.Logger {
-	logger := logrus.New()
-	logger.ReplaceHooks(make(logrus.LevelHooks))
-	logger.SetFormatter(logutils.NewTestJSONFormatter())
-	logger.SetLevel(logrus.DebugLevel)
-	logger.SetOutput(os.Stderr)
-	return logger
+	InitLoggerForTests()
+	return logrus.StandardLogger()
+}
+
+// NewSlogLoggerForTests creates a new slog logger for test environments.
+func NewSlogLoggerForTests() *slog.Logger {
+	InitLoggerForTests()
+	return slog.Default()
 }
 
 // WrapLogger wraps an existing logger entry and returns
-// an value satisfying the Logger interface
+// a value satisfying the Logger interface
 func WrapLogger(logger *logrus.Entry) Logger {
 	return &logWrapper{Entry: logger}
 }
 
-// NewLogger creates a new empty logger
+// NewLogger creates a new empty logrus logger.
 func NewLogger() *logrus.Logger {
-	logger := logrus.New()
-	logger.SetFormatter(logutils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
-	return logger
+	return logrus.StandardLogger()
 }
 
 // Logger describes a logger value
@@ -157,7 +236,7 @@ func UserMessageFromError(err error) string {
 	if err == nil {
 		return ""
 	}
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		return trace.DebugReport(err)
 	}
 	var buf bytes.Buffer

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -19,19 +19,23 @@ package utils
 import (
 	"crypto/x509"
 	"fmt"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUserMessageFromError(t *testing.T) {
 	// Behavior is different in debug
-	priorLevel := logrus.GetLevel()
-	logrus.SetLevel(logrus.InfoLevel)
+	defaultLogger := slog.Default()
+
+	var leveler slog.LevelVar
+	leveler.Set(slog.LevelInfo)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: &leveler})))
 	t.Cleanup(func() {
-		logrus.SetLevel(priorLevel)
+		slog.SetDefault(defaultLogger)
 	})
 
 	tests := []struct {

--- a/lib/utils/log/levels.go
+++ b/lib/utils/log/levels.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SlogLevelToLogrusLevel converts a [slog.Level] to its equivalent
+// [logrus.Level].
+func SlogLevelToLogrusLevel(level slog.Level) logrus.Level {
+	switch level {
+	case TraceLevel:
+		return logrus.TraceLevel
+	case slog.LevelDebug:
+		return logrus.DebugLevel
+	case slog.LevelInfo:
+		return logrus.InfoLevel
+	case slog.LevelWarn:
+		return logrus.WarnLevel
+	case slog.LevelError:
+		return logrus.ErrorLevel
+	default:
+		return logrus.FatalLevel
+	}
+}

--- a/lib/utils/log/writer.go
+++ b/lib/utils/log/writer.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"sync"
+)
+
+// SharedWriter is an [io.Writer] implementation that protects
+// writes with a mutex. This allows a single [io.Writer] to be shared
+// by both logrus and slog without their output clobbering each other.
+type SharedWriter struct {
+	mu sync.Mutex
+	io.Writer
+}
+
+func (s *SharedWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.Writer.Write(p)
+}
+
+// NewSharedWriter wraps the provided [io.Writer] in a writer that
+// is thread safe.
+func NewSharedWriter(w io.Writer) *SharedWriter {
+	return &SharedWriter{Writer: w}
+}

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -25,27 +25,30 @@ import (
 	"os"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
-// SwitchLoggingtoSyslog tells the default logger to send the output to syslog. This
-// code is behind a build flag because Windows does not support syslog.
-func SwitchLoggingtoSyslog() error {
-	return SwitchLoggerToSyslog(log.StandardLogger())
-}
+// SwitchLoggingToSyslog configures the default logger to send output to syslog.
+func SwitchLoggingToSyslog() error {
+	logger := logrus.StandardLogger()
 
-// SwitchLoggerToSyslog tells the logger to send the output to syslog.
-func SwitchLoggerToSyslog(logger *log.Logger) error {
-	logger.ReplaceHooks(make(log.LevelHooks))
-	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_WARNING, "")
+	hook, err := CreateSyslogHook()
 	if err != nil {
-		// syslog is not available
+		logger.Errorf("Failed to switch logging to syslog: %v.", err)
 		logger.SetOutput(os.Stderr)
 		return trace.Wrap(err)
 	}
+
+	logger.ReplaceHooks(make(logrus.LevelHooks))
 	logger.AddHook(hook)
-	// ... and disable stderr:
 	logger.SetOutput(io.Discard)
+
 	return nil
+}
+
+// CreateSyslogHook provides a [logrus.Hook] that sends output to syslog.
+func CreateSyslogHook() (logrus.Hook, error) {
+	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_WARNING, "")
+	return hook, trace.Wrap(err)
 }

--- a/lib/utils/syslog_windows.go
+++ b/lib/utils/syslog_windows.go
@@ -18,10 +18,10 @@ package utils
 
 import (
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-// SwitchLoggerToSyslog always returns an error on Windows.
-func SwitchLoggerToSyslog(logger *log.Logger) error {
-	return trace.NotImplemented("cannot use syslog on Windows")
+// CreateSyslogHook always returns an error on Windows.
+func CreateSyslogHook() (logrus.Hook, error) {
+	return nil, trace.NotImplemented("cannot use syslog on Windows")
 }

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -36,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/lib/tbot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/utils"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -90,8 +90,8 @@ func Run(args []string, stdout io.Writer) error {
 	startCmd.Flag("oneshot", "If set, quit after the first renewal.").BoolVar(&cf.Oneshot)
 	startCmd.Flag("diag-addr", "If set and the bot is in debug mode, a diagnostics service will listen on specified address.").StringVar(&cf.DiagAddr)
 	startCmd.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
-		Default(config.LogFormatText).
-		EnumVar(&cf.LogFormat, config.LogFormatJSON, config.LogFormatText)
+		Default(utils.LogFormatText).
+		EnumVar(&cf.LogFormat, utils.LogFormatJSON, utils.LogFormatText)
 
 	initCmd := app.Command("init", "Initialize a certificate destination directory for writes from a separate bot user.")
 	initCmd.Flag("destination-dir", "Directory to write short-lived machine certificates to.").StringVar(&cf.DestinationDir)
@@ -101,8 +101,8 @@ func Run(args []string, stdout io.Writer) error {
 	initCmd.Flag("init-dir", "If using a config file and multiple destinations are configured, controls which destination dir to configure.").StringVar(&cf.InitDir)
 	initCmd.Flag("clean", "If set, remove unexpected files and directories from the destination.").BoolVar(&cf.Clean)
 	initCmd.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
-		Default(config.LogFormatText).
-		EnumVar(&cf.LogFormat, config.LogFormatJSON, config.LogFormatText)
+		Default(utils.LogFormatText).
+		EnumVar(&cf.LogFormat, utils.LogFormatJSON, utils.LogFormatText)
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
 	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server (On-Prem installs) or Proxy Server (Cloud installs).").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
@@ -116,8 +116,8 @@ func Run(args []string, stdout io.Writer) error {
 	configureCmd.Flag("token", "A bot join token, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
 	configureCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&cf.ConfigureOutput)
 	configureCmd.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
-		Default(config.LogFormatText).
-		EnumVar(&cf.LogFormat, config.LogFormatJSON, config.LogFormatText)
+		Default(utils.LogFormatText).
+		EnumVar(&cf.LogFormat, utils.LogFormatJSON, utils.LogFormatText)
 
 	migrateCmd := app.Command("migrate", "Migrates a config file from an older version to the newest version. Outputs to stdout by default.")
 	migrateCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&cf.ConfigureOutput)
@@ -377,21 +377,19 @@ func handleSignals(log logrus.FieldLogger, cancel context.CancelFunc, reloadCh c
 }
 
 func setupLogger(debug bool, format string) error {
-	level := logrus.InfoLevel
+	level := slog.LevelInfo
 	if debug {
-		level = logrus.DebugLevel
+		level = slog.LevelDebug
 	}
-	utils.InitLogger(utils.LoggingForDaemon, level)
 
 	switch format {
-	case config.LogFormatJSON:
-		formatter := &logutils.JSONFormatter{}
-		logrus.SetFormatter(formatter)
-	case config.LogFormatText, "":
-	// Nothing to do, this is the default set up by utils.InitLogger
+	case utils.LogFormatJSON:
+	case utils.LogFormatText, "":
 	default:
 		return trace.BadParameter("unsupported log format %q", format)
 	}
+
+	utils.InitLogger(utils.LoggingForDaemon, level, utils.WithLogFormat(format))
 
 	return nil
 }

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -109,7 +110,7 @@ func Run(commands []CLICommand) {
 // TryRun is a helper function for Run to call - it runs a tctl command and returns an error.
 // This is useful for testing tctl, because we can capture the returned error in tests.
 func TryRun(commands []CLICommand, args []string) error {
-	utils.InitLogger(utils.LoggingForCLI, log.WarnLevel)
+	utils.InitLogger(utils.LoggingForCLI, slog.LevelWarn)
 
 	// app is the command line parser
 	app := utils.InitCLIParser("tctl", GlobalHelpString)
@@ -250,7 +251,7 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 	// --debug flag
 	if ccf.Debug {
 		cfg.Debug = ccf.Debug
-		utils.InitLogger(utils.LoggingForCLI, log.DebugLevel)
+		utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
 		log.Debugf("Debug logging has been enabled.")
 	}
 	cfg.Log = log.StandardLogger()

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"os/user"
@@ -78,7 +79,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	}
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
-	utils.InitLogger(utils.LoggingForDaemon, log.ErrorLevel)
+	utils.InitLogger(utils.LoggingForDaemon, slog.LevelError)
 	app = utils.InitCLIParser("teleport", "Teleport Access Platform. Learn more at https://goteleport.com")
 
 	// define global flags:
@@ -860,7 +861,7 @@ func dumpConfigFile(outputURI, contents, comment string) (string, error) {
 func onSCP(scpFlags *scp.Flags) (err error) {
 	// when 'teleport scp' is executed, it cannot write logs to stderr (because
 	// they're automatically replayed by the scp client)
-	utils.SwitchLoggingtoSyslog()
+	utils.SwitchLoggingToSyslog()
 	if len(scpFlags.Target) == 0 {
 		return trace.BadParameter("teleport scp: missing an argument")
 	}

--- a/tool/teleport/common/wait.go
+++ b/tool/teleport/common/wait.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -46,7 +47,7 @@ type waitFlags struct {
 }
 
 func onWaitDuration(flags waitFlags) error {
-	utils.InitLogger(utils.LoggingForCLI, log.DebugLevel)
+	utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
 	defer cancel()
 
@@ -54,7 +55,7 @@ func onWaitDuration(flags waitFlags) error {
 }
 
 func onWaitNoResolve(flags waitFlags) error {
-	utils.InitLogger(utils.LoggingForCLI, log.DebugLevel)
+	utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
 	defer cancel()
 

--- a/tool/tsh/common/daemon.go
+++ b/tool/tsh/common/daemon.go
@@ -18,9 +18,9 @@ package common
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/lib/teleterm"
@@ -34,9 +34,9 @@ func onDaemonStart(cf *CLIConf) error {
 	defer cancel()
 
 	if cf.Debug {
-		utils.InitLogger(utils.LoggingForDaemon, logrus.DebugLevel)
+		utils.InitLogger(utils.LoggingForDaemon, slog.LevelDebug)
 	} else {
-		utils.InitLogger(utils.LoggingForDaemon, logrus.InfoLevel)
+		utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
 	}
 
 	err := teleterm.Serve(ctx, teleterm.Config{

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"net"
 	"net/url"
@@ -619,9 +620,9 @@ func initLogger(cf *CLIConf) {
 	isDebug, _ := strconv.ParseBool(os.Getenv(debugEnvVar))
 	cf.Debug = cf.Debug || isDebug
 	if cf.Debug {
-		utils.InitLogger(utils.LoggingForCLI, logrus.DebugLevel)
+		utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
 	} else {
-		utils.InitLogger(utils.LoggingForCLI, logrus.WarnLevel)
+		utils.InitLogger(utils.LoggingForCLI, slog.LevelWarn)
 	}
 }
 


### PR DESCRIPTION
In all places that a logrus logger is being initialized an equivalent slog logger is now being intialized as well. The TeleportProcess was also updated to have a slog.Logger which is created with the same fields that its logrus equivalent has. This does not convert any logging to actually use slog yet, but does pave the way for conversions to start.