### PR TITLE
Add the `tsh device dmi-read` command

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1425,6 +1425,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = deviceCmd.keyget.run(&cf)
 	case deviceCmd.activateCredential.FullCommand():
 		err = deviceCmd.activateCredential.run(&cf)
+	case deviceCmd.dmiRead.FullCommand():
+		err = deviceCmd.dmiRead.run(&cf)
 	case kubectl.FullCommand():
 		idx := slices.Index(args, kubectl.FullCommand())
 		err = onKubectlCommand(&cf, args, args[idx:])


### PR DESCRIPTION
The `tsh device dmi-read` command is used to read system information, such as various serial numbers, in an escalated context (although it still works without privilege).

For example:

```shell
# Non-privileged, notice the lack of serials.
$ tsh device dmi-read
{"ProductName":"21J50013US","ProductSerial":"","BoardSerial":"","ChassisAssetTag":"No Asset Information"}

# Privileged.
$ sudo tsh device dmi-read
Place your right index finger on the fingerprint reader  <-- printed by sudo
{"ProductName":"21J50013US","ProductSerial":"PF0A0AAA","BoardSerial":"L1AA00A00A0","ChassisAssetTag":"No Asset Information"}

# Privileged, separate sudo invocation to avoid mixing output.
$ sudo -v
Place your right index finger on the fingerprint reader
$ sudo -n tsh device dmi-read
{"ProductName":"21J50013US","ProductSerial":"PF0A0AAA","BoardSerial":"L1AA00A00A0","ChassisAssetTag":"No Asset Information"}
```

To be used by the Linux device trust implementation.

https://github.com/gravitational/teleport.e/issues/827

