### PR TITLE
Add Slack access list reminders.

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -230,8 +230,6 @@ func (a *App) sendMessages(ctx context.Context, accessList *accesslist.AccessLis
 				log.Debugf("User %s has already been notified for access list %s", recipient.Name, accessList.GetName())
 				userNotifications[recipient.Name] = lastNotification
 				continue
-			} else {
-				log.Debugf("User %s should be notified for access list %s", recipient.Name, accessList.GetName())
 			}
 
 			recipients = append(recipients, recipient)
@@ -247,11 +245,12 @@ func (a *App) sendMessages(ctx context.Context, accessList *accesslist.AccessLis
 		return trace.Wrap(err)
 	}
 
+	var errs []error
 	for _, recipient := range recipients {
 		if err := a.bot.SendReviewReminders(ctx, recipient, accessList); err != nil {
-			log.WithError(err).Errorf("Error sending access review reminders for access list %s", accessList.GetName())
+			errs = append(errs, err)
 		}
 	}
 
-	return nil
+	return trace.NewAggregate(errs...)
 }

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -225,7 +225,8 @@ func (a *App) sendMessages(ctx context.Context, accessList *accesslist.AccessLis
 	} else {
 		// Calculate days from start.
 		daysFromStart := now.Sub(notificationStart) / oneDay
-		windowStart = notificationStart.Add(daysFromStart * oneWeek)
+		windowStart = notificationStart.Add(daysFromStart * oneDay)
+		log.Infof("windowStart: %s, now: %s", windowStart.String(), now.String())
 	}
 
 	recipients := []common.Recipient{}

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -133,7 +133,7 @@ func TestAccessListReminders(t *testing.T) {
 		Audit: accesslist.Audit{
 			NextAuditDate: clock.Now().Add(28 * 24 * time.Hour), // Four weeks out from today
 			Notifications: accesslist.Notifications{
-				Start: time.Hour * 24 * 14, // Start alerting at two weeks before audit date
+				Start: oneDay * 14, // Start alerting at two weeks before audit date
 			},
 		},
 	})
@@ -143,35 +143,39 @@ func TestAccessListReminders(t *testing.T) {
 	advanceAndLookForRecipients(t, bot, as, clock, 0, accessList)
 
 	// Advance by one week, expect no notifications.
-	advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessList)
 
 	// Advance by one week, expect a notification. "not-found" will be missing as a recipient.
-	advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList, "owner1")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessList, "owner1")
 
 	// Add a new owner.
 	accessList.Spec.Owners = append(accessList.Spec.Owners, accesslist.Owner{Name: "owner2"})
 
 	// Advance by one day, expect a notification only to the new owner.
-	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList, "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList, "owner2")
 
 	// Advance by one day, expect no notifications.
-	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
 
 	// Advance by five more days, to the next week, expect two notifications
-	advanceAndLookForRecipients(t, bot, as, clock, 24*5*time.Hour, accessList, "owner1", "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessList, "owner1", "owner2")
 
 	// Advance by one day, expect no notifications
-	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
 
 	// Advance by one day, expect no notifications
-	advanceAndLookForRecipients(t, bot, as, clock, 24*time.Hour, accessList)
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList)
 
 	// Advance by five more days, to the next week, expect two notifications
-	advanceAndLookForRecipients(t, bot, as, clock, 24*5*time.Hour, accessList, "owner1", "owner2")
+	advanceAndLookForRecipients(t, bot, as, clock, oneDay*5, accessList, "owner1", "owner2")
 
 	// Advance 60 days a day at a time, expect two notifications each time.
 	for i := 0; i < 60; i++ {
-		advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList, "owner1", "owner2")
+		// Make sure we only get a notification once per day by iterating through each 6 hours at a time.
+		for j := 0; j < 3; j++ {
+			advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessList)
+		}
+		advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessList, "owner1", "owner2")
 	}
 }
 
@@ -202,5 +206,5 @@ func advanceAndLookForRecipients(t *testing.T,
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
-	}, 5*time.Second, 250*time.Millisecond)
+	}, 5*time.Second, 5*time.Millisecond)
 }

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -44,8 +44,8 @@ func (m *mockMessagingBot) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
-	m.lastReminderRecipients = recipients
+func (m *mockMessagingBot) SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error {
+	m.lastReminderRecipients = append(m.lastReminderRecipients, recipient)
 	return nil
 }
 
@@ -56,6 +56,12 @@ func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string)
 	}
 
 	return fetchedRecipient, nil
+}
+
+func (m *mockMessagingBot) SupportedApps() []common.App {
+	return []common.App{
+		NewApp(m),
+	}
 }
 
 type mockPluginConfig struct {

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -169,9 +169,9 @@ func TestAccessListReminders(t *testing.T) {
 	// Advance by five more days, to the next week, expect two notifications
 	advanceAndLookForRecipients(t, bot, as, clock, 24*5*time.Hour, accessList, "owner1", "owner2")
 
-	// Advance by one year a week at a time, expect two notifications each time.
-	for i := 0; i < 52; i++ {
-		advanceAndLookForRecipients(t, bot, as, clock, 24*7*time.Hour, accessList, "owner1", "owner2")
+	// Advance 60 days a day at a time, expect two notifications each time.
+	for i := 0; i < 60; i++ {
+		advanceAndLookForRecipients(t, bot, as, clock, oneDay, accessList, "owner1", "owner2")
 	}
 }
 

--- a/integrations/access/accesslist/bot.go
+++ b/integrations/access/accesslist/bot.go
@@ -27,5 +27,5 @@ type MessagingBot interface {
 	common.MessagingBot
 
 	// SendReviewReminders will send a review reminder that an access list needs to be reviewed.
-	SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error
+	SendReviewReminders(ctx context.Context, recipient common.Recipient, accessList *accesslist.AccessList) error
 }

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -33,10 +33,6 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
 )
 
-func init() {
-	common.RegisterAppCreator("accessrequest", NewApp)
-}
-
 const (
 	// handlerTimeout is used to bound the execution time of watcher event handler.
 	handlerTimeout = time.Second * 5
@@ -55,13 +51,10 @@ type App struct {
 }
 
 // NewApp will create a new access request application.
-func NewApp(bot common.MessagingBot) (common.App, error) {
-	if _, ok := bot.(MessagingBot); !ok {
-		return nil, trace.BadParameter("bot does not support this app")
-	}
+func NewApp(bot MessagingBot) common.App {
 	app := &App{}
 	app.job = lib.NewServiceJob(app.run)
-	return app, nil
+	return app
 }
 
 func (a *App) Init(baseApp *common.BaseApp) error {

--- a/integrations/access/common/bot.go
+++ b/integrations/access/common/bot.go
@@ -30,4 +30,6 @@ type MessagingBot interface {
 	// a communication channel (e.g. MsTeams needs to install the app for the user before being able to send
 	// notifications)
 	FetchRecipient(ctx context.Context, recipient string) (*Recipient, error)
+	// SupportedApps are the apps supported by this bot.
+	SupportedApps() []App
 }

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -108,6 +108,13 @@ func (b DiscordBot) CheckHealth(ctx context.Context) error {
 	return nil
 }
 
+// SupportedApps are the apps supported by this bot.
+func (b DiscordBot) SupportedApps() []common.App {
+	return []common.App{
+		accessrequest.NewApp(b),
+	}
+}
+
 // SendReviewReminders will send a review reminder that an access list needs to be reviewed.
 func (b DiscordBot) SendReviewReminders(ctx context.Context, recipients []common.Recipient, accessList *accesslist.AccessList) error {
 	return trace.NotImplemented("access list review reminder is not yet implemented")

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -214,6 +214,13 @@ func NewBot(conf Config, clusterName, webProxyAddr string) (Bot, error) {
 	}, nil
 }
 
+// SupportedApps are the apps supported by this bot.
+func (b Bot) SupportedApps() []common.App {
+	return []common.App{
+		accessrequest.NewApp(b),
+	}
+}
+
 func (b Bot) CheckHealth(ctx context.Context) error {
 	_, err := b.GetMe(ctx)
 	return err

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -40,6 +40,13 @@ type Bot struct {
 	webProxyURL *url.URL
 }
 
+// SupportedApps are the apps supported by this bot.
+func (b *Bot) SupportedApps() []common.App {
+	return []common.App{
+		accessrequest.NewApp(b),
+	}
+}
+
 // CheckHealth checks if the bot can connect to its messaging service
 func (b *Bot) CheckHealth(ctx context.Context) error {
 	return trace.Wrap(b.client.CheckHealth(ctx))

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -39,6 +39,13 @@ type Bot struct {
 	webProxyURL *url.URL
 }
 
+// SupportedApps are the apps supported by this bot.
+func (b *Bot) SupportedApps() []common.App {
+	return []common.App{
+		accessrequest.NewApp(b),
+	}
+}
+
 // CheckHealth checks if the bot can connect to its messaging service
 func (b *Bot) CheckHealth(ctx context.Context) error {
 	return trace.Wrap(b.client.CheckHealth(ctx))

--- a/integrations/access/slack/app.go
+++ b/integrations/access/slack/app.go
@@ -27,5 +27,7 @@ const (
 
 // NewSlackApp initializes a new teleport-slack app and returns it.
 func NewSlackApp(conf *Config) *common.BaseApp {
-	return common.NewApp(conf, slackPluginName)
+	app := common.NewApp(conf, slackPluginName)
+	app.Clock = conf.clock
+	return app
 }

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -230,7 +230,7 @@ func (b Bot) FetchRecipient(ctx context.Context, name string) (*common.Recipient
 func (b Bot) slackAccessListReminderMsgSection(accessList *accesslist.AccessList) []BlockItem {
 	nextAuditDate := accessList.Spec.Audit.NextAuditDate
 
-	name := fmt.Sprintf("*%s* (name: %s)", accessList.Spec.Title, accessList.GetName())
+	name := fmt.Sprintf("*%s*", accessList.Spec.Title)
 	var msg string
 	if b.clock.Now().After(nextAuditDate) {
 		daysSinceDue := int(b.clock.Since(nextAuditDate).Hours() / 24)

--- a/integrations/access/slack/slack_test.go
+++ b/integrations/access/slack/slack_test.go
@@ -652,19 +652,19 @@ func (s *SlackSuite) TestAccessListReminder() {
 
 	// 2 weeks before date, should trigger reminder.
 	clock.Advance(45 * 24 * time.Hour)
-	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// 1 weeks before date, should trigger reminder.
 	clock.Advance(7 * 24 * time.Hour)
-	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// On the date, should trigger reminder.
 	clock.Advance(7 * 24 * time.Hour)
-	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* is due for a review by 2023-03-01. Please review it soon!")
 
 	// Past the date, should trigger reminder.
 	clock.Advance(7 * 24 * time.Hour)
-	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is 7 day(s) past due for a review! Please review it.")
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* is 7 day(s) past due for a review! Please review it.")
 }
 
 func (s *SlackSuite) requireReminderMsgEqual(id, text string) {

--- a/integrations/access/slack/slack_test.go
+++ b/integrations/access/slack/slack_test.go
@@ -28,12 +28,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/integrations/access/accessrequest"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/auth"
@@ -110,7 +113,7 @@ func (s *SlackSuite) SetupSuite() {
 
 	conditions := types.RoleConditions{Request: &types.AccessRequestConditions{Roles: []string{"editor"}}}
 	if teleportFeatures.AdvancedAccessWorkflows {
-		conditions.Request.Thresholds = []types.AccessReviewThreshold{types.AccessReviewThreshold{Approve: 2, Deny: 2}}
+		conditions.Request.Thresholds = []types.AccessReviewThreshold{{Approve: 2, Deny: 2}}
 	}
 	role, err := bootstrap.AddRole("foo", types.RoleSpecV6{Allow: conditions})
 	require.NoError(t, err)
@@ -141,8 +144,9 @@ func (s *SlackSuite) SetupSuite() {
 	role, err = bootstrap.AddRole("access-slack", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			Rules: []types.Rule{
-				types.NewRule("access_request", []string{"list", "read"}),
-				types.NewRule("access_plugin_data", []string{"update"}),
+				types.NewRule(types.KindAccessList, []string{"list", "read"}),
+				types.NewRule(types.KindAccessRequest, []string{"list", "read"}),
+				types.NewRule(types.KindAccessPluginData, []string{"update"}),
 			},
 		},
 	})
@@ -611,6 +615,66 @@ func (s *SlackSuite) TestExpiration() {
 	statusLine, err := getStatusLine(msgUpdate)
 	require.NoError(t, err)
 	assert.Equal(t, "*Status*: ⌛ EXPIRED", statusLine)
+}
+
+func (s *SlackSuite) TestAccessListReminder() {
+	t := s.T()
+
+	if !s.teleportFeatures.AdvancedAccessWorkflows {
+		t.Skip("Doesn't work in OSS version")
+	}
+
+	reviewer := s.fakeSlack.StoreUser(User{Profile: UserProfile{Email: s.userNames.reviewer1}})
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+	s.appConfig.clock = clock
+	s.startApp()
+
+	accessList, err := accesslist.NewAccessList(header.Metadata{
+		Name: "access-list",
+	}, accesslist.Spec{
+		Title: "simple title",
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+		Owners: []accesslist.Owner{
+			{Name: s.userNames.reviewer1},
+		},
+		Audit: accesslist.Audit{
+			NextAuditDate: time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = s.ruler().AccessListClient().UpsertAccessList(ctx, accessList)
+	require.NoError(t, err)
+
+	// 2 weeks before date, should trigger reminder.
+	clock.Advance(45 * 24 * time.Hour)
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+
+	// 1 weeks before date, should trigger reminder.
+	clock.Advance(7 * 24 * time.Hour)
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+
+	// On the date, should trigger reminder.
+	clock.Advance(7 * 24 * time.Hour)
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is due for a review by 2023-03-01. Please review it soon!")
+
+	// Past the date, should trigger reminder.
+	clock.Advance(7 * 24 * time.Hour)
+	s.requireReminderMsgEqual(reviewer.ID, "Access List *simple title* (name: access-list) is 7 day(s) past due for a review! Please review it.")
+}
+
+func (s *SlackSuite) requireReminderMsgEqual(id, text string) {
+	t := s.T()
+
+	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
+	require.NoError(t, err)
+	require.Equal(t, id, msg.Channel)
+	require.IsType(t, SectionBlock{}, msg.BlockItems[0].Block)
+	require.Equal(t, text, (msg.BlockItems[0].Block).(SectionBlock).Text.GetText())
 }
 
 func (s *SlackSuite) TestRace() {


### PR DESCRIPTION
Access list review reminders will now be sent to owners via Slack every week until the access list is reviewed. Some small modifications were made to the access list application to support partial success. Additionally, some changes were made to the way access applications are instantiated to maintain compatibility with enterprise.

changelog: Access list review reminders will now be sent via Slack.