### PR TITLE
Machine ID: Use `api/client.Client` rather than `auth.Client`

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -122,9 +122,14 @@ func (a *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 	return session, nil
 }
 
+type appSessionWatcher interface {
+	GetAppSession(context.Context, types.GetAppSessionRequest) (types.WebSession, error)
+	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
+}
+
 // WaitForAppSession will block until the requested application session shows up in the
 // cache or a timeout occurs.
-func WaitForAppSession(ctx context.Context, sessionID, user string, ap ReadProxyAccessPoint) error {
+func WaitForAppSession(ctx context.Context, sessionID, user string, ap appSessionWatcher) error {
 	req := waitForWebSessionReq{
 		newWatcherFn: ap.NewWatcher,
 		getSessionFn: func(ctx context.Context, sessionID string) (types.WebSession, error) {

--- a/lib/tbot/bot_identity.go
+++ b/lib/tbot/bot_identity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	apiclient "github.com/gravitational/teleport/api/client"
 	"math"
 	"time"
 
@@ -157,7 +158,7 @@ func botIdentityFromAuth(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	ident *identity.Identity,
-	client auth.ClientI,
+	client *apiclient.Client,
 	ttl time.Duration,
 ) (*identity.Identity, error) {
 	log.Info("Fetching bot identity using existing bot identity.")

--- a/lib/tbot/impersonated_identity.go
+++ b/lib/tbot/impersonated_identity.go
@@ -175,7 +175,7 @@ type identityConfigurator = func(req *proto.UserCertsRequest)
 // certs.
 func (b *Bot) generateIdentity(
 	ctx context.Context,
-	client auth.ClientI,
+	client *apiclient.Client,
 	currentIdentity *identity.Identity,
 	output config.Output,
 	defaultRoles []string,
@@ -264,7 +264,7 @@ func (b *Bot) generateIdentity(
 	return newIdentity, nil
 }
 
-func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Database, error) {
+func getDatabase(ctx context.Context, clt *apiclient.Client, name string) (types.Database, error) {
 	servers, err := apiclient.GetAllResources[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindDatabaseServer,
@@ -285,7 +285,7 @@ func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Data
 	return db, trace.Wrap(err)
 }
 
-func (b *Bot) getRouteToDatabase(ctx context.Context, client auth.ClientI, output *config.DatabaseOutput) (proto.RouteToDatabase, error) {
+func (b *Bot) getRouteToDatabase(ctx context.Context, client *apiclient.Client, output *config.DatabaseOutput) (proto.RouteToDatabase, error) {
 	if output.Service == "" {
 		return proto.RouteToDatabase{}, nil
 	}
@@ -316,7 +316,7 @@ func (b *Bot) getRouteToDatabase(ctx context.Context, client auth.ClientI, outpu
 	}, nil
 }
 
-func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.KubeCluster, error) {
+func getKubeCluster(ctx context.Context, clt *apiclient.Client, name string) (types.KubeCluster, error) {
 	servers, err := apiclient.GetAllResources[types.KubeServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindKubeServer,
@@ -337,7 +337,7 @@ func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.K
 	return cluster, trace.Wrap(err)
 }
 
-func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Application, error) {
+func getApp(ctx context.Context, clt *apiclient.Client, appName string) (types.Application, error) {
 	servers, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindAppServer,
@@ -361,7 +361,7 @@ func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Applic
 	return apps[0], nil
 }
 
-func (b *Bot) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client auth.ClientI, output *config.ApplicationOutput) (proto.RouteToApp, error) {
+func (b *Bot) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *apiclient.Client, output *config.ApplicationOutput) (proto.RouteToApp, error) {
 	app, err := getApp(ctx, client, output.AppName)
 	if err != nil {
 		return proto.RouteToApp{}, trace.Wrap(err)
@@ -395,11 +395,11 @@ func (b *Bot) getRouteToApp(ctx context.Context, botIdentity *identity.Identity,
 // impersonated identity.
 func (b *Bot) generateImpersonatedIdentity(
 	ctx context.Context,
-	botClient auth.ClientI,
+	botClient *apiclient.Client,
 	botIdentity *identity.Identity,
 	output config.Output,
 	defaultRoles []string,
-) (impersonatedIdentity *identity.Identity, impersonatedClient auth.ClientI, err error) {
+) (impersonatedIdentity *identity.Identity, impersonatedClient *apiclient.Client, err error) {
 	impersonatedIdentity, err = b.generateIdentity(
 		ctx, botClient, botIdentity, output, defaultRoles, nil,
 	)
@@ -601,7 +601,7 @@ func (b *Bot) renewOutputs(
 // requests for the same information. This is shared between all of the
 // outputs.
 type outputRenewalCache struct {
-	client auth.ClientI
+	client *apiclient.Client
 
 	cfg *config.BotConfig
 	mu  sync.Mutex
@@ -711,7 +711,7 @@ type outputProvider struct {
 	*outputRenewalCache
 	// impersonatedClient is a client using the impersonated identity configured
 	// for that output.
-	impersonatedClient auth.ClientI
+	impersonatedClient *apiclient.Client
 }
 
 // GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	apiclient "github.com/gravitational/teleport/api/client"
 	"net/http"
 	"net/http/pprof"
 	"sync"
@@ -34,7 +35,6 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
@@ -430,7 +430,7 @@ func (b *Bot) checkIdentity(ident *identity.Identity) error {
 // identity. Note that depending on the connection address given, this may
 // attempt to connect via the proxy and therefore requires both SSH and TLS
 // credentials.
-func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (auth.ClientI, error) {
+func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*apiclient.Client, error) {
 	if id.SSHCert == nil || id.X509Cert == nil {
 		return nil, trace.BadParameter("auth client requires a fully formed identity")
 	}


### PR DESCRIPTION
Bit of a long term experiment to just track which RPCs remain - maybe Teleport 15.0 would be nice.

Remaining RPCs:
- GenerateHostCert
- GetRemoteClusters