### PR TITLE
Add docs for resource-based labels

### DIFF
--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -41,7 +41,7 @@ but filter and limit access to the servers based on their AWS region.
 
 (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/3. Install Teleport
+## Step 1/4. Install Teleport
 
 1. Select a host for running the Teleport agent.
 
@@ -74,7 +74,7 @@ as a resource:
    $ export INVITE_TOKEN=<token>
    ```
 
-## Step 2/3. Apply a static label
+## Step 2/4. Apply a static label
 
 You can configure static labels by editing the Teleport configuration file, then
 starting Teleport.
@@ -191,7 +191,7 @@ ssh_service:
     teleport.hidden/team-id: ai-lab-01
 ``` 
 
-## Step 3/3. Apply dynamic labels using commands
+## Step 3/4. Apply dynamic labels using commands
 
 As with static labels, you can apply dynamic labels by editing the
 Teleport configuration file, then restarting the Teleport service on your server.
@@ -279,6 +279,75 @@ computer. Your Teleport user must be authorized to access the server.
    ---------------- -------------- ------------------------------------------------------
    ip-192-168-13-57 ⟵ Tunnel       arch=x86_64,environment=dev,hostname=ip-192-168-13-57
    ```
+
+## Step 4/4. Apply labels to a running instance with `server_info`
+
+<Notice type="note">
+   Applying labels to a running instance is only supported for servers.
+</Notice>
+
+You can apply labels to a running Teleport instance without
+restarting it by creating a `server_info` resource for the instance.
+The `server_info` resource is matched to the resource it applies to by its name.
+Allowed matching schemes include:
+
+- `si-<name>`, where `<name>` is the name of the resource.
+- For instances that were created by EC2 VM discovery,
+`aws-<account-id>-<instance-id>`, where `<account-id>` and `<instance-id>` are the
+account ID and instance ID of the EC2 instance.
+
+To add labels to a running instance:
+
+1. Create the file `server_info.yaml` and paste the following into it:
+
+   ```yaml
+   # server_info.yaml
+   kind: server_info
+   metadata:
+      # Replace "example-node" with the name of the node to apply labels to
+      name: si-example-node
+   spec:
+      new_labels:
+         "foo": "bar"
+   ```
+
+   Run the following to create the `server_info` resource:
+
+   ```code
+   $ tctl create server_info.yaml
+   ```
+
+1. Verify that you have added the label by running the following command on your local
+computer. Your Teleport user must be authorized to access the server. Note that Teleport
+applies labels from `server_info` resources gradually to prevent strain on the Auth Service in
+larger clusters, so it may take several minutes for the new labels to appear.
+
+   ```code
+   $ tsh ls
+   ```
+
+   You should see output similar to the following with the `foo` label displayed:
+
+   ```code
+   Node Name        Address        Labels                                                                                                                   
+   ---------------- -------------- ------------------------------------------------------
+   ip-192-168-13-57 ⟵ Tunnel       foo=bar,hostname=ip-192-168-13-57
+   ```
+
+Labels set with the `server_info` resource do not persist across restarts, but
+as long as the `server_info` resource still exists the labels will eventually
+be set again. To remove labels set with a `server_info` resource, replace the
+old resource with one that has no labels:
+
+```yaml
+# server_info.yaml
+kind: server_info
+metadata:
+   # Replace "example-node" with the name of the node to apply labels to
+   name: si-example-node
+spec:
+   new_labels:
+```
 
 ## Next steps
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -329,8 +329,9 @@ larger clusters, so it may take several minutes for the new labels to appear.
    ```
 
 Resource-based labels are stored in memory on servers, so if a server restarts it may temporarily lose
-its resource-based labels until the Auth Service applies them again. To update resource-based labels,
-recreate the `server_info` resource with updated labels.
+its resource-based labels until the Auth Service applies them again. Because of this, it is not safe to
+use resource-based labels in an RBAC deny rule. To update resource-based labels, recreate the
+`server_info` resource with updated labels.
 
 ## Next steps
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -13,9 +13,9 @@ the following:
 This guide demonstrates how to add labels to enrolled server resources.
 However, you can follow similar steps to add labels to other types of resources.
 
-## Static, dynamic, and ephemeral labels
+## Static, dynamic, and resource-based labels
 
-The labels you assign to resources can be **static labels**, **dynamic labels**, or **ephemeral labels**.
+The labels you assign to resources can be **static labels**, **dynamic labels**, or **resource-based labels**.
 
 - Static labels are hardcoded in the Teleport configuration file and don't change 
 while the `teleport` process is running. For example, you might use a static label to identify 
@@ -23,10 +23,10 @@ the resources in a `staging` or `production` environment.
 - Dynamic labels—also known as **commands-based labels**—allow you to generate labels at runtime. 
 With a dynamic label, the `teleport` process executes an external command on its host at 
 a configurable frequency and the output of the command becomes the label value.
-- Ephemeral labels allow you to add labels to an instance without restarting the `teleport`
-process or editing the configuration file. They are not preserved between restarts.
+- Resource-based labels allow you to add labels to an instance without restarting the `teleport`
+process or editing the configuration file.
 
-You can add multiple static, dynamic, and ephemeral labels for the same resource.
+You can add multiple static, dynamic, and resource-based labels for the same resource.
 However, you can't add static labels that use the same key with different values or use
 a static label to define multiple potential values.
 
@@ -43,7 +43,7 @@ but filter and limit access to the servers based on their AWS region.
 
 (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/4. Install Teleport
+### Install Teleport
 
 1. Select a host for running the Teleport agent.
 
@@ -76,7 +76,7 @@ as a resource:
    $ export INVITE_TOKEN=<token>
    ```
 
-## Step 2/4. Apply a static label
+### Apply a static label
 
 You can configure static labels by editing the Teleport configuration file, then
 starting Teleport.
@@ -193,7 +193,7 @@ ssh_service:
     teleport.hidden/team-id: ai-lab-01
 ``` 
 
-## Step 3/4. Apply dynamic labels using commands
+### Apply dynamic labels using commands
 
 As with static labels, you can apply dynamic labels by editing the
 Teleport configuration file, then restarting the Teleport service on your server.
@@ -282,17 +282,15 @@ computer. Your Teleport user must be authorized to access the server.
    ip-192-168-13-57 ⟵ Tunnel       arch=x86_64,environment=dev,hostname=ip-192-168-13-57
    ```
 
-## Step 4/4. Apply ephemeral labels using `server_info`
+### Apply resource-based labels
 
-<Notice type="note">
-   Applying ephemeral labels is only supported for servers.
-</Notice>
+Applying resource-based labels is only supported for servers.
 
-You can apply ephemeral labels to a Teleport instance by creating a `server_info`
+You can apply resource-based labels to a Teleport instance by creating a `server_info`
 resource for the instance. For a server with name `<name>`, its matching `server_info`
 should be named `si-<name>`.
 
-To add ephemeral labels:
+To add resource-based labels:
 
 1. Create the file `server_info.yaml` and paste the following into it:
 
@@ -330,8 +328,8 @@ larger clusters, so it may take several minutes for the new labels to appear.
    ip-192-168-13-57 ⟵ Tunnel       foo=bar,hostname=ip-192-168-13-57
    ```
 
-Although ephemeral labels do not persist across restarts, they will be set again
-as long as the `server_info` resource still exists. To update ephemeral labels,
+Resource-based labels are stored in memory on servers, so if a server restarts it may temporarily lose
+its resource-based labels until the Auth Service applies them again. To update resource-based labels,
 recreate the `server_info` resource with updated labels.
 
 ## Next steps

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -13,9 +13,9 @@ the following:
 This guide demonstrates how to add labels to enrolled server resources.
 However, you can follow similar steps to add labels to other types of resources.
 
-## Static and dynamic labels
+## Static, dynamic, and ephemeral labels
 
-The labels you assign to resources can be **static labels** or **dynamic labels**.
+The labels you assign to resources can be **static labels**, **dynamic labels**, or **ephemeral labels**.
 
 - Static labels are hardcoded in the Teleport configuration file and don't change 
 while the `teleport` process is running. For example, you might use a static label to identify 
@@ -23,8 +23,10 @@ the resources in a `staging` or `production` environment.
 - Dynamic labels—also known as **commands-based labels**—allow you to generate labels at runtime. 
 With a dynamic label, the `teleport` process executes an external command on its host at 
 a configurable frequency and the output of the command becomes the label value.
+- Ephemeral labels allow you to add labels to an instance without restarting the `teleport`
+process or editing the configuration file. They are not preserved between restarts.
 
-You can add multiple static and dynamic labels for the same resource.
+You can add multiple static, dynamic, and ephemeral labels for the same resource.
 However, you can't add static labels that use the same key with different values or use
 a static label to define multiple potential values.
 
@@ -280,23 +282,17 @@ computer. Your Teleport user must be authorized to access the server.
    ip-192-168-13-57 ⟵ Tunnel       arch=x86_64,environment=dev,hostname=ip-192-168-13-57
    ```
 
-## Step 4/4. Apply labels to a running instance with `server_info`
+## Step 4/4. Apply ephemeral labels using `server_info`
 
 <Notice type="note">
-   Applying labels to a running instance is only supported for servers.
+   Applying ephemeral labels is only supported for servers.
 </Notice>
 
-You can apply labels to a running Teleport instance without
-restarting it by creating a `server_info` resource for the instance.
-The `server_info` resource is matched to the resource it applies to by its name.
-Allowed matching schemes include:
+You can apply ephemeral labels to a Teleport instance by creating a `server_info`
+resource for the instance. For a server with name `<name>`, its matching `server_info`
+should be named `si-<name>`.
 
-- `si-<name>`, where `<name>` is the name of the resource.
-- For instances that were created by EC2 VM discovery,
-`aws-<account-id>-<instance-id>`, where `<account-id>` and `<instance-id>` are the
-account ID and instance ID of the EC2 instance.
-
-To add labels to a running instance:
+To add ephemeral labels:
 
 1. Create the file `server_info.yaml` and paste the following into it:
 
@@ -318,7 +314,7 @@ To add labels to a running instance:
    ```
 
 1. Verify that you have added the label by running the following command on your local
-computer. Your Teleport user must be authorized to access the server. Note that Teleport
+computer. Your Teleport user must be authorized to access the server. Teleport
 applies labels from `server_info` resources gradually to prevent strain on the Auth Service in
 larger clusters, so it may take several minutes for the new labels to appear.
 
@@ -334,20 +330,9 @@ larger clusters, so it may take several minutes for the new labels to appear.
    ip-192-168-13-57 ⟵ Tunnel       foo=bar,hostname=ip-192-168-13-57
    ```
 
-Labels set with the `server_info` resource do not persist across restarts, but
-as long as the `server_info` resource still exists the labels will eventually
-be set again. To remove labels set with a `server_info` resource, replace the
-old resource with one that has no labels:
-
-```yaml
-# server_info.yaml
-kind: server_info
-metadata:
-   # Replace "example-node" with the name of the node to apply labels to
-   name: si-example-node
-spec:
-   new_labels:
-```
+Although ephemeral labels do not persist across restarts, they will be set again
+as long as the `server_info` resource still exists. To update ephemeral labels,
+recreate the `server_info` resource with updated labels.
 
 ## Next steps
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -43,7 +43,7 @@ but filter and limit access to the servers based on their AWS region.
 
 (!docs/pages/includes/tctl.mdx!)
 
-### Install Teleport
+## Step 1/2. Install Teleport
 
 1. Select a host for running the Teleport agent.
 
@@ -75,6 +75,11 @@ as a resource:
    ```code
    $ export INVITE_TOKEN=<token>
    ```
+
+## Step 2/2. Apply labels
+
+Follow any or all of the sections below to add different types of labels to
+your resource.
 
 ### Apply a static label
 
@@ -292,19 +297,35 @@ should be named `si-<name>`.
 
 To add resource-based labels:
 
+1. Run `tctl get node/<Var name="hostname"/>` to get the name of the node resource to apply labels to.
+   You should get output similar to the following:
+
+   ```yaml
+   kind: node
+   metadata:
+      expires: "2024-01-12T00:41:17.355013266Z"
+      id: <id>
+      name: <name-uuid>
+      revision: <revision-uuid>
+   spec:
+      # ...
+   ```
+
+   Save the value of `metadata.name` for the next step.
+
 1. Create the file `server_info.yaml` and paste the following into it:
 
    ```yaml
    # server_info.yaml
    kind: server_info
    metadata:
-      # Replace "example-node" with the name of the node to apply labels to
-      name: si-example-node
+      name: si-<node-name>
    spec:
       new_labels:
          "foo": "bar"
    ```
 
+   Replace `<node-name>` with the resource name you saved in the previous step.
    Run the following to create the `server_info` resource:
 
    ```code
@@ -328,9 +349,11 @@ larger clusters, so it may take several minutes for the new labels to appear.
    ip-192-168-13-57 ⟵ Tunnel       dynamic/foo=bar,hostname=ip-192-168-13-57
    ```
 
-Note that all resource-based labels created with `tctl` will have the
-`dynamic/` prefix. This prefix forbids the label from being used in a
-role's deny rules.
+<Admonition type="warning">
+   All resource-based labels created with `tctl` will have the
+   `dynamic/` prefix. This prefix forbids the label from being used in a
+   role's deny rules.
+</Admonition>
 
 To update resource-based labels, recreate the `server_info` resource with updated labels.
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -320,18 +320,19 @@ larger clusters, so it may take several minutes for the new labels to appear.
    $ tsh ls
    ```
 
-   You should see output similar to the following with the `foo` label displayed:
+   You should see output similar to the following with the `dynamic/foo` label displayed:
 
    ```code
    Node Name        Address        Labels                                                                                                                   
    ---------------- -------------- ------------------------------------------------------
-   ip-192-168-13-57 ⟵ Tunnel       foo=bar,hostname=ip-192-168-13-57
+   ip-192-168-13-57 ⟵ Tunnel       dynamic/foo=bar,hostname=ip-192-168-13-57
    ```
 
-Resource-based labels are stored in memory on servers, so if a server restarts it may temporarily lose
-its resource-based labels until the Auth Service applies them again. Because of this, it is not safe to
-use resource-based labels in an RBAC deny rule. To update resource-based labels, recreate the
-`server_info` resource with updated labels.
+Note that all resource-based labels created with `tctl` will have the
+`dynamic/` prefix. This prefix forbids the label from being used in a
+role's deny rules.
+
+To update resource-based labels, recreate the `server_info` resource with updated labels.
 
 ## Next steps
 


### PR DESCRIPTION
This change adds documentation for labels created with the `server_info` resource.