### PR TITLE
Add an overview of the Teleport documentation

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -8,6 +8,10 @@
           "title": "Get Started with Teleport",
           "slug": "/"
         },
+	{
+	  "title": "Documentation Overview",
+	  "slug": "/documentation-overview/"
+	},
         {
           "title": "Core Concepts",
           "slug": "/core-concepts/"

--- a/docs/pages/documentation-overview.mdx
+++ b/docs/pages/documentation-overview.mdx
@@ -1,0 +1,121 @@
+---
+title: Documentation Overview
+description: Explains the sections of the documentation.
+---
+
+This page provides a tour of the major sections of the Teleport documentation.
+
+We maintain a separate version of the Teleport documentation for each major
+version of Teleport. If you are running a version earlier than
+v(=teleport.major_version=), or want a preview of the next version's
+documentation, adjust the dropdown menu at the top of the page.
+
+## Get started
+
+If you are curious to see how Teleport works, you can get started by [spinning
+up a demo cluster](./index.mdx) on a Linux server. After seeing how your
+demo Teleport cluster lets you securely access a server and play back your SSH
+sessions, you can configure RBAC, add resources, and protect your home lab with
+Teleport.
+
+Once you are ready to learn more about Teleport, read our [Core Concepts
+guide](./core-concepts.mdx), which introduces the components of a Teleport
+cluster. You can refer to this glossary as you continue through the
+documentation.
+
+## Critical guides
+
+Guides in the "Home" section include information that all Teleport users will
+probably need to consult at some point:
+
+- [Installation](./installation.mdx): How to install Teleport binaries on your
+  environment. If you are just getting started with Teleport, we recommend
+  spinning up a [demo cluster](./index.mdx) or signing up for a [Teleport Team
+  trial](https://goteleport.com/signup).
+- [Frequently Asked Questions](./faq.mdx): If this page does not answer your
+  question, try our AI-assisted search box on the left sidebar.
+- [Usage Reporting and Billing](./usage-billing.mdx): How Teleport calculates
+  usage metrics to determine customer billing.
+- [Upcoming Releases](./upcoming-releases.mdx): Features to be introduced in
+  future versions of Teleport.
+- [Changelog](./changelog.mdx): A comprehensive collection of release notes.
+- [Teleport Assist](./ai-assist.mdx): How to use the AI-guided Teleport client.
+
+## Choose an edition
+
+After trying out Teleport, you are ready to deploy a cluster to your
+infrastructure. Teleport has four editions: 
+
+- Teleport Team
+- Teleport Enterprise Cloud
+- Teleport Enterprise
+- Teleport Community Edition
+
+You can compare these in our [Choose an
+Edition](./choose-an-edition/introduction.mdx) section.
+
+## Deploy a cluster
+
+Once you know which edition you would like to deploy, read our [Deploy a
+Cluster](./deploy-a-cluster/introduction.mdx) documentation for how to launch a
+fully fledged Teleport cluster in production. (If you are using Teleport
+Enterprise Cloud, you can skip this step.) This section shows you the best
+practices to follow for a high-availability Teleport cluster, and how to deploy
+Teleport on your cloud provider of choice.
+
+## Manage access
+
+Now that you have a running Teleport cluster, set up role-based access controls
+to enable secure access to your infrastructure.  You can define roles with
+granular permissions and use Teleport's integrations with Single Sign-On
+providers to automatically map these roles to users. You can also set up Access
+Requests to enable just-in-time access to your infrastructure. Read [Manage
+Access](./access-controls/introduction.mdx) to get started.
+
+## Manage your cluster
+
+With your Teleport cluster configured, you can now begin Day Two operations
+such as upgrades, adding agents to the cluster, and integrating Teleport with
+third-party tools. Read [Manage your
+Cluster](./management/introduction.mdx) for more information.
+
+## Add your infrastructure
+
+Teleport is protocol aware and provides functionality that is unique to each
+protocol it supports. To enable access to a protocol, deploy the appropriate
+Teleport service and configure it to communicate with resources in your
+infrastructure. 
+
+Read about how to enable access to:
+
+- [Servers](./server-access/getting-started.mdx), including OpenSSH servers that
+  [do not have Teleport installed](./server-access/guides/openssh.mdx)
+- [Kubernetes clusters](./kubernetes-access/introduction.mdx)
+- [Databases](./database-access/introduction.mdx)
+- [Applications](./application-access/introduction.mdx)
+- [Remote desktops](./desktop-access/introduction.mdx)
+
+You can also set up [Machine ID](./machine-id/introduction.mdx) to enable
+service accounts to access resources in your infrastructure with short-lived
+credentials.
+
+## Extend Teleport for your organization
+
+Teleport is highly customizable, exposing much of its functionality via a gRPC
+API. For example, you can build API clients to register infrastructure
+automatically or manage Access Requests using your organization's unique
+workflows. Read how to build applications that interact with Teleport's API in
+our [API guides](./api/introduction.mdx).
+
+## Learn more about Teleport
+
+Get more information about Teleport by reading our library of architecture,
+reference, and developer guides. See the
+[Upcoming Releases](./upcoming-releases.mdx) section for a glimpse of features we
+will release in the next Teleport version. Consult our
+[Reference](./reference/introduction.mdx) guides for comprehensive lists of
+configuration options, CLI flags, and more. For detailed explanations of how
+Teleport works, see the [Architecture](./architecture/introduction.mdx) section.
+
+Finally, if you're interested in adding to Teleport's documentation, view
+our [contribution guide](./contributing/documentation.mdx). 

--- a/docs/pages/documentation-overview.mdx
+++ b/docs/pages/documentation-overview.mdx
@@ -6,17 +6,17 @@ description: Explains the sections of the documentation.
 This page provides a tour of the major sections of the Teleport documentation.
 
 We maintain a separate version of the Teleport documentation for each major
-version of Teleport. If you are running a version earlier than
+version of Teleport that we support. If you are running a version earlier than
 v(=teleport.major_version=), or want a preview of the next version's
 documentation, adjust the dropdown menu at the top of the page.
 
 ## Get started
 
 If you are curious to see how Teleport works, you can get started by [spinning
-up a demo cluster](./index.mdx) on a Linux server. After seeing how your
-demo Teleport cluster lets you securely access a server and play back your SSH
-sessions, you can configure RBAC, add resources, and protect your home lab with
-Teleport.
+up a demo cluster](./index.mdx) on a Linux server. After seeing how your demo
+Teleport cluster lets you securely access a server and play back your SSH
+sessions, you can configure RBAC, add resources, and protect your infrastructure
+with Teleport.
 
 Once you are ready to learn more about Teleport, read our [Core Concepts
 guide](./core-concepts.mdx), which introduces the components of a Teleport
@@ -66,7 +66,7 @@ Teleport on your cloud provider of choice.
 ## Manage access
 
 Now that you have a running Teleport cluster, set up role-based access controls
-to enable secure access to your infrastructure.  You can define roles with
+to enable secure access to your infrastructure. You can define roles with
 granular permissions and use Teleport's integrations with Single Sign-On
 providers to automatically map these roles to users. You can also set up Access
 Requests to enable just-in-time access to your infrastructure. Read [Manage


### PR DESCRIPTION
Closes #34038

Help visitors to the Teleport documentation find their way through the docs site by including a description of each docs page in an overview guide.

This change is based on adapting the former Teleport index page (prior to #27703).