### PR TITLE
Configure jest to show seed used for test run

### DIFF
--- a/web/packages/build/jest/config.js
+++ b/web/packages/build/jest/config.js
@@ -36,4 +36,5 @@ module.exports = {
     escapeString: true,
     printBasicPrototype: true,
   },
+  showSeed: true,
 };


### PR DESCRIPTION
In case of flaky tests that depend on test order, running the suite again with the same seed should allow us to reproduce failures locally.