### PR TITLE
[v13] Prepare `SearchBar` for the integration with unified resources

### DIFF
--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -63,7 +63,7 @@ it('does not display empty results copy after selecting two filters', () => {
     ...getMockedSearchContext(),
     filters: [
       { filter: 'cluster', clusterUri: '/clusters/foo' },
-      { filter: 'resource-type', resourceType: 'servers' },
+      { filter: 'resource-type', resourceType: 'node' },
     ],
     inputValue: '',
   }));

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -64,13 +64,6 @@ export const SearchContextProvider: FC = props => {
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [activePicker, setActivePicker] = useState(actionPicker);
-  // TODO(ravicious): Consider using another data structure for search filters as we know that we
-  // always have only two specific filters: one for clusters and one for resource type.
-  //
-  // This could probably be represented by an object instead plus an array for letting the user
-  // provide those filters in any order they want. The array would be used in the UI that renders
-  // the filters while code that uses the search filters, such as ResourcesService.searchResources,
-  // could operate on the object instead.
   const [filters, setFilters] = useState<SearchFilter[]>([]);
 
   function changeActivePicker(picker: SearchPicker): void {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -203,7 +203,7 @@ describe('getActionPickerStatus', () => {
       ];
       const status = getActionPickerStatus({
         inputValue: '',
-        filters: [{ filter: 'resource-type', resourceType: 'servers' }],
+        filters: [{ filter: 'resource-type', resourceType: 'node' }],
         filterActionsAttempt: makeSuccessAttempt([]),
         allClusters: [],
         actionAttempts: [makeSuccessAttempt([])],

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -16,15 +16,9 @@
 
 import React, { ReactElement, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
-import {
-  Box,
-  ButtonBorder,
-  ButtonPrimary,
-  Flex,
-  Label as DesignLabel,
-  Text,
-} from 'design';
+import { Box, ButtonBorder, Flex, Label as DesignLabel, Text } from 'design';
 import * as icons from 'design/Icon';
+import { Cross as CloseIcon } from 'design/Icon';
 import { Highlight } from 'shared/components/Highlight';
 import { Attempt, hasFinished } from 'shared/hooks/useAsync';
 
@@ -873,22 +867,49 @@ function HighlightField(props: {
 
 function FilterButton(props: { text: string; onClick(): void }) {
   return (
-    <ButtonPrimary
-      px={2}
+    <Flex
+      justifyContent="center"
+      alignItems="center"
+      css={`
+        color: ${props => props.theme.colors.buttons.text};
+        background: ${props => props.theme.colors.spotBackground[1]};
+        border-radius: ${props => props.theme.radii[2]}px;
+      `}
+      px="6px"
       size="small"
-      title={props.text}
-      onClick={props.onClick}
     >
+      <CloseIcon
+        color="buttons.text"
+        mr={1}
+        mt="1px"
+        title="Remove filter"
+        onClick={props.onClick}
+        css={`
+          cursor: pointer;
+          border-radius: ${props => props.theme.radii[1]}px;
+
+          :hover {
+            background: ${props => props.theme.colors.spotBackground[1]};
+          }
+
+          > svg {
+            height: 13px;
+            width: 13px;
+          }
+        `}
+      />
       <span
+        title={props.text}
         css={`
           max-width: calc(${props => props.theme.space[9]}px * 2);
           text-overflow: ellipsis;
           white-space: nowrap;
           overflow: hidden;
+          cursor: default;
         `}
       >
         {props.text}
       </span>
-    </ButtonPrimary>
+    </Flex>
   );
 }

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -34,6 +34,7 @@ import {
   SearchResultCluster,
   SearchResultResourceType,
   SearchFilter,
+  SupportedResourceType,
 } from 'teleterm/ui/Search/searchResult';
 import * as tsh from 'teleterm/services/tshd/types';
 import * as uri from 'teleterm/ui/uri';
@@ -120,7 +121,7 @@ export function ActionPicker(props: { input: ReactElement }) {
       return (
         <FilterButton
           key="resource-type"
-          text={s.resourceType}
+          text={resourceTypeToPrettyName[s.resourceType]}
           onClick={() => removeFilter(s)}
         />
       );
@@ -491,9 +492,9 @@ const resourceIcons: Record<
     lineHeight: string;
   }>
 > = {
-  kubes: icons.Kubernetes,
-  servers: icons.Server,
-  databases: icons.Database,
+  kube_cluster: icons.Kubernetes,
+  node: icons.Server,
+  db: icons.Database,
 };
 
 function ResourceTypeFilterItem(
@@ -508,7 +509,7 @@ function ResourceTypeFilterItem(
         Search for{' '}
         <strong>
           <Highlight
-            text={props.searchResult.resource}
+            text={resourceTypeToPrettyName[props.searchResult.resource]}
             keywords={[props.searchResult.nameMatch]}
           />
         </strong>
@@ -913,3 +914,9 @@ function FilterButton(props: { text: string; onClick(): void }) {
     </Flex>
   );
 }
+
+const resourceTypeToPrettyName: Record<SupportedResourceType, string> = {
+  db: 'databases',
+  node: 'servers',
+  kube_cluster: 'kubes',
+};

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -505,7 +505,7 @@ function ResourceTypeFilterItem(
       iconColor="text.slightlyMuted"
     >
       <Text typography="body1">
-        Search only for{' '}
+        Search for{' '}
         <strong>
           <Highlight
             text={props.searchResult.resource}

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -120,7 +120,7 @@ export function ActionPicker(props: { input: ReactElement }) {
     if (s.filter === 'resource-type') {
       return (
         <FilterButton
-          key="resource-type"
+          key={`resource-type-${s.resourceType}`}
           text={resourceTypeToPrettyName[s.resourceType]}
           onClick={() => removeFilter(s)}
         />

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -34,7 +34,7 @@ import {
   SearchResultCluster,
   SearchResultResourceType,
   SearchFilter,
-  SupportedResourceType,
+  ResourceTypeFilter,
 } from 'teleterm/ui/Search/searchResult';
 import * as tsh from 'teleterm/services/tshd/types';
 import * as uri from 'teleterm/ui/uri';
@@ -912,7 +912,7 @@ function FilterButton(props: { text: string; onClick(): void }) {
   );
 }
 
-const resourceTypeToPrettyName: Record<SupportedResourceType, string> = {
+const resourceTypeToPrettyName: Record<ResourceTypeFilter, string> = {
   db: 'databases',
   node: 'servers',
   kube_cluster: 'kubes',

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -902,10 +902,7 @@ function FilterButton(props: { text: string; onClick(): void }) {
       <span
         title={props.text}
         css={`
-          max-width: calc(${props => props.theme.space[9]}px * 2);
-          text-overflow: ellipsis;
           white-space: nowrap;
-          overflow: hidden;
           cursor: default;
         `}
       >

--- a/web/packages/teleterm/src/ui/Search/pickers/PickerContainer.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/PickerContainer.ts
@@ -19,7 +19,11 @@ import styled from 'styled-components';
 export const PickerContainer = styled.div`
   display: flex;
   flex-direction: column;
-  position: absolute;
+  position: fixed;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
   box-sizing: border-box;
   z-index: 1000;
   font-size: 12px;
@@ -27,14 +31,15 @@ export const PickerContainer = styled.div`
   background: ${props => props.theme.colors.levels.elevated};
   box-shadow: ${props => props.theme.boxShadow[1]};
   border-radius: ${props => props.theme.radii[2]}px;
-  // we have to use a border of the same width as in SearchBar when it is closed to keep
-  // the layout from shifting when switching between open and closed state
-  border: 1px solid ${props => props.theme.colors.levels.elevated};
   text-shadow: none;
   // Prevents inner items from covering the border on rounded corners.
   overflow: hidden;
 
   // Account for border.
-  width: calc(100% + 2px);
   margin-top: -1px;
+
+  // These values are adjusted so that the cluster selector and search input
+  // are minimally covered by the picker.
+  max-width: 660px;
+  width: 76%;
 `;

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -289,7 +289,7 @@ const SearchResultItems = () => {
     }),
     {
       kind: 'resource-type-filter',
-      resource: 'kubes',
+      resource: 'kube_cluster',
       nameMatch: '',
       score: 0,
     },

--- a/web/packages/teleterm/src/ui/Search/searchResult.ts
+++ b/web/packages/teleterm/src/ui/Search/searchResult.ts
@@ -27,7 +27,7 @@ type ResourceSearchResultBase<
   score: number;
 };
 
-export type SupportedResourceType = 'kubes' | 'servers' | 'databases';
+export type SupportedResourceType = 'kube_cluster' | 'node' | 'db';
 
 export type SearchResultServer =
   ResourceSearchResultBase<resourcesServiceTypes.SearchResultServer>;

--- a/web/packages/teleterm/src/ui/Search/searchResult.ts
+++ b/web/packages/teleterm/src/ui/Search/searchResult.ts
@@ -27,6 +27,8 @@ type ResourceSearchResultBase<
   score: number;
 };
 
+export type SupportedResourceType = 'kubes' | 'servers' | 'databases';
+
 export type SearchResultServer =
   ResourceSearchResultBase<resourcesServiceTypes.SearchResultServer>;
 export type SearchResultDatabase =
@@ -41,7 +43,7 @@ export type SearchResultCluster = {
 };
 export type SearchResultResourceType = {
   kind: 'resource-type-filter';
-  resource: 'kubes' | 'servers' | 'databases';
+  resource: SupportedResourceType;
   nameMatch: string;
   score: number;
 };
@@ -103,7 +105,7 @@ export const searchableFields: {
 
 export interface ResourceTypeSearchFilter {
   filter: 'resource-type';
-  resourceType: 'kubes' | 'servers' | 'databases';
+  resourceType: SupportedResourceType;
 }
 
 export interface ClusterSearchFilter {
@@ -112,3 +114,15 @@ export interface ClusterSearchFilter {
 }
 
 export type SearchFilter = ResourceTypeSearchFilter | ClusterSearchFilter;
+
+export function isResourceTypeSearchFilter(
+  searchFilter: SearchFilter
+): searchFilter is ResourceTypeSearchFilter {
+  return searchFilter.filter === 'resource-type';
+}
+
+export function isClusterSearchFilter(
+  searchFilter: SearchFilter
+): searchFilter is ClusterSearchFilter {
+  return searchFilter.filter === 'cluster';
+}

--- a/web/packages/teleterm/src/ui/Search/searchResult.ts
+++ b/web/packages/teleterm/src/ui/Search/searchResult.ts
@@ -18,6 +18,7 @@ import type { ClusterUri } from 'teleterm/ui/uri';
 import type { Cluster } from 'teleterm/services/tshd/types';
 
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
+import type { SharedUnifiedResource } from 'shared/components/UnifiedResources';
 
 type ResourceSearchResultBase<
   Result extends resourcesServiceTypes.SearchResult
@@ -27,7 +28,10 @@ type ResourceSearchResultBase<
   score: number;
 };
 
-export type SupportedResourceType = 'kube_cluster' | 'node' | 'db';
+export type SupportedResourceType = Extract<
+  SharedUnifiedResource['resource']['kind'],
+  'node' | 'kube_cluster' | 'db'
+>;
 
 export type SearchResultServer =
   ResourceSearchResultBase<resourcesServiceTypes.SearchResultServer>;

--- a/web/packages/teleterm/src/ui/Search/searchResult.ts
+++ b/web/packages/teleterm/src/ui/Search/searchResult.ts
@@ -28,7 +28,7 @@ type ResourceSearchResultBase<
   score: number;
 };
 
-export type SupportedResourceType = Extract<
+export type ResourceTypeFilter = Extract<
   SharedUnifiedResource['resource']['kind'],
   'node' | 'kube_cluster' | 'db'
 >;
@@ -47,7 +47,7 @@ export type SearchResultCluster = {
 };
 export type SearchResultResourceType = {
   kind: 'resource-type-filter';
-  resource: SupportedResourceType;
+  resource: ResourceTypeFilter;
   nameMatch: string;
   score: number;
 };
@@ -109,7 +109,7 @@ export const searchableFields: {
 
 export interface ResourceTypeSearchFilter {
   filter: 'resource-type';
-  resourceType: SupportedResourceType;
+  resourceType: ResourceTypeFilter;
 }
 
 export interface ClusterSearchFilter {

--- a/web/packages/teleterm/src/ui/Search/searchResult.ts
+++ b/web/packages/teleterm/src/ui/Search/searchResult.ts
@@ -18,7 +18,6 @@ import type { ClusterUri } from 'teleterm/ui/uri';
 import type { Cluster } from 'teleterm/services/tshd/types';
 
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
-import type { SharedUnifiedResource } from 'shared/components/UnifiedResources';
 
 type ResourceSearchResultBase<
   Result extends resourcesServiceTypes.SearchResult
@@ -28,10 +27,7 @@ type ResourceSearchResultBase<
   score: number;
 };
 
-export type ResourceTypeFilter = Extract<
-  SharedUnifiedResource['resource']['kind'],
-  'node' | 'kube_cluster' | 'db'
->;
+export type ResourceTypeFilter = 'node' | 'kube_cluster' | 'db';
 
 export type SearchResultServer =
   ResourceSearchResultBase<resourcesServiceTypes.SearchResultServer>;

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -158,7 +158,7 @@ describe('useResourceSearch', () => {
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledWith({
       clusterUri: cluster.uri,
       search: 'foo',
-      filter: undefined,
+      filters: [],
       limit: 100,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(
@@ -189,7 +189,7 @@ describe('useResourceSearch', () => {
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledWith({
       clusterUri: cluster.uri,
       search: '',
-      filter: undefined,
+      filters: [],
       limit: 5,
     });
     expect(appContext.resourcesService.searchResources).toHaveBeenCalledTimes(

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -30,6 +30,7 @@ import {
   searchableFields,
   ResourceSearchResult,
   FilterSearchResult,
+  SupportedResourceType,
 } from './searchResult';
 
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
@@ -178,10 +179,10 @@ export function useFilterSearch() {
         });
       };
       const getResourceType = () => {
-        let resourceTypes = [
-          'servers' as const,
-          'databases' as const,
-          'kubes' as const,
+        let resourceTypes: SupportedResourceType[] = [
+          'node' as const,
+          'db' as const,
+          'kube_cluster' as const,
         ].filter(resourceType => {
           const isFilterForResourceTypeAdded = filters.some(searchFilter => {
             return (

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -41,6 +41,12 @@ export type CrossClusterResourceSearchResult = {
   search: string;
 };
 
+const SUPPORTED_RESOURCE_TYPES: SupportedResourceType[] = [
+  'node',
+  'db',
+  'kube_cluster',
+];
+
 /**
  * useResourceSearch returns a function which searches for the given list of space-separated keywords across
  * all root and leaf clusters that the user is currently logged in to.
@@ -179,11 +185,7 @@ export function useFilterSearch() {
         });
       };
       const getResourceType = () => {
-        let resourceTypes: SupportedResourceType[] = [
-          'node' as const,
-          'db' as const,
-          'kube_cluster' as const,
-        ].filter(resourceType => {
+        let resourceTypes = SUPPORTED_RESOURCE_TYPES.filter(resourceType => {
           const isFilterForResourceTypeAdded = filters.some(searchFilter => {
             return (
               searchFilter.filter === 'resource-type' &&

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -30,7 +30,7 @@ import {
   searchableFields,
   ResourceSearchResult,
   FilterSearchResult,
-  SupportedResourceType,
+  ResourceTypeFilter,
 } from './searchResult';
 
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
@@ -41,7 +41,7 @@ export type CrossClusterResourceSearchResult = {
   search: string;
 };
 
-const SUPPORTED_RESOURCE_TYPES: SupportedResourceType[] = [
+const SUPPORTED_RESOURCE_TYPES: ResourceTypeFilter[] = [
   'node',
   'db',
   'kube_cluster',

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -157,7 +157,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filters: ['servers'],
+      filters: ['node'],
       limit: 10,
     });
     expect(searchResults).toHaveLength(1);

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -123,7 +123,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filter: undefined,
+      filters: undefined,
       limit: 10,
     });
     expect(searchResults).toHaveLength(3);
@@ -157,10 +157,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filter: {
-        filter: 'resource-type',
-        resourceType: 'servers',
-      },
+      filters: ['servers'],
       limit: 10,
     });
     expect(searchResults).toHaveLength(1);
@@ -184,7 +181,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filter: undefined,
+      filters: undefined,
       limit: 10,
     });
     expect(searchResults).toHaveLength(3);

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -123,7 +123,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filters: undefined,
+      filters: [],
       limit: 10,
     });
     expect(searchResults).toHaveLength(3);
@@ -181,7 +181,7 @@ describe('searchResources', () => {
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
       search: '',
-      filters: undefined,
+      filters: [],
       limit: 10,
     });
     expect(searchResults).toHaveLength(3);

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -16,9 +16,9 @@
 
 import { pluralize } from 'shared/utils/text';
 
-import type { ResourceTypeSearchFilter } from 'teleterm/ui/Search/searchResult';
 import type * as types from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
+import type { SupportedResourceType } from 'teleterm/ui/Search/searchResult';
 
 export class ResourcesService {
   constructor(private tshClient: types.TshClient) {}
@@ -73,14 +73,12 @@ export class ResourcesService {
   async searchResources({
     clusterUri,
     search,
-    filter,
+    filters,
     limit,
   }: {
     clusterUri: uri.ClusterUri;
     search: string;
-    // TODO(ravicious): Accept just `server | database | kube` as searchFilter here, wrap it in a
-    // variant of a discriminated union in searchResult.ts.
-    filter: ResourceTypeSearchFilter | undefined;
+    filters: SupportedResourceType[] | undefined;
     limit: number;
   }): Promise<PromiseSettledResult<SearchResult[]>[]> {
     const params = { search, clusterUri, sort: null, limit };
@@ -115,11 +113,11 @@ export class ResourcesService {
         err => Promise.reject(new ResourceSearchError(clusterUri, 'kube', err))
       );
 
-    const promises = filter
+    const promises = filters?.length
       ? [
-          filter.resourceType === 'servers' && getServers(),
-          filter.resourceType === 'databases' && getDatabases(),
-          filter.resourceType === 'kubes' && getKubes(),
+          filters.includes('servers') && getServers(),
+          filters.includes('databases') && getDatabases(),
+          filters.includes('kubes') && getKubes(),
         ].filter(Boolean)
       : [getServers(), getDatabases(), getKubes()];
 

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -115,9 +115,9 @@ export class ResourcesService {
 
     const promises = filters?.length
       ? [
-          filters.includes('servers') && getServers(),
-          filters.includes('databases') && getDatabases(),
-          filters.includes('kubes') && getKubes(),
+          filters.includes('node') && getServers(),
+          filters.includes('db') && getDatabases(),
+          filters.includes('kube_cluster') && getKubes(),
         ].filter(Boolean)
       : [getServers(), getDatabases(), getKubes()];
 

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -78,7 +78,7 @@ export class ResourcesService {
   }: {
     clusterUri: uri.ClusterUri;
     search: string;
-    filters: SupportedResourceType[] | undefined;
+    filters: SupportedResourceType[];
     limit: number;
   }): Promise<PromiseSettledResult<SearchResult[]>[]> {
     const params = { search, clusterUri, sort: null, limit };

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -18,7 +18,7 @@ import { pluralize } from 'shared/utils/text';
 
 import type * as types from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
-import type { SupportedResourceType } from 'teleterm/ui/Search/searchResult';
+import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
 
 export class ResourcesService {
   constructor(private tshClient: types.TshClient) {}
@@ -78,7 +78,7 @@ export class ResourcesService {
   }: {
     clusterUri: uri.ClusterUri;
     search: string;
-    filters: SupportedResourceType[];
+    filters: ResourceTypeFilter[];
     limit: number;
   }): Promise<PromiseSettledResult<SearchResult[]>[]> {
     const params = { search, clusterUri, sort: null, limit };


### PR DESCRIPTION
Backport #34402 to branch/v13

Changelog: Allow selecting multiple resource filters in the search bar in Connect