### PR TITLE
[v13] chore: Bump Buf to v1.28.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-          version: v1.27.0
+          version: v1.28.0
       - uses: bufbuild/buf-lint-action@v1
       - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@v1

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -11,7 +11,7 @@ LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= v1.27.0
+BUF_VERSION ?= v1.28.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #34539 to branch/v13.

Update to the latest version.

* https://github.com/bufbuild/buf/releases/tag/v1.28.0