### PR TITLE
Discovery: Use Integration credentials for fetchers

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -709,6 +709,12 @@ type ReadDiscoveryAccessPoint interface {
 
 	// ListDiscoveryConfigs returns a paginated list of Discovery Config resources.
 	ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error)
+
+	// GetIntegration returns the specified integration resource.
+	GetIntegration(ctx context.Context, name string) (types.Integration, error)
+
+	// GetProxies returns a list of registered proxies.
+	GetProxies() ([]types.Server, error)
 }
 
 // DiscoveryAccessPoint is an API interface implemented by a certificate authority (CA) to be
@@ -745,6 +751,9 @@ type DiscoveryAccessPoint interface {
 
 	// SubmitUsageEvent submits an external usage event.
 	SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEventRequest) error
+
+	// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+	GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error)
 }
 
 // ReadOktaAccessPoint is a read only API interface to be
@@ -1269,6 +1278,11 @@ func (w *DiscoveryWrapper) UpsertServerInfo(ctx context.Context, si types.Server
 // SubmitUsageEvent submits an external usage event.
 func (w *DiscoveryWrapper) SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEventRequest) error {
 	return w.NoCache.SubmitUsageEvent(ctx, req)
+}
+
+// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+func (w *DiscoveryWrapper) GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error) {
+	return w.NoCache.GenerateAWSOIDCToken(ctx, req)
 }
 
 // Close closes all associated resources

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -485,6 +485,7 @@ type Services struct {
 	services.ConnectionsDiagnostic
 	services.StatusInternal
 	services.Integrations
+	services.IntegrationsTokenGenerator
 	services.DiscoveryConfigs
 	services.Okta
 	services.AccessLists
@@ -514,6 +515,11 @@ func (r *Services) GetWebSession(ctx context.Context, req types.GetWebSessionReq
 // Implements ReadAccessPoint
 func (r *Services) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
 	return r.Identity.WebTokens().Get(ctx, req)
+}
+
+// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+func (r *Services) GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error) {
+	return r.IntegrationsTokenGenerator.GenerateAWSOIDCToken(ctx, req)
 }
 
 // OktaClient returns the okta client.

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -70,7 +70,9 @@ func (s *Service) GenerateAWSOIDCToken(ctx context.Context, req *integrationpb.G
 		Audience: types.IntegrationAWSOIDCAudience,
 		Subject:  types.IntegrationAWSOIDCSubject,
 		Issuer:   req.Issuer,
-		Expires:  s.clock.Now().Add(time.Minute),
+		// Token expiration is not controlled by the Expires property.
+		// It is defined by assumed IAM Role's "Maximum session duration" (usually 1h).
+		Expires: s.clock.Now().Add(time.Minute),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -988,6 +988,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindServerInfo, services.RW()),
 						types.NewRule(types.KindApp, services.RW()),
 						types.NewRule(types.KindDiscoveryConfig, services.RO()),
+						types.NewRule(types.KindIntegration, append(services.RO(), types.VerbUse)),
 					},
 					// Discovery service should only access kubes/apps/dbs that originated from discovery.
 					KubernetesLabels: types.Labels{types.OriginLabel: []string{types.OriginCloud}},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -398,6 +398,8 @@ func ForDiscovery(cfg Config) Config {
 		{Kind: types.KindDatabase},
 		{Kind: types.KindApp},
 		{Kind: types.KindDiscoveryConfig},
+		{Kind: types.KindIntegration},
+		{Kind: types.KindProxy},
 	}
 	cfg.QueueSize = defaults.DiscoveryQueueSize
 	return cfg

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -377,6 +377,9 @@ type awsAssumeRoleOpts struct {
 func (a *awsAssumeRoleOpts) checkAndSetDefaults() error {
 	switch a.credentialsSource {
 	case credentialsSourceAmbient:
+		if a.integration != "" {
+			return trace.BadParameter("integration and ambient credentials cannot be used at the same time")
+		}
 	case credentialsSourceIntegration:
 		if a.integration == "" {
 			return trace.BadParameter("missing integration name")
@@ -424,7 +427,7 @@ func WithCredentialsMaybeIntegration(integration string) AWSAssumeRoleOptionFn {
 		return withIntegrationCredentials(integration)
 	}
 
-	return withAmbientCredentials()
+	return WithAmbientCredentials()
 }
 
 // withIntegrationCredentials configures options with an Integration that must be used to fetch Credentials to assume a role.
@@ -436,8 +439,8 @@ func withIntegrationCredentials(integration string) AWSAssumeRoleOptionFn {
 	}
 }
 
-// withAmbientCredentials configures options to use the ambient credentials.
-func withAmbientCredentials() AWSAssumeRoleOptionFn {
+// WithAmbientCredentials configures options to use the ambient credentials.
+func WithAmbientCredentials() AWSAssumeRoleOptionFn {
 	return func(options *awsAssumeRoleOpts) {
 		options.credentialsSource = credentialsSourceAmbient
 	}

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -377,7 +377,6 @@ type awsAssumeRoleOpts struct {
 func (a *awsAssumeRoleOpts) checkAndSetDefaults() error {
 	switch a.credentialsSource {
 	case credentialsSourceAmbient:
-		a.integration = ""
 	case credentialsSourceIntegration:
 		if a.integration == "" {
 			return trace.BadParameter("missing integration name")

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -738,8 +738,6 @@ func (c *cloudClients) getAWSSessionForRegion(region string, opts awsAssumeRoleO
 	cacheKey := awsSessionCacheKey{
 		region:      region,
 		integration: opts.integration,
-		roleARN:     opts.assumeRoleARN,
-		externalID:  opts.assumeRoleExternalID,
 	}
 
 	return utils.FnCacheGet(context.Background(), c.awsSessionsCache, cacheKey, func(ctx context.Context) (*awssession.Session, error) {

--- a/lib/cloud/clients_test.go
+++ b/lib/cloud/clients_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientGetAWSSessionIntegration(t *testing.T) {
+	dummyIntegration := "integration-test"
+	dummyRegion := "test-region-123"
+
+	t.Run("without an integration, must return a missing aws integration session provider error", func(t *testing.T) {
+		ctx := context.Background()
+
+		client, err := NewClients()
+		require.NoError(t, err)
+
+		_, err = client.GetAWSSession(ctx, "us-region-2", WithIntergration("integration-test"))
+		require.True(t, trace.IsBadParameter(err), "expected err to be BadParameter, got %+v", err)
+		require.ErrorContains(t, err, "missing aws integration session provider")
+	})
+
+	t.Run("with  an integration session provider, must return the session", func(t *testing.T) {
+		ctx := context.Background()
+		dummySession := &awssession.Session{
+			Config: &aws.Config{
+				Region: &dummyRegion,
+			},
+		}
+
+		client, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
+			assert.Equal(t, dummyIntegration, integration)
+			assert.Equal(t, dummyRegion, region)
+			return dummySession, nil
+		}))
+		require.NoError(t, err)
+
+		sess, err := client.GetAWSSession(ctx, dummyRegion, WithIntergration("integration-test"))
+		require.NoError(t, err)
+		require.Equal(t, dummySession, sess)
+	})
+
+	t.Run("with an integration session provider, but no integration is requested, must not call the integration session provider", func(t *testing.T) {
+		ctx := context.Background()
+
+		client, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
+			assert.Fail(t, "should not be called")
+			return nil, nil
+		}))
+		require.NoError(t, err)
+
+		sess, err := client.GetAWSSession(ctx, dummyRegion)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+	})
+}

--- a/lib/cloud/clients_test.go
+++ b/lib/cloud/clients_test.go
@@ -34,15 +34,17 @@ func TestClientGetAWSSessionIntegration(t *testing.T) {
 	t.Run("without an integration, must return a missing aws integration session provider error", func(t *testing.T) {
 		ctx := context.Background()
 
-		client, err := NewClients()
+		clients, err := NewClients()
 		require.NoError(t, err)
 
-		_, err = client.GetAWSSession(ctx, "us-region-2", WithIntergration("integration-test"))
+		t.Cleanup(func() { require.NoError(t, clients.Close()) })
+
+		_, err = clients.GetAWSSession(ctx, "us-region-2", WithIntegration("integration-test"))
 		require.True(t, trace.IsBadParameter(err), "expected err to be BadParameter, got %+v", err)
 		require.ErrorContains(t, err, "missing aws integration session provider")
 	})
 
-	t.Run("with  an integration session provider, must return the session", func(t *testing.T) {
+	t.Run("with an integration session provider, must return the session", func(t *testing.T) {
 		ctx := context.Background()
 		dummySession := &awssession.Session{
 			Config: &aws.Config{
@@ -50,14 +52,15 @@ func TestClientGetAWSSessionIntegration(t *testing.T) {
 			},
 		}
 
-		client, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
+		clients, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
 			assert.Equal(t, dummyIntegration, integration)
 			assert.Equal(t, dummyRegion, region)
 			return dummySession, nil
 		}))
 		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, clients.Close()) })
 
-		sess, err := client.GetAWSSession(ctx, dummyRegion, WithIntergration("integration-test"))
+		sess, err := clients.GetAWSSession(ctx, dummyRegion, WithIntegration("integration-test"))
 		require.NoError(t, err)
 		require.Equal(t, dummySession, sess)
 	})
@@ -65,13 +68,14 @@ func TestClientGetAWSSessionIntegration(t *testing.T) {
 	t.Run("with an integration session provider, but no integration is requested, must not call the integration session provider", func(t *testing.T) {
 		ctx := context.Background()
 
-		client, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
+		clients, err := NewClients(WithAWSIntegrationSessionProvider(func(ctx context.Context, region, integration string) (*awssession.Session, error) {
 			assert.Fail(t, "should not be called")
 			return nil, nil
 		}))
 		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, clients.Close()) })
 
-		sess, err := client.GetAWSSession(ctx, dummyRegion)
+		sess, err := clients.GetAWSSession(ctx, dummyRegion)
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 	})

--- a/lib/integrations/awsoidc/clientsv1.go
+++ b/lib/integrations/awsoidc/clientsv1.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/oidc"
+)
+
+// FetchToken returns the token.
+func (j IdentityToken) FetchToken(ctx credentials.Context) ([]byte, error) {
+	return []byte(j), nil
+}
+
+// IntegrationTokenGenerator is an interface that indicates which APIs are required to generate an Integration Token.
+type IntegrationTokenGenerator interface {
+	// GetIntegration returns the specified integration resources.
+	GetIntegration(ctx context.Context, name string) (types.Integration, error)
+
+	// GetProxies returns a list of registered proxies.
+	GetProxies() ([]types.Server, error)
+
+	// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+	GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error)
+}
+
+// NewSessionV1 creates a new AWS Session for the region using the integration as source of credentials.
+// This session is usable for AWS SDK Go V1.
+func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region string, integrationName string) (*session.Session, error) {
+	integration, err := client.GetIntegration(ctx, integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsOIDCIntegration := integration.GetAWSOIDCIntegrationSpec()
+	if awsOIDCIntegration == nil {
+		return nil, trace.BadParameter("invalid integration subkind, expected awsoidc, got %s", integration.GetSubKind())
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigDisable,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	issuer, err := oidc.IssuerForCluster(ctx, client)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	token, err := client.GenerateAWSOIDCToken(ctx, types.GenerateAWSOIDCTokenRequest{
+		Issuer: issuer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	stsSTS := sts.New(sess)
+	roleProvider := stscreds.NewWebIdentityRoleProviderWithOptions(
+		stsSTS,
+		awsOIDCIntegration.RoleARN,
+		"",
+		IdentityToken(token),
+	)
+	awsCredentials := credentials.NewCredentials(roleProvider)
+
+	awsConfig := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(awsCredentials)
+
+	session, err := session.NewSessionWithOptions(session.Options{
+		Config:            *awsConfig,
+		SharedConfigState: session.SharedConfigDisable,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return session, nil
+}

--- a/lib/integrations/awsoidc/clientsv1_test.go
+++ b/lib/integrations/awsoidc/clientsv1_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type mockIntegrationsTokenGenerator struct {
+	proxies      []types.Server
+	integrations map[string]types.Integration
+}
+
+// GetIntegration returns the specified integration resources.
+func (m *mockIntegrationsTokenGenerator) GetIntegration(ctx context.Context, name string) (types.Integration, error) {
+	if ig, found := m.integrations[name]; found {
+		return ig, nil
+	}
+
+	return nil, trace.NotFound("integration not found")
+}
+
+// GetProxies returns a list of registered proxies.
+func (m *mockIntegrationsTokenGenerator) GetProxies() ([]types.Server, error) {
+	return m.proxies, nil
+}
+
+// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+func (m *mockIntegrationsTokenGenerator) GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error) {
+	return "token-goes-here", nil
+}
+
+func TestNewSessionV1(t *testing.T) {
+	ctx := context.Background()
+
+	dummyIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "myawsintegration"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+		},
+	)
+	require.NoError(t, err)
+
+	dummyProxy, err := types.NewServer(
+		"proxy-123", types.KindProxy,
+		types.ServerSpecV2{
+			PublicAddrs: []string{"https://localhost:3080/"},
+		},
+	)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name             string
+		region           string
+		integration      string
+		expectedErr      require.ErrorAssertionFunc
+		sessionValidator func(*testing.T, *session.Session)
+	}{
+		{
+			name:        "valid",
+			region:      "us-dummy-1",
+			integration: "myawsintegration",
+			expectedErr: require.NoError,
+			sessionValidator: func(t *testing.T, s *session.Session) {
+				require.Equal(t, aws.String("us-dummy-1"), s.Config.Region)
+			},
+		},
+		{
+			name:        "not found error when integration is missing",
+			region:      "us-dummy-1",
+			integration: "not-found",
+			expectedErr: notFounCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTokenGenertor := &mockIntegrationsTokenGenerator{
+				proxies: []types.Server{dummyProxy},
+				integrations: map[string]types.Integration{
+					dummyIntegration.GetName(): dummyIntegration,
+				},
+			}
+			awsSessionOut, err := NewSessionV1(ctx, mockTokenGenertor, tt.region, tt.integration)
+
+			tt.expectedErr(t, err)
+			if tt.sessionValidator != nil {
+				tt.sessionValidator(t, awsSessionOut)
+			}
+		})
+	}
+
+}

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -266,7 +266,9 @@ func getAWSResourceMatcherToCluster(kubeCluster types.KubeCluster, resourceMatch
 func getAWSClientRestConfig(cloudClients cloud.Clients, clock clockwork.Clock, resourceMatchers []services.ResourceMatcher) dynamicCredsClient {
 	return func(ctx context.Context, cluster types.KubeCluster) (*rest.Config, time.Time, error) {
 		region := cluster.GetAWSConfig().Region
-		var opts []cloud.AWSAssumeRoleOptionFn
+		opts := []cloud.AWSAssumeRoleOptionFn{
+			cloud.WithAmbientCredentials(),
+		}
 		if awsAssume := getAWSResourceMatcherToCluster(cluster, resourceMatchers); awsAssume != nil {
 			opts = append(opts, cloud.WithAssumeRole(awsAssume.AssumeRoleARN, awsAssume.ExternalID))
 		}

--- a/lib/services/integration.go
+++ b/lib/services/integration.go
@@ -46,6 +46,12 @@ type IntegrationsGetter interface {
 	GetIntegration(ctx context.Context, name string) (types.Integration, error)
 }
 
+// IntegrationsTokenGenerator defines methods to generate tokens for Integrations.
+type IntegrationsTokenGenerator interface {
+	// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+	GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error)
+}
+
 // MarshalIntegration marshals the Integration resource to JSON.
 func MarshalIntegration(ig types.Integration, opts ...MarshalOption) ([]byte, error) {
 	if err := ig.CheckAndSetDefaults(); err != nil {

--- a/lib/srv/db/cassandra/handshake.go
+++ b/lib/srv/db/cassandra/handshake.go
@@ -198,7 +198,10 @@ func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Aut
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	baseSession, err := a.cloudClients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	baseSession, err := a.cloudClients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -207,7 +210,9 @@ func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Aut
 		externalID = meta.ExternalID
 	}
 	session, err := a.cloudClients.GetAWSSession(ctx, meta.Region,
-		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID))
+		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -78,7 +78,10 @@ func newAWS(ctx context.Context, config awsConfig) (*awsClient, error) {
 	}
 
 	meta := config.database.GetAWS()
-	iam, err := config.clients.GetAWSIAMClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	iam, err := config.clients.GetAWSIAMClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -312,7 +315,10 @@ func (r *rdsDBConfigurator) ensureIAMAuth(ctx context.Context, db types.Database
 func (r *rdsDBConfigurator) enableIAMAuth(ctx context.Context, db types.Database) error {
 	r.log.Debug("Enabling IAM auth for RDS.")
 	meta := db.GetAWS()
-	rdsClt, err := r.clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	rdsClt, err := r.clients.GetAWSRDSClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -245,7 +245,7 @@ func (c *IAM) getAWSIdentity(ctx context.Context, database types.Database) (awsl
 		return c.agentIdentity, nil
 	}
 	c.mu.RUnlock()
-	sts, err := c.cfg.Clients.GetAWSSTSClient(ctx, meta.Region)
+	sts, err := c.cfg.Clients.GetAWSSTSClient(ctx, meta.Region, cloud.WithAmbientCredentials())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -116,7 +116,10 @@ func (m *Metadata) updateAWS(ctx context.Context, database types.Database, fetch
 // fetchRDSMetadata fetches metadata for the provided RDS or Aurora database.
 func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -150,7 +153,10 @@ func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database
 // fetchRDSProxyMetadata fetches metadata for the provided RDS Proxy database.
 func (m *Metadata) fetchRDSProxyMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -164,7 +170,10 @@ func (m *Metadata) fetchRDSProxyMetadata(ctx context.Context, database types.Dat
 // fetchRedshiftMetadata fetches metadata for the provided Redshift database.
 func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	redshift, err := m.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	redshift, err := m.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -179,7 +188,10 @@ func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Dat
 // Serverless database.
 func (m *Metadata) fetchRedshiftServerlessMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	client, err := m.cfg.Clients.GetAWSRedshiftServerlessClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := m.cfg.Clients.GetAWSRedshiftServerlessClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -193,7 +205,10 @@ func (m *Metadata) fetchRedshiftServerlessMetadata(ctx context.Context, database
 // fetchElastiCacheMetadata fetches metadata for the provided ElastiCache database.
 func (m *Metadata) fetchElastiCacheMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	elastiCacheClient, err := m.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	elastiCacheClient, err := m.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -210,7 +225,10 @@ func (m *Metadata) fetchElastiCacheMetadata(ctx context.Context, database types.
 // fetchMemoryDBMetadata fetches metadata for the provided MemoryDB database.
 func (m *Metadata) fetchMemoryDBMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	memoryDBClient, err := m.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	memoryDBClient, err := m.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/resource_checker_credentials.go
+++ b/lib/srv/db/cloud/resource_checker_credentials.go
@@ -104,7 +104,7 @@ func (c *credentialsChecker) getAWSIdentity(ctx context.Context, meta *types.AWS
 	}
 
 	identity, err := utils.FnCacheGet(ctx, c.cache, types.CloudAWS, func(ctx context.Context) (aws.Identity, error) {
-		client, err := c.cloudClients.GetAWSSTSClient(ctx, "")
+		client, err := c.cloudClients.GetAWSSTSClient(ctx, "", cloud.WithAmbientCredentials())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/cloud/resource_checker_url_aws.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws.go
@@ -68,7 +68,10 @@ func (c *urlChecker) logAWSAccessDeniedError(database types.Database, accessDeni
 
 func (c *urlChecker) checkRDS(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	rdsClient, err := c.clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	rdsClient, err := c.clients.GetAWSRDSClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -110,7 +113,10 @@ func (c *urlChecker) checkRDSCluster(ctx context.Context, database types.Databas
 
 func (c *urlChecker) checkRDSProxy(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	rdsClient, err := c.clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	rdsClient, err := c.clients.GetAWSRDSClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -137,7 +143,10 @@ func (c *urlChecker) checkRDSProxyCustomEndpoint(ctx context.Context, database t
 
 func (c *urlChecker) checkRedshift(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	redshift, err := c.clients.GetAWSRedshiftClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	redshift, err := c.clients.GetAWSRedshiftClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -153,7 +162,10 @@ func (c *urlChecker) checkRedshift(ctx context.Context, database types.Database)
 
 func (c *urlChecker) checkRedshiftServerless(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	client, err := c.clients.GetAWSRedshiftServerlessClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := c.clients.GetAWSRedshiftServerlessClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -185,7 +197,10 @@ func (c *urlChecker) checkRedshiftServerlessWorkgroup(ctx context.Context, datab
 
 func (c *urlChecker) checkElastiCache(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	elastiCacheClient, err := c.clients.GetAWSElastiCacheClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	elastiCacheClient, err := c.clients.GetAWSElastiCacheClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -202,7 +217,10 @@ func (c *urlChecker) checkElastiCache(ctx context.Context, database types.Databa
 
 func (c *urlChecker) checkMemoryDB(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	memoryDBClient, err := c.clients.GetAWSMemoryDBClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	memoryDBClient, err := c.clients.GetAWSMemoryDBClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -215,7 +233,10 @@ func (c *urlChecker) checkMemoryDB(ctx context.Context, database types.Database)
 
 func (c *urlChecker) checkOpenSearch(ctx context.Context, database types.Database) error {
 	meta := database.GetAWS()
-	client, err := c.clients.GetAWSOpenSearchClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := c.clients.GetAWSOpenSearchClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/elasticache.go
+++ b/lib/srv/db/cloud/users/elasticache.go
@@ -72,7 +72,10 @@ func (f *elastiCacheFetcher) FetchDatabaseUsers(ctx context.Context, database ty
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := f.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -168,7 +168,10 @@ func newSecretStore(ctx context.Context, database types.Database, clients cloud.
 	secretStoreConfig := database.GetSecretStore()
 
 	meta := database.GetAWS()
-	client, err := clients.GetAWSSecretsManagerClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := clients.GetAWSSecretsManagerClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/memorydb.go
+++ b/lib/srv/db/cloud/users/memorydb.go
@@ -73,7 +73,10 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	client, err := f.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -177,7 +177,10 @@ func NewAuth(config AuthConfig) (Auth, error) {
 // when connecting to RDS and Aurora databases.
 func (a *dbAuth) GetRDSAuthToken(ctx context.Context, sessionCtx *Session) (string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -209,7 +212,10 @@ permissions (note that IAM changes may take a few minutes to propagate):
 // password when connecting to Redshift databases.
 func (a *dbAuth) GetRedshiftAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	redshiftClient, err := a.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	redshiftClient, err := a.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
@@ -255,7 +261,10 @@ func (a *dbAuth) GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx 
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
-	baseSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	baseSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
@@ -266,7 +275,9 @@ func (a *dbAuth) GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx 
 	// Assume the configured AWS role before assuming the role we need to get the
 	// auth token. This allows cross-account AWS access.
 	client, err := a.cfg.Clients.GetAWSRedshiftServerlessClient(ctx, meta.Region,
-		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID))
+		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", "", trace.AccessDenied(`Could not generate Redshift Serverless auth token:
 
@@ -413,7 +424,10 @@ func (a *dbAuth) GetAzureAccessToken(ctx context.Context, sessionCtx *Session) (
 // GetElastiCacheRedisToken generates an ElastiCache Redis auth token.
 func (a *dbAuth) GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Session) (string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -435,7 +449,10 @@ func (a *dbAuth) GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Sessi
 // GetMemoryDBToken generates a MemoryDB auth token.
 func (a *dbAuth) GetMemoryDBToken(ctx context.Context, sessionCtx *Session) (string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -884,7 +901,7 @@ func (a *dbAuth) GetAWSIAMCreds(ctx context.Context, sessionCtx *Session) (strin
 			awsAccountID = assumeRoleARN.AccountID
 		default:
 			a.cfg.Log.Debugf("Fetching AWS Account ID to build role ARN")
-			stsClient, err := a.cfg.Clients.GetAWSSTSClient(ctx, dbAWS.Region)
+			stsClient, err := a.cfg.Clients.GetAWSSTSClient(ctx, dbAWS.Region, cloud.WithAmbientCredentials())
 			if err != nil {
 				return "", "", "", trace.Wrap(err)
 			}
@@ -903,7 +920,10 @@ func (a *dbAuth) GetAWSIAMCreds(ctx context.Context, sessionCtx *Session) (strin
 		return "", "", "", trace.Wrap(err)
 	}
 
-	baseSession, err := a.cfg.Clients.GetAWSSession(ctx, dbAWS.Region, cloud.WithAssumeRoleFromAWSMeta(dbAWS))
+	baseSession, err := a.cfg.Clients.GetAWSSession(ctx, dbAWS.Region,
+		cloud.WithAssumeRoleFromAWSMeta(dbAWS),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", "", "", trace.Wrap(err)
 	}
@@ -915,7 +935,10 @@ func (a *dbAuth) GetAWSIAMCreds(ctx context.Context, sessionCtx *Session) (strin
 		awsExternalID = dbAWS.ExternalID
 	}
 
-	sess, err := a.cfg.Clients.GetAWSSession(ctx, dbAWS.Region, cloud.WithChainedAssumeRole(baseSession, arn, awsExternalID))
+	sess, err := a.cfg.Clients.GetAWSSession(ctx, dbAWS.Region,
+		cloud.WithChainedAssumeRole(baseSession, arn, awsExternalID),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return "", "", "", trace.Wrap(err)
 	}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -137,7 +137,10 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 	defer e.Audit.OnSessionEnd(e.Context, e.sessionCtx)
 
 	meta := e.sessionCtx.Database.GetAWS()
-	awsSession, err := e.CloudClients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	awsSession, err := e.CloudClients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/opensearch/engine.go
+++ b/lib/srv/db/opensearch/engine.go
@@ -134,7 +134,10 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 	}
 
 	meta := e.sessionCtx.Database.GetAWS()
-	awsSession, err := e.CloudClients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	awsSession, err := e.CloudClients.GetAWSSession(ctx, meta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(meta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -360,7 +360,9 @@ func checkUserIAMAuthIsEnabled(ctx context.Context, sessionCtx *common.Session, 
 
 func checkElastiCacheUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
 	client, err := clients.GetAWSElastiCacheClient(ctx, awsMeta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(awsMeta))
+		cloud.WithAssumeRoleFromAWSMeta(awsMeta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -381,7 +383,9 @@ func checkElastiCacheUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Cli
 
 func checkMemoryDBUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
 	client, err := clients.GetAWSMemoryDBClient(ctx, awsMeta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(awsMeta))
+		cloud.WithAssumeRoleFromAWSMeta(awsMeta),
+		cloud.WithAmbientCredentials(),
+	)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -44,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
@@ -142,7 +144,12 @@ func (c *Config) CheckAndSetDefaults() error {
 kubernetes matchers are present.`)
 	}
 	if c.CloudClients == nil {
-		cloudClients, err := cloud.NewClients()
+		awsIntegrationSessionProvider := func(ctx context.Context, region, integration string) (*session.Session, error) {
+			return awsoidc.NewSessionV1(ctx, c.AccessPoint, region, integration)
+		}
+		cloudClients, err := cloud.NewClients(
+			cloud.WithAWSIntegrationSessionProvider(awsIntegrationSessionProvider),
+		)
 		if err != nil {
 			return trace.Wrap(err, "unable to create cloud clients")
 		}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -402,6 +402,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 							matcherAssumeRole.RoleARN,
 							matcherAssumeRole.ExternalID,
 						),
+						cloud.WithAmbientCredentials(),
 					)
 					if err != nil {
 						return trace.Wrap(err)
@@ -716,8 +717,9 @@ func genInstancesLogStr[T any](instances []T, getID func(T) string) string {
 }
 
 func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
+	// TODO(marco): support AWS SSM Client backed by an integration
 	// TODO(gavin): support assume_role_arn for ec2.
-	ec2Client, err := s.CloudClients.GetAWSSSMClient(s.ctx, instances.Region)
+	ec2Client, err := s.CloudClients.GetAWSSSMClient(s.ctx, instances.Region, cloud.WithAmbientCredentials())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -55,6 +55,9 @@ type awsFetcherConfig struct {
 	// Log is a field logger to provide structured logging for each matcher,
 	// based on its config settings by default.
 	Log logrus.FieldLogger
+	// Integration is the integration name to be used to fetch credentials.
+	// When present, it will use this integration and discard any local credentials.
+	Integration string
 }
 
 // CheckAndSetDefaults validates the config and sets defaults.
@@ -72,11 +75,16 @@ func (cfg *awsFetcherConfig) CheckAndSetDefaults(component string) error {
 		return trace.BadParameter("missing parameter Region")
 	}
 	if cfg.Log == nil {
+		credentialsSource := "environment"
+		if cfg.Integration != "" {
+			credentialsSource = fmt.Sprintf("integration:%s", cfg.Integration)
+		}
 		cfg.Log = logrus.WithFields(logrus.Fields{
 			trace.Component: "watch:" + component,
 			"labels":        cfg.Labels,
 			"region":        cfg.Region,
 			"role":          cfg.AssumeRole,
+			"credentials":   credentialsSource,
 		})
 	}
 	return nil

--- a/lib/srv/discovery/fetchers/db/aws_elasticache.go
+++ b/lib/srv/discovery/fetchers/db/aws_elasticache.go
@@ -47,7 +47,9 @@ func (f *elastiCachePlugin) ComponentShortName() string {
 // TODO(greedy52) support ElastiCache global datastore.
 func (f *elastiCachePlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	ecClient, err := cfg.AWSClients.GetAWSElastiCacheClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_elasticache.go
+++ b/lib/srv/discovery/fetchers/db/aws_elasticache.go
@@ -48,7 +48,7 @@ func (f *elastiCachePlugin) ComponentShortName() string {
 func (f *elastiCachePlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	ecClient, err := cfg.AWSClients.GetAWSElastiCacheClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_elasticache.go
+++ b/lib/srv/discovery/fetchers/db/aws_elasticache.go
@@ -48,7 +48,7 @@ func (f *elastiCachePlugin) ComponentShortName() string {
 func (f *elastiCachePlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	ecClient, err := cfg.AWSClients.GetAWSElastiCacheClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_memorydb.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb.go
@@ -46,7 +46,7 @@ func (f *memoryDBPlugin) ComponentShortName() string {
 func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	memDBClient, err := cfg.AWSClients.GetAWSMemoryDBClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_memorydb.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb.go
@@ -46,7 +46,7 @@ func (f *memoryDBPlugin) ComponentShortName() string {
 func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	memDBClient, err := cfg.AWSClients.GetAWSMemoryDBClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_memorydb.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb.go
@@ -45,7 +45,9 @@ func (f *memoryDBPlugin) ComponentShortName() string {
 // GetDatabases returns MemoryDB databases matching the watcher's selectors.
 func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	memDBClient, err := cfg.AWSClients.GetAWSMemoryDBClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_opensearch.go
+++ b/lib/srv/discovery/fetchers/db/aws_opensearch.go
@@ -45,7 +45,7 @@ func (f *openSearchPlugin) ComponentShortName() string {
 func (f *openSearchPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	opensearchClient, err := cfg.AWSClients.GetAWSOpenSearchClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_opensearch.go
+++ b/lib/srv/discovery/fetchers/db/aws_opensearch.go
@@ -45,7 +45,7 @@ func (f *openSearchPlugin) ComponentShortName() string {
 func (f *openSearchPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	opensearchClient, err := cfg.AWSClients.GetAWSOpenSearchClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_opensearch.go
+++ b/lib/srv/discovery/fetchers/db/aws_opensearch.go
@@ -43,8 +43,10 @@ func (f *openSearchPlugin) ComponentShortName() string {
 
 // GetDatabases returns OpenSearch databases.
 func (f *openSearchPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	opensearchClient, err := cfg.AWSClients.GetAWSOpenSearchClient(ctx,
-		cfg.Region, cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+	opensearchClient, err := cfg.AWSClients.GetAWSOpenSearchClient(ctx, cfg.Region,
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -48,7 +48,9 @@ func (f *rdsDBInstancesPlugin) ComponentShortName() string {
 // GetDatabases returns a list of database resources representing RDS instances.
 func (f *rdsDBInstancesPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -123,7 +125,9 @@ func (f *rdsAuroraClustersPlugin) ComponentShortName() string {
 // GetDatabases returns a list of database resources representing RDS clusters.
 func (f *rdsAuroraClustersPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -49,7 +49,7 @@ func (f *rdsDBInstancesPlugin) ComponentShortName() string {
 func (f *rdsDBInstancesPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -126,7 +126,7 @@ func (f *rdsAuroraClustersPlugin) ComponentShortName() string {
 func (f *rdsAuroraClustersPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -49,7 +49,7 @@ func (f *rdsDBInstancesPlugin) ComponentShortName() string {
 func (f *rdsDBInstancesPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -126,7 +126,7 @@ func (f *rdsAuroraClustersPlugin) ComponentShortName() string {
 func (f *rdsAuroraClustersPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -44,7 +44,9 @@ func (f *rdsDBProxyPlugin) ComponentShortName() string {
 // Proxies and custom endpoints.
 func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -45,7 +45,7 @@ func (f *rdsDBProxyPlugin) ComponentShortName() string {
 func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -45,7 +45,7 @@ func (f *rdsDBProxyPlugin) ComponentShortName() string {
 func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -42,7 +42,9 @@ type redshiftPlugin struct{}
 // GetDatabases returns Redshift databases matching the watcher's selectors.
 func (f *redshiftPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	redshiftClient, err := cfg.AWSClients.GetAWSRedshiftClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -43,7 +43,7 @@ type redshiftPlugin struct{}
 func (f *redshiftPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	redshiftClient, err := cfg.AWSClients.GetAWSRedshiftClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -43,7 +43,7 @@ type redshiftPlugin struct{}
 func (f *redshiftPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	redshiftClient, err := cfg.AWSClients.GetAWSRedshiftClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
@@ -59,7 +59,7 @@ type rssAPI = redshiftserverlessiface.RedshiftServerlessAPI
 func (f *redshiftServerlessPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	client, err := cfg.AWSClients.GetAWSRedshiftServerlessClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntergration(cfg.Integration),
+		cloud.WithIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
@@ -59,7 +59,7 @@ type rssAPI = redshiftserverlessiface.RedshiftServerlessAPI
 func (f *redshiftServerlessPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	client, err := cfg.AWSClients.GetAWSRedshiftServerlessClient(ctx, cfg.Region,
 		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithIntegration(cfg.Integration),
+		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
@@ -58,7 +58,9 @@ type rssAPI = redshiftserverlessiface.RedshiftServerlessAPI
 // GetDatabases returns Redshift Serverless databases matching the watcher's selectors.
 func (f *redshiftServerlessPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
 	client, err := cfg.AWSClients.GetAWSRedshiftServerlessClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID))
+		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		cloud.WithIntergration(cfg.Integration),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -77,11 +77,12 @@ func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []t
 			for _, makeFetcher := range makeFetchers {
 				for _, region := range matcher.Regions {
 					fetcher, err := makeFetcher(awsFetcherConfig{
-						AWSClients: clients,
-						Type:       matcherType,
-						AssumeRole: assumeRole,
-						Labels:     matcher.Tags,
-						Region:     region,
+						AWSClients:  clients,
+						Type:        matcherType,
+						AssumeRole:  assumeRole,
+						Labels:      matcher.Tags,
+						Region:      region,
+						Integration: matcher.Integration,
 					})
 					if err != nil {
 						return nil, trace.Wrap(err)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -166,7 +166,9 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
 			// TODO(gavin): support assume_role_arn for ec2.
-			ec2Client, err := clients.GetAWSEC2Client(ctx, region)
+			ec2Client, err := clients.GetAWSEC2Client(ctx, region,
+				cloud.WithIntergration(matcher.Integration),
+			)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -167,7 +167,7 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 		for _, region := range matcher.Regions {
 			// TODO(gavin): support assume_role_arn for ec2.
 			ec2Client, err := clients.GetAWSEC2Client(ctx, region,
-				cloud.WithIntegration(matcher.Integration),
+				cloud.WithCredentialsMaybeIntegration(matcher.Integration),
 			)
 			if err != nil {
 				return nil, trace.Wrap(err)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -167,7 +167,7 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 		for _, region := range matcher.Regions {
 			// TODO(gavin): support assume_role_arn for ec2.
 			ec2Client, err := clients.GetAWSEC2Client(ctx, region,
-				cloud.WithIntergration(matcher.Integration),
+				cloud.WithIntegration(matcher.Integration),
 			)
 			if err != nil {
 				return nil, trace.Wrap(err)


### PR DESCRIPTION
Context https://github.com/gravitational/teleport/issues/25494

This adds an Integration Session Generator for AWS Clients.
When a matcher has an integration, it will use this generator to fetch an AWS session instead of using the ambient credentials.