### PR TITLE
[v14] docs: correct fips image name reference

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -385,7 +385,7 @@ below), and are tagged for easier searching.
 | - | - | - | - | - |
 | `teleport-oss-(=teleport.version=)-$TIMESTAMP` | OSS | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: oss`, `TeleportFipsEnabled: false` | 146628656107 |
 | `teleport-ent-(=teleport.version=)-$TIMESTAMP` | Enterprise | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: false` | 146628656107 |
-| `teleport-oss-(=teleport.version=)-fips-$TIMESTAMP` | Enterprise | Yes | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: true` | 146628656107 |
+| `teleport-ent-(=teleport.version=)-fips-$TIMESTAMP` | Enterprise | Yes | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: true` | 146628656107 |
 
 All images are based on Amazon Linux 2023 and have been hardened using the
 Amazon EC2 ImageBuilder [STIG](https://public.cyber.mil/stigs/) hardening


### PR DESCRIPTION
Backport #34593 to branch/v14