### PR TITLE
Keep a device data cache in-process

### DIFF
--- a/lib/devicetrust/native/device_darwin.go
+++ b/lib/devicetrust/native/device_darwin.go
@@ -49,7 +49,7 @@ func enrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	cd, err := collectDeviceData(CollectedDataAlwaysEscalate)
+	cd, err := CollectDeviceData(CollectedDataAlwaysEscalate)
 	if err != nil {
 		return nil, trace.Wrap(err, "collecting device data")
 	}

--- a/lib/devicetrust/native/device_linux_test.go
+++ b/lib/devicetrust/native/device_linux_test.go
@@ -38,6 +38,13 @@ func TestCollectDeviceData_linux(t *testing.T) {
 	// Silence logging for tests.
 	log.SetLevel(log.PanicLevel)
 
+	// Do not cache data during testing.
+	skipCacheBefore := cachedDeviceData.skipCache
+	cachedDeviceData.skipCache = true
+	t.Cleanup(func() {
+		cachedDeviceData.skipCache = skipCacheBefore
+	})
+
 	u, err := user.Current()
 	require.NoError(t, err, "reading current user")
 

--- a/lib/devicetrust/native/tpm_device.go
+++ b/lib/devicetrust/native/tpm_device.go
@@ -151,7 +151,7 @@ func (d *tpmDevice) enrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 	}
 	defer ak.Close(tpm)
 
-	deviceData, err := collectDeviceData(CollectedDataAlwaysEscalate)
+	deviceData, err := CollectDeviceData(CollectedDataAlwaysEscalate)
 	if err != nil {
 		return nil, trace.Wrap(err, "collecting device data")
 	}


### PR DESCRIPTION
Keep a short-lived device data cache in process in order to avoid multiple concurrent collections.

Various device commands collect data in order to identify the current device (any invocation that uses the --current-device flag). Furthermore, device data is required for device enrollment and authentication ceremonies. Put together, these may lead to multiple collections in a short interval. This wasn't much of a problem, but with the addition of Linux devices this may lead to multiple "sudo" prompts:

```shell
# Before
$ tsh device enroll --current-device
Determining machine model and serial number, if prompted please type the sudo password
Determining machine model and serial number, if prompted please type the sudo password
Device "AAAAAAAA"/Linux enrolled

# After
$ tsh device enroll --current-device
Determining machine model and serial number, if prompted please type the sudo password
Determining machine model and serial number, if prompted please type the sudo password
Device "AAAAAAAA"/Linux enrolled
```

https://github.com/gravitational/teleport.e/issues/827