### PR TITLE
Bump cloud version to 14.1.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1732,8 +1732,8 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.4.3",
-      "major_version": "13",
+      "version": "14.1.3",
+      "major_version": "14",
       "sla": {
         "monthly_percentage": "99.9%",
         "monthly_downtime": "44 minutes"
@@ -2969,7 +2969,7 @@
       "destination": "/database-access/auto-user-provisioning/",
       "permanent": true
     },
-    {	
+    {
       "source": "/database-access/guides/rds-proxy/",
       "destination": "/database-access/guides/",
       "permanent": true


### PR DESCRIPTION
We'll be moving onboarding to 14.x this week so the docs need to be bumped.