### PR TITLE
Expand the width of SSH tabs in the web UI

### DIFF
--- a/web/packages/teleport/src/Console/Tabs/TabItem.tsx
+++ b/web/packages/teleport/src/Console/Tabs/TabItem.tsx
@@ -78,7 +78,7 @@ function fromProps({ theme, active }) {
 }
 
 const StyledTabItem = styled(Flex)`
-  max-width: 200px;
+  max-width: 450px;
   height: 100%;
   ${fromProps}
 `;

--- a/web/packages/teleport/src/Console/Tabs/Tabs.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.tsx
@@ -67,7 +67,7 @@ export function Tabs(props: Props & { parties: stores.Parties }) {
           style={{
             flex: '1',
             flexBasis: '0',
-            flexGrow: '1',
+            flexGrow: '0',
           }}
         />
       );

--- a/web/packages/teleport/src/Console/Tabs/__snapshots__/Tabs.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/Tabs/__snapshots__/Tabs.story.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`render ConsoleTabs 1`] = `
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  max-width: 200px;
+  max-width: 450px;
   height: 100%;
   border: none;
   border-right: 1px solid #0C143D;
@@ -86,7 +86,7 @@ exports[`render ConsoleTabs 1`] = `
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  max-width: 200px;
+  max-width: 450px;
   height: 100%;
   border: none;
   border-right: 1px solid #0C143D;
@@ -175,7 +175,7 @@ exports[`render ConsoleTabs 1`] = `
   >
     <div
       class="c2"
-      style="flex: 1; flex-basis: 0px; flex-grow: 1;"
+      style="flex: 1; flex-basis: 0px; flex-grow: 0;"
     >
       <button
         class="c3"
@@ -209,7 +209,7 @@ exports[`render ConsoleTabs 1`] = `
     </div>
     <div
       class="c8"
-      style="flex: 1; flex-basis: 0px; flex-grow: 1;"
+      style="flex: 1; flex-basis: 0px; flex-grow: 0;"
     >
       <button
         class="c3"
@@ -243,7 +243,7 @@ exports[`render ConsoleTabs 1`] = `
     </div>
     <div
       class="c8"
-      style="flex: 1; flex-basis: 0px; flex-grow: 1;"
+      style="flex: 1; flex-basis: 0px; flex-grow: 0;"
     >
       <button
         class="c3"


### PR DESCRIPTION
- Increase the maximum width from 200px to 450px
- Prevent the tab from automatically growing to its max width

Closes #3859

Changelog: increase the maximum width of the console tabs in the web UI.