### PR TITLE
Fix incorrect permissions for X11 Unix socket

### DIFF
--- a/lib/sshutils/x11/conn.go
+++ b/lib/sshutils/x11/conn.go
@@ -74,7 +74,7 @@ func OpenNewXServerListener(displayOffset int, maxDisplay int, screen uint32) (X
 	}
 
 	// Create /tmp/.X11-unix if it doesn't exist (such as in CI)
-	if err := os.Mkdir(x11SockDir(), 1777); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := os.Mkdir(x11SockDir(), 0o777|os.ModeSticky); err != nil && !errors.Is(err, os.ErrExist) {
 		return nil, Display{}, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
We were passing decimal 1777 instead of octal.

Closes #24819

Changelog: Fix incorrect permissions when opening X11 listener.