### PR TITLE
docs: Mark AWS GSLB deployment as Enterprise only

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -178,7 +178,7 @@
             {
               "title": "AWS Multi-Region Proxy Deployment",
               "slug": "/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment/",
-              "forScopes": ["oss", "enterprise"]
+              "forScopes": ["enterprise"]
             },
             {
               "title": "GCP",
@@ -2969,7 +2969,7 @@
       "destination": "/database-access/auto-user-provisioning/",
       "permanent": true
     },
-    {	
+    {
       "source": "/database-access/guides/rds-proxy/",
       "destination": "/database-access/guides/",
       "permanent": true


### PR DESCRIPTION
The AWS GSLB deployment guide requires/references proxy peering, so shouldn't be offered to OSS users.
