### PR TITLE
[v14] docs: Mark AWS GSLB deployment as Enterprise only

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -241,10 +241,7 @@
             {
               "title": "AWS Multi-Region Proxy Deployment",
               "slug": "/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment/",
-              "forScopes": [
-                "oss",
-                "enterprise"
-              ]
+              "forScopes": ["enterprise"]
             },
             {
               "title": "GCP",
@@ -839,7 +836,7 @@
               "slug": "/management/operations/enroll-agent-into-automatic-updates/",
               "forScopes": [
                 "enterprise",
-                "cloud", 
+                "cloud",
                 "team"
               ]
             }
@@ -3229,7 +3226,7 @@
       "destination": "/database-access/auto-user-provisioning/",
       "permanent": true
     },
-    {	
+    {
       "source": "/database-access/guides/rds-proxy/",
       "destination": "/database-access/guides/",
       "permanent": true


### PR DESCRIPTION
Backports #34621 to `branch/v14`