### PR TITLE
[v14] Prevent `.tsh/environment` values from overloading prior set values

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1207,9 +1207,6 @@ func (id *IdentityContext) GetUserMetadata() apievents.UserMetadata {
 func buildEnvironment(ctx *ServerContext) []string {
 	env := &envutils.SafeEnv{}
 
-	// gather all dynamically defined environment variables
-	ctx.VisitEnv(env.Add)
-
 	// Parse the local and remote addresses to build SSH_CLIENT and
 	// SSH_CONNECTION environment variables.
 	remoteHost, remotePort, err := net.SplitHostPort(ctx.ServerConn.RemoteAddr().String())
@@ -1242,6 +1239,9 @@ func buildEnvironment(ctx *ServerContext) []string {
 	env.Add(teleport.SSHTeleportHostUUID, ctx.srv.ID())
 	env.Add(teleport.SSHTeleportClusterName, ctx.ClusterName)
 	env.Add(teleport.SSHTeleportUser, ctx.Identity.TeleportUser)
+
+	// At the end gather all dynamically defined environment variables
+	ctx.VisitEnv(env.Add)
 
 	return *env
 }

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1217,8 +1217,8 @@ func buildEnvironment(ctx *ServerContext) []string {
 		if err != nil {
 			ctx.Logger.Debugf("Failed to split local address: %v.", err)
 		} else {
-			env.Add("SSH_CLIENT", fmt.Sprintf("%s %s %s", remoteHost, remotePort, localPort))
-			env.Add("SSH_CONNECTION", fmt.Sprintf("%s %s %s %s", remoteHost, remotePort, localHost, localPort))
+			env.AddTrusted("SSH_CLIENT", fmt.Sprintf("%s %s %s", remoteHost, remotePort, localPort))
+			env.AddTrusted("SSH_CONNECTION", fmt.Sprintf("%s %s %s %s", remoteHost, remotePort, localHost, localPort))
 		}
 	}
 
@@ -1226,22 +1226,22 @@ func buildEnvironment(ctx *ServerContext) []string {
 	session := ctx.getSession()
 	if session != nil {
 		if session.term != nil {
-			env.Add("TERM", session.term.GetTermType())
-			env.Add("SSH_TTY", session.term.TTY().Name())
+			env.AddTrusted("TERM", session.term.GetTermType())
+			env.AddTrusted("SSH_TTY", session.term.TTY().Name())
 		}
 		if session.id != "" {
-			env.Add(teleport.SSHSessionID, string(session.id))
+			env.AddTrusted(teleport.SSHSessionID, string(session.id))
 		}
 	}
 
 	// Set some Teleport specific environment variables: SSH_TELEPORT_USER,
 	// SSH_TELEPORT_HOST_UUID, and SSH_TELEPORT_CLUSTER_NAME.
-	env.Add(teleport.SSHTeleportHostUUID, ctx.srv.ID())
-	env.Add(teleport.SSHTeleportClusterName, ctx.ClusterName)
-	env.Add(teleport.SSHTeleportUser, ctx.Identity.TeleportUser)
+	env.AddTrusted(teleport.SSHTeleportHostUUID, ctx.srv.ID())
+	env.AddTrusted(teleport.SSHTeleportClusterName, ctx.ClusterName)
+	env.AddTrusted(teleport.SSHTeleportUser, ctx.Identity.TeleportUser)
 
 	// At the end gather all dynamically defined environment variables
-	ctx.VisitEnv(env.Add)
+	ctx.VisitEnv(env.AddUnique)
 
 	return *env
 }

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -801,10 +801,10 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 	}
 
 	// Add in Teleport specific environment variables.
-	env.AddFull(c.Environment...)
+	env.AddFullTrusted(c.Environment...)
 
 	// If any additional environment variables come from PAM, apply them as well.
-	env.AddFull(pamEnvironment...)
+	env.AddFullTrusted(pamEnvironment...)
 
 	// If the server allows reading in of ~/.tsh/environment read it in
 	// and pass environment variables along to new session.
@@ -815,7 +815,7 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		env.AddFull(userEnvs...)
+		env.AddFullUnique(userEnvs...)
 	}
 
 	// after environment is fully built, set it to cmd
@@ -959,7 +959,7 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 
 	// build env for `teleport exec`
 	env := &envutils.SafeEnv{}
-	env.AddFull(cmdmsg.Environment...)
+	env.AddFullTrusted(cmdmsg.Environment...)
 	env.AddExecEnvironment()
 
 	// Build the "teleport exec" command.

--- a/lib/utils/envutils/environment.go
+++ b/lib/utils/envutils/environment.go
@@ -86,25 +86,25 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 	return *env, nil
 }
 
-var unsafeEnvironmentVars = map[string]bool{
+var unsafeEnvironmentVars = map[string]struct{}{
 	// Linux
-	"LD_ASSUME_KERNEL":         true,
-	"LD_AUDIT":                 true,
-	"LD_BIND_NOW":              true,
-	"LD_BIND_NOT":              true,
-	"LD_DYNAMIC_WEAK":          true,
-	"LD_LIBRARY_PATH":          true,
-	"LD_ORIGIN_PATH":           true,
-	"LD_POINTER_GUARD":         true,
-	"LD_PREFER_MAP_32BIT_EXEC": true,
-	"LD_PRELOAD":               true,
-	"LD_PROFILE":               true,
-	"LD_RUNPATH":               true,
-	"LD_RPATH":                 true,
-	"LD_USE_LOAD_BIAS":         true,
+	"LD_ASSUME_KERNEL":         {},
+	"LD_AUDIT":                 {},
+	"LD_BIND_NOW":              {},
+	"LD_BIND_NOT":              {},
+	"LD_DYNAMIC_WEAK":          {},
+	"LD_LIBRARY_PATH":          {},
+	"LD_ORIGIN_PATH":           {},
+	"LD_POINTER_GUARD":         {},
+	"LD_PREFER_MAP_32BIT_EXEC": {},
+	"LD_PRELOAD":               {},
+	"LD_PROFILE":               {},
+	"LD_RUNPATH":               {},
+	"LD_RPATH":                 {},
+	"LD_USE_LOAD_BIAS":         {},
 	// macOS
-	"DYLD_INSERT_LIBRARIES": true,
-	"DYLD_LIBRARY_PATH":     true,
+	"DYLD_INSERT_LIBRARIES": {},
+	"DYLD_LIBRARY_PATH":     {},
 }
 
 // SafeEnv allows you to build a system environment while avoiding potentially dangerous environment conditions.  In
@@ -116,9 +116,7 @@ type SafeEnv []string
 func (e *SafeEnv) Add(k, v string) {
 	k = strings.TrimSpace(k)
 	v = strings.TrimSpace(v)
-	if k == "" || k == "=" {
-		return
-	} else if e.unsafeKey(k) {
+	if e.unsafeKey(k) {
 		return
 	}
 
@@ -133,9 +131,7 @@ valueLoop:
 		kv = strings.TrimSpace(kv)
 
 		key := strings.SplitN(kv, "=", 2)[0]
-		if key == "" { // weird case if the string is empty or '='
-			continue valueLoop
-		} else if e.unsafeKey(key) {
+		if e.unsafeKey(key) {
 			continue valueLoop
 		}
 
@@ -144,6 +140,10 @@ valueLoop:
 }
 
 func (e *SafeEnv) unsafeKey(key string) bool {
+	if key == "" || key == "=" {
+		return false
+	}
+
 	upperKey := strings.ToUpper(key)
 	if _, unsafe := unsafeEnvironmentVars[upperKey]; unsafe {
 		return true

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -36,6 +36,7 @@ foo=bar=baz
 foo=
 
 =bar
+bar=foo
 LD_PRELOAD=attack
 `)
 
@@ -53,7 +54,7 @@ LD_PRELOAD=attack
 	require.NoError(t, err)
 
 	// check we parsed it correctly
-	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "foo=bar=baz", "foo="}))
+	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "bar=foo"}))
 }
 
 func TestSafeEnvAdd(t *testing.T) {
@@ -82,6 +83,18 @@ func TestSafeEnvAdd(t *testing.T) {
 			keys:     []string{" foo "},
 			values:   []string{" bar "},
 			expected: []string{"foo=bar"},
+		},
+		{
+			name:     "duplicate ignore",
+			keys:     []string{"one", "one"},
+			values:   []string{"v1", "v2"},
+			expected: []string{"one=v1"},
+		},
+		{
+			name:     "duplicate ignore different case",
+			keys:     []string{"one", "ONE"},
+			values:   []string{"v1", "v2"},
+			expected: []string{"one=v1"},
 		},
 		{
 			name:     "skip dangerous exact",
@@ -139,6 +152,16 @@ func TestSafeEnvAddFull(t *testing.T) {
 			name:       "whitespace trim",
 			fullValues: []string{" foo=bar "},
 			expected:   []string{"foo=bar"},
+		},
+		{
+			name:       "duplicate ignore",
+			fullValues: []string{"one=v1", "one=v2"},
+			expected:   []string{"one=v1"},
+		},
+		{
+			name:       "duplicate ignore different case",
+			fullValues: []string{"one=v1", "ONE=v2"},
+			expected:   []string{"one=v1"},
 		},
 		{
 			name:       "skip dangerous exact",

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -164,6 +164,11 @@ func TestSafeEnvAddFull(t *testing.T) {
 			expected:   []string{"one=v1"},
 		},
 		{
+			name:       "double equal value",
+			fullValues: []string{"foo=bar=badvalue"},
+			expected:   []string{"foo=bar=badvalue"},
+		},
+		{
 			name:       "skip dangerous exact",
 			fullValues: []string{"foo=bar", "LD_PRELOAD=ignored"},
 			expected:   []string{"foo=bar"},

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -54,65 +54,81 @@ LD_PRELOAD=attack
 	require.NoError(t, err)
 
 	// check we parsed it correctly
-	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "bar=foo"}))
+	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "foo=bar=baz", "foo=", "bar=foo"}))
 }
 
 func TestSafeEnvAdd(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name     string
-		keys     []string
-		values   []string
-		expected []string
+		name             string
+		excludeDuplicate bool
+		keys             []string
+		values           []string
+		expected         []string
 	}{
 		{
-			name:     "normal add",
-			keys:     []string{"foo"},
-			values:   []string{"bar"},
-			expected: []string{"foo=bar"},
+			name:             "normal add",
+			excludeDuplicate: true,
+			keys:             []string{"foo"},
+			values:           []string{"bar"},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:     "double add",
-			keys:     []string{"one", "two"},
-			values:   []string{"v1", "v2"},
-			expected: []string{"one=v1", "two=v2"},
+			name:             "double add",
+			excludeDuplicate: true,
+			keys:             []string{"one", "two"},
+			values:           []string{"v1", "v2"},
+			expected:         []string{"one=v1", "two=v2"},
 		},
 		{
-			name:     "whitespace trim",
-			keys:     []string{" foo "},
-			values:   []string{" bar "},
-			expected: []string{"foo=bar"},
+			name:             "whitespace trim",
+			excludeDuplicate: true,
+			keys:             []string{" foo "},
+			values:           []string{" bar "},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:     "duplicate ignore",
-			keys:     []string{"one", "one"},
-			values:   []string{"v1", "v2"},
-			expected: []string{"one=v1"},
+			name:             "duplicate ignore",
+			excludeDuplicate: true,
+			keys:             []string{"one", "one"},
+			values:           []string{"v1", "v2"},
+			expected:         []string{"one=v1"},
 		},
 		{
-			name:     "duplicate ignore different case",
-			keys:     []string{"one", "ONE"},
-			values:   []string{"v1", "v2"},
-			expected: []string{"one=v1"},
+			name:             "duplicate different case ignore",
+			excludeDuplicate: true,
+			keys:             []string{"one", "ONE"},
+			values:           []string{"v1", "v2"},
+			expected:         []string{"one=v1"},
 		},
 		{
-			name:     "skip dangerous exact",
-			keys:     []string{"foo", "LD_PRELOAD"},
-			values:   []string{"bar", "ignored"},
-			expected: []string{"foo=bar"},
+			name:             "duplicate allowed",
+			excludeDuplicate: false,
+			keys:             []string{"one", "one"},
+			values:           []string{"v1", "v2"},
+			expected:         []string{"one=v1", "one=v2"},
 		},
 		{
-			name:     "skip dangerous lowercase",
-			keys:     []string{"foo", "ld_preload"},
-			values:   []string{"bar", "ignored"},
-			expected: []string{"foo=bar"},
+			name:             "skip dangerous exact",
+			excludeDuplicate: true,
+			keys:             []string{"foo", "LD_PRELOAD"},
+			values:           []string{"bar", "ignored"},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:     "skip dangerous with whitespace",
-			keys:     []string{"foo", "  LD_PRELOAD"},
-			values:   []string{"bar", "ignored"},
-			expected: []string{"foo=bar"},
+			name:             "skip dangerous lowercase",
+			excludeDuplicate: true,
+			keys:             []string{"foo", "ld_preload"},
+			values:           []string{"bar", "ignored"},
+			expected:         []string{"foo=bar"},
+		},
+		{
+			name:             "skip dangerous with whitespace",
+			excludeDuplicate: true,
+			keys:             []string{"foo", "  LD_PRELOAD"},
+			values:           []string{"bar", "ignored"},
+			expected:         []string{"foo=bar"},
 		},
 	}
 
@@ -123,7 +139,7 @@ func TestSafeEnvAdd(t *testing.T) {
 
 			env := &SafeEnv{}
 			for i := range tc.keys {
-				env.Add(tc.keys[i], tc.values[i])
+				env.add(tc.excludeDuplicate, tc.keys[i], tc.values[i])
 			}
 			result := []string(*env)
 
@@ -134,54 +150,70 @@ func TestSafeEnvAdd(t *testing.T) {
 
 func TestSafeEnvAddFull(t *testing.T) {
 	testCases := []struct {
-		name       string
-		fullValues []string
-		expected   []string
+		name             string
+		excludeDuplicate bool
+		fullValues       []string
+		expected         []string
 	}{
 		{
-			name:       "normal add",
-			fullValues: []string{"foo=bar"},
-			expected:   []string{"foo=bar"},
+			name:             "normal add",
+			excludeDuplicate: true,
+			fullValues:       []string{"foo=bar"},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:       "double add",
-			fullValues: []string{"one=v1", "two=v2"},
-			expected:   []string{"one=v1", "two=v2"},
+			name:             "double add",
+			excludeDuplicate: true,
+			fullValues:       []string{"one=v1", "two=v2"},
+			expected:         []string{"one=v1", "two=v2"},
 		},
 		{
-			name:       "whitespace trim",
-			fullValues: []string{" foo=bar "},
-			expected:   []string{"foo=bar"},
+			name:             "whitespace trim",
+			excludeDuplicate: true,
+			fullValues:       []string{" foo=bar "},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:       "duplicate ignore",
-			fullValues: []string{"one=v1", "one=v2"},
-			expected:   []string{"one=v1"},
+			name:             "duplicate ignore",
+			excludeDuplicate: true,
+			fullValues:       []string{"one=v1", "one=v2"},
+			expected:         []string{"one=v1"},
 		},
 		{
-			name:       "duplicate ignore different case",
-			fullValues: []string{"one=v1", "ONE=v2"},
-			expected:   []string{"one=v1"},
+			name:             "duplicate ignore different case",
+			excludeDuplicate: true,
+			fullValues:       []string{"one=v1", "ONE=v2"},
+			expected:         []string{"one=v1"},
 		},
 		{
-			name:       "double equal value",
-			fullValues: []string{"foo=bar=badvalue"},
-			expected:   []string{"foo=bar=badvalue"},
+			name:             "duplicate allowed",
+			excludeDuplicate: false,
+			fullValues:       []string{"one=v1", "one=v2"},
+			expected:         []string{"one=v1", "one=v2"},
 		},
 		{
-			name:       "skip dangerous exact",
-			fullValues: []string{"foo=bar", "LD_PRELOAD=ignored"},
-			expected:   []string{"foo=bar"},
+			name:             "double equal value",
+			excludeDuplicate: true,
+			fullValues:       []string{"foo=bar=badvalue"},
+			expected:         []string{"foo=bar=badvalue"},
 		},
 		{
-			name:       "skip dangerous lowercase",
-			fullValues: []string{"foo=bar", "ld_preload=ignored"},
-			expected:   []string{"foo=bar"},
+			name:             "skip dangerous exact",
+			excludeDuplicate: true,
+			fullValues:       []string{"foo=bar", "LD_PRELOAD=ignored"},
+			expected:         []string{"foo=bar"},
 		},
 		{
-			name:       "skip dangerous with whitespace",
-			fullValues: []string{"foo=bar", "  LD_PRELOAD=ignored"},
-			expected:   []string{"foo=bar"},
+			name:             "skip dangerous lowercase",
+			excludeDuplicate: true,
+			fullValues:       []string{"foo=bar", "ld_preload=ignored"},
+			expected:         []string{"foo=bar"},
+		},
+		{
+			name:             "skip dangerous with whitespace",
+			excludeDuplicate: true,
+			fullValues:       []string{"foo=bar", "  LD_PRELOAD=ignored"},
+			expected:         []string{"foo=bar"},
 		},
 	}
 
@@ -191,7 +223,7 @@ func TestSafeEnvAddFull(t *testing.T) {
 			t.Parallel()
 
 			env := &SafeEnv{}
-			env.AddFull(tc.fullValues...)
+			env.addFull(tc.excludeDuplicate, tc.fullValues)
 			result := []string(*env)
 
 			require.Equal(t, tc.expected, result)


### PR DESCRIPTION
Backport #34277 to branch/v14

changelog: Environment values can not be overridden from the .tsh/environment file, only unique keys will be inserted into the environment.