### PR TITLE
[v14] Added release server publishing retry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -408,10 +408,8 @@ steps:
   - echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"
   - echo "$RELEASES_KEY" | base64 -d > "$RELCLI_KEY"
   - trap "rm -rf /tmpfs/creds" EXIT
-  - |-
-    docker run -i -v /tmpfs/creds:/tmpfs/creds \
-      -e DRONE_REPO -e DRONE_TAG -e RELCLI_BASE_URL -e RELCLI_CERT -e RELCLI_KEY \
-      $RELCLI_IMAGE auto_destroy -f -v 6
+  - docker run -i -v /tmpfs/creds:/tmpfs/creds -e DRONE_REPO -e DRONE_TAG -e RELCLI_BASE_URL
+    -e RELCLI_CERT -e RELCLI_KEY $RELCLI_IMAGE auto_destroy -f -v 6
   environment:
     RELCLI_BASE_URL: https://releases-prod.platform.teleport.sh
     RELCLI_CERT: /tmpfs/creds/releases.crt
@@ -16583,10 +16581,9 @@ steps:
   - echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"
   - echo "$RELEASES_KEY" | base64 -d > "$RELCLI_KEY"
   - trap "rm -rf /tmpfs/creds" EXIT
-  - |-
-    docker run -i -v /tmpfs/creds:/tmpfs/creds \
-      -e DRONE_REPO -e DRONE_TAG -e RELCLI_BASE_URL -e RELCLI_CERT -e RELCLI_KEY \
-      $RELCLI_IMAGE auto_publish -f -v 6
+  - for i in $(seq 10); do docker run -i -v /tmpfs/creds:/tmpfs/creds -e DRONE_REPO
+    -e DRONE_TAG -e RELCLI_BASE_URL -e RELCLI_CERT -e RELCLI_KEY $RELCLI_IMAGE auto_publish
+    -f -v 6 && break; done || false
   environment:
     RELCLI_BASE_URL: https://releases-prod.platform.teleport.sh
     RELCLI_CERT: /tmpfs/creds/releases.crt
@@ -16625,6 +16622,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 275ec5e2c83bfe2e2cc7d532a3130328b983b48faed1fd3a5b54a507fdd0f96b
+hmac: fd52fd49638234d6e708f49a021e5c2873114d9f5a752c04738685c29f62d9dd
 
 ...


### PR DESCRIPTION
* Added release server publishing retry
* dronegen: Run auto_publish 10 times (from 3) in a loop

Change the drone generation to use a loop to run the `auto_publish`
relcli command instead of listing them one-by-one and loop 10 times
instead of 3. The loop will terminate the first time `relcli` succeeds.

The loop has an `|| false` at the end to ensure the loop command fails
if all invocations of `relcli` fail. With `set -e`, even though the exit
status of the loop is non-zero, the shell seems to continue. With the
`|| false` at the end, it makes it exit on failure. I'm not sure exactly
how drone runs the commands so this may not be necessary but it seems
safer.

e.g.

    set -e
    for i in $(seq 10); do false && break; done
    echo hello

This will echo "hello" even though all invocations inside the loop
failed.

    set -e
    for i in $(seq 10); do false && break; done || false
    echo hello

This will not echo "hello" - `set -e` causes an exit before that command
due to the `|| false`.

Backport: https://github.com/gravitational/teleport/pull/34605

---

Note: Backport did not apply cleanly (.drone.yml ones never do).
Backported with:

   git cherry-pick -n 2dd1abbf588009583d0fc25660dc55d841bbe445
   git restore -WS .drone.yml
   make dronegen
   git add .drone.yml
   git commit -c 2dd1abbf588009583d0fc25660dc55d841bbe445