### PR TITLE
[v14] Fix PROXY protocol handling of dedicated kube listener with TLS routing

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4415,16 +4415,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
-		proxyProtocol := cfg.Proxy.PROXYProtocolMode
-		if clusterNetworkConfig.GetProxyListenerMode() == types.ProxyListenerMode_Multiplex {
-			// If ProxyListenerMode is MULTIPLEX it means that the ALPN listener handles the PROXY line
-			// and sends the connection to the Proxy Kube listener. When it does, it uses the same net.Conn
-			// and doesn't dial so the PROXY Protocol cannot be present. Under those circumstances,
-			// ProxyProtocol for Proxy Kube listener must be off.
-
-			proxyProtocol = multiplexer.PROXYProtocolOff
-		}
-
 		kubeServer, err = kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 			ForwarderConfig: kubeproxy.ForwarderConfig{
 				Namespace:                     apidefaults.Namespace,
@@ -4460,7 +4450,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Log:                      log,
 			IngressReporter:          ingressReporter,
 			KubernetesServersWatcher: kubeServerWatcher,
-			PROXYProtocolMode:        proxyProtocol,
+			PROXYProtocolMode:        cfg.Proxy.PROXYProtocolMode,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Backport #34317 to branch/v14

Manual backport, there was one line mismatch in the test code.

Changelog: Fix accessing dedicated Proxy Kube port when TLS routing is enabled.