### PR TITLE
Assign reviewer on post-release PRs

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -104,6 +104,8 @@ jobs:
           git switch -c $BRANCH_NAME
           git commit -am "[auto] docs: Update version to ${{ github.event.release.tag_name }}"
           git push --set-upstream origin $BRANCH_NAME
-          gh pr create --fill --label=automated --label=documentation --label=no-changelog --base=${{ steps.get-branch.outputs.branch }}
+          gh pr create --fill --base=${{ steps.get-branch.outputs.branch }} \
+             --label=automated --label=documentation --label=no-changelog \
+             --reviewer=${{ github.event.release.author.login }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -50,6 +50,6 @@ jobs:
         run: |
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub"
-          TELEPORT_VERSION=${{ inputs.version }} make -C assets/aws create-update-pr
+          TELEPORT_VERSION=${{ inputs.version }} AMI_PR_REVIEWER=${{ github.event.release.author.login }} make -C assets/aws create-update-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -136,4 +136,4 @@ create-update-pr: update-ami-ids-terraform
 	git checkout -b $(AUTO_BRANCH_NAME)
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
-	gh pr create --fill --label=automated --label=terraform --label=no-changelog
+	gh pr create --fill --label=automated --label=terraform --label=no-changelog $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))


### PR DESCRIPTION
Now that our post-release PRs are automated, the individual publishing the release only has to look out for them to be posted and help push them through. This often gets forgotten, and the post release work doesn't get merged in a timely manner. Fix this by ensuring that the individual who published the release is automatically tagged as a reviewer of the PRs.