### PR TITLE
web: use desktop name instead of addr in audit event summary

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -6903,7 +6903,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            User [joe] was denied access to Windows desktop [Administrator@100.104.52.89:3389] on [desktopaccess.com]
+            User [joe] was denied access to Windows desktop [Administrator@undefined] on [desktopaccess.com]
           </td>
           <td
             style="min-width: 120px;"
@@ -6951,7 +6951,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            Session for Windows desktop [Administrator@100.104.52.89:3389] on [desktopaccess.com] has ended for user [joe]
+            Session for Windows desktop [Administrator@undefined] on [desktopaccess.com] has ended for user [joe]
           </td>
           <td
             style="min-width: 120px;"
@@ -6999,7 +6999,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            User [joe] has connected to Windows desktop [Administrator@100.104.52.89:3389] on [desktopaccess.com]
+            User [joe] has connected to Windows desktop [Administrator@undefined] on [desktopaccess.com]
           </td>
           <td
             style="min-width: 120px;"

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -6903,7 +6903,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            User [joe] was denied access to Windows desktop [Administrator@undefined] on [desktopaccess.com]
+            User [joe] was denied access to Windows desktop [Administrator@desktop-name] on [desktopaccess.com]
           </td>
           <td
             style="min-width: 120px;"
@@ -6951,7 +6951,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            Session for Windows desktop [Administrator@undefined] on [desktopaccess.com] has ended for user [joe]
+            Session for Windows desktop [Administrator@desktop-name] on [desktopaccess.com] has ended for user [joe]
           </td>
           <td
             style="min-width: 120px;"
@@ -6999,7 +6999,7 @@ exports[`list of all events 1`] = `
           <td
             style="word-break: break-word;"
           >
-            User [joe] has connected to Windows desktop [Administrator@undefined] on [desktopaccess.com]
+            User [joe] has connected to Windows desktop [Administrator@desktop-name] on [desktopaccess.com]
           </td>
           <td
             style="min-width: 120px;"

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -1755,6 +1755,7 @@ export const events = [
     cluster_name: 'im-a-cluster-name',
     code: 'TDP00I',
     desktop_addr: '100.104.52.89:3389',
+    desktop_name: 'desktop-name',
     desktop_labels: {
       env: 'prod',
       foo: 'bar',
@@ -1775,6 +1776,7 @@ export const events = [
     cluster_name: 'im-a-cluster-name',
     code: 'TDP01I',
     desktop_addr: '100.104.52.89:3389',
+    desktop_name: 'desktop-name',
     desktop_labels: {
       env: 'prod',
       foo: 'bar',
@@ -1793,6 +1795,7 @@ export const events = [
     cluster_name: 'im-a-cluster-name',
     code: 'TDP00W',
     desktop_addr: '100.104.52.89:3389',
+    desktop_name: 'desktop-name',
     desktop_labels: {
       env: 'prod',
       foo: 'bar',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1158,8 +1158,8 @@ export const formatters: Formatters = {
   [eventCodes.DESKTOP_SESSION_STARTED]: {
     type: 'windows.desktop.session.start',
     desc: 'Windows Desktop Session Started',
-    format: ({ user, windows_domain, desktop_addr, windows_user }) => {
-      let message = `User [${user}] has connected to Windows desktop [${windows_user}@${desktop_addr}]`;
+    format: ({ user, windows_domain, desktop_name, windows_user }) => {
+      let message = `User [${user}] has connected to Windows desktop [${windows_user}@${desktop_name}]`;
       if (windows_domain) {
         message += ` on [${windows_domain}]`;
       }
@@ -1169,8 +1169,8 @@ export const formatters: Formatters = {
   [eventCodes.DESKTOP_SESSION_STARTED_FAILED]: {
     type: 'windows.desktop.session.start',
     desc: 'Windows Desktop Session Denied',
-    format: ({ user, windows_domain, desktop_addr, windows_user }) => {
-      let message = `User [${user}] was denied access to Windows desktop [${windows_user}@${desktop_addr}]`;
+    format: ({ user, windows_domain, desktop_name, windows_user }) => {
+      let message = `User [${user}] was denied access to Windows desktop [${windows_user}@${desktop_name}]`;
       if (windows_domain) {
         message += ` on [${windows_domain}]`;
       }
@@ -1180,8 +1180,8 @@ export const formatters: Formatters = {
   [eventCodes.DESKTOP_SESSION_ENDED]: {
     type: 'windows.desktop.session.end',
     desc: 'Windows Desktop Session Ended',
-    format: ({ user, windows_domain, desktop_addr, windows_user }) => {
-      let desktopMessage = `[${windows_user}@${desktop_addr}]`;
+    format: ({ user, windows_domain, desktop_name, windows_user }) => {
+      let desktopMessage = `[${windows_user}@${desktop_name}]`;
       if (windows_domain) {
         desktopMessage += ` on [${windows_domain}]`;
       }

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1055,6 +1055,7 @@ export type RawEvents = {
     typeof eventCodes.DESKTOP_SESSION_STARTED,
     {
       desktop_addr: string;
+      desktop_name: string;
       windows_user: string;
       windows_domain: string;
     }
@@ -1063,6 +1064,7 @@ export type RawEvents = {
     typeof eventCodes.DESKTOP_SESSION_STARTED_FAILED,
     {
       desktop_addr: string;
+      desktop_name: string;
       windows_user: string;
       windows_domain: string;
     }
@@ -1071,6 +1073,7 @@ export type RawEvents = {
     typeof eventCodes.DESKTOP_SESSION_ENDED,
     {
       desktop_addr: string;
+      desktop_name: string;
       windows_user: string;
       windows_domain: string;
     }


### PR DESCRIPTION
Fixes #34392

Changelog: use the desktop name instead of address in the audit log view.