### PR TITLE
Emit events in CreateAuditStream for v13 clients

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -352,7 +352,8 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 			var errors []error
 			errors = append(errors, eventStream.RecordEvent(stream.Context(), preparedEvent))
 
-			// Emit the event as well for v13 clients.
+			// v13 clients expect this request to also emit the event, so emit here
+			// just for them.
 			switch event.GetType() {
 			// Don't emit really verbose events.
 			case events.ResizeEvent, events.SessionDiskEvent, events.SessionPrintEvent, events.AppSessionRequestEvent, "":

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -354,13 +354,33 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 				switch {
 				case events.IsPermanentEmitError(err):
 					g.WithError(err).WithField("event", event).
-						Error("Failed to EmitAuditEvent due to a permanent error. Event wil be omitted.")
+						Error("Failed to RecordEvent due to a permanent error. Event wil be omitted.")
 					continue
 				default:
 					return trace.Wrap(err)
 				}
 			}
-			event.Size()
+
+			// Emit the event as well for v13 clients.
+			switch event.GetType() {
+			// Don't emit really verbose events.
+			case events.ResizeEvent, events.SessionDiskEvent, events.SessionPrintEvent, events.AppSessionRequestEvent, "":
+			default:
+				clientVersion, versionExists := metadata.ClientVersionFromContext(stream.Context())
+				if versionExists && semver.New(clientVersion).Major <= 13 {
+					if err := auth.EmitAuditEvent(stream.Context(), event); err != nil {
+						switch {
+						case events.IsPermanentEmitError(err):
+							g.WithError(err).WithField("event", event).
+								Error("Failed to EmitAuditEvent due to a permanent error. Event wil be omitted.")
+							continue
+						default:
+							return trace.Wrap(err)
+						}
+					}
+				}
+			}
+
 			processed += int64(event.Size())
 			seconds := time.Since(streamStart) / time.Second
 			counter++

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -349,17 +349,8 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 			setter := &events.NoOpPreparer{}
 			start := time.Now()
 			preparedEvent, _ := setter.PrepareSessionEvent(event)
-			err = eventStream.RecordEvent(stream.Context(), preparedEvent)
-			if err != nil {
-				switch {
-				case events.IsPermanentEmitError(err):
-					g.WithError(err).WithField("event", event).
-						Error("Failed to RecordEvent due to a permanent error. Event wil be omitted.")
-					continue
-				default:
-					return trace.Wrap(err)
-				}
-			}
+			var errors []error
+			errors = append(errors, eventStream.RecordEvent(stream.Context(), preparedEvent))
 
 			// Emit the event as well for v13 clients.
 			switch event.GetType() {
@@ -368,16 +359,19 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 			default:
 				clientVersion, versionExists := metadata.ClientVersionFromContext(stream.Context())
 				if versionExists && semver.New(clientVersion).Major <= 13 {
-					if err := auth.EmitAuditEvent(stream.Context(), event); err != nil {
-						switch {
-						case events.IsPermanentEmitError(err):
-							g.WithError(err).WithField("event", event).
-								Error("Failed to EmitAuditEvent due to a permanent error. Event wil be omitted.")
-							continue
-						default:
-							return trace.Wrap(err)
-						}
-					}
+					errors = append(errors, auth.EmitAuditEvent(stream.Context(), event))
+				}
+			}
+
+			err = trace.NewAggregate(errors...)
+			if err != nil {
+				switch {
+				case events.IsPermanentEmitError(err):
+					g.WithError(err).WithField("event", event).
+						Error("Failed to EmitAuditEvent due to a permanent error. Event wil be omitted.")
+					continue
+				default:
+					return trace.Wrap(err)
 				}
 			}
 


### PR DESCRIPTION
This change fixes a regression where some session events (session.start, session.leave, session.end) were not being emitted when a v13 client is connected to a v14 auth server.

Fixes #34596.

Changelog: Fixed auth server not emitting session events for v13 clients