### PR TITLE
Access list app in plugin ceases to run when endpoints not implemented.

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -137,6 +137,10 @@ func (a *App) run(ctx context.Context) error {
 				var accessLists []*accesslist.AccessList
 				accessLists, nextToken, err = a.apiClient.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
 				if err != nil {
+					if trace.IsNotImplemented(err) {
+						log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
+						return nil
+					}
 					log.Errorf("error listing access lists: %v", err)
 					continue
 				}


### PR DESCRIPTION
When access list endpoints are not implemented, the access list app in the access plugins will cease to run. This could happen if the integration is being run against an open source server.

Output from tests:

```
DEBU   Watcher connected test:TestSlackbot/TestMessagePosting watcherjob/watcherjob.go:155
INFO   Plugin is ready test:TestSlackbot/TestMessagePosting common/app.go:156
INFO   Looking for Access List Review reminders test:TestSlackbot/TestMessagePosting accesslist/app.go:132
ERRO   access list endpoint is not implemented on this auth server, so the access list app is ceasing to run. test:TestSlackbot/TestMessagePosting accesslist/app.go:141
INFO   Successfully posted messages channel_id:U3 message_id:1700161628301756345.1 request_id:19655e5e-fb63-49f7-8f20-4c92a8d02206 request_op:put request_state:PENDING test:TestSlackbot/TestMessagePosting accessrequest/app.go:276
```