### PR TITLE
[v14] Fixed tag builds using commit instead of tag ref

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -299,7 +299,7 @@ steps:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 30m0s -workflow release-windows.yaml -workflow-ref=${DRONE_BRANCH}
-    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT} '
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_BRANCH} '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -4982,7 +4982,7 @@ steps:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 30m0s -workflow release-windows.yaml -workflow-ref=${DRONE_TAG}
-    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT} '
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -16622,6 +16622,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: fd52fd49638234d6e708f49a021e5c2873114d9f5a752c04738685c29f62d9dd
+hmac: d34cacc9bae89579ff6fc90d253c055187925256fc8e775619eed5578bce0cc1
 
 ...

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -20,11 +20,11 @@ import (
 )
 
 func ghaWindowsPushPipeline() pipeline {
-	return getWindowsPipeline(triggerPush, "push", "${DRONE_BRANCH}")
+	return getWindowsPipeline(triggerPush, "push", "DRONE_BRANCH")
 }
 
 func windowsTagPipelineGHA() pipeline {
-	return getWindowsPipeline(triggerTag, "tag", "${DRONE_TAG}")
+	return getWindowsPipeline(triggerTag, "tag", "DRONE_TAG")
 }
 
 func getWindowsPipeline(pipelineTrigger trigger, triggerName, reference string) pipeline {
@@ -37,8 +37,8 @@ func getWindowsPipeline(pipelineTrigger trigger, triggerName, reference string) 
 					name:              "release-windows.yaml",
 					timeout:           30 * time.Minute,
 					slackOnError:      true,
-					srcRefVar:         "DRONE_COMMIT",
-					ref:               reference,
+					srcRefVar:         reference,
+					ref:               fmt.Sprintf("${%s}", reference),
 					shouldTagWorkflow: true,
 				},
 			},


### PR DESCRIPTION
Tag builds for Windows are broken in the following ways:

* The ref used to determine asset version includes a short commit hash
  (this will cause promotion issues)

* Upon retry of a build (or a new tag with the same commit), builds will
  fail as the old release is not properly cleaned up

Changing the reference used to a branch/tag reference should fix the
issue for both. Note that the second issue is still bugged for push
pipelines, but we almost never retry them so it's not really worth
fixing there right now.

Backport: https://github.com/gravitational/teleport/pull/34668