### PR TITLE
[v12] Fixed tag builds using commit instead of tag ref

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -299,7 +299,7 @@ steps:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 30m0s -workflow release-windows.yaml -workflow-ref=${DRONE_BRANCH}
-    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT} '
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_BRANCH} '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -5139,7 +5139,7 @@ steps:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 30m0s -workflow release-windows.yaml -workflow-ref=${DRONE_TAG}
-    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT} '
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -19266,6 +19266,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 07b6aca0cc517b436f02bf9a850bcc9cdab6ec56668441b0313b7b180a335627
+hmac: 97023fe987fc6108b545bb3fd028f2e135492aa4098a8e2305a659fe7e0c8912
 
 ...

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -20,11 +20,11 @@ import (
 )
 
 func ghaWindowsPushPipeline() pipeline {
-	return getWindowsPipeline(triggerPush, "push", "${DRONE_BRANCH}")
+	return getWindowsPipeline(triggerPush, "push", "DRONE_BRANCH")
 }
 
 func windowsTagPipelineGHA() pipeline {
-	return getWindowsPipeline(triggerTag, "tag", "${DRONE_TAG}")
+	return getWindowsPipeline(triggerTag, "tag", "DRONE_TAG")
 }
 
 func getWindowsPipeline(pipelineTrigger trigger, triggerName, reference string) pipeline {
@@ -37,8 +37,8 @@ func getWindowsPipeline(pipelineTrigger trigger, triggerName, reference string) 
 					name:              "release-windows.yaml",
 					timeout:           30 * time.Minute,
 					slackOnError:      true,
-					srcRefVar:         "DRONE_COMMIT",
-					ref:               reference,
+					srcRefVar:         reference,
+					ref:               fmt.Sprintf("${%s}", reference),
 					shouldTagWorkflow: true,
 				},
 			},


### PR DESCRIPTION
Tag builds for Windows are broken in the following ways:

* The ref used to determine asset version includes a short commit hash
  (this will cause promotion issues)

* Upon retry of a build (or a new tag with the same commit), builds will
  fail as the old release is not properly cleaned up

Changing the reference used to a branch/tag reference should fix the
issue for both. Note that the second issue is still bugged for push
pipelines, but we almost never retry them so it's not really worth
fixing there right now.

Backport: https://github.com/gravitational/teleport/pull/34668