### PR TITLE
Pin additional 3rd party GitHub actions

### DIFF
--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,10 +60,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,13 +38,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build etcd image
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: ${{ github.workspace }}
           file: .github/services/Dockerfile.etcd

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -15,16 +15,16 @@ jobs:
         run: |
           echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.TELEPORT_USAGE_IAM_ROLE_ARN }}
           aws-region: us-east-1
-      - uses: aws-actions/amazon-ecr-login@v2
+      - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registry-type: public
       # Build and publish container image on ECR.
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: "examples/teleport-usage"
           tags: public.ecr.aws/gravitational/teleport-usage:${{ steps.version.outputs.version }}

--- a/.github/workflows/check-devbox.yaml
+++ b/.github/workflows/check-devbox.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.6.1
+        uses: jetpack-io/devbox-install-action@a0bd99f5de03156cc900bbbeb830f07d3d39aab0 # v0.6.1
         with:
           enable-cache: true
           devbox-version: 0.5.10

--- a/.github/workflows/kube-integration-tests-non-root.yaml
+++ b/.github/workflows/kube-integration-tests-non-root.yaml
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
 
       - name: Create KinD cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         with:
           cluster_name: kind
           config: fixtures/kind/config.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,47 +40,47 @@ jobs:
       # Run various golangci-lint checks.
       # TODO(codingllama): Using go.work could save a bunch of repetition here.
       - name: golangci-lint (api)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: api
           skip-cache: true
       - name: golangci-lint (teleport)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --build-tags libfido2,piv
           skip-cache: true
       - name: golangci-lint (kube-agent-updater)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: integrations/kube-agent-updater
           skip-cache: true
       - name: golangci-lint (assets/backport)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: assets/backport
           skip-cache: true
       - name: golangci-lint (build.assets/tooling)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: build.assets/tooling
           skip-cache: true
 
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@382440cdb8ec7bc25a68d7b4711163d95f7cc3aa # v1.28.1
         with:
           github_token: ${{ github.token }}
           version: v1.28.0
-      - uses: bufbuild/buf-lint-action@v1
+      - uses: bufbuild/buf-lint-action@044d13acb1f155179c606aaa2e53aea304d22058 # v1.1.0
       - name: buf breaking from parent to self
-        uses: bufbuild/buf-breaking-action@v1
+        uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1.1.3
         with:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
       - name: buf breaking from self to master
-        uses: bufbuild/buf-breaking-action@v1
+        uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1.1.3
         if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
         with:
           input: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"


### PR DESCRIPTION
We favor determinism and security in our CI and CD automation.

As part of this, we want to ensure we can review, changes, roll them out at an expected time, and roll them back if something breaks.  All of this is enabled by using pinned versions of GitHub actions instead of floating tags.

This PR pins all actions in this repo, except for:

* First party actions (from a `gravitational/` repo). We control the code review and deploy process for these, negating security & determinism concerns.
* 2nd party actions (from the `actions/` or `github/` repos). We trust that if these were compromised, we'd not be the most valuable target. Furthermore, these are by far the most common actions, and we save a deal of sustaining work by not manually approving upgrades.

All of these pins (and the comments specifying the tag) will be automatically updated by dependabot, as seen in https://github.com/gravitational/teleport/pull/32099/files

Contributes to https://github.com/gravitational/security-findings/issues/50