### PR TITLE
Return an user-friendly message on TPM permission errors

### DIFF
--- a/lib/devicetrust/native/device_linux.go
+++ b/lib/devicetrust/native/device_linux.go
@@ -56,7 +56,7 @@ func enrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 }
 
 func signChallenge(chal []byte) (sig []byte, err error) {
-	return linuxDevice.signChallenge(chal)
+	return nil, errors.New("signChallenge not implemented for TPM devices")
 }
 
 func getDeviceCredential() (*devicepb.DeviceCredential, error) {

--- a/lib/devicetrust/native/device_windows.go
+++ b/lib/devicetrust/native/device_windows.go
@@ -17,6 +17,7 @@ package native
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"os"
 	"os/exec"
 	"os/user"
@@ -48,7 +49,7 @@ func enrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 }
 
 func signChallenge(chal []byte) (sig []byte, err error) {
-	return windowsDevice.signChallenge(chal)
+	return nil, errors.New("signChallenge not implemented for TPM devices")
 }
 
 func getDeviceCredential() (*devicepb.DeviceCredential, error) {

--- a/lib/devicetrust/native/tpm_common.go
+++ b/lib/devicetrust/native/tpm_common.go
@@ -64,7 +64,7 @@ func setupDeviceStateDir(getBaseDir func() (string, error)) (*deviceState, error
 	case os.IsNotExist(err):
 		// If it doesn't exist, we can create it and return as we know
 		// the perms are correct as we created it.
-		if err := os.Mkdir(deviceStateDirPath, 0700); err != nil {
+		if err := os.MkdirAll(deviceStateDirPath, 0700); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	case err != nil:

--- a/lib/devicetrust/native/tpm_device.go
+++ b/lib/devicetrust/native/tpm_device.go
@@ -441,14 +441,6 @@ func (d *tpmDevice) solveTPMAuthnDeviceChallenge(
 	}, nil
 }
 
-// signChallenge is not implemented for TPM devices, as platform attestation
-// is used instead.
-func (d *tpmDevice) signChallenge(_ []byte) (sig []byte, err error) {
-	// NotImplemented may be interpreted as lack of server-side support, so
-	// BadParameter is used instead.
-	return nil, trace.BadParameter("signChallenge not implemented for TPM devices")
-}
-
 func attestPlatform(tpm *attest.TPM, ak *attest.AK, nonce []byte) (*attest.PlatformParameters, error) {
 	config := &attest.PlatformAttestConfig{}
 


### PR DESCRIPTION
Transform this:

```shell
$ tsh device enroll --current-device
> ERROR: opening tpm
> open /dev/tpmrm0: permission denied
```

into this:

```shell
$ tsh device enroll --current-device
> ERROR: Failed to open the TPM device. Consider assigning the user to the `tss`
group or creating equivalent udev rules.See
https://goteleport.com/docs/access-controls/device-trust/device-management/#troubleshooting.
```

(I've also snuck in a couple of small change along with it.)

https://github.com/gravitational/teleport.e/issues/827