### PR TITLE
Prohibit the Okta service from resetting user passwords

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3425,6 +3425,11 @@ func (a *ServerWithRoles) CreateResetPasswordToken(ctx context.Context, req Crea
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if a.hasBuiltinRole(types.RoleOkta) {
+		return nil, trace.AccessDenied("access denied")
+	}
+
 	return a.authServer.CreateResetPasswordToken(ctx, req)
 }
 

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -36,6 +36,25 @@ func newOktaUser(t *testing.T) types.User {
 	return user
 }
 
+// newTestServerWithRoles creates a self-cleaning `ServerWithRoles`, configured
+// with a given
+func newTestServerWithRoles(t *testing.T, srv *TestAuthServer, role types.SystemRole) *ServerWithRoles {
+
+	authzContext := authz.ContextWithUser(context.Background(), TestBuiltin(role).I)
+	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
+	require.NoError(t, err)
+
+	authWithRole := &ServerWithRoles{
+		authServer: srv.AuthServer,
+		alog:       srv.AuditLog,
+		context:    *ctxIdentity,
+	}
+
+	t.Cleanup(func() { authWithRole.Close() })
+
+	return authWithRole
+}
+
 // TestOktaServiceUserCRUD() asserts that user operations involving Okta-origin
 // users obey the following rules:
 //
@@ -45,37 +64,25 @@ func newOktaUser(t *testing.T) types.User {
 //
 // TODO(tcsc): DELETE IN 16.0.0 (or when user management is excised from ServerWithRoles)
 func TestOktaServiceUserCRUD(t *testing.T) {
-	// Given an RBAC-checking `ServerWithRoles` configured with the built-in
-	// Okta Role...
 	ctx := context.Background()
 
+	// Given an auth server...
 	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
 
-	oktaAuthContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestBuiltin(types.RoleOkta).I))
-	require.NoError(t, err)
+	// And an RBAC-checking `ServerWithRoles` facade configured with the
+	// built-in Okta Role...
+	authWithOktaRole := newTestServerWithRoles(t, srv, types.RoleOkta)
 
-	authWithOktaRole := &ServerWithRoles{
-		authServer: srv.AuthServer,
-		alog:       srv.AuditLog,
-		context:    *oktaAuthContext,
-	}
-	t.Cleanup(func() { authWithOktaRole.Close() })
-
-	botAuthContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestBuiltin(types.RoleAdmin).I))
-	require.NoError(t, err)
-
-	authWithBotRole := &ServerWithRoles{
-		authServer: srv.AuthServer,
-		alog:       srv.AuditLog,
-		context:    *botAuthContext,
-	}
-	t.Cleanup(func() { authWithBotRole.Close() })
+	// And another RBAC-checking `ServerWithRoles` facade configured with the
+	// something other than the built-in Okta Role...
+	authWithAdminRole := newTestServerWithRoles(t, srv, types.RoleAdmin)
 
 	t.Run("create", func(t *testing.T) {
 		t.Run("okta service creating okta users is allowed", func(t *testing.T) {
 			user := newOktaUser(t)
-			_, err = authWithOktaRole.CreateUser(ctx, user)
+			_, err := authWithOktaRole.CreateUser(ctx, user)
 			require.NoError(t, err)
 		})
 
@@ -91,7 +98,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 		t.Run("non-okta service creating an okta user is an error", func(t *testing.T) {
 			user := newOktaUser(t)
 
-			_, err = authWithBotRole.CreateUser(ctx, user)
+			_, err := authWithAdminRole.CreateUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -101,7 +108,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 		t.Run("okta service updating okta user is allowed", func(t *testing.T) {
 			// Given an existing okta user
 			user := newOktaUser(t)
-			user, err = srv.AuthServer.CreateUser(ctx, user)
+			user, err := srv.AuthServer.CreateUser(ctx, user)
 			require.NoError(t, err)
 
 			// When I (as the Okta service) modify the user and attempt to update the backend record...
@@ -163,7 +170,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 			user.SetOrigin(types.OriginDynamic)
 
 			// Expect the attempt to fail
-			_, err = authWithBotRole.UpdateUser(ctx, user)
+			_, err = authWithAdminRole.UpdateUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -176,7 +183,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			// When I (as a non-Okta service) attempt modify that user
 			user.SetTraits(map[string][]string{"foo": {"bar", "baz"}})
-			_, err = authWithBotRole.UpdateUser(ctx, user)
+			_, err = authWithAdminRole.UpdateUser(ctx, user)
 
 			// Expect the attempt to fail
 			require.Error(t, err)
@@ -241,7 +248,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 		t.Run("non-okta service creating okta user is an error", func(t *testing.T) {
 			user := newOktaUser(t)
-			_, err = authWithBotRole.UpsertUser(ctx, user)
+			_, err = authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -254,7 +261,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.SetOrigin(types.OriginDynamic)
 
-			_, err = authWithBotRole.UpsertUser(ctx, user)
+			_, err = authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -267,7 +274,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.AddRole(teleport.PresetAccessRoleName)
 
-			_, err = authWithBotRole.UpsertUser(ctx, user)
+			_, err = authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -342,7 +349,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 			require.NoError(t, err)
 			modified.SetOrigin(types.OriginDynamic)
 
-			err = authWithBotRole.CompareAndSwapUser(ctx, modified, original)
+			err = authWithAdminRole.CompareAndSwapUser(ctx, modified, original)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -360,7 +367,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 			require.NoError(t, err)
 			modified.AddRole(teleport.PresetAccessRoleName)
 
-			err = authWithBotRole.CompareAndSwapUser(ctx, modified, original)
+			err = authWithAdminRole.CompareAndSwapUser(ctx, modified, original)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -395,11 +402,62 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 			user, err = srv.AuthServer.CreateUser(ctx, user)
 			require.NoError(t, err)
 
-			err = authWithBotRole.DeleteUser(ctx, user.GetName())
+			err = authWithAdminRole.DeleteUser(ctx, user.GetName())
 			require.NoError(t, err)
 
 			_, err = srv.AuthServer.GetUser(ctx, user.GetName(), false)
 			require.True(t, trace.IsNotFound(err), "Expected not found, got %s", err.Error())
 		})
+	})
+}
+
+func TestOktaMayNotResetPasswords(t *testing.T) {
+	ctx := context.Background()
+
+	// Given an auth server...
+	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	// And an RBAC-checking `ServerWithRoles` facade configured with the
+	// built-in Okta Role...
+	authWithOktaRole := newTestServerWithRoles(t, srv, types.RoleOkta)
+
+	t.Run("okta user", func(t *testing.T) {
+		// Given an existing okta in the user DB
+		existing := newOktaUser(t)
+		existing, err = srv.AuthServer.CreateUser(ctx, existing)
+		require.NoError(t, err)
+
+		_, err = authWithOktaRole.CreateResetPasswordToken(ctx,
+			CreateUserTokenRequest{Name: existing.GetName()})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err), "Expected access denied, got %T: %s", err, err.Error())
+	})
+
+	t.Run("non-okta user", func(t *testing.T) {
+		// Given an existing non-okta existing
+		existing, err := types.NewUser(t.Name())
+		require.NoError(t, err)
+		existing, err = srv.AuthServer.CreateUser(ctx, existing)
+		require.NoError(t, err)
+
+		_, err = authWithOktaRole.CreateResetPasswordToken(ctx,
+			CreateUserTokenRequest{Name: existing.GetName()})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err), "Expected access denied, got %T: %s", err, err.Error())
+	})
+
+	t.Run("resetting non-existent user must not leak info", func(t *testing.T) {
+		// Given a request to reset the password for a non-existent
+		// user, when I try to reset the token
+		_, err = authWithOktaRole.CreateResetPasswordToken(ctx,
+			CreateUserTokenRequest{Name: t.Name()})
+
+		// Expect the operation to fail with "access denied" rather
+		// than "not found", so as not to leak the existence of the
+		// user with different error codes
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err), "Expected access denied, got %T: %s", err, err.Error())
 	})
 }


### PR DESCRIPTION
There are no circumstances where the Okta service should be resetting
a user password, so creating a reset token is strictly prohibited.

Includes some test refactoring to re-use the general Okta user CRUD test
machinery to test this change.

Special thanks to @tigrato for spotting this.
