### PR TITLE
Always run build-native-deps before start-term

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build-term": "yarn workspace @gravitational/teleterm build",
     "start-term": "yarn workspace @gravitational/teleterm start",
     "package-term": "yarn workspace @gravitational/teleterm package",
-    "build-native-deps-for-term": "yarn workspace @gravitational/teleterm build-native-deps",
     "storybook": "start-storybook -p 9002 -c web/.storybook -s web/.storybook/public",
     "test": "jest",
     "test-coverage": "jest --coverage && web/scripts/print-coverage-link.sh",

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -39,22 +39,15 @@ process](#build-process) section.
 
 ## Development
 
-> [!IMPORTANT]
-> **Make sure to run `yarn build-native-deps-for-term` first** before attempting to launch the app in
-development mode. That's because Electron is running its own version of Node. That command will
-fetch or build native packages that were made for that specific version of Node.
-
 ```sh
 cd teleport
-yarn install
-yarn build-native-deps-for-term
+yarn install && make build/tsh
 ```
 
 To launch `teleterm` in development mode:
 
 ```sh
 cd teleport
-
 yarn start-term
 
 # By default, the dev version assumes that the tsh binary is at build/tsh.
@@ -62,7 +55,9 @@ yarn start-term
 CONNECT_TSH_BIN_PATH=$PWD/build/tsh yarn start-term
 ```
 
-For a quick restart which restarts the Electron app and the `tsh` daemon, press `F6`.
+For a quick restart which restarts the Electron app and the tsh daemon, press `F6` while the
+Electron window is open. If you recompiled tsh, this is going to pick up any new changes as well as
+any changes introduced to the main process of the Electron app.
 
 ### Development-only tools
 

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "start": "webpack serve --config webpack.renderer.dev.config.js --progress",
+    "start": "yarn build-native-deps && webpack serve --config webpack.renderer.dev.config.js --progress",
     "start-main": "webpack build --config webpack.main.config.js --mode=development --progress --watch",
     "start-electron": "electron build/app/dist/main/main.js",
     "build": "yarn build-main && yarn build-renderer",


### PR DESCRIPTION
During the hackathon, we saw that having to remember to run `yarn build-native-deps-for-term` is a source of a lot of confusion for other devs. And even if someone knows the in and outs of how Electron handles native dependencies, remembering to do this is still just an unnecessary thing to keep in your head.

Instead, we can just always run `electron-builder install-app-deps` before each start of a dev server. If the deps were already built, the command returns in less than a second. Executing this inside a Windows VM takes 3–4 seconds on my laptop.