### PR TITLE
Update device trust docs with Linux support

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -799,6 +799,7 @@
     "tokentokentoken",
     "tolerations",
     "topk",
+    "tpmrm",
     "trustedclusters",
     "trustpolicy",
     "truststore",

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -1,5 +1,5 @@
 ---
-title: Device Trust 
+title: Device Trust
 description: Teleport Device Trust Concepts
 layout: tocless-doc
 videoBanner: gBQyj_X1LVw
@@ -8,12 +8,12 @@ videoBanner: gBQyj_X1LVw
 <Admonition type="warning">
   Device Trust supports the following components:
 
-  - User devices: macOS and Windows.
+  - User devices: macOS, Windows and Linux.
   - Teleport client: `tsh` and Teleport connect.
   - Resources: SSH, Database and Kubernetes.
 
-  Support for other operating systems, access from Web UI and application
-  access is planned for upcoming Teleport versions.
+  Support for Web UI and application access are planned for upcoming Teleport
+  versions.
 </Admonition>
 
 ## Concepts
@@ -64,14 +64,14 @@ On macOS devices, Device Trust uses the Secure Enclave in order to store a
 device private key. That key is used to solve device challenges issued by the
 Teleport Auth Service, proving the identity of the trusted device.
 
-On Windows devices, a Trusted Platform Module (TPM) is used to perform an
-attestation as to the state of the device. This attestation is signed by a
+On Windows and Linux devices, a Trusted Platform Module (TPM) is used to perform
+an attestation as to the state of the device. This attestation is signed by a
 private key that is also protected by the TPM.
 
 The signed attestation ensures that the Teleport Auth Service knows both the state
 of the device and that the request has come from the device.
 
-That said, a device is as "trustworthy" as the enrollment process. If enrollment operator
+That said, a device is as trustworthy as the enrollment process. If enrollment operator
 enrolls a malicious device to Teleport, establishing trust with Secure Enclave or TPM is
 already defeated at this point. The more trusted the enrollment environment and operator,
 the better the ongoing guarantees that the device itself is trustworthy.

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -1,12 +1,7 @@
 ---
-title: Manage Trusted Devices 
+title: Manage Trusted Devices
 description: Learn how to manage Trusted Devices
 ---
-
-<Admonition type="warning" title="Supported Device Type">
-Device trust works on macOS and Windows devices. Support for other operating
-systems and access features is planned for upcoming Teleport versions.
-</Admonition>
 
 ### Prerequisites
 
@@ -48,8 +43,10 @@ $ tsh device asset-tag
     The serial number is visible under Apple menu -> "About This Mac" -> "Serial number".
   </TabItem>
 
-  <TabItem label="Windows">
-    Windows devices can have multiple serial numbers depending on the configuration made by the manufacturer.
+  <TabItem label="Windows and Linux">
+    Windows and Linux devices can have multiple serial numbers depending on the
+    configuration made by the manufacturer.
+
     Teleport will pick the first available value from the following:
     - System asset tag
     - System serial number
@@ -58,56 +55,31 @@ $ tsh device asset-tag
     To find the value chosen by Teleport, run the following command:
 
     ```code
-    $ tsh device collect
-    DeviceCollectedData {
-      ...
-      "serial_number": "(=devicetrust.asset_tag=)",
-      ...
-    }
+    $ tsh device asset-tag
+    (=devicetrust.asset_tag=)
     ```
   </TabItem>
 </Tabs>
 </Details>
-Use the serial number to register device:
-<Tabs>
-  <TabItem label="macOS">
-    Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/>
-    with the serial number obtained from the device you wish to enroll and run `tctl devices add` command:
 
-    ```code
-    $ tctl devices add --os=macos --asset-tag="<Var name="(=devicetrust.asset_tag=)"/>"
-    Device <Var name="(=devicetrust.asset_tag=)"/>/macos added to the inventory
-    ```
 
-    Use `tctl` to check that the device has been registered:
+Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to
+be registered"/> with the serial number of the device you wish to enroll and run
+the `tctl devices add` command:
 
-    ```code
-    $ tctl devices ls
-    Asset Tag    OS    Enroll Status Device ID
-    ------------ ----- ------------- ------------------------------------
-    (=devicetrust.asset_tag=) macOS not enrolled  (=devicetrust.device_id=)
-    ```
-  </TabItem>
+```code
+$ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'
+Device <Var name="(=devicetrust.asset_tag=)"/>/macos added to the inventory
+```
 
-  <TabItem label="Windows">
-    Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/>
-    with the serial number obtained from the device you wish to enroll and run `tctl devices add` command:
+Use `tctl` to check that the device has been registered:
 
-    ```code
-    $ tctl devices add --os=windows --asset-tag="<Var name="(=devicetrust.asset_tag=)"/>"
-    Device <Var name="(=devicetrust.asset_tag=)"/>/windows added to the inventory
-    ```
-
-    Use `tctl` to check that the device has been registered:
-
-    ```code
-    $ tctl devices ls
-    Asset Tag    OS    Enroll Status Device ID
-    ------------ ----- ------------- ------------------------------------
-    (=devicetrust.asset_tag=) windows not enrolled  (=devicetrust.device_id=)
-    ```
-  </TabItem>
-</Tabs>
+```code
+$ tctl devices ls
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+(=devicetrust.asset_tag=) macOS not enrolled  (=devicetrust.device_id=)
+```
 
 <Admonition type="warning" title="Device Role">
   For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices.
@@ -301,8 +273,8 @@ command; `enroll` is necessary to execute `tsh device enroll`.
 
 ## Configuring a TPM EKCert CA allow-list
 
-This advice only applies to Device Trust on platforms that use TPMs. For now,
-this is just Windows.
+This advice only applies to Device Trust on platforms that use TPMs, such as
+Windows and Linux.
 
 Some TPMs include a certificate—known as an EKCert—signed by the
 manufacturer's certificate authority (CA). This certificate allows a third party

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Device Trust 
+title: Getting Started with Device Trust
 description: Get started with Teleport Device Trust
 videoBanner: gBQyj_X1LVw
 ---
@@ -7,12 +7,12 @@ videoBanner: gBQyj_X1LVw
 <Admonition type="warning">
   Device Trust supports the following components:
 
-  - User devices: macOS and Windows.
+  - User devices: macOS, Windows and Linux.
   - Teleport client: `tsh` and Teleport connect.
   - Resources: SSH, Database and Kubernetes.
 
-  Support for other operating systems, access from Web UI and application
-  access is planned for upcoming Teleport versions.
+  Support for Web UI and application access are planned for upcoming Teleport
+  versions.
 </Admonition>
 
 Device Trust requires two of the following steps to have been configured:

--- a/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
@@ -12,3 +12,14 @@ Teleport as such. Follow the [registration](
 [enrollment](
 ../../access-controls/device-trust/device-management.mdx#enroll-a-trusted-device) steps
 and make sure to `tsh logout` and `tsh login` after enrollment is done.
+
+### "Failed to open the TPM device" on Linux
+
+Linux users need permissions to read and write from the TPM device, /dev/tpmrm0.
+Without such permissions `tsh` would need `sudo` prompts for most operations.
+
+The simplest way to solve this is to check if your distro ships with the `tss`
+group and assign it to your OS user. If that is not possible, or you are looking
+for a different solution, we recommend creating udev rules similar to the ones
+shipped by the [TPM2 Software Stack](
+https://github.com/tpm2-software/tpm2-tss/blob/ede63dd1ac1f0a46029d457304edcac2162bfab8/dist/tpm-udev.rules#L4).

--- a/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
@@ -15,7 +15,7 @@ and make sure to `tsh logout` and `tsh login` after enrollment is done.
 
 ### "Failed to open the TPM device" on Linux
 
-Linux users need permissions to read and write from the TPM device, /dev/tpmrm0.
+Linux users need permissions to read and write from the TPM device, `/dev/tpmrm0`.
 Without such permissions `tsh` would need `sudo` prompts for most operations.
 
 The simplest way to solve this is to check if your distro ships with the `tss`

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -5,7 +5,7 @@
   - A device with TPM 2.0.
   - A user with administrator privileges. This is only required during enrollment.
   - `tsh` v13.1.2 or newer. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).
-- To enroll a Linux device, you neeed:
+- To enroll a Linux device, you need:
   - A device with TPM 2.0.
   - A user with permissions to use the /dev/tpmrm0 device (typically done by
     assigning the `tss` group to the user).

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -1,9 +1,12 @@
 - To enroll a macOS device, you need:
-  - A signed and notarized `tsh` binary for enrollment.
+  - A signed and notarized `tsh` binary, v12.0.0 or newer.
     [Download the macOS tsh installer](../../installation.mdx#macos).
-  - A Teleport version newer than v12.0.0.
 - To enroll a Windows device, you need:
-  - A device that includes a TPM with 2.0 support.
-  - `tsh` installed on the device. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).
-  - Credentials for a user with administrator privileges for the device. This is only required during enrollment.
-  - A Teleport version newer than v13.1.2.
+  - A device with TPM 2.0.
+  - A user with administrator privileges. This is only required during enrollment.
+  - `tsh` v13.1.2 or newer. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).
+- To enroll a Linux device, you neeed:
+  - A device with TPM 2.0.
+  - A user with permissions to use the /dev/tpmrm0 device (typically done by
+    assigning the `tss` group to the user).
+  - `tsh` v15.0.0 or newer. [Install tsh for Linux](../../installation.mdx#linux).


### PR DESCRIPTION
Add Linux to the supported OSes, mention it where appropriate and add a troubleshooting item for lack of TPM permissions.

https://github.com/gravitational/teleport.e/issues/827