### PR TITLE
[v13] Reorganize service config test fields

### DIFF
--- a/integration/assist/command_test.go
+++ b/integration/assist/command_test.go
@@ -225,7 +225,7 @@ func setupTeleport(t *testing.T, testDir, openaiMockURL string) *helpers.TeleIns
 	rcConf.Auth.AssistAPIKey = "test"
 	openAIConfig := openai.DefaultConfig("test")
 	openAIConfig.BaseURL = openaiMockURL + "/v1"
-	rcConf.OpenAIConfig = &openAIConfig
+	rcConf.Testing.OpenAIConfig = &openAIConfig
 	require.NoError(t, err)
 	rcConf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 

--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -60,11 +60,11 @@ func TestDatabaseAccess(t *testing.T) {
 	pack := SetupDatabaseTest(t,
 		// set tighter rotation intervals
 		WithLeafConfig(func(config *servicecfg.Config) {
-			config.PollingPeriod = 5 * time.Second
+			config.Testing.PollingPeriod = 5 * time.Second
 			config.RotationConnectionInterval = 2 * time.Second
 		}),
 		WithRootConfig(func(config *servicecfg.Config) {
-			config.PollingPeriod = 5 * time.Second
+			config.Testing.PollingPeriod = 5 * time.Second
 			config.RotationConnectionInterval = 2 * time.Second
 			config.Proxy.MySQLServerVersion = "8.0.1"
 		}),
@@ -269,7 +269,7 @@ func (p *DatabasePack) testRotateTrustedCluster(t *testing.T) {
 
 	pw := phaseWatcher{
 		clusterRootName: clusterRootName,
-		pollingPeriod:   rootCluster.Process.Config.PollingPeriod,
+		pollingPeriod:   rootCluster.Process.Config.Testing.PollingPeriod,
 		clock:           p.clock,
 		siteAPI:         rootCluster.GetSiteAPI(clusterLeafName),
 		certType:        types.DatabaseCA,

--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -60,11 +60,11 @@ func TestDatabaseAccess(t *testing.T) {
 	pack := SetupDatabaseTest(t,
 		// set tighter rotation intervals
 		WithLeafConfig(func(config *servicecfg.Config) {
-			config.Testing.PollingPeriod = 5 * time.Second
+			config.PollingPeriod = 5 * time.Second
 			config.RotationConnectionInterval = 2 * time.Second
 		}),
 		WithRootConfig(func(config *servicecfg.Config) {
-			config.Testing.PollingPeriod = 5 * time.Second
+			config.PollingPeriod = 5 * time.Second
 			config.RotationConnectionInterval = 2 * time.Second
 			config.Proxy.MySQLServerVersion = "8.0.1"
 		}),
@@ -269,7 +269,7 @@ func (p *DatabasePack) testRotateTrustedCluster(t *testing.T) {
 
 	pw := phaseWatcher{
 		clusterRootName: clusterRootName,
-		pollingPeriod:   rootCluster.Process.Config.Testing.PollingPeriod,
+		pollingPeriod:   rootCluster.Process.Config.PollingPeriod,
 		clock:           p.clock,
 		siteAPI:         rootCluster.GetSiteAPI(clusterLeafName),
 		certType:        types.DatabaseCA,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -435,7 +435,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	}
 	tconf.Log = i.Log
 	tconf.DataDir = dataDir
-	tconf.UploadEventsC = i.UploadEventsC
+	tconf.Testing.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy.Enabled = true
 	tconf.Auth.ClusterName, err = services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
 		ClusterName: i.Secrets.SiteName,
@@ -676,7 +676,7 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *servicecfg.Config, authPor
 	}
 
 	tconf.SetToken("token")
-	tconf.UploadEventsC = i.UploadEventsC
+	tconf.Testing.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy = servicecfg.CachePolicy{
 		Enabled: true,
 	}
@@ -731,7 +731,7 @@ func (i *TeleInstance) StartApp(conf *servicecfg.Config) (*service.TeleportProce
 		Addr:        i.Web,
 	})
 	conf.SetToken("token")
-	conf.UploadEventsC = i.UploadEventsC
+	conf.Testing.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
 
@@ -781,7 +781,7 @@ func (i *TeleInstance) StartApps(configs []*servicecfg.Config) ([]*service.Telep
 				Addr:        i.Web,
 			})
 			cfg.SetToken("token")
-			cfg.UploadEventsC = i.UploadEventsC
+			cfg.Testing.UploadEventsC = i.UploadEventsC
 			cfg.Auth.Enabled = false
 			cfg.Proxy.Enabled = false
 
@@ -843,7 +843,7 @@ func (i *TeleInstance) StartDatabase(conf *servicecfg.Config) (*service.Teleport
 		Addr:        i.Web,
 	})
 	conf.SetToken("token")
-	conf.UploadEventsC = i.UploadEventsC
+	conf.Testing.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
 	conf.Apps.Enabled = false
@@ -904,7 +904,7 @@ func (i *TeleInstance) StartKube(t *testing.T, conf *servicecfg.Config, clusterN
 		Addr:        i.Web,
 	})
 	conf.SetToken("token")
-	conf.UploadEventsC = i.UploadEventsC
+	conf.Testing.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
 	conf.Apps.Enabled = false
@@ -954,7 +954,7 @@ func (i *TeleInstance) StartNodeAndProxy(t *testing.T, name string) (sshPort, we
 	tconf.SetToken("token")
 	tconf.HostUUID = name
 	tconf.Hostname = name
-	tconf.UploadEventsC = i.UploadEventsC
+	tconf.Testing.UploadEventsC = i.UploadEventsC
 	tconf.DataDir = dataDir
 	tconf.CachePolicy = servicecfg.CachePolicy{
 		Enabled: true,
@@ -1047,7 +1047,7 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnelclient.Server, 
 	tconf.SetAuthServerAddress(*authServer)
 	tconf.CachePolicy = servicecfg.CachePolicy{Enabled: true}
 	tconf.DataDir = dataDir
-	tconf.UploadEventsC = i.UploadEventsC
+	tconf.Testing.UploadEventsC = i.UploadEventsC
 	tconf.HostUUID = cfg.Name
 	tconf.Hostname = cfg.Name
 	tconf.SetToken("token")

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -245,8 +245,8 @@ func newHSMAuthConfig(ctx context.Context, t *testing.T, storageConfig *backend.
 	config.PollingPeriod = 1 * time.Second
 	config.SSH.Enabled = false
 	config.Proxy.Enabled = false
-	config.ClientTimeout = time.Second
-	config.ShutdownTimeout = time.Minute
+	config.Testing.ClientTimeout = time.Second
+	config.Testing.ShutdownTimeout = time.Minute
 	config.DataDir = t.TempDir()
 	config.Auth.ListenAddr.Addr = net.JoinHostPort(hostName, "0")
 	config.Auth.PublicAddrs = []utils.NetAddr{
@@ -303,7 +303,7 @@ func newProxyConfig(ctx context.Context, t *testing.T, authAddr utils.NetAddr, l
 	config.Proxy.WebAddr.Addr = net.JoinHostPort(hostName, "0")
 	config.CachePolicy.Enabled = true
 	config.PollingPeriod = 1 * time.Second
-	config.ShutdownTimeout = time.Minute
+	config.Testing.ShutdownTimeout = time.Minute
 	config.DataDir = t.TempDir()
 	config.SetAuthServerAddress(authAddr)
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5611,7 +5611,7 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *servicecf
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Proxy.DisableDatabaseProxy = true
 	tconf.Proxy.DisableALPNSNIListener = true
-	tconf.Testing.PollingPeriod = time.Second
+	tconf.PollingPeriod = time.Second
 	tconf.Testing.ClientTimeout = time.Second
 	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
 	tconf.MaxRetryPeriod = time.Second

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1473,7 +1473,7 @@ func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
 
 			conf.DataDir = t.TempDir()
 			conf.SetToken("token")
-			conf.UploadEventsC = i.UploadEventsC
+			conf.Testing.UploadEventsC = i.UploadEventsC
 			conf.SetAuthServerAddress(*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))))
 			conf.HostUUID = name
 			conf.Hostname = name
@@ -5611,9 +5611,9 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *servicecf
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Proxy.DisableDatabaseProxy = true
 	tconf.Proxy.DisableALPNSNIListener = true
-	tconf.PollingPeriod = time.Second
-	tconf.ClientTimeout = time.Second
-	tconf.ShutdownTimeout = 2 * tconf.ClientTimeout
+	tconf.Testing.PollingPeriod = time.Second
+	tconf.Testing.ClientTimeout = time.Second
+	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
 	tconf.MaxRetryPeriod = time.Second
 	return tconf
 }
@@ -7492,7 +7492,7 @@ func testListResourcesAcrossClusters(t *testing.T, suite *integrationTestSuite) 
 
 			conf.DataDir = t.TempDir()
 			conf.SetToken("token")
-			conf.UploadEventsC = i.UploadEventsC
+			conf.Testing.UploadEventsC = i.UploadEventsC
 			conf.SetAuthServerAddress(*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))))
 			conf.HostUUID = name
 			conf.Hostname = name

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1322,9 +1322,9 @@ func (s *KubeSuite) teleKubeConfig(hostname string) *servicecfg.Config {
 	tconf.Log = s.log
 	tconf.SSH.Enabled = true
 	tconf.Proxy.DisableWebInterface = true
-	tconf.PollingPeriod = 500 * time.Millisecond
-	tconf.ClientTimeout = time.Second
-	tconf.ShutdownTimeout = 2 * tconf.ClientTimeout
+	tconf.Testing.PollingPeriod = 500 * time.Millisecond
+	tconf.Testing.ClientTimeout = time.Second
+	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
 
 	// set kubernetes specific parameters
 	tconf.Proxy.Kube.Enabled = true

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1322,7 +1322,7 @@ func (s *KubeSuite) teleKubeConfig(hostname string) *servicecfg.Config {
 	tconf.Log = s.log
 	tconf.SSH.Enabled = true
 	tconf.Proxy.DisableWebInterface = true
-	tconf.Testing.PollingPeriod = 500 * time.Millisecond
+	tconf.PollingPeriod = 500 * time.Millisecond
 	tconf.Testing.ClientTimeout = time.Second
 	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -809,7 +809,7 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 	if _, err := process.WaitForEvent(process.GracefulExitContext(), TeleportReadyEvent); err != nil {
 		return nil
 	}
-	process.log.Infof("The new service has started successfully. Starting syncing rotation status with period %v.", process.Config.Testing.PollingPeriod)
+	process.log.Infof("The new service has started successfully. Starting syncing rotation status with period %v.", process.Config.PollingPeriod)
 
 	periodic := interval.New(interval.Config{
 		Duration:      process.Config.RotationConnectionInterval,
@@ -872,8 +872,8 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 	defer watcher.Close()
 
 	periodic := interval.New(interval.Config{
-		Duration:      process.Config.Testing.PollingPeriod,
-		FirstDuration: utils.HalfJitter(process.Config.Testing.PollingPeriod),
+		Duration:      process.Config.PollingPeriod,
+		FirstDuration: utils.HalfJitter(process.Config.PollingPeriod),
 		Jitter:        retryutils.NewSeventhJitter(),
 	})
 	defer periodic.Stop()

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -128,7 +128,7 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 
 		// Used for testing that auth service will attempt to reconnect in the provided duration.
 		select {
-		case process.Config.ConnectFailureC <- retry.Duration():
+		case process.Config.Testing.ConnectFailureC <- retry.Duration():
 		default:
 		}
 
@@ -179,8 +179,8 @@ func (process *TeleportProcess) authServerTooOld(resp *proto.PingResponse) error
 	}
 
 	version := teleport.Version
-	if process.Config.TeleportVersion != "" {
-		version = process.Config.TeleportVersion
+	if process.Config.Testing.TeleportVersion != "" {
+		version = process.Config.Testing.TeleportVersion
 	}
 	teleportVersion, err := semver.NewVersion(version)
 	if err != nil {
@@ -809,7 +809,7 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 	if _, err := process.WaitForEvent(process.GracefulExitContext(), TeleportReadyEvent); err != nil {
 		return nil
 	}
-	process.log.Infof("The new service has started successfully. Starting syncing rotation status with period %v.", process.Config.PollingPeriod)
+	process.log.Infof("The new service has started successfully. Starting syncing rotation status with period %v.", process.Config.Testing.PollingPeriod)
 
 	periodic := interval.New(interval.Config{
 		Duration:      process.Config.RotationConnectionInterval,
@@ -872,8 +872,8 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 	defer watcher.Close()
 
 	periodic := interval.New(interval.Config{
-		Duration:      process.Config.PollingPeriod,
-		FirstDuration: utils.HalfJitter(process.Config.PollingPeriod),
+		Duration:      process.Config.Testing.PollingPeriod,
+		FirstDuration: utils.HalfJitter(process.Config.Testing.PollingPeriod),
 		Jitter:        retryutils.NewSeventhJitter(),
 	})
 	defer periodic.Stop()
@@ -1272,7 +1272,7 @@ func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *t
 		Context:   process.ExitContext(),
 		ProxyAddr: addr,
 		Insecure:  lib.IsInsecureDevMode(),
-		Timeout:   process.Config.ClientTimeout,
+		Timeout:   process.Config.Testing.ClientTimeout,
 	})
 
 	resolver, err := reversetunnelclient.CachingResolver(process.ExitContext(), resolver, process.Clock)
@@ -1297,7 +1297,7 @@ func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *t
 			apiclient.LoadTLS(tlsConfig),
 		},
 		CircuitBreakerConfig: process.Config.CircuitBreakerConfig,
-		DialTimeout:          process.Config.ClientTimeout,
+		DialTimeout:          process.Config.Testing.ClientTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1318,10 +1318,10 @@ func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *t
 
 func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tlsConfig *tls.Config, role types.SystemRole) (*auth.Client, error) {
 	var cltParams []roundtrip.ClientParam
-	if process.Config.ClientTimeout != 0 {
+	if process.Config.Testing.ClientTimeout != 0 {
 		cltParams = []roundtrip.ClientParam{
-			auth.ClientParamIdleConnTimeout(process.Config.ClientTimeout),
-			auth.ClientParamResponseHeaderTimeout(process.Config.ClientTimeout),
+			auth.ClientParamIdleConnTimeout(process.Config.Testing.ClientTimeout),
+			auth.ClientParamResponseHeaderTimeout(process.Config.Testing.ClientTimeout),
 		}
 	}
 
@@ -1343,7 +1343,7 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tls
 		Credentials: []apiclient.Credentials{
 			apiclient.LoadTLS(tlsConfig),
 		},
-		DialTimeout:          process.Config.ClientTimeout,
+		DialTimeout:          process.Config.Testing.ClientTimeout,
 		CircuitBreakerConfig: process.Config.CircuitBreakerConfig,
 		DialOpts:             dialOpts,
 	}, cltParams...)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -745,7 +745,7 @@ func waitAndReload(ctx context.Context, cfg servicecfg.Config, srv Process, newT
 		return nil, trace.BadParameter("the new service has failed to start")
 	}
 	cfg.Log.Infof("New service has started successfully.")
-	shutdownTimeout := cfg.ShutdownTimeout
+	shutdownTimeout := cfg.Testing.ShutdownTimeout
 	if shutdownTimeout == 0 {
 		// The default shutdown timeout is very generous to avoid disrupting
 		// longer running connections.
@@ -1683,8 +1683,8 @@ func (process *TeleportProcess) initAuthService() error {
 		// cfg.OpenAIConfig is set in tests to change the OpenAI API endpoint
 		// Like for proxy, if a custom OpenAIConfig is passed, the token from
 		// cfg.Auth.AssistAPIKey is ignored and the one from the config is used.
-		if cfg.OpenAIConfig != nil {
-			embedderClient = ai.NewClientFromConfig(*cfg.OpenAIConfig)
+		if cfg.Testing.OpenAIConfig != nil {
+			embedderClient = ai.NewClientFromConfig(*cfg.Testing.OpenAIConfig)
 		} else {
 			embedderClient = ai.NewClient(cfg.Auth.AssistAPIKey)
 		}
@@ -1731,7 +1731,7 @@ func (process *TeleportProcess) initAuthService() error {
 			CipherSuites:            cfg.CipherSuites,
 			KeyStoreConfig:          cfg.Auth.KeyStore,
 			Emitter:                 checkingEmitter,
-			Streamer:                events.NewReportingStreamer(checkingStreamer, process.Config.UploadEventsC),
+			Streamer:                events.NewReportingStreamer(checkingStreamer, process.Config.Testing.UploadEventsC),
 			TraceClient:             traceClt,
 			FIPS:                    cfg.FIPS,
 			LoadAllCAs:              cfg.Auth.LoadAllCAs,
@@ -2820,7 +2820,7 @@ func (process *TeleportProcess) initUploaderService() error {
 		Streamer:     uploaderClient,
 		ScanDir:      uploadsDir,
 		CorruptedDir: corruptedDir,
-		EventsC:      process.Config.UploadEventsC,
+		EventsC:      process.Config.Testing.UploadEventsC,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -3828,7 +3828,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				KEXAlgorithms:                 cfg.KEXAlgorithms,
 				MACAlgorithms:                 cfg.MACAlgorithms,
 				DataDir:                       process.Config.DataDir,
-				PollingPeriod:                 process.Config.PollingPeriod,
+				PollingPeriod:                 process.Config.Testing.PollingPeriod,
 				FIPS:                          cfg.FIPS,
 				Emitter:                       streamEmitter,
 				Log:                           process.log,
@@ -3968,7 +3968,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Router:           proxyRouter,
 			SessionControl:   sessionController,
 			PROXYSigner:      proxySigner,
-			OpenAIConfig:     cfg.OpenAIConfig,
+			OpenAIConfig:     cfg.Testing.OpenAIConfig,
 			NodeWatcher:      nodeWatcher,
 		}
 		webHandler, err := web.NewHandler(webConfig)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3828,7 +3828,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				KEXAlgorithms:                 cfg.KEXAlgorithms,
 				MACAlgorithms:                 cfg.MACAlgorithms,
 				DataDir:                       process.Config.DataDir,
-				PollingPeriod:                 process.Config.Testing.PollingPeriod,
+				PollingPeriod:                 process.Config.PollingPeriod,
 				FIPS:                          cfg.FIPS,
 				Emitter:                       streamEmitter,
 				Log:                           process.log,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1680,7 +1680,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 	var embedderClient embedding.Embedder
 	if cfg.Auth.AssistAPIKey != "" {
-		// cfg.OpenAIConfig is set in tests to change the OpenAI API endpoint
+		// cfg.Testing.OpenAIConfig is set in tests to change the OpenAI API endpoint
 		// Like for proxy, if a custom OpenAIConfig is passed, the token from
 		// cfg.Auth.AssistAPIKey is ignored and the one from the config is used.
 		if cfg.Testing.OpenAIConfig != nil {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -751,8 +751,8 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.SSH.Enabled = true
 	cfg.MaxRetryPeriod = 5 * time.Millisecond
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
-	cfg.ConnectFailureC = make(chan time.Duration, 5)
-	cfg.ClientTimeout = time.Millisecond
+	cfg.Testing.ConnectFailureC = make(chan time.Duration, 5)
+	cfg.Testing.ClientTimeout = time.Millisecond
 	cfg.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
 	cfg.Log = utils.NewLoggerForTests()
 	process, err := NewTeleport(cfg)
@@ -772,7 +772,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// wait for connection to fail
 		select {
-		case duration := <-process.Config.ConnectFailureC:
+		case duration := <-process.Config.Testing.ConnectFailureC:
 			stepMin := step * time.Duration(i) / 2
 			stepMax := step * time.Duration(i+1)
 
@@ -846,7 +846,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	currentVersion, err := semver.NewVersion(teleport.Version)
 	require.NoError(t, err)
 	currentVersion.Major++
-	nodeCfg.TeleportVersion = currentVersion.String()
+	nodeCfg.Testing.TeleportVersion = currentVersion.String()
 
 	t.Run("with version check", func(t *testing.T) {
 		testVersionCheck(t, nodeCfg, false)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -186,6 +186,10 @@ type Config struct {
 	// to inherit and use for listeners, used for in-process updates.
 	FileDescriptors []FileDescriptor
 
+	// PollingPeriod is set to override default internal polling periods
+	// of sync agents, used to speed up integration tests.
+	PollingPeriod time.Duration
+
 	// CAPins are the SKPI hashes of the CAs used to verify the Auth Server.
 	CAPins []string
 
@@ -264,10 +268,6 @@ type ConfigTesting struct {
 
 	// UploadEventsC is a channel for upload events used in tests
 	UploadEventsC chan events.UploadEvent `json:"-"`
-
-	// PollingPeriod is set to override default internal polling periods
-	// of sync agents, used to speed up integration tests.
-	PollingPeriod time.Duration
 
 	// ClientTimeout is set to override default client timeouts
 	// used by internal clients, used to speed up integration tests.
@@ -632,8 +632,8 @@ func applyDefaults(cfg *Config) {
 		cfg.Log = logrus.StandardLogger()
 	}
 
-	if cfg.Testing.PollingPeriod == 0 {
-		cfg.Testing.PollingPeriod = defaults.LowResPollingPeriod
+	if cfg.PollingPeriod == 0 {
+		cfg.PollingPeriod = defaults.LowResPollingPeriod
 	}
 }
 

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -279,11 +279,6 @@ type ConfigTesting struct {
 	// TeleportVersion is used to control the Teleport version in tests.
 	TeleportVersion string
 
-	// KubeMultiplexerIgnoreSelfConnections signals that Proxy TLS server's listener should
-	// require PROXY header if 'proxyProtocolMode: true' even from self connections. Used in tests as all connections are self
-	// connections there.
-	KubeMultiplexerIgnoreSelfConnections bool
-
 	// OpenAIConfig contains the optional OpenAI client configuration used by
 	// auth and proxy. When it's not set (the default, we don't offer a way to
 	// set it when executing the regular Teleport binary) we use the default

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -182,33 +182,15 @@ type Config struct {
 	// endpoint extended with additional /debug handlers
 	Debug bool
 
-	// UploadEventsC is a channel for upload events
-	// used in tests
-	UploadEventsC chan events.UploadEvent `json:"-"`
-
 	// FileDescriptors is an optional list of file descriptors for the process
 	// to inherit and use for listeners, used for in-process updates.
 	FileDescriptors []FileDescriptor
-
-	// PollingPeriod is set to override default internal polling periods
-	// of sync agents, used to speed up integration tests.
-	PollingPeriod time.Duration
-
-	// ClientTimeout is set to override default client timeouts
-	// used by internal clients, used to speed up integration tests.
-	ClientTimeout time.Duration
-
-	// ShutdownTimeout is set to override default shutdown timeout.
-	ShutdownTimeout time.Duration
 
 	// CAPins are the SKPI hashes of the CAs used to verify the Auth Server.
 	CAPins []string
 
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
-
-	// TeleportVersion is used to control the Teleport version in tests.
-	TeleportVersion string
 
 	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
 	FIPS bool
@@ -236,9 +218,6 @@ type Config struct {
 	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
 	MaxRetryPeriod time.Duration
 
-	// ConnectFailureC is a channel to notify of failures to connect to auth (used in tests).
-	ConnectFailureC chan time.Duration
-
 	// TeleportHome is the path to tsh configuration and data, used
 	// for loading profiles when TELEPORT_HOME is set
 	TeleportHome string
@@ -255,15 +234,8 @@ type Config struct {
 	// InstanceMetadataClient specifies the instance metadata client.
 	InstanceMetadataClient cloud.InstanceMetadata
 
-	// OpenAIConfig contains the optional OpenAI client configuration used by
-	// auth and proxy. When it's not set (the default, we don't offer a way to
-	// set it when executing the regular Teleport binary) we use the default
-	// configuration with auth tokens passed from Auth.AssistAPIKey or
-	// Proxy.AssistAPIKey. We set this only when testing to avoid calls to reach
-	// the real OpenAI API.
-	// Note: When set, this overrides Auth and Proxy's AssistAPIKey settings.
-	OpenAIConfig *openai.ClientConfig
-
+	// Testing is a group of properties that are used in tests.
+	Testing ConfigTesting
 	// token is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//
@@ -284,6 +256,42 @@ type Config struct {
 	// and the value is retrieved via AuthServerAddresses() and set via SetAuthServerAddresses()
 	// as we still need to keep multiple addresses and return them for older config versions.
 	authServers []utils.NetAddr
+}
+
+type ConfigTesting struct {
+	// ConnectFailureC is a channel to notify of failures to connect to auth (used in tests).
+	ConnectFailureC chan time.Duration
+
+	// UploadEventsC is a channel for upload events used in tests
+	UploadEventsC chan events.UploadEvent `json:"-"`
+
+	// PollingPeriod is set to override default internal polling periods
+	// of sync agents, used to speed up integration tests.
+	PollingPeriod time.Duration
+
+	// ClientTimeout is set to override default client timeouts
+	// used by internal clients, used to speed up integration tests.
+	ClientTimeout time.Duration
+
+	// ShutdownTimeout is set to override default shutdown timeout.
+	ShutdownTimeout time.Duration
+
+	// TeleportVersion is used to control the Teleport version in tests.
+	TeleportVersion string
+
+	// KubeMultiplexerIgnoreSelfConnections signals that Proxy TLS server's listener should
+	// require PROXY header if 'proxyProtocolMode: true' even from self connections. Used in tests as all connections are self
+	// connections there.
+	KubeMultiplexerIgnoreSelfConnections bool
+
+	// OpenAIConfig contains the optional OpenAI client configuration used by
+	// auth and proxy. When it's not set (the default, we don't offer a way to
+	// set it when executing the regular Teleport binary) we use the default
+	// configuration with auth tokens passed from Auth.AssistAPIKey or
+	// Proxy.AssistAPIKey. We set this only when testing to avoid calls to reach
+	// the real OpenAI API.
+	// Note: When set, this overrides Auth and Proxy's AssistAPIKey settings.
+	OpenAIConfig *openai.ClientConfig
 }
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.
@@ -551,7 +559,7 @@ func ApplyDefaults(cfg *Config) {
 
 	cfg.RotationConnectionInterval = defaults.HighResPollingPeriod
 	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
-	cfg.ConnectFailureC = make(chan time.Duration, 1)
+	cfg.Testing.ConnectFailureC = make(chan time.Duration, 1)
 	cfg.CircuitBreakerConfig = breaker.DefaultBreakerConfig(cfg.Clock)
 }
 
@@ -624,8 +632,8 @@ func applyDefaults(cfg *Config) {
 		cfg.Log = logrus.StandardLogger()
 	}
 
-	if cfg.PollingPeriod == 0 {
-		cfg.PollingPeriod = defaults.LowResPollingPeriod
+	if cfg.Testing.PollingPeriod == 0 {
+		cfg.Testing.PollingPeriod = defaults.LowResPollingPeriod
 	}
 }
 


### PR DESCRIPTION
Backport #34208 to branch/v13

Manual backport, as some code touched by the original PR was not backported to v13, fortunately by the nature of PR it just doesn't compile if something is missing or vice versa.