### PR TITLE
fix: External Audit Storage: check for athena URI and ignore others

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1383,7 +1383,11 @@ func adminCreds() (*int, *int, error) {
 // cloud-provider storage. Otherwise a local file-based handler is used which stores the recordings
 // on disk.
 func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditConfig, dataDir string, externalCloudAudit *externalcloudaudit.Configurator) (events.MultipartHandler, error) {
-	if !auditConfig.ShouldUploadSessions() {
+	uriString := auditConfig.AuditSessionsURI()
+	if externalCloudAudit.IsUsed() {
+		uriString = externalCloudAudit.GetSpec().SessionsRecordingsURI
+	}
+	if len(uriString) == 0 {
 		recordsDir := filepath.Join(dataDir, events.RecordsDir)
 		if err := os.MkdirAll(recordsDir, teleport.SharedDirMode); err != nil {
 			return nil, trace.ConvertSystemError(err)
@@ -1396,7 +1400,7 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 		}
 		return handler, nil
 	}
-	uri, err := apiutils.ParseSessionsURI(auditConfig.AuditSessionsURI())
+	uri, err := apiutils.ParseSessionsURI(uriString)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1416,15 +1420,10 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 		config := s3sessions.Config{
 			UseFIPSEndpoint: auditConfig.GetUseFIPSEndpoint(),
 		}
-		s3URI := uri
 		if externalCloudAudit.IsUsed() {
 			config.Credentials = awscredentials.NewCredentials(externalCloudAudit.CredentialsProviderSDKV1())
-			s3URI, err = apiutils.ParseSessionsURI(externalCloudAudit.GetSpec().SessionsRecordingsURI)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 		}
-		if err := config.SetFromURL(s3URI, auditConfig.Region()); err != nil {
+		if err := config.SetFromURL(uri, auditConfig.Region()); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -1464,13 +1463,18 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 }
 
 // initAuthExternalAuditLog initializes the auth server's audit log.
-func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend, tracingProvider *tracing.Provider, externalCloudAudit *externalcloudaudit.Configurator) (events.AuditLogger, error) {
+func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.ClusterAuditConfig, externalCloudAudit *externalcloudaudit.Configurator) (events.AuditLogger, error) {
+	ctx := process.ExitContext()
 	var hasNonFileLog bool
 	var loggers []events.AuditLogger
 	for _, eventsURI := range auditConfig.AuditEventsURIs() {
 		uri, err := apiutils.ParseSessionsURI(eventsURI)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if externalCloudAudit.IsUsed() && (len(loggers) > 0 || uri.Scheme != teleport.ComponentAthena) {
+			process.log.Info("Skipping events URI %s because External Audit Storage is enabled", eventsURI)
+			continue
 		}
 		switch uri.Scheme {
 		case pgevents.Schema, pgevents.AltSchema:
@@ -1528,16 +1532,19 @@ func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAudi
 			hasNonFileLog = true
 			cfg := athena.Config{
 				Region:  auditConfig.Region(),
-				Backend: backend,
+				Backend: process.backend,
 			}
-			if tracingProvider != nil {
-				cfg.Tracer = tracingProvider.Tracer(teleport.ComponentAthena)
+			if process.TracingProvider != nil {
+				cfg.Tracer = process.TracingProvider.Tracer(teleport.ComponentAthena)
 			}
 			err = cfg.SetFromURL(uri)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			if externalCloudAudit.IsUsed() {
+				// External Audit Storage uses the topicArn, largeEventsS3, and
+				// queueURL from the athena audit_events_uri passed by cloud,
+				// and overwrites the remaining fields.
 				if err := cfg.UpdateForExternalCloudAudit(ctx, externalCloudAudit.GetSpec(), externalCloudAudit.CredentialsProvider()); err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -1591,6 +1598,10 @@ func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAudi
 	}
 
 	if len(loggers) < 1 {
+		if externalCloudAudit.IsUsed() {
+			return nil, trace.BadParameter("athena audit_events_uri must be configured when External Audit Storage is enabled")
+
+		}
 		return nil, nil
 	}
 
@@ -1669,7 +1680,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 		// initialize external loggers.  may return (nil, nil) if no
 		// external loggers have been defined.
-		externalLog, err := initAuthExternalAuditLog(process.ExitContext(), cfg.Auth.AuditConfig, process.backend, process.TracingProvider, externalCloudAudit)
+		externalLog, err := process.initAuthExternalAuditLog(cfg.Auth.AuditConfig, externalCloudAudit)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1387,7 +1387,7 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 	if externalCloudAudit.IsUsed() {
 		uriString = externalCloudAudit.GetSpec().SessionsRecordingsURI
 	}
-	if len(uriString) == 0 {
+	if uriString == "" {
 		recordsDir := filepath.Join(dataDir, events.RecordsDir)
 		if err := os.MkdirAll(recordsDir, teleport.SharedDirMode); err != nil {
 			return nil, trace.ConvertSystemError(err)
@@ -1473,7 +1473,7 @@ func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.Clust
 			return nil, trace.Wrap(err)
 		}
 		if externalCloudAudit.IsUsed() && (len(loggers) > 0 || uri.Scheme != teleport.ComponentAthena) {
-			process.log.Info("Skipping events URI %s because External Audit Storage is enabled", eventsURI)
+			process.log.Infof("Skipping events URI %s because External Audit Storage is enabled", eventsURI)
 			continue
 		}
 		switch uri.Scheme {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1462,6 +1462,8 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 	}
 }
 
+var externalAuditMissingAthenaError = trace.BadParameter("athena audit_events_uri must be configured when External Audit Storage is enabled")
+
 // initAuthExternalAuditLog initializes the auth server's audit log.
 func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.ClusterAuditConfig, externalCloudAudit *externalcloudaudit.Configurator) (events.AuditLogger, error) {
 	ctx := process.ExitContext()
@@ -1599,7 +1601,7 @@ func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.Clust
 
 	if len(loggers) < 1 {
 		if externalCloudAudit.IsUsed() {
-			return nil, trace.BadParameter("athena audit_events_uri must be configured when External Audit Storage is enabled")
+			return nil, externalAuditMissingAthenaError
 
 		}
 		return nil, nil

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -54,11 +54,13 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/athena"
+	"github.com/gravitational/teleport/lib/integrations/externalcloudaudit"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -431,6 +433,12 @@ func TestServiceInitExternalLog(t *testing.T) {
 	for _, tt := range tts {
 		backend, err := memory.New(memory.Config{})
 		require.NoError(t, err)
+		process := &TeleportProcess{
+			Supervisor: &LocalSupervisor{
+				exitContext: context.Background(),
+			},
+			backend: backend,
+		}
 
 		t.Run(strings.Join(tt.events, ","), func(t *testing.T) {
 			// isErr implies isNil.
@@ -442,7 +450,7 @@ func TestServiceInitExternalLog(t *testing.T) {
 				AuditEventsURI: tt.events,
 			})
 			require.NoError(t, err)
-			loggers, err := initAuthExternalAuditLog(context.Background(), auditConfig, backend, nil /* tracingProvider */, nil /* externalCloudAudit */)
+			loggers, err := process.initAuthExternalAuditLog(auditConfig, nil /* externalCloudAudit */)
 			if tt.isErr {
 				require.Error(t, err)
 			} else {
@@ -459,42 +467,113 @@ func TestServiceInitExternalLog(t *testing.T) {
 }
 
 func TestAthenaAuditLogSetup(t *testing.T) {
-	sampleValidConfig := "athena://db.table?topicArn=arn:aws:sns:eu-central-1:accnr:topicName&queryResultsS3=s3://testbucket/query-result/&workgroup=workgroup&locationS3=s3://testbucket/events-location&queueURL=https://sqs.eu-central-1.amazonaws.com/accnr/sqsname&largeEventsS3=s3://testbucket/largeevents"
+	ctx := context.Background()
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
+
+	sampleAthenaURI := "athena://db.table?topicArn=arn:aws:sns:eu-central-1:accnr:topicName&queryResultsS3=s3://testbucket/query-result/&workgroup=workgroup&locationS3=s3://testbucket/events-location&queueURL=https://sqs.eu-central-1.amazonaws.com/accnr/sqsname&largeEventsS3=s3://testbucket/largeevents"
+	sampleFileURI := "file:///tmp/teleport-test/events"
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	process := &TeleportProcess{
+		Supervisor: &LocalSupervisor{
+			exitContext: context.Background(),
+		},
+		backend: backend,
+		log:     utils.NewLoggerForTests(),
+	}
+
+	integrationSvc, err := local.NewIntegrationsService(backend)
+	require.NoError(t, err)
+	oidcIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "aws-integration-1"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "role1",
+		},
+	)
+	require.NoError(t, err)
+	_, err = integrationSvc.CreateIntegration(ctx, oidcIntegration)
+	require.NoError(t, err)
+
+	ecaSvc := local.NewExternalCloudAuditService(backend)
+	_, err = ecaSvc.GenerateDraftExternalCloudAudit(ctx, "aws-integration-1", "us-west-2")
+	require.NoError(t, err)
+
+	externalCloudAuditDisabled, err := externalcloudaudit.NewConfigurator(ctx, ecaSvc, integrationSvc)
+	require.NoError(t, err)
+	err = ecaSvc.PromoteToClusterExternalCloudAudit(ctx)
+	require.NoError(t, err)
+	externalCloudAuditEnabled, err := externalcloudaudit.NewConfigurator(ctx, ecaSvc, integrationSvc)
+	require.NoError(t, err)
+
 	tests := []struct {
-		name   string
-		uri    string
-		wantFn func(*testing.T, events.AuditLogger, error)
+		name          string
+		uris          []string
+		externalAudit *externalcloudaudit.Configurator
+		expectErr     error
+		wantFn        func(*testing.T, events.AuditLogger)
 	}{
 		{
-			name: "valid athena config",
-			uri:  sampleValidConfig,
-			wantFn: func(t *testing.T, alog events.AuditLogger, err error) {
-				require.NoError(t, err)
+			name:          "valid athena config",
+			uris:          []string{sampleAthenaURI},
+			externalAudit: externalCloudAuditDisabled,
+			wantFn: func(t *testing.T, alog events.AuditLogger) {
 				v, ok := alog.(*athena.Log)
 				require.True(t, ok, "invalid logger type, got %T", v)
 			},
 		},
 		{
-			name: "config with rate limit - should use events.SearchEventsLimiter",
-			uri:  sampleValidConfig + "&limiterRefillAmount=3&limiterBurst=2",
-			wantFn: func(t *testing.T, alog events.AuditLogger, err error) {
-				require.NoError(t, err)
+			name:          "config with rate limit - should use events.SearchEventsLimiter",
+			uris:          []string{sampleAthenaURI + "&limiterRefillAmount=3&limiterBurst=2"},
+			externalAudit: externalCloudAuditDisabled,
+			wantFn: func(t *testing.T, alog events.AuditLogger) {
 				_, ok := alog.(*events.SearchEventsLimiter)
 				require.True(t, ok, "invalid logger type, got %T", alog)
 			},
 		},
+		{
+			name:          "multilog",
+			uris:          []string{sampleAthenaURI, sampleFileURI},
+			externalAudit: externalCloudAuditDisabled,
+			wantFn: func(t *testing.T, alog events.AuditLogger) {
+				_, ok := alog.(*events.MultiLog)
+				require.True(t, ok, "invalid logger type, got %T", alog)
+			},
+		},
+		{
+			name:          "external audit storage without athena uri",
+			uris:          []string{sampleFileURI},
+			externalAudit: externalCloudAuditEnabled,
+			expectErr:     trace.BadParameter("athena audit_events_uri must be configured when External Audit Storage is enabled"),
+		},
+		{
+			name:          "external audit storage with multiple uris",
+			uris:          []string{sampleAthenaURI, sampleFileURI},
+			externalAudit: externalCloudAuditEnabled,
+			wantFn: func(t *testing.T, alog events.AuditLogger) {
+				// should not be MultiLog even though multi URIs passed
+				v, ok := alog.(*athena.Log)
+				require.True(t, ok, "invalid logger type, got %T", v)
+			},
+		},
 	}
-	backend, err := memory.New(memory.Config{})
-	require.NoError(t, err)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			auditConfig, err := types.NewClusterAuditConfig(types.ClusterAuditConfigSpecV2{
-				AuditEventsURI:   []string{tt.uri},
+				AuditEventsURI:   tt.uris,
 				AuditSessionsURI: "s3://testbucket/sessions-rec",
 			})
 			require.NoError(t, err)
-			log, err := initAuthExternalAuditLog(context.Background(), auditConfig, backend, nil /* tracingProvider */, nil /* externalCloudAudit */)
-			tt.wantFn(t, log, err)
+			log, err := process.initAuthExternalAuditLog(auditConfig, tt.externalAudit)
+			require.ErrorIs(t, err, tt.expectErr)
+			if tt.expectErr != nil {
+				return
+			}
+			tt.wantFn(t, log)
 		})
 	}
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -548,7 +548,7 @@ func TestAthenaAuditLogSetup(t *testing.T) {
 			name:          "external audit storage without athena uri",
 			uris:          []string{sampleFileURI},
 			externalAudit: externalCloudAuditEnabled,
-			expectErr:     trace.BadParameter("athena audit_events_uri must be configured when External Audit Storage is enabled"),
+			expectErr:     externalAuditMissingAthenaError,
 		},
 		{
 			name:          "external audit storage with multiple uris",


### PR DESCRIPTION
There must be an existing athena events URI for External Audit Storage to be enabled.
If users enable External Audit Storage they do not want us to store events on our infra, so this avoids setting up a MultiLog that would write events to multiple backends if multiple audit URIs are passed.

This is paired with https://github.com/gravitational/teleport.e/pull/2669 that tries to prevent users from enabling the feature if they don't already have an athena events URI configured.