### PR TITLE
Connect My Computer: Reload certs if user already has role but role got updated with new login

### DIFF
--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -428,7 +428,7 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 		{
 			name:                     "user already has existing role that does not include current system username",
 			assignExistingRoleToUser: true,
-			assertCertsReloaded:      require.False,
+			assertCertsReloaded:      require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -446,6 +446,23 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			name:                     "user already has existing role with modified owner node label",
 			assignExistingRoleToUser: true,
 			assertCertsReloaded:      require.False,
+			existingRole: func(userName string) types.RoleV6 {
+				return types.RoleV6{
+					Spec: types.RoleSpecV6{
+						Allow: types.RoleConditions{
+							NodeLabels: types.Labels{
+								types.ConnectMyComputerNodeOwnerLabel: []string{"bogus-username"},
+							},
+							Logins: []string{systemUser.Username},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:                     "user already has existing role that does not include current system username and has modified owner node label",
+			assignExistingRoleToUser: true,
+			assertCertsReloaded:      require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{


### PR DESCRIPTION
Closes #34341.

Check out the description of the issue above for the rationale behind this change.

The tldr is that during the setup of Connect My Computer we make some changes to the user account in the cluster which result in new logins being available to the user. Teleport Connect has to then reload the certs so that the user can ssh using those new logins. We used to reload the certs only after assigning a new role to the user. We didn't do it after adding a new login to an existing role that was already assigned to the user. This is what this PR fixes.

Best reviewed commit by commit, with whitespace ignored of course.

Changelog: Fixed a Connect My Computer issue in Teleport Connect where the list of SSH logins would not get updated during the setup on another device with a different system username