### PR TITLE
Update localStorage item key for AccessGraphSQLEnabled

### DIFF
--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -253,7 +253,7 @@ const storage = {
   },
 
   getAccessGraphSQLEnabled(): boolean {
-    const item = window.localStorage.getItem(KeysEnum.ACCESS_GRAPH_ENABLED);
+    const item = window.localStorage.getItem(KeysEnum.ACCESS_GRAPH_SQL_ENABLED);
     if (item) {
       return JSON.parse(item);
     }


### PR DESCRIPTION
The localStorage item key corresponding to the 'AccessGraphSQLEnabled' state has been updated. This is a typo from the initial implementation.