### PR TITLE
Fixed additional license format issues

### DIFF
--- a/api/types/accountrecovery.go
+++ b/api/types/accountrecovery.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/types/installer.go
+++ b/api/types/installer.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/types/ui_config.go
+++ b/api/types/ui_config.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/common/status_test.go
+++ b/integrations/access/common/status_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/app.go
+++ b/integrations/access/mattermost/app.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/config.go
+++ b/integrations/access/mattermost/config.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/helper_test.go
+++ b/integrations/access/mattermost/helper_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/mattermost_test.go
+++ b/integrations/access/mattermost/mattermost_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integrations/access/mattermost/types.go
+++ b/integrations/access/mattermost/types.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auditd/auditd.go
+++ b/lib/auditd/auditd.go
@@ -1,7 +1,6 @@
 //go:build !linux
 
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auditd/common.go
+++ b/lib/auditd/common.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package assistv1

--- a/lib/auth/keygen/keygen.go
+++ b/lib/auth/keygen/keygen.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auth/webauthncli/fuzz_test.go
+++ b/lib/auth/webauthncli/fuzz_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auth/webauthncli/u2f_other.go
+++ b/lib/auth/webauthncli/u2f_other.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +14,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build !windows
-// +build !windows
 
 package webauthncli
 

--- a/lib/auth/webauthnwin/webauthn_other.go
+++ b/lib/auth/webauthnwin/webauthn_other.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +14,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build !windows
-// +build !windows
 
 package webauthnwin
 

--- a/lib/services/assist.go
+++ b/lib/services/assist.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package services

--- a/lib/services/installer.go
+++ b/lib/services/installer.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/services/local/assistant.go
+++ b/lib/services/local/assistant.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package local

--- a/lib/services/local/assistant_test.go
+++ b/lib/services/local/assistant_test.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package local_test

--- a/lib/services/local/userpreferences.go
+++ b/lib/services/local/userpreferences.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package local

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/services/ui_config.go
+++ b/lib/services/ui_config.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/services/userpreferences.go
+++ b/lib/services/userpreferences.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package services

--- a/lib/srv/forward/sshserver_test.go
+++ b/lib/srv/forward/sshserver_test.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package forward

--- a/lib/srv/reexec_other.go
+++ b/lib/srv/reexec_other.go
@@ -1,3 +1,6 @@
+//go:build !linux
+// +build !linux
+
 // Copyright 2021 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +14,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build !linux
-// +build !linux
 
 package srv
 

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package srv

--- a/lib/sshutils/sftp/utils.go
+++ b/lib/sshutils/sftp/utils.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package sftp

--- a/lib/system/signal.go
+++ b/lib/system/signal.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2021 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build !windows
 
 package system
 

--- a/lib/teleterm/clusters/cluster_auth_test.go
+++ b/lib/teleterm/clusters/cluster_auth_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/utils/cert/selfsigned.go
+++ b/lib/utils/cert/selfsigned.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package cert

--- a/lib/web/mfa.go
+++ b/lib/web/mfa.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/web/ui/lock.go
+++ b/lib/web/ui/lock.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/web/userpreferences.go
+++ b/lib/web/userpreferences.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixed another handful of inconsistencies with our license headers, which have been causing linters to complain when ran on the entire codebase. This mostly replaces `/**` with `/*`, removes an extra ` *` on the second line of certain headers, `build` comments at the top of files.