### PR TITLE
Additional license format fixes

### DIFF
--- a/api/types/events_test.go
+++ b/api/types/events_test.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package types

--- a/api/types/watch_status.go
+++ b/api/types/watch_status.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package types

--- a/lib/auditd/auditd_linux.go
+++ b/lib/auditd/auditd_linux.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/auditd/auditd_test.go
+++ b/lib/auditd/auditd_test.go
@@ -1,7 +1,6 @@
 //go:build linux
 
 /*
- *
  * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/bpf/common_linux.go
+++ b/lib/bpf/common_linux.go
@@ -2,7 +2,6 @@
 // +build bpf,!386
 
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package bpf

--- a/lib/srv/reexec_linux.go
+++ b/lib/srv/reexec_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 // Copyright 2021-2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +14,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build linux
-// +build linux
 
 package srv
 

--- a/web/packages/teleport/src/HeadlessRequest/Cards.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/Cards.tsx
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2023 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 import { Card, CardSuccess, Text } from 'design';

--- a/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.test.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.test.ts
@@ -23,7 +23,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
+/*
  Copyright 2022 Gravitational, Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/makeCert/makeCert.ts
@@ -23,7 +23,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
+/*
  Copyright 2022 Gravitational, Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/getKeyName.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/getKeyName.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I missed a few files in the last PR. This mostly cleans up `/**`, extra empty `*` lines, and another misplaced `+build` comment.