### PR TITLE
docs: use default pre-set roles in tsh examples

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -262,9 +262,9 @@ $ tsh status
 # > Profile URL:  https://proxy.example.com:3080
 #   Logged in as: johndoe
 #  Cluster:      proxy.example.com
-#   Roles:        admin*
+#   Roles:        access, auditor, editor
 #   Logins:       root, admin, guest
-#   Kubernetes:   disabled
+#   Kubernetes:   enabled
 #  Valid until:  2017-04-25 15:02:30 -0700 PDT [valid for 1h0m0s]
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
@@ -278,9 +278,9 @@ $ tsh status
 # > Profile URL:  https://mytenant.teleport.sh:443
 #   Logged in as: johndoe
 #  Cluster:      mytenant.teleport.sh
-#   Roles:        admin*
+#   Roles:        access, editor, auditor
 #   Logins:       root, admin, guest
-#   Kubernetes:   disabled
+#   Kubernetes:   enabled
 #  Valid until:  2017-04-25 15:02:30 -0700 PDT [valid for 1h0m0s]
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -993,7 +993,7 @@ $ tsh status
 # > Profile URL:  https://proxy.example.com:3080
 #   Logged in as:       benarent
 #   Cluster:            aws
-#   Roles:              admin*
+#   Roles:              access, editor, auditor
 #   Logins:             benarent, root, ec2-user, ubunutu
 #   Kubernetes:         enabled
 #   Kubernetes cluster: "gke_bens-demos_us-central1-c_gks-demo"


### PR DESCRIPTION
`admin` role was removed several versions ago so updating with default roles. 