### PR TITLE
Fixed resource type filters to be matched by a readable name

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -34,7 +34,6 @@ import {
   SearchResultCluster,
   SearchResultResourceType,
   SearchFilter,
-  ResourceTypeFilter,
 } from 'teleterm/ui/Search/searchResult';
 import * as tsh from 'teleterm/services/tshd/types';
 import * as uri from 'teleterm/ui/uri';
@@ -44,7 +43,10 @@ import { assertUnreachable } from 'teleterm/ui/utils';
 
 import { SearchAction } from '../actions';
 import { useSearchContext } from '../SearchContext';
-import { CrossClusterResourceSearchResult } from '../useSearch';
+import {
+  CrossClusterResourceSearchResult,
+  resourceTypeToReadableName,
+} from '../useSearch';
 
 import { useActionAttempts } from './useActionAttempts';
 import { getParameterPicker } from './pickers';
@@ -121,7 +123,7 @@ export function ActionPicker(props: { input: ReactElement }) {
       return (
         <FilterButton
           key={`resource-type-${s.resourceType}`}
-          text={resourceTypeToPrettyName[s.resourceType]}
+          text={resourceTypeToReadableName[s.resourceType]}
           onClick={() => removeFilter(s)}
         />
       );
@@ -509,7 +511,7 @@ function ResourceTypeFilterItem(
         Search for{' '}
         <strong>
           <Highlight
-            text={resourceTypeToPrettyName[props.searchResult.resource]}
+            text={resourceTypeToReadableName[props.searchResult.resource]}
             keywords={[props.searchResult.nameMatch]}
           />
         </strong>
@@ -911,9 +913,3 @@ function FilterButton(props: { text: string; onClick(): void }) {
     </Flex>
   );
 }
-
-const resourceTypeToPrettyName: Record<ResourceTypeFilter, string> = {
-  db: 'databases',
-  node: 'servers',
-  kube_cluster: 'kubes',
-};

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -218,6 +218,31 @@ describe('useResourceSearch', () => {
 });
 
 describe('useFiltersSearch', () => {
+  it('resource type filter is matched by the readable name', () => {
+    const appContext = new MockAppContext();
+    appContext.clustersService.setState(draftState => {
+      const rootCluster = makeRootCluster();
+      draftState.clusters.set(rootCluster.uri, rootCluster);
+    });
+
+    const { result } = renderHook(() => useFilterSearch(), {
+      wrapper: ({ children }) => (
+        <MockAppContextProvider appContext={appContext}>
+          {children}
+        </MockAppContextProvider>
+      ),
+    });
+    const clusterFilters = result.current('serv', []);
+    expect(clusterFilters).toEqual([
+      {
+        kind: 'resource-type-filter',
+        resource: 'node',
+        nameMatch: 'serv',
+        score: 100,
+      },
+    ]);
+  });
+
   it('does not return cluster filters if there is only one cluster', () => {
     const appContext = new MockAppContext();
     appContext.clustersService.setState(draftState => {

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -196,7 +196,9 @@ export function useFilterSearch() {
         });
         if (search) {
           resourceTypes = resourceTypes.filter(resourceType =>
-            resourceType.toLowerCase().includes(search.toLowerCase())
+            resourceTypeToReadableName[resourceType]
+              .toLowerCase()
+              .includes(search.toLowerCase())
           );
         }
         return resourceTypes.map(resourceType => ({
@@ -380,3 +382,9 @@ function getResourceSearchMode(
 function getLengthScore(searchTerm: string, matchedValue: string): number {
   return Math.floor((searchTerm.length / matchedValue.length) * 100);
 }
+
+export const resourceTypeToReadableName: Record<ResourceTypeFilter, string> = {
+  db: 'databases',
+  node: 'servers',
+  kube_cluster: 'kubes',
+};


### PR DESCRIPTION
In the PR https://github.com/gravitational/teleport/pull/34402 we switched our resource type filters to use Web UI types (`node`, `db`, etc).
Unfortunately, I missed the fact that these types were used directly in the filter function, so now if you type 'serv' in the search bar, no results are shown, because it doesn't match the new type ('node', etc).

The good news is that I merged the bug after the Friday release, but I'd like to get it into v14 and v13 before today's release.