### PR TITLE
Machine ID: Handle Kernel Version check failing more gracefully

### DIFF
--- a/lib/tbot/botfs/botfs_test.go
+++ b/lib/tbot/botfs/botfs_test.go
@@ -29,8 +29,7 @@ import (
 func TestReadWrite(t *testing.T) {
 	dir := t.TempDir()
 
-	secureWriteExpected, err := HasSecureWriteSupport()
-	require.NoError(t, err)
+	secureWriteExpected := HasSecureWriteSupport()
 
 	expectedData := []byte{1, 2, 3, 4}
 

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -422,10 +422,10 @@ func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
 }
 
 // HasACLSupport determines if this binary / system supports ACLs.
-func HasACLSupport() (bool, error) {
+func HasACLSupport() bool {
 	// We just assume Linux _can_ support ACLs here, and will test for support
 	// at runtime.
-	return true, nil
+	return true
 }
 
 // HasSecureWriteSupport determines if `CreateSecure()` should be supported
@@ -434,16 +434,16 @@ func HasACLSupport() (bool, error) {
 //
 // We've encountered this being incorrect in environments where access to the
 // kernel is hampered e.g. seccomp/apparmor/container runtimes.
-func HasSecureWriteSupport() (bool, error) {
+func HasSecureWriteSupport() bool {
 	minKernel := semver.New(Openat2MinKernel)
 	version, err := utils.KernelVersion()
 	if err != nil {
 		log.WithError(err).Info("Failed to determine kernel version. It will be assumed secure write support is not available.")
-		return false, nil
+		return false
 	}
 	if version.LessThan(*minKernel) {
-		return false, nil
+		return false
 	}
 
-	return true, nil
+	return true
 }

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -438,7 +438,8 @@ func HasSecureWriteSupport() (bool, error) {
 	minKernel := semver.New(Openat2MinKernel)
 	version, err := utils.KernelVersion()
 	if err != nil {
-		return false, trace.Wrap(err)
+		log.WithError(err).Info("Failed to determine kernel version. It will be assumed secure write support is not available.")
+		return false, nil
 	}
 	if version.LessThan(*minKernel) {
 		return false, nil

--- a/lib/tbot/botfs/fs_other.go
+++ b/lib/tbot/botfs/fs_other.go
@@ -112,13 +112,13 @@ func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
 
 // HasACLSupport determines if this binary / system supports ACLs. This
 // catch-all implementation just returns false.
-func HasACLSupport() (bool, error) {
-	return false, nil
+func HasACLSupport() bool {
+	return false
 }
 
 // HasSecureWriteSupport determines if `CreateSecure()` should be supported
 // on this OS / kernel version. This is only supported on Linux, so this
 // catch-all implementation just returns false.
-func HasSecureWriteSupport() (bool, error) {
-	return false, nil
+func HasSecureWriteSupport() bool {
+	return false
 }

--- a/tool/tbot/init_test.go
+++ b/tool/tbot/init_test.go
@@ -165,9 +165,6 @@ func TestInitMaybeACLs(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	hasACLSupport, err := botfs.HasACLSupport()
-	require.NoError(t, err)
-
 	currentUser, err := user.Current()
 	require.NoError(t, err)
 
@@ -176,7 +173,7 @@ func TestInitMaybeACLs(t *testing.T) {
 
 	// Determine if we expect init to use ACLs.
 	expectACLs := false
-	if hasACLSupport {
+	if botfs.HasACLSupport() {
 		if err := testACL(t.TempDir(), currentUser, opts); err == nil {
 			expectACLs = true
 		}
@@ -227,9 +224,7 @@ outputs:
 
 // TestInitSymlink tests tbot init with a symlink in the path.
 func TestInitSymlink(t *testing.T) {
-	secureWriteSupported, err := botfs.HasSecureWriteSupport()
-	require.NoError(t, err)
-	if !secureWriteSupported {
+	if !botfs.HasSecureWriteSupport() {
 		t.Skip("Secure write not supported on this system.")
 	}
 


### PR DESCRIPTION
Previously, if this check failed, `tbot` would crash out, e.g:

```
lstat /proc/sys/kernel/osrelease: no such file or directory
```

This occurred in a restricted container environment where much of `/proc/sys` is not available (Spacelift).

It makes more sense to gracefully degrade to not using kernel features we expect from newer versions.

Closes https://github.com/gravitational/teleport/issues/34390

changelog: fix `tbot` crashing when used in environments where the kernel version cannot be queried.