### PR TITLE
[v14] Emit events in CreateAuditStream for v13 clients

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -340,7 +340,8 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 			var errors []error
 			errors = append(errors, eventStream.RecordEvent(stream.Context(), preparedEvent))
 
-			// Emit the event as well for v13 clients.
+			// v13 clients expect this request to also emit the event, so emit here
+			// just for them.
 			switch event.GetType() {
 			// Don't emit really verbose events.
 			case events.ResizeEvent, events.SessionDiskEvent, events.SessionPrintEvent, events.AppSessionRequestEvent, "":


### PR DESCRIPTION
Backport #34667 to branch/v14

Changelog: Fixed auth server not emitting session events for v13 clients