### PR TITLE
[v14] feat: add external label to athena metrics

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -139,6 +139,9 @@ type Config struct {
 	// Tracer is used to create spans
 	Tracer oteltrace.Tracer
 
+	externalAuditStorage bool
+	metrics              *athenaMetrics
+
 	// TODO(tobiaszheller): add FIPS config in later phase.
 }
 
@@ -286,6 +289,16 @@ func (cfg *Config) CheckAndSetDefaults(ctx context.Context) error {
 		cfg.Tracer = tracing.NoopTracer(teleport.ComponentAthena)
 	}
 
+	if cfg.metrics == nil {
+		cfg.metrics, err = newAthenaMetrics(athenaMetricsConfig{
+			batchInterval:        cfg.BatchMaxInterval,
+			externalAuditStorage: cfg.externalAuditStorage,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	return nil
 }
 
@@ -386,6 +399,7 @@ func (cfg *Config) SetFromURL(url *url.URL) error {
 }
 
 func (cfg *Config) UpdateForExternalCloudAudit(ctx context.Context, spec *externalcloudaudit.ExternalCloudAuditSpec, credentialsProvider aws.CredentialsProvider) error {
+	cfg.externalAuditStorage = true
 	cfg.LocationS3 = spec.AuditEventsLongTermURI
 	cfg.Workgroup = spec.AthenaWorkgroup
 	cfg.QueryResultsS3 = spec.AthenaResultsURI
@@ -425,14 +439,6 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// metricConsumerBatchProcessingDuration is defined after checking config, because
-	// its bucket depends on batchMaxInterval.
-	metricConsumerBatchProcessingDuration := metricConsumerBatchProcessingDuration(cfg.BatchMaxInterval)
-
-	if err := metrics.RegisterPrometheusCollectors(append(prometheusCollectors, metricConsumerBatchProcessingDuration)...); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	querier, err := newQuerier(querierConfig{
 		tablename:                    cfg.TableName,
 		database:                     cfg.Database,
@@ -451,7 +457,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 
 	consumerCtx, consumerCancel := context.WithCancel(ctx)
 
-	consumer, err := newConsumer(cfg, consumerCancel, metricConsumerBatchProcessingDuration)
+	consumer, err := newConsumer(cfg, consumerCancel)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -500,90 +506,115 @@ func isValidUrlWithScheme(s string) (string, bool) {
 	return u.Scheme, true
 }
 
-func metricConsumerBatchProcessingDuration(batchInterval time.Duration) prometheus.Histogram {
-	batchSeconds := batchInterval.Seconds()
-	return prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerBatchPorcessingDuration,
-			Help:      "Duration of processing single batch of events in parquetlog",
-			// For 60s batch interval it will look like:
-			// 6.00, 12.00, 30.00, 45.00, 54.00, 59.01, 64.48, 70.47, 77.01, 84.15, 91.96, 100.49, 109.81, 120.00
-			// We want some visibility if batch takes very small amount of time, but we are mostly interested
-			// in range from 0.9*batch to 2*batch.
-			Buckets: append([]float64{0.1 * batchSeconds, 0.2 * batchSeconds, 0.5 * batchSeconds, 0.75 * batchSeconds}, prometheus.ExponentialBucketsRange(0.9*batchSeconds, 2*batchSeconds, 10)...),
-		},
-	)
+type athenaMetricsConfig struct {
+	batchInterval        time.Duration
+	externalAuditStorage bool
 }
 
-var (
-	consumerS3parquetFlushDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerS3FlushDuration,
-			Help:      "Duration of flush and close of s3 parquet files in parquetlog",
-			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
-			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
-		},
-	)
+type athenaMetrics struct {
+	consumerBatchProcessingDuration      prometheus.Histogram
+	consumerS3parquetFlushDuration       prometheus.Histogram
+	consumerDeleteMessageDuration        prometheus.Histogram
+	consumerBatchSize                    prometheus.Histogram
+	consumerBatchCount                   prometheus.Counter
+	consumerLastProcessedTimestamp       prometheus.Gauge
+	consumerAgeOfOldestProcessedMessage  prometheus.Gauge
+	consumerNumberOfErrorsFromSQSCollect prometheus.Counter
+}
 
-	consumerDeleteMessageDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerDeleteEventsDuration,
-			Help:      "Duration of delation of events on SQS in parquetlog",
-			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
-			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
-		},
-	)
-
-	consumerBatchSize = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerBatchSize,
-			Help:      "Size of single batch of events in parquetlog",
-			Buckets:   prometheus.ExponentialBucketsRange(200, 100*1024*1024 /* 100 MB*/, 10),
-		},
-	)
-
-	consumerBatchCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerBatchCount,
-			Help:      "Number of events in single batch in parquetlog",
-		},
-	)
-
-	consumerLastProcessedTimestamp = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerLastProcessedTimestamp,
-			Help:      "Timestamp of last finished consumer execution",
-		},
-	)
-
-	consumerAgeOfOldestProcessedMessage = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerOldestProcessedMessage,
-			Help:      "Age of oldest processed message in seconds",
-		},
-	)
-
-	consumerNumberOfErrorsFromSQSCollect = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: teleport.MetricNamespace,
-			Name:      teleport.MetricParquetlogConsumerCollectFailed,
-			Help:      "Number of errors received from sqs collect",
-		},
-	)
-
-	prometheusCollectors = []prometheus.Collector{
-		consumerS3parquetFlushDuration, consumerDeleteMessageDuration,
-		consumerBatchSize, consumerBatchCount,
-		consumerLastProcessedTimestamp, consumerAgeOfOldestProcessedMessage,
-		consumerNumberOfErrorsFromSQSCollect,
+func newAthenaMetrics(cfg athenaMetricsConfig) (*athenaMetrics, error) {
+	constLabels := prometheus.Labels{
+		"external": strconv.FormatBool(cfg.externalAuditStorage),
 	}
-)
+	batchSeconds := cfg.batchInterval.Seconds()
+
+	m := &athenaMetrics{
+		consumerBatchProcessingDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: teleport.MetricNamespace,
+				Name:      teleport.MetricParquetlogConsumerBatchPorcessingDuration,
+				Help:      "Duration of processing single batch of events in parquetlog",
+				// For 60s batch interval it will look like:
+				// 6.00, 12.00, 30.00, 45.00, 54.00, 59.01, 64.48, 70.47, 77.01, 84.15, 91.96, 100.49, 109.81, 120.00
+				// We want some visibility if batch takes very small amount of time, but we are mostly interested
+				// in range from 0.9*batch to 2*batch.
+				Buckets:     append([]float64{0.1 * batchSeconds, 0.2 * batchSeconds, 0.5 * batchSeconds, 0.75 * batchSeconds}, prometheus.ExponentialBucketsRange(0.9*batchSeconds, 2*batchSeconds, 10)...),
+				ConstLabels: constLabels,
+			},
+		),
+		consumerS3parquetFlushDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: teleport.MetricNamespace,
+				Name:      teleport.MetricParquetlogConsumerS3FlushDuration,
+				Help:      "Duration of flush and close of s3 parquet files in parquetlog",
+				// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
+				// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
+				Buckets:     prometheus.ExponentialBuckets(0.001, 2, 16),
+				ConstLabels: constLabels,
+			},
+		),
+		consumerDeleteMessageDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: teleport.MetricNamespace,
+				Name:      teleport.MetricParquetlogConsumerDeleteEventsDuration,
+				Help:      "Duration of delation of events on SQS in parquetlog",
+				// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
+				// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
+				Buckets:     prometheus.ExponentialBuckets(0.001, 2, 16),
+				ConstLabels: constLabels,
+			},
+		),
+		consumerBatchSize: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace:   teleport.MetricNamespace,
+				Name:        teleport.MetricParquetlogConsumerBatchSize,
+				Help:        "Size of single batch of events in parquetlog",
+				Buckets:     prometheus.ExponentialBucketsRange(200, 100*1024*1024 /* 100 MB*/, 10),
+				ConstLabels: constLabels,
+			},
+		),
+		consumerBatchCount: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace:   teleport.MetricNamespace,
+				Name:        teleport.MetricParquetlogConsumerBatchCount,
+				Help:        "Number of events in single batch in parquetlog",
+				ConstLabels: constLabels,
+			},
+		),
+		consumerLastProcessedTimestamp: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   teleport.MetricNamespace,
+				Name:        teleport.MetricParquetlogConsumerLastProcessedTimestamp,
+				Help:        "Timestamp of last finished consumer execution",
+				ConstLabels: constLabels,
+			},
+		),
+		consumerAgeOfOldestProcessedMessage: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   teleport.MetricNamespace,
+				Name:        teleport.MetricParquetlogConsumerOldestProcessedMessage,
+				Help:        "Age of oldest processed message in seconds",
+				ConstLabels: constLabels,
+			},
+		),
+		consumerNumberOfErrorsFromSQSCollect: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace:   teleport.MetricNamespace,
+				Name:        teleport.MetricParquetlogConsumerCollectFailed,
+				Help:        "Number of errors received from sqs collect",
+				ConstLabels: constLabels,
+			},
+		),
+	}
+
+	return m, trace.Wrap(metrics.RegisterPrometheusCollectors(
+		m.consumerBatchProcessingDuration,
+		m.consumerS3parquetFlushDuration,
+		m.consumerDeleteMessageDuration,
+		m.consumerBatchSize,
+		m.consumerBatchCount,
+		m.consumerLastProcessedTimestamp,
+		m.consumerAgeOfOldestProcessedMessage,
+		m.consumerNumberOfErrorsFromSQSCollect,
+	))
+}

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -158,6 +158,7 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 		QueueURL:                   "https://queue-url",
 		PublisherConsumerAWSConfig: dummyAWSCfg,
 		Backend:                    mockBackend{},
+		metrics:                    &athenaMetrics{},
 	}
 	tests := []struct {
 		name    string
@@ -305,7 +306,7 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 			err := cfg.CheckAndSetDefaults(context.Background())
 			if tt.wantErr == "" {
 				require.NoError(t, err, "CheckAndSetDefaults return unexpected err")
-				require.Empty(t, cmp.Diff(tt.want, cfg, cmpopts.EquateApprox(0, 0.0001), cmpopts.IgnoreFields(Config{}, "Clock", "UIDGenerator", "LogEntry", "Tracer"), cmp.AllowUnexported(Config{})))
+				require.Empty(t, cmp.Diff(tt.want, cfg, cmpopts.EquateApprox(0, 0.0001), cmpopts.IgnoreFields(Config{}, "Clock", "UIDGenerator", "LogEntry", "Tracer", "metrics"), cmp.AllowUnexported(Config{})))
 			} else {
 				require.ErrorContains(t, err, tt.wantErr)
 			}

--- a/lib/events/athena/consumer.go
+++ b/lib/events/athena/consumer.go
@@ -32,7 +32,6 @@ import (
 	sqsTypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/segmentio/parquet-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
@@ -103,20 +102,20 @@ type s3downloader interface {
 	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (n int64, err error)
 }
 
-func newConsumer(cfg Config, cancelFn context.CancelFunc, metricConsumerBatchProcessingDuration prometheus.Histogram) (*consumer, error) {
+func newConsumer(cfg Config, cancelFn context.CancelFunc) (*consumer, error) {
 	sqsClient := sqs.NewFromConfig(*cfg.PublisherConsumerAWSConfig)
 
 	collectCfg := sqsCollectConfig{
 		sqsReceiver: sqsClient,
 		queueURL:    cfg.QueueURL,
 		// TODO(nklaassen): use s3 manager from teleport observability.
-		payloadDownloader:                     manager.NewDownloader(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig)),
-		payloadBucket:                         cfg.largeEventsBucket,
-		visibilityTimeout:                     int32(cfg.BatchMaxInterval.Seconds()),
-		batchMaxItems:                         cfg.BatchMaxItems,
-		errHandlingFn:                         errHandlingFnFromSQS(cfg.LogEntry),
-		logger:                                cfg.LogEntry,
-		metricConsumerBatchProcessingDuration: metricConsumerBatchProcessingDuration,
+		payloadDownloader: manager.NewDownloader(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig)),
+		payloadBucket:     cfg.largeEventsBucket,
+		visibilityTimeout: int32(cfg.BatchMaxInterval.Seconds()),
+		batchMaxItems:     cfg.BatchMaxItems,
+		errHandlingFn:     errHandlingFnFromSQS(&cfg),
+		logger:            cfg.LogEntry,
+		metrics:           cfg.metrics,
 	}
 	err := collectCfg.CheckAndSetDefaults()
 	if err != nil {
@@ -292,8 +291,8 @@ func (c *consumer) processBatchOfEvents(ctx context.Context) (reachedMaxSize boo
 	start := time.Now()
 	var size int
 	defer func() {
-		consumerLastProcessedTimestamp.SetToCurrentTime()
-		c.collectConfig.metricConsumerBatchProcessingDuration.Observe(time.Since(start).Seconds())
+		c.collectConfig.metrics.consumerLastProcessedTimestamp.SetToCurrentTime()
+		c.collectConfig.metrics.consumerBatchProcessingDuration.Observe(time.Since(start).Seconds())
 	}()
 
 	msgsCollector := newSqsMessagesCollector(c.collectConfig)
@@ -343,7 +342,7 @@ type sqsCollectConfig struct {
 	logger        log.FieldLogger
 	errHandlingFn func(ctx context.Context, errC chan error)
 
-	metricConsumerBatchProcessingDuration prometheus.Histogram
+	metrics *athenaMetrics
 }
 
 func (cfg *sqsCollectConfig) CheckAndSetDefaults() error {
@@ -388,8 +387,8 @@ func (cfg *sqsCollectConfig) CheckAndSetDefaults() error {
 	if cfg.errHandlingFn == nil {
 		return trace.BadParameter("errHandlingFn is not specified")
 	}
-	if cfg.metricConsumerBatchProcessingDuration == nil {
-		return trace.BadParameter("metricConsumerBatchProcessingDuration is not specified")
+	if cfg.metrics == nil {
+		return trace.BadParameter("metrics is not specified")
 	}
 	return nil
 }
@@ -479,12 +478,12 @@ func (s *sqsMessagesCollector) fromSQS(ctx context.Context) {
 	wg.Wait()
 	close(eventsC)
 	if fullBatchMetadata.Count > 0 {
-		consumerBatchCount.Add(float64(fullBatchMetadata.Count))
-		consumerBatchSize.Observe(float64(fullBatchMetadata.Size))
-		consumerAgeOfOldestProcessedMessage.Set(time.Since(fullBatchMetadata.OldestTimestamp).Seconds())
+		s.cfg.metrics.consumerBatchCount.Add(float64(fullBatchMetadata.Count))
+		s.cfg.metrics.consumerBatchSize.Observe(float64(fullBatchMetadata.Size))
+		s.cfg.metrics.consumerAgeOfOldestProcessedMessage.Set(time.Since(fullBatchMetadata.OldestTimestamp).Seconds())
 	} else {
 		// When no messages were processed, clear gauge metric.
-		consumerAgeOfOldestProcessedMessage.Set(0)
+		s.cfg.metrics.consumerAgeOfOldestProcessedMessage.Set(0)
 	}
 }
 
@@ -664,15 +663,15 @@ type eventAndAckID struct {
 	receiptHandle string
 }
 
-func errHandlingFnFromSQS(logger log.FieldLogger) func(ctx context.Context, errC chan error) {
+func errHandlingFnFromSQS(cfg *Config) func(ctx context.Context, errC chan error) {
 	return func(ctx context.Context, errC chan error) {
 		var errorsCount int
 
 		defer func() {
 			if errorsCount > maxErrorCountForLogsOnSQSReceive {
-				logger.Errorf("Got %d errors from SQS collector, printed only first %d", errorsCount, maxErrorCountForLogsOnSQSReceive)
+				cfg.LogEntry.Errorf("Got %d errors from SQS collector, printed only first %d", errorsCount, maxErrorCountForLogsOnSQSReceive)
 			}
-			consumerNumberOfErrorsFromSQSCollect.Add(float64(errorsCount))
+			cfg.metrics.consumerNumberOfErrorsFromSQSCollect.Add(float64(errorsCount))
 		}()
 
 		for {
@@ -686,7 +685,7 @@ func errHandlingFnFromSQS(logger log.FieldLogger) func(ctx context.Context, errC
 				}
 				errorsCount++
 				if errorsCount <= maxErrorCountForLogsOnSQSReceive {
-					logger.WithError(err).Error("Failure processing SQS messages")
+					cfg.LogEntry.WithError(err).Error("Failure processing SQS messages")
 				}
 			}
 		}
@@ -789,7 +788,7 @@ eventLoop:
 	}
 	eventLoopFinishedTime := time.Now()
 	defer func() {
-		consumerS3parquetFlushDuration.Observe(time.Since(eventLoopFinishedTime).Seconds())
+		c.collectConfig.metrics.consumerS3parquetFlushDuration.Observe(time.Since(eventLoopFinishedTime).Seconds())
 	}()
 	for _, pw := range perDateWriter {
 		if err := pw.Close(); err != nil {
@@ -834,7 +833,7 @@ func (c *consumer) deleteMessagesFromQueue(ctx context.Context, handles []string
 	}
 	start := time.Now()
 	defer func() {
-		consumerDeleteMessageDuration.Observe(time.Since(start).Seconds())
+		c.collectConfig.metrics.consumerDeleteMessageDuration.Observe(time.Since(start).Seconds())
 	}()
 	const (
 		// maxDeleteBatchSize defines maximum number of handles passed to deleteMessage endpoint, limited by AWS.


### PR DESCRIPTION
Backport #34731 to branch/v14

This commit adds an `external: true` or `external: false` label to all Prometheus metrics published by the athena audit log, indicating whether External Audit Storage is used.
This will make is easier to filter metrics by usage of the feature, and directly measure usage of the feature.