### PR TITLE
Fix missing MFA prompt hint

### DIFF
--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -48,6 +48,10 @@ func NewCLIPrompt(cfg *PromptConfig, writer io.Writer) *CLIPrompt {
 
 // Run prompts the user to complete an MFA authentication challenge.
 func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if c.cfg.PromptReason != "" {
+		fmt.Fprintln(c.writer, c.cfg.PromptReason)
+	}
+
 	var wg sync.WaitGroup
 	runOpts, err := c.cfg.getRunOptions(ctx, chal)
 	if err != nil {


### PR DESCRIPTION
I mistakenly removed the MFA prompt hint logic in https://github.com/gravitational/teleport/pull/34087, which has only hit master.