### PR TITLE
[v13] Fill `tsh kubectl version` with the correct version details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ RELEASE_DIR := $(CURDIR)/$(BUILDDIR)/artifacts
 ifeq ("$(TELEPORT_DEBUG)","true")
 BUILDFLAGS ?= $(ADDFLAGS) -gcflags=all="-N -l"
 else
-BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s' -trimpath
+BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath
 endif
 
 GO_ENV_OS := $(shell go env GOOS)
@@ -251,7 +251,7 @@ CC=arm-linux-gnueabihf-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s -debugtramp=2' -trimpath
+BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s -debugtramp=2 $(KUBECTL_SETVERSION)' -trimpath
 endif
 endif # OS == linux
 
@@ -262,7 +262,7 @@ ifneq ("$(ARCH)","amd64")
 $(error "Building for windows requires ARCH=amd64")
 endif
 CGOFLAG = CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s' -trimpath -buildmode=exe
+BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath -buildmode=exe
 endif
 
 CGOFLAG_TSH ?= $(CGOFLAG)
@@ -304,6 +304,8 @@ $(BUILDDIR)/teleport: ensure-webassets bpf-bytecode rdpclient
 # NOTE: Any changes to the `tsh` build here must be copied to `windows.go` in Dronegen until
 # 		we can use this Makefile for native Windows builds.
 .PHONY: $(BUILDDIR)/tsh
+$(BUILDDIR)/tsh: KUBECTL_VERSION ?= $(shell go run ./build.assets/kubectl-version/main.go)
+$(BUILDDIR)/tsh: KUBECTL_SETVERSION ?= -X k8s.io/component-base/version.gitVersion=$(KUBECTL_VERSION)
 $(BUILDDIR)/tsh:
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
 

--- a/build.assets/kubectl-version/main.go
+++ b/build.assets/kubectl-version/main.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command version-check that outputs the version of kubectl used by the build.
+// It doesn't live in the build.assets/tooling/ directory because it needs to
+// be built with the go.mod file from the teleport root directory.
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	// Import the kubectl module to get the version
+	// This is a hack to get the version of kubectl
+	// without having to parse the go.mod file.
+	_ "k8s.io/kubectl"
+)
+
+func main() {
+	version, ok := getKubectlModVersion()
+	if !ok {
+		fmt.Println("kubectl version not found")
+		os.Exit(1)
+	}
+	fmt.Println(version)
+}
+
+// getKubectlModVersion returns the version of the kubectl module
+// and replaces the v0 prefix with v1.
+// This is a hack to get the version of kubectl
+// without having to parse the go.mod file.
+func getKubectlModVersion() (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == "k8s.io/kubectl" {
+			return strings.Replace(dep.Version, "v0.", "v1.", 1), true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Backport #32913 to branch/v13

Changelog: Override the version of tsh kubectl with the upstream kubectl version used.