### PR TITLE
Request resource refresh after removing the Connect My Computer agent

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
@@ -28,6 +28,7 @@ import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspace
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { AgentProcessState } from 'teleterm/mainProcess/types';
 import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 import {
   AgentCompatibilityError,
@@ -270,9 +271,11 @@ function ShowState(props: {
   return (
     <MockAppContextProvider appContext={appContext}>
       <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-        <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
-          <Status />
-        </ConnectMyComputerContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
+            <Status />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
       </MockWorkspaceContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -20,7 +20,7 @@ import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspace
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
-
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { AgentProcessState } from 'teleterm/mainProcess/types';
 
 import { NavigationMenu } from './NavigationMenu';
@@ -193,9 +193,11 @@ function ShowState({
   return (
     <MockAppContextProvider appContext={appContext}>
       <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
-        <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
-          <NavigationMenu />
-        </ConnectMyComputerContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={cluster.uri}>
+            <NavigationMenu />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
       </MockWorkspaceContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -38,6 +38,7 @@ import {
   isAccessDeniedError,
   isNotFoundError,
 } from 'teleterm/services/tshd/errors';
+import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 import { assertUnreachable, retryWithRelogin } from '../utils';
 
@@ -123,6 +124,7 @@ export const ConnectMyComputerContextProvider: FC<{
     workspacesService,
     usageService,
   } = ctx;
+  const { requestResourcesRefresh } = useResourcesContext();
   clustersService.useState();
 
   const [
@@ -301,6 +303,7 @@ export const ConnectMyComputerContextProvider: FC<{
             rootClusterUri
           )
         );
+        requestResourcesRefresh();
       } catch (e) {
         if (isAccessDeniedError(e)) {
           hasAccessDeniedError = true;
@@ -343,6 +346,7 @@ export const ConnectMyComputerContextProvider: FC<{
       markAgentAsNotConfigured,
       removeConnections,
       rootClusterUri,
+      requestResourcesRefresh,
     ])
   );
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -301,13 +301,13 @@ function renderState({
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ConnectMyComputerContextProvider rootClusterUri={rootClusterUri}>
-          <ResourcesContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={rootClusterUri}>
             <Wrapper>
               <DocumentCluster visible={true} doc={doc} />
             </Wrapper>
-          </ResourcesContextProvider>
-        </ConnectMyComputerContextProvider>
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
       </MockWorkspaceContextProvider>
     </AppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -85,6 +85,7 @@ export function DocumentsRenderer(props: {
           key={workspace.rootClusterUri}
         >
           <WorkspaceContextProvider value={workspace}>
+            {/* ConnectMyComputerContext depends on ResourcesContext. */}
             <ResourcesContextProvider>
               <ConnectMyComputerContextProvider
                 rootClusterUri={workspace.rootClusterUri}


### PR DESCRIPTION
During the setup of Connect My Computer, Connect adds a new node to the cluster. However, if you already had a tab with a list of resources open, this would mean that it now shows stale data – it does not include the new node. To fix this problem, we added resources context with two functions. Connect My Computer calls `requestResourcesRefresh` after a successful setup and the component with a list of resources adds a listener with `onResourcesRefreshRequest` and refreshes the list of resources when needed.

However, Connect My Computer allows you to also remove the agent. This action attempts to call `DeleteNode` on the auth server. In this scenario, we wouldn't refresh the list of resources which is what this PR fixes. Now if you delete the agent, any open tab with a list of resources will be refreshed and will no longer include the Connect My Computer node.