### PR TITLE
[v14] Add default database support for PostgreSQL Auto-user provisioning

### DIFF
--- a/docs/pages/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/postgres.mdx
@@ -59,7 +59,11 @@ to ensure that your configuration is correct.
 Users created by Teleport will be placed in the `teleport-auto-user` group in
 the database, which will be created automatically if it doesn't exist.
 
-(!docs/pages/includes/database-access/auto-user-provisioning/db-definition.mdx protocol="postgres" uri="localhost:5432" !)
+(!docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx protocol="postgres" uri="localhost:5432" default="the same database that the user is accessing" !)
+
+<Admonition type="warning" title="Procedure Privileges in PostgreSQL 15+">
+(!docs/pages/includes/database-access/auto-user-provisioning/postgres15-grant-create.mdx!)
+</Admonition>
 
 ## Step 2/3. Configure Teleport role
 
@@ -79,6 +83,12 @@ Users created within the database will:
 ## Step 3/3. Connect to the database
 
 (!docs/pages/includes/database-access/auto-user-provisioning/connect.mdx gui="pgAdmin"!)
+
+## Troubleshooting
+
+### Permission denied for schema public error
+
+(!docs/pages/includes/database-access/auto-user-provisioning/postgres15-grant-create.mdx!)
 
 ## Next steps
 

--- a/docs/pages/includes/config-reference/database-config.yaml
+++ b/docs/pages/includes/config-reference/database-config.yaml
@@ -96,6 +96,14 @@ db_service:
       # When this option is set the Database Agent doesn't try to check the MySQL server version.
       server_version: 8.0.28
 
+    # Optional admin user configuration for Automatic User Provisioning.
+    admin_user:
+      # Name of the admin user.
+      name: "teleport-admin"
+      #  Optional default database the admin user logs into. See individual
+      #  guides for default value.
+      default_database: "teleport"
+
     # Optional AWS configuration for AWS hosted databases. AWS region- and
     # service-specific configurations can usually be auto-detected from the
     # endpoint.

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
@@ -1,3 +1,4 @@
+{{ default="'teleport'" }}
 Next, enable the database admin on the Teleport database configuration:
 
 <Tabs>
@@ -12,7 +13,7 @@ db_service:
     admin_user:
       name: "teleport-admin"
       # Optional default database the admin user logs into. Default is
-      # "teleport" if not specified.
+      # {{ default }}, if not specified.
       # default_database: teleport
 ```
 </TabItem>
@@ -28,7 +29,7 @@ spec:
   admin_user:
     name: "teleport-admin"
     # Optional default database the admin user logs into. Default is
-    # "teleport" if not specified.
+    # {{ default }}, if not specified.
     # default_database: teleport
 ```
 </TabItem>

--- a/docs/pages/includes/database-access/auto-user-provisioning/postgres15-grant-create.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/postgres15-grant-create.mdx
@@ -1,0 +1,11 @@
+PostgreSQL 15 revokes the `CREATE` permission from all users except a database
+owner from the public (or default) schema.
+
+Grant the admin user `CREATE` privilege so the admin user can create procedures:
+```sql
+GRANT CREATE ON SCHEMA public TO "teleport-admin";
+```
+
+If `admin_user.default_database` is specified, the `CREATE` privilege is only
+required for the database specified in the `default_database`. Otherwise, you
+have to repeat the privilege grant for every database Teleport will access.

--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -30,13 +30,24 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
 
+func (e *Engine) connectAsAdmin(ctx context.Context, sessionCtx *common.Session) (*pgx.Conn, error) {
+	// Log into GetAdminUser().DefaultDatabase if specified, otherwise use
+	// database name from db route.
+	loginDatabase := sessionCtx.DatabaseName
+	if sessionCtx.Database.GetAdminUser().DefaultDatabase != "" {
+		loginDatabase = sessionCtx.Database.GetAdminUser().DefaultDatabase
+	}
+	conn, err := e.pgxConnect(ctx, sessionCtx.WithUserAndDatabase(sessionCtx.Database.GetAdminUser().Name, loginDatabase))
+	return conn, trace.Wrap(err)
+}
+
 // ActivateUser creates or enables the database user.
 func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) error {
 	if sessionCtx.Database.GetAdminUser().Name == "" {
 		return trace.BadParameter("Teleport does not have admin user configured for this database")
 	}
 
-	conn, err := e.pgxConnect(ctx, sessionCtx.WithUser(sessionCtx.Database.GetAdminUser().Name))
+	conn, err := e.connectAsAdmin(ctx, sessionCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -72,7 +83,7 @@ func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session)
 		return trace.BadParameter("Teleport does not have admin user configured for this database")
 	}
 
-	conn, err := e.pgxConnect(ctx, sessionCtx.WithUser(sessionCtx.Database.GetAdminUser().Name))
+	conn, err := e.connectAsAdmin(ctx, sessionCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -100,7 +111,7 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 		return trace.BadParameter("Teleport does not have admin user configured for this database")
 	}
 
-	conn, err := e.pgxConnect(ctx, sessionCtx.WithUser(sessionCtx.Database.GetAdminUser().Name))
+	conn, err := e.connectAsAdmin(ctx, sessionCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #34420 to branch/v14

changelog: Added default database support for PostgreSQL Auto-user provisioning