### PR TITLE
Remove read/write timeouts to unbreak app access

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4068,9 +4068,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 					limiter.MakeMiddleware(proxyLimiter),
 					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
 				),
-				ReadTimeout:       apidefaults.DefaultIOTimeout,
+				// Note: read/write timeouts *should not* be set here because it
+				// will break some application access use-cases.
 				ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-				WriteTimeout:      apidefaults.DefaultIOTimeout,
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1051,10 +1051,10 @@ func (s *Server) newHTTPServer(clusterName string) *http.Server {
 	s.authMiddleware.Wrap(s)
 
 	return &http.Server{
+		// Note: read/write timeouts *should not* be set here because it will
+		// break application access.
 		Handler:           httplib.MakeTracingHandler(s.authMiddleware, teleport.ComponentApp),
-		ReadTimeout:       apidefaults.DefaultIOTimeout,
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-		WriteTimeout:      apidefaults.DefaultIOTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/30248 broke application access scenarios with long-running requests. In our internal usage it affected our release publishing pipelines where publishing assets to a release server was timing out after 30 seconds. And customers have started to experiencing [similar issues](https://github.com/gravitational/customer-sensitive-requests/issues/160).

This PR removes read/write timeouts in places that affect application access requests. In addition to local testing, the fix was confirmed by upgrading app agent that serves release server to a dev version with this change and running a successful release.

Changelog: Fixed issue with application access requests and web UI large file downloads timing out after 30 seconds.