### PR TITLE
Remove agent binary before retrying Connect My Computer setup

### DIFF
--- a/web/packages/teleterm/src/mainProcess/agentDownloader/agentDownloader.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentDownloader/agentDownloader.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment node
+ */
+/**
  * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/packages/teleterm/src/mainProcess/agentDownloader/fileDownloader.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentDownloader/fileDownloader.test.ts
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment jsdom
+ */
+/**
  * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 /*
 Copyright 2023 Gravitational, Inc.
 

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.test.ts
@@ -99,7 +99,8 @@ test('previous config file is removed before calling teleport configure', async 
   ).resolves.toBeUndefined();
 
   expect(fs.rm).toHaveBeenCalledWith(
-    `${userDataDir}/agents/cluster.local/config.yaml`
+    `${userDataDir}/agents/cluster.local/config.yaml`,
+    { force: true }
   );
 });
 

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -42,13 +42,7 @@ export async function createAgentConfigFile(
   );
 
   // remove the config file if exists
-  try {
-    await fs.rm(configFile);
-  } catch (e) {
-    if (e.code !== 'ENOENT') {
-      throw e;
-    }
-  }
+  await fs.rm(configFile, { force: true });
 
   const labels = Object.entries({
     [constants.ConnectMyComputerNodeOwnerLabel]: args.username,

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -16,7 +16,7 @@
 
 import { promisify } from 'node:util';
 import { execFile } from 'node:child_process';
-import { access, rm } from 'node:fs/promises';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import * as constants from 'shared/constants';
@@ -43,7 +43,7 @@ export async function createAgentConfigFile(
 
   // remove the config file if exists
   try {
-    await rm(configFile);
+    await fs.rm(configFile);
   } catch (e) {
     if (e.code !== 'ENOENT') {
       throw e;
@@ -82,7 +82,7 @@ export async function removeAgentDirectory(
     rootClusterUri
   );
   // `force` ignores exceptions if path does not exist
-  await rm(agentDirectory, { recursive: true, force: true });
+  await fs.rm(agentDirectory, { recursive: true, force: true });
 }
 
 export async function isAgentConfigFileCreated(
@@ -94,7 +94,7 @@ export async function isAgentConfigFileCreated(
     rootClusterUri
   );
   try {
-    await access(configFile);
+    await fs.access(configFile);
     return true;
   } catch (e) {
     if (e.code === 'ENOENT') {

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -124,9 +124,9 @@ export class MockMainProcessClient implements MainProcessClient {
     return '';
   }
 
-  removeAgentDirectory() {
-    return Promise.resolve();
-  }
+  async removeAgentDirectory() {}
+
+  async tryRemoveConnectMyComputerAgentBinary() {}
 
   signalUserInterfaceReadiness() {}
 }

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -354,6 +354,10 @@ export default class MainProcess {
       ) => removeAgentDirectory(this.settings, args.rootClusterUri)
     );
 
+    ipcMain.handle(MainProcessIpc.TryRemoveConnectMyComputerAgentBinary, () =>
+      this.agentRunner.tryRemoveAgentBinary()
+    );
+
     ipcMain.handle(
       'main-process-connect-my-computer-run-agent',
       async (

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -146,6 +146,11 @@ export default function createMainProcessClient(): MainProcessClient {
         args
       );
     },
+    tryRemoveConnectMyComputerAgentBinary() {
+      return ipcRenderer.invoke(
+        MainProcessIpc.TryRemoveConnectMyComputerAgentBinary
+      );
+    },
     openAgentLogsDirectory(args: { rootClusterUri: RootClusterUri }) {
       return ipcRenderer.invoke('main-process-open-agent-logs-directory', args);
     },

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -144,6 +144,13 @@ export type MainProcessClient = {
   }): Promise<boolean>;
   killAgent(args: { rootClusterUri: RootClusterUri }): Promise<void>;
   removeAgentDirectory(args: { rootClusterUri: RootClusterUri }): Promise<void>;
+  /**
+   * tryRemoveConnectMyComputerAgentBinary removes the agent binary but only if all agents are
+   * stopped.
+   *
+   * Rejects on filesystem errors.
+   */
+  tryRemoveConnectMyComputerAgentBinary(): Promise<void>;
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
   signalUserInterfaceReadiness(args: { success: boolean }): void;
@@ -257,6 +264,7 @@ export enum RendererIpc {
 
 export enum MainProcessIpc {
   GetRuntimeSettings = 'main-process-get-runtime-settings',
+  TryRemoveConnectMyComputerAgentBinary = 'main-process-try-remove-connect-my-computer-agent-binary',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -367,7 +367,7 @@ function AgentSetup() {
     },
   ];
 
-  const runSteps = useCallback(async () => {
+  const runSteps = async () => {
     function withEventOnFailure(
       fn: () => Promise<[void, Error]>,
       failedStep: string
@@ -415,19 +415,7 @@ function AgentSetup() {
     // to notice that all four steps have completed.
     await wait(750);
     markAgentAsConfigured();
-  }, [
-    setCreateRoleAttempt,
-    setDownloadAgentAttempt,
-    setGenerateConfigFileAttempt,
-    setJoinClusterAttempt,
-    runCreateRoleAttempt,
-    runDownloadAgentAttempt,
-    runGenerateConfigFileAttempt,
-    runJoinClusterAttempt,
-    markAgentAsConfigured,
-    ctx.usageService,
-    rootCluster.uri,
-  ]);
+  };
 
   useEffect(() => {
     if (
@@ -440,13 +428,7 @@ function AgentSetup() {
     ) {
       runSteps();
     }
-  }, [
-    downloadAgentAttempt,
-    generateConfigFileAttempt,
-    joinClusterAttempt,
-    createRoleAttempt,
-    runSteps,
-  ]);
+  }, []);
 
   const hasSetupFailed = steps.some(s => s.attempt.status === 'error');
   const { clusterName, hostname } = useAgentProperties();

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -212,6 +212,7 @@ function AccessError(props: { access: ConnectMyComputerAccessNoAccess }) {
 function AgentSetup() {
   const logger = useLogger('AgentSetup');
   const ctx = useAppContext();
+  const { mainProcessClient, notificationsService } = ctx;
   const { rootClusterUri } = useWorkspaceContext();
   const {
     startAgent,
@@ -430,6 +431,30 @@ function AgentSetup() {
     }
   }, []);
 
+  const retryRunSteps = async () => {
+    try {
+      // This will remove the binary but only if no other agents are running.
+      //
+      // Removing the binary is useful in situations where the download got corrupted or the OS
+      // decided to ban the binary from being executed for some reason. In those cases,
+      // redownloading the binary might resolve the problem.
+      //
+      // If other agents are running, then we at least know that there's probably no problems with
+      // the binary itself, in which case we can simply ignore the fact that it wasn't removed and
+      // carry on.
+      await mainProcessClient.tryRemoveConnectMyComputerAgentBinary();
+    } catch (error) {
+      const { agentBinaryPath } = mainProcessClient.getRuntimeSettings();
+      notificationsService.notifyError({
+        title: 'Could not remove the agent binary',
+        description: `Please try removing the binary manually to continue. The binary is at ${agentBinaryPath}. The error message was: ${error.message}`,
+      });
+      return;
+    }
+
+    await runSteps();
+  };
+
   const hasSetupFailed = steps.some(s => s.attempt.status === 'error');
   const { clusterName, hostname } = useAgentProperties();
 
@@ -450,7 +475,7 @@ function AgentSetup() {
         }))}
       />
       {hasSetupFailed && (
-        <ButtonPrimary alignSelf="center" onClick={runSteps}>
+        <ButtonPrimary alignSelf="center" onClick={retryRunSteps}>
           Retry
         </ButtonPrimary>
       )}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -134,6 +134,11 @@ export interface DocumentGatewayCliClient extends DocumentBase {
   status: '' | 'connecting' | 'connected' | 'error';
 }
 
+/**
+ * DocumentGatewayKube replaced DocumentTshKube in Connect v14. Before removing DocumentTshKube
+ * completely, we should add a migration that transforms all DocumentTshKube docs into
+ * DocumentGatewayKube docs when loading the workspace state from disk.
+ */
 export interface DocumentGatewayKube extends DocumentBase {
   kind: 'doc.gateway_kube';
   rootClusterId: string;


### PR DESCRIPTION
Closes #34342, this issue also describes the rationale for this change.

During the setup, Connect My Computer downloads the `teleport` binary which it uses to add the device running Connect as an SSH node to the cluster. This PR makes it so that if the setup fails and the user clicks "Retry", we remove the binary. This will result in the binary being downloaded again.

I also included little bits of relevant and less relevant (like the comment about DocumentTshKube) cleanup.