### PR TITLE
[v14] Update "Allowed Users" in `tsh db ls" for databases with auto-user enabled

### DIFF
--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -577,6 +577,7 @@ func ProfileNameFromProxyAddress(store ProfileStore, proxyAddr string) (string, 
 // AccessInfo returns the complete services.AccessInfo for this profile.
 func (p *ProfileStatus) AccessInfo() *services.AccessInfo {
 	return &services.AccessInfo{
+		Username:           p.Username,
 		Roles:              p.Roles,
 		Traits:             p.Traits,
 		AllowedResourceIDs: p.AllowedResourceIDs,

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 func newTestFSProfileStore(t *testing.T) *FSProfileStore {
@@ -109,4 +112,32 @@ func TestProfileNameFromProxyAddress(t *testing.T) {
 		_, err := ProfileNameFromProxyAddress(store, ":443")
 		require.Error(t, err)
 	})
+}
+
+func TestProfileStatusAccessInfo(t *testing.T) {
+	allowedResourceIDs := []types.ResourceID{{
+		ClusterName: "cluster",
+		Kind:        types.KindNode,
+		Name:        "uuid",
+	}}
+	traits := wrappers.Traits{
+		"trait1": {"value1", "value2"},
+		"trait2": {"value3", "value4"},
+	}
+
+	wantAccessInfo := &services.AccessInfo{
+		Username:           "alice",
+		Roles:              []string{"role1", "role2"},
+		Traits:             traits,
+		AllowedResourceIDs: allowedResourceIDs,
+	}
+
+	profileStatus := ProfileStatus{
+		Username:           "alice",
+		Roles:              []string{"role1", "role2"},
+		Traits:             traits,
+		AllowedResourceIDs: allowedResourceIDs,
+	}
+
+	require.Equal(t, wantAccessInfo, profileStatus.AccessInfo())
 }

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -265,7 +265,7 @@ type AccessInfo struct {
 	// access restrictions should be applied. Used for search-based access
 	// requests.
 	AllowedResourceIDs []types.ResourceID
-	// Username is the Telepeort username.
+	// Username is the Teleport username.
 	Username string
 }
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -934,10 +934,6 @@ func ExtractAllowedResourcesFromCert(cert *ssh.Certificate) ([]types.ResourceID,
 	return allowedResources, trace.Wrap(err)
 }
 
-func ExtractUsernameFromCert(cert *ssh.Certificate) (string, error) {
-	return "", nil
-}
-
 // NewRoleSet returns new RoleSet based on the roles
 func NewRoleSet(roles ...types.Role) RoleSet {
 	// unauthenticated Nop role should not have any privileges

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -934,6 +934,10 @@ func ExtractAllowedResourcesFromCert(cert *ssh.Certificate) ([]types.ResourceID,
 	return allowedResources, trace.Wrap(err)
 }
 
+func ExtractUsernameFromCert(cert *ssh.Certificate) (string, error) {
+	return "", nil
+}
+
 // NewRoleSet returns new RoleSet based on the roles
 func NewRoleSet(roles ...types.Role) RoleSet {
 	// unauthenticated Nop role should not have any privileges

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -2082,6 +2082,7 @@ func makeAccessCheckerWithRoleSet(roleSet RoleSet) AccessChecker {
 		roleNames[i] = role.GetName()
 	}
 	accessInfo := &AccessInfo{
+		Username:           "alice",
 		Roles:              roleNames,
 		Traits:             nil,
 		AllowedResourceIDs: nil,
@@ -3912,6 +3913,17 @@ func TestRoleSetEnumerateDatabaseUsersAndNames(t *testing.T) {
 		URI:      "uri",
 	})
 	require.NoError(t, err)
+	dbAutoUser, err := types.NewDatabaseV3(types.Metadata{
+		Name:   "auto-user",
+		Labels: map[string]string{"env": "prod"},
+	}, types.DatabaseSpecV3{
+		Protocol: "postgres",
+		URI:      "localhost:5432",
+		AdminUser: &types.DatabaseAdminUser{
+			Name: "teleport-admin",
+		},
+	})
+	require.NoError(t, err)
 	roleDevStage := &types.RoleV6{
 		Metadata: types.Metadata{Name: "dev-stage", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
@@ -3967,17 +3979,39 @@ func TestRoleSetEnumerateDatabaseUsersAndNames(t *testing.T) {
 		},
 	}
 
+	roleAutoUser := &types.RoleV6{
+		Metadata: types.Metadata{Name: "auto-user", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Options: types.RoleOptions{
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
+			},
+			Allow: types.RoleConditions{
+				Namespaces:     []string{apidefaults.Namespace},
+				DatabaseLabels: types.Labels{"env": []string{"prod"}},
+				DatabaseRoles:  []string{"dev"},
+				DatabaseNames:  []string{"*"},
+				DatabaseUsers:  []string{types.Wildcard},
+			},
+		},
+	}
+
 	testCases := []struct {
-		name       string
-		roles      RoleSet
-		server     types.Database
-		enumResult EnumerationResult
+		name             string
+		roles            RoleSet
+		server           types.Database
+		enumDBUserResult EnumerationResult
+		enumDBNameResult EnumerationResult
 	}{
 		{
 			name:   "deny overrides allow",
 			roles:  RoleSet{roleAllowDenySame},
 			server: dbStage,
-			enumResult: EnumerationResult{
+			enumDBUserResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{"root": false},
+				wildcardAllowed:  false,
+				wildcardDenied:   false,
+			},
+			enumDBNameResult: EnumerationResult{
 				allowedDeniedMap: map[string]bool{"root": false},
 				wildcardAllowed:  false,
 				wildcardDenied:   false,
@@ -3987,7 +4021,12 @@ func TestRoleSetEnumerateDatabaseUsersAndNames(t *testing.T) {
 			name:   "developer allowed any username in stage database except root",
 			roles:  RoleSet{roleDevStage, roleDevProd},
 			server: dbStage,
-			enumResult: EnumerationResult{
+			enumDBUserResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{"dev": true, "root": false},
+				wildcardAllowed:  true,
+				wildcardDenied:   false,
+			},
+			enumDBNameResult: EnumerationResult{
 				allowedDeniedMap: map[string]bool{"dev": true, "root": false},
 				wildcardAllowed:  true,
 				wildcardDenied:   false,
@@ -3997,7 +4036,12 @@ func TestRoleSetEnumerateDatabaseUsersAndNames(t *testing.T) {
 			name:   "developer allowed only specific username/database in prod database",
 			roles:  RoleSet{roleDevStage, roleDevProd},
 			server: dbProd,
-			enumResult: EnumerationResult{
+			enumDBUserResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{"dev": true, "root": false},
+				wildcardAllowed:  false,
+				wildcardDenied:   false,
+			},
+			enumDBNameResult: EnumerationResult{
 				allowedDeniedMap: map[string]bool{"dev": true, "root": false},
 				wildcardAllowed:  false,
 				wildcardDenied:   false,
@@ -4007,20 +4051,41 @@ func TestRoleSetEnumerateDatabaseUsersAndNames(t *testing.T) {
 			name:   "there may be users disallowed from all users",
 			roles:  RoleSet{roleDevStage, roleDevProd, roleNoDBAccess},
 			server: dbProd,
-			enumResult: EnumerationResult{
+			enumDBUserResult: EnumerationResult{
 				allowedDeniedMap: map[string]bool{"dev": false, "root": false},
 				wildcardAllowed:  false,
 				wildcardDenied:   true,
+			},
+			enumDBNameResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{"dev": false, "root": false},
+				wildcardAllowed:  false,
+				wildcardDenied:   true,
+			},
+		},
+		{
+			name:   "auto-user provisioning enabled",
+			roles:  RoleSet{roleAutoUser},
+			server: dbAutoUser,
+			enumDBUserResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{"alice": true},
+				wildcardAllowed:  false,
+				wildcardDenied:   false,
+			},
+			enumDBNameResult: EnumerationResult{
+				allowedDeniedMap: map[string]bool{},
+				wildcardAllowed:  true,
+				wildcardDenied:   false,
 			},
 		},
 	}
 	for _, tc := range testCases {
 		accessChecker := makeAccessCheckerWithRoleSet(tc.roles)
 		t.Run(tc.name, func(t *testing.T) {
-			enumResult := accessChecker.EnumerateDatabaseUsers(tc.server)
-			require.Equal(t, tc.enumResult, enumResult)
+			enumResult, err := accessChecker.EnumerateDatabaseUsers(tc.server)
+			require.NoError(t, err)
+			require.Equal(t, tc.enumDBUserResult, enumResult)
 			enumResult = accessChecker.EnumerateDatabaseNames(tc.server)
-			require.Equal(t, tc.enumResult, enumResult)
+			require.Equal(t, tc.enumDBNameResult, enumResult)
 		})
 	}
 }
@@ -7603,6 +7668,7 @@ func TestNewAccessCheckerForRemoteCluster(t *testing.T) {
 	}
 
 	accessInfo := AccessInfoFromUserState(user)
+	require.Equal(t, "mockCurrentUser", accessInfo.Username)
 	accessChecker, err := NewAccessCheckerForRemoteCluster(context.Background(), accessInfo, "clustername", currentUserRoleGetter)
 	require.NoError(t, err)
 

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -238,7 +238,10 @@ func (c *Cluster) GetAllowedDatabaseUsers(ctx context.Context, dbURI string) ([]
 		return nil, trace.Wrap(err)
 	}
 
-	dbUsers := accessChecker.EnumerateDatabaseUsers(db)
+	dbUsers, err := accessChecker.EnumerateDatabaseUsers(db)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return dbUsers.Allowed(), nil
 }

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -1122,7 +1122,10 @@ func getDefaultDBUser(db types.Database, checker services.AccessChecker) (string
 		// ref: https://redis.io/commands/auth
 		extraUsers = append(extraUsers, defaults.DefaultRedisUsername)
 	}
-	dbUsers := checker.EnumerateDatabaseUsers(db, extraUsers...)
+	dbUsers, err := checker.EnumerateDatabaseUsers(db, extraUsers...)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
 	allowed := dbUsers.Allowed()
 	if len(allowed) == 1 {
 		return allowed[0], nil

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2803,7 +2803,11 @@ type databaseWithUsers struct {
 }
 
 func getDBUsers(db types.Database, accessChecker services.AccessChecker) *dbUsers {
-	users := accessChecker.EnumerateDatabaseUsers(db)
+	users, err := accessChecker.EnumerateDatabaseUsers(db)
+	if err != nil {
+		log.Warnf("Failed to EnumerateDatabaseUsers for database %v: %v.", db.GetName(), err)
+		return &dbUsers{}
+	}
 	var denied []string
 	allowed := users.Allowed()
 	if users.WildcardAllowed() {
@@ -2858,17 +2862,6 @@ func serializeDatabasesAllClusters(dbListings []databaseListing, format string) 
 }
 
 func formatUsersForDB(database types.Database, accessChecker services.AccessChecker) (users string) {
-	// When auto-user provisioning is enabled, only username is allowed. `tsh
-	// db ls` will add a footnote for "(+)" to explain this.
-	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
-		autoUser, _, _ := accessChecker.CheckDatabaseRoles(database)
-		if autoUser.IsEnabled() {
-			defer func() {
-				users = users + " (Auto-provisioned)"
-			}()
-		}
-	}
-
 	// may happen if fetching the role set failed for any reason.
 	if accessChecker == nil {
 		return "(unknown)"
@@ -2877,6 +2870,16 @@ func formatUsersForDB(database types.Database, accessChecker services.AccessChec
 	dbUsers := getDBUsers(database, accessChecker)
 	if len(dbUsers.Allowed) == 0 {
 		return "(none)"
+	}
+
+	// Add a note for auto-provisioned user.
+	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
+		autoUser, _, _ := accessChecker.CheckDatabaseRoles(database)
+		if autoUser.IsEnabled() {
+			defer func() {
+				users = users + " (Auto-provisioned)"
+			}()
+		}
 	}
 
 	if len(dbUsers.Denied) == 0 {
@@ -2953,7 +2956,6 @@ func showDatabasesAsText(w io.Writer, clusterFlag string, databases []types.Data
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn([]string{"Name", "Description", "Allowed Users", "Labels", "Connect"}, rows, "Labels")
 	}
-
 	fmt.Fprintln(w, t.AsBuffer().String())
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2874,8 +2874,10 @@ func formatUsersForDB(database types.Database, accessChecker services.AccessChec
 
 	// Add a note for auto-provisioned user.
 	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
-		autoUser, _, _ := accessChecker.CheckDatabaseRoles(database)
-		if autoUser.IsEnabled() {
+		autoUser, _, err := accessChecker.CheckDatabaseRoles(database)
+		if err != nil {
+			log.Warnf("Failed to CheckDatabaseRoles for database %v: %v.", database.GetName(), err)
+		} else if autoUser.IsEnabled() {
 			defer func() {
 				users = users + " (Auto-provisioned)"
 			}()

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -4442,6 +4442,17 @@ func TestListDatabasesWithUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	dbWithAutoUser, err := types.NewDatabaseV3(types.Metadata{
+		Name: "auto-user",
+	}, types.DatabaseSpecV3{
+		Protocol: "postgres",
+		URI:      "localhost:5432",
+		AdminUser: &types.DatabaseAdminUser{
+			Name: "teleport-admin",
+		},
+	})
+	require.NoError(t, err)
+
 	roleDevStage := &types.RoleV6{
 		Metadata: types.Metadata{Name: "dev-stage", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
@@ -4526,6 +4537,14 @@ func TestListDatabasesWithUsers(t *testing.T) {
 			},
 			wantText: "[dev]",
 		},
+		{
+			name:     "database with automatic user provisioning",
+			database: dbWithAutoUser,
+			wantUsers: &dbUsers{
+				Allowed: []string{"alice"},
+			},
+			wantText: "[alice] (+)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -4533,7 +4552,9 @@ func TestListDatabasesWithUsers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			accessChecker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, "clustername", tt.roles)
+			accessChecker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+				Username: "alice",
+			}, "clustername", tt.roles)
 
 			gotUsers := getDBUsers(tt.database, accessChecker)
 			require.Equal(t, tt.wantUsers, gotUsers)


### PR DESCRIPTION
Backport #34671 to branch/v14

changelog: Fix an issue "Allowed Users" in "tsh db ls" shows wrong user for databases with Automatic User Provisioning enabled