### PR TITLE
[docs] clarify database name override label

### DIFF
--- a/docs/pages/database-access/guides/aws-discovery.mdx
+++ b/docs/pages/database-access/guides/aws-discovery.mdx
@@ -146,7 +146,9 @@ Service's IAM identity as the policy attachment target, and once for each AWS
 IAM role that is used for `assume_role_arn`.
 </Details>
 
-## Step 4/4. Start the Discovery Service
+## Step 4/4. Use the Discovery Service
+
+### Start the Discovery Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Discovery Service"!)
 
@@ -154,10 +156,10 @@ After the Discovery Service starts, database servers matching the tags and
 regions specified in the AWS section are added to the Teleport cluster
 automatically.
 
+### List registered databases
+
 You can list them with the `tctl get db` command or check a specific database
 with `tctl get db/<database-name>`.
-
-<Admonition type="note" title="database names">
 
 The default name of the discovered database includes the AWS resource ID,
 endpoint and matcher types, AWS region and account ID to ensure uniqueness, for
@@ -170,8 +172,6 @@ can be used for `tctl` and `tsh` commands.
 
 You can override the default name by applying the `TeleportDatabaseName` AWS
 tag to the AWS database resource.
-
-</Admonition>
 
 ## Next
 - Learn about [Dynamic Registration](./dynamic-registration.mdx) by the

--- a/docs/pages/database-access/guides/aws-discovery.mdx
+++ b/docs/pages/database-access/guides/aws-discovery.mdx
@@ -157,6 +157,22 @@ automatically.
 You can list them with the `tctl get db` command or check a specific database
 with `tctl get db/<database-name>`.
 
+<Admonition type="note" title="database names">
+
+The default name of the discovered database includes the AWS resource ID,
+endpoint and matcher types, AWS region and account ID to ensure uniqueness, for
+example `my-postgres-rds-aurora-us-east-1-123456789012`.
+
+A discovered database with the default name also has a shorter display name
+that consists only the AWS resource ID and the endpoint type, for example
+`my-postgres`, `my-postgres-reader`. Either the full name or the display name
+can be used for `tctl` and `tsh` commands.
+
+You can override the default name by applying the `TeleportDatabaseName` AWS
+tag to the AWS database resource.
+
+</Admonition>
+
 ## Next
 - Learn about [Dynamic Registration](./dynamic-registration.mdx) by the
   Teleport Database Service.

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -97,10 +97,6 @@ $ tsh db ls
 
 </Tabs>
 
-<Admonition type="note" title="Note">
-  You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
-</Admonition>
-
 To retrieve credentials for a database and connect to it:
 
 ```code

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -394,15 +394,12 @@ $ tsh db ls
 # aurora-mysql-reader            Aurora cluster in us-west-1 (reader endpoint) ...
 ```
 
-<Admonition type="note" title="Note">
+<Admonition type="note" title="Discovered endpoints">
 
   Primary, reader, and custom endpoints of Aurora clusters have names with the
   format
   `<cluster-id>`, `<cluster-id>-reader`, and
   `<cluster-id>-custom-<endpoint-name>` respectively.
-
-  You can override the `<cluster-id>` part of the name with the
-  `TeleportDatabaseName` AWS tag.
 
 </Admonition>
 

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -257,10 +257,6 @@ $ tsh db ls
 
 </Tabs>
 
-<Admonition type="note" title="Note">
-  You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
-</Admonition>
-
 To retrieve credentials for a database and connect to it:
 
 ```code

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -153,13 +153,6 @@ Name        Description                    Labels
 my-redshift Redshift cluster in us-east-1  ...
 ```
 
-<Admonition type="note" title="Note">
-
-You can override the database name by applying the `TeleportDatabaseName`
-AWS tag to the resource. The value of the tag will be used as the database name.
-
-</Admonition>
-
 To connect to the Redshift Serverless instance:
 
 ```code

--- a/docs/pages/database-access/reference/labels.mdx
+++ b/docs/pages/database-access/reference/labels.mdx
@@ -12,7 +12,7 @@ of the following values:
 | - | - |
 | `cloud`   | database resources created by auto-discovery. |
 | `config`  | database resources manually defined in the `database_service.databases` section of `teleport.yaml`. |
-| `dynamic` | database resources created through [dynamic registration](https://goteleport.com/docs/database-access/guides/dynamic-registration/) like `tcl create` command. |
+| `dynamic` | database resources created through [dynamic registration](../guides/dynamic-registration.mdx) like `tcl create` command. |
 
 ## Auto-discovery
 

--- a/docs/pages/database-access/reference/labels.mdx
+++ b/docs/pages/database-access/reference/labels.mdx
@@ -12,13 +12,23 @@ of the following values:
 | - | - |
 | `cloud`   | database resources created by auto-discovery. |
 | `config`  | database resources manually defined in the `database_service.databases` section of `teleport.yaml`. |
-| `dynamic` | database resources created with "tctl create" command or web interface. |
+| `dynamic` | database resources created through [dynamic registration](https://goteleport.com/docs/database-access/guides/dynamic-registration/) like `tcl create` command. |
 
 ## Auto-discovery
 
 The labels of auto-discovered databases primarily come from the tags that are
 assigned to the original cloud resources, such as the resources tags of an
 Amazon RDS instance. 
+
+The following tags will override Teleport's default behavior if assigned to the
+original cloud resources:
+
+| Tag name | Description |
+| - | - |
+| `TeleportDatabaseName`                   | Overrides the name of the discovered database. |
+| `teleport.dev/database_name`             | (AWS only) Overrides the name of the discovered database. |
+| `teleport.dev/db-admin`                  | (AWS only) Specifies the name of the admin user for Automatic User Provisioning. |
+| `teleport.dev/db-admin-default-database` | (AWS only) Overrides the default database the admin user logs into for Automatic User Provisioning. |
 
 Additionally, Teleport will generate certain labels derived from the cloud
 resource attributes:

--- a/docs/pages/database-access/reference/labels.mdx
+++ b/docs/pages/database-access/reference/labels.mdx
@@ -26,7 +26,7 @@ original cloud resources:
 | Tag name | Description |
 | - | - |
 | `TeleportDatabaseName`                   | Overrides the name of the discovered database. |
-| `teleport.dev/database_name`             | (AWS only) Overrides the name of the discovered database. |
+| `teleport.dev/database_name`             | (AWS only, legacy) Overrides the name of the discovered database. `TeleportDatabaseName` is preferred. |
 | `teleport.dev/db-admin`                  | (AWS only) Specifies the name of the admin user for Automatic User Provisioning. |
 | `teleport.dev/db-admin-default-database` | (AWS only) Overrides the default database the admin user logs into for Automatic User Provisioning. |
 


### PR DESCRIPTION
changes:
- Added a section in discovery guide on database naming
- Added a section in database label reference on all "override" labels
- Removed original notes on `TeleportDatabaseName` from AWS guides