### PR TITLE
External Audit Storage: raise cluster alerts for elevated error rates

### DIFF
--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -306,7 +306,7 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 			err := cfg.CheckAndSetDefaults(context.Background())
 			if tt.wantErr == "" {
 				require.NoError(t, err, "CheckAndSetDefaults return unexpected err")
-				require.Empty(t, cmp.Diff(tt.want, cfg, cmpopts.EquateApprox(0, 0.0001), cmpopts.IgnoreFields(Config{}, "Clock", "UIDGenerator", "LogEntry", "Tracer", "metrics"), cmp.AllowUnexported(Config{})))
+				require.Empty(t, cmp.Diff(tt.want, cfg, cmpopts.EquateApprox(0, 0.0001), cmpopts.IgnoreFields(Config{}, "Clock", "UIDGenerator", "LogEntry", "Tracer", "metrics", "ObserveWriteEventsError"), cmp.AllowUnexported(Config{})))
 			} else {
 				require.ErrorContains(t, err, tt.wantErr)
 			}

--- a/lib/events/athena/consumer.go
+++ b/lib/events/athena/consumer.go
@@ -82,6 +82,10 @@ type consumer struct {
 	sqsDeleter sqsDeleter
 	queueURL   string
 
+	// observeWriteEventsError is called once for each error (including nil
+	// errors) from writing events to S3.
+	observeWriteEventsError func(error)
+
 	// cancelRun is used to cancel consumer.Run
 	cancelRun context.CancelFunc
 
@@ -147,8 +151,9 @@ func newConsumer(cfg Config, cancelFn context.CancelFunc) (*consumer, error) {
 			}
 			return fw, nil
 		},
-		cancelRun: cancelFn,
-		finished:  make(chan struct{}),
+		observeWriteEventsError: cfg.ObserveWriteEventsError,
+		cancelRun:               cancelFn,
+		finished:                make(chan struct{}),
 	}, nil
 }
 
@@ -181,6 +186,7 @@ func (c *consumer) Close() error {
 func (c *consumer) processEventsContinuously(ctx context.Context) {
 	processBatchOfEventsWithLogging := func(context.Context) (reachedMaxBatch bool) {
 		reachedMaxBatch, err := c.processBatchOfEvents(ctx)
+		c.observeWriteEventsError(err)
 		if err != nil {
 			// Ctx.Cancel is used to stop batcher
 			if ctx.Err() != nil {

--- a/lib/integrations/externalcloudaudit/configurator_test.go
+++ b/lib/integrations/externalcloudaudit/configurator_test.go
@@ -157,7 +157,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 
 			modules.SetTestModules(t, tt.modules)
 
-			c, err := NewConfigurator(ctx, ecaSvc, integrationSvc)
+			c, err := NewConfigurator(ctx, ecaSvc, integrationSvc, nil /*alertService*/)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantIsUsed, c.IsUsed(),
 				"Configurator.IsUsed() = %v, want %v", c.IsUsed(), tt.wantIsUsed)
@@ -204,7 +204,7 @@ func TestCredentialsCache(t *testing.T) {
 	}
 
 	// Create a configurator with a fake clock and STS client.
-	c, err := NewConfigurator(ctx, svc, integrationSvc, WithClock(clock), WithSTSClient(stsClient))
+	c, err := NewConfigurator(ctx, svc, integrationSvc, nil /*alertService*/, WithClock(clock), WithSTSClient(stsClient))
 	require.NoError(t, err)
 	require.True(t, c.IsUsed())
 

--- a/lib/integrations/externalcloudaudit/error_counter.go
+++ b/lib/integrations/externalcloudaudit/error_counter.go
@@ -1,0 +1,396 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalcloudaudit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+)
+
+const (
+	eventEmitFailureClusterAlert                  = "event-emit"
+	eventEmitFailureClusterAlertMsgTemplate       = "External Audit Storage: experiencing elevated error rate emitting events. Recent error message: %s"
+	eventSearchFailureClusterAlert                = "event-search"
+	eventSearchFailureClusterAlertMsgTemplate     = "External Audit Storage: experiencing elevated error rate searching events. Recent error message: %s"
+	sessionUploadFailureClusterAlert              = "session-upload"
+	sessionUploadFailureClusterAlertMsgTemplate   = "External Audit Storage: experiencing elevated error rate uploading session recordings. Recent error message: %s"
+	sessionDownloadFailureClusterAlert            = "session-download"
+	sessionDownloadFailureClusterAlertMsgTemplate = "External Audit Storage: experiencing elevated error rate downloading session recordings. Recent error message: %s"
+
+	syncInterval = 30 * time.Second
+)
+
+var log = logrus.WithField(trace.Component, "ExternalAuditStorage")
+
+// ClusterAlertService abstracts a service providing Upsert and Delete
+// operations for cluster alerts.
+type ClusterAlertService interface {
+	// UpsertClusterAlert creates the specified alert, overwriting any preexising alert with the same ID.
+	UpsertClusterAlert(ctx context.Context, alert types.ClusterAlert) error
+	// DeleteClusterAlert deletes the cluster alert with the specified ID.
+	DeleteClusterAlert(ctx context.Context, alertID string) error
+}
+
+// ErrorCounter is used when the External Audit Storage feature is enabled to
+// store audit events and session recordings on external infrastructure. It
+// effectively provides audit middlewares that count errors and raise or clear
+// cluster alerts based on recent error rates. Cluster alerts are used to
+// surface this information because Cloud customers don't have access to their
+// own Auth server logs.
+type ErrorCounter struct {
+	emits     errorCount
+	searches  errorCount
+	uploads   errorCount
+	downloads errorCount
+
+	alertService ClusterAlertService
+	clock        clockwork.Clock
+
+	categories []errorCategory
+}
+
+// NewErrorCounter takes a ClusterAlertService that will be used to raise or
+// clear cluster alerts and returns a new ErrorCounter.
+func NewErrorCounter(alertService ClusterAlertService) *ErrorCounter {
+	c := &ErrorCounter{
+		alertService: alertService,
+		clock:        clockwork.NewRealClock(),
+	}
+	c.categories = []errorCategory{
+		{
+			alertName:    eventEmitFailureClusterAlert,
+			alertMessage: eventEmitFailureClusterAlertMsgTemplate,
+			// Raise a cluster alert if the recent error rate reaches 40%.
+			alertThreshold: 0.4,
+			// Don't alert until there have been at least 10 errors.
+			minErrorsForAlert: 10,
+			// Clear the alert if the recent error rate is below 5%.
+			clearAlertThreshold: 0.05,
+			// Don't clear the alert unless there have been at least 10
+			// successes.
+			minSuccessesForClear: 10,
+			count:                &c.emits,
+		},
+		{
+			alertName:            eventSearchFailureClusterAlert,
+			alertMessage:         eventSearchFailureClusterAlertMsgTemplate,
+			minErrorsForAlert:    4,
+			alertThreshold:       0.4,
+			minSuccessesForClear: 4,
+			clearAlertThreshold:  0.05,
+			count:                &c.searches,
+		},
+		{
+			alertName:            sessionUploadFailureClusterAlert,
+			alertMessage:         sessionUploadFailureClusterAlertMsgTemplate,
+			minErrorsForAlert:    4,
+			alertThreshold:       0.4,
+			minSuccessesForClear: 8,
+			clearAlertThreshold:  0.05,
+			count:                &c.uploads,
+		},
+		{
+			alertName:            sessionDownloadFailureClusterAlert,
+			alertMessage:         sessionDownloadFailureClusterAlertMsgTemplate,
+			minErrorsForAlert:    4,
+			alertThreshold:       0.4,
+			minSuccessesForClear: 2,
+			clearAlertThreshold:  0.05,
+			count:                &c.downloads,
+		},
+	}
+	return c
+}
+
+// WrapAuditLogger returns an [events.AuditLogger] that will forward all calls
+// to [wrapped] and observe all errors encountered.
+func (c *ErrorCounter) WrapAuditLogger(wrapped events.AuditLogger) *ErrorCountingLogger {
+	return newErrorCountingLogger(wrapped, &c.emits, &c.searches)
+}
+
+// WrapSessionHandler returns an [events.MultipartHandler] that will forward all
+// calls to [wrapped] and observe all errors encountered.
+func (c *ErrorCounter) WrapSessionHandler(wrapped events.MultipartHandler) *ErrorCountingSessionHandler {
+	return newErrorCountingSessionHandler(wrapped, &c.uploads, &c.downloads)
+}
+
+// ObserveEmitError can be called to observe relevant event emit errors not
+// captured by WrapAuditLogger. In particular this should be used by the Athena
+// consumer which batches event writes to S3.
+func (c *ErrorCounter) ObserveEmitError(err error) {
+	c.emits.observe(err)
+}
+
+type errorCategory struct {
+	alertName            string
+	alertMessage         string
+	alertThreshold       float32
+	clearAlertThreshold  float32
+	minErrorsForAlert    uint64
+	minSuccessesForClear uint64
+	count                *errorCount
+}
+
+func (c *ErrorCounter) run(exitContext context.Context) {
+	ticker := c.clock.NewTicker(syncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-exitContext.Done():
+			return
+		case <-ticker.Chan():
+		}
+		c.sync(exitContext)
+	}
+}
+
+func (c *ErrorCounter) sync(ctx context.Context) {
+	var allAlertActions alertActions
+	for _, category := range c.categories {
+		allAlertActions.merge(category.sync())
+	}
+
+	for _, newAlert := range allAlertActions.newAlerts {
+		alert, err := types.NewClusterAlert(newAlert.name, newAlert.message,
+			types.WithAlertSeverity(types.AlertSeverity_HIGH),
+			types.WithAlertLabel(types.AlertOnLogin, "yes"),
+			types.WithAlertLabel(types.AlertVerbPermit, "external_cloud_audit:create"))
+		if err != nil {
+			log.Infof("ErrorCounter failed to create cluster alert %s: %s", newAlert.name, err)
+			continue
+		}
+		if err := c.alertService.UpsertClusterAlert(ctx, alert); err != nil {
+			log.Infof("ErrorCounter failed to upsert cluster alert %s: %s", newAlert.name, err)
+		}
+	}
+	for _, alertToClear := range allAlertActions.clearAlerts {
+		if err := c.alertService.DeleteClusterAlert(ctx, alertToClear); err != nil && !trace.IsNotFound(err) {
+			log.Infof("ErrorCounter failed to delete cluster alert %s: %s", alertToClear, err)
+		}
+	}
+}
+
+func (c *errorCategory) sync() alertActions {
+	errorCount, successCount := c.count.errors.Load(), c.count.successes.Load()
+	var errorRate float32
+	// Avoid NaN
+	if errorCount > 0 {
+		errorRate = float32(errorCount) / float32(errorCount+successCount)
+	}
+	err := c.count.recentError.Load()
+	if errorCount >= c.minErrorsForAlert && successCount >= c.minSuccessesForClear {
+		// A good number of observations have happened since the last reset and
+		// the results are mixed, reset the count to bias in favor of more
+		// recent observations.
+		// This doesn't prevent raising or clearing an alert below if a
+		// threshold has been met.
+		// This condition avoids resetting the count prematurely if errors are
+		// happening slowly.
+		c.count.reset()
+	}
+	if errorCount >= c.minErrorsForAlert &&
+		errorRate >= c.alertThreshold {
+		// Raising an alert, reset the count so that recovery can be detected
+		// quickly.
+		c.count.reset()
+		return alertActions{
+			newAlerts: []alert{{
+				name:    c.alertName,
+				message: fmt.Sprintf(c.alertMessage, *err),
+			}},
+		}
+	}
+	if successCount >= c.minSuccessesForClear &&
+		errorRate <= c.clearAlertThreshold {
+		// Counted sufficient successes to clear any alert, reset the count so
+		// that future errors can be detected quickly.
+		c.count.reset()
+		return alertActions{
+			clearAlerts: []string{c.alertName},
+		}
+	}
+	return alertActions{}
+}
+
+type alertActions struct {
+	clearAlerts []string
+	newAlerts   []alert
+}
+
+func (a *alertActions) merge(o alertActions) {
+	a.clearAlerts = append(a.clearAlerts, o.clearAlerts...)
+	a.newAlerts = append(a.newAlerts, o.newAlerts...)
+}
+
+type alert struct {
+	name    string
+	message string
+}
+
+type errorCount struct {
+	recentError atomic.Pointer[error]
+	errors      atomic.Uint64
+	successes   atomic.Uint64
+}
+
+func (c *errorCount) observe(err error) {
+	if err != nil {
+		c.recentError.Store(&err)
+		c.errors.Add(1)
+	} else {
+		c.successes.Add(1)
+	}
+}
+
+func (c *errorCount) reset() {
+	c.errors.Store(0)
+	c.successes.Store(0)
+}
+
+// ErrorCountingLogger wraps an AuditLogger and counts errors on emit and search
+// operations.
+type ErrorCountingLogger struct {
+	wrapped events.AuditLogger
+
+	emits    *errorCount
+	searches *errorCount
+}
+
+func newErrorCountingLogger(wrapped events.AuditLogger, emits, searches *errorCount) *ErrorCountingLogger {
+	return &ErrorCountingLogger{
+		wrapped:  wrapped,
+		emits:    emits,
+		searches: searches,
+	}
+}
+
+// Close calls [c.wrapped.Close]
+func (c *ErrorCountingLogger) Close() error {
+	return c.wrapped.Close()
+}
+
+// EmitAuditEvent calls [c.wrapped.EmitAuditEvent] and counts the error or
+// success.
+func (c *ErrorCountingLogger) EmitAuditEvent(ctx context.Context, e apievents.AuditEvent) error {
+	err := c.wrapped.EmitAuditEvent(ctx, e)
+	c.emits.observe(err)
+	return err
+}
+
+// SearchEvents calls [c.wrapped.SearchEvents] and counts the error or
+// success.
+func (c *ErrorCountingLogger) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	events, key, err := c.wrapped.SearchEvents(ctx, req)
+	c.searches.observe(err)
+	return events, key, err
+}
+
+// SearchSessionEvents calls [c.wrapped.SearchSessionEvents] and counts the error or
+// success.
+func (c *ErrorCountingLogger) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
+	events, key, err := c.wrapped.SearchSessionEvents(ctx, req)
+	c.searches.observe(err)
+	return events, key, err
+}
+
+// ErrorCountingSessionHandler wraps a MultipartHandler and counts errors on all
+// operations.
+type ErrorCountingSessionHandler struct {
+	wrapped events.MultipartHandler
+
+	uploads   *errorCount
+	downloads *errorCount
+}
+
+func newErrorCountingSessionHandler(wrapped events.MultipartHandler, uploads, downloads *errorCount) *ErrorCountingSessionHandler {
+	return &ErrorCountingSessionHandler{
+		wrapped:   wrapped,
+		uploads:   uploads,
+		downloads: downloads,
+	}
+}
+
+// Upload calls [c.wrapped.Upload] and counts the error or success.
+func (c *ErrorCountingSessionHandler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	res, err := c.wrapped.Upload(ctx, sessionID, reader)
+	c.uploads.observe(err)
+	return res, err
+}
+
+// Download calls [c.wrapped.Download] and counts the error or success.
+func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	err := c.wrapped.Download(ctx, sessionID, writer)
+	c.downloads.observe(err)
+	return err
+}
+
+// CreateUpload calls [c.wrapped.CreateUpload] and counts the error or success.
+func (c *ErrorCountingSessionHandler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+	res, err := c.wrapped.CreateUpload(ctx, sessionID)
+	c.uploads.observe(err)
+	return res, err
+}
+
+// CompleteUpload calls [c.wrapped.CompleteUpload] and counts the error or success.
+func (c *ErrorCountingSessionHandler) CompleteUpload(ctx context.Context, upload events.StreamUpload, parts []events.StreamPart) error {
+	err := c.wrapped.CompleteUpload(ctx, upload, parts)
+	c.uploads.observe(err)
+	return err
+}
+
+// ReserveUploadPart calls [c.wrapped.ReserveUploadPart] and counts the error or success.
+func (c *ErrorCountingSessionHandler) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
+	err := c.wrapped.ReserveUploadPart(ctx, upload, partNumber)
+	c.uploads.observe(err)
+	return err
+}
+
+// UploadPart calls [c.wrapped.UploadPart] and counts the error or success.
+func (c *ErrorCountingSessionHandler) UploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64, partBody io.ReadSeeker) (*events.StreamPart, error) {
+	part, err := c.wrapped.UploadPart(ctx, upload, partNumber, partBody)
+	c.uploads.observe(err)
+	return part, err
+}
+
+// ListParts calls [c.wrapped.ListParts] and counts the error or success.
+func (c *ErrorCountingSessionHandler) ListParts(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
+	parts, err := c.wrapped.ListParts(ctx, upload)
+	c.uploads.observe(err)
+	return parts, err
+}
+
+// ListUploads calls [c.wrapped.ListUploads] and counts the error or success.
+func (c *ErrorCountingSessionHandler) ListUploads(ctx context.Context) ([]events.StreamUpload, error) {
+	uploads, err := c.wrapped.ListUploads(ctx)
+	c.uploads.observe(err)
+	return uploads, err
+}
+
+// GetUploadMetadata calls [c.wrapped.GetUploadMetadata] and counts the error or success.
+func (c *ErrorCountingSessionHandler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
+	return c.wrapped.GetUploadMetadata(sessionID)
+}

--- a/lib/integrations/externalcloudaudit/error_counter_test.go
+++ b/lib/integrations/externalcloudaudit/error_counter_test.go
@@ -1,0 +1,250 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalcloudaudit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+)
+
+func TestErrorCounter(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testError := errors.New("test error")
+
+	for _, tc := range []struct {
+		desc         string
+		steps        []testStep
+		expectAlerts []alert
+	}{
+		{
+			desc: "upload errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.errHandler.Upload(ctx, "", nil)
+						pack.successHandler.Upload(ctx, "", nil)
+					},
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{{
+				name:    sessionUploadFailureClusterAlert,
+				message: fmt.Sprintf(sessionUploadFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "download errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.errHandler.Download(ctx, "", nil)
+						pack.successHandler.Download(ctx, "", nil)
+					},
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{{
+				name:    sessionDownloadFailureClusterAlert,
+				message: fmt.Sprintf(sessionDownloadFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "emit errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.observeEmitError(testError)
+						pack.observeEmitError(nil)
+					},
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{{
+				name:    eventEmitFailureClusterAlert,
+				message: fmt.Sprintf(eventEmitFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "search errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.successLogger.SearchEvents(ctx, events.SearchEventsRequest{})
+						pack.errLogger.SearchEvents(ctx, events.SearchEventsRequest{})
+					},
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{{
+				name:    eventSearchFailureClusterAlert,
+				message: fmt.Sprintf(eventSearchFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "alert recovery",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) { pack.errLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 10,
+				},
+				{
+					action: func(pack *testPack) { pack.successLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{},
+		},
+		{
+			desc: "quick alert after many successes",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) { pack.successLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 1000,
+				},
+				{
+					action: func(pack *testPack) { pack.errLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{{
+				name:    eventSearchFailureClusterAlert,
+				message: fmt.Sprintf(eventSearchFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "quick recovery after many errors",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) { pack.errLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 1000,
+				},
+				{
+					action: func(pack *testPack) { pack.successLogger.SearchEvents(ctx, events.SearchEventsRequest{}) },
+					repeat: 10,
+				},
+			},
+			expectAlerts: []alert{},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			alertService := newFakeAlertService()
+			counter := NewErrorCounter(alertService)
+			pack := &testPack{
+				errLogger:        counter.WrapAuditLogger(&errorLogger{err: testError}),
+				successLogger:    counter.WrapAuditLogger(&errorLogger{err: nil}),
+				errHandler:       counter.WrapSessionHandler(&errorHandler{err: testError}),
+				successHandler:   counter.WrapSessionHandler(&errorHandler{err: nil}),
+				observeEmitError: counter.ObserveEmitError,
+			}
+
+			for _, step := range tc.steps {
+				for i := 0; i < max(step.repeat, 1); i++ {
+					step.action(pack)
+				}
+				// Reliably advancing the clock and waiting for the run loop to
+				// finish syncing would require instrumenting the non-test code,
+				// so this test just manually calls sync.
+				counter.sync(ctx)
+			}
+			for _, expected := range tc.expectAlerts {
+				assert.Equal(t, expected.message, alertService.alerts[expected.name])
+			}
+			assert.Len(t, alertService.alerts, len(tc.expectAlerts))
+		})
+	}
+
+}
+
+type testPack struct {
+	errLogger        events.AuditLogger
+	successLogger    events.AuditLogger
+	errHandler       events.MultipartHandler
+	successHandler   events.MultipartHandler
+	observeEmitError func(error)
+}
+
+type testStep struct {
+	repeat int
+	action func(*testPack)
+}
+
+type fakeAlertService struct {
+	alerts map[string]string
+}
+
+func newFakeAlertService() *fakeAlertService {
+	return &fakeAlertService{
+		alerts: make(map[string]string),
+	}
+}
+
+func (f *fakeAlertService) UpsertClusterAlert(ctx context.Context, alert types.ClusterAlert) error {
+	f.alerts[alert.GetName()] = alert.Spec.Message
+	return nil
+}
+
+func (f *fakeAlertService) DeleteClusterAlert(ctx context.Context, alertID string) error {
+	if _, found := f.alerts[alertID]; !found {
+		return trace.NotFound("cluster alert %s not found", alertID)
+	}
+	delete(f.alerts, alertID)
+	return nil
+}
+
+type errorLogger struct {
+	err error
+	events.AuditLogger
+}
+
+func (l *errorLogger) EmitAuditEvent(ctx context.Context, e apievents.AuditEvent) error {
+	return l.err
+}
+
+func (l *errorLogger) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	return nil, "", l.err
+}
+
+func (l *errorLogger) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
+	return nil, "", l.err
+}
+
+type errorHandler struct {
+	err error
+	events.MultipartHandler
+}
+
+func (h *errorHandler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	return "", h.err
+}
+
+func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	return h.err
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1427,9 +1427,13 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 			return nil, trace.Wrap(err)
 		}
 
-		handler, err := s3sessions.NewHandler(ctx, config)
+		var handler events.MultipartHandler
+		handler, err = s3sessions.NewHandler(ctx, config)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if externalCloudAudit.IsUsed() {
+			handler = externalCloudAudit.ErrorCounter.WrapSessionHandler(handler)
 		}
 		return handler, nil
 	case teleport.SchemeAZBlob, teleport.SchemeAZBlobHTTP:
@@ -1547,7 +1551,7 @@ func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.Clust
 				// External Audit Storage uses the topicArn, largeEventsS3, and
 				// queueURL from the athena audit_events_uri passed by cloud,
 				// and overwrites the remaining fields.
-				if err := cfg.UpdateForExternalCloudAudit(ctx, externalCloudAudit.GetSpec(), externalCloudAudit.CredentialsProvider()); err != nil {
+				if err := cfg.UpdateForExternalCloudAudit(ctx, externalCloudAudit); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}
@@ -1555,6 +1559,9 @@ func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.Clust
 			logger, err = athena.New(ctx, cfg)
 			if err != nil {
 				return nil, trace.Wrap(err)
+			}
+			if externalCloudAudit.IsUsed() {
+				logger = externalCloudAudit.ErrorCounter.WrapAuditLogger(logger)
 			}
 			if cfg.LimiterBurst > 0 {
 				// Wrap athena logger with rate limiter on search events.
@@ -6055,5 +6062,6 @@ func (process *TeleportProcess) newExternalCloudAuditConfigurator() (*externalcl
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return externalcloudaudit.NewConfigurator(process.ExitContext(), ecaSvc, integrationSvc)
+	statusService := local.NewStatusService(process.backend)
+	return externalcloudaudit.NewConfigurator(process.ExitContext(), ecaSvc, integrationSvc, statusService)
 }


### PR DESCRIPTION
This commit adds a component that observes and counts errors relevent to External Audit Storage, and periodically raises or clears cluster alerts based on the recent error rate.

This information is being surfaced to users via cluster alerts because External Audit Storage is specifically for Cloud users who have no way to check auth server logs or metrics, and the errors may be caused by their own misconfiguration.

Possible error conditions this is meant to catch:
- deleted/modified OIDC connector
- deleted/modified IAM role
- deleted/modified IAM policy
- deleted S3 buckets
- deleted Athena workgroups
- deleted/modified Glue tables
- other possible permissions issues