### PR TITLE
Fix `yum config-manager` invocation in installers and docs

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -106,7 +106,7 @@ install_teleport() {
     if [ "$ID" = "rhel" ]; then
       VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
-    sudo yum-config-manager --add-repo \
+    sudo yum config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then

--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -106,7 +106,8 @@ install_teleport() {
     if [ "$ID" = "rhel" ]; then
       VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
-    sudo yum config-manager --add-repo \
+    sudo yum install -y yum-utils
+    sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -52,7 +52,8 @@ on_gcp() {
     if [ "$ID" = "rhel" ]; then
       VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
-    sudo yum config-manager --add-repo \
+    sudo yum install -y yum-utils
+    sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -52,7 +52,7 @@ on_gcp() {
     if [ "$ID" = "rhel" ]; then
       VERSION_ID=${VERSION_ID//\.*/} # convert version numbers like '7.2' to only include the major version
     fi
-    sudo yum-config-manager --add-repo \
+    sudo yum config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then

--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -28,7 +28,7 @@
   # First, get the OS major version from $VERSION_ID so this fetches the correct
   # package version.
   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
+  $ sudo yum config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
   $ sudo yum install teleport-ent-updater
   #
   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)

--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -28,7 +28,8 @@
   # First, get the OS major version from $VERSION_ID so this fetches the correct
   # package version.
   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-  $ sudo yum config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
+  $ sudo yum install -y yum-utils
+  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
   $ sudo yum install teleport-ent-updater
   #
   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -34,7 +34,8 @@ $ source /etc/os-release
 # First, get the major version from $VERSION_ID so this fetches the correct
 # package version.
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-$ sudo yum config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+$ sudo yum install -y yum-utils
+$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
 $ sudo yum install teleport-ent
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -34,7 +34,7 @@ $ source /etc/os-release
 # First, get the major version from $VERSION_ID so this fetches the correct
 # package version.
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+$ sudo yum config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
 $ sudo yum install teleport-ent
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)


### PR DESCRIPTION
This change fixes the invocation of the yum config manager in both the default installers and the docs.

Fixes #34538.

Changelog: Fixed default installer yum error on RHEL and Amazon Linux