### PR TITLE
operator: Add Dockerfile for use with GitHub Actions

### DIFF
--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -1,0 +1,105 @@
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
+
+# BUILDPLATFORM is provided by Docker/buildx
+FROM --platform=$BUILDPLATFORM docker.io/debian:12 as builder
+ARG BUILDARCH
+
+## Install dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    unzip \
+    # x86_64 dependencies and build tools
+    build-essential \
+    # ARM dependencies
+    libc6-dev-armhf-cross \
+    gcc-arm-linux-gnueabihf \
+    # ARM64 dependencies
+    libc6-dev-arm64-cross \
+    gcc-aarch64-linux-gnu \
+    # i386 dependencies
+    libc6-dev-i386-cross \
+    gcc-i686-linux-gnu
+
+# Create a basic Makefile in /tmp/v from build.assets/versions.mk to print
+# the program versions we need.
+RUN mkdir -p /tmp/v
+COPY build.assets/versions.mk /tmp/v
+COPY <<-EOT /tmp/v/Makefile
+  include versions.mk
+  print-go-version:; @echo $(or $(GOLANG_VERSION),$(error GOLANG_VERSION not defined))
+  print-protoc-version:; @echo $(or $(PROTOC_VERSION),$(error PROTOC_VERSION not defined))
+EOT
+
+# Install Go.
+RUN GOLANG_VERSION=$(make -s -C /tmp/v print-go-version) && \
+    mkdir -p /opt && \
+    curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | \
+      tar xz -C /opt && \
+    chmod a+w /var/lib && \
+    chmod a-w /
+
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="$PATH:/opt/go/bin:/go/bin"
+
+# Install protoc.
+RUN PROTOC_VERSION=$(make -s -C /tmp/v print-protoc-version) && \
+  PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
+  PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
+  case "$BUILDARCH" in \
+    amd64) PROTOC_ARCH=x86_64 ;; \
+    arm64) PROTOC_ARCH=aarch_64 ;; \
+    *) printf 'Unknown $BUILDARCH (%s). Cannot determine protoc host arch\n' "$BUILDARCH"; exit 1 ;; \
+  esac && \
+  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-$PROTOC_ARCH.zip" && \
+  unzip "$PB_FILE" -d /usr/local && \
+  rm -f "$PB_FILE"
+
+## Build the operator
+
+WORKDIR /go/src/github.com/gravitational/teleport
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# We have to copy the API before `go mod download` because go.mod has a replace directive for it
+COPY api/ api/
+
+# Download and Cache dependencies before building and copying source
+# This will prevent re-downloading the operator's dependencies if they have not changed as this
+# `run` layer will be cached
+RUN go mod download
+
+COPY *.go ./
+COPY lib/ lib/
+COPY gen/ gen/
+COPY integrations/operator/apis/ integrations/operator/apis/
+COPY integrations/operator/controllers/ integrations/operator/controllers/
+COPY integrations/operator/sidecar/ integrations/operator/sidecar/
+COPY integrations/operator/main.go integrations/operator/main.go
+COPY integrations/operator/namespace.go integrations/operator/namespace.go
+
+ARG TARGETOS
+ARG TARGETARCH
+
+# Build the program
+# CGO is required for github.com/gravitational/teleport/lib/system
+RUN case "$TARGETARCH" in \
+      amd64) COMPILER_NAME=x86_64-linux-gnu-gcc ;; \
+      arm64) COMPILER_NAME=aarch64-linux-gnu-gcc ;; \
+      arm)   COMPILER_NAME=arm-linux-gnueabihf-gcc ;; \
+      *) printf 'Unknown $TARGETARCH (%s). Cannot determine C compiler\n' "$TARGETARCH"; exit 1 ;; \
+    esac; \
+    echo "Targeting $TARGETOS/$TARGETARCH with CC=$COMPILER_NAME" && \
+    CGO_ENABLED=1 CC=$COMPILER_NAME GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -a -o /go/bin/teleport-operator github.com/gravitational/teleport/integrations/operator
+
+# Create the image with the build operator on the $TARGETPLATFORM
+# TARGETPLATFORM is provided by Docker/buildx
+FROM --platform=$TARGETPLATFORM $BASE_IMAGE
+WORKDIR /
+COPY --from=builder /go/bin/teleport-operator .
+
+ENTRYPOINT ["/teleport-operator"]


### PR DESCRIPTION
Add a new `Dockerfile.gha` alongside the existing `Dockerfile` that can
build the operator container image without any build args. The build
args it had could be determined from inside the Dockerfile, so doing
this removes the need to pass them in. This in turn makes it simpler to
call from CI and to build locally.

In particular, `GOLANG_VERSION` and `PROTOC_VERSION` are taken from
`build.assets/versions.mk`, and `COMPILER_NAME` is determined from the
predefined `$TARGETARCH` arg.

Once Drone no longer builds the operator on any branch, this
`Dockerfile` will replace the previous one, with the `Makefile` updated
to remove the build args. It is done this way as previous changes to the
build of the operator were not backported to v12 and v13, complicating
backporting changes to existing files.