### PR TITLE
Don't force the use of FIPS endpoints for DynamoDB Streams and Application Auto Scaling

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
@@ -141,6 +142,9 @@ func getIID(ctx context.Context, t *testing.T) imds.InstanceIdentityDocument {
 func getCallerIdentity(t *testing.T) *sts.GetCallerIdentityOutput {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			EC2MetadataEnableFallback: aws.Bool(false),
+		},
 	})
 	require.NoError(t, err)
 	stsService := sts.New(sess)

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -472,11 +472,11 @@ func newSTSClient(ctx context.Context, cfg *stsIdentityRequestConfig) (*sts.STS,
 	if cfg.fipsEndpointOption == endpoints.FIPSEndpointStateEnabled &&
 		!slices.Contains(validSTSEndpoints, strings.TrimPrefix(stsClient.Endpoint, "https://")) {
 		// The AWS SDK will generate invalid endpoints when attempting to
-		// resolve the FIPS endpoint for a region which does not have one.
+		// resolve the FIPS endpoint for a region that does not have one.
 		// In this case, try to use the FIPS endpoint in us-east-1. This should
-		// work for all regions in the standard partition. In GovCloud we should
+		// work for all regions in the standard partition. In GovCloud, we should
 		// not hit this because all regional endpoints support FIPS. In China or
-		// other partitions this will fail and FIPS mode will not be supported.
+		// other partitions, this will fail, and FIPS mode will not be supported.
 		log.Infof("AWS SDK resolved FIPS STS endpoint %s, which does not appear to be valid. "+
 			"Attempting to use the FIPS STS endpoint for us-east-1.",
 			stsClient.Endpoint)


### PR DESCRIPTION
DynamoDB Streams and Application Auto Scaling do not currently have FIPS endpoints in non-GovCloud, leading to invalid endpoints for FIPS users running in AWS Standard.

See also: https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service

Regression from #34170.

Fixes #34804.

Additionally, clean-up a few more AWS session initiations to be consistent and clear.

changelog: Don't force the use of FIPS endpoints for DynamoDB Streams and Application Auto Scaling