### PR TITLE
[v14] Update distroless images to use Debian 12

### DIFF
--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,8 +1,8 @@
 # This Dockerfile is used to build Teleport on ARM only.
-# We are using the official Debian 11 image as a base image
+# We are using the official Debian 12 image as a base image
 # because the final binary must be compatible with distroless
-# images that are also Debian 11 based: https://github.com/GoogleContainerTools/distroless
-FROM docker.io/library/debian:11
+# images that are also Debian 12 based: https://github.com/GoogleContainerTools/distroless
+FROM docker.io/library/debian:12
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/build-test-compat.sh
+++ b/build.assets/build-test-compat.sh
@@ -34,15 +34,19 @@ DISTROS=(
   "debian:9"
   "debian:10"
   "debian:11"
+  "debian:12"
   # Distroless Debian fails because of missing libgcc_s.so.1
   # https://github.com/gravitational/teleport/issues/14538
-  #"gcr.io/distroless/base-debian11"
-  "gcr.io/distroless/cc"
+  #"gcr.io/distroless/base-debian12"
+  "gcr.io/distroless/cc-debian11"
+  "gcr.io/distroless/cc-debian12"
   "amazonlinux:1"
   "amazonlinux:2"
+  "amazonlinux:2023"
   "archlinux"
   "oraclelinux:7"
   "oraclelinux:8"
+  "oraclelinux:9"
   "fedora:34"
   "fedora:latest"
 )

--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -1,11 +1,11 @@
-ARG BASE_IMAGE=gcr.io/distroless/cc-debian11
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:11 AS staging
+FROM debian:12 AS staging
 RUN apt-get update 
 COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
-FROM debian:11 AS teleport
+FROM debian:12 AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -161,8 +161,8 @@ either:
 
 |Image name|Troubleshooting Tools?|Image base|
 |-|-|-|
-|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 11](https://github.com/GoogleContainerTools/distroless)|
-|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 11](https://github.com/GoogleContainerTools/distroless)|
+|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
+|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
 
 For testing, we always recommend that you use the latest released version of
 Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
@@ -177,8 +177,8 @@ considered deprecated, and they may be removed in future releases.
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
-| `(=teleport.latest_ent_docker_image=)` | No | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
-| `(=teleport.latest_ent_debug_docker_image=)` | Yes | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
+| `(=teleport.latest_ent_docker_image=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `(=teleport.latest_ent_debug_docker_image=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
 We also provide the following images for FIPS builds of Teleport Enterprise:
 

--- a/integrations/kube-agent-updater/Dockerfile
+++ b/integrations/kube-agent-updater/Dockerfile
@@ -1,5 +1,6 @@
 ARG BUILDBOX
-ARG BASE_IMAGE=gcr.io/distroless/static-debian11
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12
+
 # BUILDPLATFORM is provided by Docker/buildx
 FROM --platform=$BUILDPLATFORM $BUILDBOX as builder
 

--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -35,7 +35,7 @@ import (
 
 var distrolessKey = []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q\nOqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==\n-----END PUBLIC KEY-----")
 
-func Test_NewCosignSignleKeyValidator(t *testing.T) {
+func Test_NewCosignSingleKeyValidator(t *testing.T) {
 	a, err := NewCosignSingleKeyValidator(distrolessKey, "distroless")
 	require.NoError(t, err)
 	require.Equal(t, "distroless-799a5c21a7f8c39707274cbd065ba2e1969d8d29", a.Name())

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -1,5 +1,7 @@
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
+
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM docker.io/debian:11 as builder
+FROM --platform=$BUILDPLATFORM docker.io/debian:12 as builder
 ARG BUILDARCH
 
 ## Install dependencies.
@@ -77,7 +79,7 @@ RUN echo "Targeting $TARGETOS/$TARGETARCH with CC=$COMPILER_NAME" && \
 
 # Create the image with the build operator on the $TARGETPLATFORM
 # TARGETPLATFORM is provided by Docker/buildx
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/cc
+FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 WORKDIR /
 COPY --from=builder /go/bin/teleport-operator .
 

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -353,7 +353,7 @@ download() {
     fi
     # if we have a hashing utility installed, also download and validate the checksum
     SHA_COMMAND=""
-    # shasum is installed by default on MacOS and some distros
+    # shasum is installed by default on macOS and some distros
     if check_exists shasum; then
         SHA_COMMAND="shasum -a 256"
     # sha256sum is installed by default in some other distros
@@ -491,7 +491,7 @@ install_teleport_node_config() {
       "${LABELS_FLAG[@]}" \
       --output ${TELEPORT_CONFIG_PATH}
 }
-# checks whether the given host is running MacOS
+# checks whether the given host is running macOS
 is_macos_host() { if [[ ${OSTYPE} == "darwin"* ]]; then return 0; else return 1; fi }
 # checks whether teleport is already running on the host
 is_running_teleport() {
@@ -684,7 +684,7 @@ if [[ "${OSTYPE}" == "linux"* ]]; then
         fi
     fi
 elif [[ "${OSTYPE}" == "darwin"* ]]; then
-    # macos host, now detect arch
+    # macOS host, now detect arch
     TELEPORT_BINARY_TYPE="darwin"
     ARCH=$(uname -m)
     log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
@@ -696,7 +696,7 @@ elif [[ "${OSTYPE}" == "darwin"* ]]; then
         log_important "Error: unsupported architecture from uname -m: ${ARCH}"
         exit 1
     fi
-    log "Detected MacOS ${ARCH} architecture, using Teleport arch ${TELEPORT_ARCH}"
+    log "Detected macOS ${ARCH} architecture, using Teleport arch ${TELEPORT_ARCH}"
     TELEPORT_FORMAT="tarball"
     if launchd_plist_file_exists; then
         log_header "Warning: Found existing Teleport launchd config ${LAUNCHD_CONFIG_PATH}/${LAUNCHD_PLIST_FILE}."
@@ -889,7 +889,7 @@ install_from_repo() {
         fi
         apt-get update
         apt-get install -y ${PACKAGE_LIST}
-    elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ] || [ "$ID" = "centos" ] ; then
+    elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ] || [ "$ID" = "centos" ]; then
         if [ "$ID" = "rhel" ]; then
             VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
         fi
@@ -957,7 +957,7 @@ is_repo_available() {
     # The following distros+version have a Teleport repository to install from.
     case "${ID}-${VERSION_ID}" in
         ubuntu-16.04* | ubuntu-18.04* | ubuntu-20.04* | ubuntu-22.04* | \
-        debian-9* | debian-10* | debian-11* | \
+        debian-9* | debian-10* | debian-11* | debian-12* | \
         rhel-7* | rhel-8* | rhel-9* | \
         centos-7* | centos-8* | centos-9* | \
         amzn-2 | amzn-2023 | \
@@ -1009,13 +1009,13 @@ if is_using_systemd; then
     fi
     start_teleport_systemd
     print_welcome_message
-# install launchd config on MacOS hosts
+# install launchd config on macOS hosts
 elif is_macos_host; then
-    log "Host is running MacOS"
+    log "Host is running macOS"
     install_launchd_config
     start_teleport_launchd
     print_welcome_message
-# not a MacOS host and no systemd available, print a warning
+# not a macOS host and no systemd available, print a warning
 # and temporarily start Teleport in the foreground
 else
     log "Host does not appear to be using systemd"


### PR DESCRIPTION
Backport of #31620.

`e` companion -- https://github.com/gravitational/teleport.e/pull/2718

https://github.com/GoogleContainerTools/distroless#debian-12

Note that the debian12 images no longer include OpenSSL, which we don't need anyway, as we statically link our own copy for tsh and other purposes.

Also, add Debian 12 to various places, as a supported OS.

Other included changes:
* Standardize how we select which distroless release to use.
* Ensure a specific distroless version is used instead of latest.
* Add new Amazon Linux and Oracle Linux releases to compatibility testing.
* Correct s/MacOS/macOS/ in install script.

changelog: Update distroless images to use Debian 12