### PR TITLE
[v14] Connect My Computer: Reload certs if user already has role but role got updated with new login

### DIFF
--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -335,15 +335,18 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 	require.NoError(t, err)
 
 	tests := []struct {
-		name               string
-		userAlreadyHasRole bool
-		existingRole       func(userName string) types.RoleV6
+		name                     string
+		assertCertsReloaded      require.BoolAssertionFunc
+		existingRole             func(userName string) types.RoleV6
+		assignExistingRoleToUser bool
 	}{
 		{
-			name: "role does not exist",
+			name:                "role does not exist",
+			assertCertsReloaded: require.True,
 		},
 		{
-			name: "role exists and includes current system username",
+			name:                "role exists and includes current system username",
+			assertCertsReloaded: require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -358,7 +361,8 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name: "role exists and does not include current system username",
+			name:                "role exists and does not include current system username",
+			assertCertsReloaded: require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -373,7 +377,8 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name: "role exists and has no logins",
+			name:                "role exists and has no logins",
+			assertCertsReloaded: require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -388,7 +393,8 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name: "role exists and owner node label was changed",
+			name:                "role exists and owner node label was changed",
+			assertCertsReloaded: require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -403,8 +409,9 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name:               "user already has existing role that includes current system username",
-			userAlreadyHasRole: true,
+			name:                     "user already has existing role that includes current system username",
+			assignExistingRoleToUser: true,
+			assertCertsReloaded:      require.False,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -419,8 +426,9 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name:               "user already has existing role that does not include current system username",
-			userAlreadyHasRole: true,
+			name:                     "user already has existing role that does not include current system username",
+			assignExistingRoleToUser: true,
+			assertCertsReloaded:      require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -435,8 +443,26 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			},
 		},
 		{
-			name:               "user already has existing role with modified owner node label",
-			userAlreadyHasRole: true,
+			name:                     "user already has existing role with modified owner node label",
+			assignExistingRoleToUser: true,
+			assertCertsReloaded:      require.False,
+			existingRole: func(userName string) types.RoleV6 {
+				return types.RoleV6{
+					Spec: types.RoleSpecV6{
+						Allow: types.RoleConditions{
+							NodeLabels: types.Labels{
+								types.ConnectMyComputerNodeOwnerLabel: []string{"bogus-username"},
+							},
+							Logins: []string{systemUser.Username},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:                     "user already has existing role that does not include current system username and has modified owner node label",
+			assignExistingRoleToUser: true,
+			assertCertsReloaded:      require.True,
 			existingRole: func(userName string) types.RoleV6 {
 				return types.RoleV6{
 					Spec: types.RoleSpecV6{
@@ -492,9 +518,9 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 
 			// Create a new user to avoid colliding with other tests.
 			// Assign to the user the role with allow rules and the existing role if present.
-			if test.userAlreadyHasRole {
+			if test.assignExistingRoleToUser {
 				if existingRole == nil {
-					t.Log("userAlreadyHasRole must be used together with existingRole")
+					t.Log("assignExistingRoleToUser must be used together with existingRole")
 					t.Fail()
 					return
 				}
@@ -554,13 +580,7 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			})
 			require.NoError(t, err)
 
-			if test.userAlreadyHasRole {
-				require.False(t, response.CertsReloaded,
-					"expected the handler to signal that the certs were not reloaded since the user was already assigned the role")
-			} else {
-				require.True(t, response.CertsReloaded,
-					"expected the handler to signal that the certs were reloaded since the user was just assigned a new role")
-			}
+			test.assertCertsReloaded(t, response.CertsReloaded, "CertsReloaded is the opposite of the expected value")
 
 			// Verify that the role exists.
 			role, err := authServer.GetRole(ctx, roleName)

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -98,6 +98,8 @@ func (s *RoleSetup) Run(ctx context.Context, accessAndIdentity AccessAndIdentity
 		return noCertsReloaded, trace.Wrap(err)
 	}
 
+	reloadCerts := false
+
 	if !doesRoleExist {
 		s.cfg.Log.Infof("Creating the role %v.", roleName)
 
@@ -131,6 +133,9 @@ func (s *RoleSetup) Run(ctx context.Context, accessAndIdentity AccessAndIdentity
 
 			existingRole.SetLogins(types.Allow, append(allowedLogins, systemUser.Username))
 			isRoleDirty = true
+			// Reload certs at the later stage because we added new a new login to the Connect My Computer
+			// role. The certs need to be reloaded to include the new role.
+			reloadCerts = true
 		}
 
 		// Ensure that the owner label has the expected value.
@@ -166,42 +171,49 @@ func (s *RoleSetup) Run(ctx context.Context, accessAndIdentity AccessAndIdentity
 
 	if hasCMCRole {
 		s.cfg.Log.Infof("The user %v already has the role %v.", clusterUser.GetName(), roleName)
-		return noCertsReloaded, nil
+	} else {
+		s.cfg.Log.Infof("Adding the role %v to the user %v.", roleName, clusterUser.GetName())
+		clusterUser.AddRole(roleName)
+		timeoutCtx, cancel := context.WithTimeout(ctx, resourceUpdateTimeout)
+		defer cancel()
+		err = s.syncResourceUpdate(timeoutCtx, accessAndIdentity, clusterUser, func(ctx context.Context) error {
+			return trace.Wrap(accessAndIdentity.UpdateUser(ctx, clusterUser),
+				"updating user %v", clusterUser.GetName())
+		})
+		if err != nil {
+			return noCertsReloaded, trace.Wrap(err)
+		}
+		// Reload certs because we just assigned a new role to the user. The certs need to be reloaded
+		// to include the new logins that the role includes.
+		reloadCerts = true
 	}
 
-	s.cfg.Log.Infof("Adding the role %v to the user %v.", roleName, clusterUser.GetName())
-	clusterUser.AddRole(roleName)
-	timeoutCtx, cancel := context.WithTimeout(ctx, resourceUpdateTimeout)
-	defer cancel()
-	err = s.syncResourceUpdate(timeoutCtx, accessAndIdentity, clusterUser, func(ctx context.Context) error {
-		return trace.Wrap(accessAndIdentity.UpdateUser(ctx, clusterUser),
-			"updating user %v", clusterUser.GetName())
-	})
-	if err != nil {
-		return noCertsReloaded, trace.Wrap(err)
+	if reloadCerts {
+		s.cfg.Log.Info("Reissuing certs.")
+		// ReissueUserCerts called with CertCacheDrop and a bogus access request ID in DropAccessRequests
+		// allows us to refresh the role list in the certs without forcing the user to relogin.
+		//
+		// Sending bogus request IDs is not documented but it is covered by tests. Refreshing roles based
+		// on the server state is necessary for tsh request drop to work.
+		//
+		// If passing bogus request IDs ever needs to be removed, then there are two options here:
+		// * Pass a wildcard instead. This will break setups where people use access requests to make
+		//   Connect My Computer work. Most users will probably not use access requests for that though.
+		// * Invalidate the stored certs somehow to force the user to relogin. If Connect makes a request
+		//   after role setup and [client.IsErrorResolvableWithRelogin] returns true for the error from
+		//   the response, Connect will ask the user to relogin.
+		//
+		// TODO(ravicious): Expand auth.ServerWithRoles.GenerateUserCerts to support refreshing role
+		// list without having to send a bogus request ID, like how lib/auth.HTTPClient.ExtendWebSession
+		// works.
+		err = certManager.ReissueUserCerts(ctx, client.CertCacheDrop, client.ReissueParams{
+			RouteToCluster:     cluster.Name,
+			DropAccessRequests: []string{fmt.Sprintf("bogus-request-id-%v", uuid.NewString())},
+		})
+		return RoleSetupResult{CertsReloaded: true}, trace.Wrap(err)
+	} else {
+		return RoleSetupResult{CertsReloaded: false}, nil
 	}
-
-	s.cfg.Log.Info("Reissuing certs.")
-	// ReissueUserCerts called with CertCacheDrop and a bogus access request ID in DropAccessRequests
-	// allows us to refresh the role list in the certs without forcing the user to relogin.
-	//
-	// Sending bogus request IDs is not documented but it is covered by tests. Refreshing roles based
-	// on the server state is necessary for tsh request drop to work.
-	//
-	// If passing bogus request IDs ever needs to be removed, then there are two options here:
-	// * Pass a wildcard instead. This will break setups where people use access requests to make
-	//   Connect My Computer work. Most users will probably not use access requests for that though.
-	// * Invalidate the stored certs somehow to force the user to relogin. If Connect makes a request
-	//   after role setup and [client.IsErrorResolvableWithRelogin] returns true for the error from
-	//   the response, Connect will ask the user to relogin.
-	//
-	// TODO(ravicious): Expand auth.ServerWithRoles.GenerateUserCerts to support refreshing role
-	// list without having to send a bogus request ID.
-	err = certManager.ReissueUserCerts(ctx, client.CertCacheDrop, client.ReissueParams{
-		RouteToCluster:     cluster.Name,
-		DropAccessRequests: []string{fmt.Sprintf("bogus-request-id-%v", uuid.NewString())},
-	})
-	return RoleSetupResult{CertsReloaded: true}, trace.Wrap(err)
 }
 
 const resourceUpdateTimeout = 15 * time.Second


### PR DESCRIPTION
Backport #34717.

master has changes the signature of `UpdateUser`, it now returns both the updated user and an error, so I had to manually fix this conflict when backporting to v14.