### PR TITLE
[v12] Update distroless images to use Debian 12

### DIFF
--- a/build.assets/build-test-compat.sh
+++ b/build.assets/build-test-compat.sh
@@ -34,15 +34,19 @@ DISTROS=(
   "debian:9"
   "debian:10"
   "debian:11"
+  "debian:12"
   # Distroless Debian fails because of missing libgcc_s.so.1
   # https://github.com/gravitational/teleport/issues/14538
-  #"gcr.io/distroless/base-debian11"
-  "gcr.io/distroless/cc"
+  #"gcr.io/distroless/base-debian12"
+  "gcr.io/distroless/cc-debian11"
+  "gcr.io/distroless/cc-debian12"
   "amazonlinux:1"
   "amazonlinux:2"
+  "amazonlinux:2023"
   "archlinux"
   "oraclelinux:7"
   "oraclelinux:8"
+  "oraclelinux:9"
   "fedora:34"
   "fedora:latest"
 )

--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -1,11 +1,11 @@
-ARG BASE_IMAGE=gcr.io/distroless/cc-debian11
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:11 AS staging
+FROM debian:12 AS staging
 RUN apt-get update 
 COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
-FROM debian:11 AS teleport
+FROM debian:12 AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -160,8 +160,8 @@ either:
 
 |Image name|Troubleshooting Tools?|Image base|
 |-|-|-|
-|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 11](https://github.com/GoogleContainerTools/distroless)|
-|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 11](https://github.com/GoogleContainerTools/distroless)|
+|`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
+|`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
 
 For testing, we always recommend that you use the latest released version of
 Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
@@ -176,8 +176,8 @@ considered deprecated, and they may be removed in future releases.
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
-| `(=teleport.latest_ent_docker_image=)` | No | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
-| `(=teleport.latest_ent_debug_docker_image=)` | Yes | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
+| `(=teleport.latest_ent_docker_image=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `(=teleport.latest_ent_debug_docker_image=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
 
 We also provide the following images for FIPS builds of Teleport Enterprise:
 

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -347,7 +347,7 @@ download() {
     fi
     # if we have a hashing utility installed, also download and validate the checksum
     SHA_COMMAND=""
-    # shasum is installed by default on MacOS and some distros
+    # shasum is installed by default on macOS and some distros
     if check_exists shasum; then
         SHA_COMMAND="shasum -a 256"
     # sha256sum is installed by default in some other distros
@@ -485,7 +485,7 @@ install_teleport_node_config() {
       "${LABELS_FLAG[@]}" \
       --output ${TELEPORT_CONFIG_PATH}
 }
-# checks whether the given host is running MacOS
+# checks whether the given host is running macOS
 is_macos_host() { if [[ ${OSTYPE} == "darwin"* ]]; then return 0; else return 1; fi }
 # checks whether teleport is already running on the host
 is_running_teleport() {
@@ -675,7 +675,7 @@ if [[ "${OSTYPE}" == "linux-gnu"* ]]; then
         fi
     fi
 elif [[ "${OSTYPE}" == "darwin"* ]]; then
-    # macos host, now detect arch
+    # macOS host, now detect arch
     TELEPORT_BINARY_TYPE="darwin"
     ARCH=$(uname -m)
     log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
@@ -689,7 +689,7 @@ elif [[ "${OSTYPE}" == "darwin"* ]]; then
         log_important "Error: unsupported architecture from uname -m: ${ARCH}"
         exit 1
     fi
-    log "Detected MacOS ${ARCH} architecture, using Teleport arch ${TELEPORT_ARCH}"
+    log "Detected macOS ${ARCH} architecture, using Teleport arch ${TELEPORT_ARCH}"
     TELEPORT_FORMAT="tarball"
 else
     log_important "Error - unsupported platform: ${OSTYPE}"
@@ -874,7 +874,7 @@ install_from_repo() {
         fi
         apt-get update
         apt-get install -y ${PACKAGE_LIST}
-    elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ] || [ "$ID" = "centos" ] ; then
+    elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ] || [ "$ID" = "centos" ]; then
         if [ "$ID" = "rhel" ]; then
             VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
         fi
@@ -931,7 +931,7 @@ is_repo_available() {
     # The following distros+version have a Teleport repository to install from.
     case "${ID}-${VERSION_ID}" in
         ubuntu-16.04* | ubuntu-18.04* | ubuntu-20.04* | ubuntu-22.04* | \
-        debian-9* | debian-10* | debian-11* | \
+        debian-9* | debian-10* | debian-11* | debian-12* | \
         rhel-7* | rhel-8* | rhel-9* | \
         centos-7* | centos-8* | centos-9* | \
         amzn-2)
@@ -982,13 +982,13 @@ if is_using_systemd; then
     fi
     start_teleport_systemd
     print_welcome_message
-# install launchd config on MacOS hosts
+# install launchd config on macOS hosts
 elif is_macos_host; then
-    log "Host is running MacOS"
+    log "Host is running macOS"
     install_launchd_config
     start_teleport_launchd
     print_welcome_message
-# not a MacOS host and no systemd available, print a warning
+# not a macOS host and no systemd available, print a warning
 # and temporarily start Teleport in the foreground
 else
     log "Host does not appear to be using systemd"


### PR DESCRIPTION
Backport of #31620.

`e` companion -- https://github.com/gravitational/teleport.e/pull/2720

https://github.com/GoogleContainerTools/distroless#debian-12

Note that the debian12 images no longer include OpenSSL, which we don't need anyway, as we statically link our own copy for tsh and other purposes.

Also, add Debian 12 to various places, as a supported OS.

Other included changes:
* Standardize how we select which distroless release to use.
* Ensure a specific distroless version is used instead of latest.
* Add new Amazon Linux and Oracle Linux releases to compatibility testing.
* Correct s/MacOS/macOS/ in install script.

changelog: Update distroless images to use Debian 12