### PR TITLE
[TAG] Point access-graph to the Teleport replacement code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
       "e-teleport/*": ["e/web/teleport/src/*"],
       "e-teleterm/*": ["e/web/teleterm/src/*"],
       "gen-proto-js/*": ["gen/proto/js/*"],
-      "access-graph": ["../web/src"],
+      "access-graph": ["e/web/teleport/src/AccessGraph/Loader.tsx"],
     },
     "outDir": "dist"
   },


### PR DESCRIPTION
Previously, the `access-graph` module pointed to the access-graph source code (to ensure correct typings). This was incorrect as in our CI builds, the `access-graph` code doesn't exist.

This changes it to point to the correct place (`Loader.tsx`). The typings will still be correct as this and access-graph both export a React component called `AccessGraph`.