### PR TITLE
Remove temporary reexports of moved functions

### DIFF
--- a/web/packages/teleport/src/lib/util.ts
+++ b/web/packages/teleport/src/lib/util.ts
@@ -16,24 +16,6 @@ limitations under the License.
 
 import { AuthType } from 'teleport/services/user';
 
-// TODO(ravicious): Refactor teleport.e and teleterm.e to import pluralize from shared/utils/text
-// and remove this temporary reexport.
-export {
-  /**
-   * @deprecated Import pluralize from `shared/utils/text` instead.
-   */
-  pluralize,
-} from 'shared/utils/text';
-
-// TODO(gzdunek): Refactor teleport.e to import compareSemVers from shared/utils/semVer
-// and remove this temporary reexport.
-export {
-  /**
-   * @deprecated Import compareSemVers from `shared/utils/semVer` instead.
-   */
-  compareSemVers,
-} from 'shared/utils/semVer';
-
 export const openNewTab = (url: string) => {
   const element = document.createElement('a');
   element.setAttribute('href', `${url}`);


### PR DESCRIPTION
`pluralize` was moved in [#24520 bc8fa80b3287](https://github.com/gravitational/teleport/pull/24520/commits/bc8fa80b3287d6c89c98e2211ea9d5d4e8d095e2), `compareSemVers` in [#28698 4e27517009](https://github.com/gravitational/teleport/pull/28698/commits/4e27517009c581166f577acd85ae53487bf68275).

Initially I wanted to submit two separate PRs for each removal of a reexport: the move of `pluralize` was backported to v13 and v14 while `compareSemVers` was backported only to v14. However, teleport.e v13 still uses `pluralize` from the old locations – it looks like I forgot to backport a PR in teleport.e. Instead of spending time on this, I'm just going to remove both reexports in master and v14 only. Leaving that old reexport in v13 should not be a problem since any new code that will be backported to v13 will use `pluralize` from the new location, which does exist on v13.