### PR TITLE
[v12] Create separate Dockerfile for distroless FIPS images

### DIFF
--- a/build.assets/charts/Dockerfile-distroless-fips
+++ b/build.assets/charts/Dockerfile-distroless-fips
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
 FROM debian:12 AS staging
-RUN apt-get update 
+RUN apt-get update
 COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
@@ -18,7 +18,7 @@ ARG TELEPORT_RELEASE_INFIX
 ARG TELEPORT_VERSION
 # TARGETARCH is supplied by the `buildx` mechanics
 ARG TARGETARCH
-ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}_${TARGETARCH}.deb
+ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}-fips_${TARGETARCH}.deb
 COPY $TELEPORT_DEB_FILE_NAME ./$TELEPORT_DEB_FILE_NAME
 RUN dpkg-deb -R $TELEPORT_DEB_FILE_NAME /opt/staging && \
     mkdir -p /opt/staging/etc/teleport && \
@@ -30,4 +30,4 @@ FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging /
 COPY --from=staging /opt/staging/root /
 COPY --from=staging /opt/staging/status /var/lib/dpkg/status.d
-ENTRYPOINT ["/usr/bin/dumb-init", "/usr/local/bin/teleport", "start", "-c", "/etc/teleport/teleport.yaml"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/usr/local/bin/teleport", "start", "-c", "/etc/teleport/teleport.yaml", "--fips"]


### PR DESCRIPTION
Backport of #32626.

`e` companion -- https://github.com/gravitational/teleport.e/pull/2717

Ref #30950.