### PR TITLE
Do not show 'not supported' tooltip when pinning is supported

### DIFF
--- a/web/packages/shared/components/ToolTip/HoverTooltip.tsx
+++ b/web/packages/shared/components/ToolTip/HoverTooltip.tsx
@@ -79,7 +79,8 @@ export const HoverTooltip: React.FC<{
         <StyledOnHover
           px={2}
           py={1}
-          fontSize="10px"
+          fontWeight="regular"
+          typography="subtitle2"
           css={`
             word-wrap: break-word;
           `}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -317,7 +317,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         text: shouldUnpin ? 'Unpin Selected' : 'Pin Selected',
         Icon: PushPin,
         tooltip:
-          pinning.kind !== 'not-supported'
+          pinning.kind === 'not-supported'
             ? PINNING_NOT_SUPPORTED_MESSAGE
             : null,
         disabled:


### PR DESCRIPTION
I noticed that the tooltip 'The cluster does not support pinning resources...' is shown when the pinning is supported. The reason is simple, the condition showing it was incorrect.

I also corrected the style of the tooltip, which previously had a line height that was too high:
<img width="550" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/aa1b895b-f028-4e41-9020-cd7513a33d1c">
After:
<img width="550" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/0a77bf4e-a2d7-490f-a41c-08d6177508b2">

Changelog: Do not display a tooltip about unsupported resource pinning when it is supported in Web UI