### PR TITLE
External Audit Storage: bootstrap script improvements

### DIFF
--- a/lib/integrations/awsoidc/externalcloudaudit_iam_config.go
+++ b/lib/integrations/awsoidc/externalcloudaudit_iam_config.go
@@ -16,6 +16,7 @@ package awsoidc
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -64,6 +65,8 @@ func ConfigureExternalCloudAudit(
 	clt ConfigureExternalCloudAuditClient,
 	params *config.IntegrationConfExternalCloudAudit,
 ) error {
+	fmt.Println("\nConfiguring necessary IAM permissions for External Audit Storage")
+
 	policyCfg := &awslib.ExternalCloudAuditPolicyConfig{
 		Partition:           params.Partition,
 		Region:              params.Region,
@@ -105,6 +108,7 @@ func ConfigureExternalCloudAudit(
 		return trace.Wrap(err)
 	}
 
+	fmt.Printf("Attaching inline policy %s to role %s\n", params.Policy, params.Role)
 	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
 		PolicyName:     &params.Policy,
 		RoleName:       &params.Role,

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -43,7 +43,7 @@ func Commands() []CLICommand {
 		&ProxyCommand{},
 		&ResourceCommand{},
 		&EditCommand{},
-		&ExternalCloudAuditCommand{},
+		&ExternalAuditStorageCommand{},
 		&LoadtestCommand{},
 		&DevicesCommand{},
 		&SAMLCommand{},

--- a/tool/tctl/common/externalcloudaudit_command.go
+++ b/tool/tctl/common/externalcloudaudit_command.go
@@ -26,34 +26,34 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
-// ExternalCloudAuditCommand implements "tctl externalcloudaudit" group of commands.
-type ExternalCloudAuditCommand struct {
+// ExternalAuditStorageCommand implements "tctl externalauditstorage" group of commands.
+type ExternalAuditStorageCommand struct {
 	config *servicecfg.Config
 
 	integrationName string
 	region          string
 
-	// promote implements the "tctl externalcloudaudit promote" subcommand.
+	// promote implements the "tctl externalauditstorage promote" subcommand.
 	promote *kingpin.CmdClause
-	// generate implements the "tctl externalcloudaudit generate" subcommand.
+	// generate implements the "tctl externalauditstorage generate" subcommand.
 	generate *kingpin.CmdClause
 }
 
 // Initialize allows ExternalCloudAuditCommand to plug itself into the CLI parser.
-func (c *ExternalCloudAuditCommand) Initialize(app *kingpin.Application, config *servicecfg.Config) {
+func (c *ExternalAuditStorageCommand) Initialize(app *kingpin.Application, config *servicecfg.Config) {
 	c.config = config
 
-	externalCloudAudit := app.Command("externalcloudaudit", "Operate on external cloud audit configuration.").Hidden()
-	c.promote = externalCloudAudit.Command("promote", "Promotes existing draft external cloud audit to be used in cluster").Hidden()
+	externalAuditStorage := app.Command("externalauditstorage", "Operate on external cloud audit configuration.").Alias("externalcloudaudit").Hidden()
+	c.promote = externalAuditStorage.Command("promote", "Promotes existing draft external cloud audit to be used in cluster").Hidden()
 
 	// This command should remain hidden it is only meant for development/test.
-	c.generate = externalCloudAudit.Command("generate", "Generates an external cloud audit configuration with randomized resource names and saves it as the current draft").Hidden()
+	c.generate = externalAuditStorage.Command("generate", "Generates an external cloud audit configuration with randomized resource names and saves it as the current draft").Hidden()
 	c.generate.Flag("integration", "Name of an existing AWS OIDC integration").Required().StringVar(&c.integrationName)
 	c.generate.Flag("region", "AWS region where infrastructure will be hosted").Required().StringVar(&c.region)
 }
 
 // TryRun attempts to run subcommands.
-func (c *ExternalCloudAuditCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.promote.FullCommand():
 		err = c.Promote(ctx, client)
@@ -67,13 +67,13 @@ func (c *ExternalCloudAuditCommand) TryRun(ctx context.Context, cmd string, clie
 
 // Promote calls PromoteToClusterExternalCloudAudit, which results in enabling
 // external cloud audit in cluster based on existing draft.
-func (c *ExternalCloudAuditCommand) Promote(ctx context.Context, clt auth.ClientI) error {
+func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt auth.ClientI) error {
 	return trace.Wrap(clt.ExternalCloudAuditClient().PromoteToClusterExternalCloudAudit(ctx))
 }
 
 // Generate creates an external cloud audit configuration with randomized
 // resource names and saves it as the current draft.
-func (c *ExternalCloudAuditCommand) Generate(ctx context.Context, clt auth.ClientI) error {
+func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt auth.ClientI) error {
 	_, err := clt.ExternalCloudAuditClient().GenerateDraftExternalCloudAudit(ctx, c.integrationName, c.region)
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
Previously the bootstrap script had no output if it was successful and didn't make it clear that it actually did anything. This change adds some output to inform the user what is being done, and renames to command to `externalauditstorage` to align with the new naming for the feature.

Example command invocation:

```
> teleport integration configure externalauditstorage --bootstrap \
  --aws-region=us-west-2 --role=nic-byob-test \
  --policy=ExternalCloudAuditPolicy-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04 \
  --session-recordings=s3://teleport-longterm-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04/sessions \
  --audit-events=s3://teleport-longterm-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04/events \
  --athena-results=s3://teleport-transient-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04/query_results \
  --athena-workgroup=teleport_events_8b0df11a_74cd_4e4c_bc71_dbe96b8e4e04 \
  --glue-database=teleport_events_8b0df11a_74cd_4e4c_bc71_dbe96b8e4e04 \
  --glue-table=teleport_events

Bootstrapping External Audit Storage infrastructure
Creating long term storage S3 bucket teleport-longterm-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04
Applying object lock configuration to long term storage S3 bucket with default retention period of 4 years
Creating transient storage S3 bucket teleport-transient-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04
Applying bucket lifecycle configuration to transient storage S3 bucket
Creating Athena workgroup teleport_events_8b0df11a_74cd_4e4c_bc71_dbe96b8e4e04
Creating Glue database teleport_events_8b0df11a_74cd_4e4c_bc71_dbe96b8e4e04
Creating Glue table teleport_events

Configuring necessary IAM permissions for External Audit Storage
Attaching inline policy ExternalCloudAuditPolicy-8b0df11a-74cd-4e4c-bc71-dbe96b8e4e04 to role nic-byob-test
```