### PR TITLE
Fix installer to only use `--azure-client-id` if requested

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -110,7 +110,9 @@ on_gcp() {
   sudo /usr/local/bin/teleport node configure \
     --proxy="{{ .PublicProxyAddr }}" \
     --join-method=${JOIN_METHOD} \
+    {{- if .AzureClientID }}
     --azure-client-id="{{ .AzureClientID }}" \
+    {{ end -}}
     --token="$1" \
     --output=file \
     --labels="${LABELS}"

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1083,SC2215,SC2288 # caused by Go templating, and shellcheck won't parse if the lines are excluded individually
 
 set -eu
 


### PR DESCRIPTION
This change updates the default installer to only use the `--azure-client-id` flag to configure the node when an Azure client ID is present. This fixes a bug where the default installer from a v14 cluster would fail when trying to install a v13 node.

Fixes #34860.

Changelog: Fixed error when installing a v13 node with the default installer from a v14 cluster