### PR TITLE
Export auth server version for upgrader

### DIFF
--- a/lib/versioncontrol/upgradewindow/upgradewindow.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow.go
@@ -47,7 +47,7 @@ const (
 	unitScheduleFile = "schedule"
 
 	// unitVersionFile is the name of the file to which the version is exported.
-	unitVersionFile = "version"
+	unitVersionFile = "auth-version"
 
 	// unitConfigDir is the configuration directory of the teleport-upgrade unit.
 	unitConfigDir = "/etc/teleport-upgrade.d"


### PR DESCRIPTION
Paired with https://github.com/gravitational/teleport.e/pull/2722
Supports https://github.com/gravitational/cloud/issues/6773

Teleport will now export the auth server version:
- On kube agents, the auth server version will be exported to the backend with key `agent-auth-version`.
- On systemd agents, the auth server version will be exported to the `/etc/teleport-upgrade.d/version` unit file.

This is necessary for the teleport-upgrade script to be able to identify the auth server version, and prevent an upgrade if the target upgrade version is a newer major version than the auth server.