### PR TITLE
fix: typo in comment

### DIFF
--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -54,7 +54,7 @@ var (
 		`^(?P<prefix>[^}{]*)` +
 			// variable is anything in brackets {{}} that is not { or }
 			`{{(?P<expression>\s*[^}{]*\s*)}}` +
-			// prefix is anything that is not { or }
+			// suffix is anything that is not { or }
 			`(?P<suffix>[^}{]*)$`,
 	)
 )


### PR DESCRIPTION
There's a tiny typo in the comment: `prefix` should be `suffix`. 
I think this change will make it easier to correctly understand the code.

Hope this helps.