### PR TITLE
[v14] Do not show 'not supported' tooltip when pinning is supported

### DIFF
--- a/web/packages/shared/components/ToolTip/HoverTooltip.tsx
+++ b/web/packages/shared/components/ToolTip/HoverTooltip.tsx
@@ -79,7 +79,8 @@ export const HoverTooltip: React.FC<{
         <StyledOnHover
           px={2}
           py={1}
-          fontSize="10px"
+          fontWeight="regular"
+          typography="subtitle2"
           css={`
             word-wrap: break-word;
           `}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -317,7 +317,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         text: shouldUnpin ? 'Unpin Selected' : 'Pin Selected',
         Icon: PushPin,
         tooltip:
-          pinning.kind !== 'not-supported'
+          pinning.kind === 'not-supported'
             ? PINNING_NOT_SUPPORTED_MESSAGE
             : null,
         disabled:


### PR DESCRIPTION
Backport #34895 to branch/v14