### PR TITLE
[v14] Machine ID: Add experimental ClientCredentialOutput for Operator's use (#34442)

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -53,6 +53,8 @@ type Config struct {
 	// PromptAdminRequestMFA is used to prompt the user for MFA on admin requests when needed.
 	// If nil, the client will not prompt for MFA.
 	PromptAdminRequestMFA func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
+	// Insecure turns off TLS certificate verification when enabled.
+	Insecure bool
 }
 
 // Connect creates a valid client connection to the auth service.  It may
@@ -91,7 +93,7 @@ func connectViaAuthDirect(ctx context.Context, cfg *Config) (auth.ClientI, error
 			apiclient.LoadTLS(cfg.TLS),
 		},
 		CircuitBreakerConfig:     cfg.CircuitBreakerConfig,
-		InsecureAddressDiscovery: cfg.TLS.InsecureSkipVerify,
+		InsecureAddressDiscovery: cfg.Insecure,
 		DialTimeout:              cfg.DialTimeout,
 		PromptAdminRequestMFA:    cfg.PromptAdminRequestMFA,
 	})
@@ -119,7 +121,7 @@ func connectViaProxyTunnel(ctx context.Context, cfg *Config) (auth.ClientI, erro
 	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
 		Context:   ctx,
 		ProxyAddr: cfg.AuthServers[0].String(),
-		Insecure:  cfg.TLS.InsecureSkipVerify,
+		Insecure:  cfg.Insecure,
 		Timeout:   cfg.DialTimeout,
 	})
 
@@ -134,7 +136,7 @@ func connectViaProxyTunnel(ctx context.Context, cfg *Config) (auth.ClientI, erro
 		Resolver:              resolver,
 		ClientConfig:          cfg.SSH,
 		Log:                   cfg.Log,
-		InsecureSkipTLSVerify: cfg.TLS.InsecureSkipVerify,
+		InsecureSkipTLSVerify: cfg.Insecure,
 		ClusterCAs:            cfg.TLS.RootCAs,
 	})
 	if err != nil {

--- a/lib/tbot/bot_identity.go
+++ b/lib/tbot/bot_identity.go
@@ -178,7 +178,6 @@ func botIdentityFromAuth(
 	newIdentity, err := identity.ReadIdentityFromStore(
 		ident.Params(),
 		certs,
-		identity.BotKinds()...,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "reading renewed identity")
@@ -241,6 +240,6 @@ func botIdentityFromToken(log logrus.FieldLogger, cfg *config.BotConfig) (*ident
 		PrivateKeyBytes: tlsPrivateKey,
 		PublicKeyBytes:  sshPublicKey,
 		TokenHashBytes:  []byte(tokenHash),
-	}, certs, identity.BotKinds()...)
+	}, certs)
 	return ident, trace.Wrap(err)
 }

--- a/lib/tbot/config/bot_test.go
+++ b/lib/tbot/config/bot_test.go
@@ -245,7 +245,7 @@ func getTestIdent(t *testing.T, username string, reqs ...identRequest) *identity
 	ident, err := identity.ReadIdentityFromStore(&identity.LoadIdentityParams{
 		PrivateKeyBytes: privateKey,
 		PublicKeyBytes:  tlsPublicKeyPEM,
-	}, certs, identity.DestinationKinds()...)
+	}, certs)
 	require.NoError(t, err)
 
 	return ident

--- a/lib/tbot/config/destination_nop.go
+++ b/lib/tbot/config/destination_nop.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+)
+
+const DestinationNopType = "nop"
+
+// DestinationNop does nothing! Useful for odd scenarios where a destination
+// has to be returned but there is none to return.
+type DestinationNop struct{}
+
+// CheckAndSetDefaults does nothing! It is necessary to implement the
+// Destination interface.
+func (dm *DestinationNop) CheckAndSetDefaults() error {
+	return nil
+}
+
+// Init does nothing! It is necessary to implement the Destination interface.
+func (dm *DestinationNop) Init(_ context.Context, subdirs []string) error {
+	// Nothing to do.
+	return nil
+}
+
+// Verify does nothing! It is necessary to implement the Destination interface.
+func (dm *DestinationNop) Verify(keys []string) error {
+	// Nothing to do.
+	return nil
+}
+
+// Write does nothing! It is necessary to implement the Destination interface.
+func (dm *DestinationNop) Write(_ context.Context, name string, data []byte) error {
+	// Nothing to do.
+	return nil
+}
+
+// Read does nothing, it behaves as if the requested artifact could not be
+// found! It is necessary to implement the Destination interface.
+func (dm *DestinationNop) Read(_ context.Context, name string) ([]byte, error) {
+	// Nothing to do.
+	return nil, trace.NotFound("reading from a nop destination results in no data")
+}
+
+// String returns a human-readable string that describes this instance.
+func (dm *DestinationNop) String() string {
+	return DestinationNopType
+}
+
+// TryLock does nothing! It is necessary to implement the Destination interface.
+func (dm *DestinationNop) TryLock() (func() error, error) {
+	return func() error {
+		return nil
+	}, nil
+}
+
+// MarshalYAML enables the yaml package to correctly marshal the Destination
+// as YAML including the type header.
+func (dm *DestinationNop) MarshalYAML() (interface{}, error) {
+	type raw DestinationNop
+	return withTypeHeader((*raw)(dm), DestinationNopType)
+}

--- a/lib/tbot/config/output_client_credential.go
+++ b/lib/tbot/config/output_client_credential.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+)
+
+// Assert that this UnstableClientCredentialOutput can be used as client
+// credential.
+var _ client.Credentials = new(UnstableClientCredentialOutput)
+
+const UnstableClientCredentialOutputType = "unstable_client_credential"
+
+// UnstableClientCredentialOutput is an experimental tbot output which is
+// compatible with the client.Credential interface. This allows tbot to be
+// used as an in-memory source of credentials for the Teleport API client and
+// removes the need to write credentials to a filesystem.
+//
+// Unstable: no API stability promises are made for this struct and its methods.
+// Available configuration options may change and the signatures of methods may
+// be modified. This output is currently part of an experiment and could be
+// removed in a future release.
+type UnstableClientCredentialOutput struct {
+	mu     sync.Mutex
+	facade *identity.Facade
+	ready  chan struct{}
+}
+
+// Ready returns a channel which closes when the Output is ready to be used
+// as a client credential. Using this as a credential before Ready closes is
+// unsupported.
+func (o *UnstableClientCredentialOutput) Ready() <-chan struct{} {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.ready == nil {
+		o.ready = make(chan struct{})
+		if o.facade != nil {
+			close(o.ready)
+		}
+	}
+	return o.ready
+}
+
+// Dialer implements the client.Credential interface. It does nothing.
+func (o *UnstableClientCredentialOutput) Dialer(c client.Config) (client.ContextDialer, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return nil, trace.NotImplemented("no dialer")
+}
+
+// TLSConfig implements the client.Credential interface and return the
+// tls.Config from the underlying identity.Facade.
+func (o *UnstableClientCredentialOutput) TLSConfig() (*tls.Config, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.facade == nil {
+		return nil, trace.BadParameter("credentials not yet ready")
+	}
+	return o.facade.TLSConfig()
+}
+
+// SSHClientConfig implements the client.Credential interface and return the
+// ssh.ClientConfig from the underlying identity.Facade.
+func (o *UnstableClientCredentialOutput) SSHClientConfig() (*ssh.ClientConfig, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.facade == nil {
+		return nil, trace.BadParameter("credentials not yet ready")
+	}
+	return o.facade.SSHClientConfig()
+}
+
+// Render implements the Destination interface and is called regularly by the
+// bot with new credentials. Render passes these credentials down to the
+// underlying facade so that they can be used in TLS/SSH configs.
+func (o *UnstableClientCredentialOutput) Render(_ context.Context, _ provider, ident *identity.Identity) error {
+	// We're hijacking the Render method to receive a new identity in each
+	// renewal round.
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.facade == nil {
+		if o.ready != nil {
+			close(o.ready)
+		}
+		o.facade = identity.NewFacade(false, false, ident)
+		return nil
+	}
+	o.facade.Set(ident)
+	return nil
+}
+
+// Init implements the Destination interface and does nothing in this
+// implementation.
+func (o *UnstableClientCredentialOutput) Init(ctx context.Context) error {
+	return nil
+}
+
+// GetDestination implements the Destination interface and does nothing in this
+// implementation.
+func (o *UnstableClientCredentialOutput) GetDestination() bot.Destination {
+	return &DestinationNop{}
+}
+
+// GetRoles implements the Destination interface and returns an empty slice in
+// this implementation. This causes all available roles to be used with the
+// identity.
+func (o *UnstableClientCredentialOutput) GetRoles() []string {
+	return []string{}
+}
+
+// CheckAndSetDefaults implements the Destination interface and does nothing in
+// this implementation.
+func (o *UnstableClientCredentialOutput) CheckAndSetDefaults() error {
+	return nil
+}
+
+// Describe implements the Destination interface and returns no file
+// descriptions in this implementation, this is because no files are written.
+func (o *UnstableClientCredentialOutput) Describe() []FileDescription {
+	return []FileDescription{}
+}
+
+// MarshalYAML enables the yaml package to correctly marshal the Destination
+// as YAML including the type header.
+func (o *UnstableClientCredentialOutput) MarshalYAML() (interface{}, error) {
+	type raw UnstableClientCredentialOutput
+	return withTypeHeader((*raw)(o), UnstableClientCredentialOutputType)
+}
+
+// String returns a human readable description of this output.
+func (o *UnstableClientCredentialOutput) String() string {
+	return UnstableClientCredentialOutputType
+}

--- a/lib/tbot/config/template_ssh_client_test.go
+++ b/lib/tbot/config/template_ssh_client_test.go
@@ -53,7 +53,7 @@ func TestTemplateSSHClient_Render(t *testing.T) {
 			cfg, err := newTestConfig("example.com")
 			require.NoError(t, err)
 
-			// ident is passed in, but not used.
+			// identity is passed in, but not used.
 			var ident *identity.Identity
 			dest := &DestinationDirectory{
 				Path:     dir,

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -29,15 +29,10 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -72,9 +67,8 @@ var log = logrus.WithFields(logrus.Fields{
 	trace.Component: teleport.ComponentTBot,
 })
 
-// Identity is collection of certificates and signers that represent server
-// identity. This is derived from Teleport's usual auth.Identity with small
-// modifications to work with user rather than host certificates.
+// Identity is collection of raw key and certificate data as well as the
+// parsed equivalents that make up a Teleport identity.
 type Identity struct {
 	// PrivateKeyBytes is a PEM encoded private key
 	PrivateKeyBytes []byte
@@ -89,16 +83,26 @@ type Identity struct {
 	TLSCACertsBytes [][]byte
 	// SSHCACertBytes is a list of SSH CAs encoded in the authorized_keys format.
 	SSHCACertBytes [][]byte
+	// TokenHashBytes is the hash of the original join token
+	TokenHashBytes []byte
+
+	// Below fields are "computed" by ReadIdentityFromStore - this essentially
+	// validates the raw data and saves these being continually recomputed.
 	// KeySigner is an SSH host certificate signer
 	KeySigner ssh.Signer
 	// SSHCert is a parsed SSH certificate
 	SSHCert *ssh.Certificate
-	// X509Cert is an X509 client certificate
+	// SSHHostCheckers holds the parsed SSH CAs
+	SSHHostCheckers []ssh.PublicKey
+	// X509Cert is the parsed X509 client certificate
 	X509Cert *x509.Certificate
-	// ClusterName is a name of host's cluster
+	// TLSCAPool is the parsed TLS CAs
+	TLSCAPool *x509.CertPool
+	// TLSCert is the parsed TLS client certificate
+	TLSCert *tls.Certificate
+	// ClusterName is a name of host's cluster determined from the
+	// x509 certificate.
 	ClusterName string
-	// TokenHashBytes is the hash of the original join token
-	TokenHashBytes []byte
 }
 
 // LoadIdentityParams contains parameters beyond proto.Certs needed to load a
@@ -136,260 +140,126 @@ func (i *Identity) String() string {
 	return fmt.Sprintf("Identity(%v)", strings.Join(out, ","))
 }
 
-// CertInfo returns diagnostic information about certificate
-func CertInfo(cert *x509.Certificate) string {
-	return fmt.Sprintf("cert(%v issued by %v:%v)", cert.Subject.CommonName, cert.Issuer.CommonName, cert.Issuer.SerialNumber)
-}
-
-// TLSCertInfo returns diagnostic information about certificate
-func TLSCertInfo(cert *tls.Certificate) string {
-	x509cert, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		return err.Error()
-	}
-	return CertInfo(x509cert)
-}
-
-// CertAuthorityInfo returns debugging information about certificate authority
-func CertAuthorityInfo(ca types.CertAuthority) string {
-	var out []string
-	for _, keyPair := range ca.GetTrustedTLSKeyPairs() {
-		cert, err := tlsca.ParseCertificatePEM(keyPair.Cert)
-		if err != nil {
-			out = append(out, err.Error())
-		} else {
-			out = append(out, fmt.Sprintf("trust root(%v:%v)", cert.Subject.CommonName, cert.Subject.SerialNumber))
-		}
-	}
-	return fmt.Sprintf("cert authority(state: %v, phase: %v, roots: %v)", ca.GetRotation().State, ca.GetRotation().Phase, strings.Join(out, ", "))
-}
-
-// HasTSLConfig returns true if this identity has TLS certificate and private key
-func (i *Identity) HasTLSConfig() bool {
-	return len(i.TLSCACertsBytes) != 0 && len(i.TLSCertBytes) != 0
-}
-
-// HasPrincipals returns whether identity has principals
-func (i *Identity) HasPrincipals(additionalPrincipals []string) bool {
-	set := utils.StringsSet(i.SSHCert.ValidPrincipals)
-	for _, principal := range additionalPrincipals {
-		if _, ok := set[principal]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// HasDNSNames returns true if TLS certificate has required DNS names
-func (i *Identity) HasDNSNames(dnsNames []string) bool {
-	if i.X509Cert == nil {
-		return false
-	}
-	set := utils.StringsSet(i.X509Cert.DNSNames)
-	for _, dnsName := range dnsNames {
-		if _, ok := set[dnsName]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// TLSConfig returns TLS config for mutual TLS authentication
-// can return NotFound error if there are no TLS credentials setup for identity
-func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(cipherSuites)
-	if !i.HasTLSConfig() {
-		return nil, trace.NotFound("no TLS credentials setup for this identity")
-	}
-	tlsCert, err := keys.X509KeyPair(i.TLSCertBytes, i.PrivateKeyBytes)
-	if err != nil {
-		return nil, trace.BadParameter("failed to parse private key: %v", err)
-	}
-	certPool := x509.NewCertPool()
-	for j := range i.TLSCACertsBytes {
-		parsedCert, err := tlsca.ParseCertificatePEM(i.TLSCACertsBytes[j])
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse CA certificate")
-		}
-		certPool.AddCert(parsedCert)
-	}
-	tlsConfig.Certificates = []tls.Certificate{tlsCert}
-	tlsConfig.RootCAs = certPool
-	tlsConfig.ClientCAs = certPool
-	tlsConfig.ServerName = apiutils.EncodeClusterName(i.ClusterName)
-	return tlsConfig, nil
-}
-
-func (i *Identity) getSSHCheckers() ([]ssh.PublicKey, error) {
-	checkers, err := apisshutils.ParseAuthorizedKeys(i.SSHCACertBytes)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return checkers, nil
-}
-
-// SSHClientConfig returns a ssh.ClientConfig used by the bot to connect to
-// the reverse tunnel server.
-func (i *Identity) SSHClientConfig(fips bool) (*ssh.ClientConfig, error) {
-	callback, err := apisshutils.NewHostKeyCallback(
-		apisshutils.HostKeyCallbackConfig{
-			GetHostCheckers: i.getSSHCheckers,
-			FIPS:            fips,
-		})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if len(i.SSHCert.ValidPrincipals) < 1 {
-		return nil, trace.BadParameter("user cert has no valid principals")
-	}
-	config := &ssh.ClientConfig{
-		User:            i.SSHCert.ValidPrincipals[0],
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(i.KeySigner)},
-		HostKeyCallback: callback,
-		Timeout:         apidefaults.DefaultIOTimeout,
-	}
-	if fips {
-		config.Config = ssh.Config{
-			KeyExchanges: defaults.FIPSKEXAlgorithms,
-			MACs:         defaults.FIPSMACAlgorithms,
-			Ciphers:      defaults.FIPSCiphers,
-		}
-	}
-
-	return config, nil
-}
-
 // ReadIdentityFromStore reads stored identity credentials
-func ReadIdentityFromStore(params *LoadIdentityParams, certs *proto.Certs, kinds ...ArtifactKind) (*Identity, error) {
-	var identity Identity
-
+func ReadIdentityFromStore(params *LoadIdentityParams, certs *proto.Certs) (*Identity, error) {
 	// Note: in practice we should always expect certificates to have all
 	// fields set even though destinations do not contain sufficient data to
 	// load a stored identity. This works in practice because we never read
 	// destination identities from disk and only read them from the result of
 	// `generateUserCerts`, which is always fully-formed.
-
-	if len(certs.SSH) == 0 {
+	switch {
+	case len(certs.SSH) == 0:
 		return nil, trace.BadParameter("identity requires SSH certificates but they are unset")
-	}
-
-	if len(certs.TLSCACerts) == 0 || len(certs.TLS) == 0 {
+	case len(params.PrivateKeyBytes) == 0:
+		return nil, trace.BadParameter("missing private key")
+	case len(certs.TLSCACerts) == 0 || len(certs.TLS) == 0:
 		return nil, trace.BadParameter("identity requires TLS certificates but they are empty")
 	}
 
-	err := ReadSSHIdentityFromKeyPair(&identity, params.PrivateKeyBytes, params.PrivateKeyBytes, certs.SSH)
+	sshHostCheckers, keySigner, sshCert, err := parseSSHIdentity(
+		params.PrivateKeyBytes, certs.SSH, certs.SSHCACerts,
+	)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "parsing ssh identity")
 	}
 
-	if len(certs.SSHCACerts) != 0 {
-		identity.SSHCACertBytes = certs.SSHCACerts
+	clusterName, x509Cert, tlsCert, tlsCAPool, err := ParseTLSIdentity(
+		params.PrivateKeyBytes, certs.TLS, certs.TLSCACerts,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing tls identity")
 	}
 
-	// Parse the key pair to verify that identity parses properly for future use.
-	if err := ReadTLSIdentityFromKeyPair(&identity, params.PrivateKeyBytes, certs.TLS, certs.TLSCACerts); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	return &Identity{
+		PublicKeyBytes:  params.PublicKeyBytes,
+		PrivateKeyBytes: params.PrivateKeyBytes,
+		CertBytes:       certs.SSH,
+		SSHCACertBytes:  certs.SSHCACerts,
+		TLSCertBytes:    certs.TLS,
+		TLSCACertsBytes: certs.TLSCACerts,
+		TokenHashBytes:  params.TokenHashBytes,
 
-	identity.PublicKeyBytes = params.PublicKeyBytes
-	identity.PrivateKeyBytes = params.PrivateKeyBytes
-	identity.TokenHashBytes = params.TokenHashBytes
-
-	return &identity, nil
+		// These fields are "computed"
+		ClusterName:     clusterName,
+		KeySigner:       keySigner,
+		SSHCert:         sshCert,
+		SSHHostCheckers: sshHostCheckers,
+		X509Cert:        x509Cert,
+		TLSCert:         tlsCert,
+		TLSCAPool:       tlsCAPool,
+	}, nil
 }
 
-// ReadTLSIdentityFromKeyPair reads TLS identity from key pair
-func ReadTLSIdentityFromKeyPair(identity *Identity, keyBytes, certBytes []byte, caCertsBytes [][]byte) error {
-	if len(keyBytes) == 0 {
-		return trace.BadParameter("missing private key")
-	}
-
-	if len(certBytes) == 0 {
-		return trace.BadParameter("missing certificate")
-	}
-
-	cert, err := tlsca.ParseCertificatePEM(certBytes)
+// ParseTLSIdentity reads TLS identity from key pair
+func ParseTLSIdentity(
+	keyBytes []byte, certBytes []byte, caCertsBytes [][]byte,
+) (clusterName string, x509Cert *x509.Certificate, tlsCert *tls.Certificate, certPool *x509.CertPool, err error) {
+	x509Cert, err = tlsca.ParseCertificatePEM(certBytes)
 	if err != nil {
-		return trace.Wrap(err, "failed to parse TLS certificate")
+		return "", nil, nil, nil, trace.Wrap(err, "parsing certificate")
 	}
 
-	if len(cert.Issuer.Organization) == 0 {
-		return trace.BadParameter("missing CA organization")
+	if len(x509Cert.Issuer.Organization) == 0 {
+		return "", nil, nil, nil, trace.BadParameter("certificate missing CA organization")
 	}
-
-	clusterName := cert.Issuer.Organization[0]
+	clusterName = x509Cert.Issuer.Organization[0]
 	if clusterName == "" {
-		return trace.BadParameter("missing cluster name")
+		return "", nil, nil, nil, trace.BadParameter("certificate missing cluster name")
 	}
 
-	identity.ClusterName = clusterName
-	identity.PrivateKeyBytes = keyBytes
-	identity.TLSCertBytes = certBytes
-	identity.TLSCACertsBytes = caCertsBytes
-	identity.X509Cert = cert
+	certPool = x509.NewCertPool()
+	for j := range caCertsBytes {
+		parsedCert, err := tlsca.ParseCertificatePEM(caCertsBytes[j])
+		if err != nil {
+			return "", nil, nil, nil, trace.Wrap(err, "parsing CA certificate")
+		}
+		certPool.AddCert(parsedCert)
+	}
 
-	// The passed in ciphersuites don't appear to matter here since the returned
-	// *tls.Config is never actually used?
-	_, err = identity.TLSConfig(utils.DefaultCipherSuites())
+	cert, err := keys.X509KeyPair(certBytes, keyBytes)
 	if err != nil {
-		return trace.Wrap(err)
+		return "", nil, nil, nil, trace.Wrap(err, "parse private key")
 	}
-	return nil
+
+	return clusterName, x509Cert, &cert, certPool, nil
 }
 
-// ReadSSHIdentityFromKeyPair reads identity from initialized keypair
-func ReadSSHIdentityFromKeyPair(identity *Identity, keyBytes, publicKeyBytes, certBytes []byte) error {
-	if len(keyBytes) == 0 {
-		return trace.BadParameter("PrivateKey: missing private key")
-	}
-
-	if len(publicKeyBytes) == 0 {
-		return trace.BadParameter("PublicKey: missing public key")
-	}
-
-	if len(certBytes) == 0 {
-		return trace.BadParameter("Cert: missing parameter")
-	}
-
-	cert, err := apisshutils.ParseCertificate(certBytes)
+// parseSSHIdentity reads identity from initialized keypair
+func parseSSHIdentity(
+	keyBytes, certBytes []byte, caBytes [][]byte,
+) (hostCheckers []ssh.PublicKey, certSigner ssh.Signer, cert *ssh.Certificate, err error) {
+	cert, err = apisshutils.ParseCertificate(certBytes)
 	if err != nil {
-		return trace.BadParameter("failed to parse server certificate: %v", err)
+		return nil, nil, nil, trace.Wrap(err, "parsing certificate")
 	}
 
 	signer, err := ssh.ParsePrivateKey(keyBytes)
 	if err != nil {
-		return trace.BadParameter("failed to parse private key: %v", err)
+		return nil, nil, nil, trace.Wrap(err, "parsing key")
 	}
 	// this signer authenticates using certificate signed by the cert authority
 	// not only by the public key
-	certSigner, err := ssh.NewCertSigner(cert, signer)
+	certSigner, err = ssh.NewCertSigner(cert, signer)
 	if err != nil {
-		return trace.BadParameter("unsupported private key: %v", err)
+		return nil, nil, nil, trace.Wrap(err, "creating signer from certificate and key")
 	}
 
 	// check principals on certificate
 	if len(cert.ValidPrincipals) < 1 {
-		return trace.BadParameter("valid principals: at least one valid principal is required")
+		return nil, nil, nil, trace.BadParameter("valid principals: at least one valid principal is required")
 	}
 	for _, validPrincipal := range cert.ValidPrincipals {
 		if validPrincipal == "" {
-			return trace.BadParameter("valid principal can not be empty: %q", cert.ValidPrincipals)
+			return nil, nil, nil, trace.BadParameter("valid principal can not be empty: %q", cert.ValidPrincipals)
 		}
 	}
 
-	clusterName := cert.Permissions.Extensions[teleport.CertExtensionTeleportRouteToCluster]
-	if clusterName == "" {
-		return trace.BadParameter("missing cert extension %v", teleport.CertExtensionTeleportRouteToCluster)
+	hostCheckers, err = apisshutils.ParseAuthorizedKeys(caBytes)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err, "parsing ca bytes")
 	}
 
-	identity.ClusterName = clusterName
-	identity.PrivateKeyBytes = keyBytes
-	identity.PublicKeyBytes = publicKeyBytes
-	identity.CertBytes = certBytes
-	identity.KeySigner = certSigner
-	identity.SSHCert = cert
-
-	return nil
+	return hostCheckers, certSigner, cert, nil
 }
 
 // VerifyWrite attempts to write to the .write-test artifact inside the given
@@ -483,5 +353,5 @@ func LoadIdentity(ctx context.Context, d bot.Destination, kinds ...ArtifactKind)
 
 	log.Debugf("Loaded %d SSH CA certs and %d TLS CA certs", len(certs.SSHCACerts), len(certs.TLSCACerts))
 
-	return ReadIdentityFromStore(&params, &certs, kinds...)
+	return ReadIdentityFromStore(&params, &certs)
 }

--- a/lib/tbot/identity/identity_facade.go
+++ b/lib/tbot/identity/identity_facade.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/net/http2"
+
+	"github.com/gravitational/teleport/api/client"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// Assert that this Facade can be used as client credential.
+var _ client.Credentials = new(Facade)
+
+// Facade manages storing a rotating identity, and presenting it as
+// something compatible with a client.Credentials
+type Facade struct {
+	mu       sync.RWMutex
+	identity *Identity
+
+	// These don't need locking as they are configuration values that are
+	// only set on construction
+	fips     bool
+	insecure bool
+	// initialIdentity is used in some special circumstances where the value
+	// must remain stable.
+	initialIdentity *Identity
+}
+
+func NewFacade(
+	fips bool,
+	insecure bool,
+	initialIdentity *Identity,
+) *Facade {
+	f := &Facade{
+		fips:            fips,
+		identity:        initialIdentity,
+		insecure:        insecure,
+		initialIdentity: initialIdentity,
+	}
+
+	return f
+}
+
+func (f *Facade) Get() *Identity {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.identity
+}
+
+func (f *Facade) Set(newIdentity *Identity) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.identity = newIdentity
+}
+
+func (f *Facade) Dialer(_ client.Config) (client.ContextDialer, error) {
+	// Returning a dialer isn't necessary for this credential.
+	return nil, trace.NotImplemented("no dialer")
+}
+
+func (f *Facade) TLSConfig() (*tls.Config, error) {
+	cipherSuites := utils.DefaultCipherSuites()
+	if f.fips {
+		cipherSuites = defaults.FIPSCipherSuites
+	}
+
+	// Build a "dynamic" tls.Config which can support a changing cert and root
+	// CA pool.
+	cfg := &tls.Config{
+		// Set the default NextProto of "h2". Based on the value in
+		// configureTLS()
+		NextProtos:   []string{http2.NextProtoTLS},
+		CipherSuites: cipherSuites,
+
+		// GetClientCertificate is used instead of the static Certificates
+		// field.
+		Certificates: nil,
+		GetClientCertificate: func(
+			_ *tls.CertificateRequestInfo,
+		) (*tls.Certificate, error) {
+			// GetClientCertificate callback is used to allow us to dynamically
+			// change the certificate when reloaded.
+			f.mu.RLock()
+			defer f.mu.RUnlock()
+			return f.identity.TLSCert, nil
+		},
+
+		// VerifyConnection is actually used instead of the static RootCAs
+		// field - however, we also populate the RootCAs field to work around
+		// a lot of Teleport code which relies on this field. This means we
+		// may not handle CA rotations when using certain connection
+		RootCAs: f.initialIdentity.TLSCAPool,
+		// InsecureSkipVerify is forced true to ensure that only our
+		// VerifyConnection callback is used to verify the server's presented
+		// certificate.
+		InsecureSkipVerify: true,
+		VerifyConnection: func(state tls.ConnectionState) error {
+			// This VerifyConnection callback is based on the standard library
+			// implementation of verifyServerCertificate in the `tls` package.
+			// We provide our own implementation so we can dynamically handle
+			// a changing CA Roots pool.
+			if f.insecure {
+				return nil
+			}
+			f.mu.RLock()
+			defer f.mu.RUnlock()
+			opts := x509.VerifyOptions{
+				DNSName:       state.ServerName,
+				Intermediates: x509.NewCertPool(),
+				Roots:         f.identity.TLSCAPool,
+			}
+			for _, cert := range state.PeerCertificates[1:] {
+				// Whilst we don't currently use intermediate certs at
+				// Teleport, including this here means that we are
+				// future-proofed in case we do.
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := state.PeerCertificates[0].Verify(opts)
+			return err
+		},
+		ServerName: apiutils.EncodeClusterName(f.initialIdentity.ClusterName),
+	}
+
+	return cfg, nil
+}
+
+func (f *Facade) SSHClientConfig() (*ssh.ClientConfig, error) {
+	hostKeyCallback, err := sshutils.NewHostKeyCallback(sshutils.HostKeyCallbackConfig{
+		GetHostCheckers: func() ([]ssh.PublicKey, error) {
+			f.mu.RLock()
+			defer f.mu.RUnlock()
+			return f.identity.SSHHostCheckers, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a "dynamic" ssh config. Based roughly on
+	// `sshutils.ProxyClientSSHConfig` with modifications to make it work with
+	// dynamically changing credentials and CAs.
+	cfg := &ssh.ClientConfig{
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeysCallback(func() (signers []ssh.Signer, err error) {
+				f.mu.RLock()
+				defer f.mu.RUnlock()
+				return []ssh.Signer{f.identity.KeySigner}, nil
+			}),
+		},
+		HostKeyCallback: hostKeyCallback,
+		Timeout:         apidefaults.DefaultIOTimeout,
+		// We use this because we can't always guarantee that a user will have
+		// a principal other than this (they may not have access to SSH nodes)
+		// and the actual user here doesn't matter for auth server API
+		// authentication. All that matters is that the principal specified here
+		// is stable across all certificates issued to the user, since this
+		// value cannot be changed in a following rotation -
+		// SSHSessionJoinPrincipal is included on all user ssh certs.
+		//
+		// This is a bit of a hack - the ideal solution is a refactor of the
+		// API client in order to support the SSH config being generated at
+		// time of use, rather than a single SSH config being made dynamic.
+		// ~ noah
+		User: "-teleport-internal-join",
+	}
+	if f.fips {
+		cfg.Config = ssh.Config{
+			KeyExchanges: defaults.FIPSKEXAlgorithms,
+			MACs:         defaults.FIPSMACAlgorithms,
+			Ciphers:      defaults.FIPSCiphers,
+		}
+	}
+	return cfg, nil
+}

--- a/lib/tbot/impersonated_identity.go
+++ b/lib/tbot/impersonated_identity.go
@@ -256,7 +256,7 @@ func (b *Bot) generateIdentity(
 	newIdentity, err := identity.ReadIdentityFromStore(&identity.LoadIdentityParams{
 		PrivateKeyBytes: privateKey,
 		PublicKeyBytes:  publicKey,
-	}, certs, identity.DestinationKinds()...)
+	}, certs)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -495,6 +495,8 @@ func (b *Bot) generateImpersonatedIdentity(
 
 		return routedIdentity, impersonatedClient, nil
 	case *config.SSHHostOutput:
+		return impersonatedIdentity, impersonatedClient, nil
+	case *config.UnstableClientCredentialOutput:
 		return impersonatedIdentity, impersonatedClient, nil
 	default:
 		return nil, nil, trace.BadParameter("generateImpersonatedIdentity does not support output type (%T)", output)

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -370,12 +370,10 @@ func tlsIdentFromDest(ctx context.Context, t *testing.T, dest bot.Destination) *
 	require.NoError(t, err)
 	hostCABytes, err := dest.Read(ctx, config.HostCAPath)
 	require.NoError(t, err)
-	ident := &identity.Identity{}
-	err = identity.ReadTLSIdentityFromKeyPair(ident, keyBytes, certBytes, [][]byte{hostCABytes})
+	_, x509Cert, _, _, err := identity.ParseTLSIdentity(keyBytes, certBytes, [][]byte{hostCABytes})
 	require.NoError(t, err)
-
 	tlsIdent, err := tlsca.FromSubject(
-		ident.X509Cert.Subject, ident.X509Cert.NotAfter,
+		x509Cert.Subject, x509Cert.NotAfter,
 	)
 	require.NoError(t, err)
 	return tlsIdent

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -355,6 +355,7 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 		return nil, trace.Wrap(err)
 	}
 	authConfig.TLS.InsecureSkipVerify = ccf.Insecure
+	authConfig.Insecure = ccf.Insecure
 	authConfig.AuthServers = cfg.AuthServerAddresses()
 	authConfig.Log = cfg.Log
 
@@ -413,6 +414,7 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authcl
 		return nil, trace.Wrap(err)
 	}
 	authConfig.TLS.InsecureSkipVerify = ccf.Insecure
+	authConfig.Insecure = ccf.Insecure
 	authConfig.SSH, err = key.ProxyClientSSHConfig(rootCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Backports #34442 

changelog: Add experimental UnstableClientCredentialOutput that provides tbot based authentication for the Teleport API client.