### PR TITLE
Make copy to clipboard work in Connect

### DIFF
--- a/web/packages/design/src/utils/copyToClipboard.ts
+++ b/web/packages/design/src/utils/copyToClipboard.ts
@@ -15,13 +15,18 @@
  */
 
 /**
- * copyToClipboard copies text to clipboard.
+ * Copies text to clipboard.
+ * Works only in browser, not in Electron.
  *
  * @param textToCopy the text to copy to clipboard
  */
-export default function copyToClipboard(textToCopy: string): Promise<any> {
-  return navigator.clipboard.writeText(textToCopy).catch(err => {
-    // This can happen if the user denies clipboard permissions:
+export default async function copyToClipboard(
+  textToCopy: string
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(textToCopy);
+  } catch (err) {
+    // Error can happen if the user denies clipboard permissions.
     window.prompt('Cannot copy to clipboard. Use ctrl/cmd + c', err);
-  });
+  }
 }

--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -38,6 +38,7 @@ export function CardsView({
   onPinResource,
   isProcessing,
   pinningSupport,
+  onCopyToClipboard,
 }: ResourceViewProps) {
   return (
     <CardsContainer className="CardsContainer" gap={2}>
@@ -56,6 +57,7 @@ export function CardsView({
           selected={selectedResources.includes(key)}
           selectResource={() => onSelectResource(key)}
           pinResource={() => onPinResource(key)}
+          onCopyToClipboard={onCopyToClipboard}
         />
       ))}
       {isProcessing && (

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 
 import { ButtonBorder } from 'design';
 import { gap } from 'design/system';
+import copyToClipboard from 'design/utils/copyToClipboard';
 
 import { apps } from 'teleport/Apps/fixtures';
 import { databases } from 'teleport/Databases/fixtures';
@@ -135,6 +136,7 @@ export const Cards: Story = {
             cardViewProps={res.cardViewProps}
             labels={res.labels}
             ActionButton={res.ActionButton}
+            onCopyToClipboard={copyToClipboard}
           />
         ))}
       </Grid>

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -59,6 +59,7 @@ export function ResourceCard({
   pinResource,
   selectResource,
   selected,
+  onCopyToClipboard,
 }: Omit<ResourceItemProps, 'listViewProps'>) {
   const { primaryDesc, secondaryDesc } = cardViewProps;
 
@@ -201,7 +202,9 @@ export function ResourceCard({
                   </Text>
                 </HoverTooltip>
               </SingleLineBox>
-              {hovered && <CopyButton name={name} mr={2} />}
+              {hovered && (
+                <CopyButton name={name} mr={2} onCopy={onCopyToClipboard} />
+              )}
               {ActionButton}
             </Flex>
             <Flex flexDirection="row" alignItems="center">

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -35,6 +35,7 @@ export function ListView({
   onPinResource,
   pinningSupport,
   isProcessing,
+  onCopyToClipboard,
 }: ResourceViewProps) {
   return (
     <Flex className="ListContainer">
@@ -53,6 +54,7 @@ export function ListView({
           selected={selectedResources.includes(key)}
           selectResource={() => onSelectResource(key)}
           pinResource={() => onPinResource(key)}
+          onCopyToClipboard={onCopyToClipboard}
         />
       ))}
       {isProcessing && (

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { ButtonBorder, Flex } from 'design';
+import copyToClipboard from 'design/utils/copyToClipboard';
 
 import { apps } from 'teleport/Apps/fixtures';
 import { databases } from 'teleport/Databases/fixtures';
@@ -126,6 +127,7 @@ export const ListItems: Story = {
             listViewProps={res.listViewProps}
             labels={res.labels}
             ActionButton={res.ActionButton}
+            onCopyToClipboard={copyToClipboard}
           />
         ))}
       </Flex>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -43,6 +43,7 @@ export function ResourceListItem({
   pinResource,
   selectResource,
   selected,
+  onCopyToClipboard,
 }: Omit<ResourceItemProps, 'cardViewProps'>) {
   const { description, resourceType, addr } = listViewProps;
 
@@ -131,7 +132,9 @@ export function ResourceListItem({
               align-self: start;
             `}
           >
-            {hovered && <CopyButton name={name} ml={1} />}
+            {hovered && (
+              <CopyButton name={name} ml={1} onCopy={onCopyToClipboard} />
+            )}
           </Box>
         </Flex>
 
@@ -328,6 +331,7 @@ const ShowLabelsButton = styled(ButtonIcon)`
     &:focus {
       background: ${props => props.theme.colors.buttons.secondary.hover};
     }
+
     &:active {
       background: ${props => props.theme.colors.buttons.secondary.active};
     }

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -17,6 +17,7 @@
 import React, { useState } from 'react';
 
 import { ButtonBorder } from 'design';
+import copyToClipboard from 'design/utils/copyToClipboard';
 
 import { apps } from 'teleport/Apps/fixtures';
 import { databases } from 'teleport/Databases/fixtures';
@@ -138,6 +139,7 @@ const story = ({
             ActionButton: <ButtonBorder size="small">Connect</ButtonBorder>,
           },
         }))}
+        onCopyToClipboard={copyToClipboard}
       />
     );
   };

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -140,6 +140,7 @@ interface UnifiedResourcesProps {
   updateUnifiedResourcesPreferences(
     preferences: UnifiedResourcePreferences
   ): void;
+  onCopyToClipboard(text: string): void;
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -458,6 +459,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
             item: mapResourceToViewItem(unifiedResource),
             key: generateUnifiedResourceKey(unifiedResource.resource),
           }))}
+          onCopyToClipboard={props.onCopyToClipboard}
         />
       )}
       <div ref={setTrigger} />

--- a/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
@@ -18,7 +18,6 @@ import React, { useState, useRef, useEffect } from 'react';
 
 import ButtonIcon from 'design/ButtonIcon';
 import { Check, Copy } from 'design/Icon';
-import copyToClipboard from 'design/utils/copyToClipboard';
 
 import { HoverTooltip } from 'shared/components/ToolTip';
 
@@ -26,10 +25,12 @@ export function CopyButton({
   name,
   mr,
   ml,
+  onCopy,
 }: {
   name: string;
   mr?: number;
   ml?: number;
+  onCopy(text: string): void;
 }) {
   const copySuccess = 'Copied!';
   const copyDefault = 'Click to copy';
@@ -47,7 +48,7 @@ export function CopyButton({
   const handleCopy = () => {
     clearCurrentTimeout();
     setCopiedText(copySuccess);
-    copyToClipboard(name);
+    onCopy(name);
     // Change to default text after 1 second
     timeout.current = setTimeout(() => {
       setCopiedText(copyDefault);

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -144,6 +144,7 @@ export type ResourceItemProps = {
   selected: boolean;
   pinned: boolean;
   pinningSupport: PinningSupport;
+  onCopyToClipboard(text: string): void;
 };
 
 // Props that are needed for the Card view.
@@ -184,4 +185,5 @@ export type ResourceViewProps = {
   pinningSupport: PinningSupport;
   isProcessing: boolean;
   mappedResources: { item: UnifiedResourceViewItem; key: string }[];
+  onCopyToClipboard(text: string): void;
 };

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -17,6 +17,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { Flex } from 'design';
+import copyToClipboard from 'design/utils/copyToClipboard';
 
 import {
   FilterKind,
@@ -267,6 +268,7 @@ function ClusterResources({
             </Flex>
           </>
         }
+        onCopyToClipboard={copyToClipboard}
       />
     </FeatureBox>
   );

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -129,6 +129,8 @@ export class MockMainProcessClient implements MainProcessClient {
   async tryRemoveConnectMyComputerAgentBinary() {}
 
   signalUserInterfaceReadiness() {}
+
+  writeTextToClipboard() {}
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -28,6 +28,7 @@ import {
   MenuItemConstructorOptions,
   nativeTheme,
   shell,
+  clipboard,
 } from 'electron';
 
 import { FileStorage, RuntimeSettings } from 'teleterm/types';
@@ -391,6 +392,13 @@ export default class MainProcess {
         }
       ) => {
         event.returnValue = this.agentRunner.getLogs(args.rootClusterUri);
+      }
+    );
+
+    ipcMain.on(
+      MainProcessIpc.WriteTextToClipboard,
+      (_, args: { text: string }) => {
+        clipboard.writeText(args.text);
       }
     );
 

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -185,5 +185,8 @@ export default function createMainProcessClient(): MainProcessClient {
     signalUserInterfaceReadiness(args: { success: boolean }) {
       ipcRenderer.send(WindowsManagerIpc.SignalUserInterfaceReadiness, args);
     },
+    writeTextToClipboard(text: string) {
+      ipcRenderer.send(MainProcessIpc.WriteTextToClipboard, { text });
+    },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -154,6 +154,7 @@ export type MainProcessClient = {
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
   signalUserInterfaceReadiness(args: { success: boolean }): void;
+  writeTextToClipboard(text: string): void;
 };
 
 export type ChildProcessAddresses = {
@@ -265,6 +266,7 @@ export enum RendererIpc {
 export enum MainProcessIpc {
   GetRuntimeSettings = 'main-process-get-runtime-settings',
   TryRemoveConnectMyComputerAgentBinary = 'main-process-try-remove-connect-my-computer-agent-binary',
+  WriteTextToClipboard = 'main-process-write-text-to-clipboard',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -183,6 +183,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
           }}
         />
       }
+      onCopyToClipboard={appContext.mainProcessClient.writeTextToClipboard}
     />
   );
 }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/30422
e counterpart https://github.com/gravitational/teleport.e/pull/2725

In Electron we can't use `navigator.clipboard.writeText` to copy text, instead we have [`clipboard` module](https://www.electronjs.org/docs/latest/api/clipboard) for it. I added a new IPC `writeTextToClipboard` for it.

`copyToClipobard` has been removed from `UnifiedResources` completely, now it is passed through to the component through props. 

I'm going to backport to v14 the "shared" part.
 