### PR TITLE
Simplify `Dockerfile-centos7-fips` and prepare for FIPS arm64 builds

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15-amd64
 
     steps:
       - name: Checkout base
@@ -109,7 +109,7 @@ jobs:
               exit 1; \
             fi; \
           done
-          
+
       - name: Check for bloat
         id: check_branch_bloat
         run: |

--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -1,23 +1,18 @@
 name: Build CentOS 7 Buildbox Assets Images
 run-name: Build CentOS 7 Buildbox Assets Images
 on:
-  # Only allow manual triggers
   workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * 0' # At 1:00 PM UTC every Sunday
 
 env:
   REGISTRY: ghcr.io
-  BUILDBOX_BASE_NAME: ghcr.io/gravitational/teleport-buildbox
 
 jobs:
   buildbox-centos7-assets:
     name: Build CentOS 7 Asset Buildbox
-    strategy:
-      matrix:
-        # Build assets on x86 and ARM64.
-        runner: [ ubuntu-22.04-32core, ['self-hosted', 'linux', 'arm64'] ]
-    # Use bigger worker. Clang takes a while to build.
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 720
+    # Build assets on x86 for now, as no GHA-hosted runner for ARM64.
+    runs-on: ubuntu-22.04-32core
 
     permissions:
       contents: read
@@ -37,17 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure required packages are installed
-        run: |
-          os_id=$(awk -F= '/^ID/{print $2}' /etc/os-release)
-          if [[ ! "$os_id" =~ ^ubuntu.* ]]; then
-            sudo dnf upgrade-minimal -y
-            sudo dnf install -y make
-          fi
-
       # We need to keep env vars in sync, so, we can't use standard build actions
-      - name: Build buildbox assets image
-        run: cd build.assets && make build-centos7-assets
-
-      - name: Docker push the latest built image
-        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)
+      - name: Build and push buildbox assets image
+        run: cd build.assets && make build-centos7-assets PUSH=1

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -5,7 +5,10 @@ on:
     paths:
       - .github/workflows/build-ci-buildbox-images.yaml
       - build.assets/Dockerfile
+      - build.assets/Dockerfile-arm
       - build.assets/Dockerfile-centos7
+      - build.assets/Dockerfile-centos7-fips
+      - build.assets/Dockerfile-node
       - build.assets/Makefile
       - build.assets/images.mk
       - build.assets/versions.mk
@@ -15,12 +18,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BUILDBOX_BASE_NAME: ghcr.io/gravitational/teleport-buildbox
 
 jobs:
   buildbox:
     name: Build Ubuntu Buildbox
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-32core
 
     permissions:
       contents: read
@@ -41,15 +43,39 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # We need to keep env vars in sync, so, we can't use standard build actions
-      - name: Build buildbox image
-        run: cd build.assets && make buildbox
+      - name: Build and push buildbox image
+        run: cd build.assets && make buildbox PUSH=1
 
-      - name: Docker push the latest built image
-        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)
+  buildbox-arm:
+    name: Build Debian ARM Buildbox
+    runs-on: ubuntu-22.04-32core
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build and push buildbox image
+        run: cd build.assets && make buildbox-arm PUSH=1
 
   buildbox-centos7:
     name: Build CentOS 7 Buildbox
-    runs-on: ubuntu-latest
+    # Build assets on x86 for now, as no GHA-hosted runner for ARM64.
+    runs-on: ubuntu-22.04-32core
 
     permissions:
       contents: read
@@ -71,7 +97,57 @@ jobs:
 
       # We need to keep env vars in sync, so, we can't use standard build actions
       - name: Build buildbox image
-        run: cd build.assets && make buildbox-centos7
+        run: cd build.assets && make buildbox-centos7 PUSH=1
 
-      - name: Docker push the latest built image
-        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)
+  buildbox-centos7-fips:
+    name: Build CentOS 7 FIPS Buildbox
+    # Build assets on x86 for now, as no GHA-hosted runner for ARM64.
+    runs-on: ubuntu-22.04-32core
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build buildbox image
+        run: cd build.assets && make buildbox-centos7-fips PUSH=1
+
+  buildbox-node:
+    name: Build Node.js Buildbox
+    runs-on: ubuntu-22.04-32core
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build and push buildbox image
+        run: cd build.assets && make buildbox-node PUSH=1

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15-amd64
       env:
         GOCACHE: /tmp/gocache
 

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
       - 'web/**'
       - 'rfd/**'
-      - '**/*.md*'      
+      - '**/*.md*'
 
 jobs:
   build:
@@ -24,7 +24,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15-amd64
       env:
         GOCACHE: /tmp/gocache
         WEBASSETS_SKIP_BUILD: 1

--- a/Makefile
+++ b/Makefile
@@ -1214,6 +1214,10 @@ enter-root:
 enter/centos7:
 	make -C build.assets enter/centos7
 
+.PHONY:enter/centos7-fips
+enter/centos7-fips:
+	make -C build.assets enter/centos7-fips
+
 .PHONY:enter/grpcbox
 enter/grpcbox:
 	make -C build.assets enter/grpcbox

--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -4,7 +4,7 @@
 dnf -y update
 
 # Install
-#  - uuid used for random token generation,
+#  - uuid used for random token generation
 #  - python for certbot
 dnf install -y uuid python3
 
@@ -34,6 +34,7 @@ if [[ "${TELEPORT_FIPS}" == 1 ]]; then
     # add --fips to 'teleport start' commands in FIPS mode
     sed -i -E 's_^(ExecStart=/usr/local/bin/teleport start)_\1 --fips_' /etc/systemd/system/teleport*.service
     # https://docs.aws.amazon.com/linux/al2023/ug/fips-mode.html
+    dnf install -y crypto-policies crypto-policies-scripts
     fips-mode-setup --enable
 fi
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -1,37 +1,48 @@
-ARG RUST_VERSION
+# syntax=docker/dockerfile:1
 
-## GIT2 ###################################################################
+# Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
+ARG BUILDBOX_CENTOS7_ASSETS
+FROM ${BUILDBOX_CENTOS7_ASSETS} AS teleport-buildbox-centos7-assets
 
-# git2 packages are not available on ARM64, so we need to build it from source.
-FROM centos:7 AS git2
+## BASE ###################################################################
 
-ARG BUILDARCH
-ARG TARGETARCH
-ARG DEVTOOLSET
+FROM --platform=$BUILDPLATFORM centos:7 AS base
 
 # devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
 # published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
+ARG BUILDARCH
+ARG DEVTOOLSET
+ENV BUILDARCH=${BUILDARCH} \
+    DEVTOOLSET=${DEVTOOLSET}
 
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    cat <<EOF > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
+[${DEVTOOLSET}-build]
+name=${DEVTOOLSET} - Build
+baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/
+gpgcheck=0
+enabled=1
+EOF
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y \
-    ca-certificates  \
-    curl-devel  \
-    expat-devel  \
-    gettext-devel  \
-    openssl-devel  \
-    zlib-devel  \
-    perl-CPAN  \
-    perl-devel wget && \
+    yum install -y epel-release && \
+    yum install -y centos-release-scl-rh && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
     yum install -y \
-    centos-release-scl && \
+      ca-certificates \
+      centos-release-scl \
+      # Needed for Clang/LLVM
+      cmake3 \
+      curl-devel \
+      expat-devel  \
+      gettext-devel \
+      openssl-devel \
+      zlib-devel \
+      perl-CPAN \
+      perl-devel \
+      scl-utils \
+      wget && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
@@ -39,6 +50,14 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
+
+## GIT2 ###################################################################
+
+# git2 packages are not available on ARM64, so we need to build it from source.
+FROM --platform=$BUILDPLATFORM base AS git2
+
+# Install additional required dependencies.
+RUN yum-builddep -y git
 
 RUN git clone --depth=1 https://github.com/git/git.git -b v2.42.0 && \
     cd git && \
@@ -48,41 +67,17 @@ RUN git clone --depth=1 https://github.com/git/git.git -b v2.42.0 && \
     make -j"$(nproc)" all && \
     DESTDIR=/opt/git make install"
 
-# Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
-ARG BUILDARCH
-FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport15-${BUILDARCH} AS teleport-buildbox-centos7-assets
-
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
-FROM centos:7 AS libfido2
+FROM --platform=$BUILDPLATFORM base AS libfido2
 
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum install -y centos-release-scl-rh && \
-    yum update -y && \
-    yum install -y \
-        cmake3 \
-        git \
+# Install additional required dependencies.
+RUN yum install -y \
         libudev-devel \
+        perl-Digest-SHA \
         perl-IPC-Cmd \
         zlib-devel && \
-    yum clean all
-
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc && \
     yum clean all
 
 # Install libudev-zero.
@@ -104,13 +99,15 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     make install
 
 # Install openssl.
-# install_sw install only binaries, skips docs.
+# Specific install arguments used to skip docs.
+# Note that FIPS is enabled as part of this build, but it is unused without the
+# necessary configuration (which is included as part of the separate FIPS buildbox).
 RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.12 && \
     cd openssl && \
     [ "$(git rev-parse HEAD)" = 'c3cc0f1386b0544383a61244a4beeb762b67498f' ] && \
-    ./config --release -fPIC --libdir=/usr/local/lib64 && \
+    ./config enable-fips --release -fPIC --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
-    make install_sw
+    make install_sw install_ssldirs install_fips
 # Necessary for libfido2 to find the correct libcrypto.
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 
@@ -134,38 +131,17 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
 
 ## LIBBPF #####################################################################
 
-FROM centos:7 AS libbpf
+FROM --platform=$BUILDPLATFORM base AS libbpf
 
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-# Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-        centos-release-scl \
-        scl-utils && \
-    yum clean all
-
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-make && \
+# Install additional required dependencies.
+RUN yum install -y \
+        elfutils-libelf-devel && \
     yum clean all
 
 # Install custom package with -fPIC.
 COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
-RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm && \
+RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static-*.el*.${BUILDARCH}.rpm && \
     rm -rf /opt/custom-packages
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -181,34 +157,12 @@ RUN mkdir -p /opt && cd /opt && \
 
 ## LIBPCSCLITE #####################################################################
 
-FROM centos:7 AS libpcsclite
-
-ARG DEVTOOLSET
-ARG TARGETARCH
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
+FROM --platform=$BUILDPLATFORM base AS libpcsclite
 
 # Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
+RUN yum install -y \
         autoconf-archive \
-        libudev-devel \
-        scl-utils \
-        centos-release-scl && \
-    yum clean all
-
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-gcc-c++ && \
+        libudev-devel && \
     yum clean all
 
 # Install libpcsclite - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -222,15 +176,14 @@ RUN git clone --depth=1 https://github.com/gravitational/PCSC.git -b ${LIBPCSCLI
 
 ## BUILDBOX ###################################################################
 
-FROM centos:7 AS buildbox
+FROM base AS buildbox
 
 ENV LANGUAGE=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-ARG GOLANG_VERSION
-ARG RUST_VERSION
+ARG BUILDARCH
 ARG DEVTOOLSET
 ARG TARGETARCH
 
@@ -239,52 +192,36 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-    # required by libbpf
-    centos-release-scl \
+# Install additional required dependencies.
+RUN yum install -y \
+    elfutils-libelf-devel \
     net-tools \
+    # required by boringssl
+    ninja-build \
     # required by Teleport PAM support
     pam-devel \
     perl-IPC-Cmd \
     tree \
     # used by our Makefile
     which \
-    zip && \
+    zip \
+    zlib-devel && \
     yum clean all && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8
 
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-gcc-c++ \
-        ${DEVTOOLSET}-make && \
-    yum clean all
-
 # Install custom packages with -fPIC.
 COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
-RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm \
-        /opt/custom-packages/zlib-static.*.rpm && \
+RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static-*.el*.${BUILDARCH}.rpm \
+        /opt/custom-packages/zlib-static-*.el*.${BUILDARCH}.rpm && \
     rm -rf /opt/custom-packages
 
 # Override the old git in /usr/local installed by yum. We need git 2+ on GitHub Actions.
 COPY --from=git2 /opt/git /
 
-ARG BUILDARCH
-
 # Install Go.
-RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -298,6 +235,7 @@ COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
 # Install Rust.
+ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
@@ -308,6 +246,8 @@ RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
 
 RUN chmod a-w /
 
+# Install Rust using the ci user, as that is the user that
+# will run builds using the Rust toolchains we install here.
 USER ci
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \
@@ -316,12 +256,14 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 
 ARG WASM_PACK_VERSION
 # Install wasm-pack for targeting WebAssembly from Rust.
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --version ${WASM_PACK_VERSION}"
 
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.
 USER root
+RUN chmod -R a+w $CARGO_HOME
 COPY --from=libfido2 /usr/local/include/ /usr/local/include/
+COPY --from=libfido2 /usr/local/ssl/ /usr/local/ssl/
 COPY --from=libfido2 /usr/local/lib64/engines-3/ /usr/local/lib64/engines-3/
 COPY --from=libfido2 /usr/local/lib64/ossl-modules/ /usr/local/lib64/ossl-modules/
 COPY --from=libfido2 /usr/local/lib64/pkgconfig/ /usr/local/lib64/pkgconfig/
@@ -358,8 +300,7 @@ COPY --from=libpcsclite \
 ARG LIBBPF_VERSION
 COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 
-# Download pre-built CentOS 7 assets with clang needed to build BPF tools.
-ARG BUILDARCH
+# Copy the pre-built CentOS 7 assets with clang. Needed to build BoringSSL and BPF tools.
 COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1
 
-FROM centos:7 AS centos-devtoolset
+FROM --platform=$BUILDPLATFORM centos:7 AS centos-devtoolset
 
+ARG BUILDARCH
 ARG DEVTOOLSET
-ARG TARGETARCH
 
 # devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
 # published to the official CentOS SCL repos.
-RUN if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
+RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
     cat <<EOF > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
 [${DEVTOOLSET}-build]
 name=${DEVTOOLSET} - Build
-baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/
+baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/
 gpgcheck=0
 enabled=1
 EOF
@@ -20,7 +20,7 @@ EOF
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum update -y && \
-    yum -y install centos-release-scl-rh && \
+    yum install -y centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
         cmake3 \
@@ -36,7 +36,7 @@ RUN yum install --nogpgcheck -y \
     yum clean all
 
 # Use just created devtool image with newer GCC and Cmake
-FROM centos-devtoolset as clang12
+FROM --platform=$BUILDPLATFORM centos-devtoolset as clang12
 
 ARG DEVTOOLSET
 
@@ -73,17 +73,19 @@ RUN useradd --user-group --create-home --shell=/bin/bash mockbuild
 RUN mkdir -p /opt/custom-packages && cd /opt && \
     yumdownloader --source elfutils-libelf-devel-static && \
     yum-builddep -y elfutils-libelf-devel-static && \
-    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" elfutils-*.src.rpm && \
-    if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
-    cp /root/rpmbuild/RPMS/${TARGETARCH}/elfutils-libelf-devel-static-*.el7.${TARGETARCH}.rpm /opt/custom-packages/
+    export DIST=$(rpm -qp --queryformat '%{RELEASE}' elfutils-*.src.rpm | cut -d '.' -f 2) && \
+    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" --define "dist .${DIST}" elfutils-*.src.rpm && \
+    if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    cp /root/rpmbuild/RPMS/${BUILDARCH}/elfutils-libelf-devel-static-*${DIST}.${BUILDARCH}.rpm /opt/custom-packages/
 
 # Recompile and install zlib with -fPIC.
 RUN mkdir -p /opt/custom-packages && cd /opt && \
     yumdownloader --source zlib-static && \
     yum-builddep -y zlib-static && \
-    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" zlib-*.src.rpm && \
-    if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
-    cp /root/rpmbuild/RPMS/${TARGETARCH}/zlib-static-*.el7.${TARGETARCH}.rpm /opt/custom-packages/
+    export DIST=$(rpm -qp --queryformat '%{RELEASE}' zlib-*.src.rpm | cut -d '.' -f 2) && \
+    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" --define "dist .${DIST}" zlib-*.src.rpm && \
+    if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    cp /root/rpmbuild/RPMS/${BUILDARCH}/zlib-static-*${DIST}.${BUILDARCH}.rpm /opt/custom-packages/
 
 # Create the final image with Clang and custom builds only. We're using this Docker image as a tar.gz
 # mainly because we want to keep our artifacts on GitHub, and GH doesn't support blobs, only Docker images.

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -1,154 +1,65 @@
-# Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
-ARG BUILDARCH
-FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport15-${BUILDARCH} AS teleport-buildbox-centos7-assets
+# syntax=docker/dockerfile:1
 
-FROM centos:7 AS libbpf
+ARG BUILDBOX_CENTOS7
+FROM ${BUILDBOX_CENTOS7}
 
-ARG BUILDARCH
-ARG TARGETARCH
-ARG DEVTOOLSET
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-# Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-        centos-release-scl \
-        scl-utils && \
-    yum clean all
-
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-gcc-c++ \
-        ${DEVTOOLSET}-make && \
-    yum clean all
-
-# Install custom package with -fPIC.
-COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
-RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm && \
-    rm -rf /opt/custom-packages
-
-# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
-# BUILD_STATIC_ONLY - builds only static libraries without shared ones
-# EXTRA_CFLAGS - additional CFLAGS to pass to the compiler. fPIC is required so the library code can be moved around in memory
-# DESTDIR - where to install the library
-# V=1 - verbose build
-ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && \
-    curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
-    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable ${DEVTOOLSET} "BUILD_STATIC_ONLY=y EXTRA_CFLAGS=-fPIC DESTDIR=/opt/libbpf V=1 make install install_uapi_headers"
-
-FROM centos:7
-
-ARG BUILDARCH
-ARG TARGETARCH
-ARG DEVTOOLSET
-
-ENV LANGUAGE=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8 \
-    LC_CTYPE=en_US.UTF-8
-
-ARG UID
-ARG GID
-RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
-     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
-
-# devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
-# published to the official CentOS SCL repos.
-ENV DEVTOOLSET=${DEVTOOLSET} \
-    TARGETARCH=${TARGETARCH}
-
-RUN bash -c 'if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi; \
-    echo -e "[${DEVTOOLSET}-build]\nname=${DEVTOOLSET} - Build\nbaseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${TARGETARCH}/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/${DEVTOOLSET}-build.repo'
-
-# Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-    # required by libbpf
-    centos-release-scl \
-    # required by Clang/LLVM
-    cmake3 \
-    git \
-    net-tools \
-    # required by boringssl
-    ninja-build \
-    # required by Teleport PAM support
-    pam-devel \
-    perl-IPC-Cmd \
-    tree \
-    # used by our Makefile
-    which \
-    zip && \
-    yum clean all
-
-# As mentioned above, these packages are unsigned.
-RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-gcc-c++ \
-        ${DEVTOOLSET}-make && \
-    yum clean all
-
-# Install Go.
-ARG GOLANG_VERSION
-RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/${GOLANG_VERSION}.linux-${BUILDARCH}.tar.gz | tar xz && \
-    mkdir -p /go/src/github.com/gravitational/teleport && \
-    chmod a+w /go && \
-    chmod a+w /var/lib && \
-    chmod a-w /
+# Set environment variables used for enabling FIPS mode
+# `GOEXPERIMENT=boringcrypto` -- enable FIPS mode (BoringCrypto) for Go
+# https://github.com/golang/go/blob/master/src/crypto/internal/boring/README.md
+# `OPENSSL_FIPS=1` -- enable FIPS mode for OpenSSL
+# https://www.openssl.org/docs/man3.0/man7/fips_module.html
 ENV GOEXPERIMENT=boringcrypto \
-    GOPATH="/go" \
-    GOROOT="/opt/go" \
-    PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+    OPENSSL_FIPS=1
 
-# Install PAM module and policies for testing.
-COPY pam/ /opt/pam_teleport/
-RUN make -C /opt/pam_teleport install
+# Enable OpenSSL FIPS mode by default
+# https://www.openssl.org/docs/man3.0/man7/fips_module.html
+RUN cat >/usr/local/ssl/openssl.cnf <<EOF
+config_diagnostics = 1
+openssl_conf = openssl_init
 
-RUN chmod a-w /
+.include /usr/local/ssl/fipsmodule.cnf
 
-ARG RUST_VERSION
-ENV RUSTUP_HOME=/usr/local/rustup \
-     CARGO_HOME=/usr/local/cargo \
-     PATH=/usr/local/cargo/bin:$PATH \
-     RUST_VERSION=$RUST_VERSION
+[openssl_init]
+providers = provider_sect
 
-RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
-    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+[provider_sect]
+fips = fips_sect
+base = base_sect
 
-# Install Rust using the ci user, as that is the user that
-# will run builds using the Rust toolchains we install here.
+[base_sect]
+activate = 1
+EOF
+
 USER ci
-RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
-    rustup --version && \
-    cargo --version && \
-    rustc --version && \
-    rustup component add rustfmt clippy && \
-    rustup target add ${TARGETARCH}-unknown-linux-gnu
 
-ARG WASM_PACK_VERSION
-# Install wasm-pack for targeting WebAssembly from Rust.
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+# Validate that environment variables were set
+RUN echo "Ensure environment variables are set" && \
+    [ -n "$GOEXPERIMENT" ] && \
+    [ -n "$OPENSSL_FIPS" ]
 
-ARG LIBBPF_VERSION
-COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
+# Validate that Go binaries have BoringCrypto enabled
+RUN cat >/tmp/boringtest.go <<EOF
+package main
 
-# Download pre-built CentOS 7 assets with clang needed to build BoringSSL and BPF tools.
-COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
+import (
+	"crypto/boring"
+	"os"
+)
+
+func main() {
+	if !boring.Enabled() {
+		os.Exit(1)
+	}
+}
+EOF
+
+RUN echo "Ensure Go is using BoringCrypto" && \
+    go run /tmp/boringtest.go
+
+RUN echo "Ensure OpenSSL is using FIPS module" && \
+    ! openssl md5 /tmp/boringtest.go > /dev/null 2>&1
+
+RUN rm /tmp/boringtest.go
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,7 +18,7 @@ KUBECONFIG ?=
 TEST_KUBE ?=
 
 OS ?= linux
-ARCH ?= amd64
+ARCH ?= $(shell go env GOARCH)
 
 UID := $$(id -u)
 GID := $$(id -g)
@@ -26,7 +26,7 @@ NOROOT := -u $(UID):$(GID)
 
 HOST_ARCH := $(shell uname -m)
 RUNTIME_ARCH_x86_64 := amd64
-# uname returns different value on Linux (aarch64) and MacOS (arm64).
+# uname returns different value on Linux (aarch64) and macOS (arm64).
 RUNTIME_ARCH_arm64 := arm64
 RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
@@ -87,7 +87,7 @@ PULL_ON_CI = $(if $(filter $(CI),true),docker inspect --type=image $(1) >/dev/nu
 #
 .PHONY:build
 build: buildbox-centos7 webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) release-unix-preserving-webassets
 
 #
@@ -95,7 +95,7 @@ build: buildbox-centos7 webassets
 #
 .PHONY:build-binaries
 build-binaries: buildbox-centos7 webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) full
 
 #
@@ -103,7 +103,7 @@ build-binaries: buildbox-centos7 webassets
 #
 .PHONY:build-enterprise-binaries
 build-enterprise-binaries: buildbox-centos7 webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
 		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) PIV=$(PIV) clean full
 
 #
@@ -112,7 +112,7 @@ build-enterprise-binaries: buildbox-centos7 webassets
 #
 .PHONY:build-binaries-fips
 build-binaries-fips: buildbox-centos7-fips webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) \
 		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) FIPS=yes clean full
 
 #
@@ -125,7 +125,7 @@ build-binaries-fips: buildbox-centos7-fips webassets
 .PHONY:buildbox
 buildbox:
 	$(call PULL_ON_CI,$(BUILDBOX))
-	DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -140,6 +140,7 @@ buildbox:
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
 		--cache-from $(BUILDBOX) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX) .
 
 # Builds a Docker buildbox for FIPS
@@ -155,39 +156,35 @@ buildbox-fips: buildbox-centos7-fips
 .PHONY:buildbox-centos7
 buildbox-centos7:
 	$(REQUIRE_HOST_ARCH)
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7))
-	DOCKER_BUILDKIT=1 docker build \
+	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH))
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
-		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
-		--build-arg TARGETARCH=$(HOST_ARCH) \
+		--build-arg BUILDBOX_CENTOS7_ASSETS=$(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
+		--build-arg BUILDARCH=$(HOST_ARCH) \
+		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
-		--cache-from $(BUILDBOX_CENTOS7) \
-		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
+		--cache-from $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
+		$(if $(PUSH),--push,--load) \
+		--tag $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) -f Dockerfile-centos7 .
 
 #
 # Builds a Docker buildbox for CentOS 7 FIPS builds
+# Uses regular CentOS 7 buildbox as base, so limited arguments are needed.
 #
 .PHONY:buildbox-centos7-fips
-buildbox-centos7-fips:
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS))
-	docker build \
-		--build-arg UID=$(UID) \
-		--build-arg GID=$(GID) \
-		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
-		--build-arg TARGETARCH=$(HOST_ARCH) \
-		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
-		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
-		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
-		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
-		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
+buildbox-centos7-fips: buildbox-centos7
+	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH))
+	docker buildx build \
+		--build-arg BUILDBOX_CENTOS7=$(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
+		--cache-from $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) \
+		$(if $(PUSH),--push,--load) \
+		--tag $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) -f Dockerfile-centos7-fips .
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds
@@ -197,15 +194,15 @@ buildbox-centos7-fips:
 .PHONY:buildbox-arm
 buildbox-arm:
 	$(call PULL_ON_CI,$(BUILDBOX_ARM))
-	docker build \
+	docker buildx build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
-		--cache-from $(BUILDBOX) \
-		--cache-from $(BUILDBOX_ARM) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--cache-from $(BUILDBOX_ARM) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -220,7 +217,7 @@ endif
 .PHONY:buildbox-node
 buildbox-node:
 	$(call PULL_ON_CI,$(BUILDBOX_NODE))
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
@@ -228,6 +225,7 @@ buildbox-node:
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--cache-from $(BUILDBOX_NODE) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_NODE) -f Dockerfile-node .
 
 #
@@ -373,7 +371,7 @@ enter-root: buildbox
 .PHONY:enter/centos7
 enter/centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
-		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7) /bin/bash
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) /bin/bash
 
 #
 # Starts a root shell inside the centos7 container
@@ -381,7 +379,23 @@ enter/centos7: buildbox-centos7
 .PHONY:enter-root/centos7
 enter-root/centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -ti \
-		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7) /bin/bash
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) /bin/bash
+
+#
+# Starts shell inside the centos7-fips container
+#
+.PHONY:enter/centos7-fips
+enter/centos7-fips: buildbox-centos7-fips
+	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) /bin/bash
+
+#
+# Starts a root shell inside the centos7-fips container
+#
+.PHONY:enter-root/centos7-fips
+enter-root/centos7-fips: buildbox-centos7-fips
+	docker run $(DOCKERFLAGS) -ti \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) /bin/bash
 
 #
 # Starts a shell inside the grpcbox.
@@ -418,7 +432,11 @@ release-386:
 
 .PHONY: release-arm64
 release-arm64:
-	$(MAKE) release-centos7 ARCH=arm64 BUILDBOX_CENTOS7=$(BUILDBOX_ARM64)
+	$(MAKE) release-centos7 ARCH=arm64 FIDO2=yes PIV=yes
+
+.PHONY: release-arm64-fips
+release-arm64-fips:
+	$(MAKE) release-centos7-fips ARCH=arm64 FIPS=yes
 
 .PHONY: release-arm
 release-arm:
@@ -462,7 +480,7 @@ release: $(BUILDBOX_TARGET)
 .PHONY:release-fips
 release-fips: buildbox-centos7-fips webassets
 	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) \
 		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=yes
 
 #
@@ -478,7 +496,7 @@ release-fips: buildbox-centos7-fips webassets
 .PHONY:release-centos7
 release-centos7: buildbox-centos7 webassets
 	$(REQUIRE_HOST_ARCH)
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH) \
 		/usr/bin/scl enable $(DEVTOOLSET) 'make release-unix-preserving-webassets -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
 
 #
@@ -491,7 +509,7 @@ release-centos7: buildbox-centos7 webassets
 #
 .PHONY:release-centos7-fips
 release-centos7-fips: buildbox-centos7-fips webassets
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS)-$(RUNTIME_ARCH) \
 		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
 
 #
@@ -519,7 +537,7 @@ docsbox:
 
 .PHONY:test-docs
 test-docs: docsbox
-	docker run --platform=linux/amd64 -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
+	docker run -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
 		/bin/sh -c "yarn markdown-lint-external-links"
 
 #
@@ -562,9 +580,12 @@ print-buildbox-version:
 #
 .PHONY:build-centos7-assets
 build-centos7-assets:
-	docker build \
+	docker buildx build \
+		--build-arg BUILDARCH=$(HOST_ARCH) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
-		--build-arg TARGETARCH=$(HOST_ARCH) \
+		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
+		--cache-from $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .
 

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -25,7 +25,7 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 # It's leaner, meaner, faster and not supposed to compile code.
 .PHONY: grpcbox
 grpcbox:
-	DOCKER_BUILDKIT=1 $(DOCKER) build \
+	$(DOCKER) buildx build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \

--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -3,16 +3,15 @@
 # These values may need to be updated in `dronegen/container_image_products.go` if
 # they change here
 BUILDBOX_VERSION ?= teleport15
-BUILDBOX_BASE_NAME ?= public.ecr.aws/gravitational/teleport-buildbox
+BUILDBOX_BASE_NAME ?= ghcr.io/gravitational/teleport-buildbox
 
 BUILDBOX = $(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)
 BUILDBOX_CENTOS7 = $(BUILDBOX_BASE_NAME)-centos7:$(BUILDBOX_VERSION)
+BUILDBOX_CENTOS7_ASSETS = $(BUILDBOX_BASE_NAME)-centos7-assets:$(BUILDBOX_VERSION)
 BUILDBOX_CENTOS7_FIPS = $(BUILDBOX_BASE_NAME)-centos7-fips:$(BUILDBOX_VERSION)
-BUILDBOX_ARM64 = $(BUILDBOX_BASE_NAME)-arm64:$(BUILDBOX_VERSION)
 BUILDBOX_ARM = $(BUILDBOX_BASE_NAME)-arm:$(BUILDBOX_VERSION)
 BUILDBOX_UI = $(BUILDBOX_BASE_NAME)-ui:$(BUILDBOX_VERSION)
 BUILDBOX_NODE = $(BUILDBOX_BASE_NAME)-node:$(BUILDBOX_VERSION)
-BUILDBOX_CENTOS7_ASSETS = $(BUILDBOX_BASE_NAME)-centos7-assets:$(BUILDBOX_VERSION)
 
 .PHONY:show-buildbox-base-image
 show-buildbox-base-image:


### PR DESCRIPTION
Replace `Dockerfile-centos7-fips` with a simple version that just uses the existing `Dockerfile-centos7` image with some extra modifications (specifically, enabling BoringCrypto for Go and configuring OpenSSL to use FIPS mode).

Several changes were made to `Dockerfile-centos7` to support this.

There is a mix of `public.ecr.aws` and `ghcr.io` being used for the buildboxes. The default now uses `ghcr.io`.

Buildbox images on ECR did not include the architecture as part of the tag, while GHCR did. Dronegen is changed to include the architecture in ECR as well for consistency.

Additionally, start building arm and CentOS 7 FIPS buildbox images in GHA to bring it in sync with `dronegen/buildbox.go`, as well as additionally build on amd64 for the two CentOS 7 buildboxes.

Ref #5068.
Ref #10581.