### PR TITLE
Deflake `TestIntegrations/Discovery` again

### DIFF
--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -17,8 +17,6 @@ package helpers
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -87,12 +85,6 @@ func WaitForClusters(tun reversetunnelclient.Server, expected int) func() bool {
 		if err != nil {
 			return false
 		}
-
-		names := make([]string, 0, len(clusters))
-		for _, c := range clusters {
-			names = append(names, c.GetName())
-		}
-		fmt.Fprintf(os.Stderr, "current clusters: %q\n", names)
 
 		if len(clusters) < expected {
 			return false

--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -17,6 +17,8 @@ package helpers
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -85,6 +87,12 @@ func WaitForClusters(tun reversetunnelclient.Server, expected int) func() bool {
 		if err != nil {
 			return false
 		}
+
+		names := make([]string, 0, len(clusters))
+		for _, c := range clusters {
+			names = append(names, c.GetName())
+		}
+		fmt.Fprintf(os.Stderr, "current clusters: %q\n", names)
 
 		if len(clusters) < expected {
 			return false
@@ -175,8 +183,6 @@ func CheckTrustedClustersCanConnect(ctx context.Context, t *testing.T, tcSetup T
 
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
 
 	// Try and connect to a node in the Aux cluster from the Main cluster using

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2525,9 +2525,9 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	require.NoError(t, err)
 
 	// Wait for both cluster to see each other via reverse tunnels.
-	require.Eventually(t, helpers.WaitForClusters(a.Tunnel, 2), 10*time.Second, 1*time.Second,
+	require.Eventually(t, helpers.WaitForClusters(a.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(b.Tunnel, 2), 10*time.Second, 1*time.Second,
+	require.Eventually(t, helpers.WaitForClusters(b.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
 
 	var (
@@ -2890,8 +2890,6 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
 
 	// Make sure that GetNodes returns nodes in the remote site. This makes
 	// sure identity aware GetNodes works for remote clusters. Testing of the
@@ -3225,8 +3223,6 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
 
 	cmd := []string{"echo", "hello world"}
@@ -3723,8 +3719,6 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
 
 	// Wait for both nodes to show up before attempting to dial to them.
 	err = helpers.WaitForNodeCount(ctx, main, clusterAux, 2)
@@ -3891,8 +3885,6 @@ func testTrustedClusterAgentless(t *testing.T, suite *integrationTestSuite) {
 
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(leaf.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
 
 	// create agentless node in leaf cluster
@@ -7548,7 +7540,6 @@ func createTrustedClusterPair(t *testing.T, suite *integrationTestSuite, extraSe
 	}
 
 	require.Eventually(t, helpers.WaitForClusters(root.Tunnel, 1), 10*time.Second, 1*time.Second)
-	require.Eventually(t, helpers.WaitForClusters(leaf.Tunnel, 1), 10*time.Second, 1*time.Second)
 
 	// Create client.
 	creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4069,7 +4069,7 @@ func testDiscovery(t *testing.T, suite *integrationTestSuite) {
 
 	// create load balancer for main cluster proxies
 	frontend := *utils.MustParseAddr(net.JoinHostPort(Loopback, "0"))
-	lb, err := utils.NewLoadBalancer(ctx, frontend)
+	lb, err := utils.NewRandomLoadBalancer(ctx, frontend)
 	require.NoError(t, err)
 	require.NoError(t, lb.Listen())
 	go lb.Serve()

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -667,8 +667,6 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
 
 	require.Eventually(t, func() bool {
 		tc, err := main.Process.GetAuthServer().GetRemoteCluster(aux.Secrets.SiteName)
@@ -944,8 +942,6 @@ func testKubeTrustedClustersSNI(t *testing.T, suite *KubeSuite) {
 
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(main.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(aux.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
 
 	require.Eventually(t, func() bool {

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -214,8 +214,6 @@ func (p *Suite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname string) {
 	// Wait for both cluster to see each other via reverse tunnels.
 	require.Eventually(t, helpers.WaitForClusters(p.root.Tunnel, 1), 10*time.Second, 1*time.Second,
 		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(p.leaf.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
 
 	// Wait for both nodes to show up before attempting to dial to them.
 	err = helpers.WaitForNodeCount(context.Background(), p.root, p.leaf.Secrets.SiteName, 2)

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -270,7 +271,7 @@ func TestALPNSNIHTTPSProxy(t *testing.T) {
 	addr, err := apihelpers.GetLocalIP()
 	require.NoError(t, err)
 
-	suite := newSuite(t,
+	_ = newSuite(t,
 		withRootClusterConfig(rootClusterStandardConfig(t)),
 		withLeafClusterConfig(leafClusterStandardConfig(t)),
 		withRootClusterNodeName(addr),
@@ -281,13 +282,9 @@ func TestALPNSNIHTTPSProxy(t *testing.T) {
 		withStandardRoleMapping(),
 	)
 
-	// Wait for both cluster to see each other via reverse tunnels.
-	require.Eventually(t, helpers.WaitForClusters(suite.root.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(suite.leaf.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-
-	require.Greater(t, ph.Count(), 0, "proxy did not intercept any connection")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.NotZero(t, ph.Count())
+	}, 10*time.Second, time.Second, "http proxy did not intercept any connection")
 }
 
 // TestMultiPortHTTPSProxy tests if the reverse tunnel uses http_proxy
@@ -311,7 +308,7 @@ func TestMultiPortHTTPSProxy(t *testing.T) {
 	addr, err := apihelpers.GetLocalIP()
 	require.NoError(t, err)
 
-	suite := newSuite(t,
+	_ = newSuite(t,
 		withRootClusterConfig(rootClusterStandardConfig(t)),
 		withLeafClusterConfig(leafClusterStandardConfig(t)),
 		withRootClusterNodeName(addr),
@@ -322,13 +319,9 @@ func TestMultiPortHTTPSProxy(t *testing.T) {
 		withStandardRoleMapping(),
 	)
 
-	// Wait for both cluster to see each other via reverse tunnels.
-	require.Eventually(t, helpers.WaitForClusters(suite.root.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-	require.Eventually(t, helpers.WaitForClusters(suite.leaf.Tunnel, 1), 10*time.Second, 1*time.Second,
-		"Two clusters do not see each other: tunnels are not working.")
-
-	require.Greater(t, ph.Count(), 0, "proxy did not intercept any connection")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.NotZero(t, ph.Count())
+	}, 10*time.Second, time.Second, "http proxy did not intercept any connection")
 }
 
 // TestAlpnSniProxyKube tests Kubernetes access with custom Kube API mock where traffic is forwarded via


### PR DESCRIPTION
This PR attempts to fix some flakiness in `TestIntegrations/Discovery` by having `helpers.WaitForClusters` actually wait for clusters, and by switching to a random load balancer rather than a round robin one, which I think might've cause some timeouts due to unfortunate resonance between hitting webapi/find on the reverse tunnel resolver and the actual reverse tunnel connection.