### PR TITLE
integrations/operator: publish `teleport-operator` Helm chart

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -928,6 +928,7 @@ steps:
       - cd /go/chart
       - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-cluster
       - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-kube-agent
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-cluster/charts/teleport-operator
       # copy index.html to root of the S3 bucket
       - cp /go/src/github.com/gravitational/teleport/examples/chart/index.html /go/chart
       # this will index all previous versions of the charts downloaded from the S3 bucket,
@@ -11346,6 +11347,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: e5a7a7ed15691a8b042e3ec23f9d0831fb10a6f025ecb65f8cebf80c20ad5110
+hmac: 726e2318bf863cbc7345206c6716db4fd7e96573bf418517267431409ca0f1ea
 
 ...

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -32,6 +32,17 @@
         --set proxyAddr=${PROXY_ENDPOINT?} \
         --set authToken=${JOIN_TOKEN?} \
         --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}</pre>
+    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster/charts/teleport-operator">teleport-operator:</a></b>
+      # Install the Teleport Kubernetes Operator to manage Teleport resources from Kubernetes.
+      # The operator can run against any remote Teleport cluster and reconcile its resources.
+      # Click the link above to see the README.
+
+      helm install ${RELEASE_NAME?} teleport/teleport-operator \
+        --create-namespace \
+        --namespace ${NAMESPACE?} \
+        --set authAddr="${TELEPORT_ADDR?}" \
+        --set token="${JOIN_TOKEN?}"</pre>
+    <br />
     <h3>Changelog</h3>
     <pre>See the <a href="https://goteleport.com/docs/changelog/">Teleport Changelog</a> for a list of important changes between Helm chart versions.</pre>
   </body>

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -1,13 +1,16 @@
 # Teleport Cluster
 
-This chart sets up a single node Teleport cluster.
-It uses a persistent volume claim for storage.
-Great for getting started with Teleport.
+This chart sets up a Teleport cluster composed of at least 1 Proxy instance
+and 1 Auth instance. When applicable, the chart will default to 2 pods to
+provide high-availability.
 
 ## Important Notices
 
 - The chart version follows the Teleport version. e.g. chart v10.x can run Teleport v10.x and v11.x, but is not compatible with Teleport 9.x
-- Teleport does mutual TLS to authenticate clients. It currently does not support running behind a L7 LoadBalancer, like a Kubernetes `Ingress`. It requires being exposed through a L4 LoadBalancer (Kubernetes `Service`).
+- Teleport does mutual TLS to authenticate clients. Establishing mTLS through a L7
+  LoadBalancer, like a Kubernetes `Ingress` [requires ALPN support](https://goteleport.com/docs/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies).
+  Exposing Teleport through a `Service` with type `LoadBalancer` is still recommended
+  because its the most flexible and least complex setup.
 
 ## Getting Started
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/README.md
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/README.md
@@ -1,0 +1,28 @@
+# Teleport Operator
+
+This chart deploys the Teleport Kubernetes Operator. The operator allows to manage
+Teleport resources from inside Kubernetes.
+
+## Important notice
+
+The chart version follows the Teleport and Teleport Kube Operator version. e.g.
+chart v15.0.1 runs the operator version 15.0.1 by default. To control which
+operator version is deployed, use the `--version` Helm flag.
+
+## Deployment
+
+The chart can be deployed in two ways:
+- in standalone mode by running
+  ```shell
+  helm install teleport/teleport-operator teleport-operator --set authAddr=teleport.example.com:443 --set token=my-operator-token
+  ```
+  See [the standalone guide](https://goteleport.com/docs/management/dynamic-resources/teleport-operator-standalone/) for more details.
+- as a dependency of the `teleport-cluster` Helm chart by adding `--set operator.enabled=true`. See
+  [the operator within teleport-cluster chart guide](https://goteleport.com/docs/management/dynamic-resources/teleport-operator-helm/).
+
+## Values and reference
+
+The `values.yaml` is documented through comment or via
+[the reference docs](https://goteleport.com/docs/reference/helm-reference/teleport-operator/).
+
+Please make sure you are looking at the correct version when looking at the values reference.


### PR DESCRIPTION
This PR:
- publishes the `teleport-operator` Helm chart
- mentions the `teleport-operator` chart in the registry index
- adds a chart README for the `teleport-operator` chart
- fixes stale documentation in `teleport-cluster` chart README


Changelog: publish a new `teleport-operator` chart that deploys a standalone Teleport Kubernetes Operator.