### PR TITLE
Vite proxy: Constrict too permissive regexes for site name

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -89,9 +89,13 @@ export function createViteConfig(
       config.base = '/web';
     } else {
       config.plugins.push(htmlPlugin(target));
+      // siteName matches everything between the slashes.
+      const siteName = '([^\\/]+)';
 
       config.server.proxy = {
-        '^\\/v1\\/webapi\\/sites\\/(.*?)\\/connect': {
+        // The format of the regex needs to assume that the slashes are escaped, for example:
+        // \/v1\/webapi\/sites\/:site\/connect
+        [`^\\/v1\\/webapi\\/sites\\/${siteName}\\/connect`]: {
           target: `wss://${target}`,
           changeOrigin: false,
           secure: false,
@@ -102,7 +106,7 @@ export function createViteConfig(
           changeOrigin: false,
           secure: false,
         },
-        '^\\/v1\\/webapi\\/sites\\/(.*?)\\/assistant': {
+        [`^\\/v1\\/webapi\\/sites\\/${siteName}\\/assistant`]: {
           target: `wss://${target}`,
           changeOrigin: false,
           secure: false,


### PR DESCRIPTION
The previous regex for /connect was too permissive and would match the endpoint for diagnostics as well:

    \/v1\/webapi\/sites\/teleport-local\/connect
    \/v1\/webapi\/sites\/teleport-local\/diagnostics\/connections

`/diagnostics/connections` doesn't use WebSocket, so this proxy redirect would make any request to that endpoint fail.