### PR TITLE
Metrics: add running services metric

### DIFF
--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -277,21 +277,21 @@ var metricsServicesRunning = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: teleport.MetricNamespace,
 		Name:      teleport.MetricTeleportServices,
-		Help:      "Subset (discovery_service,) of Teleport services currently enabled and running",
+		Help:      "Teleport services currently enabled and running",
 	},
 	[]string{teleport.TagServiceName},
 )
 var metricsServicesRunningMap = map[string]string{
-	"discovery.init": "discovery_service",
-	"ssh.node": "ssh_service",
-	"auth.tls": "auth_service",
-	"proxy.init": "proxy_service",
-	"kube.init": "kubernetes_service",
-	"apps.start": "application_service",
-	"db.init": "database_service",
+	"discovery.init":       "discovery_service",
+	"ssh.node":             "ssh_service",
+	"auth.tls":             "auth_service",
+	"proxy.web":            "proxy_service",
+	"kube.init":            "kubernetes_service",
+	"apps.start":           "application_service",
+	"db.init":              "database_service",
 	"windows_desktop.init": "windows_desktop_service",
-	"okta.init": "okta_service",
-	"jamf.init": "jamf_service",
+	"okta.init":            "okta_service",
+	"jamf.init":            "jamf_service",
 }
 
 func (s *LocalSupervisor) serve(srv Service) {

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -277,7 +277,7 @@ var metricsServicesRunning = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: teleport.MetricNamespace,
 		Name:      teleport.MetricTeleportServices,
-		Help:      "Teleport Services",
+		Help:      "Subset (discovery_service,) of Teleport services currently enabled and running",
 	},
 	[]string{teleport.TagServiceName},
 )
@@ -325,8 +325,7 @@ func (s *LocalSupervisor) Start() error {
 		return nil
 	}
 
-	err := metrics.RegisterPrometheusCollectors(metricsServicesRunning)
-	if err != nil {
+	if err := metrics.RegisterPrometheusCollectors(metricsServicesRunning); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 // Supervisor implements the simple service logic - registering
@@ -271,11 +273,24 @@ type ExitEventPayload struct {
 	Error error
 }
 
+var metricsServicesRunning = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      teleport.MetricTeleportServices,
+		Help:      "Teleport Services",
+	},
+	[]string{teleport.TagServiceName},
+)
+
 func (s *LocalSupervisor) serve(srv Service) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
 		defer s.RemoveService(srv)
+
+		metricsServicesRunning.WithLabelValues(srv.Name()).Inc()
+		defer metricsServicesRunning.WithLabelValues(srv.Name()).Dec()
+
 		l := s.log.WithField("service", srv.Name())
 		l.Debug("Service has started.")
 		err := srv.Serve()
@@ -303,6 +318,11 @@ func (s *LocalSupervisor) Start() error {
 	if len(s.services) == 0 {
 		s.log.Warning("Supervisor has no services to run. Exiting.")
 		return nil
+	}
+
+	err := metrics.RegisterPrometheusCollectors(metricsServicesRunning)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	for _, srv := range s.services {

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -19,7 +19,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -282,8 +281,8 @@ var metricsServicesRunning = prometheus.NewGaugeVec(
 	},
 	[]string{teleport.TagServiceName},
 )
-var metricsServicesRunningAllowList = []string{
-	"discovery.init",
+var metricsServicesRunningMap = map[string]string{
+	"discovery.init": "discovery_service",
 }
 
 func (s *LocalSupervisor) serve(srv Service) {
@@ -292,9 +291,9 @@ func (s *LocalSupervisor) serve(srv Service) {
 		defer s.wg.Done()
 		defer s.RemoveService(srv)
 
-		if slices.Contains(metricsServicesRunningAllowList, srv.Name()) {
-			metricsServicesRunning.WithLabelValues(srv.Name()).Inc()
-			defer metricsServicesRunning.WithLabelValues(srv.Name()).Dec()
+		if label, ok := metricsServicesRunningMap[srv.Name()]; ok {
+			metricsServicesRunning.WithLabelValues(label).Inc()
+			defer metricsServicesRunning.WithLabelValues(label).Dec()
 		}
 
 		l := s.log.WithField("service", srv.Name())

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -283,6 +283,15 @@ var metricsServicesRunning = prometheus.NewGaugeVec(
 )
 var metricsServicesRunningMap = map[string]string{
 	"discovery.init": "discovery_service",
+	"ssh.node": "ssh_service",
+	"auth.tls": "auth_service",
+	"proxy.init": "proxy_service",
+	"kube.init": "kubernetes_service",
+	"apps.start": "application_service",
+	"db.init": "database_service",
+	"windows_desktop.init": "windows_desktop_service",
+	"okta.init": "okta_service",
+	"jamf.init": "jamf_service",
 }
 
 func (s *LocalSupervisor) serve(srv Service) {

--- a/metrics.go
+++ b/metrics.go
@@ -288,8 +288,8 @@ const (
 
 	// TagServiceName is the prometheus label to indicate what services are running in the current proxy.
 	// Those services are monitored using the Supervisor.
-	// Only a subset of services are monitored. See [lib/service.metricsServicesRunningAllowList]
-	// Eg, discovery.init
+	// Only a subset of services are monitored. See [lib/service.metricsServicesRunningMap]
+	// Eg, discovery_service
 	TagServiceName = "service_name"
 )
 

--- a/metrics.go
+++ b/metrics.go
@@ -242,6 +242,9 @@ const (
 	// (as defined by types.PluginStatus) for a plugin instance
 	MetricHostedPluginStatus = "hosted_plugin_status"
 
+	// MetricTeleportServices tracks which services are currently running in the current Teleport Process.
+	MetricTeleportServices = "services"
+
 	// TagRange is a tag specifying backend requests
 	TagRange = "range"
 
@@ -282,6 +285,11 @@ const (
 	// were used for the agent.
 	// This value comes from UpstreamInventoryAgentMetadata (sourced in lib/inventory/metadata.fetchInstallMethods).
 	TagInstallMethods = "install_methods"
+
+	// TagServiceName is the prometheus label to indicate what services are running in the current proxy.
+	// Those services are monitored using the Supervisor.
+	// Eg, proxy.web, discovery.init, ssh.node, auth.tls ...
+	TagServiceName = "service_name"
 )
 
 const (

--- a/metrics.go
+++ b/metrics.go
@@ -288,7 +288,8 @@ const (
 
 	// TagServiceName is the prometheus label to indicate what services are running in the current proxy.
 	// Those services are monitored using the Supervisor.
-	// Eg, proxy.web, discovery.init, ssh.node, auth.tls ...
+	// Only a subset of services are monitored. See [lib/service.metricsServicesRunningAllowList]
+	// Eg, discovery.init
 	TagServiceName = "service_name"
 )
 


### PR DESCRIPTION
This PR adds a new gauge metric: `teleport_services`
This metric has a label identifying the service and whether or not it is running.
Those services are the ones started in the supervisor, but only a subset of those is allowed.
Eg, discovery.init

When the service stops, the counter is decreased.

This gives us an overview of the currently running services in the process.

Demo:
```shell
> curl --silent http://127.0.0.1.nip.io:3000/metrics | grep teleport_services
# HELP teleport_services Teleport services currently enabled and running
# TYPE teleport_services gauge
teleport_services{service_name="auth_service"} 1
teleport_services{service_name="discovery_service"} 1
teleport_services{service_name="proxy_service"} 1
teleport_services{service_name="ssh_service"} 1
```

changelog: metrics: new gauge that indicates the Discovery Service' state