### PR TITLE
docs: add troubleshooting operator ns

### DIFF
--- a/docs/pages/management/dynamic-resources/teleport-operator.mdx
+++ b/docs/pages/management/dynamic-resources/teleport-operator.mdx
@@ -247,6 +247,14 @@ $ kubectl logs "$AUTH_POD" -c operator
   To diagnose reconciliation issues, you will have to inspect all pods to find the one reconciling the resources.
 </Admonition>
 
+### The operator does not see the resource
+
+If you created the resource, can get it with `kubectl get <resource-type>`, but
+the resource status stays empty and the operator does not produce logs, please
+check if the resource lives in the `teleport-cluster` namespace.
+
+The operator only watches for resource in its own namespace.
+
 ### Cluster instability after enabling the Operator
 
 If enabling the Teleport Kubernetes Operator leads to cluster instability such as degraded proxy state, inability to log into the Teleport cluster,

--- a/docs/pages/management/dynamic-resources/teleport-operator.mdx
+++ b/docs/pages/management/dynamic-resources/teleport-operator.mdx
@@ -249,11 +249,11 @@ $ kubectl logs "$AUTH_POD" -c operator
 
 ### The operator does not see the resource
 
-If you created the resource, can get it with `kubectl get <resource-type>`, but
-the resource status stays empty and the operator does not produce logs, please
+If you created a resource, and can get it with `kubectl get <resource-type>`, but
+the resource status stays empty and the operator does not produce logs,
 check if the resource lives in the `teleport-cluster` namespace.
 
-The operator only watches for resource in its own namespace.
+The operator only watches for resources in its own namespace.
 
 ### Cluster instability after enabling the Operator
 


### PR DESCRIPTION
Addresses a common issue: the CR is not deployed in the operator namespace. ([See slack thread](https://gravitational.slack.com/archives/C058PHKCGU9/p1701111226010679))

This PR is intentionally against `branch/v14` because I have a pending operator documentation PR in master that won't be backported and also contains the change.