### PR TITLE
[v14] docs: Update the CMVP certificate used for BoringCrypto's FIPS 140-2 compliance

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -197,5 +197,5 @@ is emitted to the Audit Log.
 
 - TLS protocol version is restricted to TLS 1.2.
 - All uses of non-compliant algorithms such as NaCl are removed and replaced with compliant algorithms such as AES-GCM.
-- Teleport is compiled with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
+- Teleport is compiled with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407).
 - User, host, and CA certificates (and host keys for recording proxy mode) only use 2048-bit RSA private keys.


### PR DESCRIPTION
Backport #33846 to branch/v14