### PR TITLE
Check for auth version incompatibility (kube)

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -148,7 +148,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	versionUpdater := controller.NewVersionUpdater(versionGetter, imageValidators, maintenanceTriggers, baseImage)
+	authVersion := version.NewAuthVersionGetter(mgr.GetClient())
+
+	versionUpdater := controller.NewVersionUpdater(versionGetter, imageValidators, maintenanceTriggers, baseImage, authVersion)
 
 	// Controller registration
 	deploymentController := controller.DeploymentVersionUpdater{

--- a/integrations/kube-agent-updater/pkg/controller/errors.go
+++ b/integrations/kube-agent-updater/pkg/controller/errors.go
@@ -47,3 +47,18 @@ func (e *NoNewVersionError) Error() string {
 	}
 	return fmt.Sprintf("no new version (current: %q, next: %q)", e.CurrentVersion, e.NextVersion)
 }
+
+// IncompatibleVersionError indicates that the target version is incompatible with the auth server version
+type IncompatibleVersionError struct {
+	Message     string `json:"message"`
+	AuthVersion string `json:"authVersion"`
+	NextVersion string `json:"nextVersion"`
+}
+
+// Error returns a log friendly description of an error
+func (e *IncompatibleVersionError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("next version is incompatible with auth version (auth: %q, next: %q)", e.AuthVersion, e.NextVersion)
+}

--- a/integrations/kube-agent-updater/pkg/version/auth.go
+++ b/integrations/kube-agent-updater/pkg/version/auth.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+	v1 "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const authVersionKeyName = "agent-auth-version"
+
+// AuthVersionGetter gets the auth server version.
+type AuthVersionGetter interface {
+	Get(context.Context, kclient.Object) (string, error)
+}
+
+type authVersionGetter struct {
+	kclient.Client
+}
+
+// NewAuthVersionGetter creates a new AuthVersionGetter
+func NewAuthVersionGetter(client kclient.Client) AuthVersionGetter {
+	return &authVersionGetter{Client: client}
+}
+
+// Get returns the auth version stored in the shared state secret
+func (a *authVersionGetter) Get(ctx context.Context, object kclient.Object) (string, error) {
+	secretName := fmt.Sprintf("%s-shared-state", object.GetName())
+	var secret v1.Secret
+	err := a.Client.Get(ctx, kclient.ObjectKey{Namespace: object.GetNamespace(), Name: secretName}, &secret)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	rawData, ok := secret.Data[authVersionKeyName]
+	if !ok {
+		return "", trace.Errorf("secret %s does not have key %s", secretName, authVersionKeyName)
+	}
+	version, err := EnsureSemver(string(rawData))
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return version, nil
+}

--- a/integrations/kube-agent-updater/pkg/version/auth_test.go
+++ b/integrations/kube-agent-updater/pkg/version/auth_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAuthVersionGetter_Get(t *testing.T) {
+	// Test setup: generating and loading fixtures
+	ctx := context.Background()
+	namespace := "bar"
+
+	fixtures := &v1.SecretList{Items: []v1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-key-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{"foo": []byte("bar")},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-json-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{authVersionKeyName: []byte(`{"foo": "bar"}`)},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-auth-version-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{authVersionKeyName: []byte(".13")},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "valid-auth-version-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{authVersionKeyName: []byte("13.4.5")},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "prefix-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{authVersionKeyName: []byte("v13.4.5")},
+		},
+	}}
+
+	clientBuilder := fake.NewClientBuilder()
+	clientBuilder.WithLists(fixtures)
+	client := clientBuilder.Build()
+
+	tests := []struct {
+		name      string
+		object    kclient.Object
+		want      string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "no secret",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "not-found", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret no key",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "no-key", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret invalid JSON",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "invalid-json", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret invalid auth version",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "invalid-auth-version", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "valid auth version",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "valid-auth-version", Namespace: namespace}},
+			want:      "v13.4.5",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "prefix auth version",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "prefix", Namespace: namespace}},
+			want:      "v13.4.5",
+			assertErr: require.NoError,
+		},
+	}
+	// Doing the real test
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authVersionGetter := NewAuthVersionGetter(client)
+			version, err := authVersionGetter.Get(ctx, tt.object)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.want, version)
+		})
+	}
+}

--- a/integrations/kube-agent-updater/pkg/version/mock.go
+++ b/integrations/kube-agent-updater/pkg/version/mock.go
@@ -19,6 +19,8 @@ package version
 import (
 	"context"
 	"strings"
+
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetterMock is a fake version.Getter that return a static answer. This is used
@@ -43,4 +45,27 @@ func NewGetterMock(version string, err error) Getter {
 		version: semVersion,
 		err:     err,
 	}
+}
+
+// MockAuthVersionGetter is a fake version.AuthVersionGetter used for testing
+type MockAuthVersionGetter struct {
+	version string
+	err     error
+}
+
+// NewMockAuthVersionGetter creates a MockAuthVersionGetter
+func NewMockAuthVersionGetter(version string, err error) AuthVersionGetter {
+	semVersion := version
+	if semVersion != "" && !strings.HasPrefix(semVersion, "v") {
+		semVersion = "v" + version
+	}
+	return &MockAuthVersionGetter{
+		version: semVersion,
+		err:     err,
+	}
+}
+
+// Get returns the statically defined version.
+func (m *MockAuthVersionGetter) Get(_ context.Context, _ kclient.Object) (string, error) {
+	return m.version, m.err
 }


### PR DESCRIPTION
Paired with https://github.com/gravitational/teleport/pull/34917

Currently, the teleport-upgrader is allowed to upgrade a Teleport agent to a newer major version than the control plane, making it incompatible with the control plane.

# Context
The reason we did not have this check in the first place is because this can allow the agent to become bricked. If the agent is upgraded to a broken version that cannot communicate with the auth server, the agent would no longer automatically update and be stuck in that state.

We have decided to make this change as a temporary solution so that we can make progress in this issue https://github.com/gravitational/cloud/issues/6773. Once we're in a stable state, we'll rework the auto upgrades to be more compatible with the version/upgrade management of Teleport Cloud.