### PR TITLE
Enforce react-in-jsx-scope ESLint rule

### DIFF
--- a/web/packages/build/.eslintrc.js
+++ b/web/packages/build/.eslintrc.js
@@ -63,6 +63,14 @@ module.exports = {
         'jest/no-large-snapshots': ['warn', { maxSize: 200 }],
       },
     },
+    // Overrides below exist only to avoid breaking the build. Remove them after addressing the
+    // issues in the underlying files.
+    {
+      files: ['e/web/teleport/src/AccessGraph/AccessGraph.tsx'],
+      rules: {
+        'react/react-in-jsx-scope': 0,
+      },
+    },
   ],
   rules: {
     'import/order': [
@@ -134,7 +142,7 @@ module.exports = {
     'react/no-did-update-set-state': 1,
     'react/no-unknown-property': 1,
     'react/prop-types': 0,
-    'react/react-in-jsx-scope': 1,
+    'react/react-in-jsx-scope': 2,
     'react/self-closing-comp': 0,
     'react/sort-comp': 0,
     'react/jsx-wrap-multilines': 1,

--- a/web/packages/shared/components/FieldSelect/shared.tsx
+++ b/web/packages/shared/components/FieldSelect/shared.tsx
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from 'react';
+
 export const defaultRule = () => () => ({ valid: true });
 
 export const LabelTip = ({ text }) => (

--- a/web/packages/teleport/src/Assist/Conversation/Avatar.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Avatar.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import styled from 'styled-components';
 
 import teleport from 'design/assets/images/icons/teleport.png';


### PR DESCRIPTION
`web/packages/shared/components/FieldSelect/shared.tsx` did not include React in its scope which broke any story which made use of `FieldSelect`.

I'm ignoring `e/web/teleport/src/AccessGraph/AccessGraph.tsx` instead of fixing it because I don't have time to shepherd e changes and e ref updates + backports. Stories related to Access Graph are broken at the moment anyway, see https://github.com/gravitational/teleport.e/issues/2675.