### PR TITLE
Ensure that socketpairs are close-on-exec

### DIFF
--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -198,7 +198,8 @@ func (w *TrackingWriter) Write(b []byte) (int, error) {
 	return n, trace.Wrap(err)
 }
 
-// ConnWithAddr is a [net.Conn] wrapper that allows the local and remote address to be overridden.
+// ConnWithAddr is a [net.Conn] wrapper that allows the local and remote address
+// to be overridden.
 type ConnWithAddr struct {
 	net.Conn
 	LocalAddrOverride  net.Addr
@@ -237,6 +238,8 @@ func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithAddr {
 	}
 }
 
+// NewConnWithAddr wraps a [net.Conn] optionally overriding the local and remote
+// addresses with the provided ones, if non-nil.
 func NewConnWithAddr(conn net.Conn, localAddr, remoteAddr net.Addr) *ConnWithAddr {
 	return &ConnWithAddr{
 		Conn: conn,

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -198,7 +198,7 @@ func (w *TrackingWriter) Write(b []byte) (int, error) {
 	return n, trace.Wrap(err)
 }
 
-// ConnWithAddr is a [net.Conn] wrapper that allows us to override addresses.
+// ConnWithAddr is a [net.Conn] wrapper that allows the local and remote address to be overridden.
 type ConnWithAddr struct {
 	net.Conn
 	LocalAddrOverride  net.Addr
@@ -228,7 +228,7 @@ func (c *ConnWithAddr) NetConn() net.Conn {
 	return c.Conn
 }
 
-// NewConnWithSrcAddr wraps provided connection and overrides client remote address
+// NewConnWithSrcAddr wraps provided connection and overrides client remote address.
 func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithAddr {
 	return &ConnWithAddr{
 		Conn: conn,

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -198,29 +198,50 @@ func (w *TrackingWriter) Write(b []byte) (int, error) {
 	return n, trace.Wrap(err)
 }
 
-// ConnWithSrcAddr is a net.Conn wrapper that allows us to specify remote client address
-type ConnWithSrcAddr struct {
+// ConnWithAddr is a [net.Conn] wrapper that allows us to override addresses.
+type ConnWithAddr struct {
 	net.Conn
-	clientSrcAddr net.Addr
+	LocalAddrOverride  net.Addr
+	RemoteAddrOverride net.Addr
 }
 
-// RemoteAddr returns specified client source address
-func (c *ConnWithSrcAddr) RemoteAddr() net.Addr {
-	if c.clientSrcAddr == nil {
-		return c.Conn.RemoteAddr()
+// LocalAddr implements [net.Conn].
+func (c *ConnWithAddr) LocalAddr() net.Addr {
+	if c.LocalAddrOverride != nil {
+		return c.LocalAddrOverride
 	}
-	return c.clientSrcAddr
+
+	return c.Conn.LocalAddr()
 }
 
-// NetConn returns the underlying net.Conn.
-func (c *ConnWithSrcAddr) NetConn() net.Conn {
+// RemoteAddr implements [net.Conn].
+func (c *ConnWithAddr) RemoteAddr() net.Addr {
+	if c.RemoteAddrOverride != nil {
+		return c.RemoteAddrOverride
+	}
+
+	return c.Conn.RemoteAddr()
+}
+
+// NetConn returns the underlying [net.Conn].
+func (c *ConnWithAddr) NetConn() net.Conn {
 	return c.Conn
 }
 
 // NewConnWithSrcAddr wraps provided connection and overrides client remote address
-func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithSrcAddr {
-	return &ConnWithSrcAddr{
-		Conn:          conn,
-		clientSrcAddr: clientSrcAddr,
+func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithAddr {
+	return &ConnWithAddr{
+		Conn: conn,
+
+		RemoteAddrOverride: clientSrcAddr,
+	}
+}
+
+func NewConnWithAddr(conn net.Conn, localAddr, remoteAddr net.Addr) *ConnWithAddr {
+	return &ConnWithAddr{
+		Conn: conn,
+
+		LocalAddrOverride:  localAddr,
+		RemoteAddrOverride: remoteAddr,
 	}
 }

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -202,14 +202,14 @@ func (w *TrackingWriter) Write(b []byte) (int, error) {
 // to be overridden.
 type ConnWithAddr struct {
 	net.Conn
-	LocalAddrOverride  net.Addr
-	RemoteAddrOverride net.Addr
+	localAddrOverride  net.Addr
+	remoteAddrOverride net.Addr
 }
 
 // LocalAddr implements [net.Conn].
 func (c *ConnWithAddr) LocalAddr() net.Addr {
-	if c.LocalAddrOverride != nil {
-		return c.LocalAddrOverride
+	if c.localAddrOverride != nil {
+		return c.localAddrOverride
 	}
 
 	return c.Conn.LocalAddr()
@@ -217,8 +217,8 @@ func (c *ConnWithAddr) LocalAddr() net.Addr {
 
 // RemoteAddr implements [net.Conn].
 func (c *ConnWithAddr) RemoteAddr() net.Addr {
-	if c.RemoteAddrOverride != nil {
-		return c.RemoteAddrOverride
+	if c.remoteAddrOverride != nil {
+		return c.remoteAddrOverride
 	}
 
 	return c.Conn.RemoteAddr()
@@ -234,7 +234,7 @@ func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithAddr {
 	return &ConnWithAddr{
 		Conn: conn,
 
-		RemoteAddrOverride: clientSrcAddr,
+		remoteAddrOverride: clientSrcAddr,
 	}
 }
 
@@ -244,7 +244,7 @@ func NewConnWithAddr(conn net.Conn, localAddr, remoteAddr net.Addr) *ConnWithAdd
 	return &ConnWithAddr{
 		Conn: conn,
 
-		LocalAddrOverride:  localAddr,
-		RemoteAddrOverride: remoteAddr,
+		localAddrOverride:  localAddr,
+		remoteAddrOverride: remoteAddr,
 	}
 }

--- a/lib/utils/pipenetconn_atomic.go
+++ b/lib/utils/pipenetconn_atomic.go
@@ -1,0 +1,38 @@
+//go:build unix && !darwin
+
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+// cloexecSocketpair returns a unix/local stream socketpair whose file
+// descriptors are flagged close-on-exec. This implementation creates the
+// socketpair directly in close-on-exec mode.
+func cloexecSocketpair() (uintptr, uintptr, error) {
+	// SOCK_CLOEXEC on socketpair is supported since Linux 2.6.27 and go's
+	// minimum requirement is 2.6.32 (FreeBSD supports it since FreeBSD 10 and
+	// go 1.20+ requires FreeBSD 12)
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return 0, 0, trace.Wrap(err)
+	}
+
+	return uintptr(fds[0]), uintptr(fds[1]), nil
+}

--- a/lib/utils/pipenetconn_forklock.go
+++ b/lib/utils/pipenetconn_forklock.go
@@ -1,0 +1,42 @@
+//go:build darwin
+
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+// cloexecSocketpair returns a unix/local stream socketpair whose file
+// descriptors are flagged close-on-exec. This implementation acquires
+// [syscall.ForkLock] as it creates the socketpair and sets the two file
+// descriptors close-on-exec.
+func cloexecSocketpair() (uintptr, uintptr, error) {
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
+
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return 0, 0, trace.Wrap(err)
+	}
+
+	syscall.CloseOnExec(fds[0])
+	syscall.CloseOnExec(fds[1])
+
+	return uintptr(fds[0]), uintptr(fds[1]), nil
+}

--- a/lib/utils/pipenetconn_unix_test.go
+++ b/lib/utils/pipenetconn_unix_test.go
@@ -34,10 +34,9 @@ func TestDualPipeNetConnCloseOnExec(t *testing.T) {
 	for _, c := range []net.Conn{c1, c2} {
 		c = unwrapNetConn(c)
 
-		sysConn, ok := c.(syscall.Conn)
-		require.True(t, ok)
+		require.Implements(t, (*syscall.Conn)(nil), c)
 
-		rawConn, err := sysConn.SyscallConn()
+		rawConn, err := c.(syscall.Conn).SyscallConn()
 		require.NoError(t, err)
 
 		require.NoError(t, rawConn.Control(func(fd uintptr) {
@@ -45,7 +44,7 @@ func TestDualPipeNetConnCloseOnExec(t *testing.T) {
 			require.NoError(t, err)
 
 			isCloseOnExec := flags&unix.FD_CLOEXEC == unix.FD_CLOEXEC
-			require.True(t, isCloseOnExec)
+			require.True(t, isCloseOnExec, "expected file descriptor to have close-on-exec flag (FD_CLOEXEC, %x), got flags %x", unix.FD_CLOEXEC, flags)
 		}))
 
 	}

--- a/lib/utils/pipenetconn_unix_test.go
+++ b/lib/utils/pipenetconn_unix_test.go
@@ -1,0 +1,66 @@
+//go:build unix
+
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestDualPipeNetConnCloseOnExec(t *testing.T) {
+	c1, c2, err := DualPipeNetConn(nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, c1.Close()) })
+	t.Cleanup(func() { require.NoError(t, c2.Close()) })
+
+	for _, c := range []net.Conn{c1, c2} {
+		c = unwrapNetConn(c)
+
+		sysConn, ok := c.(syscall.Conn)
+		require.True(t, ok)
+
+		rawConn, err := sysConn.SyscallConn()
+		require.NoError(t, err)
+
+		require.NoError(t, rawConn.Control(func(fd uintptr) {
+			flags, err := unix.FcntlInt(fd, unix.F_GETFD, 0)
+			require.NoError(t, err)
+
+			isCloseOnExec := flags&unix.FD_CLOEXEC == unix.FD_CLOEXEC
+			require.True(t, isCloseOnExec)
+		}))
+
+	}
+}
+
+func unwrapNetConn(c net.Conn) net.Conn {
+	for {
+		unwrapper, ok := c.(interface{ NetConn() net.Conn })
+		if !ok {
+			return c
+		}
+		unwrapped := unwrapper.NetConn()
+		if unwrapped == nil {
+			return c
+		}
+		c = unwrapped
+	}
+}


### PR DESCRIPTION
The current implementation of `utils.DualPipeNetConn` on UNIX uses the `socketpair` syscall to spawn two unix stream sockets connected to each other, and it does so by calling the syscall, converting the file descriptors to `*os.File` objects, and then converting them to the appropriate `net.Conn` with `net.FileConn` before closing the `*os.File`s.

The second conversion duplicates the file descriptors, and results in file descriptors that are flagged close-on-exec, but the former simply takes ownership of the file descriptors returned by `socketpair`, which are not flagged close-on-exec. A fork/exec between the socketpair and the closing of the original file descriptors will leak the file descriptors to the spawned subprocess.

The only use of `DualPipeNetConn` is in `lib/srv/foward` (only used by the Teleport Proxy), and the pipe is used to forward along a SSH connection, so the most that an untrusted child process can do is disrupt SSH connections, if the socketpair survives the file descriptor shuffling done by `os/exec` to spawn the process.

To flag the socketpair file descriptors as close-on-exec on darwin we have to rely on `runtime.ForkLock`, as there's no way to directly spawn the socketpair with cloexec; other supported UNIXes can, so they don't need to hold the lock.

The test was manually ran (and passed) on darwin arm64 (macOS Sonoma 14.1.1 (23B81)).