### PR TITLE
Use automatic runtime for `@babel/preset-react`

### DIFF
--- a/web/.storybook/.babelrc
+++ b/web/.storybook/.babelrc
@@ -1,8 +1,3 @@
 {
-  "extends": "./../packages/build/.babelrc",
-  "presets": [
-    "@babel/preset-react",
-    "@babel/preset-typescript"
-  ]
+  "extends": "./../packages/build/.babelrc"
 }
-

--- a/web/packages/build/.babelrc.js
+++ b/web/packages/build/.babelrc.js
@@ -25,7 +25,7 @@ function makePresets(test = false) {
   if (test) {
     return [
       ['@babel/preset-env', { targets: { node: 'current' } }],
-      '@babel/preset-react',
+      ['@babel/preset-react', { runtime: 'automatic' }],
       '@babel/preset-typescript',
     ];
   }
@@ -38,7 +38,7 @@ function makePresets(test = false) {
           'last 2 chrome version, last 2 edge version, last 2 firefox version, last 2 safari version',
       },
     ],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
   ];
 }
 

--- a/web/packages/build/.eslintrc.js
+++ b/web/packages/build/.eslintrc.js
@@ -128,13 +128,11 @@ module.exports = {
     'react/jsx-no-duplicate-props': 2,
     'react/jsx-sort-prop-types': 0,
     'react/jsx-sort-props': 0,
-    'react/jsx-uses-react': 1,
     'react/jsx-uses-vars': 1,
     'react/no-did-mount-set-state': 1,
     'react/no-did-update-set-state': 1,
     'react/no-unknown-property': 1,
     'react/prop-types': 0,
-    'react/react-in-jsx-scope': 1,
     'react/self-closing-comp': 0,
     'react/sort-comp': 0,
     'react/jsx-wrap-multilines': 1,
@@ -144,6 +142,10 @@ module.exports = {
 
     'react-hooks/rules-of-hooks': 1,
     'react-hooks/exhaustive-deps': 1,
+
+    // Turned off because we use automatic runtime.
+    'react/jsx-uses-react': 0,
+    'react/react-in-jsx-scope': 0,
   },
   settings: {
     react: {


### PR DESCRIPTION
`web/packages/shared/components/FieldSelect/shared.tsx` did not include React in its scope which broke any story which made use of `FieldSelect`, for example [Kube TestConnection](http://localhost:9002/?path=/story/teleport-discover-kube-testconnection--init-with-local).

However, importing React into scope is not needed since React 17, as long as you use automatic runtime, see https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup. This PR switches the runtime to automatic so that we no longer need to remember about importing React.

---

Originally I wanted to enforce `react-in-jsx-scope` (#35027) but soon I realized that this is unnecessary.

The next step would be to [remove unused React imports](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports). I don't have time to take care of this at the moment, so I'm going to create an issue for this (https://github.com/gravitational/teleport/issues/35039).

I tested this change by verifying that the following items run without problems:

* dev version of Web UI and Connect
* prod version of Web UI, ent Web UI and Connect
* Storybook