### PR TITLE
Allow copying to clipboard in Electron

### DIFF
--- a/web/packages/design/src/utils/copyToClipboard.ts
+++ b/web/packages/design/src/utils/copyToClipboard.ts
@@ -26,8 +26,16 @@ export default async function copyToClipboard(
     await navigator.clipboard.writeText(textToCopy);
   } catch (error) {
     // This can happen if the user denies clipboard permissions.
-    window.alert(
-      `Cannot copy to clipboard. Use Ctrl/Cmd + C.\n${error.message}`
-    );
+    handleError(error, textToCopy);
+  }
+}
+
+function handleError(error: Error, textToCopy: string): void {
+  const message = `Cannot copy to clipboard. Use Ctrl/Cmd + C.\n${error.message}`;
+  try {
+    // window.prompt doesn't work in Electron.
+    window.prompt(message, textToCopy);
+  } catch (error) {
+    window.alert(message);
   }
 }

--- a/web/packages/design/src/utils/copyToClipboard.ts
+++ b/web/packages/design/src/utils/copyToClipboard.ts
@@ -19,9 +19,7 @@
  *
  * @param textToCopy the text to copy to clipboard
  */
-export default async function copyToClipboard(
-  textToCopy: string
-): Promise<void> {
+export async function copyToClipboard(textToCopy: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(textToCopy);
   } catch (error) {

--- a/web/packages/design/src/utils/copyToClipboard.ts
+++ b/web/packages/design/src/utils/copyToClipboard.ts
@@ -15,13 +15,19 @@
  */
 
 /**
- * copyToClipboard copies text to clipboard.
+ * Copies text to clipboard.
  *
  * @param textToCopy the text to copy to clipboard
  */
-export default function copyToClipboard(textToCopy: string): Promise<any> {
-  return navigator.clipboard.writeText(textToCopy).catch(err => {
-    // This can happen if the user denies clipboard permissions:
-    window.prompt('Cannot copy to clipboard. Use ctrl/cmd + c', err);
-  });
+export default async function copyToClipboard(
+  textToCopy: string
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(textToCopy);
+  } catch (error) {
+    // This can happen if the user denies clipboard permissions.
+    window.alert(
+      `Cannot copy to clipboard. Use Ctrl/Cmd + C.\n${error.message}`
+    );
+  }
 }

--- a/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
@@ -18,7 +18,7 @@ import React, { useState, useRef, useEffect } from 'react';
 
 import ButtonIcon from 'design/ButtonIcon';
 import { Check, Copy } from 'design/Icon';
-import copyToClipboard from 'design/utils/copyToClipboard';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
 
 import { HoverTooltip } from 'shared/components/ToolTip';
 

--- a/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.tsx
+++ b/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.tsx
@@ -17,7 +17,7 @@
 import React, { useRef } from 'react';
 import styled from 'styled-components';
 import { Box, ButtonPrimary, Card, Flex, Text } from 'design';
-import copyToClipboard from 'design/utils/copyToClipboard';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
 import selectElementContent from 'design/utils/selectElementContent';
 
 import { RecoveryCodes } from 'teleport/services/auth';

--- a/web/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.tsx
+++ b/web/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import copyToClipboard from 'design/utils/copyToClipboard';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
 import selectElementContent from 'design/utils/selectElementContent';
 import { ButtonPrimary, Box, Flex } from 'design';
 import { useTheme } from 'styled-components';

--- a/web/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/web/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -16,7 +16,7 @@
 
 import React, { useRef } from 'react';
 import styled from 'styled-components';
-import copyToClipboard from 'design/utils/copyToClipboard';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
 import selectElementContent from 'design/utils/selectElementContent';
 import { ButtonSecondary, Box, Flex } from 'design';
 import { Copy, Check } from 'design/Icon';

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import path from 'path';
+import path from 'node:path';
+import * as url from 'node:url';
 
 import {
   app,
@@ -53,6 +54,7 @@ export class WindowsManager {
     resolve: () => void;
     reject: (error: Error) => void;
   };
+  private readonly windowUrl: string;
 
   constructor(
     private fileStorage: FileStorage,
@@ -90,6 +92,7 @@ export class WindowsManager {
       { role: 'copy' },
       { role: 'paste' },
     ]);
+    this.windowUrl = getWindowUrl(settings.dev);
   }
 
   createWindow(): void {
@@ -129,13 +132,7 @@ export class WindowsManager {
 
     // shows the window when the DOM is ready, so we don't have a brief flash of a blank screen
     window.once('ready-to-show', window.show);
-
-    if (this.settings.dev) {
-      window.loadURL('https://localhost:8080');
-    } else {
-      window.loadFile(path.join(__dirname, '../renderer/index.html'));
-    }
-
+    window.loadURL(this.windowUrl);
     window.webContents.on('context-menu', (_, props) => {
       this.popupUniversalContextMenu(window, props);
     });
@@ -342,4 +339,21 @@ export class WindowsManager {
       ...getPositionAndSize(),
     };
   }
+}
+
+/**
+ * Returns a URL that will be loaded by `BrowserWindow`.
+ * This URL points either to a dev server or to index.html file
+ * for the packaged app.
+ * */
+function getWindowUrl(isDev: boolean): string {
+  if (isDev) {
+    return 'https://localhost:8080/';
+  }
+
+  return url
+    .pathToFileURL(
+      path.resolve(app.getAppPath(), __dirname, '../renderer/index.html')
+    )
+    .toString();
 }


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/30422
This PR enables the `clipboard-sanitized-write` permission for the `BrowserWindow`.
This was suggested in [my previous PR](https://github.com/gravitational/teleport/pull/34929#discussion_r1406350364), and indeed, it is much more convenient to use than a separate IPC.

When it comes to security, exposing that API doesn't seem to have any negative consequences. The only difference I see is that the IPC allowed only text content, while the Clipboard API allows for any content. However, this content seems to be sanitized (and it is allowed in a regular browser anyway). 
The small advantage (comparing to the IPC) is that we get the browser protection for:
>The request to write to the clipboard must be triggered during a user gesture. A call to clipboard.write or clipboard.writeText outside the scope of a user gesture (such as "click" or "touch" event handlers) will result in the immediate rejection of the promise returned by the API call.

(I tested it and it works).

To increase the overall security, I followed the suggestion from Doyensec blog:
>If your application needs to allow the renderer process permission to access some web APIs, you can add exceptions by modifying the permission handler. We recommend checking if the origin requesting permission matches an expected origin.

To achieve that, I had to extract the window URL to be known upfront (so we can check if it maches `requestingUrl`).
I tested the change to `loadURL` on macOS, Windows and Ubuntu. 