### PR TITLE
[v13] Access list user requirements check before member expiry check.

### DIFF
--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -247,18 +247,14 @@ func (a AccessListMembershipChecker) IsAccessListMember(ctx context.Context, ide
 		return trace.Wrap(err)
 	}
 
-	expires := member.Spec.Expires
-	if expires.IsZero() {
-		return nil
-	}
-
-	if !a.clock.Now().Before(expires) {
-		return trace.AccessDenied("user %s's membership has expired in the access list", username)
-	}
-
 	if !UserMeetsRequirements(identity, accessList.Spec.MembershipRequires) {
 		return trace.AccessDenied("user %s is a member, but does not have the roles or traits required to be a member of this list", username)
 	}
+
+	if !member.Spec.Expires.IsZero() && !a.clock.Now().Before(member.Spec.Expires) {
+		return trace.AccessDenied("user %s's membership has expired in the access list", username)
+	}
+
 	return nil
 }
 

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -417,9 +417,39 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 			},
 		},
 		{
+			name: "is member with no expiration and missing roles",
+			identity: tlsca.Identity{
+				Username: member3,
+				Groups:   []string{"mrole1"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
 			name: "is member with missing traits",
 			identity: tlsca.Identity{
 				Username: member1,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1"},
+					"mtrait2": {"mvalue3"},
+				},
+			},
+			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "is member with no expiration and missing traits",
+			identity: tlsca.Identity{
+				Username: member3,
 				Groups:   []string{"mrole1", "mrole2"},
 				Traits: map[string][]string{
 					"mtrait1": {"mvalue1"},


### PR DESCRIPTION
Backport #35038 to branch/v13

changelog: Fixed issue with the absence of membership expiry circumventing membership requirements check.