### PR TITLE
[v14] Fix installer to only use `--azure-client-id` if requested

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -110,7 +110,9 @@ on_gcp() {
   sudo /usr/local/bin/teleport node configure \
     --proxy="{{ .PublicProxyAddr }}" \
     --join-method=${JOIN_METHOD} \
+    {{- if .AzureClientID }}
     --azure-client-id="{{ .AzureClientID }}" \
+    {{ end -}}
     --token="$1" \
     --output=file \
     --labels="${LABELS}"

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1083,SC2215,SC2288 # caused by Go templating, and shellcheck won't parse if the lines are excluded individually
 
 set -eu
 


### PR DESCRIPTION
Backport #34904 to branch/v14

Changelog: Fixed error when installing a v13 node with the default installer from a v14 cluster