### PR TITLE
Remove bypass for dependabot on `dependency-review` check

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   dependency-review:
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@main
     permissions:
       contents: read


### PR DESCRIPTION
The bypass `if` for dependabot PRs added in #19745 is failing `dependency-review` due to this workflow effectively just proxying to another workflow in `shared-workflows`. This is causing the workflow to not run at all, and since it's required, it's causing dependabot PRs to not pass status checks. Remove the bypass for now to make checks pass again.