### PR TITLE
Continue completing uploads on not found errors

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -201,8 +201,11 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 
 		log.Debugf("upload has %d parts", len(parts))
 
-		if err := u.cfg.Uploader.CompleteUpload(ctx, upload, parts); err != nil {
-			return trace.Wrap(err, "completing upload")
+		if err := u.cfg.Uploader.CompleteUpload(ctx, upload, parts); trace.IsNotFound(err) {
+			log.WithError(err).Debug("Upload not found, moving on to next upload")
+			continue
+		} else if err != nil {
+			return trace.Wrap(err)
 		}
 		log.Debug("Completed upload")
 		completed++


### PR DESCRIPTION
Prior to this change, if we failed to complete an upload, the completed would error out and stop processing uploads until the next interval (5 minutes later). This leads to us falling behind and allowing a large number of uncompleted uploads to accumulate, particularly when there are multiple auth servers attempting to complete the same set of uploads.

Fixes gravitational/cloud#5938

Changelog: Allow Teleport to complete abandoned uploads faster in HA deployments.