### PR TITLE
chore: Ignore AWS SDK v2 upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
+      # TODO(codingllama): Remove ignore once AWS SDK can be upgraded.
+      # https://github.com/snowflakedb/gosnowflake/issues/970#issuecomment-1829186629
+      - dependency-name: github.com/aws/aws-sdk-go-v2*
       # Breaks backwards compatibility
       - dependency-name: github.com/gravitational/ttlmap
       # Must be kept in-sync with libbpf


### PR DESCRIPTION
Temporarily ignore automatic AWS SDK v2 upgrades while its breaking changes are addressed by other dependencies.