### PR TITLE
Fix the IsAssistEnabled response

### DIFF
--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai"
 	embeddinglib "github.com/gravitational/teleport/lib/ai/embedding"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -195,6 +196,11 @@ func (a *Service) CreateAssistantMessage(ctx context.Context, req *assist.Create
 
 // IsAssistEnabled returns true if the assist is enabled or not on the auth level.
 func (a *Service) IsAssistEnabled(ctx context.Context, _ *assist.IsAssistEnabledRequest) (*assist.IsAssistEnabledResponse, error) {
+	if !modules.GetModules().Features().Assist {
+		// If the assist feature is not enabled on the license, the assist is not enabled.
+		return &assist.IsAssistEnabledResponse{Enabled: false}, nil
+	}
+
 	// If the embedder is not configured, the assist is not enabled as we cannot compute embeddings.
 	if a.embedder == nil {
 		return &assist.IsAssistEnabledResponse{Enabled: false}, nil

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4554,7 +4554,7 @@ func TestGetWebConfig(t *testing.T) {
 	expectedCfg.IsUsageBasedBilling = true
 	expectedCfg.AutomaticUpgrades = true
 	expectedCfg.AutomaticUpgradesTargetVersion = "v99.0.1"
-	expectedCfg.AssistEnabled = true
+	expectedCfg.AssistEnabled = false
 
 	// request and verify enabled features are enabled.
 	re, err = clt.Get(ctx, endpoint, nil)


### PR DESCRIPTION
A condition was added in the IsAssistEnabled function to check the license status of the Assist feature. Now, the function explicitly checks if the Assist feature is enabled in the license. This makes the check to be more explicit as the current implementation returns true only base on the API key and ACL control the feature access.