### PR TITLE
[v12] docs: fix typo in Postgres guide

### DIFF
--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -66,7 +66,7 @@ to the PostgreSQL configuration file, `postgresql.conf`:
 ssl = on
 ssl_cert_file = '/path/to/server.crt'
 ssl_key_file = '/path/to/server.key'
-ssl_ca_file = '/path/toa/server.cas'
+ssl_ca_file = '/path/to/server.cas'
 ```
 
 See [Secure TCP/IP Connections with SSL](https://www.postgresql.org/docs/current/ssl-tcp.html)


### PR DESCRIPTION
Backport #35036 to branch/v12