### PR TITLE
drone: Fix signature

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16622,6 +16622,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: b21b22a73c61317b6cd4005514f1f59b2e44543e6f0a111f428398c14dab1e84
+hmac: d34cacc9bae89579ff6fc90d253c055187925256fc8e775619eed5578bce0cc1
 
 ...


### PR DESCRIPTION
The current drone.yml is causing drone to ask for approval for builds.
This is because the drone signature is incorrect.

eb7362962368cb1b9156501aef2667e6c1ee0e14 updated it on the PR correctly
at first, but followed up with another that got the wrong signature.

The signature was generated with:

    make dronegen

and

    drone sign --save gravitational/teleport

Both generated the same sig/hash, in this commit.