### PR TITLE
Fix link syntax in Core Concepts

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -227,4 +227,4 @@ in the root cluster to be mapped to roles and permissions defined in the leaf cl
 For more information about how to configure a trust relationship between clusters,
 see [Configure Trusted Clusters](./management/admin/trustedclusters.mdx). 
 For an overview of the architecture used in a trusted cluster relationship, see 
-[Trusted Cluster Architecture]](./architecture/trustedclusters.mdx).
+[Trusted Cluster Architecture](./architecture/trustedclusters.mdx).


### PR DESCRIPTION
The last link on that page had the anchor part of closed incorrectly.