### PR TITLE
Ensure a slog.Logger is always set on the service config

### DIFF
--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -673,6 +673,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Log = logrus.StandardLogger()
 	}
 
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
 	if cfg.PollingPeriod == 0 {
 		cfg.PollingPeriod = defaults.LowResPollingPeriod
 	}


### PR DESCRIPTION
Prevents panics by using the default slog logger if the configured logger is not set. This was already being done in `ApplyDefaults(cfg *Config)` but was missed in `applyDefaults(cfg *Config)`.