### PR TITLE
bump cloud version (14.2.0)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1732,7 +1732,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "14.1.3",
+      "version": "14.2.0",
       "major_version": "14",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Update docs to use the latest Cloud version number

ref: https://github.com/gravitational/cloud/issues/6743