### PR TITLE
Discover: Add UI for connection test for Connect My Computer

### DIFF
--- a/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/LegacyTestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/LegacyTestConnection.story.tsx
@@ -26,10 +26,10 @@ import { UserContext } from 'teleport/User/UserContext';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 
-import { TestConnection } from './TestConnection';
+import { LegacyTestConnection } from './LegacyTestConnection';
 
 export default {
-  title: 'Teleport/Discover/ConnectMyComputer/TestConnection',
+  title: 'Teleport/Discover/ConnectMyComputer/LegacyTestConnection',
   loaders: [mswLoader],
 };
 
@@ -46,7 +46,7 @@ const agentStepProps = {
 export const SingleLogin = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };
@@ -67,7 +67,7 @@ SingleLogin.parameters = {
 export const MultipleLogins = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };
@@ -88,7 +88,7 @@ MultipleLogins.parameters = {
 export const NoLogins = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };
@@ -109,7 +109,7 @@ NoLogins.parameters = {
 export const NoRole = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };
@@ -131,7 +131,7 @@ NoRole.parameters = {
 export const ReloadUserProcessing = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };
@@ -149,7 +149,7 @@ ReloadUserProcessing.parameters = {
 export const ReloadUserError = () => {
   return (
     <Provider>
-      <TestConnection {...agentStepProps} />
+      <LegacyTestConnection {...agentStepProps} />
     </Provider>
   );
 };

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/LegacyTestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/LegacyTestConnection.tsx
@@ -45,7 +45,7 @@ import { NodeMeta } from '../../useDiscover';
 
 import type { AgentStepProps } from '../../types';
 
-export const TestConnection = (props: AgentStepProps) => {
+export const LegacyTestConnection = (props: AgentStepProps) => {
   const { userService, storeUser } = useTeleport();
   const meta = props.agentMeta as NodeMeta;
 

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/LegacyTestConnection/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { TestConnection } from './TestConnection';
+export { LegacyTestConnection } from './LegacyTestConnection';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+import { rest } from 'msw';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { nodes } from 'teleport/Nodes/fixtures';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  DiscoverProvider,
+  DiscoverContextState,
+} from 'teleport/Discover/useDiscover';
+
+import { TestConnection } from './TestConnection';
+
+export default {
+  title: 'Teleport/Discover/ConnectMyComputer/TestConnection',
+  loaders: [mswLoader],
+};
+
+initialize();
+
+const node = { ...nodes[0] };
+node.sshLogins = [
+  ...node.sshLogins,
+  'george_washington_really_long_name_testing',
+];
+const agentStepProps = {
+  prevStep: () => {},
+  nextStep: () => {},
+  agentMeta: { resourceName: node.hostname, node, agentMatcherLabels: [] },
+};
+
+export const SingleLogin = () => (
+  <Provider>
+    <TestConnection {...agentStepProps} />
+  </Provider>
+);
+
+SingleLogin.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+      rest.get(cfg.api.connectMyComputerLoginsPath, (req, res, ctx) =>
+        res(ctx.json({ logins: ['foo'] }))
+      ),
+    ],
+  },
+};
+
+export const MultipleLogins = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+MultipleLogins.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+      rest.get(cfg.api.connectMyComputerLoginsPath, (req, res, ctx) =>
+        res(
+          ctx.json({
+            logins: [
+              'foo',
+              'bar',
+              'baz',
+              'czesława_maria_de_domo_cieślak_primo_voto_gospodarek_secundo_voto_kowalczyk',
+            ],
+          })
+        )
+      ),
+    ],
+  },
+};
+
+export const NoLogins = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+NoLogins.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+      rest.get(cfg.api.connectMyComputerLoginsPath, (req, res, ctx) =>
+        res(ctx.json({ logins: [] }))
+      ),
+    ],
+  },
+};
+
+export const NoRole = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+NoRole.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.json({}))
+      ),
+      rest.get(cfg.api.connectMyComputerLoginsPath, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json({ error: { message: 'No role found' } }))
+      ),
+    ],
+  },
+};
+
+export const ReloadUserProcessing = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+ReloadUserProcessing.parameters = {
+  msw: {
+    handlers: [
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(ctx.delay('infinite'))
+      ),
+    ],
+  },
+};
+
+export const ReloadUserError = () => {
+  return (
+    <Provider>
+      <TestConnection {...agentStepProps} />
+    </Provider>
+  );
+};
+
+ReloadUserError.parameters = {
+  msw: {
+    handlers: [
+      // The first handler returns an error immediately. Subsequent requests return after a delay so
+      // that we can show a spinner after clicking on "Retry".
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res.once(
+          ctx.status(500),
+          ctx.json({ message: 'Could not renew session' })
+        )
+      ),
+      rest.post(cfg.api.webRenewTokenPath, (req, res, ctx) =>
+        res(
+          ctx.delay(1000),
+          ctx.status(500),
+          ctx.json({ error: { message: 'Could not renew session' } })
+        )
+      ),
+    ],
+  },
+};
+
+const Provider = ({ children }) => {
+  const ctx = createTeleportContext();
+  const discoverCtx: DiscoverContextState = {
+    ...agentStepProps,
+    currentStep: 0,
+    onSelectResource: () => null,
+    resourceSpec: undefined,
+    exitFlow: () => null,
+    viewConfig: null,
+    indexedViews: [],
+    setResourceSpec: () => null,
+    updateAgentMeta: () => null,
+    emitErrorEvent: () => null,
+    emitEvent: () => null,
+    eventState: null,
+  };
+
+  return (
+    <MemoryRouter
+      initialEntries={[
+        { pathname: cfg.routes.discover, state: { entity: 'server' } },
+      ]}
+    >
+      <ContextProvider ctx={ctx}>
+        <DiscoverProvider mockCtx={discoverCtx}>{children}</DiscoverProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { Flex } from 'design';
+
+import { Header } from 'teleport/Discover/Shared';
+
+import { NodeMeta } from '../../useDiscover';
+
+import type { AgentStepProps } from '../../types';
+
+export const TestConnection = (props: AgentStepProps) => {
+  const meta = props.agentMeta as NodeMeta;
+  return (
+    <Flex flexDirection="column" alignItems="flex-start" mb={2} gap={4}>
+      <div>
+        <Header>Test Connection to &ldquo;{meta.node.hostname}&rdquo;</Header>
+      </div>
+    </Flex>
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -94,6 +94,16 @@ export function TestConnection(props: AgentStepProps) {
 
     if (logins.length > 0) {
       setSelectedLoginOpt(mapLoginToSelectOption(logins[0]));
+
+      // Start the test automatically if there are no logins to choose from.
+      if (logins.length == 1) {
+        const { mfaRequired } = await testConnection(logins[0]);
+
+        // If MFA is required, let's just wait for the user to start the connection themselves.
+        if (mfaRequired) {
+          cancelMfaDialog();
+        }
+      }
     }
   };
 
@@ -120,7 +130,7 @@ export function TestConnection(props: AgentStepProps) {
   }
 
   function testConnection(login: string, mfaResponse?: MfaAuthnResponse) {
-    runConnectionDiagnostic(
+    return runConnectionDiagnostic(
       {
         resourceKind: 'node',
         resourceName: props.agentMeta.resourceName,

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright 2023 Gravitational, Inc
+ * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,118 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import { ButtonSecondary, Text, Box, LabelInput } from 'design';
+import Select from 'shared/components/Select';
 
-import { Flex } from 'design';
-
-import { Header } from 'teleport/Discover/Shared';
+import cfg from 'teleport/config';
+import ReAuthenticate from 'teleport/components/ReAuthenticate';
+import { openNewTab } from 'teleport/lib/util';
+import {
+  useConnectionDiagnostic,
+  Header,
+  ActionButtons,
+  HeaderSubtitle,
+  ConnectionDiagnosticResult,
+  StyledBox,
+} from 'teleport/Discover/Shared';
+import { sortNodeLogins } from 'teleport/services/nodes';
 
 import { NodeMeta } from '../../useDiscover';
 
+import type { Option } from 'shared/components/Select';
 import type { AgentStepProps } from '../../types';
+import type { MfaAuthnResponse } from 'teleport/services/mfa';
 
-export const TestConnection = (props: AgentStepProps) => {
-  const meta = props.agentMeta as NodeMeta;
+export function TestConnection(props: AgentStepProps) {
+  const {
+    runConnectionDiagnostic,
+    attempt,
+    diagnosis,
+    nextStep,
+    prevStep,
+    canTestConnection,
+    showMfaDialog,
+    cancelMfaDialog,
+  } = useConnectionDiagnostic();
+  const node = (props.agentMeta as NodeMeta).node;
+  const logins = sortNodeLogins(node.sshLogins);
+
+  function startSshSession(login: string) {
+    const url = cfg.getSshConnectRoute({
+      clusterId: node.clusterId,
+      serverId: node.id,
+      login,
+    });
+
+    openNewTab(url);
+  }
+
+  function testConnection(login: string, mfaResponse?: MfaAuthnResponse) {
+    runConnectionDiagnostic(
+      {
+        resourceKind: 'node',
+        resourceName: props.agentMeta.resourceName,
+        sshPrincipal: login,
+      },
+      mfaResponse
+    );
+  }
+
+  const usernameOpts = logins.map(l => ({ value: l, label: l }));
+  // There will always be one login, as the user cannot proceed
+  // the step that requires users to have at least one login.
+  const [selectedOpt, setSelectedOpt] = useState(usernameOpts[0]);
+
   return (
-    <Flex flexDirection="column" alignItems="flex-start" mb={2} gap={4}>
-      <div>
-        <Header>Test Connection to &ldquo;{meta.node.hostname}&rdquo;</Header>
-      </div>
-    </Flex>
+    <Box>
+      {showMfaDialog && (
+        <ReAuthenticate
+          onMfaResponse={res => testConnection(selectedOpt.value, res)}
+          onClose={cancelMfaDialog}
+        />
+      )}
+      <Header>Test Connection</Header>
+      <HeaderSubtitle>
+        Optionally verify that you can successfully connect to the server you
+        just added.
+      </HeaderSubtitle>
+      <StyledBox mb={5}>
+        <Text bold>Step 1</Text>
+        <Text typography="subtitle1" mb={3}>
+          Pick the OS user to test
+        </Text>
+        <Box width="320px">
+          <LabelInput>Select Login</LabelInput>
+          <Select
+            value={selectedOpt}
+            options={usernameOpts}
+            onChange={(o: Option) => setSelectedOpt(o)}
+            isDisabled={attempt.status === 'processing'}
+          />
+        </Box>
+      </StyledBox>
+      <ConnectionDiagnosticResult
+        attempt={attempt}
+        diagnosis={diagnosis}
+        canTestConnection={canTestConnection}
+        testConnection={() => testConnection(selectedOpt.value)}
+        stepNumber={2}
+        stepDescription="Verify that the server is accessible"
+      />
+      <StyledBox>
+        <Text bold>Step 3</Text>
+        <Text typography="subtitle1" mb={3}>
+          Connect to the server
+        </Text>
+        <ButtonSecondary
+          width="200px"
+          onClick={() => startSshSession(selectedOpt.value)}
+        >
+          Start Session
+        </ButtonSecondary>
+      </StyledBox>
+      <ActionButtons onProceed={nextStep} lastStep={true} onPrev={prevStep} />
+    </Box>
   );
-};
+}

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
-import { ButtonSecondary, Text, Box, LabelInput } from 'design';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  ButtonPrimary,
+  ButtonSecondary,
+  Text,
+  Box,
+  LabelInput,
+  Indicator,
+  Link,
+} from 'design';
 import Select from 'shared/components/Select';
+import { useAsync } from 'shared/hooks/useAsync';
+import * as Icons from 'design/Icon';
+import * as connectMyComputer from 'shared/connectMyComputer';
 
 import cfg from 'teleport/config';
+import useTeleport from 'teleport/useTeleport';
 import ReAuthenticate from 'teleport/components/ReAuthenticate';
 import { openNewTab } from 'teleport/lib/util';
 import {
@@ -28,8 +40,10 @@ import {
   HeaderSubtitle,
   ConnectionDiagnosticResult,
   StyledBox,
+  TextIcon,
 } from 'teleport/Discover/Shared';
 import { sortNodeLogins } from 'teleport/services/nodes';
+import { ApiError } from 'teleport/services/api/parseError';
 
 import { NodeMeta } from '../../useDiscover';
 
@@ -38,18 +52,62 @@ import type { AgentStepProps } from '../../types';
 import type { MfaAuthnResponse } from 'teleport/services/mfa';
 
 export function TestConnection(props: AgentStepProps) {
+  const { userService, storeUser } = useTeleport();
   const {
     runConnectionDiagnostic,
-    attempt,
+    attempt: connectionDiagAttempt,
     diagnosis,
     nextStep,
-    prevStep,
     canTestConnection,
     showMfaDialog,
     cancelMfaDialog,
   } = useConnectionDiagnostic();
   const node = (props.agentMeta as NodeMeta).node;
-  const logins = sortNodeLogins(node.sshLogins);
+  const [selectedLoginOpt, setSelectedLoginOpt] = useState<Option>();
+
+  const abortController = useRef<AbortController>();
+  // When the user sets up Connect My Computer in Teleport Connect, a new role gets added to the
+  // user. Because of that, we need to reload the current session so that the user is able to
+  // connect to the new node, without having to log in to the cluster again.
+  //
+  // We also need to fetch the list of logins from that role. The user might have many logins
+  // available, but the Connect My Computer agent is always started by the system user that is
+  // running Connect. As such, the Connect My Computer role should include that valid login.
+  const [fetchLoginsAttempt, fetchLogins] = useAsync(
+    useCallback(
+      async (signal: AbortSignal) => {
+        await userService.reloadUser(signal);
+
+        return await userService.fetchConnectMyComputerLogins(signal);
+      },
+      [userService]
+    )
+  );
+
+  const fetchLoginsAndUpdateLoginSelection = async (signal: AbortSignal) => {
+    // fetchLogins is from useAsync which always resolves the underlying promise and uses a Go-style
+    // API for error handling.
+    const [logins, err] = await fetchLogins(signal);
+    if (err) {
+      return;
+    }
+
+    if (logins.length > 0) {
+      setSelectedLoginOpt(mapLoginToSelectOption(logins[0]));
+    }
+  };
+
+  useEffect(() => {
+    abortController.current = new AbortController();
+
+    if (fetchLoginsAttempt.status === '') {
+      fetchLoginsAndUpdateLoginSelection(abortController.current.signal);
+    }
+
+    return () => {
+      abortController.current.abort();
+    };
+  }, []);
 
   function startSshSession(login: string) {
     const url = cfg.getSshConnectRoute({
@@ -72,60 +130,171 @@ export function TestConnection(props: AgentStepProps) {
     );
   }
 
-  const usernameOpts = logins.map(l => ({ value: l, label: l }));
-  // There will always be one login, as the user cannot proceed
-  // the step that requires users to have at least one login.
-  const [selectedOpt, setSelectedOpt] = useState(usernameOpts[0]);
+  const hasMultipleLogins =
+    fetchLoginsAttempt.status === 'success' &&
+    fetchLoginsAttempt.data.length > 1;
+  // If there are multiple logins available, we show an extra step at the beginning, so we have to
+  // account for that when numbering the steps.
+  const stepOffset = hasMultipleLogins ? 1 : 0;
 
   return (
     <Box>
       {showMfaDialog && (
         <ReAuthenticate
-          onMfaResponse={res => testConnection(selectedOpt.value, res)}
+          onMfaResponse={res => testConnection(selectedLoginOpt.value, res)}
           onClose={cancelMfaDialog}
         />
       )}
-      <Header>Test Connection</Header>
+      <Header>
+        Test Connection to &ldquo;{props.agentMeta.resourceName}&rdquo;
+      </Header>
       <HeaderSubtitle>
-        Optionally verify that you can successfully connect to the server you
-        just added.
+        Optionally verify that you can connect to the computer you just added.
       </HeaderSubtitle>
-      <StyledBox mb={5}>
-        <Text bold>Step 1</Text>
-        <Text typography="subtitle1" mb={3}>
-          Pick the OS user to test
-        </Text>
-        <Box width="320px">
-          <LabelInput>Select Login</LabelInput>
-          <Select
-            value={selectedOpt}
-            options={usernameOpts}
-            onChange={(o: Option) => setSelectedOpt(o)}
-            isDisabled={attempt.status === 'processing'}
-          />
-        </Box>
-      </StyledBox>
-      <ConnectionDiagnosticResult
-        attempt={attempt}
-        diagnosis={diagnosis}
-        canTestConnection={canTestConnection}
-        testConnection={() => testConnection(selectedOpt.value)}
-        stepNumber={2}
-        stepDescription="Verify that the server is accessible"
+
+      {(fetchLoginsAttempt.status === '' ||
+        fetchLoginsAttempt.status === 'processing') && <Indicator />}
+
+      {fetchLoginsAttempt.status === 'error' &&
+        (fetchLoginsAttempt.error instanceof ApiError &&
+        fetchLoginsAttempt.error.response.status === 404 ? (
+          <FetchLoginsAttemptError
+            buttonText="Refresh"
+            buttonOnClick={() => window.location.reload()}
+          >
+            <>
+              For Connect My Computer to work, the role{' '}
+              {connectMyComputer.getRoleNameForUser(storeUser.getUsername())}{' '}
+              must be assigned to you.
+              <br />
+              {$restartSetupInstructions}
+            </>
+          </FetchLoginsAttemptError>
+        ) : (
+          <FetchLoginsAttemptError
+            buttonText="Retry"
+            buttonOnClick={() =>
+              fetchLoginsAndUpdateLoginSelection(abortController.current.signal)
+            }
+          >
+            <>Encountered Error: {fetchLoginsAttempt.statusText}</>
+          </FetchLoginsAttemptError>
+        ))}
+
+      {fetchLoginsAttempt.status === 'success' &&
+        (fetchLoginsAttempt.data.length === 0 ? (
+          <FetchLoginsAttemptError
+            buttonText="Refresh"
+            buttonOnClick={() => window.location.reload()}
+          >
+            <>
+              The role{' '}
+              {connectMyComputer.getRoleNameForUser(storeUser.getUsername())}{' '}
+              does not contain any logins. It has likely been manually edited.
+              <br />
+              {$restartSetupInstructions}
+            </>
+          </FetchLoginsAttemptError>
+        ) : (
+          <>
+            {hasMultipleLogins && (
+              <StepSkeletonPickUser>
+                <Box width="320px">
+                  <LabelInput>Select Login</LabelInput>
+                  <Select
+                    value={selectedLoginOpt}
+                    options={sortNodeLogins(fetchLoginsAttempt.data).map(
+                      mapLoginToSelectOption
+                    )}
+                    onChange={(o: Option) => setSelectedLoginOpt(o)}
+                    isDisabled={connectionDiagAttempt.status === 'processing'}
+                  />
+                </Box>
+              </StepSkeletonPickUser>
+            )}
+            <ConnectionDiagnosticResult
+              attempt={connectionDiagAttempt}
+              diagnosis={diagnosis}
+              canTestConnection={canTestConnection}
+              testConnection={() => testConnection(selectedLoginOpt.value)}
+              stepNumber={1 + stepOffset}
+              stepDescription="Verify that your computer is accessible"
+              numberAndDescriptionOnSameLine
+            />
+            <StyledBox>
+              <Text bold mb={3}>
+                Step {2 + stepOffset}: Connect to Your Computer
+              </Text>
+              <ButtonSecondary
+                width="200px"
+                onClick={() => startSshSession(selectedLoginOpt.value)}
+              >
+                Start Session
+              </ButtonSecondary>
+            </StyledBox>
+          </>
+        ))}
+      <ActionButtons
+        disableProceed={
+          fetchLoginsAttempt.status !== 'success' ||
+          fetchLoginsAttempt.data.length === 0
+        }
+        onProceed={nextStep}
+        lastStep={true}
+        // onPrev is not passed on purpose to disable the back button. The flow would go back to
+        // polling which wouldn't make sense as the user has already connected their computer so the
+        // step would poll forever, unless the user removed the agent and configured it again.
       />
-      <StyledBox>
-        <Text bold>Step 3</Text>
-        <Text typography="subtitle1" mb={3}>
-          Connect to the server
-        </Text>
-        <ButtonSecondary
-          width="200px"
-          onClick={() => startSshSession(selectedOpt.value)}
-        >
-          Start Session
-        </ButtonSecondary>
-      </StyledBox>
-      <ActionButtons onProceed={nextStep} lastStep={true} onPrev={prevStep} />
     </Box>
   );
 }
+
+const StepSkeletonPickUser = (props: { children: React.ReactNode }) => (
+  <StyledBox mb={5}>
+    <Text bold mb={3}>
+      Step 1: Pick the OS user to test
+    </Text>
+    {props.children}
+  </StyledBox>
+);
+
+/**
+ * To display the first step, fetchLoginsAttempt must be successful, hence why we show errors from
+ * fetchLoginsAttempt within the first step.
+ */
+const FetchLoginsAttemptError = (props: {
+  children: React.ReactNode;
+  buttonText: string;
+  buttonOnClick: () => void;
+}) => (
+  <StepSkeletonPickUser>
+    <>
+      <TextIcon mt={2} mb={3}>
+        <Icons.Warning size="medium" ml={1} mr={2} color="error.main" />
+        <Text>{props.children}</Text>
+      </TextIcon>
+
+      <ButtonPrimary type="button" onClick={props.buttonOnClick}>
+        {props.buttonText}
+      </ButtonPrimary>
+    </>
+  </StepSkeletonPickUser>
+);
+
+const mapLoginToSelectOption = (login: string) => ({
+  value: login,
+  label: login,
+});
+
+const $restartSetupInstructions = (
+  <>
+    Refresh this page to repeat the process of enrolling a new resource and then{' '}
+    <Link
+      href="https://goteleport.com/docs/connect-your-client/teleport-connect/#restarting-the-setup"
+      target="_blank"
+    >
+      restart the Connect My Computer setup
+    </Link>{' '}
+    in Teleport Connect.
+  </>
+);

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -172,13 +172,11 @@ export function TestConnection(props: AgentStepProps) {
             buttonText="Refresh"
             buttonOnClick={() => window.location.reload()}
           >
-            <>
-              For Connect My Computer to work, the role{' '}
-              {connectMyComputer.getRoleNameForUser(storeUser.getUsername())}{' '}
-              must be assigned to you.
-              <br />
-              {$restartSetupInstructions}
-            </>
+            For Connect My Computer to work, the role{' '}
+            {connectMyComputer.getRoleNameForUser(storeUser.getUsername())} must
+            be assigned to you.
+            <br />
+            {$restartSetupInstructions}
           </FetchLoginsAttemptError>
         ) : (
           <FetchLoginsAttemptError
@@ -187,7 +185,7 @@ export function TestConnection(props: AgentStepProps) {
               fetchLoginsAndUpdateLoginSelection(abortController.current.signal)
             }
           >
-            <>Encountered Error: {fetchLoginsAttempt.statusText}</>
+            Encountered Error: {fetchLoginsAttempt.statusText}
           </FetchLoginsAttemptError>
         ))}
 
@@ -197,13 +195,11 @@ export function TestConnection(props: AgentStepProps) {
             buttonText="Refresh"
             buttonOnClick={() => window.location.reload()}
           >
-            <>
-              The role{' '}
-              {connectMyComputer.getRoleNameForUser(storeUser.getUsername())}{' '}
-              does not contain any logins. It has likely been manually edited.
-              <br />
-              {$restartSetupInstructions}
-            </>
+            The role{' '}
+            {connectMyComputer.getRoleNameForUser(storeUser.getUsername())} does
+            not contain any logins. It has likely been manually edited.
+            <br />
+            {$restartSetupInstructions}
           </FetchLoginsAttemptError>
         ) : (
           <>
@@ -278,16 +274,14 @@ const FetchLoginsAttemptError = (props: {
   buttonOnClick: () => void;
 }) => (
   <StepSkeletonPickUser>
-    <>
-      <TextIcon mt={2} mb={3}>
-        <Icons.Warning size="medium" ml={1} mr={2} color="error.main" />
-        <Text>{props.children}</Text>
-      </TextIcon>
+    <TextIcon mt={2} mb={3}>
+      <Icons.Warning size="medium" ml={1} mr={2} color="error.main" />
+      <Text>{props.children}</Text>
+    </TextIcon>
 
-      <ButtonPrimary type="button" onClick={props.buttonOnClick}>
-        {props.buttonText}
-      </ButtonPrimary>
-    </>
+    <ButtonPrimary type="button" onClick={props.buttonOnClick}>
+      {props.buttonText}
+    </ButtonPrimary>
   </StepSkeletonPickUser>
 );
 

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TestConnection } from './TestConnection';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -21,7 +21,7 @@ import { DiscoverEvent } from 'teleport/services/userEvent';
 import { ResourceSpec } from '../SelectResource';
 
 import { SetupConnect } from './SetupConnect';
-import { TestConnection } from './TestConnection';
+import { LegacyTestConnection } from './LegacyTestConnection';
 
 export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.ConnectMyComputer,
@@ -34,7 +34,7 @@ export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
     {
       // TODO(ravicious): Rename this to "Test Connection" after implementing the connection test.
       title: 'Start a Session',
-      component: TestConnection,
+      component: LegacyTestConnection,
       eventName: DiscoverEvent.TestConnection,
       // TODO(ravicious): Manually emit success event on test connection success.
       manuallyEmitSuccessEvent: true,

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -17,11 +17,13 @@
 import { ResourceViewConfig } from 'teleport/Discover/flow';
 import { Finished, ResourceKind } from 'teleport/Discover/Shared';
 import { DiscoverEvent } from 'teleport/services/userEvent';
+import { storageService } from 'teleport/services/storageService';
 
 import { ResourceSpec } from '../SelectResource';
 
 import { SetupConnect } from './SetupConnect';
 import { LegacyTestConnection } from './LegacyTestConnection';
+import { TestConnection } from './TestConnection';
 
 export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.ConnectMyComputer,
@@ -31,14 +33,20 @@ export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
       component: SetupConnect,
       eventName: DiscoverEvent.DeployService,
     },
-    {
-      // TODO(ravicious): Rename this to "Test Connection" after implementing the connection test.
-      title: 'Start a Session',
-      component: LegacyTestConnection,
-      eventName: DiscoverEvent.TestConnection,
-      // TODO(ravicious): Manually emit success event on test connection success.
-      manuallyEmitSuccessEvent: true,
-    },
+    storageService.isDiscoverConnectMyComputerNewConnectionTestEnabled()
+      ? {
+          title: 'Test Connection',
+          component: TestConnection,
+          eventName: DiscoverEvent.TestConnection,
+          // TODO(ravicious): Manually emit success event on test connection success.
+          manuallyEmitSuccessEvent: true,
+        }
+      : {
+          title: 'Start a Session',
+          component: LegacyTestConnection,
+          eventName: DiscoverEvent.TestConnection,
+          manuallyEmitSuccessEvent: true,
+        },
     {
       title: 'Finished',
       component: Finished,

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -38,7 +38,6 @@ export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
           title: 'Test Connection',
           component: TestConnection,
           eventName: DiscoverEvent.TestConnection,
-          // TODO(ravicious): Manually emit success event on test connection success.
           manuallyEmitSuccessEvent: true,
         }
       : {

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
@@ -29,6 +29,14 @@ export const Init = () => (
   <ConnectionDiagnosticResult {...props} diagnosis={null} />
 );
 
+export const NumberAndDescriptionOnSameLine = () => (
+  <ConnectionDiagnosticResult
+    {...props}
+    numberAndDescriptionOnSameLine
+    diagnosis={null}
+  />
+);
+
 export const DiagnosisSuccess = () => (
   <ConnectionDiagnosticResult
     {...props}

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -33,6 +33,7 @@ export function ConnectionDiagnosticResult({
   testConnection,
   stepNumber,
   stepDescription,
+  numberAndDescriptionOnSameLine,
 }: Props) {
   const showDiagnosisOutput = !!diagnosis || attempt.status === 'failed';
 
@@ -62,10 +63,18 @@ export function ConnectionDiagnosticResult({
 
   return (
     <StyledBox mb={5}>
-      <Text bold>Step {stepNumber}</Text>
-      <Text typography="subtitle1" mb={3}>
-        {stepDescription}
-      </Text>
+      {numberAndDescriptionOnSameLine ? (
+        <Text bold mb={3}>
+          Step {stepNumber}: {stepDescription}
+        </Text>
+      ) : (
+        <>
+          <Text bold>Step {stepNumber}</Text>
+          <Text typography="subtitle1" mb={3}>
+            {stepDescription}
+          </Text>
+        </>
+      )}
       <Flex alignItems="center" mt={3}>
         {canTestConnection ? (
           <>
@@ -170,4 +179,5 @@ export type Props = {
   testConnection(): void;
   stepNumber: number;
   stepDescription: string;
+  numberAndDescriptionOnSameLine?: boolean;
 };

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
@@ -44,17 +44,21 @@ export function useConnectionDiagnostic() {
 
   const [showMfaDialog, setShowMfaDialog] = useState(false);
 
-  // runConnectionDiagnostic depending on the value of `mfaAuthnResponse` does the following:
-  //   1) If param `mfaAuthnResponse` is undefined or null, it will check if MFA is required.
-  //      - If MFA is required, it sets a flag that indicates a users
-  //        MFA credentials are required, and skips the request to test connection.
-  //      - If MFA is NOT required, it makes the request to test connection.
-  //   2) If param `mfaAuthnResponse` is defined, it skips checking if MFA is required,
-  //      and makes the request to test connection.
+  /**
+   * runConnectionDiagnostic depending on the value of `mfaAuthnResponse` does the following:
+   *   1) If param `mfaAuthnResponse` is undefined or null, it will check if MFA is required.
+   *      - If MFA is required, it sets a flag that indicates a users
+   *        MFA credentials are required, and skips the request to test connection.
+   *      - If MFA is NOT required, it makes the request to test connection.
+   *   2) If param `mfaAuthnResponse` is defined, it skips checking if MFA is required,
+   *      and makes the request to test connection.
+   *
+   * The return value can be used within event handlers where you cannot depend on React state.
+   */
   async function runConnectionDiagnostic(
     req: ConnectionDiagnosticRequest,
     mfaAuthnResponse?: MfaAuthnResponse
-  ) {
+  ): Promise<{ mfaRequired: boolean }> {
     setDiagnosis(null); // reset since user's can re-test connection.
     setRanDiagnosis(true);
     setShowMfaDialog(false);
@@ -67,7 +71,7 @@ export function useConnectionDiagnostic() {
         const sessionMfa = await auth.checkMfaRequired(mfaReq);
         if (sessionMfa.required) {
           setShowMfaDialog(true);
-          return;
+          return { mfaRequired: true };
         }
       }
 
@@ -97,6 +101,8 @@ export function useConnectionDiagnostic() {
       handleError(err);
       emitErrorEvent(err.message);
     }
+
+    return { mfaRequired: false };
   }
 
   function cancelMfaDialog() {

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -36,6 +36,7 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
   KeysEnum.USER_PREFERENCES,
   KeysEnum.RECOMMEND_FEATURE,
   KeysEnum.UNIFIED_RESOURCES_DISABLED,
+  KeysEnum.DISCOVER_CONNECT_MY_COMPUTER_NEW_CONNECTION_TEST_ENABABLED,
 ];
 
 export const storageService = {
@@ -274,6 +275,14 @@ export const storageService = {
     window.localStorage.setItem(
       KeysEnum.EXTERNAL_AUDIT_STORAGE_CTA_DISABLED,
       JSON.stringify(true)
+    );
+  },
+
+  isDiscoverConnectMyComputerNewConnectionTestEnabled(): boolean {
+    return (
+      window.localStorage.getItem(
+        KeysEnum.DISCOVER_CONNECT_MY_COMPUTER_NEW_CONNECTION_TEST_ENABABLED
+      ) === 'true'
     );
   },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -36,6 +36,8 @@ export const KeysEnum = {
   ACCESS_GRAPH_SQL_ENABLED: 'grv_teleport_access_graph_sql_enabled',
   EXTERNAL_AUDIT_STORAGE_CTA_DISABLED:
     'grv_teleport_external_audit_storage_disabled',
+  DISCOVER_CONNECT_MY_COMPUTER_NEW_CONNECTION_TEST_ENABABLED:
+    'grv_teleport_discover_connect_my_computer_new_connection_test_enabled',
 };
 
 // SurveyRequest is the request for sending data to the back end


### PR DESCRIPTION
<img width="850" alt="cmc-conn-test" src="https://github.com/gravitational/teleport/assets/27113/c46f5cde-da65-43d4-b887-34433e4d355c">


This PR adds just the UI for a proper connection test that actually attempts to connect to the node and shows diagnostic messages. The diagnostic messages are yet to be customized towards Connect My Computer (#32206), for now the test behaves the same way as if we were testing a regular SSH node.

I also added a feature flag so that I don't have to wait with merging this PR before I have the backend changes ready.

The implementation is done in a few simple steps:

1. Take the existing test step, rename it to `LegacyTestConnection`.
1. Add a new step in its place with the contents from `Server/TestConnection`.
1. Take parts related to Connect My Computer from `LegacyTestConnection` and fit them into the new component copied from Server.

I had to balance [Figma designs](https://www.figma.com/file/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?type=design&node-id=1386-30152&mode=design&t=6yyuYcsKq3c645DS-4) with how the existing implementation looks like, both for Connect My Computer and a regular server. Mostly this meant keeping step numbers on the same line as descriptions and how particular buttons and actions are called.

To test this locally, you need to enable the feature flag:

```javascript
localStorage.setItem('grv_teleport_discover_connect_my_computer_new_connection_test_enabled', 'true')
```