### PR TITLE
ec2discovery: Use a random name for the install script

### DIFF
--- a/lib/configurators/aws/ec2discovery.go
+++ b/lib/configurators/aws/ec2discovery.go
@@ -15,22 +15,13 @@
 package aws
 
 import (
-	crand "crypto/rand"
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
-	mrand "math/rand"
-	"time"
+
+	"github.com/google/uuid"
 )
 
 func EC2DiscoverySSMDocument(proxy string) string {
-	randomBytes := make([]byte, 4)
-	if _, err := crand.Read(randomBytes); err != nil {
-		// on error from crypto rand fallback to less secure math random
-		mathRand := mrand.New(mrand.NewSource(time.Now().UnixNano()))
-		binary.LittleEndian.PutUint32(randomBytes, mathRand.Uint32())
-	}
-	randString := hex.EncodeToString(randomBytes)
+	randString := uuid.New().String()
 
 	return fmt.Sprintf(ec2DiscoverySSMDocument, randString, proxy, randString)
 }

--- a/lib/configurators/aws/ec2discovery.go
+++ b/lib/configurators/aws/ec2discovery.go
@@ -21,14 +21,9 @@ import (
 )
 
 func EC2DiscoverySSMDocument(proxy string) string {
-	randString := uuid.New().String()
+	randString := uuid.New().String() // Secure random so the filename can not be guessed to avoid possible script injection
 
-	return fmt.Sprintf(ec2DiscoverySSMDocument, randString, proxy, randString)
-}
-
-const EC2DiscoveryPolicyName = "TeleportEC2Discovery"
-
-const ec2DiscoverySSMDocument = `
+	return fmt.Sprintf(`
 schemaVersion: '2.2'
 description: aws:runShellScript
 parameters:
@@ -52,4 +47,7 @@ mainSteps:
     timeoutSeconds: '300'
     runCommand:
       - /bin/sh /tmp/installTeleport-%s.sh "{{ token }}"
-`
+`, randString, proxy, randString)
+}
+
+const EC2DiscoveryPolicyName = "TeleportEC2Discovery"

--- a/lib/configurators/aws/ec2discovery.go
+++ b/lib/configurators/aws/ec2discovery.go
@@ -21,7 +21,7 @@ import (
 )
 
 func EC2DiscoverySSMDocument(proxy string) string {
-	randString := uuid.New().String() // Secure random so the filename can not be guessed to avoid possible script injection
+	randString := uuid.NewString() // Secure random so the filename can not be guessed to avoid possible script injection
 
 	return fmt.Sprintf(`
 schemaVersion: '2.2'


### PR DESCRIPTION
This change makes the install script name to have a random suffix so that it can not be guessed.  This PR fixes https://github.com/gravitational/teleport-private/issues/900 (see issue for more details)