### PR TITLE
dependency-review: Add `base-ref` config and instructions

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -11,4 +11,4 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      base-ref: master
+      base-ref: ${{ github.event.pull_request.base.sha || 'master' }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,3 +10,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    with:
+      base-ref: master

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -6,6 +6,7 @@ This checklist is to be run prior to cutting the release branch.
 - [ ] Make a new docs/VERSION folder
 - [ ] Update VERSION in Makefile to next dev tag
 - [ ] Update TELEPORT_VERSION in assets/aws/Makefile
+- [ ] Update `base-ref` to point to the new release branch in `.github/workflows/dependency-review.yaml`
 - [ ] Update mentions of the version in examples/ and README.md
 - [ ] Search code for DELETE IN and REMOVE IN comments and clean up if appropriate
 - [ ] Update docs/faq.mdx "Which version of Teleport is supported?" section with release date and support info


### PR DESCRIPTION
We need to have this configuration on the release branches or merge queue will fail to work correctly.  Currently it is trying to diff to the `master` branch.