### PR TITLE
Hide External Audit Storage integration tile from on-prem enterprise

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
@@ -18,6 +18,10 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 
+import { ContextProvider } from 'teleport/index';
+import TeleportContext from 'teleport/teleportContext';
+import cfg from 'teleport/config';
+
 import { IntegrationTiles } from './IntegrationTiles';
 
 test('render', async () => {
@@ -57,4 +61,23 @@ test('render disabled', async () => {
   // so "toBeDisabled" interprets it as false.
   // eslint-disable-next-line jest-dom/prefer-enabled-disabled
   expect(tile).toHaveAttribute('disabled');
+});
+
+test('dont render External Audit Storage for enterprise unless it is cloud', async () => {
+  cfg.isEnterprise = true;
+  const ctx = new TeleportContext();
+  ctx.isEnterprise = true;
+  ctx.isCloud = false;
+
+  render(
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <IntegrationTiles />
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  expect(
+    screen.queryByText(/AWS External Audit Storage/i)
+  ).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
@@ -40,7 +40,8 @@ export function IntegrationTiles({
   // TODO(mcbattirola): isUsageBasedBilling is used here and in other
   // parts of the app as synonym with Team product, but this
   // will change in the future.
-  const isEnterprise = cfg.isEnterprise && !cfg.isUsageBasedBilling;
+  const isCloudEnterprise = cfg.isEnterprise && !cfg.isUsageBasedBilling;
+  const isOnpremEnterprise = cfg.isEnterprise && !cfg.isCloud;
 
   return (
     <>
@@ -74,24 +75,29 @@ export function IntegrationTiles({
           />
         )}
       </IntegrationTile>
-      <IntegrationTile
-        disabled={!hasExternalAuditStorage || !isEnterprise}
-        as={hasExternalAuditStorage ? Link : null}
-        to={
-          hasExternalAuditStorage
-            ? cfg.getIntegrationEnrollRoute(
-                IntegrationKind.ExternalAuditStorage
-              )
-            : null
-        }
-        data-testid="tile-external-audit-storage"
-      >
-        <Box mt={3} mb={2}>
-          <AWSIcon size={80} />
-        </Box>
-        <Text>AWS External Audit Storage</Text>
-        {renderExternalAuditStorageBadge(hasExternalAuditStorage, isEnterprise)}
-      </IntegrationTile>
+      {!isOnpremEnterprise && (
+        <IntegrationTile
+          disabled={!hasExternalAuditStorage || !isCloudEnterprise}
+          as={hasExternalAuditStorage ? Link : null}
+          to={
+            hasExternalAuditStorage
+              ? cfg.getIntegrationEnrollRoute(
+                  IntegrationKind.ExternalAuditStorage
+                )
+              : null
+          }
+          data-testid="tile-external-audit-storage"
+        >
+          <Box mt={3} mb={2}>
+            <AWSIcon size={80} />
+          </Box>
+          <Text>AWS External Audit Storage</Text>
+          {renderExternalAuditStorageBadge(
+            hasExternalAuditStorage,
+            isCloudEnterprise
+          )}
+        </IntegrationTile>
+      )}
     </>
   );
 }


### PR DESCRIPTION
This PR adds a conditional to hide the External Audit Storage integration tile from enterprise non-cloud clusters.

This also renames a variable from `isEnterprise` to `isCloudEnterprise` to better reflect its meaning.

The behavior now is:

OSS -> Tile disabled
Enterprise on-prem -> No tile (implemented in this PR)
Enterprise Team -> Tile disabled
Enterprise Cloud (non-team) -> Tile enabled