### PR TITLE
Web: Audit use of `isUsageBasedBilling` flag

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -77,6 +77,10 @@ type WebConfig struct {
 	HideInaccessibleFeatures bool `json:"hideInaccessibleFeatures"`
 	// CustomTheme is a string that represents the name of the custom theme that the WebUI should use.
 	CustomTheme string `json:"customTheme"`
+	// IsTeam is true if [Features.ProductType] = Team
+	IsTeam bool `json:"isTeam"`
+	// IsIGSEnabled is true if [Features.IdentityGovernance] = true
+	IsIGSEnabled bool `json:"isIgsEnabled"`
 }
 
 // UIConfig provides config options for the web UI served by the proxy service.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1583,6 +1583,8 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		AssistEnabled:                  assistEnabled,
 		HideInaccessibleFeatures:       clusterFeatures.GetFeatureHiding(),
 		CustomTheme:                    clusterFeatures.GetCustomTheme(),
+		IsTeam:                         clusterFeatures.GetProductType() == proto.ProductType_PRODUCT_TYPE_TEAM,
+		IsIGSEnabled:                   clusterFeatures.GetIdentityGovernance(),
 	}
 
 	resource, err := h.cfg.ProxyClient.GetClusterName()

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
@@ -37,10 +37,7 @@ export function IntegrationTiles({
   hasIntegrationAccess?: boolean;
   hasExternalAuditStorage?: boolean;
 }) {
-  // TODO(mcbattirola): isUsageBasedBilling is used here and in other
-  // parts of the app as synonym with Team product, but this
-  // will change in the future.
-  const isCloudEnterprise = cfg.isEnterprise && !cfg.isUsageBasedBilling;
+  const isCloudEnterprise = cfg.isCloud && !cfg.isTeam;
   const isOnpremEnterprise = cfg.isEnterprise && !cfg.isCloud;
 
   return (

--- a/web/packages/teleport/src/Sessions/Sessions.story.test.tsx
+++ b/web/packages/teleport/src/Sessions/Sessions.story.test.tsx
@@ -32,13 +32,14 @@ test('loaded', () => {
 });
 
 test('active sessions CTA', () => {
-  cfg.isUsageBasedBilling = true;
+  cfg.isTeam = true;
+  cfg.isEnterprise = true;
   const { container } = render(<ActiveSessionsCTA />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('moderated sessions CTA', () => {
-  cfg.isUsageBasedBilling = true;
+test('moderated sessions CTA for non-enterprise', () => {
+  cfg.isEnterprise = false;
   const { container } = render(<ModeratedSessionsCTA />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -482,7 +482,7 @@ exports[`active sessions CTA 1`] = `
       <a
         class="c4"
         height="36px"
-        href="https://goteleport.com/r/upgrade-team?4.4.0-dev&utm_campaign=CTA_ACTIVE_SESSIONS"
+        href="https://goteleport.com/r/upgrade-team?e_4.4.0-dev&utm_campaign=CTA_ACTIVE_SESSIONS"
         kind="primary"
         rel="noreferrer"
         style="text-transform: none;"
@@ -2083,7 +2083,7 @@ exports[`loaded 1`] = `
 </div>
 `;
 
-exports[`moderated sessions CTA 1`] = `
+exports[`moderated sessions CTA for non-enterprise 1`] = `
 .c21 {
   box-sizing: border-box;
   width: 80px;

--- a/web/packages/teleport/src/Sessions/useSessions.ts
+++ b/web/packages/teleport/src/Sessions/useSessions.ts
@@ -51,6 +51,7 @@ export default function useSessions(ctx: Ctx, clusterId: string) {
   return {
     attempt,
     sessions,
+    // moderated is available with any enterprise editions
     showModeratedSessionsCTA: !ctx.isEnterprise,
     showActiveSessionsCTA: ctx.lockedFeatures.activeSessions,
   };

--- a/web/packages/teleport/src/Support/Support.story.test.tsx
+++ b/web/packages/teleport/src/Support/Support.story.test.tsx
@@ -49,7 +49,8 @@ test('support Enterprise', () => {
 });
 
 test('support Enterprise with CTA', () => {
-  cfg.isUsageBasedBilling = true;
+  cfg.isEnterprise = true;
+  cfg.isTeam = true;
   const { container } = render(<SupportEnterpriseWithCTA />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -1093,7 +1093,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c8"
-          href="https://goteleport.com/r/upgrade-team?4.4.0-dev&utm_campaign=CTA_PREMIUM_SUPPORT"
+          href="https://goteleport.com/r/upgrade-team?e_4.4.0-dev&utm_campaign=CTA_PREMIUM_SUPPORT"
           kind="primary"
           rel="noreferrer"
           style="text-transform: none;"

--- a/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.test.tsx
+++ b/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.test.tsx
@@ -26,7 +26,17 @@ import { CtaEvent, userEventService } from 'teleport/services/userEvent';
 
 import { ButtonLockedFeature } from './ButtonLockedFeature';
 
+const defaultIsTeamFlag = cfg.isTeam;
+const defaultIsEnterpriseFlag = cfg.isEnterprise;
+
 describe('buttonLockedFeature', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+
+    cfg.isTeam = defaultIsTeamFlag;
+    cfg.isEnterprise = defaultIsEnterpriseFlag;
+  });
+
   test('renders the children', () => {
     const content = "this is the button's content";
     renderWithContext(<ButtonLockedFeature>{content}</ButtonLockedFeature>);
@@ -49,7 +59,8 @@ describe('buttonLockedFeature', () => {
 
   test('it has upgrade-team href for Team Plan', () => {
     const version = ctx.storeUser.state.cluster.authVersion;
-    cfg.isUsageBasedBilling = true;
+    cfg.isTeam = true;
+    cfg.isEnterprise = true;
 
     renderWithContext(
       <ButtonLockedFeature noIcon={true}>text</ButtonLockedFeature>
@@ -74,7 +85,8 @@ describe('buttonLockedFeature', () => {
 
   test('it has upgrade-community href for community edition', () => {
     const version = ctx.storeUser.state.cluster.authVersion;
-    cfg.isUsageBasedBilling = false;
+    cfg.isTeam = false;
+    cfg.isEnterprise = false;
     renderWithContext(
       <ButtonLockedFeature noIcon={true}>text</ButtonLockedFeature>,
       {
@@ -102,6 +114,32 @@ describe('buttonLockedFeature', () => {
     );
   });
 
+  test('it has upgrade-igs href for Enterprise + IGS Plan', () => {
+    const version = ctx.storeUser.state.cluster.authVersion;
+    cfg.isTeam = false;
+    cfg.isEnterprise = true;
+
+    renderWithContext(
+      <ButtonLockedFeature noIcon={true}>text</ButtonLockedFeature>
+    );
+    expect(screen.getByText('text').closest('a')).toHaveAttribute(
+      'href',
+      `https://goteleport.com/r/upgrade-igs?e_${version}&utm_campaign=CTA_UNSPECIFIED`
+    );
+
+    renderWithContext(
+      <ButtonLockedFeature noIcon={true} event={CtaEvent.CTA_ACCESS_REQUESTS}>
+        othertext
+      </ButtonLockedFeature>
+    );
+    expect(screen.getByText('othertext').closest('a')).toHaveAttribute(
+      'href',
+      `https://goteleport.com/r/upgrade-igs?e_${version}&utm_campaign=${
+        CtaEvent[CtaEvent.CTA_ACCESS_REQUESTS]
+      }`
+    );
+  });
+
   describe('userEventService', () => {
     beforeEach(() => {
       jest.spyOn(userEventService, 'captureCtaEvent');
@@ -122,6 +160,7 @@ describe('buttonLockedFeature', () => {
     });
 
     test('invokes userEventService for enterprise', async () => {
+      cfg.isEnterprise = true;
       renderWithContext(
         <ButtonLockedFeature event={CtaEvent.CTA_ACCESS_REQUESTS}>
           content

--- a/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
+++ b/web/packages/teleport/src/components/ButtonLockedFeature/ButtonLockedFeature.tsx
@@ -20,12 +20,11 @@ import { ButtonPrimary } from 'design/Button';
 import { Unlock } from 'design/Icon';
 import Flex from 'design/Flex';
 
+import cfg from 'teleport/config';
 import { getSalesURL } from 'teleport/services/sales';
 
 import { CtaEvent, userEventService } from 'teleport/services/userEvent';
 import useTeleport from 'teleport/useTeleport';
-
-import cfg from 'teleport/config';
 
 export type Props = {
   children: React.ReactNode;
@@ -42,12 +41,9 @@ export function ButtonLockedFeature({
 }: Props) {
   const ctx = useTeleport();
   const version = ctx.storeUser.state.cluster.authVersion;
-  const isEnterprise = ctx.isEnterprise;
-
-  const isUsageBased = cfg.isUsageBasedBilling;
 
   function handleClick() {
-    if (isEnterprise) {
+    if (cfg.isEnterprise) {
       userEventService.captureCtaEvent(event);
     }
   }
@@ -56,7 +52,7 @@ export function ButtonLockedFeature({
     <ButtonPrimary
       as="a"
       target="blank"
-      href={getSalesURL(version, isEnterprise, isUsageBased, event)}
+      href={getSalesURL(version, cfg.isEnterprise, event)}
       onClick={handleClick}
       py="12px"
       width="100%"

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -48,6 +48,12 @@ const cfg = {
   isUsageBasedBilling: false,
   hideInaccessibleFeatures: false,
   customTheme: '',
+  // isTeam is true if [Features.ProductType] == Team
+  isTeam: false,
+  // isIgsEnabled refers to Identity Governance & Security product.
+  // It refers to a group of features: access request, device trust,
+  // access list, and access monitoring.
+  isIgsEnabled: false,
 
   configDir: '$HOME/.config',
 
@@ -349,6 +355,14 @@ const cfg = {
     if (cfg.auth.authType === 'local') return 'local';
 
     return 'sso';
+  },
+
+  // isLegacyEnterprise describes product that should have legacy support
+  // where certain features access remain unlimited. This was before
+  // product EUB (enterprise usage based) was introduced.
+  // eg: access request and device trust.
+  isLegacyEnterprise() {
+    return cfg.isEnterprise && !cfg.isUsageBasedBilling;
   },
 
   getAuthType() {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -45,6 +45,10 @@ const cfg = {
   tunnelPublicAddress: '',
   recoveryCodesEnabled: false,
   // IsUsageBasedBilling determines if the user subscription is usage-based (pay-as-you-go).
+  // Historically, this flag used to refer to "Cloud Team" product,
+  // but with the new EUB (Enterprise Usage Based) product, it can mean either EUB or Team.
+  // Use the `isTeam` config flag to determine if product used is Team.
+  // EUB can be determined from a combination of existing config flags eg: `isCloud && !isTeam`.
   isUsageBasedBilling: false,
   hideInaccessibleFeatures: false,
   customTheme: '',

--- a/web/packages/teleport/src/services/sales/index.ts
+++ b/web/packages/teleport/src/services/sales/index.ts
@@ -17,8 +17,9 @@
 import { CtaEvent } from 'teleport/services/userEvent';
 import cfg from 'teleport/config';
 
-// These URL's are the shorten URL version. These shorten URL
+// These URLs are the shorten URL version. These marketing URL's
 // are defined in the "next" repo.
+// eg: https://github.com/gravitational/next/pull/2298
 const UPGRADE_TEAM_URL = 'https://goteleport.com/r/upgrade-team';
 const UPGRADE_COMMUNITY_URL = 'https://goteleport.com/r/upgrade-community';
 // UPGRADE_IGS_URL is enterprise upgrading to enterprise with Identity Governance & Security

--- a/web/packages/teleport/src/services/sales/index.ts
+++ b/web/packages/teleport/src/services/sales/index.ts
@@ -15,9 +15,14 @@
  */
 
 import { CtaEvent } from 'teleport/services/userEvent';
+import cfg from 'teleport/config';
 
+// These URL's are the shorten URL version. These shorten URL
+// are defined in the "next" repo.
 const UPGRADE_TEAM_URL = 'https://goteleport.com/r/upgrade-team';
 const UPGRADE_COMMUNITY_URL = 'https://goteleport.com/r/upgrade-community';
+// UPGRADE_IGS_URL is enterprise upgrading to enterprise with Identity Governance & Security
+const UPGRADE_IGS_URL = 'https://goteleport.com/r/upgrade-igs';
 
 function getParams(
   version: string,
@@ -32,10 +37,12 @@ function getParams(
 export function getSalesURL(
   version: string,
   isEnterprise: boolean,
-  isUsageBased: boolean,
   event?: CtaEvent
 ) {
-  const url = isUsageBased ? UPGRADE_TEAM_URL : UPGRADE_COMMUNITY_URL;
+  let url = UPGRADE_COMMUNITY_URL;
+  if (isEnterprise) {
+    url = cfg.isTeam ? UPGRADE_TEAM_URL : UPGRADE_IGS_URL;
+  }
   const params = getParams(version, isEnterprise, event);
   return `${url}?${params}`;
 }

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -66,15 +66,20 @@ class TeleportContext implements types.Context {
 
   // lockedFeatures are the features disabled in the user's cluster.
   // Mainly used to hide features and/or show CTAs when the user cluster doesn't support it.
-  // TODO(mcbattirola): use cluster features instead of only using `isUsageBasedBilling`
+  // TODO(mcbattirola): use cluster features instead of only using `isTeam`
   // to determine which feature is locked
   lockedFeatures: types.LockedFeatures = {
-    authConnectors: cfg.isUsageBasedBilling,
-    activeSessions: cfg.isUsageBasedBilling,
-    accessRequests: cfg.isUsageBasedBilling,
-    premiumSupport: cfg.isUsageBasedBilling,
-    trustedDevices: cfg.isUsageBasedBilling,
-    externalCloudAudit: cfg.isUsageBasedBilling,
+    authConnectors: cfg.isTeam,
+    activeSessions: cfg.isTeam,
+    premiumSupport: cfg.isTeam,
+    externalCloudAudit: cfg.isTeam,
+    // Below should be locked for the following cases:
+    //  1) is team
+    //  2) is not a legacy and igs is not enabled. legacies should have unlimited access.
+    accessRequests:
+      cfg.isTeam || (!cfg.isLegacyEnterprise() && !cfg.isIgsEnabled),
+    trustedDevices:
+      cfg.isTeam || (!cfg.isLegacyEnterprise() && !cfg.isIgsEnabled),
   };
 
   // init fetches data required for initial rendering of components.


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/2317

- [x] 🔴  before merge, requires: https://github.com/gravitational/next/pull/2298, for the IGS CTA `upgrade link`

`isUsageBasedBilling` flag used to mean `isTeam`, but it can now also mean `usage based enterprise`.
This PR goes through each `isUsageBasedBilling` flag in the web UI and replaces it with `isTeam` where necessary

Also adds checks for `igs` support and this PR only accounts for `access request` and `device trust`.

i tagged people who i thought might have the most knowledge on our CTA's
cc @bl-nero 

i did my best to compare test with `before this PR` and `after this PR`:

https://docs.google.com/spreadsheets/d/17xRXtnY9MGX_Er79lDk089s3Z9E2nXVcM3d7QLd9VwU/edit?usp=sharing