### PR TITLE
Clarify error message for host user lookup timeouts

### DIFF
--- a/api/utils/user.go
+++ b/api/utils/user.go
@@ -58,7 +58,7 @@ func currentUser(getUser userGetter, timeout time.Duration) (*user.User, error) 
 		return u.user, trace.Wrap(u.err)
 	case <-timer.C:
 		return nil, trace.LimitExceeded(
-			"looking up the current host user exceeded timeout, try explicitly specifying the Teleport user or host user with --user or --login",
+			"unexpected host user lookup timeout, please explicitly specify the Teleport user with \"--user\" and the host user \"--login\" to skip host user lookup",
 		)
 	}
 }


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/24156, we added a host user lookup timeout to rectify environments where the lookup hang, such as AD setups under high load.

The error message for the timeout says to supply `--user` or `--login`, but users actually need to supply both:
 - `--user` only on login where it's then stored in the profile
 - `--login` on all commands

Slack thread - https://goteleport.slack.com/archives/C0582MBSMHN/p1700646468010939