### PR TITLE
RFD 155 - Scoped Webauthn Credentials

### DIFF
--- a/rfd/0155-scoped-webauthn-credentials.md
+++ b/rfd/0155-scoped-webauthn-credentials.md
@@ -188,6 +188,10 @@ Initially, reuse will only be permitted for the following admin action RPCs:
 - `rpc UpsertTokenV2`
 - `rpc CreateTokenV2`
 - `rpc GenerateToken`
+- `rpc CreateBot`
+- `rpc UpdateBot`
+- `rpc UpsertBot`
+- `rpc DeleteBot`
 
 These RPCs are currently used for "bulk" requests such as:
 
@@ -226,13 +230,13 @@ endpoints:
   - `rpc CreateAccessRequest`
   - `rpc SetAccessRequestState`
   - `rpc SubmitAccessReview`
-  - `AccessRequestPromote`
-  - `CreateAccessListReview`
+  - `rpc AccessRequestPromote`
+  - `rpc CreateAccessListReview`
 - CA management
   - `http rotateCertAuthority`
   - `http rotateExternalCertAuthority`
-  - `rpc upsertCertAuthority`
-  - `rpc deleteCertAuthority`
+  - `rpc UpsertCertAuthority`
+  - `rpc DeleteCertAuthority`
   - `rpc DeleteCertAuthority`
 - Certificate generation
   - `rpc GenerateHostCert`

--- a/rfd/0155-scoped-webauthn-credentials.md
+++ b/rfd/0155-scoped-webauthn-credentials.md
@@ -1,0 +1,197 @@
+---
+authors: Brian Joerger (bjoerger@goteleport.com)
+state: draft
+---
+
+# RFD 155 - Scoped Webauthn Credentials
+
+## Required Approvers
+
+- Engineering: @rosstimothy && @codingllama
+- Product: @klizhentas || @xinding33
+- Security: @jentfoo
+
+## What
+
+Add and enforce scope for webauthn credentials.
+
+## Why
+
+Today, when a client performs a webauthn ceremony, the resulting webauthn
+credentials can be used to perform actions other than what the client initially
+intended.
+
+For example, webauthn credentials intended for per-session MFA could be used
+instead for login. This means that if an attacker gets a hold of a user's
+webauthn credentials before the client consumes them, an attacker with the
+user's password could login as the user. Adding scope to the webauthn
+credentials would prevent the attacker from using the stolen webauthn
+credentials freely.
+
+Adding scope also enables us to allow webauthn credentials to be reused within
+specific scopes. For example, for admin actions it may make sense to allow the
+client to reuse a single webauthn credential for a string of requests that are
+functionally a single action, such as creating a new user and their corresponding
+invite token.
+
+## Details
+
+### Security
+
+Enforcing scope for webauthn credentials strictly improves security, as it is a
+purely restrictive change that prevents certain attack vectors, as described
+in [Why](#why).
+
+On the other hand, allowing clients to reuse webauthn credentials could have
+negative security implications if not handled carefully. Specifically, the
+client and server must clearly define:
+
+1. The webauthn credential's scope - client provided
+2. The number of reuses permitted - client provided
+3. The expiration of the credentials - server enforced (5 minutes)
+
+Additionally, reusing credentials will be limited to specific scopes where it
+is required. For now, this is only "admin actions", so any other scope will be
+forbidden from reusing webauthn credentials by the Auth server. Sensitive operations
+like "login" and "recovery" must never allow reuse.
+
+### Proto
+
+```proto
+// webauthn.proto
+
+message SessionData {
+  bytes challenge = 1 [(gogoproto.jsontag) = "challenge,omitempty"];
+  bytes user_id = 2 [(gogoproto.jsontag) = "userId,omitempty"];
+  repeated bytes allow_credentials = 3 [(gogoproto.jsontag) = "allowCredentials,omitempty"];
+  bool resident_key = 4 [(gogoproto.jsontag) = "residentKey,omitempty"];
+  string user_verification = 5 [(gogoproto.jsontag) = "userVerification,omitempty"];
+
+  // new:
+  // Scope authorized by this webauthn session. Ex: "login".
+  Scope scope = 6 [(gogoproto.jsontag) = "scope,omitempty"];
+  // UsesRemaining is a count of how many more times this session can be used for authentication
+  // before the session expires and is deleted. When set to 0 (default) or 1, the session will
+  // be deleted after the first authentication.
+  int64 uses_remaining = 7;
+}
+
+// Scope is a scope authorized by a webauthn session.
+enum Scope {
+  SCOPE_UNSPECIFIED = 0;
+  SCOPE_LOGIN = 1;
+  SCOPE_PASSWORDLESS_LOGIN = 2;
+  // MFA device management
+  SCOPE_MANAGE_DEVICES = 3;
+  // Account recovery - reset password, devices, etc.
+  SCOPE_RECOVERY = 4;
+  // Used for per-session MFA and moderated session presence checks
+  SCOPE_SESSION = 5;
+  SCOPE_HEADLESS = 6;
+  SCOPE_ADMIN_ACTION = 7;
+}
+
+// authservice.proto
+
+message CreateAuthenticateChallengeRequest {
+  oneof Request {
+    UserCredentials UserCredentials = 1 [(gogoproto.jsontag) = "user_credentials,omitempty"];
+    string RecoveryStartTokenID = 2 [(gogoproto.jsontag) = "recovery_start_token_id,omitempty"];
+    ContextUser ContextUser = 3 [(gogoproto.jsontag) = "context_user,omitempty"];
+    Passwordless Passwordless = 4 [(gogoproto.jsontag) = "passwordless,omitempty"];
+  }
+  IsMFARequiredRequest MFARequiredCheck = 5 [(gogoproto.jsontag) = "mfa_required_check,omitempty"];
+  
+  // new:
+  // Scope is the authorization scope for this MFA challenge. Ex: login.
+  // Only applies to webauthn challenges.
+  webauthn.Scope Scope = 6 [(gogoproto.jsontag) = "scope,omitempty"];
+  // Uses is the number of times resulting webauthn credentials can be used.
+  // Only applies to webauthn challenges with scopes that allow reuse.
+  int64 Uses = 7 [(gogoproto.jsontag) = "uses,omitempty"];
+}
+```
+
+### Client changes
+
+Clients will be expected to provide a scope when requesting an MFA challenge
+through `rpc CreateAuthenticateChallenge`. For specific login and device
+management endpoints, the scope will be automatically set on the server side.
+
+Clients can optionally provide a number of uses which will be allowed, though
+reuse is only allowed for the admin action scope.
+
+### Server changes
+
+#### Scope
+
+When verifying a webauthn credential against the user's stored webauthn
+challenge, the Auth Server will check that the stored scope matches the scope
+that the Auth server is verifying for. For example, if the Auth server is
+verifying a webauthn credential for scope "login", but webauthn challenge
+stored for the user has scope "headless", the verification will fail.
+
+#### Reuse
+
+After verifying a webauthn credential, the Auth server will check the `Uses`
+field of the stored challenge. If there are 0 (default) or 1 uses remaining,
+the challenge will be deleted and the client's webauthn credentials rendered
+useless. If there is more than 1 use remaining, the field will be decremented
+and updated in the backend.
+
+#### Expiration
+
+Webauthn challenges are always set to expire after 5 minutes. However, as we've
+seen with Dynamo DB, these expirations are not always strictly respected.
+Therefore, the Auth server will start checking the expiration of stored
+webauthn challenges. If the challenge is past it's expiration, the Auth server
+will delete it from the backend explicitly.
+
+### UX
+
+There should be no changes to UX, other than reducing the number of MFA taps
+required for certain admin actions from several down to one.
+
+### Backward Compatibility
+
+In order to maintain backwards compatibility with old clients, scope will not
+be enforced until the next major version after this feature is released.
+
+However, any new features tied to scope, such as webauthn credential reuse,
+will only be permitted to clients that do provide scope.
+
+### Audit Events
+
+Currently, MFA audit details are quite limited. We only emit the MFA device used
+for some MFA actions, such as login. We will add 2 new audit events for better
+coverage.
+
+```proto
+// events.proto
+message CreateMFAAuthChallenge {
+  Metadata Metadata = 1;
+  UserMetadata User = 2;
+  webauthn.Scope Scope = 3;
+  int64 Uses = 4;
+}
+
+message ValidateMFAAuthResponse {
+  Metadata Metadata = 1;
+  UserMetadata User = 2;
+  MFADeviceMetadata Device = 3;
+  webauthn.Scope Scope = 4;
+  int64 UsesRemaining = 5;
+}
+```
+
+### Product Usage
+
+```proto
+// MFAVerificationEvent is emitted when an MFA verification event is completed.
+message MFAVerificationEvent {
+  // anonymized
+  string user_name = 1;
+  string mfa_type = 2;
+  string scope = 3;
+}
+```

--- a/rfd/0155-scoped-webauthn-credentials.md
+++ b/rfd/0155-scoped-webauthn-credentials.md
@@ -72,7 +72,14 @@ message SessionData {
 +  bool AllowReuse = 7 [(gogoproto.jsontag) = "allow_reuse,omitempty"];
 }
 
+
+
 +// Scope is a scope authorized by a webauthn challenge resolution.
++//
++// Note: New scopes can be added to cover new use cases, or to split existing
++// scopes into more granular scopes. For example, passwordless and headless login
++// could be included under the "login" scope, but splitting them into their own
++// scopes improves the security of each.
 +enum ChallengeScope {
 +  SCOPE_UNSPECIFIED = 0;
 +  // Standard webauthn login.


### PR DESCRIPTION
This feature was initially suggested by @jentfoo [in this discussion](https://github.com/gravitational/teleport/pull/27588#discussion_r1231470745).

I intend to use this feature for admin actions to allow safe reuse of webauthn credentials for specific "bulk" admin actions:
- Creating a user - 1 MFA for CreateUser and 1 for CreateResetPasswordToken
- Updating a SAML Idp service provider - 1 MFA CreateSAMLIDP... to check existence, and 1 for UpdateSAMLIDP...
- Bulk creating of resources with tctl create
- Creating cloud invites with the button in the WebUI