### PR TITLE
operator: Fix GHA Dockerfile with new/old paths

### DIFF
--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -77,9 +77,10 @@ COPY lib/ lib/
 COPY gen/ gen/
 COPY integrations/operator/apis/ integrations/operator/apis/
 COPY integrations/operator/controllers/ integrations/operator/controllers/
-COPY integrations/operator/sidecar/ integrations/operator/sidecar/
+COPY integrations/operator/embeddedtbot/ integrations/operator/embeddedtbot/
 COPY integrations/operator/main.go integrations/operator/main.go
 COPY integrations/operator/namespace.go integrations/operator/namespace.go
+COPY integrations/operator/config.go integrations/operator/config.go
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Fix the operator `Dockerfile.gha` to copy the correct paths from the
context for the build. These paths changed pretty much at the same time
as `Dockerfile.gha` was added - just an overlap in development - in
commit f31a90d4a4b2cbceadbe748669e8e46deb92d4ff, which modified the
original `Dockerfile` on which `Dockerfile.gha` is based.