### PR TITLE
Dynamic AccessLists

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -240,6 +240,11 @@ type Requires struct {
 	Traits trait.Traits `json:"traits" yaml:"traits"`
 }
 
+// IsEmpty returns true when no roles or traits are set
+func (r *Requires) IsEmpty() bool {
+	return len(r.Roles) == 0 && len(r.Traits) == 0
+}
+
 // Grants describes what access is granted by membership to the access list.
 type Grants struct {
 	// Roles are the roles that are granted to users who are members of the access list.
@@ -403,6 +408,30 @@ func (a *AccessList) CloneResource() types.ResourceWithLabels {
 	var copy *AccessList
 	utils.StrictObjectToStruct(a, &copy)
 	return copy
+}
+
+// HasImplicitOwnership returns true if the supplied AccessList uses
+// implicit ownership
+func (a *AccessList) HasImplicitOwnership() bool {
+	return a.Spec.Ownership == InclusionImplicit
+}
+
+// HasExplicitOwnership returns true if the supplied AccessList uses
+// explicit ownership
+func (a *AccessList) HasExplicitOwnership() bool {
+	return a.Spec.Ownership == InclusionExplicit
+}
+
+// HasImplicitMembership returns true if the supplied AccessList uses
+// implicit membership
+func (a *AccessList) HasImplicitMembership() bool {
+	return a.Spec.Membership == InclusionImplicit
+}
+
+// HasExplicitMembership returns true if the supplied AccessList uses
+// explicit membership
+func (a *AccessList) HasExplicitMembership() bool {
+	return a.Spec.Membership == InclusionExplicit
 }
 
 func (a *Audit) UnmarshalJSON(data []byte) error {

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -117,11 +117,27 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	return &accessList, nil
 }
 
+// ImplicitAccessListError indicates that an operation that only makes sense for
+// AccessLists with an explicit Member list has been attempted on an implicit-
+// membership AccessList
+type ImplicitAccessListError struct{}
+
+// Error implements the `error` interface for ImplicitAccessListError
+func (ImplicitAccessListError) Error() string {
+	return "requested AccessList does not have explicit member list"
+}
+
 // AccessListMembersGetter defines an interface for reading access list members.
 type AccessListMembersGetter interface {
 	// ListAccessListMembers returns a paginated list of all access list members.
-	ListAccessListMembers(ctx context.Context, accessList string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// May return a DynamicAccessListError if the requested access list has an
+	// implicit member list and the underlying implementation does not have
+	// enough information to compute the dynamic member list.
+	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
+	// May return a DynamicAccessListError if the requested access list has an
+	// implicit member list and the underlying implementation does not have
+	// enough information to compute the dynamic member record.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
 }
 
@@ -189,20 +205,23 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 
 // IsAccessListOwner will return true if the user is an owner for the current list.
 func IsAccessListOwner(identity tlsca.Identity, accessList *accesslist.AccessList) error {
-	isOwner := false
-	for _, owner := range accessList.Spec.Owners {
-		if owner.Name == identity.Username {
-			isOwner = true
-			break
-		}
-	}
-
 	// An opaque access denied error.
 	accessDenied := trace.AccessDenied("access denied")
 
-	// User is not an owner, so we'll access denied.
-	if !isOwner {
-		return accessDenied
+	if accessList.HasExplicitOwnership() {
+		isOwner := false
+
+		for _, owner := range accessList.GetOwners() {
+			if owner.Name == identity.Username {
+				isOwner = true
+				break
+			}
+		}
+
+		// User is not an owner, so we'll access denied.
+		if !isOwner {
+			return accessDenied
+		}
 	}
 
 	if !UserMeetsRequirements(identity, accessList.Spec.OwnershipRequires) {
@@ -248,21 +267,24 @@ func (a AccessListMembershipChecker) IsAccessListMember(ctx context.Context, ide
 		}
 	}
 
-	member, err := a.members.GetAccessListMember(ctx, accessList.GetName(), username)
-	if trace.IsNotFound(err) {
-		// The member has not been found, so we know they're not a member of this list.
-		return trace.NotFound("user %s is not a member of the access list", username)
-	} else if err != nil {
-		// Some other error has occurred
-		return trace.Wrap(err)
+	if accessList.HasExplicitMembership() {
+		member, err := a.members.GetAccessListMember(ctx, accessList.GetName(), username)
+		if trace.IsNotFound(err) {
+			// The member has not been found, so we know they're not a member of this list.
+			return trace.NotFound("user %s is not a member of the access list", username)
+		} else if err != nil {
+			// Some other error has occurred
+			return trace.Wrap(err)
+		}
+
+		expires := member.Spec.Expires
+		if !expires.IsZero() && !a.clock.Now().Before(expires) {
+			return trace.AccessDenied("user %s's membership has expired in the access list", username)
+		}
 	}
 
 	if !UserMeetsRequirements(identity, accessList.Spec.MembershipRequires) {
 		return trace.AccessDenied("user %s is a member, but does not have the roles or traits required to be a member of this list", username)
-	}
-
-	if !member.Spec.Expires.IsZero() && !a.clock.Now().Before(member.Spec.Expires) {
-		return trace.AccessDenied("user %s's membership has expired in the access list", username)
 	}
 
 	return nil

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -731,12 +731,15 @@ func TestAccessListReviewMarshal(t *testing.T) {
 // following requirements
 //
 // Membership:
+//
 //	Roles: mrole1, mrole2,
 //	Traits:
 //	  mtrait1: "mvalue1", "mvalue2"
 //	  mtrait2: "mvalue3", "mvalue4"
+//
 // Ownership:
-// 	nil
+//
+//	nil
 func newAccessListWithMembership(t *testing.T, membership accesslist.Inclusion) *accesslist.AccessList {
 	t.Helper()
 

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -204,6 +204,7 @@ func TestIsAccessListOwner(t *testing.T) {
 	tests := []struct {
 		name             string
 		identity         tlsca.Identity
+		ownership        accesslist.Inclusion
 		errAssertionFunc require.ErrorAssertionFunc
 	}{
 		{
@@ -216,6 +217,7 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3", "ovalue4"},
 				},
 			},
+			ownership:        accesslist.InclusionExplicit,
 			errAssertionFunc: require.NoError,
 		},
 		{
@@ -228,9 +230,8 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3", "ovalue4"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			ownership:        accesslist.InclusionExplicit,
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is owner with missing roles",
@@ -242,9 +243,8 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3", "ovalue4"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			ownership:        accesslist.InclusionExplicit,
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is owner with missing traits",
@@ -256,9 +256,46 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsAccessDenied(err))
+			ownership:        accesslist.InclusionExplicit,
+			errAssertionFunc: requireAccessDenied,
+		},
+		{
+			name: "is implicit owner",
+			identity: tlsca.Identity{
+				Username: "not-specified-owner",
+				Groups:   []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
 			},
+			ownership:        accesslist.InclusionImplicit,
+			errAssertionFunc: require.NoError,
+		},
+		{
+			name: "implicit owner with missing roles",
+			identity: tlsca.Identity{
+				Username: "not-specified-owner",
+				Groups:   []string{"orole1"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
+			},
+			ownership:        accesslist.InclusionImplicit,
+			errAssertionFunc: requireAccessDenied,
+		},
+		{
+			name: "implicit owner with missing traits",
+			identity: tlsca.Identity{
+				Username: "not-specified-owner",
+				Groups:   []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+				},
+			},
+			ownership:        accesslist.InclusionImplicit,
+			errAssertionFunc: requireAccessDenied,
 		},
 	}
 
@@ -268,6 +305,8 @@ func TestIsAccessListOwner(t *testing.T) {
 			t.Parallel()
 
 			accessList := newAccessList(t)
+			accessList.Spec.Ownership = test.ownership
+
 			test.errAssertionFunc(t, IsAccessListOwner(test.identity, accessList))
 		})
 	}
@@ -325,11 +364,17 @@ func (t *testMembersAndLockGetter) GetLocks(ctx context.Context, inForceOnly boo
 	return locks, nil
 }
 
+func requireAccessDenied(t require.TestingT, err error, i ...interface{}) {
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %T: %s", err, err.Error())
+}
+
 func TestIsAccessListMemberChecker(t *testing.T) {
 	tests := []struct {
 		name             string
 		identity         tlsca.Identity
 		memberCtx        context.Context
+		membership       accesslist.Inclusion
 		currentTime      time.Time
 		locks            map[string]types.Lock
 		errAssertionFunc require.ErrorAssertionFunc
@@ -344,6 +389,21 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: require.NoError,
+		},
+		{
+			name: "is member (dynamic)",
+			identity: tlsca.Identity{
+				Username: member1,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			membership:       accesslist.InclusionImplicit,
 			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: require.NoError,
 		},
@@ -357,6 +417,7 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
+			membership: accesslist.InclusionExplicit,
 			locks: map[string]types.Lock{
 				"test-lock": newUserLock(t, "test-lock", member1),
 			},
@@ -375,10 +436,24 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
+			membership:  accesslist.InclusionExplicit,
 			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
 				require.True(t, trace.IsNotFound(err))
 			},
+		},
+		{
+			name: "is not a member (dynamic)",
+			identity: tlsca.Identity{
+				Username: member4,
+				Groups:   []string{"nonmatching-role"},
+				Traits: map[string][]string{
+					"nonmatching-trait": {"mvalue1", "mvalue2"},
+				},
+			},
+			membership:       accesslist.InclusionImplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is expired member",
@@ -390,10 +465,9 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
-			currentTime: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "member has no expiration",
@@ -405,6 +479,7 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
+			membership:       accesslist.InclusionExplicit,
 			currentTime:      time.Date(2030, 7, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: require.NoError,
 		},
@@ -418,10 +493,9 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is member with no expiration and missing roles",
@@ -433,10 +507,9 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is member with missing traits",
@@ -448,10 +521,9 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3"},
 				},
 			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 		{
 			name: "is member with no expiration and missing traits",
@@ -463,10 +535,9 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 					"mtrait2": {"mvalue3"},
 				},
 			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
+			membership:       accesslist.InclusionExplicit,
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: requireAccessDenied,
 		},
 	}
 
@@ -477,8 +548,12 @@ func TestIsAccessListMemberChecker(t *testing.T) {
 
 			ctx := context.Background()
 
-			accessList := newAccessList(t)
-			members := newAccessListMembers(t)
+			accessList := newAccessListWithMembership(t, test.membership)
+
+			members := []*accesslist.AccessListMember{}
+			if test.membership == accesslist.InclusionExplicit {
+				members = newAccessListMembers(t)
+			}
 
 			memberMap := map[string]map[string]*accesslist.AccessListMember{}
 			for _, member := range members {
@@ -652,7 +727,17 @@ func TestAccessListReviewMarshal(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func newAccessList(t *testing.T) *accesslist.AccessList {
+// newAccessListWithMembership creates an access list for testing with the
+// following requirements
+//
+// Membership:
+//	Roles: mrole1, mrole2,
+//	Traits:
+//	  mtrait1: "mvalue1", "mvalue2"
+//	  mtrait2: "mvalue3", "mvalue4"
+// Ownership:
+// 	nil
+func newAccessListWithMembership(t *testing.T, membership accesslist.Inclusion) *accesslist.AccessList {
 	t.Helper()
 
 	accessList, err := accesslist.NewAccessList(
@@ -679,6 +764,7 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 					DayOfMonth: accesslist.FifteenthDayOfMonth,
 				},
 			},
+			Membership: membership,
 			MembershipRequires: accesslist.Requires{
 				Roles: []string{"mrole1", "mrole2"},
 				Traits: map[string][]string{
@@ -705,6 +791,11 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 	require.NoError(t, err)
 
 	return accessList
+}
+
+func newAccessList(t *testing.T) *accesslist.AccessList {
+	t.Helper()
+	return newAccessListWithMembership(t, accesslist.InclusionExplicit)
 }
 
 func newAccessListMembers(t *testing.T) []*accesslist.AccessListMember {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -54,7 +54,11 @@ const (
 	accessListLockTTL = 5 * time.Second
 )
 
-// AccessListService manages Access List resources in the Backend.
+// AccessListService manages Access List resources in the Backend. The AccessListService's
+// sole job is to manage and co-ordinate operations on the underlying AccessList,
+// AccessListMember, etc resources in the backend in order to provide a
+// consistent view to the rest of the Teleport application. It makes no decisions
+// about granting or withholding list membership.
 type AccessListService struct {
 	log           logrus.FieldLogger
 	clock         clockwork.Clock
@@ -62,6 +66,10 @@ type AccessListService struct {
 	memberService *generic.Service[*accesslist.AccessListMember]
 	reviewService *generic.Service[*accesslist.Review]
 }
+
+// compile-time assertion that the AccessListService implements the AccessLists
+// interface
+var _ services.AccessLists = (*AccessListService)(nil)
 
 // NewAccessListService creates a new AccessListService.
 func NewAccessListService(backend backend.Backend, clock clockwork.Clock) (*AccessListService, error) {
@@ -139,8 +147,39 @@ func (a *AccessListService) GetAccessListsToReview(ctx context.Context) ([]*acce
 
 // UpsertAccessList creates or updates an access list resource.
 func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *accesslist.AccessList) (*accesslist.AccessList, error) {
+	if accessList.HasImplicitOwnership() {
+		if len(accessList.Spec.Owners) > 0 {
+			return nil, trace.BadParameter("implicit ownership requires empty ownership list")
+		}
+
+		if accessList.Spec.OwnershipRequires.IsEmpty() {
+			return nil, trace.BadParameter("implicit ownership requires ownership requirements")
+		}
+	}
+
+	if accessList.HasImplicitMembership() {
+		if accessList.Spec.MembershipRequires.IsEmpty() {
+			return nil, trace.BadParameter("implicit membership requires membership requirements")
+		}
+	}
+
 	upsertWithLockFn := func() error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			oldAccessList, err := a.service.GetResource(ctx, accessList.GetName())
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+
+			if oldAccessList != nil {
+				if oldAccessList.Spec.Ownership != accessList.Spec.Ownership {
+					return trace.BadParameter("AccessList ownership cannot be changed")
+				}
+
+				if oldAccessList.Spec.Membership != accessList.Spec.Membership {
+					return trace.BadParameter("AccessList membership cannot be changed")
+				}
+			}
+
 			ownerMap := make(map[string]struct{}, len(accessList.Spec.Owners))
 			for _, owner := range accessList.Spec.Owners {
 				if _, ok := ownerMap[owner.Name]; ok {
@@ -199,14 +238,22 @@ func (a *AccessListService) DeleteAllAccessLists(ctx context.Context) error {
 }
 
 // ListAccessListMembers returns a paginated list of all access list members.
-func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessList string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
+func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
 	var members []*accesslist.AccessListMember
-	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		_, err := a.service.GetResource(ctx, accessList)
+	var al *accesslist.AccessList
+	err := a.service.RunWhileLocked(ctx, lockName(accessListName), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		var err error
+
+		al, err = a.service.GetResource(ctx, accessListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		members, nextToken, err = a.memberService.WithPrefix(accessList).ListResources(ctx, pageSize, nextToken)
+
+		if al.HasImplicitMembership() {
+			return services.ImplicitAccessListError{}
+		}
+
+		members, nextToken, err = a.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, nextToken)
 		return trace.Wrap(err)
 	})
 	if err != nil {
@@ -219,10 +266,15 @@ func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessLis
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
 	var member *accesslist.AccessListMember
 	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		_, err := a.service.GetResource(ctx, accessList)
+		al, err := a.service.GetResource(ctx, accessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		if al.HasImplicitMembership() {
+			return services.ImplicitAccessListError{}
+		}
+
 		member, err = a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
 		return trace.Wrap(err)
 	})
@@ -232,10 +284,15 @@ func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList 
 // UpsertAccessListMember creates or updates an access list member resource.
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
 	err := a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		_, err := a.service.GetResource(ctx, member.Spec.AccessList)
+		al, err := a.service.GetResource(ctx, member.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		if al.HasImplicitMembership() {
+			return services.ImplicitAccessListError{}
+		}
+
 		return trace.Wrap(a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member))
 	})
 	if err != nil {
@@ -247,16 +304,25 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 // DeleteAccessListMember hard deletes the specified access list member resource.
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
 	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		_, err := a.service.GetResource(ctx, accessList)
+		al, err := a.service.GetResource(ctx, accessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		if al.HasImplicitMembership() {
+			return services.ImplicitAccessListError{}
+		}
+
 		return trace.Wrap(a.memberService.WithPrefix(accessList).DeleteResource(ctx, memberName))
 	})
 	return trace.Wrap(err)
 }
 
-// DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
+// DeleteAllAccessListMembersForAccessList hard deletes all access list members
+// for an access list. Note that deleting all members is the only member
+// operation allowed on a list with implicit membership, as it provides a
+// mechanism for cleaning out the user list if a list is converted from explicit
+// to implicit.
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		_, err := a.service.GetResource(ctx, accessList)
@@ -277,9 +343,28 @@ func (a *AccessListService) DeleteAllAccessListMembers(ctx context.Context) erro
 
 // UpsertAccessListWithMembers creates or updates an access list resource and its members.
 func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+	if accessList.HasImplicitMembership() && len(membersIn) > 0 {
+		return nil, nil, trace.BadParameter("cannot explicitly add members to a list with implicit inclusion")
+	}
+
 	// Double the lock TTL to account for the time it takes to upsert the members.
 	upsertWithLockFn := func() error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			oldAccessList, err := a.service.GetResource(ctx, accessList.GetName())
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+
+			if oldAccessList != nil {
+				if oldAccessList.Spec.Ownership != accessList.Spec.Ownership {
+					return trace.BadParameter("AccessList ownership cannot be changed")
+				}
+
+				if oldAccessList.Spec.Membership != accessList.Spec.Membership {
+					return trace.BadParameter("AccessList membership cannot be changed")
+				}
+			}
+
 			// Create a map of the members from the request for easier lookup.
 			membersMap := make(map[string]*accesslist.AccessListMember)
 
@@ -291,7 +376,6 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 			var (
 				members      []*accesslist.AccessListMember
 				membersToken string
-				err          error
 			)
 
 			for {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.
@@ -1020,4 +1022,575 @@ func newAccessListReview(t *testing.T, accessList, name string) *accesslist.Revi
 	require.NoError(t, err)
 
 	return review
+}
+
+func TestDynamicAccessListOwnersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.OwnershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("inserting with explicit owners is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND a non-empty owner
+		// list
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.Owners = []accesslist.Owner{
+			{
+				Name:        "some-user",
+				Description: "just coz",
+			},
+		}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+}
+
+func TestDynamicAccessListMembersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set member conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Membership = accesslist.InclusionImplicit
+		list.Spec.MembershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("listing implicit members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to list the members of that list
+		_, _, err = service.ListAccessListMembers(ctx, implicitlist.GetName(), 100, "")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("getting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to query a member of that list
+		_, err = service.GetAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("deleting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to delete a member of that list
+		err = service.DeleteAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that the list has implicit
+		// membership and it can't honor the request
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("inserting with no members is allowed", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// When I attempt to upsert the list via UpsertAccessListWithMembers,
+		// but do not supply any members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{})
+
+		// Expect that the overall operation succeeds
+		require.NoError(t, err)
+
+		// ALSO Expect that the AccessList has been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.NoError(t, err)
+	})
+
+	t.Run("inserting list members is an error", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// And a membership for that list
+		m, err := accesslist.NewAccessListMember(
+			header.Metadata{
+				Name: implicitlist.GetName() + "/" + "some-user",
+			},
+			accesslist.AccessListMemberSpec{
+				AccessList: implicitlist.GetName(),
+				Name:       "some-user",
+				Membership: accesslist.InclusionExplicit,
+				AddedBy:    "system",
+				Joined:     time.Date(2016, time.December, 17, 14, 30, 55, 60, time.UTC),
+			})
+		require.NoError(t, err)
+
+		// When I attempt to upsert the list with members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{m})
+
+		// Expect that the overall operation fails
+		require.Error(t, err)
+
+		// Expect that the AccessList has not been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("deleting all list members is allowed", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// AND a membership record fora user in that list (this can happen if an
+		// existing Explicit list is made Implicit)
+		m := newAccessListMember(t, implicitlist.GetName(), "scooby")
+		err = service.memberService.WithPrefix(m.Spec.AccessList).UpsertResource(ctx, m)
+		require.NoError(t, err)
+
+		// When I try to remove all the members of that list
+		err = service.DeleteAllAccessListMembersForAccessList(
+			ctx,
+			implicitlist.GetName())
+
+		// Expect that the operation succeeds
+		require.NoError(t, err)
+
+		// And that the membership record no longer exists
+		_, err = service.memberService.WithPrefix(m.Spec.AccessList).GetResource(ctx, m.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+}
+
+func TestChangingMembershipModeIsAnError(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	upsert := func(l *accesslist.AccessList) error {
+		_, err := service.UpsertAccessList(ctx, l)
+		return err
+	}
+
+	upsertWithMembers := func(l *accesslist.AccessList) error {
+		_, _, err := service.UpsertAccessListWithMembers(ctx, l, []*accesslist.AccessListMember{})
+		return err
+	}
+
+	tests := []struct {
+		name     string
+		oldMode  accesslist.Inclusion
+		newMode  accesslist.Inclusion
+		updateFn func(*accesslist.AccessList) error
+	}{
+		{
+			name:     "explicit to implicit",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsert,
+		}, {
+			name:     "implicit to explicit",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsert,
+		}, {
+			name:     "explicit to implicit (with members)",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsertWithMembers,
+		}, {
+			name:     "implicit to explicit (with members)",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsertWithMembers,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given an AccessList with a specific Membership Inclusion type
+			list := newAccessList(t, uuid.New().String(), clock)
+			list.Spec.Membership = test.oldMode
+			_, err := service.UpsertAccessList(ctx, list)
+			require.NoError(t, err)
+
+			// When I try to change the membership type...
+			list.Spec.Membership = test.newMode
+			err = test.updateFn(list)
+
+			// Expect that the operation fails with BadParameter
+			require.Error(t, err)
+			require.Truef(t, trace.IsBadParameter(err),
+				"Expected BadParameter, got %s", err.Error())
+		})
+	}
+}
+
+func TestChangingOwnershipModeIsAnError(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	upsert := func(l *accesslist.AccessList) error {
+		_, err := service.UpsertAccessList(ctx, l)
+		return err
+	}
+
+	upsertWithMembers := func(l *accesslist.AccessList) error {
+		_, _, err := service.UpsertAccessListWithMembers(ctx, l, []*accesslist.AccessListMember{})
+		return err
+	}
+
+	tests := []struct {
+		name     string
+		oldMode  accesslist.Inclusion
+		newMode  accesslist.Inclusion
+		updateFn func(*accesslist.AccessList) error
+	}{
+		{
+			name:     "explicit to implicit",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsert,
+		}, {
+			name:     "implicit to explicit",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsert,
+		}, {
+			name:     "explicit to implicit (with members)",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsertWithMembers,
+		}, {
+			name:     "implicit to explicit (with members)",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsertWithMembers,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given an AccessList with a specific Ownership Inclusion type
+			list := newAccessList(t, uuid.New().String(), clock)
+			list.Spec.Ownership = test.oldMode
+			if test.oldMode == accesslist.InclusionImplicit {
+				list.Spec.Owners = []accesslist.Owner{}
+			}
+
+			_, err := service.UpsertAccessList(ctx, list)
+			require.NoError(t, err)
+
+			// When I try to change the ownership type...
+			list.Spec.Ownership = test.newMode
+			if test.newMode == accesslist.InclusionImplicit {
+				list.Spec.Owners = []accesslist.Owner{}
+			}
+			err = test.updateFn(list)
+
+			// Expect that the operation fails with BadParameter
+			require.Error(t, err)
+			require.Truef(t, trace.IsBadParameter(err),
+				"Expected BadParameter, got %s", err.Error())
+		})
+	}
+}
+
+func TestDynamicAccessListOwnersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.OwnershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("inserting with explicit owners is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND a non-empty owner
+		// list
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.Owners = []accesslist.Owner{
+			{
+				Name:        "some-user",
+				Description: "just coz",
+			},
+		}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+}
+
+func TestDynamicAccessListMembersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set member conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Membership = accesslist.InclusionImplicit
+		list.Spec.MembershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("listing implicit members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to list the members of that list
+		_, _, err = service.ListAccessListMembers(ctx, implicitlist.GetName(), 100, "")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("getting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to query a member of that list
+		_, err = service.GetAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("deleting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to delete a member of that list
+		err = service.DeleteAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that the list has implicit
+		// membership and it can't honor the request
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("inserting with no members is allowed", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// When I attempt to upsert the list via UpsertAccessListWithMembers,
+		// but do not supply any members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{})
+
+		// Expect that the overall operation succeeds
+		require.NoError(t, err)
+
+		// ALSO Expect that the AccessList has been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.NoError(t, err)
+	})
+
+	t.Run("inserting list members is an error", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// And a membership for that list
+		m, err := accesslist.NewAccessListMember(
+			header.Metadata{
+				Name: implicitlist.GetName() + "/" + "some-user",
+			},
+			accesslist.AccessListMemberSpec{
+				AccessList: implicitlist.GetName(),
+				Name:       "some-user",
+				Membership: accesslist.InclusionExplicit,
+				AddedBy:    "system",
+				Joined:     time.Date(2016, time.December, 17, 14, 30, 55, 60, time.UTC),
+			})
+		require.NoError(t, err)
+
+		// When I attempt to upsert the list with members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{m})
+
+		// Expect that the overall operation fails
+		require.Error(t, err)
+
+		// Expect that the AccessList has not been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("deleting all list members is allowed", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// AND a membership record fora user in that list (this can happen if an
+		// existing Explicit list is made Implicit)
+		m := newAccessListMember(t, implicitlist.GetName(), "scooby")
+		err = service.memberService.WithPrefix(m.Spec.AccessList).UpsertResource(ctx, m)
+		require.NoError(t, err)
+
+		// When I try to remove all the members of that list
+		err = service.DeleteAllAccessListMembersForAccessList(
+			ctx,
+			implicitlist.GetName())
+
+		// Expect that the operation succeeds
+		require.NoError(t, err)
+
+		// And that the membership record no longer exists
+		_, err = service.memberService.WithPrefix(m.Spec.AccessList).GetResource(ctx, m.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
 }

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.
@@ -1020,4 +1022,365 @@ func newAccessListReview(t *testing.T, accessList, name string) *accesslist.Revi
 	require.NoError(t, err)
 
 	return review
+}
+
+func TestDynamicAccessListOwnersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.OwnershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("inserting with explicit owners is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND a non-empty owner
+		// list
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Ownership = accesslist.InclusionImplicit
+		list.Spec.Owners = []accesslist.Owner{
+			{
+				Name:        "some-user",
+				Description: "just coz",
+			},
+		}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+}
+
+func TestDynamicAccessListMembersCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	t.Run("inserting without set member conditions is an error", func(t *testing.T) {
+		// Given an access list with implicit ownership AND no ownership
+		// conditions set
+		list := newAccessList(t, t.Name(), clock)
+		list.Spec.Membership = accesslist.InclusionImplicit
+		list.Spec.MembershipRequires = accesslist.Requires{}
+
+		// When I try to insert that access list
+		_, err := service.UpsertAccessList(ctx, list)
+
+		// Expect that the operation fails
+		require.Error(t, err)
+	})
+
+	t.Run("listing implicit members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to list the members of that list
+		_, _, err = service.ListAccessListMembers(ctx, implicitlist.GetName(), 100, "")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("getting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to query a member of that list
+		_, err = service.GetAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that it has implicit membership
+		// and can't compute the result for me
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("deleting list members returns ImplicitAccessListError", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// When I try to delete a member of that list
+		err = service.DeleteAccessListMember(ctx, implicitlist.GetName(), "somebody")
+
+		// The AccessList service lets me know that the list has implicit
+		// membership and it can't honor the request
+		require.ErrorIs(t, err, services.ImplicitAccessListError{})
+	})
+
+	t.Run("inserting with no members is allowed", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// When I attempt to upsert the list via UpsertAccessListWithMembers,
+		// but do not supply any members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{})
+
+		// Expect that the overall operation succeeds
+		require.NoError(t, err)
+
+		// ALSO Expect that the AccessList has been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.NoError(t, err)
+	})
+
+	t.Run("inserting list members is an error", func(t *testing.T) {
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+
+		// And a membership for that list
+		m, err := accesslist.NewAccessListMember(
+			header.Metadata{
+				Name: implicitlist.GetName() + "/" + "some-user",
+			},
+			accesslist.AccessListMemberSpec{
+				AccessList: implicitlist.GetName(),
+				Name:       "some-user",
+				Membership: accesslist.InclusionExplicit,
+				AddedBy:    "system",
+				Joined:     time.Date(2016, time.December, 17, 14, 30, 55, 60, time.UTC),
+			})
+		require.NoError(t, err)
+
+		// When I attempt to upsert the list with members
+		_, _, err = service.UpsertAccessListWithMembers(
+			ctx,
+			implicitlist,
+			[]*accesslist.AccessListMember{m})
+
+		// Expect that the overall operation fails
+		require.Error(t, err)
+
+		// Expect that the AccessList has not been inserted
+		_, err = service.GetAccessList(ctx, implicitlist.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("deleting all list members is allowed", func(t *testing.T) {
+		var err error
+
+		// Given an access list with implicit membership
+		implicitlist := newAccessList(t, t.Name(), clock)
+		implicitlist.Spec.Membership = accesslist.InclusionImplicit
+		implicitlist, err = service.UpsertAccessList(ctx, implicitlist)
+		require.NoError(t, err)
+
+		// AND a membership record fora user in that list (this can happen if an
+		// existing Explicit list is made Implicit)
+		m := newAccessListMember(t, implicitlist.GetName(), "scooby")
+		err = service.memberService.WithPrefix(m.Spec.AccessList).UpsertResource(ctx, m)
+		require.NoError(t, err)
+
+		// When I try to remove all the members of that list
+		err = service.DeleteAllAccessListMembersForAccessList(
+			ctx,
+			implicitlist.GetName())
+
+		// Expect that the operation succeeds
+		require.NoError(t, err)
+
+		// And that the membership record no longer exists
+		_, err = service.memberService.WithPrefix(m.Spec.AccessList).GetResource(ctx, m.GetName())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+}
+
+func TestChangingMembershipModeIsAnError(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	upsert := func(l *accesslist.AccessList) error {
+		_, err := service.UpsertAccessList(ctx, l)
+		return err
+	}
+
+	upsertWithMembers := func(l *accesslist.AccessList) error {
+		_, _, err := service.UpsertAccessListWithMembers(ctx, l, []*accesslist.AccessListMember{})
+		return err
+	}
+
+	tests := []struct {
+		name     string
+		oldMode  accesslist.Inclusion
+		newMode  accesslist.Inclusion
+		updateFn func(*accesslist.AccessList) error
+	}{
+		{
+			name:     "explicit to implicit",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsert,
+		}, {
+			name:     "implicit to explicit",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsert,
+		}, {
+			name:     "explicit to implicit (with members)",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsertWithMembers,
+		}, {
+			name:     "implicit to explicit (with members)",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsertWithMembers,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given an AccessList with a specific Membership Inclusion type
+			list := newAccessList(t, uuid.New().String(), clock)
+			list.Spec.Membership = test.oldMode
+			_, err := service.UpsertAccessList(ctx, list)
+			require.NoError(t, err)
+
+			// When I try to change the membership type...
+			list.Spec.Membership = test.newMode
+			err = test.updateFn(list)
+
+			// Expect that the operation fails with BadParameter
+			require.Error(t, err)
+			require.Truef(t, trace.IsBadParameter(err),
+				"Expected BadParameter, got %s", err.Error())
+		})
+	}
+}
+
+func TestChangingOwnershipModeIsAnError(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	upsert := func(l *accesslist.AccessList) error {
+		_, err := service.UpsertAccessList(ctx, l)
+		return err
+	}
+
+	upsertWithMembers := func(l *accesslist.AccessList) error {
+		_, _, err := service.UpsertAccessListWithMembers(ctx, l, []*accesslist.AccessListMember{})
+		return err
+	}
+
+	tests := []struct {
+		name     string
+		oldMode  accesslist.Inclusion
+		newMode  accesslist.Inclusion
+		updateFn func(*accesslist.AccessList) error
+	}{
+		{
+			name:     "explicit to implicit",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsert,
+		}, {
+			name:     "implicit to explicit",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsert,
+		}, {
+			name:     "explicit to implicit (with members)",
+			oldMode:  accesslist.InclusionExplicit,
+			newMode:  accesslist.InclusionImplicit,
+			updateFn: upsertWithMembers,
+		}, {
+			name:     "implicit to explicit (with members)",
+			oldMode:  accesslist.InclusionImplicit,
+			newMode:  accesslist.InclusionExplicit,
+			updateFn: upsertWithMembers,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given an AccessList with a specific Ownership Inclusion type
+			list := newAccessList(t, uuid.New().String(), clock)
+			list.Spec.Ownership = test.oldMode
+			if test.oldMode == accesslist.InclusionImplicit {
+				list.Spec.Owners = []accesslist.Owner{}
+			}
+
+			_, err := service.UpsertAccessList(ctx, list)
+			require.NoError(t, err)
+
+			// When I try to change the ownership type...
+			list.Spec.Ownership = test.newMode
+			if test.newMode == accesslist.InclusionImplicit {
+				list.Spec.Owners = []accesslist.Owner{}
+			}
+			err = test.updateFn(list)
+
+			// Expect that the operation fails with BadParameter
+			require.Error(t, err)
+			require.Truef(t, trace.IsBadParameter(err),
+				"Expected BadParameter, got %s", err.Error())
+		})
+	}
 }


### PR DESCRIPTION
Depends on #35107

Implements:
 * Access checking for Dynamic Access List Ownership
 * Access checking for Dynamic Access List Membership
 * Changes to AccessList service to handle CRUD for dynamic access lists
   * Explicitly adding members to a list with implicit membership is prohibited
   * Changing ownership modes is prohibited
   * Changing membership modes is prohibited 
 * tests for same
