### PR TITLE
Support piecemeal names and descriptions for Okta apps and user groups.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -918,6 +918,18 @@ const (
 	// that's used by reverse tunnel agents to know which proxies in each proxy
 	// group they should attempt to be connected to.
 	ProxyGroupGenerationLabel = TeleportInternalLabelPrefix + "proxygroup-gen"
+
+	// OktaAppNameLabel is the individual app name label.
+	OktaAppNameLabel = TeleportInternalLabelPrefix + "okta-app-name"
+
+	// OktaAppDescriptionLabel is the individual app description label.
+	OktaAppDescriptionLabel = TeleportInternalLabelPrefix + "okta-app-description"
+
+	// OktaGroupNameLabel is the individual group name label.
+	OktaGroupNameLabel = TeleportInternalLabelPrefix + "okta-group-name"
+
+	// OktaGroupDescriptionLabel is the individual group description label.
+	OktaGroupDescriptionLabel = TeleportInternalLabelPrefix + "okta-group-description"
 )
 
 const (

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -660,6 +660,11 @@ func ValidateResourceName(validationRegex *regexp.Regexp, name string) error {
 func FriendlyName(resource ResourceWithLabels) string {
 	// Right now, only resources sourced from Okta and nodes have friendly names.
 	if resource.Origin() == OriginOkta {
+		if appName, ok := resource.GetLabel(OktaAppNameLabel); ok {
+			return appName
+		} else if groupName, ok := resource.GetLabel(OktaGroupNameLabel); ok {
+			return groupName
+		}
 		return resource.GetMetadata().Description
 	}
 

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -503,25 +503,29 @@ func TestValidLabelKey(t *testing.T) {
 }
 
 func TestFriendlyName(t *testing.T) {
-	appNoFriendly, err := NewAppV3(Metadata{
-		Name: "no friendly",
-	}, AppSpecV3{
-		URI: "https://some-uri.com",
-	},
-	)
-	require.NoError(t, err)
+	newApp := func(t *testing.T, name, description string, labels map[string]string) Application {
+		app, err := NewAppV3(Metadata{
+			Name:        name,
+			Description: description,
+			Labels:      labels,
+		}, AppSpecV3{
+			URI: "https://some-uri.com",
+		})
+		require.NoError(t, err)
 
-	appFriendly, err := NewAppV3(Metadata{
-		Name:        "no friendly",
-		Description: "friendly name",
-		Labels: map[string]string{
-			OriginLabel: OriginOkta,
-		},
-	}, AppSpecV3{
-		URI: "https://some-uri.com",
-	},
-	)
-	require.NoError(t, err)
+		return app
+	}
+
+	newGroup := func(t *testing.T, name, description string, labels map[string]string) UserGroup {
+		group, err := NewUserGroup(Metadata{
+			Name:        name,
+			Description: description,
+			Labels:      labels,
+		}, UserGroupSpecV1{})
+		require.NoError(t, err)
+
+		return group
+	}
 
 	node, err := NewServer("node", KindNode, ServerSpecV2{
 		Hostname: "friendly hostname",
@@ -535,13 +539,38 @@ func TestFriendlyName(t *testing.T) {
 	}{
 		{
 			name:     "no friendly name",
-			resource: appNoFriendly,
+			resource: newApp(t, "no friendly", "no friendly", map[string]string{}),
 			expected: "",
 		},
 		{
-			name:     "friendly app name",
-			resource: appFriendly,
+			name: "friendly app name (uses description)",
+			resource: newApp(t, "friendly", "friendly name", map[string]string{
+				OriginLabel: OriginOkta,
+			}),
 			expected: "friendly name",
+		},
+		{
+			name: "friendly app name (uses label)",
+			resource: newApp(t, "friendly", "friendly name", map[string]string{
+				OriginLabel:      OriginOkta,
+				OktaAppNameLabel: "label friendly name",
+			}),
+			expected: "label friendly name",
+		},
+		{
+			name: "friendly group name (uses description)",
+			resource: newGroup(t, "friendly", "friendly name", map[string]string{
+				OriginLabel: OriginOkta,
+			}),
+			expected: "friendly name",
+		},
+		{
+			name: "friendly group name (uses label)",
+			resource: newGroup(t, "friendly", "friendly name", map[string]string{
+				OriginLabel:        OriginOkta,
+				OktaGroupNameLabel: "label friendly name",
+			}),
+			expected: "label friendly name",
 		},
 		{
 			name:     "friendly node name",

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -112,10 +112,16 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 		}
 	}
 
+	// Use the explicitly set Okta label if it's present.
+	description := app.GetMetadata().Description
+	if oktaDescription, ok := app.GetLabel(types.OktaAppDescriptionLabel); ok {
+		description = oktaDescription
+	}
+
 	resultApp := App{
 		Kind:         types.KindApp,
 		Name:         app.GetName(),
-		Description:  app.GetDescription(),
+		Description:  description,
 		URI:          app.GetURI(),
 		PublicAddr:   app.GetPublicAddr(),
 		Labels:       labels,

--- a/lib/web/ui/user_groups.go
+++ b/lib/web/ui/user_groups.go
@@ -57,9 +57,15 @@ func MakeUserGroups(userGroups []types.UserGroup, userGroupsToApps map[string]ty
 			}
 		}
 
+		// Use the explicitly set Okta label if it's present.
+		description := userGroup.GetMetadata().Description
+		if oktaDescription, ok := userGroup.GetLabel(types.OktaGroupDescriptionLabel); ok {
+			description = oktaDescription
+		}
+
 		uiUserGroups = append(uiUserGroups, UserGroup{
 			Name:         userGroup.GetName(),
-			Description:  userGroup.GetMetadata().Description,
+			Description:  description,
 			Labels:       uiLabels,
 			FriendlyName: types.FriendlyName(userGroup),
 			Applications: appsAndFriendlyNames,

--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -107,7 +107,7 @@ export function makeUnifiedResourceViewItemApp(
   ui: UnifiedResourceUi
 ): UnifiedResourceViewItem {
   return {
-    name: resource.name,
+    name: resource.friendlyName || resource.name,
     SecondaryIcon: ApplicationIcon,
     primaryIconName: guessAppIcon(resource),
     ActionButton: ui.ActionButton,
@@ -150,7 +150,7 @@ export function makeUnifiedResourceViewItemUserGroup(
   ui: UnifiedResourceUi
 ): UnifiedResourceViewItem {
   return {
-    name: resource.name,
+    name: resource.friendlyName || resource.name,
     SecondaryIcon: ServerIcon,
     primaryIconName: 'Server',
     ActionButton: ui.ActionButton,

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -73,6 +73,7 @@ export type UnifiedResourceUserGroup = {
   kind: 'user_group';
   name: string;
   description: string;
+  friendlyName?: string;
   labels: ResourceLabel[];
 };
 


### PR DESCRIPTION
New labels have been added to Okta apps and user groups to allow the UI to display the names and descriptions separately. Some tweaks were made to the UI endpoints that extract these labels and use them for friendly names and descriptions. Additionally, the unified resources have been updated to use the friendly name where appropriate for apps and user groups.

Note: To my knowledge the user group unified resource card is not being used, but I added in the friendly name here to ensure that if we do use it for some reason we don't forget to make this change.

changelog: Okta applications display friendly name and Okta groups display friendly names and descriptions.