### PR TITLE
Implement and use UpsertSAMLConnectorV2

### DIFF
--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -40,12 +40,14 @@ func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLCo
 
 // Create creates a Teleport saml_connector
 func (r samlConnectorClient) Create(ctx context.Context, saml types.SAMLConnector) error {
-	return trace.Wrap(r.teleportClient.UpsertSAMLConnector(ctx, saml))
+	_, err := r.teleportClient.CreateSAMLConnector(ctx, saml)
+	return trace.Wrap(err)
 }
 
 // Update updates a Teleport saml_connector
 func (r samlConnectorClient) Update(ctx context.Context, saml types.SAMLConnector) error {
-	return trace.Wrap(r.teleportClient.UpsertSAMLConnector(ctx, saml))
+	_, err := r.teleportClient.UpsertSAMLConnector(ctx, saml)
+	return trace.Wrap(err)
 }
 
 // Delete deletes a Teleport saml_connector

--- a/integrations/operator/controllers/resources/saml_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller_test.go
@@ -65,7 +65,8 @@ func (g *samlTestingPrimitives) CreateTeleportResource(ctx context.Context, name
 		return trace.Wrap(err)
 	}
 	saml.SetOrigin(types.OriginKubernetes)
-	return trace.Wrap(g.setup.TeleportClient.UpsertSAMLConnector(ctx, saml))
+	_, err = g.setup.TeleportClient.CreateSAMLConnector(ctx, saml)
+	return trace.Wrap(err)
 }
 
 func (g *samlTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.SAMLConnector, error) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1009,7 +1009,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 
 	// test saml upsert event
 	saml.SetDisplay("alapaca")
-	err = s.a.UpsertSAMLConnector(ctx, saml)
+	_, err = s.a.UpsertSAMLConnector(ctx, saml)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.SAMLConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.SAMLConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3319,20 +3319,20 @@ func (a *ServerWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID s
 }
 
 // UpsertSAMLConnector creates or updates a SAML connector.
-func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error {
+func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
 	if !modules.GetModules().Features().SAML {
-		return trace.Wrap(ErrSAMLRequiresEnterprise)
+		return nil, trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindSAML, types.VerbCreate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindSAML, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	err := a.authServer.UpsertSAMLConnector(ctx, connector)
-	return trace.Wrap(err)
+	upserted, err := a.authServer.UpsertSAMLConnector(ctx, connector)
+	return upserted, trace.Wrap(err)
 }
 
 // CreateSAMLConnector creates a new SAML connector.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -542,7 +542,7 @@ type IdentityService interface {
 	// UpdateSAMLConnector updates an existing SAML connector
 	UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 	// UpsertSAMLConnector updates or creates a SAML connector
-	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error
+	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 	// GetSAMLConnector returns SAML connector information by id
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
 	// GetSAMLConnectors gets SAML connectors list

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3754,7 +3754,7 @@ func TestSAMLValidation(t *testing.T) {
 			client, err := server.NewClient(TestUser(user.GetName()))
 			require.NoError(t, err)
 
-			err = client.UpsertSAMLConnector(ctx, connector)
+			_, err = client.UpsertSAMLConnector(ctx, connector)
 
 			if tc.assertErr != nil {
 				require.Error(t, err)

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -193,7 +193,7 @@ type Identity interface {
 	// UpdateSAMLConnector updates an existing SAML connector
 	UpdateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 	// UpsertSAMLConnector updates or creates a SAML connector
-	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error
+	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 
 	// DeleteSAMLConnector deletes OIDC Connector
 	DeleteSAMLConnector(ctx context.Context, connectorID string) error

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1296,14 +1296,14 @@ func (s *IdentityService) GetOIDCAuthRequest(ctx context.Context, stateToken str
 }
 
 // UpsertSAMLConnector upserts SAML Connector
-func (s *IdentityService) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error {
+func (s *IdentityService) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
 	if err := services.ValidateSAMLConnector(connector, nil); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	rev := connector.GetRevision()
 	value, err := services.MarshalSAMLConnector(connector)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	item := backend.Item{
 		Key:      backend.Key(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix, connector.GetName()),
@@ -1313,10 +1313,10 @@ func (s *IdentityService) UpsertSAMLConnector(ctx context.Context, connector typ
 	}
 	lease, err := s.Put(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	connector.SetRevision(lease.Revision)
-	return nil
+	return connector, nil
 }
 
 // UpdateSAMLConnector updates an existing SAML connector

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -766,11 +766,9 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 	}
 	err := services.ValidateSAMLConnector(connector, nil)
 	require.NoError(t, err)
-	err = s.WebS.UpsertSAMLConnector(ctx, connector)
+	upserted, err := s.WebS.UpsertSAMLConnector(ctx, connector)
 	require.NoError(t, err)
-	out, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, connector, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.Empty(t, cmp.Diff(upserted, connector, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	connectors, err := s.WebS.GetSAMLConnectors(ctx, true)
 	require.NoError(t, err)
@@ -820,8 +818,7 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 	connector.SetRevision(uuid.NewString())
 	connector.SetDisplay("llama")
 
-	require.NoError(t, s.WebS.UpsertSAMLConnector(ctx, connector))
-	upserted, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), true)
+	upserted, err = s.WebS.UpsertSAMLConnector(ctx, connector)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(connector, upserted, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 	require.NotEmpty(t, upserted.GetRevision())

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -900,7 +900,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.
 		return trace.Wrap(err)
 	}
 
-	if err = client.UpsertSAMLConnector(ctx, conn); err != nil {
+	if _, err = client.UpsertSAMLConnector(ctx, conn); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("authentication connector '%s' has been %s\n", connectorName, UpsertVerb(exists, rc.IsForced()))


### PR DESCRIPTION
While the api client already had support for the new upsert method it was unimplemented server side and would always fallback to the legacy UpsertSAMLConnector RPC. This implements the RPC handler and updates the signature of UpsertSAMLConnector to return the upserted connector in the same manner that Create and Update do.


Depends on https://github.com/gravitational/teleport.e/pull/2773