### PR TITLE
Remove "edited" trigger from vercel-preview action

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -9,7 +9,7 @@ env:
 on:
   pull_request:
     paths: ['docs/**']
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
According to https://frontside.com/blog/2020-05-26-github-actions-pull_request/, `edited` triggers when
> title, body, or the base branch of the PR is modified

which caused unnecessary previews when editing PR descriptions