### PR TITLE
Improve the Enterprise intro page

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -29,7 +29,10 @@ government agencies.
 
 ## Download and install
 
-You can follow the [Installation instructions](../../installation.mdx#installation-instructions) for 
+Teleport Enterprise customers can download the custom FIPS package from their
+[Teleport account](https://teleport.sh). Look for `Linux 64-bit (FedRAMP/FIPS)`.
+
+You also can follow the [Installation instructions](../../installation.mdx#installation-instructions) for 
 Teleport Enterprise edition to download and install the appropriate FIPS-compliant binaries for 
 your operating environment and package manager or from compressed archive (tarball).
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
@@ -5,129 +5,52 @@ h1: Teleport Enterprise
 ---
 
 Teleport Enterprise is a commercial product built around Teleport's open source
-core.
+core. 
+
+Like Teleport Enterprise Cloud, Teleport Enterprise includes advanced features
+such as support for SAML– and OIDC-based single sign-on providers as well as
+Just-in-Time Access Requests through integrations with Slack, PagerDuty, and
+more. Unlike Teleport Enterprise Cloud, Teleport Enterprise is self hosted,
+giving you control over the Teleport Auth Service and Proxy Service for large
+organizations with particular security needs and compliance requirements.
+
+ You can compare editions in [How to Choose a Teleport
+ Edition](../introduction.mdx).
+
+## Get started with Teleport Enterprise
+
+Teleport Enterprise Cloud offers most of the functionality available in
+self-hosted deployments of Teleport Enterprise. If you are interested in trying
+Teleport for the first time, we recommend signing up for a [free
+trial](https://goteleport.com/signup) of Teleport Team, which manages the
+Teleport Auth Service and Proxy Service for you. You can then upgrade your
+account to Teleport Enterprise Cloud. 
+
+Once you have determined that your organization would benefit most from Teleport
+Enterprise, [contact sales](https://goteleport.com/signup/enterprise/) to
+discuss the best way to proceed with your self-hosted Teleport Enterprise
+deployment.
+
+For documentation on deploying a self-hosted Teleport Enterprise cluster on your
+platform, read  our [self-hosted production deployment
+guides](../../deploy-a-cluster/introduction.mdx).
+
+## Teleport Enterprise features
 
 The table below gives a quick overview of the benefits of Teleport Enterprise.
 
 | Teleport Enterprise Feature | Description |
 | - | - |
-| [Single Sign-On (SSO)](#sso) | Allows Teleport to integrate with existing enterprise identity systems. Examples include Active Directory, GitHub, Google Apps and numerous identity middleware solutions like Auth0, Okta, and so on. Teleport supports SAML and OAuth/OpenID Connect protocols to interact with them. |
+| [Single Sign-On (SSO)](../../access-controls/sso.mdx) | Allows Teleport to integrate with existing enterprise identity systems. Examples include Active Directory, GitHub, Google Apps and numerous identity middleware solutions like Auth0, Okta, and so on. Teleport supports SAML and OAuth/OpenID Connect protocols to interact with them. |
 | [Access Requests](../../access-controls/access-requests.mdx) | Request elevated access to roles or specific resources. |
-| [FedRAMP/FIPS](#fedrampfips) | Access controls to meet the requirements in a FedRAMP System Security Plan (SSP). This includes a FIPS 140-2 friendly build of Teleport Enterprise as well as a variety of improvements to aid in complying with security controls even in FedRAMP High environments. |
+| [FedRAMP/FIPS](../../access-controls/compliance-frameworks/fedramp.mdx) | Access controls to meet the requirements in a FedRAMP System Security Plan (SSP). This includes a FIPS 140-2 friendly build of Teleport Enterprise as well as a variety of improvements to aid in complying with security controls even in FedRAMP High environments. |
 | [Hardware Security Module support](./hsm.mdx)|The Teleport Auth Service can use your organization's HSM to generate TLS credentials, ensuring a highly reliable and secure public key infrastructure.|
+| [Google Cloud KMS support](./gcp-kms.mdx)|Teleport Enterprise allows you to configure the Teleport Auth Service to use Google Cloud KMS-based private keys for establishing trust with users and Teleport services.|
 | [Moderated Sessions](../../access-controls/guides/moderated-sessions.mdx)|Allow or require moderators to be present in SSH or Kubernetes sessions.|
 | Commercial Support | Support SLA with guaranteed response times. |
 
-<Admonition
-  type="tip"
-  title="Contact Information"
->
-
-  To get started with self-hosted Teleport Enterprise, [contact
-  sales](https://goteleport.com/signup/enterprise/).
-
-  You can also sign up for a [free trial](https://goteleport.com/signup) of
-  Teleport Team, which manages the Auth Service and Proxy Service for you. You
-  can then upgrade your account to Teleport Enterprise Cloud.
-
-</Admonition>
-
-## SSO
-
-The commercial edition of Teleport allows users to retrieve their SSH
-credentials via a single sign-on (SSO) system used by the rest of the organization.
-
-Examples of supported SSO systems include commercial solutions like Okta,
-Auth0, SailPoint, OneLogin Active Directory, as well as open source products like Keycloak.
-Other identity management systems are supported as long as they provide an
-SSO mechanism based on either SAML or OpenID Connect.
-
-### How does SSO work with SSH?
-
-From the user's perspective they need to execute the following command to retrieve their SSH certificate.
-
-```code
-$ tsh login
-```
-
-Teleport can be configured with a certificate TTL to determine how often a user needs to log in.
-
-`tsh login` will print a URL into the console, which will open an SSO login
-prompt, along with the 2FA, as enforced by the SSO provider. If a user supplies
-valid credentials, Teleport will issue an SSH certificate.
-
-Moreover, SSO can be used in combination with role-based access control (RBAC)
-to enforce SSH access policies like *"developers must not touch production data"*.
-See the [SSO](../../access-controls/sso.mdx) chapter for more details.
-
-## FedRAMP/FIPS
-
-With Teleport we have built the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules.
-
-Enterprise customers can download the custom FIPS package from their [Teleport account](https://teleport.sh).
-
-Look for `Linux 64-bit (FedRAMP/FIPS)`.
-
-Using `teleport start --fips` Teleport will start in FIPS mode, Teleport will
-configure the TLS and SSH servers with FIPS compliant cryptographic algorithms.
-In FIPS mode, if non-compliant algorithms are chosen, Teleport will fail to start.
-In addition, Teleport checks if the binary was compiled against an approved
-cryptographic module (BoringCrypto) and fails to start if it was not.
-
-See our [FedRAMP Compliance for Infrastructure Access](../../access-controls/compliance-frameworks/fedramp.mdx) guide for more information.
-
-## Access Requests
-
-With Teleport, users can request access to roles or to a specific set of resources
-such as a production server. Requests can be published to tools like Slack, Jira,
-and PagerDuty for easy integration with your organization's workflows. Teleport
-Enterprise's web interface also provides for creating and approving access requests.
-
-See [Access Requests Guide for more
-information](../../access-controls/access-requests.mdx)
-
-## Hardware Security Module support
-
-Teleport relies on a TLS private key and certificate in order to encrypt traffic
-and authenticate clients. With Teleport Enterprise, you can configure Teleport
-to use TLS credentials based on your organization's Hardware Security Module,
-improving the security and reliability of Teleport's public key infrastructure.
-
-See [HSM Support](./hsm.mdx) for more information.
-
-## Moderated Sessions
-
-Moderated Sessions are SSH or Kubernetes sessions that certain Teleport users
-can participate in, observe, or terminate at will. 
-
-Teleport administrators can configure a role so that, when a user with the role
-starts a session, another user *must* join the session, satisfying your
-organization's security requirements.
-
-It is also possible to configure a role to *allow* another user to join a
-session, which is useful for teams that need to collaborate at the terminal.
-
-See [Moderated Sessions](../../access-controls/guides/moderated-sessions.mdx) for more information.
-
-## Dedicated account dashboard
-
-Teleport Enterprise subscriptions include a dedicated account dashboard with their preferred
-subdomain of [teleport.sh](https://teleport.sh). The dedicated account dashboard provides
-subscription administrators access to the license file, support links and Teleport Enterprise binary downloads.
-
 ## License file
 
-Commercial Teleport subscriptions require a valid license. See [Enterprise License File](./license.mdx) for how to manage the file in your Teleport Enterprise deployment.
-
-## Next steps
-
-To get started with Teleport Enterprise, read our [deployment
-guides](../../deploy-a-cluster/introduction.mdx). You will learn how to deploy a
-high-availability, self-hosted Teleport cluster on your platform.
-
-Unless your organization requires the Enterprise-specific features we outlined
-above, you can use Teleport Enterprise Cloud to achieve secure access to your
-infrastructure without needing to maintain the Auth and Proxy Services. 
-
-[Sign up for a free trial of Teleport Team](https://goteleport.com/signup/),
-which you can upgrade to a Teleport Enterprise Cloud account.
+Commercial Teleport subscriptions require a valid license. See [Enterprise
+License File](./license.mdx) for how to manage the file in your Teleport
+Enterprise deployment.


### PR DESCRIPTION
Fixes #34419

- Add a clearer path for new Enterprise users to get started by making the calls to action more prominent within the Enterprise intro page.

- Some text in the intro is not necessary to include, such as descriptions of Enterprise features that are also available on Teleport Enterprise Cloud. There is also already a table of features with links to relevant sections. This change removes this unnecessary information to make the "Get started" section more prominent.

- Ensure all pages in the "Teleport Enterprise" subsection have links in the intro page, including the Google Cloud KMS guide.