### PR TITLE
[branch/v12] Added OSS OS packages to APT/YUM/Zypper repos when private releases are published

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5779,9 +5779,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -series-run -series-run-filter .*apt.* -timeout 12h0m0s -workflow
     deploy-packages.yaml -workflow-ref=refs/heads/master -input "artifact-tag=${DRONE_TAG}"
-    -input "environment=$(cat "/go/vars/release-environment.txt")" -input "package-name-filter=$($DRONE_REPO_PRIVATE
-    && echo "*ent*" || echo "")" -input "package-to-test=teleport-ent" -input "release-channel=stable"
-    -input "repo-type=apt" -input "version-channel=${DRONE_TAG}" '
+    -input "environment=$(cat "/go/vars/release-environment.txt")" -input "package-to-test=teleport-ent"
+    -input "release-channel=stable" -input "repo-type=apt" -input "version-channel=${DRONE_TAG}" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -5801,9 +5800,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -series-run -series-run-filter .*yum.* -timeout 12h0m0s -workflow
     deploy-packages.yaml -workflow-ref=refs/heads/master -input "artifact-tag=${DRONE_TAG}"
-    -input "environment=$(cat "/go/vars/release-environment.txt")" -input "package-name-filter=$($DRONE_REPO_PRIVATE
-    && echo "*ent*" || echo "")" -input "package-to-test=teleport-ent" -input "release-channel=stable"
-    -input "repo-type=yum" -input "version-channel=${DRONE_TAG}" '
+    -input "environment=$(cat "/go/vars/release-environment.txt")" -input "package-to-test=teleport-ent"
+    -input "release-channel=stable" -input "repo-type=yum" -input "version-channel=${DRONE_TAG}" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -19266,6 +19264,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 97023fe987fc6108b545bb3fd028f2e135492aa4098a8e2305a659fe7e0c8912
+hmac: c94d544ca9f9fe4fc75e90f0c46dc20f3f1030d242c541f4cab4b2066a078892
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -31,10 +31,9 @@ func promoteBuildOsRepoPipeline() pipeline {
 	packageDeployments := []osPackageDeployment{
 		// Normal release pipelines
 		{
-			versionChannel:    "${DRONE_TAG}",
-			packageNameFilter: `$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")`,
-			packageToTest:     "teleport-ent",
-			displayName:       "Teleport",
+			versionChannel: "${DRONE_TAG}",
+			packageToTest:  "teleport-ent",
+			displayName:    "Teleport",
 		},
 	}
 
@@ -73,12 +72,15 @@ func buildWorkflows(releaseEnvironmentFilePath string, packageDeployments []osPa
 	for _, packageDeployment := range packageDeployments {
 		for _, repoType := range repoTypes {
 			inputs := map[string]string{
-				"repo-type":           repoType,
-				"environment":         fmt.Sprintf("$(cat %q)", releaseEnvironmentFilePath),
-				"artifact-tag":        "${DRONE_TAG}",
-				"release-channel":     "stable",
-				"version-channel":     packageDeployment.versionChannel,
-				"package-name-filter": packageDeployment.packageNameFilter,
+				"repo-type":       repoType,
+				"environment":     fmt.Sprintf("$(cat %q)", releaseEnvironmentFilePath),
+				"artifact-tag":    "${DRONE_TAG}",
+				"release-channel": "stable",
+				"version-channel": packageDeployment.versionChannel,
+			}
+
+			if packageDeployment.packageNameFilter != "" {
+				inputs["package-name-filter"] = packageDeployment.packageNameFilter
 			}
 
 			if packageDeployment.packageToTest != "" {


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/34827

Changelog: OSS Teleport packages will now be published to OS package repos when private releases are cut