### PR TITLE
Correctly clone RoleV6 when downgrading

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2091,6 +2091,11 @@ func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6,
 	if !clientVersion.LessThan(minSupportedLabelExpressionVersion) {
 		return role, nil
 	}
+	// Make a shallow copy of the role so that we don't mutate the original.
+	// This is necessary because the role is stored in the backend and it's shared
+	// between multiple clients sessions.
+	// If we mutate the original role, it will be mutated for all clients
+	// which can cause panics since it causes a race condition.
 	role = apiutils.CloneProtoMsg(role)
 	hasLabelExpression := false
 	for _, kind := range types.LabelMatcherKinds {
@@ -2166,6 +2171,11 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 		return r, false, nil
 	case types.V7:
 		var restricted bool
+		// Make a shallow copy of the role so that we don't mutate the original.
+		// This is necessary because the role is stored in the backend and it's shared
+		// between multiple clients sessions.
+		// If we mutate the original role, it will be mutated for all clients
+		// which can cause panics since it causes a race condition.
 		downgraded := apiutils.CloneProtoMsg(r)
 		downgraded.Version = types.V6
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2092,8 +2092,8 @@ func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6,
 		return role, nil
 	}
 	// Make a shallow copy of the role so that we don't mutate the original.
-	// This is necessary because the role is stored in the backend and it's shared
-	// between multiple clients sessions.
+	// This is necessary because the role is shared
+	// between multiple clients sessions when notifying about changes in watchers.
 	// If we mutate the original role, it will be mutated for all clients
 	// which can cause panics since it causes a race condition.
 	role = apiutils.CloneProtoMsg(role)
@@ -2172,8 +2172,8 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 	case types.V7:
 		var restricted bool
 		// Make a shallow copy of the role so that we don't mutate the original.
-		// This is necessary because the role is stored in the backend and it's shared
-		// between multiple clients sessions.
+		// This is necessary because the role is shared
+		// between multiple clients sessions when notifying about changes in watchers.
 		// If we mutate the original role, it will be mutated for all clients
 		// which can cause panics since it causes a race condition.
 		downgraded := apiutils.CloneProtoMsg(r)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -61,6 +61,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/assist/assistv1"
 	"github.com/gravitational/teleport/lib/auth/discoveryconfig/discoveryconfigv1"
 	integrationService "github.com/gravitational/teleport/lib/auth/integration/integrationv1"
@@ -2090,6 +2091,7 @@ func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6,
 	if !clientVersion.LessThan(minSupportedLabelExpressionVersion) {
 		return role, nil
 	}
+	role = apiutils.CloneProtoMsg(role)
 	hasLabelExpression := false
 	for _, kind := range types.LabelMatcherKinds {
 		allowLabelMatchers, err := role.GetLabelMatchers(types.Allow, kind)
@@ -2163,11 +2165,8 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 	case types.V3, types.V4, types.V5, types.V6:
 		return r, false, nil
 	case types.V7:
-		var (
-			downgraded types.RoleV6
-			restricted bool
-		)
-		downgraded = *r
+		var restricted bool
+		downgraded := apiutils.CloneProtoMsg(r)
 		downgraded.Version = types.V6
 
 		if len(downgraded.GetKubeResources(types.Deny)) > 0 {
@@ -2225,7 +2224,7 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 			restricted = true
 		}
 
-		return &downgraded, restricted, nil
+		return downgraded, restricted, nil
 	default:
 		return nil, false, trace.BadParameter("unrecognized role version %T", r.Version)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -3929,10 +3931,11 @@ func TestRoleVersions(t *testing.T) {
 
 	wildcardLabels := types.Labels{types.Wildcard: {types.Wildcard}}
 
+	originalLabels := map[string]string{"env": "staging"}
 	newRole := func(version string, spec types.RoleSpecV6) types.Role {
 		role, err := types.NewRoleWithVersion("test_rule", version, spec)
 		meta := role.GetMetadata()
-		meta.Labels = map[string]string{"env": "staging"}
+		meta.Labels = maps.Clone(originalLabels)
 		role.SetMetadata(meta)
 		require.NoError(t, err)
 		return role
@@ -4076,10 +4079,6 @@ func TestRoleVersions(t *testing.T) {
 						// and ignore it in the role diff.
 						if tc.expectDowngraded {
 							require.NotEmpty(t, gotRole.GetMetadata().Labels[types.TeleportDowngradedLabel])
-							require.NotSame(t, role, gotRole)
-							// The labels map is a pointer, so make sure it's was properly
-							// cloned.
-							require.NotSame(t, role.GetMetadata().Labels, gotRole.GetMetadata().Labels)
 						}
 					}
 					checkErr := func(err error) {
@@ -4155,6 +4154,15 @@ func TestRoleVersions(t *testing.T) {
 						} else {
 							require.NoError(t, err)
 						}
+					}
+
+					// Call maybeDowngrade directly to make sure the original
+					// role isn't modified
+					sv, err := semver.NewVersion(clientVersion)
+					if err == nil {
+						_, err := maybeDowngradeRoleToV6(ctx, role.(*types.RoleV6), sv)
+						require.NoError(t, err)
+						require.Equal(t, originalLabels, role.GetMetadata().Labels)
 					}
 				})
 			}


### PR DESCRIPTION
Fix panic caused by improper clone of `RoleV6` when downgrading. This PR forces a clone before downgrading it.

Fixes #35229

Changelog: Fixed a possible panic when downgrading Teleport Roles to older versions.