### PR TITLE
[v14] Correctly clone RoleV6 when downgrading

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2013,6 +2013,11 @@ func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6,
 	if !clientVersion.LessThan(minSupportedLabelExpressionVersion) {
 		return role, nil
 	}
+	// Make a shallow copy of the role so that we don't mutate the original.
+	// This is necessary because the role is stored in the backend and it's shared
+	// between multiple clients sessions.
+	// If we mutate the original role, it will be mutated for all clients
+	// which can cause panics since it causes a race condition.
 	role = apiutils.CloneProtoMsg(role)
 	hasLabelExpression := false
 	for _, kind := range types.LabelMatcherKinds {
@@ -2088,6 +2093,11 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 		return r, false, nil
 	case types.V7:
 		var restricted bool
+		// Make a shallow copy of the role so that we don't mutate the original.
+		// This is necessary because the role is stored in the backend and it's shared
+		// between multiple clients sessions.
+		// If we mutate the original role, it will be mutated for all clients
+		// which can cause panics since it causes a race condition.
 		downgraded := apiutils.CloneProtoMsg(r)
 		downgraded.Version = types.V6
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2014,8 +2014,8 @@ func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6,
 		return role, nil
 	}
 	// Make a shallow copy of the role so that we don't mutate the original.
-	// This is necessary because the role is stored in the backend and it's shared
-	// between multiple clients sessions.
+	// This is necessary because the role is shared
+	// between multiple clients sessions when notifying about changes in watchers.
 	// If we mutate the original role, it will be mutated for all clients
 	// which can cause panics since it causes a race condition.
 	role = apiutils.CloneProtoMsg(role)
@@ -2094,8 +2094,8 @@ func downgradeRoleToV6(r *types.RoleV6) (*types.RoleV6, bool, error) {
 	case types.V7:
 		var restricted bool
 		// Make a shallow copy of the role so that we don't mutate the original.
-		// This is necessary because the role is stored in the backend and it's shared
-		// between multiple clients sessions.
+		// This is necessary because the role is shared
+		// between multiple clients sessions when notifying about changes in watchers.
 		// If we mutate the original role, it will be mutated for all clients
 		// which can cause panics since it causes a race condition.
 		downgraded := apiutils.CloneProtoMsg(r)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -4108,6 +4108,9 @@ func TestRoleVersions(t *testing.T) {
 
 	newRole := func(version string, spec types.RoleSpecV6) types.Role {
 		role, err := types.NewRoleWithVersion("test_rule", version, spec)
+		meta := role.GetMetadata()
+		meta.Labels = map[string]string{"env": "staging"}
+		role.SetMetadata(meta)
 		require.NoError(t, err)
 		return role
 	}
@@ -4250,6 +4253,10 @@ func TestRoleVersions(t *testing.T) {
 						// and ignore it in the role diff.
 						if tc.expectDowngraded {
 							require.NotEmpty(t, gotRole.GetMetadata().Labels[types.TeleportDowngradedLabel])
+							require.NotSame(t, role, gotRole)
+							// The labels map is a pointer, so make sure it's was properly
+							// cloned.
+							require.NotSame(t, role.GetMetadata().Labels, gotRole.GetMetadata().Labels)
 						}
 					}
 					checkErr := func(err error) {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -4106,10 +4108,11 @@ func TestRoleVersions(t *testing.T) {
 
 	wildcardLabels := types.Labels{types.Wildcard: {types.Wildcard}}
 
+	originalLabels := map[string]string{"env": "staging"}
 	newRole := func(version string, spec types.RoleSpecV6) types.Role {
 		role, err := types.NewRoleWithVersion("test_rule", version, spec)
 		meta := role.GetMetadata()
-		meta.Labels = map[string]string{"env": "staging"}
+		meta.Labels = maps.Clone(originalLabels)
 		role.SetMetadata(meta)
 		require.NoError(t, err)
 		return role
@@ -4253,10 +4256,6 @@ func TestRoleVersions(t *testing.T) {
 						// and ignore it in the role diff.
 						if tc.expectDowngraded {
 							require.NotEmpty(t, gotRole.GetMetadata().Labels[types.TeleportDowngradedLabel])
-							require.NotSame(t, role, gotRole)
-							// The labels map is a pointer, so make sure it's was properly
-							// cloned.
-							require.NotSame(t, role.GetMetadata().Labels, gotRole.GetMetadata().Labels)
 						}
 					}
 					checkErr := func(err error) {
@@ -4331,6 +4330,15 @@ func TestRoleVersions(t *testing.T) {
 						} else {
 							require.NoError(t, err)
 						}
+					}
+
+					// Call maybeDowngrade directly to make sure the original
+					// role isn't modified
+					sv, err := semver.NewVersion(clientVersion)
+					if err == nil {
+						_, err := maybeDowngradeRoleToV6(ctx, role.(*types.RoleV6), sv)
+						require.NoError(t, err)
+						require.Equal(t, originalLabels, role.GetMetadata().Labels)
 					}
 				})
 			}


### PR DESCRIPTION
Backport  #35230 to branch/v14

Changelog: Fixed a possible panic when downgrading Teleport Roles to older versions.