### PR TITLE
[v12] build: Copy release artifacts to release directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ TELEPORT_DEBUG ?= false
 GITTAG=v$(VERSION)
 CGOFLAG ?= CGO_ENABLED=1
 
+# RELEASE_DIR is where the release artifacts (tarballs, pacakges, etc) are put. It
+# should be an absolute directory as it is used by e/Makefile too, from the e/ directory.
+RELEASE_DIR := $(CURDIR)/$(BUILDDIR)/artifacts
+
 # When TELEPORT_DEBUG is true, set flags to produce
 # debugger-friendly builds.
 ifeq ("$(TELEPORT_DEBUG)","true")
@@ -387,6 +391,11 @@ clean-ui:
 #
 # make release - Produces a binary release tarball.
 #
+
+# RELEASE_DIR is where release artifact files are put, such as tarballs, packages, etc.
+$(RELEASE_DIR):
+	mkdir $@
+
 .PHONY:
 export
 release:
@@ -420,7 +429,7 @@ release-arm64:
 # make build-archive - Packages the results of a build into a release tarball
 #
 .PHONY: build-archive
-build-archive:
+build-archive: | $(RELEASE_DIR)
 	@echo "---> Creating OSS release archive."
 	mkdir teleport
 	cp -rf $(BUILDDIR)/* \
@@ -431,6 +440,7 @@ build-archive:
 		teleport/
 	echo $(GITTAG) > teleport/VERSION
 	tar $(TAR_FLAGS) -c teleport | gzip -n > $(RELEASE).tar.gz
+	cp $(RELEASE).tar.gz $(RELEASE_DIR)
 	rm -rf teleport
 	@echo "---> Created $(RELEASE).tar.gz."
 
@@ -537,11 +547,14 @@ release-windows: release-windows-unsigned
 # details.
 #
 .PHONY: release-connect
-release-connect:
+release-connect: | $(RELEASE_DIR)
 	$(eval export CSC_NAME)
 	yarn install --frozen-lockfile
 	yarn build-term
 	yarn package-term -c.extraMetadata.version=$(VERSION)
+	if [ -n "$$CONNECT_TSH_APP_PATH" ]; then \
+		cp web/packages/teleterm/build/release/"Teleport Connect-"*.dmg $(RELEASE_DIR); \
+	fi
 
 #
 # Remove trailing whitespace in all markdown files under docs/.
@@ -1135,7 +1148,7 @@ endif
 
 # build .pkg
 .PHONY: pkg
-pkg:
+pkg: | $(RELEASE_DIR)
 	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
@@ -1143,15 +1156,17 @@ pkg:
 	# arch and runtime are currently ignored on OS X
 	# we pass them through for consistency - they will be dropped by the build script
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p pkg -b $(TELEPORT_BUNDLEID) -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
+	cp $(BUILDDIR)/teleport-*.pkg $(RELEASE_DIR)
 	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi
 
 # build tsh client-only .pkg
 .PHONY: pkg-tsh
-pkg-tsh:
+pkg-tsh: | $(RELEASE_DIR)
 	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
 	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) $(TARBALL_PATH_SECTION)
 	mkdir -p $(BUILDDIR)/
 	mv tsh*.pkg* $(BUILDDIR)/
+	cp $(BUILDDIR)/tsh-*.pkg $(RELEASE_DIR)
 
 # build .rpm
 .PHONY: rpm


### PR DESCRIPTION
Copy the tarball and mac packages/dmgs release artifacts to a release
artifact directory so that the CI scripts do not have to. This makes it
clearer what is and is not a release artifact and puts the logic in the
Makefile instead of the CI yaml, so it can more easily be tested locally
and to make it easier to migrate to the next CI system.

Backport: https://github.com/gravitational/teleport/pull/25460 (partial)
Companion: https://github.com/gravitational/teleport.e/pull/2804

---

This is a partial backport - just the first commit - of #25460.This PR
added universal mac builds which was not backported to v12. However it
also added the RELEASE_DIR to the Makefile which is needed for the
GitHub Actions workflow, so I'm backporting just that commit.

I will likely also update the e ref in the PR once the companion PR is merged.