### PR TITLE
Emit DiscoveryFetch Event

### DIFF
--- a/lib/srv/discovery/common/interfaces.go
+++ b/lib/srv/discovery/common/interfaces.go
@@ -30,6 +30,9 @@ type Fetcher interface {
 	Get(ctx context.Context) (types.ResourcesWithLabels, error)
 	// ResourceType identifies the resource type the fetcher is returning.
 	ResourceType() string
+	// FetcherType identifies the Fetcher Type (cloud resource name).
+	// Eg, ec2, rds, aks, gce
+	FetcherType() string
 	// Cloud returns the cloud the fetcher is operating.
 	Cloud() string
 }

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -163,6 +163,10 @@ func (m *mockFetcher) ResourceType() string {
 	return m.resourceType
 }
 
+func (m *mockFetcher) FetcherType() string {
+	return "empty"
+}
+
 func (m *mockFetcher) Cloud() string {
 	return m.cloud
 }

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -105,7 +105,11 @@ func (s *Server) getAllDatabaseFetchers() []common.Fetcher {
 	}
 	s.muDynamicDatabaseFetchers.RUnlock()
 
-	return append(allFetchers, s.databaseFetchers...)
+	allFetchers = append(allFetchers, s.databaseFetchers...)
+
+	s.submitFetchersEvent(allFetchers)
+
+	return allFetchers
 }
 
 func (s *Server) getCurrentDatabases() types.ResourcesWithLabelsMap {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1058,9 +1058,11 @@ func (s *Server) emitUsageEvents(events map[string]*usageeventsv1.ResourceCreate
 }
 
 func (s *Server) submitFetchersEvent(fetchers []common.Fetcher) {
-	// Some Matcher types have multiple fetchers.
-	// Eg, rds Matcher converts into `rds` and `aurora` Fetchers
-	// The Fetch Event is meant to represent the configured matcher type: rds
+	// Some Matcher Types have multiple fetchers, but we only care about the Matcher Type and not the actual Fetcher.
+	// Example:
+	// The `rds` Matcher Type creates two Fetchers: one for RDS and another one for Aurora
+	// Those fetchers's `FetcherType` both return `rds`, so we end up with two entries for `rds`.
+	// We must de-duplicate those entries before submitting the event.
 	type fetcherType struct {
 		cloud       string
 		fetcherType string

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -114,20 +114,35 @@ func (me *mockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEve
 }
 
 type mockUsageReporter struct {
-	mu          sync.Mutex
-	eventsCount int
+	mu                       sync.Mutex
+	resourceAddedEventCount  int
+	discoveryFetchEventCount int
 }
 
 func (m *mockUsageReporter) AnonymizeAndSubmit(events ...usagereporter.Anonymizable) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.eventsCount++
+	for _, e := range events {
+		switch e.(type) {
+		case *usagereporter.ResourceCreateEvent:
+			m.resourceAddedEventCount++
+		case *usagereporter.DiscoveryFetchEvent:
+			fmt.Printf("EVENT\n %+v\n\n", e)
+			m.discoveryFetchEventCount++
+		}
+	}
 }
 
-func (m *mockUsageReporter) EventsCount() int {
+func (m *mockUsageReporter) ResourceCreateEventCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.eventsCount
+	return m.resourceAddedEventCount
+}
+
+func (m *mockUsageReporter) DiscoveryFetchEventCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.discoveryFetchEventCount
 }
 
 type mockEC2Client struct {
@@ -504,13 +519,14 @@ func TestDiscoveryServer(t *testing.T) {
 				require.Eventually(t, func() bool {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
-					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.EventsCount()
+					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
 				}, 5000*time.Millisecond, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
-					return len(installer.GetInstalledInstances()) > 0 || reporter.EventsCount() > 0
+					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
+			require.Equal(t, 1, reporter.DiscoveryFetchEventCount())
 		})
 	}
 }
@@ -1047,11 +1063,11 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 
 			if tc.wantEvents > 0 {
 				require.Eventually(t, func() bool {
-					return reporter.EventsCount() == tc.wantEvents
+					return reporter.ResourceCreateEventCount() == tc.wantEvents
 				}, time.Second, 100*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
-					return reporter.EventsCount() != 0
+					return reporter.ResourceCreateEventCount() != 0
 				}, time.Second, 100*time.Millisecond)
 			}
 		})
@@ -1785,11 +1801,11 @@ func TestDiscoveryDatabase(t *testing.T) {
 
 			if tc.wantEvents > 0 {
 				require.Eventually(t, func() bool {
-					return reporter.EventsCount() == tc.wantEvents
+					return reporter.ResourceCreateEventCount() == tc.wantEvents
 				}, time.Second, 100*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
-					return reporter.EventsCount() != 0
+					return reporter.ResourceCreateEventCount() != 0
 				}, time.Second, 100*time.Millisecond)
 			}
 		})
@@ -1866,6 +1882,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		t.Fatal("Didn't receive reconcile event after 1s")
 	}
 
+	require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is not fetchers actually being called")
+
 	// Adding a Dynamic Matcher for a different Discovery Group, should not bring any new resources.
 	t.Run("DiscoveryGroup does not match: matcher is not loaded", func(t *testing.T) {
 		// Create a Dynamic matcher
@@ -1902,6 +1920,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("Didn't receive reconcile event after 1s")
 		}
+
+		require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is not fetchers actually being called")
 	})
 
 	t.Run("New DiscoveryConfig with valid Group", func(t *testing.T) {
@@ -1927,6 +1947,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			return len(srv.dynamicDatabaseFetchers) > 0
 		}, 1*time.Second, 100*time.Millisecond)
 
+		require.Equal(t, 0, reporter.DiscoveryFetchEventCount())
 		// Advance clock to trigger a poll.
 		clock.Advance(5 * time.Minute)
 
@@ -1943,6 +1964,18 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("Didn't receive reconcile event after 1s")
 		}
+		require.Equal(t, 1, reporter.DiscoveryFetchEventCount())
+
+		// Advance clock to trigger a poll.
+		clock.Advance(5 * time.Minute)
+		// Wait for the cycle to complete
+		select {
+		case <-waitForReconcile:
+		case <-time.After(time.Second):
+			t.Fatal("Didn't receive reconcile event after 1s")
+		}
+		// A new DiscoveryFetch event must have been emitted.
+		require.Equal(t, 2, reporter.DiscoveryFetchEventCount())
 
 		t.Run("removing the DiscoveryConfig: fetcher is removed and database is removed", func(t *testing.T) {
 			// Remove DiscoveryConfig
@@ -1966,6 +1999,9 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("Didn't receive reconcile event after 1s")
 			}
+
+			// Given that no Fetch was issued, the counter should not increment.
+			require.Equal(t, 2, reporter.DiscoveryFetchEventCount())
 		})
 	})
 }
@@ -2314,11 +2350,11 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.Eventually(t, func() bool {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
-					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.EventsCount()
+					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
-					return len(installer.GetInstalledInstances()) > 0 || reporter.EventsCount() > 0
+					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
 		})
@@ -2567,11 +2603,11 @@ func TestGCPVMDiscovery(t *testing.T) {
 				require.Eventually(t, func() bool {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
-					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.EventsCount()
+					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
-					return len(installer.GetInstalledInstances()) > 0 || reporter.EventsCount() > 0
+					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
 
@@ -2671,20 +2707,20 @@ func TestEmitUsageEvents(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 0, reporter.EventsCount())
+	require.Equal(t, 0, reporter.ResourceCreateEventCount())
 	// Check that events are emitted for new instances.
 	event := &usageeventsv1.ResourceCreateEvent{}
 	require.NoError(t, server.emitUsageEvents(map[string]*usageeventsv1.ResourceCreateEvent{
 		"inst1": event,
 		"inst2": event,
 	}))
-	require.Equal(t, 2, reporter.EventsCount())
+	require.Equal(t, 2, reporter.ResourceCreateEventCount())
 	// Check that events for duplicate instances are discarded.
 	require.NoError(t, server.emitUsageEvents(map[string]*usageeventsv1.ResourceCreateEvent{
 		"inst1": event,
 		"inst3": event,
 	}))
-	require.Equal(t, 3, reporter.EventsCount())
+	require.Equal(t, 3, reporter.ResourceCreateEventCount())
 }
 
 type fakeAccessPoint struct {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -127,7 +127,6 @@ func (m *mockUsageReporter) AnonymizeAndSubmit(events ...usagereporter.Anonymiza
 		case *usagereporter.ResourceCreateEvent:
 			m.resourceAddedEventCount++
 		case *usagereporter.DiscoveryFetchEvent:
-			fmt.Printf("EVENT\n %+v\n\n", e)
 			m.discoveryFetchEventCount++
 		}
 	}
@@ -1882,7 +1881,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		t.Fatal("Didn't receive reconcile event after 1s")
 	}
 
-	require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is not fetchers actually being called")
+	require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is no fetchers actually being called")
 
 	// Adding a Dynamic Matcher for a different Discovery Group, should not bring any new resources.
 	t.Run("DiscoveryGroup does not match: matcher is not loaded", func(t *testing.T) {
@@ -1921,7 +1920,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			t.Fatal("Didn't receive reconcile event after 1s")
 		}
 
-		require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is not fetchers actually being called")
+		require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is no fetchers actually being called")
 	})
 
 	t.Run("New DiscoveryConfig with valid Group", func(t *testing.T) {
@@ -1947,7 +1946,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			return len(srv.dynamicDatabaseFetchers) > 0
 		}, 1*time.Second, 100*time.Millisecond)
 
-		require.Equal(t, 0, reporter.DiscoveryFetchEventCount())
+		require.Zero(t, reporter.DiscoveryFetchEventCount())
 		// Advance clock to trigger a poll.
 		clock.Advance(5 * time.Minute)
 

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -151,6 +151,10 @@ func (a *aksFetcher) Cloud() string {
 	return types.CloudAzure
 }
 
+func (a *aksFetcher) FetcherType() string {
+	return types.AzureMatcherKubernetes
+}
+
 func (a *aksFetcher) String() string {
 	return fmt.Sprintf("aksFetcher(ResourceGroups=%v, Regions=%v, FilterLabels=%v)",
 		a.ResourceGroups, a.Regions, a.FilterLabels)

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -155,6 +155,11 @@ func (f *awsFetcher) ResourceType() string {
 	return types.KindDatabase
 }
 
+// FetcherType returns the type (`discovery_service.aws.[].types`) of the fetcher.
+func (f *awsFetcher) FetcherType() string {
+	return f.cfg.Type
+}
+
 // String returns the fetcher's string description.
 func (f *awsFetcher) String() string {
 	return fmt.Sprintf("awsFetcher(Type: %v, Region=%v, Labels=%v)",

--- a/lib/srv/discovery/fetchers/db/azure.go
+++ b/lib/srv/discovery/fetchers/db/azure.go
@@ -144,6 +144,11 @@ func (f *azureFetcher[DBType, ListClient]) ResourceType() string {
 	return types.KindDatabase
 }
 
+// FetcherType returns the type (`discovery_service.azure.[].types`) of the fetcher.
+func (f *azureFetcher[DBType, ListClient]) FetcherType() string {
+	return f.cfg.Type
+}
+
 // Get returns Azure DB servers matching the watcher's selectors.
 func (f *azureFetcher[DBType, ListClient]) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	databases, err := f.getDatabases(ctx)

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -192,6 +192,10 @@ func (a *eksFetcher) ResourceType() string {
 	return types.KindKubernetesCluster
 }
 
+func (a *eksFetcher) FetcherType() string {
+	return types.AWSMatcherEKS
+}
+
 func (a *eksFetcher) Cloud() string {
 	return types.CloudAWS
 }

--- a/lib/srv/discovery/fetchers/gke.go
+++ b/lib/srv/discovery/fetchers/gke.go
@@ -122,6 +122,10 @@ func (a *gkeFetcher) ResourceType() string {
 	return types.KindKubernetesCluster
 }
 
+func (a *gkeFetcher) FetcherType() string {
+	return types.GCPMatcherKubernetes
+}
+
 func (a *gkeFetcher) Cloud() string {
 	return types.CloudGCP
 }

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -228,6 +228,10 @@ func (f *KubeAppFetcher) Cloud() string {
 	return ""
 }
 
+func (f *KubeAppFetcher) FetcherType() string {
+	return types.KubernetesMatchersApp
+}
+
 func (f *KubeAppFetcher) String() string {
 	return fmt.Sprintf("KubeAppFetcher(Namespaces=%v, Labels=%v)", f.Namespaces, f.FilterLabels)
 }


### PR DESCRIPTION
When a Discovery Service performs a Fetch event, it will emit a DiscoveryFetchEvent.

Each Event contains the cloud provider and the fetcher type. Fetcher type is the resource type as defined in the Matcher. Eg, rds, ec2, aks, gce