### PR TITLE
Handle clicking on a label inside `UnifiedResources`

### DIFF
--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -128,7 +128,6 @@ const story = ({
         pinning={pinning}
         unifiedResourcePreferences={userPrefs}
         updateUnifiedResourcesPreferences={setUserPrefs}
-        onLabelClick={() => undefined}
         NoResources={undefined}
         fetchResources={fetch}
         resourcesFetchAttempt={attempt}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -30,7 +30,7 @@ import { Danger } from 'design/Alert';
 
 import './unifiedStyles.css';
 
-import { ResourcesResponse, ResourceLabel } from 'teleport/services/agents';
+import { ResourcesResponse } from 'teleport/services/agents';
 
 import {
   DefaultTab,

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -49,6 +49,7 @@ import {
   useInfiniteScroll,
 } from 'shared/hooks/useInfiniteScroll';
 import { Attempt } from 'shared/hooks/useAttemptNext';
+import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
 import {
   SharedUnifiedResource,
@@ -132,7 +133,6 @@ interface UnifiedResourcesProps {
   pinning: UnifiedResourcesPinning;
   availableKinds: FilterKind[];
   setParams(params: UnifiedResourcesQueryParams): void;
-  onLabelClick(label: ResourceLabel): void;
   /** A list of actions that can be performed on the selected items. */
   bulkActions?: BulkAction[];
   unifiedResourcePreferences: UnifiedResourcePreferences;
@@ -148,7 +148,6 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     resourcesFetchAttempt,
     resources,
     fetchResources,
-    onLabelClick,
     availableKinds,
     pinning,
     unifiedResourcePreferences,
@@ -440,7 +439,13 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         <PinningNotSupported />
       ) : (
         <ViewComponent
-          onLabelClick={onLabelClick}
+          onLabelClick={label =>
+            setParams({
+              ...params,
+              search: '',
+              query: makeAdvancedSearchQueryForLabel(label, params),
+            })
+          }
           pinnedResources={pinnedResources}
           selectedResources={selectedResources}
           onSelectResource={handleSelectResource}

--- a/web/packages/shared/utils/advancedSearchLabelQuery.ts
+++ b/web/packages/shared/utils/advancedSearchLabelQuery.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function makeAdvancedSearchQueryForLabel(
+  label: {
+    name: string;
+    value: string;
+  },
+  params: {
+    /** Contains search words/phrases separated by space. */
+    search?: string;
+    /** Query expression using the predicate language. */
+    query?: string;
+  }
+): string {
+  const queryParts: string[] = [];
+
+  // Add an existing query.
+  if (params.query) {
+    queryParts.push(params.query);
+  }
+
+  // If there is an existing simple search, convert it to predicate language and add it.
+  if (params.search) {
+    queryParts.push(`search("${params.search}")`);
+  }
+
+  const labelQuery = `labels["${label.name}"] == "${label.value}"`;
+  queryParts.push(labelQuery);
+
+  return queryParts.join(' && ');
+}

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/ServerSideSupportedList.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/ServerSideSupportedList.tsx
@@ -22,6 +22,8 @@ import { SearchPanel } from 'shared/components/Search';
 import { StyledArrowBtn } from 'design/DataTable/Pager/StyledPager';
 import { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
 
+import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
+
 import { Desktop } from 'teleport/services/desktops';
 import { Node } from 'teleport/services/nodes';
 import { useServerSidePagination } from 'teleport/components/hooks';
@@ -90,7 +92,7 @@ export function ServerSideSupportedList(props: CommonListProps) {
   }
 
   function onResourceLabelClick(label: ResourceLabel) {
-    const query = addResourceLabelToQuery(resourceFilter, label);
+    const query = makeAdvancedSearchQueryForLabel(label, resourceFilter);
     setResourceFilter({ ...resourceFilter, search: '', query });
   }
 
@@ -188,24 +190,4 @@ function getFetchFuncForServerSidePaginating(
   if (resourceKind === 'windows_desktop') {
     return ctx.desktopService.fetchDesktops;
   }
-}
-
-function addResourceLabelToQuery(filter: ResourceFilter, label: ResourceLabel) {
-  const queryParts = [];
-
-  // Add existing query
-  if (filter.query) {
-    queryParts.push(filter.query);
-  }
-
-  // If there is an existing simple search,
-  // convert it to predicate language and add it
-  if (filter.search) {
-    queryParts.push(`search("${filter.search}")`);
-  }
-
-  // Create the label query.
-  queryParts.push(`labels["${label.name}"] == "${label.value}"`);
-
-  return queryParts.join(' && ');
 }

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -108,16 +108,15 @@ function ClusterResources({
   } = useUser();
   const canCreate = teleCtx.storeUser.getTokenAccess().create;
 
-  const { params, setParams, replaceHistory, pathname, onLabelClick } =
-    useUrlFiltering({
-      sort: {
-        fieldName: 'name',
-        dir: 'ASC',
-      },
-      pinnedOnly:
-        preferences.unifiedResourcePreferences.defaultTab ===
-        DefaultTab.DEFAULT_TAB_PINNED,
-    });
+  const { params, setParams, replaceHistory, pathname } = useUrlFiltering({
+    sort: {
+      fieldName: 'name',
+      dir: 'ASC',
+    },
+    pinnedOnly:
+      preferences.unifiedResourcePreferences.defaultTab ===
+      DefaultTab.DEFAULT_TAB_PINNED,
+  });
 
   const getCurrentClusterPinnedResources = useCallback(
     () => getClusterPinnedResources(clusterId),
@@ -210,7 +209,6 @@ function ClusterResources({
         }}
         availableKinds={getAvailableKindsWithAccess(flags)}
         pinning={pinning}
-        onLabelClick={onLabelClick}
         NoResources={
           <Empty
             clusterId={clusterId}
@@ -226,13 +224,14 @@ function ClusterResources({
         }))}
         setParams={newParams => {
           setParams(newParams);
+          const isAdvancedSearch = !!newParams.query;
           replaceHistory(
             encodeUrlQueryParams(
               pathname,
-              newParams.search,
+              isAdvancedSearch ? newParams.query : newParams.search,
               newParams.sort,
               newParams.kinds,
-              !!newParams.query /* isAdvancedSearch */,
+              isAdvancedSearch,
               newParams.pinnedOnly
             )
           );

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -18,6 +18,8 @@ import { useState } from 'react';
 import { useLocation } from 'react-router';
 import { SortType } from 'design/DataTable/types';
 
+import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
+
 import history from 'teleport/services/history';
 import { ResourceFilter, ResourceLabel } from 'teleport/services/agents';
 
@@ -52,7 +54,7 @@ export function useUrlFiltering(
   }
 
   const onLabelClick = (label: ResourceLabel) => {
-    const queryAfterLabelClick = labelClickQuery(label, params);
+    const queryAfterLabelClick = makeAdvancedSearchQueryForLabel(label, params);
 
     setParams({ ...params, search: '', query: queryAfterLabelClick });
     replaceHistory(
@@ -110,25 +112,4 @@ export default function getResourceUrlQueryParams(
     // Conditionally adds the pinnedResources field based on whether its true or not
     ...(pinnedOnly === 'true' && { pinnedOnly: true }),
   };
-}
-
-function labelClickQuery(label: ResourceLabel, params: ResourceFilter) {
-  const queryParts: string[] = [];
-
-  // Add existing query
-  if (params.query) {
-    queryParts.push(params.query);
-  }
-
-  // If there is an existing simple search, convert it to predicate language and add it
-  if (params.search) {
-    queryParts.push(`search("${params.search}")`);
-  }
-
-  const labelQuery = `labels["${label.name}"] == "${label.value}"`;
-  queryParts.push(labelQuery);
-
-  const finalQuery = queryParts.join(' && ');
-
-  return finalQuery;
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -187,6 +187,7 @@ function Resources(props: {
       queryParams.resourceKinds =
         newParams.kinds as DocumentClusterResourceKind[];
       queryParams.search = newParams.search || newParams.query;
+      queryParams.advancedSearchEnabled = !!newParams.query;
     });
   }
 
@@ -196,7 +197,6 @@ function Resources(props: {
       setParams={onParamsChange}
       unifiedResourcePreferences={props.userPreferences}
       updateUnifiedResourcesPreferences={props.setUserPreferences}
-      onLabelClick={() => alert('Not implemented')}
       pinning={{ kind: 'hidden' }}
       resources={resources.map(mapToSharedResource)}
       resourcesFetchAttempt={attempt}


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/30422

e counterpart https://github.com/gravitational/teleport.e/pull/2813

Currently the `UnifiedResources` component exposes a `onLabelClick` prop. The task of that prop is to create an advanced search query for the clicked label and then update the query params. 
This requires every callsite to provide such implementation.
Instead of doing that, we can just call `setParams` inside `UnifiedResources` with the updated `search` and `query` since we have access to them.
Thanks to this, I won't have to add another implementation for Connect.

I also extracted a single implementation of `makeAdvancedSearchQueryForLabel` function, we had a few copies of it in the codebase.