### PR TITLE
[v13] Adjust GetAccessRequest to only require DynamicAccessCore.

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -689,7 +689,7 @@ ProcessReviews:
 }
 
 // GetAccessRequest is a helper function assists with loading a specific request by ID.
-func GetAccessRequest(ctx context.Context, acc DynamicAccess, reqID string) (types.AccessRequest, error) {
+func GetAccessRequest(ctx context.Context, acc DynamicAccessCore, reqID string) (types.AccessRequest, error) {
 	reqs, err := acc.GetAccessRequests(ctx, types.AccessRequestFilter{
 		ID: reqID,
 	})


### PR DESCRIPTION
The GetAccessRequest function only requires DynamicAccessCore, so the function signature has been changed to reflect this.

Note: This is not needed in master/v14, as this change came over as part of a Slack notification rework.