### PR TITLE
Switch to webclient.Find from webclient.Ping for `tbot`

### DIFF
--- a/lib/tbot/impersonated_identity.go
+++ b/lib/tbot/impersonated_identity.go
@@ -675,7 +675,9 @@ func (drc *outputRenewalCache) proxyPing(ctx context.Context) (*webclient.PingRe
 		return nil, trace.Wrap(err)
 	}
 
-	proxyPong, err := webclient.Ping(&webclient.Config{
+	// We use find instead of Ping as it's less resource intense and we can
+	// ping the AuthServer directly for its configuration if necessary.
+	proxyPong, err := webclient.Find(&webclient.Config{
 		Context:   ctx,
 		ProxyAddr: authPong.ProxyPublicAddr,
 		Insecure:  drc.cfg.Insecure,


### PR DESCRIPTION
Fixes generation of Kubernetes outputs when Auth Server is misconfigured. It's also more performant.

changelog: improves the resilience of `tbot` to misconfiguration of auth connectors when generating a Kubernetes output.