### PR TITLE
Fixed "fix-license" makefile target for AGPL-v3 change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1079,7 +1079,7 @@ lint-helm:
 	$(MAKE) -C examples/chart check-chart-ref
 
 ADDLICENSE := $(GOPATH)/bin/addlicense
-ADDLICENSE_ARGS := -c 'Gravitational, Inc' -l apache \
+ADDLICENSE_COMMON_ARGS := -c 'Gravitational, Inc.' \
 		-ignore '**/*.c' \
 		-ignore '**/*.h' \
 		-ignore '**/*.html' \
@@ -1104,14 +1104,21 @@ ADDLICENSE_ARGS := -c 'Gravitational, Inc' -l apache \
 		-ignore 'web/packages/design/src/assets/icomoon/style.css' \
 		-ignore '**/.terraform.lock.hcl' \
 		-ignore 'ignoreme'
+ADDLICENSE_AGPL3_ARGS := $(ADDLICENSE_COMMON_ARGS) \
+		-ignore 'api/**' \
+		-f $(CURDIR)/build.assets/LICENSE.header
+ADDLICENSE_APACHE2_ARGS := $(ADDLICENSE_COMMON_ARGS) \
+		-l apache
 
 .PHONY: lint-license
 lint-license: $(ADDLICENSE)
-	$(ADDLICENSE) $(ADDLICENSE_ARGS) -check * 2>/dev/null
+	$(ADDLICENSE) $(ADDLICENSE_AGPL3_ARGS) -check * 2>/dev/null
+	$(ADDLICENSE) $(ADDLICENSE_APACHE2_ARGS) -check api/* 2>/dev/null
 
 .PHONY: fix-license
 fix-license: $(ADDLICENSE)
-	$(ADDLICENSE) $(ADDLICENSE_ARGS) * 2>/dev/null
+	$(ADDLICENSE) $(ADDLICENSE_AGPL3_ARGS) * 2>/dev/null
+	$(ADDLICENSE) $(ADDLICENSE_APACHE2_ARGS) api/* 2>/dev/null
 
 $(ADDLICENSE):
 	cd && go install github.com/google/addlicense@v1.0.0


### PR DESCRIPTION
Forgot to include this minor change in the original license update PR. This is a minor fix for the "fix-license" and "check-license" makefile targets to make them work properly with the AGPL-v3 change.