### PR TITLE
feat!: Apply role device mode to App Access

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -427,7 +427,10 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		AccessPoint: srv.AuthServer,
 		LockWatcher: srv.LockWatcher,
 		// AuthServer does explicit device authorization checks.
-		DisableDeviceAuthorization: true,
+		DeviceAuthorization: authz.DeviceAuthorizationOpts{
+			DisableGlobalMode: true,
+			DisableRoleMode:   true,
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -60,6 +60,17 @@ func NewBuiltinRoleContext(role types.SystemRole) (*Context, error) {
 	return authContext, nil
 }
 
+// DeviceAuthorizationOpts captures Device Trust options for [AuthorizerOpts].
+type DeviceAuthorizationOpts struct {
+	// DisableGlobalMode disables the global device_trust.mode toggle.
+	// See [types.DeviceTrust.Mode].
+	DisableGlobalMode bool
+
+	// DisableRoleMode disables the role-based device trust toggle.
+	// See [types.RoleOption.DeviceTrustMode].
+	DisableRoleMode bool
+}
+
 // AuthorizerOpts holds creation options for [NewAuthorizer].
 type AuthorizerOpts struct {
 	ClusterName string
@@ -70,7 +81,14 @@ type AuthorizerOpts struct {
 	// DisableDeviceAuthorization disables device authorization via [Authorizer].
 	// It is meant for services that do explicit device authorization, like the
 	// Auth Server APIs. Most services should not set this field.
+	//
+	// DisableDeviceAuthorization is equivalent to both
+	// DeviceAuthorization.DisableGlobalAuthz=true and
+	// DeviceAuthorization.DisableRoleAuthz=true.
 	DisableDeviceAuthorization bool
+
+	// DeviceAuthorization holds Device Trust authorization options.
+	DeviceAuthorization DeviceAuthorizationOpts
 }
 
 // NewAuthorizer returns new authorizer using backends
@@ -86,11 +104,12 @@ func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
 		logger = logrus.WithFields(logrus.Fields{trace.Component: "authorizer"})
 	}
 	return &authorizer{
-		clusterName:                opts.ClusterName,
-		accessPoint:                opts.AccessPoint,
-		lockWatcher:                opts.LockWatcher,
-		logger:                     logger,
-		disableDeviceAuthorization: opts.DisableDeviceAuthorization,
+		clusterName:             opts.ClusterName,
+		accessPoint:             opts.AccessPoint,
+		lockWatcher:             opts.LockWatcher,
+		logger:                  logger,
+		disableGlobalDeviceMode: opts.DisableDeviceAuthorization || opts.DeviceAuthorization.DisableGlobalMode,
+		disableRoleDeviceMode:   opts.DisableDeviceAuthorization || opts.DeviceAuthorization.DisableRoleMode,
 	}, nil
 }
 
@@ -144,11 +163,13 @@ type AuthorizerAccessPoint interface {
 
 // authorizer creates new local authorizer
 type authorizer struct {
-	clusterName                string
-	accessPoint                AuthorizerAccessPoint
-	lockWatcher                *services.LockWatcher
-	disableDeviceAuthorization bool
-	logger                     logrus.FieldLogger
+	clusterName string
+	accessPoint AuthorizerAccessPoint
+	lockWatcher *services.LockWatcher
+	logger      logrus.FieldLogger
+
+	disableGlobalDeviceMode bool
+	disableRoleDeviceMode   bool
 }
 
 // Context is authorization context
@@ -170,9 +191,9 @@ type Context struct {
 	// it's identical to Identity.
 	UnmappedIdentity IdentityGetter
 
-	// disableDeviceAuthorization disables device verification.
+	// disableDeviceRoleMode disables role-based device verification.
 	// Inherited from the authorizer that creates the context.
-	disableDeviceAuthorization bool
+	disableDeviceRoleMode bool
 
 	// AdminActionVerified is whether this auth request is verified for admin actions. This
 	// either means that the request was MFA verified through the context or Hardware Key support,
@@ -262,7 +283,7 @@ func (c *Context) GetAccessState(authPref types.AuthPreference) services.AccessS
 	_, isService := c.Identity.(BuiltinRole)
 	state.MFAVerified = isService || identity.IsMFAVerified()
 
-	state.EnableDeviceVerification = !c.disableDeviceAuthorization
+	state.EnableDeviceVerification = !c.disableDeviceRoleMode
 	state.DeviceVerified = isService || dtauthz.IsTLSDeviceVerified(&identity.DeviceExtensions)
 
 	return state
@@ -303,7 +324,7 @@ func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
 	}
 
 	// Device Trust: authorize device extensions.
-	if !a.disableDeviceAuthorization {
+	if !a.disableGlobalDeviceMode {
 		if err := dtauthz.VerifyTLSUser(authPref.GetDeviceTrust(), authContext.Identity.GetIdentity()); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -484,7 +505,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 
 // authorizeLocalUser returns authz context based on the username
 func (a *authorizer) authorizeLocalUser(ctx context.Context, u LocalUser) (*Context, error) {
-	return ContextForLocalUser(ctx, u, a.accessPoint, a.clusterName, a.disableDeviceAuthorization)
+	return ContextForLocalUser(ctx, u, a.accessPoint, a.clusterName, a.disableRoleDeviceMode)
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
@@ -569,11 +590,11 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 	}
 
 	return &Context{
-		User:                       user,
-		Checker:                    checker,
-		Identity:                   WrapIdentity(identity),
-		UnmappedIdentity:           u,
-		disableDeviceAuthorization: a.disableDeviceAuthorization,
+		User:                  user,
+		Checker:               checker,
+		Identity:              WrapIdentity(identity),
+		UnmappedIdentity:      u,
+		disableDeviceRoleMode: a.disableRoleDeviceMode,
 	}, nil
 }
 
@@ -647,11 +668,11 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 		AllowedResourceIDs: nil,
 	}, a.clusterName, roleSet)
 	return &Context{
-		User:                       user,
-		Checker:                    checker,
-		Identity:                   r,
-		UnmappedIdentity:           r,
-		disableDeviceAuthorization: a.disableDeviceAuthorization,
+		User:                  user,
+		Checker:               checker,
+		Identity:              r,
+		UnmappedIdentity:      r,
+		disableDeviceRoleMode: a.disableRoleDeviceMode,
 	}, nil
 }
 
@@ -1074,16 +1095,16 @@ func ContextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig
 		AllowedResourceIDs: nil,
 	}, r.ClusterName, roleSet)
 	return &Context{
-		User:                       user,
-		Checker:                    checker,
-		Identity:                   r,
-		UnmappedIdentity:           r,
-		disableDeviceAuthorization: true, // Builtin roles skip device trust.
+		User:                  user,
+		Checker:               checker,
+		Identity:              r,
+		UnmappedIdentity:      r,
+		disableDeviceRoleMode: true, // Builtin roles skip device trust.
 	}, nil
 }
 
 // ContextForLocalUser returns a context with the local user info embedded.
-func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceAuthz bool) (*Context, error) {
+func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceRoleMode bool) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
 	user, err := accessPoint.GetUser(ctx, u.Username, false)
 	if err != nil {
@@ -1108,11 +1129,11 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	user.SetTraits(accessInfo.Traits)
 
 	return &Context{
-		User:                       user,
-		Checker:                    accessChecker,
-		Identity:                   u,
-		UnmappedIdentity:           u,
-		disableDeviceAuthorization: disableDeviceAuthz,
+		User:                  user,
+		Checker:               accessChecker,
+		Identity:              u,
+		UnmappedIdentity:      u,
+		disableDeviceRoleMode: disableDeviceRoleMode,
 	}, nil
 }
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -78,16 +78,11 @@ type AuthorizerOpts struct {
 	LockWatcher *services.LockWatcher
 	Logger      logrus.FieldLogger
 
-	// DisableDeviceAuthorization disables device authorization via [Authorizer].
-	// It is meant for services that do explicit device authorization, like the
-	// Auth Server APIs. Most services should not set this field.
-	//
-	// DisableDeviceAuthorization is equivalent to both
-	// DeviceAuthorization.DisableGlobalAuthz=true and
-	// DeviceAuthorization.DisableRoleAuthz=true.
-	DisableDeviceAuthorization bool
-
 	// DeviceAuthorization holds Device Trust authorization options.
+	//
+	// Allows services that either do explicit device authorization or don't (yet)
+	// support device trust to disable it.
+	// Most services should not set this field.
 	DeviceAuthorization DeviceAuthorizationOpts
 }
 
@@ -108,8 +103,8 @@ func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
 		accessPoint:             opts.AccessPoint,
 		lockWatcher:             opts.LockWatcher,
 		logger:                  logger,
-		disableGlobalDeviceMode: opts.DisableDeviceAuthorization || opts.DeviceAuthorization.DisableGlobalMode,
-		disableRoleDeviceMode:   opts.DisableDeviceAuthorization || opts.DeviceAuthorization.DisableRoleMode,
+		disableGlobalDeviceMode: opts.DeviceAuthorization.DisableGlobalMode,
+		disableRoleDeviceMode:   opts.DeviceAuthorization.DisableRoleMode,
 	}, nil
 }
 

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -317,11 +317,10 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 	tests := []struct {
 		name                 string
 		deviceMode           string
-		disableDeviceAuthz   bool                    // aka AuthorizerOpts.DisableDeviceAuthorization
 		deviceAuthz          DeviceAuthorizationOpts // aka AuthorizerOpts.DeviceAuthorization
 		user                 IdentityGetter
 		wantErr              string
-		wantCtxAuthnDisabled bool // defaults to disableDeviceAuthz
+		wantCtxAuthnDisabled bool // defaults to deviceAuthz.disableDeviceRoleMode
 	}{
 		{
 			name:       "user without extensions and mode=off",
@@ -333,12 +332,6 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			deviceMode: constants.DeviceTrustModeRequired,
 			user:       userWithoutExtensions,
 			wantErr:    "trusted device",
-		},
-		{
-			name:               "device authorization disabled",
-			deviceMode:         constants.DeviceTrustModeRequired,
-			disableDeviceAuthz: true,
-			user:               userWithoutExtensions,
 		},
 		{
 			name:       "global mode disabled only",
@@ -373,8 +366,11 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			wantCtxAuthnDisabled: true, // BuiltinRole ctx validation disabled by default
 		},
 		{
-			name:               "BuiltinRole: device authorization disabled",
-			disableDeviceAuthz: true,
+			name: "BuiltinRole: device authorization disabled",
+			deviceAuthz: DeviceAuthorizationOpts{
+				DisableGlobalMode: true,
+				DisableRoleMode:   true,
+			},
 			user: BuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
@@ -383,8 +379,11 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			},
 		},
 		{
-			name:               "RemoteBuiltinRole: device authorization disabled",
-			disableDeviceAuthz: true,
+			name: "RemoteBuiltinRole: device authorization disabled",
+			deviceAuthz: DeviceAuthorizationOpts{
+				DisableGlobalMode: true,
+				DisableRoleMode:   true,
+			},
 			user: RemoteBuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
@@ -408,11 +407,10 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 
 			// Create a new authorizer.
 			authorizer, err := NewAuthorizer(AuthorizerOpts{
-				ClusterName:                clusterName,
-				AccessPoint:                client,
-				LockWatcher:                watcher,
-				DisableDeviceAuthorization: test.disableDeviceAuthz,
-				DeviceAuthorization:        test.deviceAuthz,
+				ClusterName:         clusterName,
+				AccessPoint:         client,
+				LockWatcher:         watcher,
+				DeviceAuthorization: test.deviceAuthz,
 			})
 			require.NoError(t, err, "NewAuthorizer failed")
 
@@ -431,7 +429,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 
 			// Verify that the auth.Context has the correct disableDeviceAuthorization
 			// value, based on either the global toggle or role mode.
-			wantDisabled := test.disableDeviceAuthz || test.deviceAuthz.DisableRoleMode || test.wantCtxAuthnDisabled
+			wantDisabled := test.deviceAuthz.DisableRoleMode || test.wantCtxAuthnDisabled
 			assert.Equal(
 				t, wantDisabled, authCtx.disableDeviceRoleMode,
 				"auth.Context.disableDeviceAuthorization not inherited from Authorizer")

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -332,7 +332,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			name:       "nok: user without extensions and mode=required",
 			deviceMode: constants.DeviceTrustModeRequired,
 			user:       userWithoutExtensions,
-			wantErr:    "unauthorized device",
+			wantErr:    "trusted device",
 		},
 		{
 			name:               "device authorization disabled",

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -83,7 +83,7 @@ func verifyDeviceExtensions(dt *types.DeviceTrust, username string, verified boo
 		log.
 			WithField("User", username).
 			Debug("Device Trust: denied access for unidentified device")
-		return ErrTrustedDeviceRequired
+		return trace.Wrap(ErrTrustedDeviceRequired)
 	default:
 		return nil
 	}

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -32,6 +32,12 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+// ErrTrustedDeviceRequired is returned when access to a resource requires a
+// trusted device.
+var ErrTrustedDeviceRequired = &trace.AccessDeniedError{
+	Message: "access to resource requires a trusted device",
+}
+
 // IsTLSDeviceVerified returns true if ext contains all required device
 // extensions.
 func IsTLSDeviceVerified(ext *tlsca.DeviceExtensions) bool {
@@ -77,7 +83,7 @@ func verifyDeviceExtensions(dt *types.DeviceTrust, username string, verified boo
 		log.
 			WithField("User", username).
 			Debug("Device Trust: denied access for unidentified device")
-		return trace.AccessDenied("unauthorized device")
+		return ErrTrustedDeviceRequired
 	default:
 		return nil
 	}

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -139,7 +139,7 @@ func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.Device
 		assert.NoError(t, err, "%v mismatch", method)
 	}
 	assertDeniedErr := func(t *testing.T, err error) {
-		assert.ErrorContains(t, err, "unauthorized device", "%v mismatch", method)
+		assert.ErrorContains(t, err, "trusted device", "%v mismatch", method)
 		assert.True(t, trace.IsAccessDenied(err), "%v returned an error other than trace.AccessDeniedError: %T", method, err)
 	}
 

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -162,7 +162,10 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 		LockWatcher: lockWatcher,
 		Logger:      log,
 		// Device authorization breaks browser-based access.
-		DisableDeviceAuthorization: true,
+		DeviceAuthorization: authz.DeviceAuthorizationOpts{
+			DisableGlobalMode: true,
+			DisableRoleMode:   true,
+		},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1962,7 +1962,10 @@ func (process *TeleportProcess) initAuthService() error {
 		// Auth Server does explicit device authorization.
 		// Various Auth APIs must allow access to unauthorized devices, otherwise it
 		// is not possible to acquire device-aware certificates in the first place.
-		DisableDeviceAuthorization: true,
+		DeviceAuthorization: authz.DeviceAuthorizationOpts{
+			DisableGlobalMode: true,
+			DisableRoleMode:   true,
+		},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5290,8 +5290,11 @@ func (process *TeleportProcess) initApps() {
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
 			Logger:      log,
-			// Device authorization breaks browser-based access.
-			DisableDeviceAuthorization: true,
+			DeviceAuthorization: authz.DeviceAuthorizationOpts{
+				// Ignore the global device_trust.mode toggle, but allow role-based
+				// settings to be applied.
+				DisableGlobalMode: true,
+			},
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -85,15 +85,21 @@ var DefaultCertAuthorityRules = []types.Rule{
 
 // ErrTrustedDeviceRequired is returned by AccessChecker when access to a
 // resource requires a trusted device.
-var ErrTrustedDeviceRequired = trace.AccessDenied("access to resource requires a trusted device")
+var ErrTrustedDeviceRequired = &trace.AccessDeniedError{
+	Message: "access to resource requires a trusted device",
+}
 
 // ErrSessionMFARequired is returned by AccessChecker when access to a resource
 // requires an MFA check.
-var ErrSessionMFARequired = trace.AccessDenied("access to resource requires MFA")
+var ErrSessionMFARequired = &trace.AccessDeniedError{
+	Message: "access to resource requires MFA",
+}
 
 // ErrSessionMFANotRequired indicates that per session mfa will not grant
 // access to a resource.
-var ErrSessionMFANotRequired = trace.AccessDenied("MFA is not required to access resource")
+var ErrSessionMFANotRequired = &trace.AccessDeniedError{
+	Message: "MFA is not required to access resource",
+}
 
 // RoleNameForUser returns role name associated with a user.
 func RoleNameForUser(name string) string {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -3097,6 +3097,7 @@ type AccessState struct {
 	// EnableDeviceVerification enables device verification in access checks.
 	// It's recommended to set this in tandem with DeviceVerified, so device
 	// checks are easier to reason about and have a proper chance of succeeding.
+	// Used for role-based device mode checks.
 	// Defaults to false for backwards compatibility.
 	EnableDeviceVerification bool
 	// DeviceVerified is true if the user certificate contains all required

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -85,9 +86,8 @@ var DefaultCertAuthorityRules = []types.Rule{
 
 // ErrTrustedDeviceRequired is returned by AccessChecker when access to a
 // resource requires a trusted device.
-var ErrTrustedDeviceRequired = &trace.AccessDeniedError{
-	Message: "access to resource requires a trusted device",
-}
+// It's an alias to [dtauthz.ErrTrustedDeviceRequired].
+var ErrTrustedDeviceRequired = dtauthz.ErrTrustedDeviceRequired
 
 // ErrSessionMFARequired is returned by AccessChecker when access to a resource
 // requires an MFA check.

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1007,7 +1007,7 @@ func (s *Server) authorizeContext(ctx context.Context) (*authz.Context, types.Ap
 		matchers...); {
 	case errors.Is(err, services.ErrTrustedDeviceRequired):
 		// Let the trusted device error through for clarity.
-		return nil, nil, services.ErrTrustedDeviceRequired
+		return nil, nil, trace.Wrap(services.ErrTrustedDeviceRequired)
 	case err != nil:
 		s.log.WithError(err).Warnf("access denied to application %v", app.GetName())
 		return nil, nil, utils.OpaqueAccessDenied(err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -857,7 +857,7 @@ func TestAuthorize(t *testing.T) {
 			requireTrustedDevice: true,
 			wantStatus:           http.StatusForbidden,
 			assertBody: func(t *testing.T, gotBody string) bool {
-				const want = "trusted device"
+				const want = "app requires a trusted device"
 				return assert.Contains(t, gotBody, want, "response body mismatch")
 			},
 		},


### PR DESCRIPTION
Apply the role device mode, aka role.spec.options.device_trust_mode, to App Access.

Applying the role mode to App Access lets admins use fine-grained setups to require trusted devices. Access has to be done via `tsh proxy app`, as the Web UI is presently unable to authorize devices.

The "global" device toggle, configured in teleport.yaml or cluster_auth_preference, does not apply here. This is to avoid accidentally breaking all web-based access while the Web UI lacks the means to issue device-aware certificates.

https://github.com/gravitational/teleport.e/issues/2121

Changelog: BREAKING CHANGE: Allow role device_trust_mode to take effect on App Access. This may cause a behavior change if you have device_trust_mode=required roles that also target apps.