### PR TITLE
Ensure expiration of Webauthn sessions

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -23,7 +23,7 @@ import "github.com/jonboulle/clockwork"
 // SessionDataLimiter exports sdLimiter for tests.
 var SessionDataLimiter = sdLimiter
 
-// SetClock sets the identity service clock for tests.
-func (s *IdentityService) SetClock(clock clockwork.Clock) {
-	s.clock = clock
+// SetDesyncedClockForTesting sets its namesake clock in the identity service.
+func (s *IdentityService) SetDesyncedClockForTesting(clock clockwork.Clock) {
+	s.desyncedClockForTesting = clock
 }

--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -18,5 +18,12 @@
 
 package local
 
+import "github.com/jonboulle/clockwork"
+
 // SessionDataLimiter exports sdLimiter for tests.
 var SessionDataLimiter = sdLimiter
+
+// SetClock sets the identity service clock for tests.
+func (s *IdentityService) SetClock(clock clockwork.Clock) {
+	s.clock = clock
+}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -62,8 +62,8 @@ var GlobalSessionDataMaxEntries = 5000 // arbitrary
 type IdentityService struct {
 	backend.Backend
 	log logrus.FieldLogger
-	// ServiceClock is used in tests to desync the service clock from the backend clock.
-	ServiceClock clockwork.Clock
+	// clock is used in tests to desync the service clock from the backend clock.
+	clock clockwork.Clock
 }
 
 // NewIdentityService returns a new instance of IdentityService object
@@ -75,8 +75,8 @@ func NewIdentityService(backend backend.Backend) *IdentityService {
 }
 
 func (s *IdentityService) Clock() clockwork.Clock {
-	if s.ServiceClock != nil {
-		return s.ServiceClock
+	if s.clock != nil {
+		return s.clock
 	}
 	return s.Backend.Clock()
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -912,10 +912,9 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 		return nil, trace.BadParameter("missing parameter sessionID")
 	}
 
-	key := sessionDataKey(user, sessionID)
 	item, err := s.Get(ctx, sessionDataKey(user, sessionID))
 	if trace.IsNotFound(err) {
-		return nil, trace.NotFound("item %q is not found", string(key))
+		return nil, trace.NotFound("webauthn session data is not found")
 	} else if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -926,7 +925,7 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 		if err := s.Delete(ctx, item.Key); err != nil && !trace.IsNotFound(err) {
 			s.log.WithError(err).Debug("Failed to delete expired webauthn session")
 		}
-		return nil, trace.NotFound("item %q is not found", string(key))
+		return nil, trace.NotFound("webauthn session data is not found")
 	}
 
 	sd := &wanpb.SessionData{}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -62,6 +62,8 @@ var GlobalSessionDataMaxEntries = 5000 // arbitrary
 type IdentityService struct {
 	backend.Backend
 	log logrus.FieldLogger
+	// ServiceClock is used in tests to desync the service clock from the backend clock.
+	ServiceClock clockwork.Clock
 }
 
 // NewIdentityService returns a new instance of IdentityService object
@@ -70,6 +72,13 @@ func NewIdentityService(backend backend.Backend) *IdentityService {
 		Backend: backend,
 		log:     logrus.WithField(trace.Component, "identity"),
 	}
+}
+
+func (s *IdentityService) Clock() clockwork.Clock {
+	if s.ServiceClock != nil {
+		return s.ServiceClock
+	}
+	return s.Backend.Clock()
 }
 
 // DeleteAllUsers deletes all users
@@ -908,7 +917,7 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 		return nil, trace.Wrap(err)
 	}
 
-	if s.Clock().Now().After(item.Expires) {
+	if !s.Clock().Now().Before(item.Expires) {
 		// Webauthn session already expired. Some backends do not clean up expired
 		// items in a timely manner, force delete.
 		if err := s.Delete(ctx, item.Key); err != nil && !trace.IsNotFound(err) {

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -62,8 +62,8 @@ var GlobalSessionDataMaxEntries = 5000 // arbitrary
 type IdentityService struct {
 	backend.Backend
 	log logrus.FieldLogger
-	// clock is used in tests to desync the service clock from the backend clock.
-	clock clockwork.Clock
+	// desyncedClockForTesting is used in tests to desync the service clock from the backend clock.
+	desyncedClockForTesting clockwork.Clock
 }
 
 // NewIdentityService returns a new instance of IdentityService object
@@ -74,9 +74,9 @@ func NewIdentityService(backend backend.Backend) *IdentityService {
 	}
 }
 
-func (s *IdentityService) Clock() clockwork.Clock {
-	if s.clock != nil {
-		return s.clock
+func (s *IdentityService) getClock() clockwork.Clock {
+	if s.desyncedClockForTesting != nil {
+		return s.desyncedClockForTesting
 	}
 	return s.Backend.Clock()
 }
@@ -912,18 +912,21 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 		return nil, trace.BadParameter("missing parameter sessionID")
 	}
 
+	key := sessionDataKey(user, sessionID)
 	item, err := s.Get(ctx, sessionDataKey(user, sessionID))
-	if err != nil {
+	if trace.IsNotFound(err) {
+		return nil, trace.NotFound("item %q is not found", string(key))
+	} else if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !s.Clock().Now().Before(item.Expires) {
+	if !s.getClock().Now().Before(item.Expires) {
 		// Webauthn session already expired. Some backends do not clean up expired
 		// items in a timely manner, force delete.
 		if err := s.Delete(ctx, item.Key); err != nil && !trace.IsNotFound(err) {
 			s.log.WithError(err).Debug("Failed to delete expired webauthn session")
 		}
-		return nil, trace.BadParameter("webauthn session expired")
+		return nil, trace.NotFound("item %q is not found", string(key))
 	}
 
 	sd := &wanpb.SessionData{}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -908,11 +908,11 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 		return nil, trace.Wrap(err)
 	}
 
-	if s.Clock().Now().UTC().After(item.Expires) {
+	if s.Clock().Now().After(item.Expires) {
 		// Webauthn session already expired. Some backends do not clean up expired
 		// items in a timely manner, force delete.
-		if err := s.Delete(ctx, item.Key); err != nil {
-			s.log.WithError(err).Debugf("Failed to delete expired webauthn session")
+		if err := s.Delete(ctx, item.Key); err != nil && !trace.IsNotFound(err) {
+			s.log.WithError(err).Debug("Failed to delete expired webauthn session")
 		}
 		return nil, trace.BadParameter("webauthn session expired")
 	}

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -58,7 +58,10 @@ func newIdentityService(t *testing.T, clock clockwork.Clock) *local.IdentityServ
 		Clock:   clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
-	return local.NewIdentityService(backend)
+
+	identityService := local.NewIdentityService(backend)
+	identityService.ServiceClock = clock
+	return identityService
 }
 
 func TestRecoveryCodesCRUD(t *testing.T) {
@@ -763,6 +766,27 @@ func TestIdentityService_GlobalWebauthnSessionDataCRUD(t *testing.T) {
 		_, err := identity.GetGlobalWebauthnSessionData(ctx, p.scope, p.id)
 		require.NoError(t, err) // Other keys preserved
 	}
+}
+
+func TestIdentityService_WebauthnSessionDataExpiry(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	identity := newIdentityService(t, clock)
+
+	ctx := context.Background()
+	sessionData := &wanpb.SessionData{Challenge: []byte("challenge"), UserId: []byte("userid")}
+	err := identity.UpsertWebauthnSessionData(ctx, "user", "login", sessionData)
+	require.NoError(t, err)
+
+	got, err := identity.GetWebauthnSessionData(ctx, "user", "login")
+	require.NoError(t, err)
+	require.Equal(t, sessionData, got)
+
+	// If the session data is expired but not automatically removed from
+	// the backend, it should be manually deleted on retrieval attempt.
+	clock.Advance(10 * time.Minute)
+	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
+	require.ErrorIs(t, err, trace.BadParameter("webauthn session expired"), "expected webauthn session expired error but got %v", err)
 }
 
 func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) {

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -58,10 +58,7 @@ func newIdentityService(t *testing.T, clock clockwork.Clock) *local.IdentityServ
 		Clock:   clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
-
-	identityService := local.NewIdentityService(backend)
-	identityService.SetClock(clock)
-	return identityService
+	return local.NewIdentityService(backend)
 }
 
 func TestRecoveryCodesCRUD(t *testing.T) {
@@ -772,6 +769,7 @@ func TestIdentityService_WebauthnSessionDataExpiry(t *testing.T) {
 	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	identity := newIdentityService(t, clock)
+	identity.SetDesyncedClockForTesting(clock)
 
 	ctx := context.Background()
 	sessionData := &wanpb.SessionData{Challenge: []byte("challenge"), UserId: []byte("userid")}
@@ -788,7 +786,7 @@ func TestIdentityService_WebauthnSessionDataExpiry(t *testing.T) {
 	// emulate this occurrence.
 	clock.Advance(10 * time.Minute)
 	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
-	require.ErrorIs(t, err, trace.BadParameter("webauthn session expired"), "expected webauthn session expired error but got %v", err)
+	require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 
 	// Another retrieval should result in a not found error since it was deleted during the last get.
 	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -60,7 +60,7 @@ func newIdentityService(t *testing.T, clock clockwork.Clock) *local.IdentityServ
 	require.NoError(t, err)
 
 	identityService := local.NewIdentityService(backend)
-	identityService.ServiceClock = clock
+	identityService.SetClock(clock)
 	return identityService
 }
 
@@ -784,9 +784,15 @@ func TestIdentityService_WebauthnSessionDataExpiry(t *testing.T) {
 
 	// If the session data is expired but not automatically removed from
 	// the backend, it should be manually deleted on retrieval attempt.
+	// Advance the identity service clock and not the backend clock to
+	// emulate this occurrence.
 	clock.Advance(10 * time.Minute)
 	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
 	require.ErrorIs(t, err, trace.BadParameter("webauthn session expired"), "expected webauthn session expired error but got %v", err)
+
+	// Another retrieval should result in a not found error since it was deleted during the last get.
+	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
+	require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 }
 
 func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) {


### PR DESCRIPTION
Ensure Webauthn session expiration as described in [RFD 155](https://github.com/gravitational/teleport/blob/c4c9940442b444ec0904a542c54e5b0e1d56907d/rfd/0155-scoped-webauthn-credentials.md#expiration).