### PR TITLE
fix: External Audit Storage bootstrap in us-east-1

### DIFF
--- a/lib/integrations/externalauditstorage/bootstrap.go
+++ b/lib/integrations/externalauditstorage/bootstrap.go
@@ -34,7 +34,7 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gravitational/trace"
 
-	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
+	eastypes "github.com/gravitational/teleport/api/types/externalauditstorage"
 	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -51,7 +51,7 @@ type BootstrapInfraParams struct {
 	Glue   BootstrapGlueClient
 	S3     BootstrapS3Client
 
-	Spec   *ecatypes.ExternalAuditStorageSpec
+	Spec   *eastypes.ExternalAuditStorageSpec
 	Region string
 }
 
@@ -205,10 +205,8 @@ func createTransientBucket(ctx context.Context, clt BootstrapS3Client, bucketNam
 
 func createBucket(ctx context.Context, clt BootstrapS3Client, bucketName string, region string, objectLock bool) error {
 	_, err := clt.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: &bucketName,
-		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
-			LocationConstraint: s3types.BucketLocationConstraint(region),
-		},
+		Bucket:                     &bucketName,
+		CreateBucketConfiguration:  createBucketConfiguration(region),
 		ObjectLockEnabledForBucket: objectLock,
 		ACL:                        s3types.BucketCannedACLPrivate,
 		ObjectOwnership:            s3types.ObjectOwnershipBucketOwnerEnforced,
@@ -224,6 +222,18 @@ func createBucket(ctx context.Context, clt BootstrapS3Client, bucketName string,
 		},
 	})
 	return trace.Wrap(awsutil.ConvertS3Error(err), "setting versioning configuration on S3 bucket")
+}
+
+func createBucketConfiguration(region string) *s3types.CreateBucketConfiguration {
+	// No location constraint wanted for us-east-1 because it is the default and
+	// AWS has decided, in all their infinite wisdom, that the CreateBucket API
+	// should fail if you explicitly pass the default location constraint.
+	if region == "us-east-1" {
+		return nil
+	}
+	return &s3types.CreateBucketConfiguration{
+		LocationConstraint: s3types.BucketLocationConstraint(region),
+	}
 }
 
 // createAthenaWorkgroup creates an athena workgroup in which to run athena sql queries.
@@ -290,7 +300,7 @@ func createGlueInfra(ctx context.Context, clt BootstrapGlueClient, table, databa
 
 // validateAndParseS3Input parses and checks s3 input uris against our strict rules.
 // We currently enforce two buckets one for long term storage and one for transient short term storage.
-func validateAndParseS3Input(input *ecatypes.ExternalAuditStorageSpec) (auditHost, resultHost string, err error) {
+func validateAndParseS3Input(input *eastypes.ExternalAuditStorageSpec) (auditHost, resultHost string, err error) {
 	auditEventsBucket, err := url.Parse(input.AuditEventsLongTermURI)
 	if err != nil {
 		return "", "", trace.Wrap(err, "parsing audit events URI")

--- a/lib/integrations/externalauditstorage/bootstrap_test.go
+++ b/lib/integrations/externalauditstorage/bootstrap_test.go
@@ -30,18 +30,29 @@ import (
 	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
+	eastypes "github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 )
 
 func TestBootstrapInfra(t *testing.T) {
+	t.Parallel()
+	goodSpec := &eastypes.ExternalAuditStorageSpec{
+		SessionRecordingsURI:   "s3://long-term-storage-bucket/session",
+		AuditEventsLongTermURI: "s3://long-term-storage-bucket/events",
+		AthenaResultsURI:       "s3://transient-storage-bucket/query_results",
+		AthenaWorkgroup:        "teleport-workgroup",
+		GlueDatabase:           "teleport-database",
+		GlueTable:              "audit-events",
+	}
 	tt := []struct {
-		desc      string
-		region    string
-		eca       *ecatypes.ExternalAuditStorageSpec
-		errWanted string
+		desc                     string
+		region                   string
+		spec                     *eastypes.ExternalAuditStorageSpec
+		errWanted                string
+		locationConstraintWanted s3types.BucketLocationConstraint
 	}{
 		{
 			desc:      "nil input",
@@ -51,32 +62,52 @@ func TestBootstrapInfra(t *testing.T) {
 		{
 			desc:      "empty region input",
 			errWanted: "param Region required",
-			eca: &ecatypes.ExternalAuditStorageSpec{
-				SessionRecordingsURI:   "s3://long-term-storage-bucket/session",
-				AuditEventsLongTermURI: "s3://long-term-storage-bucket/events",
-				AthenaResultsURI:       "s3://transient-storage-bucket/query_results",
-				AthenaWorkgroup:        "teleport-workgroup",
-				GlueDatabase:           "teleport-database",
-				GlueTable:              "audit-events",
-			},
+			spec:      goodSpec,
 		},
 		{
-			desc:   "standard input",
-			region: "us-west-2",
-			eca: &ecatypes.ExternalAuditStorageSpec{
-				SessionRecordingsURI:   "s3://long-term-storage-bucket/session",
-				AuditEventsLongTermURI: "s3://long-term-storage-bucket/events",
-				AthenaResultsURI:       "s3://transient-storage-bucket/query_results",
-				AthenaWorkgroup:        "teleport-workgroup",
-				GlueDatabase:           "teleport-database",
-				GlueTable:              "audit-events",
-			},
+			desc:                     "us-west-2",
+			region:                   "us-west-2",
+			spec:                     goodSpec,
+			locationConstraintWanted: s3types.BucketLocationConstraintUsWest2,
+		},
+		{
+			desc:   "us-east-1",
+			region: "us-east-1",
+			spec:   goodSpec,
+			// No location constraint wanted for us-east-1 because it is the
+			// default and AWS has decided, in all their infinite wisdom, that
+			// the CreateBucket API should fail if you explicitly pass the
+			// default location constraint.
+		},
+		{
+			desc:                     "eu-central-1",
+			region:                   "eu-central-1",
+			spec:                     goodSpec,
+			locationConstraintWanted: s3types.BucketLocationConstraintEuCentral1,
+		},
+		{
+			desc:                     "ap-south-1",
+			region:                   "ap-south-1",
+			spec:                     goodSpec,
+			locationConstraintWanted: s3types.BucketLocationConstraintApSouth1,
+		},
+		{
+			desc:                     "ap-southeast-1",
+			region:                   "ap-southeast-1",
+			spec:                     goodSpec,
+			locationConstraintWanted: s3types.BucketLocationConstraintApSoutheast1,
+		},
+		{
+			desc:                     "sa-east-1",
+			region:                   "sa-east-1",
+			spec:                     goodSpec,
+			locationConstraintWanted: s3types.BucketLocationConstraintSaEast1,
 		},
 		{
 			desc:      "invalid input transient and long-term share same bucket name",
 			errWanted: "athena results bucket URI must not match audit events or session bucket URI",
 			region:    "us-west-2",
-			eca: &ecatypes.ExternalAuditStorageSpec{
+			spec: &eastypes.ExternalAuditStorageSpec{
 				SessionRecordingsURI:   "s3://long-term-storage-bucket/session",
 				AuditEventsLongTermURI: "s3://long-term-storage-bucket/events",
 				AthenaResultsURI:       "s3://long-term-storage-bucket/query_results",
@@ -89,7 +120,7 @@ func TestBootstrapInfra(t *testing.T) {
 			desc:      "invalid input audit events and session recordings have different URIs",
 			errWanted: "audit events bucket URI must match session bucket URI",
 			region:    "us-west-2",
-			eca: &ecatypes.ExternalAuditStorageSpec{
+			spec: &eastypes.ExternalAuditStorageSpec{
 				SessionRecordingsURI:   "s3://long-term-storage-bucket-sessions/session",
 				AuditEventsLongTermURI: "s3://long-term-storage-bucket-events/events",
 				AthenaResultsURI:       "s3://transient-storage-bucket/query_results",
@@ -103,14 +134,14 @@ func TestBootstrapInfra(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
 			testCtx := context.Background()
-			s3Clt := &mockBootstrapS3Client{buckets: map[string]struct{}{}}
+			s3Clt := &mockBootstrapS3Client{buckets: make(map[string]bucket)}
 			athenaClt := &mockBootstrapAthenaClient{}
 			glueClt := &mockBootstrapGlueClient{}
 			err := externalauditstorage.BootstrapInfra(testCtx, externalauditstorage.BootstrapInfraParams{
 				Athena: athenaClt,
 				Glue:   glueClt,
 				S3:     s3Clt,
-				Spec:   tc.eca,
+				Spec:   tc.spec,
 				Region: tc.region,
 			})
 			if tc.errWanted != "" {
@@ -120,30 +151,34 @@ func TestBootstrapInfra(t *testing.T) {
 				require.NoError(t, err, "an unexpected error occurred in BootstrapInfra")
 			}
 
-			ltsBucket, err := url.Parse(tc.eca.AuditEventsLongTermURI)
+			ltsBucket, err := url.Parse(tc.spec.AuditEventsLongTermURI)
 			require.NoError(t, err)
 
-			transientBucket, err := url.Parse(tc.eca.AthenaResultsURI)
+			transientBucket, err := url.Parse(tc.spec.AthenaResultsURI)
 			require.NoError(t, err)
 
-			if _, ok := s3Clt.buckets[ltsBucket.Host]; !ok {
+			if b, ok := s3Clt.buckets[ltsBucket.Host]; ok {
+				assert.Equal(t, tc.locationConstraintWanted, b.locationConstraint)
+			} else {
 				t.Fatalf("Long-term bucket: %s not created by bootstrap infra", ltsBucket.Host)
 			}
 
-			if _, ok := s3Clt.buckets[transientBucket.Host]; !ok {
+			if b, ok := s3Clt.buckets[transientBucket.Host]; ok {
+				assert.Equal(t, tc.locationConstraintWanted, b.locationConstraint)
+			} else {
 				t.Fatalf("Transient bucket: %s not created by bootstrap infra", transientBucket.Host)
 			}
 
-			require.Equal(t, glueClt.database, tc.eca.GlueDatabase)
-			require.Equal(t, glueClt.table, tc.eca.GlueTable)
-			require.Equal(t, athenaClt.workgroup, tc.eca.AthenaWorkgroup)
+			assert.Equal(t, tc.spec.GlueDatabase, glueClt.database)
+			assert.Equal(t, tc.spec.GlueTable, glueClt.table)
+			assert.Equal(t, tc.spec.AthenaWorkgroup, athenaClt.workgroup)
 
 			// Re-run bootstrap
-			require.NoError(t, externalauditstorage.BootstrapInfra(testCtx, externalauditstorage.BootstrapInfraParams{
+			assert.NoError(t, externalauditstorage.BootstrapInfra(testCtx, externalauditstorage.BootstrapInfraParams{
 				Athena: athenaClt,
 				Glue:   glueClt,
 				S3:     s3Clt,
-				Spec:   tc.eca,
+				Spec:   tc.spec,
 				Region: tc.region,
 			}))
 		})
@@ -151,7 +186,11 @@ func TestBootstrapInfra(t *testing.T) {
 }
 
 type mockBootstrapS3Client struct {
-	buckets map[string]struct{}
+	buckets map[string]bucket
+}
+
+type bucket struct {
+	locationConstraint s3types.BucketLocationConstraint
 }
 
 type mockBootstrapAthenaClient struct {
@@ -169,7 +208,13 @@ func (c *mockBootstrapS3Client) CreateBucket(ctx context.Context, params *s3.Cre
 		return nil, &s3types.BucketAlreadyExists{Message: aws.String("The bucket already exists")}
 	}
 
-	c.buckets[*params.Bucket] = struct{}{}
+	var locationConstraint s3types.BucketLocationConstraint
+	if params.CreateBucketConfiguration != nil {
+		locationConstraint = params.CreateBucketConfiguration.LocationConstraint
+	}
+	c.buckets[*params.Bucket] = bucket{
+		locationConstraint: locationConstraint,
+	}
 
 	return &s3.CreateBucketOutput{}, nil
 }


### PR DESCRIPTION
This commit fixes the S3 bucket creation for External Audit Storage when the region is us-east-1.
It's currently broken because we unconditionally set a location constraint on the bucket so that it will be in our desired region. This fails when the region is us-east-1.
Because that's the default region for S3 buckets, and AWS has decided that explicitly asking for the default is wrong.

Fixes https://github.com/gravitational/teleport/issues/35275

Changelog: fixes resource bootstrap for External Audit Storage in us-east-1.