### PR TITLE
[v14] [refactor] deprecate db/common/role.DatabaseRoleMatchers

### DIFF
--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -264,11 +264,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 	state := e.sessionCtx.GetAccessState(authPref)
 
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/clickhouse/engine.go
+++ b/lib/srv/db/clickhouse/engine.go
@@ -88,11 +88,11 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	}
 
 	state := sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database,
-		sessionCtx.DatabaseUser,
-		sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     sessionCtx.Database,
+		DatabaseUser: sessionCtx.DatabaseUser,
+		DatabaseName: sessionCtx.DatabaseName,
+	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
 		state,

--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -32,35 +32,25 @@ type RoleMatchersConfig struct {
 	DatabaseName string
 	// AutoCreateUser is whether database user will be auto-created.
 	AutoCreateUser bool
+	// DisableDatabaseNameMatcher skips DatabaseNameMatcher even if the protocol requires it.
+	DisableDatabaseNameMatcher bool
 }
 
 // GetDatabaseRoleMatchers returns database role matchers for the provided config.
 func GetDatabaseRoleMatchers(conf RoleMatchersConfig) (matchers services.RoleMatchers) {
 	// For automatic user provisioning, don't check against database users as
 	// users will be connecting as their own Teleport username.
-	if conf.Database.SupportsAutoUsers() && conf.AutoCreateUser {
-		if m := databaseNameMatcher(conf.Database.GetProtocol(), conf.DatabaseName); m != nil {
-			matchers = append(matchers, m)
+	disableDatabaseUserMatcher := conf.Database.SupportsAutoUsers() && conf.AutoCreateUser
+	if !disableDatabaseUserMatcher {
+		matchers = append(matchers, services.NewDatabaseUserMatcher(conf.Database, conf.DatabaseUser))
+	}
+
+	if !conf.DisableDatabaseNameMatcher {
+		if matcher := databaseNameMatcher(conf.Database.GetProtocol(), conf.DatabaseName); matcher != nil {
+			matchers = append(matchers, matcher)
 		}
-		return matchers
 	}
-	return DatabaseRoleMatchers(conf.Database, conf.DatabaseUser, conf.DatabaseName)
-}
-
-// DatabaseRoleMatchers returns role matchers based on the database.
-//
-// DEPRECATED: Prefer to use GetDatabaseRoleMatchers above which supports
-// automatic user provisioning and has more flexible config.
-func DatabaseRoleMatchers(db types.Database, user, database string) services.RoleMatchers {
-	roleMatchers := services.RoleMatchers{
-		services.NewDatabaseUserMatcher(db, user),
-	}
-
-	if matcher := databaseNameMatcher(db.GetProtocol(), database); matcher != nil {
-		roleMatchers = append(roleMatchers, matcher)
-	}
-
-	return roleMatchers
+	return
 }
 
 // RequireDatabaseUserMatcher returns true if databases with provided protocol

--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -53,6 +53,22 @@ func GetDatabaseRoleMatchers(conf RoleMatchersConfig) (matchers services.RoleMat
 	return
 }
 
+// DatabaseRoleMatchers returns role matchers based on the database.
+//
+// DEPRECATED: Prefer to use GetDatabaseRoleMatchers above which supports
+// automatic user provisioning and has more flexible config.
+func DatabaseRoleMatchers(db types.Database, user, database string) services.RoleMatchers {
+	roleMatchers := services.RoleMatchers{
+		services.NewDatabaseUserMatcher(db, user),
+	}
+
+	if matcher := databaseNameMatcher(db.GetProtocol(), database); matcher != nil {
+		roleMatchers = append(roleMatchers, matcher)
+	}
+
+	return roleMatchers
+}
+
 // RequireDatabaseUserMatcher returns true if databases with provided protocol
 // require database users.
 func RequireDatabaseUserMatcher(protocol string) bool {

--- a/lib/srv/db/common/role/role_test.go
+++ b/lib/srv/db/common/role/role_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestGetDatabaseRoleMatchers(t *testing.T) {
+	postgresDatabase, err := types.NewDatabaseV3(types.Metadata{
+		Name: "postgres",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+		AdminUser: &types.DatabaseAdminUser{
+			Name: "teleport-admin",
+		},
+	})
+	require.NoError(t, err)
+
+	mysqlDatabase, err := types.NewDatabaseV3(types.Metadata{
+		Name: "mysql",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolMySQL,
+		URI:      "localhost:3306",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	tests := []struct {
+		name               string
+		inputConfig        RoleMatchersConfig
+		expectRoleMatchers services.RoleMatchers
+	}{
+		{
+			name: "database name matcher required",
+			inputConfig: RoleMatchersConfig{
+				Database:     postgresDatabase,
+				DatabaseUser: "alice",
+				DatabaseName: "db1",
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+				&services.DatabaseNameMatcher{Name: "db1"},
+			},
+		},
+		{
+			name: "database name matcher not required",
+			inputConfig: RoleMatchersConfig{
+				Database:     mysqlDatabase,
+				DatabaseUser: "alice",
+				DatabaseName: "db1",
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+			},
+		},
+		{
+			name: "AutoCreateUser",
+			inputConfig: RoleMatchersConfig{
+				Database:       postgresDatabase,
+				DatabaseUser:   "alice",
+				DatabaseName:   "db1",
+				AutoCreateUser: true,
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				&services.DatabaseNameMatcher{Name: "db1"},
+			},
+		},
+		{
+			name: "DisableDatabaseNameMatcher",
+			inputConfig: RoleMatchersConfig{
+				Database:                   postgresDatabase,
+				DatabaseUser:               "alice",
+				DatabaseName:               "db1",
+				DisableDatabaseNameMatcher: true,
+			},
+			expectRoleMatchers: services.RoleMatchers{
+				services.NewDatabaseUserMatcher(postgresDatabase, "alice"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.EqualValues(t, test.expectRoleMatchers, GetDatabaseRoleMatchers(test.inputConfig))
+		})
+	}
+}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -302,11 +302,11 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	}
 
 	state := sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database,
-		sessionCtx.DatabaseUser,
-		sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     sessionCtx.Database,
+		DatabaseUser: sessionCtx.DatabaseUser,
+		DatabaseName: sessionCtx.DatabaseName,
+	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
 		state,

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -260,11 +260,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/opensearch/engine.go
+++ b/lib/srv/db/opensearch/engine.go
@@ -362,11 +362,11 @@ func (e *Engine) checkAccess(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -166,11 +166,11 @@ func fetchCredentialsOnConnect(closeCtx context.Context, sessionCtx *common.Sess
 	return func(ctx context.Context, conn *redis.Conn) error {
 		err := sessionCtx.Checker.CheckAccess(sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				sessionCtx.Database,
-				sessionCtx.DatabaseUser,
-				sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     sessionCtx.Database,
+				DatabaseUser: sessionCtx.DatabaseUser,
+				DatabaseName: sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/db/redis/cmds.go
+++ b/lib/srv/db/redis/cmds.go
@@ -175,11 +175,11 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				e.sessionCtx.Database,
-				e.sessionCtx.DatabaseUser,
-				e.sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     e.sessionCtx.Database,
+				DatabaseUser: e.sessionCtx.DatabaseUser,
+				DatabaseName: e.sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -222,11 +222,11 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
-			role.DatabaseRoleMatchers(
-				e.sessionCtx.Database,
-				e.sessionCtx.DatabaseUser,
-				e.sessionCtx.DatabaseName,
-			)...)
+			role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+				Database:     e.sessionCtx.Database,
+				DatabaseUser: e.sessionCtx.DatabaseUser,
+				DatabaseName: e.sessionCtx.DatabaseName,
+			})...)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -101,11 +101,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -358,11 +358,11 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	state := e.sessionCtx.GetAccessState(authPref)
-	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database,
-		e.sessionCtx.DatabaseUser,
-		e.sessionCtx.DatabaseName,
-	)
+	dbRoleMatchers := role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
+		Database:     e.sessionCtx.Database,
+		DatabaseUser: e.sessionCtx.DatabaseUser,
+		DatabaseName: e.sessionCtx.DatabaseName,
+	})
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
 		state,


### PR DESCRIPTION
backport of #34132 to branch/v14

The backport is required as a pre-req to backport MongoDB auto-user to branch/v14

Backport of the original change has no merge conflict but I decided to add back the deleted function on v14 to avoid breaking `e` (Oracle).