### PR TITLE
Add `cluster_auth_preferences` to shortcuts for `cluster_auth_preference`

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -127,7 +127,6 @@ func PreserveResourceID() MarshalOption {
 // ParseShortcut parses resource shortcut
 // Generally, this should include the plural of a singular resource name or vice
 // versa.
-// These shortcuts
 func ParseShortcut(in string) (string, error) {
 	if in == "" {
 		return "", trace.BadParameter("missing resource name")

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -125,6 +125,9 @@ func PreserveResourceID() MarshalOption {
 }
 
 // ParseShortcut parses resource shortcut
+// Generally, this should include the plural of a singular resource name or vice
+// versa.
+// These shortcuts
 func ParseShortcut(in string) (string, error) {
 	if in == "" {
 		return "", trace.BadParameter("missing resource name")
@@ -156,7 +159,7 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindReverseTunnel, nil
 	case types.KindTrustedCluster, "tc", "cluster", "clusters":
 		return types.KindTrustedCluster, nil
-	case types.KindClusterAuthPreference, "cluster_authentication_preferences", "cap":
+	case types.KindClusterAuthPreference, "cluster_authentication_preferences", "cluster_auth_preferences", "cap":
 		return types.KindClusterAuthPreference, nil
 	case types.KindUIConfig, "ui":
 		return types.KindUIConfig, nil


### PR DESCRIPTION
We usually offer the plural or singular version of the resource noun name as a shortcut when used by `tctl`. This wasn't the case for `cluster_auth_preferences`. I ran into this whilst supporting a customer.

changelog: Add `cluster_auth_preferences` to the shortcuts for `cluster_auth_preference`.