### PR TITLE
[v14] Database Automatic User Provisioning support for self-hosted MongoDB

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -329,6 +329,12 @@ func (d *DatabaseV3) SupportsAutoUsers() bool {
 		case DatabaseTypeSelfHosted, DatabaseTypeRDS:
 			return true
 		}
+
+	case DatabaseProtocolMongoDB:
+		switch d.GetType() {
+		case DatabaseTypeSelfHosted:
+			return true
+		}
 	}
 	return false
 }
@@ -1024,6 +1030,8 @@ const (
 	DatabaseProtocolClickHouse = "clickhouse"
 	// DatabaseProtocolMySQL is the MySQL database protocol.
 	DatabaseProtocolMySQL = "mysql"
+	// DatabaseProtocolMongoDB is the MongoDB database protocol.
+	DatabaseProtocolMongoDB = "mongodb"
 
 	// DatabaseTypeSelfHosted is the self-hosted type of database.
 	DatabaseTypeSelfHosted = "self-hosted"

--- a/lib/srv/db/autousers_test.go
+++ b/lib/srv/db/autousers_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/srv/db/mongodb"
 )
 
 // TestAutoUsersPostgres verifies automatic database user creation for Postgres.
@@ -275,6 +276,89 @@ func TestAutoUsersMySQL(t *testing.T) {
 				require.Equal(t, tc.teleportUser, e.TeleportUser)
 				require.Equal(t, tc.expectDatabaseUser, e.DatabaseUser)
 				require.False(t, e.Active)
+			case <-time.After(5 * time.Second):
+				t.Fatal("user not deactivated after 5s")
+			}
+		})
+	}
+}
+
+func TestAutoUsersMongoDB(t *testing.T) {
+	t.Setenv("TELEPORT_DISABLE_MONGODB_ADMIN_CLIENT_CACHE", "true")
+	ctx := context.Background()
+	username := "alice"
+
+	tests := []struct {
+		name             string
+		mode             types.CreateDatabaseUserMode
+		wantTeardownType mongodb.UserEventType
+	}{
+		{
+			name:             "keep",
+			mode:             types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
+			wantTeardownType: mongodb.UserEventDeactivate,
+		},
+		{
+			name:             "best_effort_drop",
+			mode:             types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+			wantTeardownType: mongodb.UserEventDelete,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			testCtx := setupTestContext(ctx, t, withSelfHostedMongoWithAdminUser("mongo-server", "teleport-admin"))
+			go testCtx.startHandlingConnections()
+
+			// Create user with role that allows user provisioning.
+			_, role, err := auth.CreateUserAndRole(testCtx.tlsServer.Auth(), username, []string{"auto"}, nil)
+			require.NoError(t, err)
+			options := role.GetOptions()
+			options.CreateDatabaseUserMode = test.mode
+			role.SetOptions(options)
+			role.SetDatabaseRoles(types.Allow, []string{"readWrite@db1", "readAnyDatabase@admin"})
+			role.SetDatabaseNames(types.Allow, []string{"db1", "db2", "admin"})
+			_, err = testCtx.tlsServer.Auth().UpsertRole(ctx, role)
+			require.NoError(t, err)
+
+			// DatabaseUser must match identity.
+			_, err = testCtx.mongoClient(ctx, username, "mongo-server", "some-other-username")
+			require.Error(t, err)
+
+			// Try to connect to the database as this user.
+			mongoClient, err := testCtx.mongoClient(ctx, username, "mongo-server", username)
+			t.Cleanup(func() {
+				if mongoClient != nil {
+					err := mongoClient.Disconnect(ctx)
+					if !strings.Contains(err.Error(), "client is disconnected") {
+						require.NoError(t, err)
+					}
+				}
+			})
+			require.NoError(t, err)
+
+			// Verify user was activated.
+			select {
+			case e := <-testCtx.mongo["mongo-server"].db.UserEventsCh():
+				require.Equal(t, "CN=alice", e.DatabaseUser)
+				require.Equal(t, []string{"readAnyDatabase@admin", "readWrite@db1"}, e.Roles)
+				require.Equal(t, mongodb.UserEventActivate, e.Type)
+			case <-time.After(5 * time.Second):
+				t.Fatal("user not activated after 5s")
+			}
+
+			// Disconnect.
+			err = mongoClient.Disconnect(ctx)
+			require.NoError(t, err)
+
+			// Verify user was teared down.
+			select {
+			case e := <-testCtx.mongo["mongo-server"].db.UserEventsCh():
+				require.Equal(t, "CN=alice", e.DatabaseUser)
+				require.Equal(t, test.wantTeardownType, e.Type)
 			case <-time.After(5 * time.Second):
 				t.Fatal("user not deactivated after 5s")
 			}

--- a/lib/srv/db/autousers_test.go
+++ b/lib/srv/db/autousers_test.go
@@ -321,7 +321,7 @@ func TestAutoUsersMongoDB(t *testing.T) {
 			role.SetOptions(options)
 			role.SetDatabaseRoles(types.Allow, []string{"readWrite@db1", "readAnyDatabase@admin"})
 			role.SetDatabaseNames(types.Allow, []string{"db1", "db2", "admin"})
-			_, err = testCtx.tlsServer.Auth().UpsertRole(ctx, role)
+			err = testCtx.tlsServer.Auth().UpsertRole(ctx, role)
 			require.NoError(t, err)
 
 			// DatabaseUser must match identity.

--- a/lib/srv/db/mongodb/autousers.go
+++ b/lib/srv/db/mongodb/autousers.go
@@ -1,0 +1,306 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/gravitational/teleport/lib/srv/db/common"
+)
+
+// user defines a MongoDB user.
+//
+// https://www.mongodb.com/docs/manual/reference/command/usersInfo/#output
+type user struct {
+	Username         string                `bson:"user"`
+	Roles            userRoles             `bson:"roles"`
+	CustomData       userCustomData        `bson:"customData"`
+	AuthRestrictions []userAuthRestriction `bson:"authenticationRestrictions"`
+}
+
+func (u *user) isLocked() bool {
+	for _, authRestriction := range u.AuthRestrictions {
+		if slices.Contains(authRestriction.ClientSource, lockedClientSource) {
+			return true
+		}
+	}
+	return false
+}
+
+// userCustomData specifies the "customData" field of a MongoDB user.
+//
+// https://www.mongodb.com/docs/manual/reference/command/createUser/
+type userCustomData struct {
+	// TeleportAutoUser identifies users that are managed by Teleport. An
+	// "admin" can search all Teleport-managed users by command:
+	// { "usersInfo": 1, "filter": { "customData.teleport-auto-user": true } }
+	TeleportAutoUser bool `bson:"teleport-auto-user"`
+}
+
+// userAuthRestriction specifies the "authenticationRestrictions" field of a
+// MongoDB user.
+//
+// https://www.mongodb.com/docs/manual/reference/command/createUser/#authentication-restrictions
+type userAuthRestriction struct {
+	ClientSource []string `bson:"clientSource"`
+}
+
+// userRole defines a role element in the "roles" slice of a MongoDB user.
+//
+// https://www.mongodb.com/docs/manual/reference/command/createUser/#roles
+type userRole struct {
+	Rolename string `bson:"role"`
+	Database string `bson:"db"`
+}
+
+type userRoles []userRole
+
+func (r userRoles) sort() {
+	slices.SortFunc(r, func(a, b userRole) int {
+		if cmpDatabase := cmp.Compare(a.Database, b.Database); cmpDatabase != 0 {
+			return cmpDatabase
+		}
+		return cmp.Compare(a.Rolename, b.Rolename)
+	})
+}
+
+// ActivateUser creates or enables the database user.
+func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) error {
+	userRoles, err := makeUserRoles(sessionCtx.DatabaseRoles)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	client, err := e.connectAsAdmin(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer client.Disconnect(ctx)
+
+	e.Log.Infof("Activating MongoDB user %q with roles %v.", sessionCtx.DatabaseUser, sessionCtx.DatabaseRoles)
+
+	user, found, err := e.getUser(ctx, sessionCtx, client)
+	switch {
+	case err != nil:
+		return trace.Wrap(err)
+	case !found:
+		return trace.Wrap(e.createUser(ctx, sessionCtx, client, userRoles))
+	case !user.CustomData.TeleportAutoUser:
+		return trace.AlreadyExists("user %q already exists in this MongoDB database and is not managed by Teleport", sessionCtx.DatabaseUser)
+	}
+
+	isActive, err := e.isUserActive(ctx, sessionCtx, client)
+	switch {
+	case err != nil:
+		return trace.Wrap(err)
+
+	case isActive:
+		if !slices.Equal(user.Roles, userRoles) {
+			return trace.CompareFailed("roles for user %q has changed. Please quit all active connections and try again.", sessionCtx.DatabaseUser)
+		}
+		e.Log.Debugf("User %q is active and roles are the same.", sessionCtx.DatabaseUser)
+		return nil
+
+	default:
+		return trace.Wrap(e.updateUser(ctx, sessionCtx, client, userRoles, []userAuthRestriction{}))
+	}
+}
+
+// DeactivateUser disables the database user.
+func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session) error {
+	e.Log.Infof("Deactivating MongoDB user %q.", sessionCtx.DatabaseUser)
+
+	client, err := e.connectAsAdmin(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer client.Disconnect(ctx)
+
+	isActive, err := e.isUserActive(ctx, sessionCtx, client)
+	switch {
+	case err != nil:
+		return trace.Wrap(err)
+
+	case isActive:
+		e.Log.Debugf("Failed to deactivate user %q: user has active connections.", sessionCtx.DatabaseUser)
+		return nil
+
+	default:
+		authRestrictions := []userAuthRestriction{{
+			ClientSource: []string{lockedClientSource},
+		}}
+		return trace.Wrap(e.updateUser(ctx, sessionCtx, client, []userRole{}, authRestrictions))
+	}
+}
+
+// DeleteUser deletes the database user.
+func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) error {
+	e.Log.Infof("Deleting MongoDB user %q.", sessionCtx.DatabaseUser)
+
+	client, err := e.connectAsAdmin(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer client.Disconnect(ctx)
+
+	isActive, err := e.isUserActive(ctx, sessionCtx, client)
+	switch {
+	case err != nil:
+		return trace.Wrap(err)
+
+	case isActive:
+		e.Log.Debugf("Failed to delete user %q: user has active connections.", sessionCtx.DatabaseUser)
+		return nil
+
+	default:
+		return trace.Wrap(e.dropUser(ctx, sessionCtx, client))
+	}
+}
+
+func (e *Engine) isUserActive(ctx context.Context, sessionCtx *common.Session, client adminClient) (bool, error) {
+	e.Log.Debugf("Checking if user %q is active.", sessionCtx.DatabaseUser)
+	var resp struct {
+		Inprog []interface{} `bson:"inprog"`
+	}
+
+	err := client.Database(adminDatabaseName).RunCommand(ctx, bson.D{
+		{Key: "currentOp", Value: true},
+		{Key: "$ownOps", Value: false},
+		{Key: "$all", Value: true},
+		{Key: "effectiveUsers", Value: bson.M{
+			"$elemMatch": bson.M{
+				"user": x509Username(sessionCtx),
+				"db":   externalDatabaseName,
+			},
+		}},
+	}).Decode(&resp)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return len(resp.Inprog) > 0, nil
+}
+
+// isShowCustomDataSupported returns true if "showCustomData" option is supported
+// for "usersInfo" command.
+//
+// "showCustomData" is introduced in 5.2. Prior to 5.2, "customData" is always shown.
+//
+// https://www.mongodb.com/docs/manual/reference/command/usersInfo/
+func (e *Engine) isShowCustomDataSupported(ctx context.Context, client adminClient) bool {
+	serverVersion, err := client.ServerVersion(ctx)
+	if err != nil {
+		e.Log.Debugf("Failed to get server version: %v. Assuming showCustomData is supported.", err)
+		return false
+	}
+	return serverVersion.Compare(*semver.New("5.2.0")) >= 0
+}
+
+func (e *Engine) getUser(ctx context.Context, sessionCtx *common.Session, client adminClient) (*user, bool, error) {
+	e.Log.Debugf("Getting user info for %q.", sessionCtx.DatabaseUser)
+	var resp struct {
+		Users []user `bson:"users"`
+	}
+
+	cmd := bson.D{
+		{Key: "usersInfo", Value: x509Username(sessionCtx)},
+	}
+	if e.isShowCustomDataSupported(ctx, client) {
+		cmd = append(cmd, bson.E{Key: "showCustomData", Value: true})
+	}
+
+	err := client.Database(externalDatabaseName).RunCommand(ctx, cmd).Decode(&resp)
+	if err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+
+	switch len(resp.Users) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		user := &resp.Users[0]
+		user.Roles.sort()
+		return user, true, nil
+	default:
+		return nil, false, trace.BadParameter("expect one MongoDB user but got %v", resp.Users)
+	}
+}
+
+func (e *Engine) createUser(ctx context.Context, sessionCtx *common.Session, client adminClient, userRoles []userRole) error {
+	e.Log.Debugf("Creating user %q.", sessionCtx.DatabaseUser)
+	return trace.Wrap(client.Database(externalDatabaseName).RunCommand(ctx, bson.D{
+		{Key: "createUser", Value: x509Username(sessionCtx)},
+		{Key: "roles", Value: userRoles},
+		{Key: "customData", Value: userCustomData{TeleportAutoUser: true}},
+		{Key: "authenticationRestrictions", Value: []userAuthRestriction{}},
+	}).Err())
+}
+
+func (e *Engine) updateUser(ctx context.Context, sessionCtx *common.Session, client adminClient, userRoles []userRole, authRestrictions []userAuthRestriction) error {
+	e.Log.Debugf("Updating user %q.", sessionCtx.DatabaseUser)
+	return trace.Wrap(client.Database(externalDatabaseName).RunCommand(ctx, bson.D{
+		{Key: "updateUser", Value: x509Username(sessionCtx)},
+		{Key: "roles", Value: userRoles},
+		{Key: "authenticationRestrictions", Value: authRestrictions},
+	}).Err())
+}
+
+func (e *Engine) dropUser(ctx context.Context, sessionCtx *common.Session, client adminClient) error {
+	e.Log.Debugf("Dropping user %q.", sessionCtx.DatabaseUser)
+	return trace.Wrap(client.Database(externalDatabaseName).RunCommand(ctx, bson.D{
+		{Key: "dropUser", Value: x509Username(sessionCtx)},
+	}).Err())
+}
+
+func makeUserRoles(roles []string) (userRoles, error) {
+	userRoles := make(userRoles, 0, len(roles))
+
+	for _, role := range roles {
+		rolename, database, ok := strings.Cut(role, "@")
+		if !ok {
+			return nil, trace.BadParameter("expect DynamoDB role in format of <role>@<db> but got %v", role)
+		}
+
+		userRoles = append(userRoles, userRole{
+			Rolename: rolename,
+			Database: database,
+		})
+	}
+	userRoles.sort()
+	return userRoles, nil
+}
+
+const (
+	// externalDatabaseName is the name of the "$external" database that
+	// manages X.509 users.
+	externalDatabaseName = "$external"
+	// adminDatabaseName is the name of the "admin" database that "currentOp"
+	// command runs at.
+	adminDatabaseName = "admin"
+	// lockedClientSource is the client source used for authentication
+	// restrictions to ensure users cannot login when deactivated.
+	lockedClientSource = "0.0.0.0"
+)

--- a/lib/srv/db/mongodb/autousers.go
+++ b/lib/srv/db/mongodb/autousers.go
@@ -1,20 +1,18 @@
 /*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package mongodb
 

--- a/lib/srv/db/mongodb/autousers_admin.go
+++ b/lib/srv/db/mongodb/autousers_admin.go
@@ -1,0 +1,279 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
+	mongoauth "go.mongodb.org/mongo-driver/x/mongo/driver/auth"
+
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// adminClient defines a subset of functions provided by *mongo.Client plus some
+// helper functions.
+type adminClient interface {
+	// Database returns a database handle based on database name.
+	Database(name string, opts ...*options.DatabaseOptions) *mongo.Database
+	// Disconnect disconnects the client.
+	Disconnect(ctx context.Context) error
+	// ServerVersion returns the server version.
+	ServerVersion(ctx context.Context) (*semver.Version, error)
+}
+
+func (e *Engine) connectAsAdmin(ctx context.Context, sessionCtx *common.Session) (adminClient, error) {
+	if isAdminClientCacheDisabled() || adminClientFnCache == nil {
+		client, err := makeBasicAdminClient(ctx, sessionCtx, e)
+		return client, trace.Wrap(err)
+	}
+
+	// The shared client will be cached for a short period. The shared client
+	// will be terminated when the cache expires and all callers released the
+	// shared client.
+	//
+	// The shared client (and mongo client in general) is goroutine-safe and
+	// handles reconnection in case of network issues.
+	//
+	// During a CA rotation, the cached client may have the wrong TLS config,
+	// but the cache should expires shortly so a new shared client will be
+	// created.
+	shareableClient, err := getShareableAdminClient(ctx, adminClientFnCache, sessionCtx, e, makeBasicAdminClient)
+	return shareableClient, trace.Wrap(err)
+}
+
+func getShareableAdminClient(ctx context.Context, cache *utils.FnCache, sessionCtx *common.Session, e *Engine, makeBasicClient makeBasicAdminClientFunc) (*shareableAdminClient, error) {
+	key := struct {
+		databaseName string
+		databaseURI  string
+		adminUser    string
+	}{
+		databaseName: sessionCtx.Database.GetName(),
+		adminUser:    sessionCtx.Database.GetAdminUser().Name,
+		// Just in case the same database name is updated to a different database server.
+		databaseURI: sessionCtx.Database.GetURI(),
+	}
+
+	shareableClient, err := utils.FnCacheGet(ctx, cache, key, func(ctx context.Context) (*shareableAdminClient, error) {
+		rawClient, err := makeBasicClient(ctx, sessionCtx, e)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		shareableClient, err := newShareableAdminClient(shareableAdminClientConfig{
+			rawClient:    rawClient,
+			adminUser:    sessionCtx.Database.GetAdminUser().Name,
+			databaseName: sessionCtx.Database.GetName(),
+			log:          e.Log,
+			clock:        e.Clock,
+		})
+		return shareableClient, trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return shareableClient.acquire(), nil
+}
+
+type shareableAdminClientConfig struct {
+	rawClient    adminClient
+	adminUser    string
+	databaseName string
+	clock        clockwork.Clock
+	log          logrus.FieldLogger
+	cleanupTTL   time.Duration
+}
+
+// checkAndSetDefaults validates config and sets defaults.
+func (c *shareableAdminClientConfig) checkAndSetDefaults() error {
+	if c.rawClient == nil {
+		return trace.BadParameter("missing mongo.Client")
+	}
+	if c.adminUser == "" {
+		return trace.BadParameter("missing adminUser")
+	}
+	if c.databaseName == "" {
+		return trace.BadParameter("missing databaseName")
+	}
+	if c.clock == nil {
+		c.clock = clockwork.NewRealClock()
+	}
+	if c.log == nil {
+		c.log = logrus.StandardLogger()
+	}
+	if c.cleanupTTL <= 0 {
+		c.cleanupTTL = adminClientCleanupTTL
+	}
+	return nil
+}
+
+type shareableAdminClient struct {
+	adminClient
+	shareableAdminClientConfig
+	wg    sync.WaitGroup
+	timer clockwork.Timer
+}
+
+func newShareableAdminClient(cfg shareableAdminClientConfig) (*shareableAdminClient, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	c := &shareableAdminClient{
+		adminClient:                cfg.rawClient,
+		shareableAdminClientConfig: cfg,
+		timer:                      cfg.clock.NewTimer(cfg.cleanupTTL),
+	}
+
+	go c.waitAndCleanup()
+	return c, nil
+}
+
+func (c *shareableAdminClient) waitAndCleanup() {
+	c.log.Debugf("Created new MongoDB connection as admin user %q on %q.", c.adminUser, c.databaseName)
+
+	// Wait until TTL.
+	<-c.timer.Chan()
+
+	// Wait until all shared sessions are released.
+	c.wg.Wait()
+
+	// Disconnect connection. This happens after cache item expired to ensure
+	// that shared client won't be reused when wrapped client was disconnected.
+	if err := c.adminClient.Disconnect(context.Background()); err != nil {
+		c.log.Warnf("Failed to disconnect MongoDB connection as admin user %q on %q: %v.", c.adminUser, c.databaseName, err)
+	} else {
+		c.log.Debugf("Terminated a MongoDB connection as admin user %q on %q.", c.adminUser, c.databaseName)
+	}
+}
+
+func (c *shareableAdminClient) acquire() *shareableAdminClient {
+	// acquire() should only be called while the client is still cached (while
+	// waitAndCleanup waits for the timer).
+	c.wg.Add(1)
+	return c
+}
+
+func (c *shareableAdminClient) Disconnect(_ context.Context) error {
+	c.wg.Done()
+	return nil
+}
+
+type makeBasicAdminClientFunc func(context.Context, *common.Session, *Engine) (adminClient, error)
+
+func makeBasicAdminClient(ctx context.Context, sessionCtx *common.Session, e *Engine) (adminClient, error) {
+	sessionCtx = sessionCtx.WithUser(sessionCtx.Database.GetAdminUser().Name)
+
+	tlsConfig, err := e.Auth.GetTLSConfig(ctx, sessionCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clientCfg, err := makeClientOptionsFromDatabaseURI(sessionCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	clientCfg.SetTLSConfig(tlsConfig)
+	clientCfg.SetAuth(mongooptions.Credential{
+		AuthMechanism: mongoauth.MongoDBX509,
+		Username:      x509Username(sessionCtx),
+	})
+
+	client, err := mongo.Connect(ctx, clientCfg)
+	return newBasicAdminClient(client), trace.Wrap(err)
+}
+
+// basicAdminClient is a simple wrapper of mongo.Client with some helper
+// functions. Note that mongo.Client is goroutine-safe.
+type basicAdminClient struct {
+	*mongo.Client
+
+	serverVersion      *semver.Version
+	serverVersionError error
+	serverVersionOnce  sync.Once
+}
+
+func newBasicAdminClient(client *mongo.Client) *basicAdminClient {
+	return &basicAdminClient{
+		Client: client,
+	}
+}
+
+func (c *basicAdminClient) ServerVersion(ctx context.Context) (*semver.Version, error) {
+	c.serverVersionOnce.Do(func() {
+		// Doesn't really matter which database to run "buildInfo" command on, and
+		// "buildInfo" doesn't require extra permissions.
+		resp := struct {
+			Version string `bson:"version"`
+		}{}
+		c.serverVersionError = c.Database(externalDatabaseName).RunCommand(ctx, bson.D{
+			{Key: "buildInfo", Value: true},
+		}).Decode(&resp)
+		if c.serverVersionError != nil {
+			return
+		}
+
+		c.serverVersion, c.serverVersionError = semver.NewVersion(resp.Version)
+	})
+	return c.serverVersion, trace.Wrap(c.serverVersionError)
+}
+
+const (
+	// adminClientFnCacheTTL specifies how long the shareableAdminClient will be
+	// cached in FnCache.
+	adminClientFnCacheTTL = time.Minute
+	// adminClientCleanupTTL specifies how long to wait to terminate the
+	// shareableAdminClient. Use a longer TTL than adminClientFnCacheTTL to make
+	// sure the shareableAdminClient will be not returned by the FnCache while
+	// getting terminated.
+	adminClientCleanupTTL = adminClientFnCacheTTL + time.Second*10
+)
+
+var adminClientFnCache *utils.FnCache
+
+func isAdminClientCacheDisabled() bool {
+	return utils.AsBool(os.Getenv("TELEPORT_DISABLE_MONGODB_ADMIN_CLIENT_CACHE"))
+}
+
+func init() {
+	if isAdminClientCacheDisabled() {
+		return
+	}
+
+	var err error
+	adminClientFnCache, err = utils.NewFnCache(utils.FnCacheConfig{
+		TTL: adminClientFnCacheTTL,
+	})
+	// This should never fail. There is also an unit test to verify it's always
+	// created. Logging error just in case.
+	if err != nil {
+		logrus.Warnf("Failed to create MongoDB admin connection cache: %v.", err)
+	}
+}

--- a/lib/srv/db/mongodb/autousers_admin.go
+++ b/lib/srv/db/mongodb/autousers_admin.go
@@ -1,20 +1,18 @@
 /*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package mongodb
 

--- a/lib/srv/db/mongodb/autousers_admin_test.go
+++ b/lib/srv/db/mongodb/autousers_admin_test.go
@@ -1,0 +1,180 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type fakeRawAdminClient struct {
+	adminClient
+
+	waitForDisconnect       context.Context
+	waitForDisconnectCancel context.CancelFunc
+}
+
+func newFakeRawAdminClient() *fakeRawAdminClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &fakeRawAdminClient{
+		waitForDisconnect:       ctx,
+		waitForDisconnectCancel: cancel,
+	}
+}
+
+func (c *fakeRawAdminClient) waitC() <-chan struct{} {
+	return c.waitForDisconnect.Done()
+}
+
+func (c *fakeRawAdminClient) isDisconnected() bool {
+	return c.waitForDisconnect.Err() != nil
+}
+
+func (c *fakeRawAdminClient) Disconnect(_ context.Context) error {
+	c.waitForDisconnectCancel()
+	return nil
+}
+
+func Test_ensure_adminClientFnCache(t *testing.T) {
+	require.NotNil(t, adminClientFnCache)
+}
+
+func Test_getShareableAdminClient(t *testing.T) {
+	ctx := context.Background()
+	fakeClock := clockwork.NewFakeClock()
+	require.NotNil(t, fakeClock)
+
+	cache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL:   adminClientFnCacheTTL,
+		Clock: fakeClock,
+	})
+	require.NoError(t, err)
+
+	db1WithAdmin1 := mustMakeMongoDatabase(t, "db1", "admin1")
+	db1WithAdmin2 := mustMakeMongoDatabase(t, "db1", "admin2")
+	db2WithAdmin := mustMakeMongoDatabase(t, "db2", "admin")
+
+	db1WithAdmin1ShareableClient := mustGetShareableAdminClient(t, cache, fakeClock, db1WithAdmin1)
+	db1WithAdmin2ShareableClient := mustGetShareableAdminClient(t, cache, fakeClock, db1WithAdmin2)
+	db2WithAdminShareableClient := mustGetShareableAdminClient(t, cache, fakeClock, db2WithAdmin)
+
+	t.Run("new client for different admin user", func(t *testing.T) {
+		require.NotSame(t, db1WithAdmin1ShareableClient, db1WithAdmin2ShareableClient)
+	})
+
+	t.Run("new client for different database", func(t *testing.T) {
+		require.NotSame(t, db1WithAdmin1ShareableClient, db2WithAdminShareableClient)
+	})
+
+	t.Run("same client for same database and admin user", func(t *testing.T) {
+		client := mustGetShareableAdminClient(t, cache, fakeClock, db1WithAdmin1)
+		require.Same(t, db1WithAdmin1ShareableClient, client)
+	})
+
+	require.NoError(t, db1WithAdmin1ShareableClient.Disconnect(ctx))
+	require.NoError(t, db1WithAdmin2ShareableClient.Disconnect(ctx))
+	require.NoError(t, db2WithAdminShareableClient.Disconnect(ctx))
+
+	fakeClock.Advance(adminClientCleanupTTL * 2)
+
+	t.Run("verify client cleanup after TTL", func(t *testing.T) {
+		requireFakeRawAdminClientDisconnected(t, db1WithAdmin2ShareableClient)
+		requireFakeRawAdminClientDisconnected(t, db2WithAdminShareableClient)
+	})
+
+	t.Run("verify client cleanup after Disconnect", func(t *testing.T) {
+		fakeRawClient, ok := db1WithAdmin1ShareableClient.adminClient.(*fakeRawAdminClient)
+		require.True(t, ok)
+
+		// db1WithAdmin1ShareableClient was acquired twice so it should be waiting.
+		require.False(t, fakeRawClient.isDisconnected())
+
+		// Now release it.
+		require.NoError(t, db1WithAdmin1ShareableClient.Disconnect(ctx))
+		requireFakeRawAdminClientDisconnected(t, db1WithAdmin1ShareableClient)
+	})
+
+	t.Run("new client after FnCache TTL", func(t *testing.T) {
+		client := mustGetShareableAdminClient(t, cache, fakeClock, db1WithAdmin1)
+		t.Cleanup(func() {
+			require.NoError(t, client.Disconnect(ctx))
+		})
+		require.NotSame(t, db1WithAdmin1ShareableClient, client)
+	})
+}
+
+func mustGetShareableAdminClient(t *testing.T, cache *utils.FnCache, clock clockwork.Clock, db types.Database) *shareableAdminClient {
+	t.Helper()
+
+	client, err := getShareableAdminClient(
+		context.Background(),
+		cache,
+		&common.Session{
+			Database: db,
+		},
+		&Engine{
+			EngineConfig: common.EngineConfig{
+				Clock: clock,
+			},
+		},
+		func(context.Context, *common.Session, *Engine) (adminClient, error) {
+			return newFakeRawAdminClient(), nil
+		},
+	)
+	require.NoError(t, err)
+	return client
+}
+
+func mustMakeMongoDatabase(t *testing.T, name, adminUser string) types.Database {
+	t.Helper()
+	db, err := types.NewDatabaseV3(types.Metadata{
+		Name: name,
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolMongoDB,
+		URI:      "localhost:8001",
+		AdminUser: &types.DatabaseAdminUser{
+			Name: adminUser,
+		},
+	})
+	require.NoError(t, err)
+	return db
+}
+
+func requireFakeRawAdminClientDisconnected(t *testing.T, client *shareableAdminClient) {
+	t.Helper()
+
+	fakeRawClient, ok := client.adminClient.(*fakeRawAdminClient)
+	require.True(t, ok)
+
+	select {
+	case <-fakeRawClient.waitC():
+		return
+	case <-time.After(time.Second):
+		require.Fail(t, "Timed out waiting for fakeRawAdminClient to Disconnect")
+	}
+}

--- a/lib/srv/db/mongodb/autousers_admin_test.go
+++ b/lib/srv/db/mongodb/autousers_admin_test.go
@@ -1,20 +1,18 @@
 /*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package mongodb
 

--- a/lib/srv/db/mongodb/autousers_test.go
+++ b/lib/srv/db/mongodb/autousers_test.go
@@ -1,0 +1,68 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_makeUserRoles(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           []string
+		checkError      require.ErrorAssertionFunc
+		expectUserRoles userRoles
+	}{
+		{
+			name: "input is invalid",
+			input: []string{
+				"read@admin",
+				"permissionWithoutPermissionDefined",
+			},
+			checkError: require.Error,
+		},
+		{
+			name: "output is sorted",
+			input: []string{
+				"write@test",
+				"my-custom-role@test2",
+				"readAnyDatabase@admin",
+				"read@test",
+			},
+			checkError: require.NoError,
+			expectUserRoles: userRoles{
+				// Sort by Database first, then Rolename.
+				{Database: "admin", Rolename: "readAnyDatabase"},
+				{Database: "test", Rolename: "read"},
+				{Database: "test", Rolename: "write"},
+				{Database: "test2", Rolename: "my-custom-role"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualUserRoles, err := makeUserRoles(test.input)
+			test.checkError(t, err)
+			require.Equal(t, test.expectUserRoles, actualUserRoles)
+		})
+	}
+}

--- a/lib/srv/db/mongodb/autousers_test.go
+++ b/lib/srv/db/mongodb/autousers_test.go
@@ -1,20 +1,18 @@
 /*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package mongodb
 

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -83,12 +83,27 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	if err != nil {
 		return trace.Wrap(err, "error authorizing database access")
 	}
+	// Automatically create the database user if needed.
+	cancelAutoUserLease, err := e.GetUserProvisioner(e).Activate(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer func() {
+		err := e.GetUserProvisioner(e).Teardown(ctx, sessionCtx)
+		if err != nil {
+			e.Log.WithError(err).Error("Failed to deactivate the user.")
+		}
+	}()
 	// Establish connection to the MongoDB server.
 	serverConn, closeFn, err := e.connect(ctx, sessionCtx)
 	if err != nil {
+		cancelAutoUserLease()
 		return trace.Wrap(err, "error connecting to the database")
 	}
 	defer closeFn()
+
+	// Release the auto-users semaphore now that we've successfully connected.
+	cancelAutoUserLease()
 
 	e.Audit.OnSessionStart(e.Context, sessionCtx, nil)
 	defer e.Audit.OnSessionEnd(e.Context, sessionCtx)
@@ -206,6 +221,12 @@ func (e *Engine) processHandshakeResponse(ctx context.Context, respMessage proto
 // authorizeConnection does authorization check for MongoDB connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context, sessionCtx *common.Session) error {
+	if sessionCtx.AutoCreateUserMode.IsEnabled() {
+		if sessionCtx.DatabaseUser != sessionCtx.Identity.Username {
+			return trace.AccessDenied("please use your Teleport username (%q) to connect instead of %q",
+				sessionCtx.Identity.Username, sessionCtx.DatabaseUser)
+		}
+	}
 	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -219,6 +240,7 @@ func (e *Engine) authorizeConnection(ctx context.Context, sessionCtx *common.Ses
 		// database name with each protocol message (for query, update, etc.) so it
 		// is checked when we receive a message from client.
 		DisableDatabaseNameMatcher: true,
+		AutoCreateUser:             sessionCtx.AutoCreateUserMode.IsEnabled(),
 	})
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
@@ -274,9 +296,10 @@ func (e *Engine) checkClientMessage(sessionCtx *common.Session, message protocol
 		sessionCtx.Database,
 		services.AccessState{MFAVerified: true},
 		role.GetDatabaseRoleMatchers(role.RoleMatchersConfig{
-			Database:     sessionCtx.Database,
-			DatabaseUser: sessionCtx.DatabaseUser,
-			DatabaseName: database,
+			Database:       sessionCtx.Database,
+			DatabaseUser:   sessionCtx.DatabaseUser,
+			DatabaseName:   database,
+			AutoCreateUser: sessionCtx.AutoCreateUserMode.IsEnabled(),
 		})...,
 	)
 }

--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -73,11 +74,14 @@ func MakeTestClient(ctx context.Context, config common.TestClientConfig, opts ..
 
 // TestServer is a test MongoDB server used in functional database access tests.
 type TestServer struct {
+	usersTracker
+
 	cfg      common.TestServerConfig
 	listener net.Listener
 	port     string
 	log      logrus.FieldLogger
 
+	serverVersion    string
 	wireVersion      int
 	activeConnection int32
 	maxMessageSize   uint32
@@ -131,9 +135,14 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 	server := &TestServer{
 		cfg: config,
 		// MongoDB uses regular TLS handshake so standard TLS listener will work.
-		listener: tls.NewListener(config.Listener, tlsConfig),
-		port:     port,
-		log:      log,
+		listener:      tls.NewListener(config.Listener, tlsConfig),
+		port:          port,
+		log:           log,
+		serverVersion: "7.0.0",
+		usersTracker: usersTracker{
+			userEventsCh: make(chan UserEvent, 100),
+			users:        make(map[string]userWithTracking),
+		},
 	}
 	for _, o := range opts {
 		o(server)
@@ -173,6 +182,12 @@ func (s *TestServer) Serve() error {
 // handleConnection receives Mongo wire messages from the client connection
 // and sends back the response messages.
 func (s *TestServer) handleConnection(conn net.Conn) error {
+	release, err := s.trackUserConnection(conn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer release()
+
 	// Read client messages and reply to them - test server supports a very
 	// basic set of commands: "isMaster", "authenticate", "ping" and "find".
 	for {
@@ -210,6 +225,22 @@ func (s *TestServer) handleMessage(message protocol.Message) (protocol.Message, 
 		return s.handleSaslStart(message)
 	case commandSaslContinue:
 		return s.handleSaslContinue(message)
+	case commandEndSessions:
+		return sendOKReply()
+	case commandBuildInfo:
+		return s.handleBuildInfo(message)
+
+	// Auto-user provisioning related commands.
+	case commandCurrentOp:
+		return s.handleCurrentOp(message)
+	case commandCreateUser:
+		return s.handleCreateUser(message)
+	case commandUsersInfo:
+		return s.handleUsersInfo(message)
+	case commandUpdateUser:
+		return s.handleUpdateUser(message)
+	case commandDropUser:
+		return s.handleDropUser(message)
 	}
 	return nil, trace.NotImplemented("unsupported message: %v", message)
 }
@@ -381,6 +412,81 @@ func (s *TestServer) handleAWSIAMSaslContinue(conversationID int32, opmsg *proto
 	return protocol.MakeOpMsg(authReply), nil
 }
 
+func (s *TestServer) handleBuildInfo(msg protocol.Message) (protocol.Message, error) {
+	return sendOKReply(withReplyKeyValue("version", s.serverVersion))
+}
+
+func (s *TestServer) handleCurrentOp(msg protocol.Message) (protocol.Message, error) {
+	opmsg, ok := msg.(*protocol.MessageOpMsg)
+	if !ok {
+		return nil, trace.BadParameter("invalid msg")
+	}
+
+	req := struct {
+		EffectiveUsers struct {
+			Match struct {
+				User string `bson:"user"`
+			} `bson:"$elemMatch"`
+		} `bson:"effectiveUsers"`
+	}{}
+	if err := bson.Unmarshal([]byte(opmsg.BodySection.Document), &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// We are cheating here as the Engine only counts the number of inprog.
+	conns := s.usersTracker.getUserRemoteConnections(req.EffectiveUsers.Match.User)
+	return sendOKReply(withReplyKeyValue("inprog", conns))
+}
+
+func (s *TestServer) handleCreateUser(msg protocol.Message) (protocol.Message, error) {
+	username, user, err := getUsernameAndUserFromMessage(msg, commandCreateUser)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.usersTracker.createUser(username, user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sendOKReply()
+}
+
+func (s *TestServer) handleUsersInfo(msg protocol.Message) (protocol.Message, error) {
+	username, err := getUsernameFromMessage(msg, commandUsersInfo)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	users := []user{}
+	if user, found := s.usersTracker.getUser(username); found {
+		users = append(users, user)
+	}
+	return sendOKReply(withReplyKeyValue("users", users))
+}
+
+func (s *TestServer) handleUpdateUser(msg protocol.Message) (protocol.Message, error) {
+	username, user, err := getUsernameAndUserFromMessage(msg, commandUpdateUser)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.usersTracker.updateUser(username, user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sendOKReply()
+}
+
+func (s *TestServer) handleDropUser(msg protocol.Message) (protocol.Message, error) {
+	username, err := getUsernameFromMessage(msg, commandDropUser)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.usersTracker.deleteUser(username); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sendOKReply()
+}
+
 // getWireVersion returns the server's wire protocol version.
 func (s *TestServer) getWireVersion() int {
 	if s.wireVersion != 0 {
@@ -412,6 +518,199 @@ func (s *TestServer) Close() error {
 	return s.listener.Close()
 }
 
+func withReplyKeyValue(key string, value any) func(bson.M) {
+	return func(reply bson.M) {
+		reply[key] = value
+	}
+}
+
+func sendOKReply(opts ...func(bson.M)) (protocol.Message, error) {
+	reply := bson.M{
+		"ok": 1,
+	}
+	for _, applyOpt := range opts {
+		applyOpt(reply)
+	}
+	replyBytes, err := bson.Marshal(reply)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return protocol.MakeOpMsg(replyBytes), nil
+}
+
+func getUsernameFromMessage(msg protocol.Message, usernameKey string) (string, error) {
+	opmsg, ok := msg.(*protocol.MessageOpMsg)
+	if !ok {
+		return "", trace.BadParameter("invalid msg")
+	}
+	username := opmsg.BodySection.Document.Lookup(usernameKey)
+	if !strings.HasPrefix(username.StringValue(), "CN=") {
+		return "", trace.BadParameter("invalid username %v", username)
+	}
+	return username.StringValue(), nil
+}
+
+func getUsernameAndUserFromMessage(msg protocol.Message, usernameKey string) (string, user, error) {
+	var user user
+	username, err := getUsernameFromMessage(msg, usernameKey)
+	if err != nil {
+		return "", user, trace.Wrap(err)
+	}
+
+	err = bson.Unmarshal([]byte(msg.(*protocol.MessageOpMsg).BodySection.Document), &user)
+	return username, user, trace.Wrap(err)
+}
+
+// UserEventType defines the type of the UserEventType.
+type UserEventType int
+
+const (
+	UserEventActivate UserEventType = iota
+	UserEventDeactivate
+	UserEventDelete
+)
+
+// UserEvent represents a user activation/deactivation event.
+type UserEvent struct {
+	// DatabaseUser is the in-database username.
+	DatabaseUser string
+	// Roles are the user Roles.
+	Roles []string
+	// Type defines the type of the UserEventType.
+	Type UserEventType
+}
+
+type userWithTracking struct {
+	user              user
+	activeConnections map[net.Conn]struct{}
+}
+
+type usersTracker struct {
+	userEventsCh chan UserEvent
+	users        map[string]userWithTracking
+	usersMu      sync.Mutex
+}
+
+// UserEventsCh returns channel that receives user activate/deactivate events.
+func (t *usersTracker) UserEventsCh() <-chan UserEvent {
+	return t.userEventsCh
+}
+
+func (t *usersTracker) trackUserConnection(conn net.Conn) (func(), error) {
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return func() {}, nil
+	}
+
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, trace.Wrap(err)
+	} else if len(tlsConn.ConnectionState().PeerCertificates) == 0 {
+		return func() {}, nil
+	}
+
+	username := "CN=" + tlsConn.ConnectionState().PeerCertificates[0].Subject.CommonName
+
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+	if user, found := t.users[username]; found {
+		user.activeConnections[conn] = struct{}{}
+	}
+
+	return func() {
+		// Untrack per-user active connections.
+		t.usersMu.Lock()
+		defer t.usersMu.Unlock()
+		if user, found := t.users[username]; found {
+			delete(user.activeConnections, conn)
+		}
+	}, nil
+}
+
+func (t *usersTracker) sendUserEvent(username string, user user, eventType UserEventType) {
+	event := UserEvent{
+		DatabaseUser: username,
+		Type:         eventType,
+	}
+	for _, role := range user.Roles {
+		event.Roles = append(event.Roles, fmt.Sprintf("%s@%s", role.Rolename, role.Database))
+	}
+	t.userEventsCh <- event
+}
+
+func (t *usersTracker) getUser(username string) (user, bool) {
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+
+	user, ok := t.users[username]
+	return user.user, ok
+}
+
+func (t *usersTracker) getUserRemoteConnections(username string) (conns []string) {
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+
+	user, ok := t.users[username]
+	if !ok {
+		return conns
+	}
+
+	for conn := range user.activeConnections {
+		conns = append(conns, conn.RemoteAddr().String())
+	}
+	return conns
+}
+
+func (t *usersTracker) createUser(username string, user user) error {
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+
+	_, found := t.users[username]
+	if found {
+		return trace.AlreadyExists("user %q already exists", username)
+	}
+
+	t.users[username] = userWithTracking{
+		user:              user,
+		activeConnections: make(map[net.Conn]struct{}),
+	}
+	go t.sendUserEvent(username, user, UserEventActivate)
+	return nil
+}
+
+func (t *usersTracker) updateUser(username string, user user) error {
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+
+	existingUser, found := t.users[username]
+	if !found {
+		return trace.NotFound("user %q not found", username)
+	}
+
+	existingUser.user = user
+	if user.isLocked() {
+		go t.sendUserEvent(username, user, UserEventDeactivate)
+	} else {
+		go t.sendUserEvent(username, user, UserEventActivate)
+	}
+	return nil
+}
+
+func (t *usersTracker) deleteUser(username string) error {
+	t.usersMu.Lock()
+	defer t.usersMu.Unlock()
+
+	existingUser, found := t.users[username]
+	if !found {
+		return trace.NotFound("user %q not found", username)
+	} else if len(existingUser.activeConnections) > 0 {
+		return trace.CompareFailed("user %q has active connections", username)
+	}
+
+	delete(t.users, username)
+	go t.sendUserEvent(username, existingUser.user, UserEventDelete)
+	return nil
+}
+
 const (
 	authMechanismAWS = "MONGODB-AWS"
 
@@ -421,6 +720,14 @@ const (
 	commandFind         = "find"
 	commandSaslStart    = "saslStart"
 	commandSaslContinue = "saslContinue"
+	commandEndSessions  = "endSessions"
+	commandBuildInfo    = "buildInfo"
+
+	commandCurrentOp  = "currentOp"
+	commandCreateUser = "createUser"
+	commandUsersInfo  = "usersInfo"
+	commandUpdateUser = "updateUser"
+	commandDropUser   = "dropUser"
 )
 
 // makeOKReply builds a generic document used to indicate success e.g.


### PR DESCRIPTION
backport of #33717 to branch/v14

changelog: Database Automatic User Provisioning support for self-hosted MongoDB

No cherry-pick conflict but have to update the license ([slack](https://gravitational.slack.com/archives/C08HF8E9F/p1701387178901619?thread_ts=1701382391.284299&cid=C08HF8E9F))