### PR TITLE
[v14] Make EKS fetcher to lazy initialize AWS EKS client

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -386,9 +386,9 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 
 	// Add kube fetchers.
 	for _, matcher := range otherMatchers {
-		matcherAssumeRole := &types.AssumeRole{}
+		matcherAssumeRole := types.AssumeRole{}
 		if matcher.AssumeRole != nil {
-			matcherAssumeRole = matcher.AssumeRole
+			matcherAssumeRole = *matcher.AssumeRole
 		}
 
 		for _, t := range matcher.Types {
@@ -409,25 +409,14 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	return nil
 }
 
-func (s *Server) getEKSFetcher(region string, assumeRole *types.AssumeRole, tags types.Labels) (common.Fetcher, error) {
-	client, err := s.CloudClients.GetAWSEKSClient(
-		s.ctx,
-		region,
-		cloud.WithAssumeRole(
-			assumeRole.RoleARN,
-			assumeRole.ExternalID,
-		),
-		cloud.WithAmbientCredentials(),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+func (s *Server) getEKSFetcher(region string, assumeRole types.AssumeRole, tags types.Labels) (common.Fetcher, error) {
 	fetcher, err := fetchers.NewEKSFetcher(
 		fetchers.EKSFetcherConfig{
-			Client:       client,
-			Region:       region,
-			FilterLabels: tags,
-			Log:          s.Log,
+			EKSClientGetter: s.CloudClients,
+			AssumeRole:      assumeRole,
+			Region:          region,
+			FilterLabels:    tags,
+			Log:             s.Log,
 		},
 	)
 	return fetcher, trace.Wrap(err)

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1040,8 +1040,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				return len(clustersNotUpdated) == 0 && clustersFoundInAuth
 			}, 5*time.Second, 200*time.Millisecond)
 
-			require.Equal(t, tc.expectedAssumedRoles, sts.GetAssumedRoleARNs(), "roles incorrectly assumed")
-			require.Equal(t, tc.expectedExternalIDs, sts.GetAssumedRoleExternalIDs(), "external IDs incorrectly assumed")
+			require.ElementsMatch(t, tc.expectedAssumedRoles, sts.GetAssumedRoleARNs(), "roles incorrectly assumed")
+			require.ElementsMatch(t, tc.expectedExternalIDs, sts.GetAssumedRoleExternalIDs(), "external IDs incorrectly assumed")
 
 			if tc.wantEvents > 0 {
 				require.Eventually(t, func() bool {
@@ -1099,7 +1099,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 			},
 		},
 		{
-			desc: "EKS fetcher is skipped on initialization error",
+			desc: "EKS fetcher is skipped on initialization error (missing region)",
 			cloudClients: &cloud.TestCloudClients{
 				STS: &mocks.STSMock{AssumeRoleErrors: map[string]error{"arn:aws:iam::123456789012:role/teleport-role": trace.AccessDenied("unauthorized")}},
 				EKS: &mocks.EKSMock{},
@@ -1108,7 +1108,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 				AWS: []types.AWSMatcher{
 					{
 						Types:   []string{"eks"},
-						Regions: []string{"eu-west-1"},
+						Regions: []string{},
 						Tags:    map[string]utils.Strings{"env": {"prod"}},
 						AssumeRole: &types.AssumeRole{
 							RoleARN:    "arn:aws:iam::123456789012:role/teleport-role",
@@ -1144,7 +1144,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 			discServer, err := New(
 				ctx,
 				&Config{
-					CloudClients:    tt.cloudClients,
+					CloudClients:    nil,
 					AccessPoint:     newFakeAccessPoint(),
 					Matchers:        tt.matchers,
 					Emitter:         &mockEmitter{},

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1101,7 +1101,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 		{
 			desc: "EKS fetcher is skipped on initialization error (missing region)",
 			cloudClients: &cloud.TestCloudClients{
-				STS: &mocks.STSMock{AssumeRoleErrors: map[string]error{"arn:aws:iam::123456789012:role/teleport-role": trace.AccessDenied("unauthorized")}},
+				STS: &mocks.STSMock{},
 				EKS: &mocks.EKSMock{},
 			},
 			matchers: Matchers{

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
@@ -39,12 +40,24 @@ const (
 
 type eksFetcher struct {
 	EKSFetcherConfig
+
+	mu     sync.Mutex
+	client eksiface.EKSAPI
+}
+
+// EKSClientGetter is an interface for getting an EKS client.
+type EKSClientGetter interface {
+	// GetAWSEKSClient returns AWS EKS client for the specified region.
+	GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSAssumeRoleOptionFn) (eksiface.EKSAPI, error)
 }
 
 // EKSFetcherConfig configures the EKS fetcher.
 type EKSFetcherConfig struct {
-	// Client is the AWS eKS client.
-	Client eksiface.EKSAPI
+	// EKSClientGetter retrieves an EKS client.
+	EKSClientGetter EKSClientGetter
+	// AssumeRole provides a role ARN and ExternalID to assume an AWS role
+	// when fetching clusters.
+	AssumeRole types.AssumeRole
 	// Region is the region where the clusters should be located.
 	Region string
 	// FilterLabels are the filter criteria.
@@ -55,8 +68,8 @@ type EKSFetcherConfig struct {
 
 // CheckAndSetDefaults validates and sets the defaults values.
 func (c *EKSFetcherConfig) CheckAndSetDefaults() error {
-	if c.Client == nil {
-		return trace.BadParameter("missing Client field")
+	if c.EKSClientGetter == nil {
+		return trace.BadParameter("missing EKSClientGetter field")
 	}
 	if len(c.Region) == 0 {
 		return trace.BadParameter("missing Region field")
@@ -78,7 +91,32 @@ func NewEKSFetcher(cfg EKSFetcherConfig) (common.Fetcher, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	return &eksFetcher{cfg}, nil
+	return &eksFetcher{EKSFetcherConfig: cfg}, nil
+}
+
+func (a *eksFetcher) getClient(ctx context.Context) (eksiface.EKSAPI, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.client != nil {
+		return a.client, nil
+	}
+
+	client, err := a.EKSClientGetter.GetAWSEKSClient(
+		ctx,
+		a.Region,
+		cloud.WithAssumeRole(
+			a.AssumeRole.RoleARN,
+			a.AssumeRole.ExternalID,
+		),
+		cloud.WithAmbientCredentials(),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	a.client = client
+
+	return a.client, nil
 }
 
 func (a *eksFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
@@ -106,7 +144,12 @@ func (a *eksFetcher) getEKSClusters(ctx context.Context) (types.KubeClusters, er
 	)
 	group.SetLimit(concurrencyLimit)
 
-	err := a.Client.ListClustersPagesWithContext(ctx,
+	client, err := a.getClient(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed getting AWS EKS client")
+	}
+
+	err = client.ListClustersPagesWithContext(ctx,
 		&eks.ListClustersInput{
 			Include: nil, // For now we should only list EKS clusters
 		},
@@ -161,7 +204,12 @@ func (a *eksFetcher) String() string {
 // If any cluster does not match the filtering criteria, this function returns a “trace.CompareFailed“ error
 // to distinguish filtering and operational errors.
 func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName string) (types.KubeCluster, error) {
-	rsp, err := a.Client.DescribeClusterWithContext(
+	client, err := a.getClient(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed getting AWS EKS client")
+	}
+
+	rsp, err := client.DescribeClusterWithContext(
 		ctx,
 		&eks.DescribeClusterInput{
 			Name: aws.String(clusterName),

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
@@ -99,10 +100,10 @@ func TestEKSFetcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := EKSFetcherConfig{
-				Client:       newPopulatedEKSMock(),
-				FilterLabels: tt.args.filterLabels,
-				Region:       tt.args.region,
-				Log:          logrus.New(),
+				EKSClientGetter: &mockEKSClientGetter{},
+				FilterLabels:    tt.args.filterLabels,
+				Region:          tt.args.region,
+				Log:             logrus.New(),
 			}
 			fetcher, err := NewEKSFetcher(cfg)
 			require.NoError(t, err)
@@ -112,6 +113,12 @@ func TestEKSFetcher(t *testing.T) {
 			require.Equal(t, tt.want.ToMap(), resources.ToMap())
 		})
 	}
+}
+
+type mockEKSClientGetter struct{}
+
+func (e *mockEKSClientGetter) GetAWSEKSClient(ctx context.Context, region string, opts ...cloud.AWSAssumeRoleOptionFn) (eksiface.EKSAPI, error) {
+	return newPopulatedEKSMock(), nil
 }
 
 type mockEKSAPI struct {


### PR DESCRIPTION
Backport #35077 to branch/v14

Changelog: Prevent EKS fetcher not having correct IAM permissions from stopping whole Discovery service start up