### PR TITLE
[v14] Add `cluster_auth_preferences` to shortcuts for `cluster_auth_preference`

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -123,6 +123,9 @@ func PreserveResourceID() MarshalOption {
 }
 
 // ParseShortcut parses resource shortcut
+// Generally, this should include the plural of a singular resource name or vice
+// versa.
+// These shortcuts
 func ParseShortcut(in string) (string, error) {
 	if in == "" {
 		return "", trace.BadParameter("missing resource name")
@@ -154,7 +157,7 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindReverseTunnel, nil
 	case types.KindTrustedCluster, "tc", "cluster", "clusters":
 		return types.KindTrustedCluster, nil
-	case types.KindClusterAuthPreference, "cluster_authentication_preferences", "cap":
+	case types.KindClusterAuthPreference, "cluster_authentication_preferences", "cluster_auth_preferences", "cap":
 		return types.KindClusterAuthPreference, nil
 	case types.KindUIConfig, "ui":
 		return types.KindUIConfig, nil

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -125,7 +125,6 @@ func PreserveResourceID() MarshalOption {
 // ParseShortcut parses resource shortcut
 // Generally, this should include the plural of a singular resource name or vice
 // versa.
-// These shortcuts
 func ParseShortcut(in string) (string, error) {
 	if in == "" {
 		return "", trace.BadParameter("missing resource name")


### PR DESCRIPTION
Backport #35312 to branch/v14

changelog: Add cluster_auth_preferences to the shortcuts for cluster_auth_preference.