### PR TITLE
Check nil before returning cluster preferences

### DIFF
--- a/lib/web/userpreferences.go
+++ b/lib/web/userpreferences.go
@@ -181,10 +181,15 @@ func userPreferencesResponse(resp *userpreferencesv1.UserPreferences) *UserPrefe
 	return jsonResp
 }
 
-func clusterPreferencesResponse(resp *userpreferencesv1.ClusterUserPreferences) ClusterUserPreferencesResponse {
-	return ClusterUserPreferencesResponse{
-		PinnedResources: resp.PinnedResources.ResourceIds,
+func clusterPreferencesResponse(prefs *userpreferencesv1.ClusterUserPreferences) ClusterUserPreferencesResponse {
+	resp := ClusterUserPreferencesResponse{}
+
+	if prefs == nil {
+		return resp
 	}
+
+	resp.PinnedResources = append(resp.PinnedResources, prefs.PinnedResources.ResourceIds...)
+	return resp
 }
 
 // assistUserPreferencesResponse creates a JSON response for the assist user preferences.

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -116,7 +116,7 @@ function ClusterResources({
       dir: 'ASC',
     },
     pinnedOnly:
-      preferences.unifiedResourcePreferences.defaultTab ===
+      preferences?.unifiedResourcePreferences?.defaultTab ===
       DefaultTab.DEFAULT_TAB_PINNED,
   });
 


### PR DESCRIPTION
This adds a nil check before returning `ClusterPreferences`. This is just in case the request auth server doesn't return the entire new `DefaultUserPreferences` object. This can happen if the auth server has not yet been updated (in a leaf cluster for example). 