### PR TITLE
[v13] Always prefer multiplex port if Kube Proxy endpoint is specified

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -824,7 +824,7 @@ func (c *Config) ParseProxyHost(proxyHost string) error {
 
 // KubeProxyHostPort returns the host and port of the Kubernetes proxy.
 func (c *Config) KubeProxyHostPort() (string, int) {
-	if c.KubeProxyAddr != "" {
+	if c.KubeProxyAddr != "" && !c.TLSRoutingEnabled {
 		addr, err := utils.ParseAddr(c.KubeProxyAddr)
 		if err == nil {
 			return addr.Host(), addr.Port(defaults.KubeListenPort)

--- a/tool/tsh/kubectl.go
+++ b/tool/tsh/kubectl.go
@@ -497,8 +497,9 @@ func isKubectlConfigCommand(kubectlCommand *cobra.Command, args []string) bool {
 
 func kubeClusterAddrFromProfile(profile *profile.Profile) string {
 	partialClientConfig := client.Config{
-		WebProxyAddr:  profile.WebProxyAddr,
-		KubeProxyAddr: profile.KubeProxyAddr,
+		WebProxyAddr:      profile.WebProxyAddr,
+		KubeProxyAddr:     profile.KubeProxyAddr,
+		TLSRoutingEnabled: profile.TLSRoutingEnabled,
 	}
 	return partialClientConfig.KubeClusterAddr()
 }


### PR DESCRIPTION
Backport #34211 to branch/v13