### PR TITLE
Prevent filesystem race in `make -j test-go test-sh test-api`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -882,7 +882,7 @@ test-rust:
 endif
 endif
 
-# Find and run all shell script unit tests (using https://github.com/bats-core/bats-core)
+# Run all shell script unit tests (using https://github.com/bats-core/bats-core)
 .PHONY: test-sh
 test-sh:
 	@if ! type bats 2>&1 >/dev/null; then \
@@ -890,7 +890,7 @@ test-sh:
 		if [ "$${DRONE}" = "true" ]; then echo "This is a failure when running in CI." && exit 1; fi; \
 		exit 0; \
 	fi; \
-	find . -iname "*.bats" -exec dirname {} \; | uniq | xargs -t -L1 bats $(BATSFLAGS)
+	bats $(BATSFLAGS) ./assets/aws/files/tests
 
 
 .PHONY: test-e2e


### PR DESCRIPTION
The `test-go`/`test-api` make targets algorithmically create and remove directories under the `./target` path. A top level `find .` in `make-sh` would sometimes traverse these generated directories while they they were being destroyed, resulting in spurious `test-sh` failures such as the following:

```console
make -j"$(nproc)" test-go test-sh test-api
...
CGO_ENABED=1 ... go test -cover -json -tags "pam bpf desktop_access_rdp" -test.run=TestChaos ./lib/events/filesessions
...
find: ‘./target/release/deps/rmetaWJZ5A1’: No such file or directory
bats ./assets/aws/files/tests
ok 1 [agent-app] config file was generated without error
...
ok 393 [starter-cluster-tlsrouting] node_service.listen_addr is set correctly
make: *** [Makefile:888: test-sh] Error 1
make: *** Waiting for unfinished jobs....
```

In this case, the bats `find` tripped over a directory that a separate test process was actively destroying, and that errors was propagated through the shell pipeline.

Instead of trying to do something smart, we can drop the `find`/`unique`/`xargs` pipeline entirely, because all bats tests currently reside in a single directory.  If/when we add bats testing elsewhere, we can get by with a list of directories, instead of auto discovery.

### Testing:

I was never able to reproduce [the original failure](https://github.com/gravitational/teleport/actions/runs/7090546512/job/19297748182#step:6:1098) on my local machine, as it is a filesystem race between different processes and highly nondeterministic.  However I was able to verify the new target works, and that it still works when run in parallel.

I also checked that if the test code is moved or deleted, the target will fail:

```
$ bats ./assets/aws/doesnotexist
Error: Test file "/home/walt/git/teleport/assets/aws/doesnotexist" does not exist
```

This ensures the make target doesn't fall out of date with the source code.