### PR TITLE
Audit use of usageBased flag in backend

### DIFF
--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -181,8 +181,7 @@ func NewDraftConfigurator(ctx context.Context, ecaSvc ExternalAuditStorageGetter
 
 func newConfigurator(ctx context.Context, spec *externalauditstorage.ExternalAuditStorageSpec, integrationSvc services.IntegrationsGetter, alertService ClusterAlertService, optFns ...func(*Options)) (*Configurator, error) {
 	// ExternalAuditStorage is only available in Cloud Enterprise
-	// (IsUsageBasedBilling indicates Teleport Team, where this is not supported)
-	if !modules.GetModules().Features().Cloud || modules.GetModules().Features().IsUsageBasedBilling {
+	if !modules.GetModules().Features().Cloud || modules.GetModules().Features().IsTeam() {
 		return &Configurator{isUsed: false}, nil
 	}
 

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -91,13 +91,6 @@ type Features struct {
 	// CustomTheme holds the name of WebUI custom theme.
 	CustomTheme string
 
-	// IsTrialProduct is true if the cluster is in trial mode.
-	//
-	// TODO: Cannot use this field until cloud/salescenter sets this field
-	// when `func FetchFromCloud` and cloud/tenant.pb.go defines this field.
-	// see `e/lib/secreports/ func cloudLimits`, where it's currently the only
-	// place where we need to determine if product is trial.
-	IsTrialProduct bool
 	// AccessGraph enables the usage of access graph.
 	AccessGraph bool
 	// IdentityGovernanceSecurity indicates whether IGS related features are enabled:

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -92,9 +92,12 @@ type Features struct {
 	CustomTheme string
 
 	// IsTrialProduct is true if the cluster is in trial mode.
+	//
+	// TODO: Cannot use this field until cloud/salescenter sets this field
+	// when `func FetchFromCloud` and cloud/tenant.pb.go defines this field.
+	// see `e/lib/secreports/ func cloudLimits`, where it's currently the only
+	// place where we need to determine if product is trial.
 	IsTrialProduct bool
-	// IsTeam is true if the cluster is a Teleport Team cluster.
-	IsTeamProduct bool
 	// AccessGraph enables the usage of access graph.
 	AccessGraph bool
 	// IdentityGovernanceSecurity indicates whether IGS related features are enabled:
@@ -212,6 +215,10 @@ func (f Features) IsLegacy() bool {
 // TODO(lisa): the isUsageBasedBilling check is temporary until nearing v15.0
 func (f Features) IGSEnabled() bool {
 	return f.IsUsageBasedBilling && f.IdentityGovernanceSecurity
+}
+
+func (f Features) IsTeam() bool {
+	return f.ProductType == ProductTypeTeam
 }
 
 // AccessResourcesGetter is a minimal interface that is used to get access lists

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -159,7 +159,7 @@ function ShowState({
   autoStart?: boolean;
 }) {
   const cluster = makeRootCluster({
-    features: { isUsageBasedBilling: true, advancedAccessWorkflows: false },
+    features: { isUsageBasedBilling: false, advancedAccessWorkflows: false },
     proxyVersion: '17.0.0',
   });
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -159,7 +159,6 @@ function ShowState({
   autoStart?: boolean;
 }) {
   const cluster = makeRootCluster({
-    features: { isUsageBasedBilling: false, advancedAccessWorkflows: false },
     proxyVersion: '17.0.0',
   });
   appContext.clustersService.state.clusters.set(cluster.uri, cluster);


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/2317

with the new EUB (enterprise usage based product) `usage based` can mean either team or eub

Goes through the backend code and looked through use of `IsUsageBasedBilling` that meant `isTeam` and replaced it with the correct flag.
