### PR TITLE
Bump cloud version 14.2.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1732,7 +1732,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "14.1.3",
+      "version": "14.2.1",
       "major_version": "14",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Update docs with latest Teleport Cloud version.

ref: https://github.com/gravitational/cloud/issues/6872
