### PR TITLE
aws_test.go: Remove UUIDs from document contents since they are random

### DIFF
--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -2341,7 +2341,13 @@ func (m *SSMMock) CreateDocumentWithContext(ctx aws.Context, input *ssm.CreateDo
 	m.expectedInput.Content = &replacedExpected
 	replacedInput := uuidRegex.ReplaceAllString(*input.Content, "")
 	input.Content = &replacedInput
-	require.Equal(m.t, m.expectedInput, input)
+	// Diff content first for a nicer error message.
+	require.Empty(m.t,
+		cmp.Diff(m.expectedInput.Content, input.Content),
+		"Document content diff (-want +got)")
+	require.Empty(m.t,
+		cmp.Diff(m.expectedInput, input, cmpopts.IgnoreFields(ssm.CreateDocumentInput{}, "Content")),
+		"Document diff (-want +got)")
 
 	return nil, nil
 }

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -21,6 +21,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -2333,6 +2334,13 @@ type SSMMock struct {
 func (m *SSMMock) CreateDocumentWithContext(ctx aws.Context, input *ssm.CreateDocumentInput, opts ...request.Option) (*ssm.CreateDocumentOutput, error) {
 
 	m.t.Helper()
+
+	// UUID's are unpredictable, so we remove them from the content
+	uuidRegex := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	replacedExpected := uuidRegex.ReplaceAllString(*m.expectedInput.Content, "")
+	m.expectedInput.Content = &replacedExpected
+	replacedInput := uuidRegex.ReplaceAllString(*input.Content, "")
+	input.Content = &replacedInput
 	require.Equal(m.t, m.expectedInput, input)
 
 	return nil, nil


### PR DESCRIPTION
After the changes in https://github.com/gravitational/teleport/pull/35152 we should no longer be able to do a direct document comparison.  There were no unit test failures in that PR, however the v12 backport did show this failure: https://github.com/gravitational/teleport/actions/runs/7104520961/job/19340024251?pr=35364

Although this change does not fix any test failures, I think we should bring in this change to ensure that this logic matches the expected behavior (keep the tests robust for future changes).