### PR TITLE
[v13]: Bump cloud version 14.2.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1880,8 +1880,8 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.4.3",
-      "major_version": "13",
+      "version": "14.2.1",
+      "major_version": "14",
       "sla": {
         "monthly_percentage": "99.9%",
         "monthly_downtime": "44 minutes"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/35358 to branch/v13