### PR TITLE
Simplify Event Handler guides

### DIFF
--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -1,0 +1,59 @@
+<Tabs>
+<TabItem label="Linux server">
+
+Earlier, we generated a file called `teleport-event-handler.toml` to configure
+the Fluentd event handler. This file includes setting similar to the following:
+
+```toml
+storage = "./storage"
+timeout = "10s"
+batch = 20
+namespace = "default"
+
+[forward.fluentd]
+ca = "/home/bob/event-handler/ca.crt"
+cert = "/home/bob/event-handler/client.crt"
+key = "/home/bob/event-handler/client.key"
+url = "https://fluentd.example.com:8888/test.log"
+session-url = "https://fluentd.example.com:8888/session"
+
+[teleport]
+addr = "example.teleport.com:443"
+identity = "identity"
+```
+
+Modify the configuration to replace `fluentd.example.com` with the domain name
+of your Fluentd deployment.
+
+</TabItem>
+<TabItem label="Helm Chart">
+
+Use the following template to create `teleport-plugin-event-handler-values.yaml`:
+
+```yaml
+eventHandler:
+  storagePath: "./storage"
+  timeout: "10s"
+  batch: 20
+  namespace: "default"
+
+teleport:
+  address: "example.teleport.com:443"
+  identitySecretName: teleport-event-handler-identity
+
+fluentd:
+  url: "https://fluentd.fluentd.svc.cluster.local/events.log"
+  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
+  certificate:
+    secretName: "teleport-event-handler-client-tls"
+    caPath: "ca.crt"
+    certPath: "client.crt"
+    keyPath: "client.key"
+
+persistentVolumeClaim:
+  enabled: true
+```
+
+</TabItem>
+</Tabs>
+

--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -1,4 +1,4 @@
-{{ client="The plugin" }}
+{{ client="plugin" secret="plugin-identity" }}
 
 Like all Teleport users, `{{ user }}` needs signed credentials in order to
 connect to your Teleport cluster. You will use the `tctl auth sign` command to
@@ -12,15 +12,15 @@ directory:
 $ tctl auth sign --user={{ user }} --out=auth.pem
 ```
 
-{{ client }} connects to the Teleport Auth Service's gRPC endpoint over TLS.
+The {{ client }} connects to the Teleport Auth Service's gRPC endpoint over TLS.
 
-The identity file, `auth.pem`, includes both TLS and SSH credentials. {{ client }}
-uses the SSH credentials to connect to the Proxy Service, which establishes a
-reverse tunnel connection to the Auth Service. {{ client }}  uses this reverse
-tunnel, along with your TLS credentials, to connect to the Auth Service's gRPC
-endpoint.
+The identity file, `auth.pem`, includes both TLS and SSH credentials. The 
+{{ client }} uses the SSH credentials to connect to the Proxy Service, which
+establishes a reverse tunnel connection to the Auth Service. The {{ client }}
+uses this reverse tunnel, along with your TLS credentials, to connect to the
+Auth Service's gRPC endpoint.
 
-<Admonition
+<Details
   title="Certificate Lifetime"
 >
 
@@ -40,4 +40,22 @@ endpoint.
   $ tsh login --proxy=teleport.example.com --ttl=60060
   ```
 
-</Admonition>
+</Details>
+
+If you are running the {{ client }} on a Linux server, create a data directory
+to hold certificate files for the {{ client }}:
+
+```code
+$ sudo mkdir -p /var/lib/teleport/api-credentials
+$ sudo mv auth.* /var/lib/teleport/plugins/api-credentials
+```
+
+If you are running the {{ client }} on Kubernetes, Create a Kubernetes secret
+that contains the Teleport identity file:
+
+```code
+$ kubectl -n teleport create secret generic --from-file=auth.pem {{ secret }}
+```
+
+Once the Teleport credentials expire, you will need to renew them by running the
+`tctl auth sign` command again.

--- a/docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx
+++ b/docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx
@@ -1,0 +1,39 @@
+In order for the Event Handler plugin to forward events from your Teleport
+cluster, it needs signed credentials from the cluster's certificate authority.
+The `teleport-event-handler` user cannot request this itself, and requires
+another user to **impersonate** this account in order to request credentials.
+
+Create a role that enables your user to impersonate the `teleport-event-handler`
+user. First, paste the following YAML document into a file called
+`teleport-event-handler-impersonator.yaml`:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: teleport-event-handler-impersonator
+spec:
+  options:
+    # max_session_ttl defines the TTL (time to live) of SSH certificates
+    # issued to the users with this role.
+    max_session_ttl: 10h
+
+  # This section declares a list of resource/verb combinations that are
+  # allowed for the users of this role. By default nothing is allowed.
+  allow:
+    impersonate:
+      users: ["teleport-event-handler"]
+      roles: ["teleport-event-handler"]
+```
+
+Next, create the role:
+
+```code
+$ tctl create teleport-event-handler-impersonator.yaml
+```
+
+Add this role to the user that generates signed credentials for the Event
+Handler:
+
+(!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
+

--- a/docs/pages/includes/start-event-handler.mdx
+++ b/docs/pages/includes/start-event-handler.mdx
@@ -1,0 +1,70 @@
+Start the Teleport Teleport Event Handler by following the instructions below. 
+
+<Tabs>
+<TabItem label="Linux server">
+On your Linux server, create a systemd service definition at the path
+`/usr/lib/systemd/system/teleport-event-handler.service` with the following
+content:
+
+```ini
+[Unit]
+Description=Teleport Event Handler
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart=/usr/local/bin/teleport-event-handler start --config=/etc/teleport-event-handler.toml
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/run/teleport-event-handler.pid
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the plugin:
+
+```code
+$ sudo systemctl enable teleport-event-handler
+$ sudo systemctl start teleport-event-handler
+```
+
+<Details title="Choose when to start exporting events">
+
+You can configure when you would like the Teleport Event Handler to begin
+exporting events when you run the `start` command. This example will start
+exporting from May 5th, 2021:
+
+```code
+$ teleport-event-handler start --config teleport-event-handler.toml --start-time "2021-05-05T00:00:00Z"
+```
+
+You can only determine the start time once, when first running the Teleport
+Event Handler. If you want to change the time frame later, remove the plugin
+state directory that you specified in the `storage` field of the handler's
+configuration file.
+
+</Details>
+
+Once the Teleport Event Handler starts, you will see notifications about scanned
+and forwarded events:
+
+```code
+$ sudo journalctl -u teleport-event-handler
+DEBU   Event sent id:f19cf375-4da6-4338-bfdc-e38334c60fd1 index:0 ts:2022-09-21
+18:51:04.849 +0000 UTC type:cert.create event-handler/app.go:140
+...
+```
+
+</TabItem>
+<TabItem label="Helm chart">
+Run the following command on your workstation:
+
+```code
+$ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
+  --values teleport-plugin-event-handler-values.yaml \
+  --version (=teleport.plugin.version=)
+```
+
+</TabItem>
+</Tabs>

--- a/docs/pages/management/export-audit-events/datadog.mdx
+++ b/docs/pages/management/export-audit-events/datadog.mdx
@@ -34,7 +34,7 @@ from Teleport's events API, and forwards them to Fluentd.
 
 (!docs/pages/includes/install-event-handler.mdx!)
 
-## Step 2/6. Configure the plugin
+## Step 2/6. Generate a plugin configuration
 
 (!docs/pages/includes/configure-event-handler.mdx!)
 
@@ -46,70 +46,11 @@ from Teleport's events API, and forwards them to Fluentd.
 
 ### Enable impersonation of the Event Handler user
 
-In order for the Teleport Event Handler plugin to forward events from your Teleport
-cluster, it needs a signed identity file from the cluster's certificate authority.
-The `teleport-event-handler` user cannot request this itself, and requires another
-user to **impersonate** this account in order to request a certificate.
-
-Create a role that enables your user to impersonate the Fluentd user. First,
-paste the following YAML document into a file called
-`teleport-event-handler-impersonator.yaml`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: teleport-event-handler-impersonator
-spec:
-  # SSH options used for user sessions
-  options:
-    # max_session_ttl defines the TTL (time to live) of SSH certificates
-    # issued to the users with this role.
-    max_session_ttl: 10h
-
-  # allow section declares a list of resource/verb combinations that are
-  # allowed for the users of this role. by default nothing is allowed.
-  allow:
-    impersonate:
-      users: ["teleport-event-handler"]
-      roles: ["teleport-event-handler"]
-```
-
-Next, create the role:
-
-```code
-$ tctl create -f teleport-event-handler-impersonator.yaml
-```
-
-(!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
 
 ### Export an identity file for the Event Handler plugin user
 
-The Teleport Event Handler plugin uses the `teleport-event-handler` role and user to
-read events. We export an identity file for the user with the `tctl auth sign`
-command.
-
-<Tabs>
-<TabItem label="Executable">
-
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler"!)
-
-</TabItem>
-<TabItem label="Helm Chart">
-
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler"!)
-
-Next, create a Kubernetes secret for the Teleport identity file:
-
-```code
-$ kubectl create secret generic teleport-event-handler-identity --from-file=auth_id=identity
-```
-
-These commands should result in a PEM-encoded file, `identity`, and a secret
-in Kubernetes with the name `teleport-event-handler-identity`.
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" secret="teleport-event-handler-identity"!)
 
 ## Step 5/6. Install Fluentd output plugin for Datadog
 
@@ -176,124 +117,22 @@ Copy the API key, and use it to add a new `<match>` block to `fluent.conf`:
 
 Restart Fluentd after saving the changes to `fluent.conf`.
 
-## Step 6/6. Start the event handler plugin
+## Step 6/6. Run the Teleport Event Handler plugin
 
-Earlier, we generated a file called `teleport-event-handler.toml` to configure
-the Fluentd event handler. This file includes setting similar to the following:
+### Configure the Event Handler
 
-<Tabs>
-<TabItem scope={["cloud","team"]} label="Cloud-Hosted">
+In this section, you will configure the Teleport Event Handler for your
+environment.
 
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
 
-[forward.fluentd]
-ca = "/home/sasha/scripts/event-handler/ca.crt"
-cert = "/home/sasha/scripts/event-handler/client.crt"
-key = "/home/sasha/scripts/event-handler/client.key"
-url = "https://localhost:8888/test.log"
+Next, modify the configuration file as follows:
 
-[teleport]
-addr = "mytenant.teleport.sh:443"
-identity = "identity"
-```
+(!docs/pages/includes/plugins/config-toml-teleport.mdx!)
 
-To start the event handler, run the following command:
+### Start the Teleport Event Handler
 
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml
-```
-
-</TabItem>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
-
-[forward.fluentd]
-ca = "/home/sasha/scripts/event-handler/ca.crt"
-cert = "/home/sasha/scripts/event-handler/client.crt"
-key = "/home/sasha/scripts/event-handler/client.key"
-url = "https://localhost:8888/test.log"
-
-[teleport]
-addr = "teleport.example.com:443"
-identity = "identity"
-```
-
-To start the event handler, run the following command:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml
-```
-
-</TabItem>
-<TabItem scope={["oss", "enterprise"]} label="Helm Chart">
-
-Use the following template to create `teleport-plugin-event-handler-values.yaml`:
-
-```yaml
-eventHandler:
-  storagePath: "./storage"
-  timeout: "10s"
-  batch: 20
-  namespace: "default"
-
-teleport:
-  address: "example.teleport.com:443"
-  identitySecretName: teleport-event-handler-identity
-
-fluentd:
-  url: "https://fluentd.fluentd.svc.cluster.local/events.log"
-  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
-  certificate:
-    secretName: "teleport-event-handler-client-tls"
-    caPath: "ca.crt"
-    certPath: "client.crt"
-    keyPath: "client.key"
-
-persistentVolumeClaim:
-  enabled: true
-```
-
-To start the event handler in Kubernetes, run the following command:
-
-```code
-$ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
-  --values teleport-plugin-event-handler-values.yaml \
-  --version (=teleport.plugin.version=)
-```
-
-</TabItem>
-</Tabs>
-
-<Admonition type="note">
-
-This example will start exporting from `May 5th 2021`:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml --start-time "2022-02-02T00:00:00Z"
-```
-
-The start time can be set only once, on the first run of the tool.
-
-If you want to change the time frame later, remove the plugin state directory
-that you specified in the `storage` field of the handler's configuration file.
-
-</Admonition>
-
-Once the handler starts, you will see notifications in Fluentd about scanned and forwarded events:
-
-```txt
-INFO[0046] Event sent id=0b5f2a3e-faa5-4d77-ab6e-362bca0994fc ts="2021-06-08 11:00:56.034 +0000 UTC" type=user.login
-...
-```
+(!docs/pages/includes/start-event-handler.mdx!)
 
 The Logs view in Datadog should now report your Teleport cluster events:
 

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -73,45 +73,11 @@ locally.
 
 ### Enable impersonation of the Event Handler plugin user
 
-In order for the Event Handler plugin to forward events from your Teleport
-cluster, it needs signed credentials from the cluster's certificate authority.
-The `teleport-event-handler` user cannot request this itself, and requires
-another user to **impersonate** this account in order to request credentials.
-
-Create a role that enables your user to impersonate the `teleport-event-handler`
-user. First, paste the following YAML document into a file called
-`teleport-event-handler-impersonator.yaml`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: teleport-event-handler-impersonator
-spec:
-  options:
-    # max_session_ttl defines the TTL (time to live) of SSH certificates
-    # issued to the users with this role.
-    max_session_ttl: 10h
-
-  # This section declares a list of resource/verb combinations that are
-  # allowed for the users of this role. By default nothing is allowed.
-  allow:
-    impersonate:
-      users: ["teleport-event-handler"]
-      roles: ["teleport-event-handler"]
-```
-
-Next, create the role:
-
-```code
-$ tctl create teleport-event-handler-impersonator.yaml
-```
-
-(!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
 
 ### Export the access plugin identity
 
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler"!)
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" secret="teleport-event-handler-identity"!)
 
 ## Step 2/4. Configure a Logstash pipeline
 
@@ -403,27 +369,12 @@ Edit the file `/etc/elasticsearch/elasticsearch.yml` to set
 
 ## Step 3/4. Run the Event Handler plugin
 
-### Complete the Event Handler configuration
+### Configure the Teleport Event Handler
 
-Earlier, we generated a file called `teleport-event-handler.toml` to configure
-the Event Handler plugin. This file includes settings similar to the following:
+In this section, you will configure the Teleport Event Handler for your
+environment.
 
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
-
-[forward.fluentd]
-ca = "/home/ca.crt"
-cert = "/home/client.crt"
-key = "/home/client.key"
-url = "https://localhost:8888/test.log"
-
-[teleport]
-addr = "example.teleport.com:443"
-identity = "identity"
-```
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
 
 Update the configuration file as follows.
 
@@ -438,62 +389,9 @@ directly, e.g., `mytenant.teleport.sh:443`.
 
 (!docs/pages/includes/plugins/config-toml-teleport.mdx!)
 
-### Start the Event Handler
+### Start the Teleport Event Handler
 
-Start the Teleport Teleport Event Handler as a daemon. To do so, create a
-systemd service definition at the path
-`/usr/lib/systemd/system/teleport-event-handler.service` with the following
-content: 
-
-```ini
-[Unit]
-Description=Teleport Event Handler
-After=network.target
-
-[Service]
-Type=simple
-Restart=on-failure
-ExecStart=/usr/local/bin/teleport-event-handler start --config=/etc/teleport-event-handler.toml
-ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/run/teleport-event-handler.pid
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Enable and start the plugin:
-
-```code
-$ sudo systemctl enable teleport-event-handler
-$ sudo systemctl start teleport-event-handler
-```
-
-<Details title="Choose when to start exporting events">
-
-You can configure when you would like the Teleport Event Handler to begin
-exporting events when you run the `start` command. This example will start
-exporting from May 5th, 2021:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml --start-time "2021-05-05T00:00:00Z"
-```
-
-You can only determine the start time once, when first running the Teleport
-Event Handler. If you want to change the time frame later, remove the plugin
-state directory that you specified in the `storage` field of the handler's
-configuration file.
-
-</Details>
-
-Once the Teleport Event Handler starts, you will see notifications about scanned
-and forwarded events:
-
-```code
-$ sudo journalctl -u teleport-event-handler
-DEBU   Event sent id:f19cf375-4da6-4338-bfdc-e38334c60fd1 index:0 ts:2022-09-21
-18:51:04.849 +0000 UTC type:cert.create event-handler/app.go:140
-...
-```
+(!docs/pages/includes/start-event-handler.mdx!)
 
 ## Step 4/4. Create a data view in Kibana
 

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -46,7 +46,7 @@ from Teleport's events API, and forwards them to Fluentd.
 
 (!docs/pages/includes/install-event-handler.mdx!)
 
-## Step 2/6. Configure the plugin
+## Step 2/6. Generate a plugin configuration
 
 (!docs/pages/includes/configure-event-handler.mdx!)
 
@@ -61,96 +61,11 @@ key from the same certificate authority for the Teleport Event Handler to use.
 
 ### Enable impersonation of the Fluentd plugin user
 
-In order for the Fluentd plugin to forward events from your Teleport cluster, it
-needs a signed identity file from the cluster's certificate authority. The
-Fluentd user cannot request this itself, and requires another user to
-**impersonate** this account in order to request a certificate.
-
-Create a role that enables your user to impersonate the Fluentd user. First,
-paste the following YAML document into a file called
-`teleport-event-handler-impersonator.yaml`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: teleport-event-handler-impersonator
-spec:
-  # SSH options used for user sessions
-  options:
-    # max_session_ttl defines the TTL (time to live) of SSH certificates
-    # issued to the users with this role.
-    max_session_ttl: 10h
-
-  # allow section declares a list of resource/verb combinations that are
-  # allowed for the users of this role. by default nothing is allowed.
-  allow:
-    impersonate:
-      users: ["teleport-event-handler"]
-      roles: ["teleport-event-handler"]
-```
-
-Next, create the role:
-
-```code
-$ tctl create -f teleport-event-handler-impersonator.yaml
-```
-
-(!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
 
 ### Export an identity file for the Fluentd plugin user
 
-The Fluentd Teleport plugin uses the `teleport-event-handler` role and user to
-read events. We export an identity file for the user with the `tctl auth sign`
-command.
-
-<Tabs>
-<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
-```code
-$ tctl auth sign --user=teleport-event-handler --out=identity
-```
-
-This command creates one PEM-encoded file, `identity`. The identity file
-includes both TLS and SSH credentials. The Event Handler plugin uses the SSH
-credentials to connect to the Proxy Service, which establishes a reverse tunnel
-connection to the Auth Service. The plugin uses this reverse tunnel, along with
-your TLS credentials, to connect to the Auth Service's gRPC endpoint.
-
-</TabItem>
-<TabItem label="Cloud-Hosted" scope={["cloud","team"]}>
-```code
-$ tctl auth sign --user=teleport-event-handler --out=identity
-```
-
-This command creates one PEM-encoded file, `identity`. The identity file
-includes both TLS and SSH credentials. Your Event Handler plugin uses the SSH
-credentials to connect to the Proxy Service, which establishes a reverse tunnel
-connection to the Auth Service. The plugin uses this reverse tunnel, along with
-your TLS credentials, to connect to the Auth Service's gRPC endpoint.
-
-</TabItem>
-<TabItem label="Helm Chart" scope={["cloud","team","oss","enterprise"]}>
-
-If you are planning to use the Helm Chart, you'll need to generate the keys
-with the `file` format, then create a secret in Kubernetes.
-
-Create the identity using the following command:
-
-```code
-$ tctl auth sign --format=file --user=teleport-event-handler --out=identity
-```
-
-Then create the Kubernetes secret:
-
-```code
-$ kubectl create secret generic teleport-event-handler-identity --from-file=auth_id=identity
-```
-
-These commands should result in a PEM-encoded file, `identity`, and a secret
-in Kubernetes with the name `teleport-event-handler-identity`.
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" secret="teleport-event-handler-identity"!)
 
 ## Step 5/6. Start the Fluentd forwarder
 
@@ -215,124 +130,22 @@ $ docker run -u $(id -u ${USER}):$(id -g ${USER}) -p 8888:8888 -v $(pwd):/keys -
 
 This will consume your current terminal, so open a new one to continue following along.
 
-## Step 6/6. Start the event handler plugin
+## Step 6/6. Run the Event Handler plugin
 
-Earlier, we generated a file called `teleport-event-handler.toml` to configure
-the Fluentd event handler. This file includes setting similar to the following:
+### Configure the Event Handler
 
-<Tabs>
-<TabItem scope={["cloud","team"]} label="Cloud-Hosted">
+In this section, you will configure the Teleport Event Handler for your
+environment.
 
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
 
-[forward.fluentd]
-ca = "/home/bob/event-handler/ca.crt"
-cert = "/home/bob/event-handler/client.crt"
-key = "/home/bob/event-handler/client.key"
-url = "https://localhost:8888/test.log"
+Next, modify the configuration file as follows:
 
-[teleport]
-addr = "example.teleport.com:443"
-identity = "identity"
-```
+(!docs/pages/includes/plugins/config-toml-teleport.mdx!)
 
-To start the event handler, run the following command:
+### Start the Teleport Event Handler
 
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml
-```
-
-</TabItem>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
-
-[forward.fluentd]
-ca = "/home/bob/event-handler/ca.crt"
-cert = "/home/bob/event-handler/client.crt"
-key = "/home/bob/event-handler/client.key"
-url = "https://localhost:8888/test.log"
-
-[teleport]
-addr = "example.teleport.com:443"
-identity = "identity"
-```
-
-To start the Event Handler, run the following command:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml
-```
-
-</TabItem>
-<TabItem scope={["oss", "enterprise"]} label="Helm Chart">
-
-Use the following template to create `teleport-plugin-event-handler-values.yaml`:
-
-```yaml
-eventHandler:
-  storagePath: "./storage"
-  timeout: "10s"
-  batch: 20
-  namespace: "default"
-
-teleport:
-  address: "example.teleport.com:443"
-  identitySecretName: teleport-event-handler-identity
-
-fluentd:
-  url: "https://fluentd.fluentd.svc.cluster.local/events.log"
-  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
-  certificate:
-    secretName: "teleport-event-handler-client-tls"
-    caPath: "ca.crt"
-    certPath: "client.crt"
-    keyPath: "client.key"
-
-persistentVolumeClaim:
-  enabled: true
-```
-
-To start the event handler in Kubernetes, run the following command:
-
-```code
-$ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
-  --values teleport-plugin-event-handler-values.yaml \
-  --version (=teleport.plugin.version=)
-```
-
-</TabItem>
-</Tabs>
-
-<Admonition type="note">
-
-This example will start exporting from `May 5th 2021`:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml --start-time "2021-05-05T00:00:00Z"
-```
-
-The start time can be set only once, on the first run of the tool.
-
-If you want to change the time frame later, remove the plugin state directory
-that you specified in the `storage` field of the handler's configuration file.
-
-</Admonition>
-
-Once the handler starts, you will see notifications about scanned and forwarded events:
-
-```txt
-INFO[0046] Event sent id=0b5f2a3e-faa5-4d77-ab6e-362bca0994fc ts="2021-06-08 11:00:56.034 +0000 UTC" type=user.login
-...
-```
+(!docs/pages/includes/start-event-handler.mdx!)
 
 ## Troubleshooting connection issues
 

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -69,61 +69,11 @@ We'll re-purpose the files generated for Fluentd in our Universal Forwarder conf
 
 ### Enable impersonation of the Teleport Event Handler plugin user
 
-In order for the Teleport Event Handler plugin to forward events from your
-Teleport cluster, it needs signed credentials from the cluster's certificate
-authority.
-
-The `teleport-event-handler` user cannot request this itself, and requires
-another user to **impersonate** this account in order to request credentials. We
-will show you how to enable impersonation for your Teleport user so you can
-retrieve credentials for the Teleport Event Handler.
-
-Create a role that enables your user to impersonate the `teleport-event-handler`
-user. First, paste the following YAML document into a file called
-`teleport-event-handler-impersonator.yaml`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: teleport-event-handler-impersonator
-spec:
-  options:
-    # max_session_ttl defines the TTL (time to live) of SSH certificates
-    # issued to the users with this role.
-    max_session_ttl: 10h
-
-  # This section declares a list of resource/verb combinations that are
-  # allowed for the users of this role. By default nothing is allowed.
-  allow:
-    impersonate:
-      users: ["teleport-event-handler"]
-      roles: ["teleport-event-handler"]
-```
-
-Next, create the role:
-
-```code
-$ tctl create -f teleport-event-handler-impersonator.yaml
-```
-
-(!docs/pages/includes/add-role-to-user.mdx role="teleport-event-handler-impersonator"!)
-
-Log out of your Teleport cluster and log in again to assume the new role.
+(!docs/pages/includes/plugins/rbac-impersonate-event-handler.mdx!)
 
 ### Export the plugin identity
 
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler"!)
-
-Move the credentials you generated to the host where you are running the
-Teleport Event Handler plugin.
-
-<Notice type="warning">
-
-Once the Teleport Event Handler's certificate expires, you will need to renew it
-by running the `tctl auth sign` command again.
-
-</Notice>
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" secret="teleport-event-handler-identity"!)
 
 ## Step 2/4. Configure the Universal Forwarder
 
@@ -333,28 +283,12 @@ and forward them to Splunk, you will ensure that the Teleport Event Handler
 plugin is configured to authenticate to the Universal Forwarder and your
 Teleport cluster, then run the Teleport Event Handler.
 
-### Complete the Teleport Event Handler configuration
+### Configure the Teleport Event Handler
 
-Earlier, we generated a file called `teleport-event-handler.toml` to configure
-the Teleport Event Handler plugin. This file includes settings similar to the
-following:
+In this section, you will configure the Teleport Event Handler for your
+environment.
 
-```toml
-storage = "./storage"
-timeout = "10s"
-batch = 20
-namespace = "default"
-
-[forward.fluentd]
-ca = "/home/ca.crt"
-cert = "/home/client.crt"
-key = "/home/client.key"
-url = "https://localhost:9061/test.log"
-
-[teleport]
-addr = "example.teleport.com:443"
-identity = "identity"
-```
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
 
 Update the configuration file as follows.
 
@@ -398,60 +332,7 @@ $ chmod +r auth.pem
 
 ### Start the Teleport Event Handler
 
-Start the Teleport Teleport Event Handler as a daemon. To do so, create a
-systemd service definition at the path
-`/usr/lib/systemd/system/teleport-event-handler.service` with the following
-content:
-
-```ini
-[Unit]
-Description=Teleport Event Handler
-After=network.target
-
-[Service]
-Type=simple
-Restart=on-failure
-ExecStart=/usr/local/bin/teleport-event-handler start --config=/etc/teleport-event-handler.toml
-ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/run/teleport-event-handler.pid
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Enable and start the plugin:
-
-```code
-$ sudo systemctl enable teleport-event-handler
-$ sudo systemctl start teleport-event-handler
-```
-
-<Details title="Choose when to start exporting events">
-
-You can configure when you would like the Teleport Event Handler to begin
-exporting events when you run the `start` command. This example will start
-exporting from May 5th, 2021:
-
-```code
-$ teleport-event-handler start --config teleport-event-handler.toml --start-time "2021-05-05T00:00:00Z"
-```
-
-You can only determine the start time once, when first running the Teleport
-Event Handler. If you want to change the time frame later, remove the plugin
-state directory that you specified in the `storage` field of the handler's
-configuration file.
-
-</Details>
-
-Once the Teleport Event Handler starts, you will see notifications about scanned
-and forwarded events:
-
-```code
-$ sudo journalctl -u teleport-event-handler
-DEBU   Event sent id:f19cf375-4da6-4338-bfdc-e38334c60fd1 index:0 ts:2022-09-21
-18:51:04.849 +0000 UTC type:cert.create event-handler/app.go:140
-...
-```
+(!docs/pages/includes/start-event-handler.mdx!)
 
 ## Step 4/4. Visualize your audit logs in Splunk
 


### PR DESCRIPTION
Make the Event Handler guides more consistent so it's easier to add Machine ID instructions in subsequent changes (to resolve #15062):

- Extract partials for editing the config and creating an Event Handler impersonator role, as well as starting the Event Handler.
- Add a `secret` parameter to the `identity-export.mdx` partial so we can reuse the `kubectl` secret generation instructions across the Event Handler guides.