### PR TITLE
[v14] use rds proxy port instead of proxy target port

### DIFF
--- a/docs/pages/database-access/reference/aws.mdx
+++ b/docs/pages/database-access/reference/aws.mdx
@@ -180,7 +180,6 @@ permissions if IAM authentication is already enabled.
               "Action": [
                   "rds:DescribeDBProxies",
                   "rds:DescribeDBProxyEndpoints",
-                  "rds:DescribeDBProxyTargets",
                   "rds:ListTagsForResource",
               ],
               "Resource": "*"
@@ -213,7 +212,6 @@ permissions if IAM authentication is already enabled.
               "Action": [
                   "rds:DescribeDBProxies",
                   "rds:DescribeDBProxyEndpoints",
-                  "rds:DescribeDBProxyTargets",
                   "rds:ListTagsForResource",
               ],
               "Resource": "*"

--- a/lib/cloud/mocks/aws_rds.go
+++ b/lib/cloud/mocks/aws_rds.go
@@ -33,12 +33,11 @@ import (
 // RDSMock mocks AWS RDS API.
 type RDSMock struct {
 	rdsiface.RDSAPI
-	DBInstances       []*rds.DBInstance
-	DBClusters        []*rds.DBCluster
-	DBProxies         []*rds.DBProxy
-	DBProxyEndpoints  []*rds.DBProxyEndpoint
-	DBEngineVersions  []*rds.DBEngineVersion
-	DBProxyTargetPort int64
+	DBInstances      []*rds.DBInstance
+	DBClusters       []*rds.DBCluster
+	DBProxies        []*rds.DBProxy
+	DBProxyEndpoints []*rds.DBProxyEndpoint
+	DBEngineVersions []*rds.DBEngineVersion
 }
 
 func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
@@ -187,15 +186,6 @@ func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rd
 		return nil, trace.NotFound("proxy endpoint %v not found", aws.StringValue(input.DBProxyEndpointName))
 	}
 	return &rds.DescribeDBProxyEndpointsOutput{DBProxyEndpoints: endpoints}, nil
-}
-
-func (m *RDSMock) DescribeDBProxyTargetsWithContext(ctx aws.Context, input *rds.DescribeDBProxyTargetsInput, options ...request.Option) (*rds.DescribeDBProxyTargetsOutput, error) {
-	// only mocking to return a port here
-	return &rds.DescribeDBProxyTargetsOutput{
-		Targets: []*rds.DBProxyTarget{{
-			Port: aws.Int64(m.DBProxyTargetPort),
-		}},
-	}, nil
 }
 
 func (m *RDSMock) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -188,7 +188,6 @@ var (
 		discovery: []string{
 			"rds:DescribeDBProxies",
 			"rds:DescribeDBProxyEndpoints",
-			"rds:DescribeDBProxyTargets",
 			"rds:ListTagsForResource",
 		},
 		metadata: []string{

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -617,7 +617,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
 					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
@@ -625,7 +625,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
@@ -649,7 +649,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
 					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
@@ -657,7 +657,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
@@ -852,7 +852,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
 					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
@@ -860,7 +860,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
@@ -973,7 +973,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource"},
+						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 				},
 				wantInlineAsBoundary: true,
@@ -1088,7 +1088,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource"},
+						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 					{
 						Effect:    awslib.EffectAllow,
@@ -1110,7 +1110,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource"},
+						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 					{
 						Effect:    awslib.EffectAllow,

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -938,12 +938,12 @@ func NewDatabasesFromRDSCluster(cluster *rds.DBCluster) (types.Databases, error)
 }
 
 // NewDatabaseFromRDSProxy creates database resource from RDS Proxy.
-func NewDatabaseFromRDSProxy(dbProxy *rds.DBProxy, port int64, tags []*rds.Tag) (types.Database, error) {
+func NewDatabaseFromRDSProxy(dbProxy *rds.DBProxy, tags []*rds.Tag) (types.Database, error) {
 	metadata, err := MetadataFromRDSProxy(dbProxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	protocol, err := rdsEngineFamilyToProtocol(aws.StringValue(dbProxy.EngineFamily))
+	protocol, port, err := rdsEngineFamilyToProtocolAndPort(aws.StringValue(dbProxy.EngineFamily))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -961,12 +961,12 @@ func NewDatabaseFromRDSProxy(dbProxy *rds.DBProxy, port int64, tags []*rds.Tag) 
 
 // NewDatabaseFromRDSProxyCustomEndpoint creates database resource from RDS
 // Proxy custom endpoint.
-func NewDatabaseFromRDSProxyCustomEndpoint(dbProxy *rds.DBProxy, customEndpoint *rds.DBProxyEndpoint, port int64, tags []*rds.Tag) (types.Database, error) {
+func NewDatabaseFromRDSProxyCustomEndpoint(dbProxy *rds.DBProxy, customEndpoint *rds.DBProxyEndpoint, tags []*rds.Tag) (types.Database, error) {
 	metadata, err := MetadataFromRDSProxyCustomEndpoint(dbProxy, customEndpoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	protocol, err := rdsEngineFamilyToProtocol(aws.StringValue(dbProxy.EngineFamily))
+	protocol, port, err := rdsEngineFamilyToProtocolAndPort(aws.StringValue(dbProxy.EngineFamily))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1521,17 +1521,17 @@ func rdsEngineToProtocol(engine string) (string, error) {
 	return "", trace.BadParameter("unknown RDS engine type %q", engine)
 }
 
-// rdsEngineFamilyToProtocol converts RDS engine family to the database protocol.
-func rdsEngineFamilyToProtocol(engineFamily string) (string, error) {
+// rdsEngineFamilyToProtocolAndPort converts RDS engine family to the database protocol and port.
+func rdsEngineFamilyToProtocolAndPort(engineFamily string) (string, int, error) {
 	switch engineFamily {
 	case rds.EngineFamilyMysql:
-		return defaults.ProtocolMySQL, nil
+		return defaults.ProtocolMySQL, RDSProxyMySQLPort, nil
 	case rds.EngineFamilyPostgresql:
-		return defaults.ProtocolPostgres, nil
+		return defaults.ProtocolPostgres, RDSProxyPostgresPort, nil
 	case rds.EngineFamilySqlserver:
-		return defaults.ProtocolSQLServer, nil
+		return defaults.ProtocolSQLServer, RDSProxySQLServerPort, nil
 	}
-	return "", trace.BadParameter("unknown RDS engine family type %q", engineFamily)
+	return "", 0, trace.BadParameter("unknown RDS engine family type %q", engineFamily)
 }
 
 // labelsFromAzureServer creates database labels for the provided Azure DB server.
@@ -2036,6 +2036,15 @@ const (
 	RDSEngineModeGlobal = "global"
 	// RDSEngineModeMultiMaster is the RDS engine mode for Multi-master clusters
 	RDSEngineModeMultiMaster = "multimaster"
+)
+
+const (
+	// RDSProxyMySQLPort is the port that RDS Proxy listens on for MySQL connections.
+	RDSProxyMySQLPort = 3306
+	// RDSProxyPostgresPort is the port that RDS Proxy listens on for Postgres connections.
+	RDSProxyPostgresPort = 5432
+	// RDSProxySQLServerPort is the port that RDS Proxy listens on for SQL Server connections.
+	RDSProxySQLServerPort = 1433
 )
 
 const (

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -1292,94 +1292,122 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 }
 
 func TestDatabaseFromRDSProxy(t *testing.T) {
-	var port int64 = 9999
-	dbProxy := &rds.DBProxy{
-		DBProxyArn:   aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-abcdef"),
-		DBProxyName:  aws.String("testproxy"),
-		EngineFamily: aws.String(rds.EngineFamilyMysql),
-		Endpoint:     aws.String("proxy.rds.test"),
-		VpcId:        aws.String("test-vpc-id"),
+	tests := []struct {
+		desc         string
+		engineFamily string
+		wantProtocol string
+		wantPort     int
+	}{
+		{
+			desc:         "mysql",
+			engineFamily: rds.EngineFamilyMysql,
+			wantProtocol: "mysql",
+			wantPort:     3306,
+		},
+		{
+			desc:         "postgres",
+			engineFamily: rds.EngineFamilyPostgresql,
+			wantProtocol: "postgres",
+			wantPort:     5432,
+		},
+		{
+			desc:         "sqlserver",
+			engineFamily: rds.EngineFamilySqlserver,
+			wantProtocol: "sqlserver",
+			wantPort:     1433,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			dbProxy := &rds.DBProxy{
+				DBProxyArn:   aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-abcdef"),
+				DBProxyName:  aws.String("testproxy"),
+				EngineFamily: aws.String(test.engineFamily),
+				Endpoint:     aws.String("proxy.rds.test"),
+				VpcId:        aws.String("test-vpc-id"),
+			}
 
-	dbProxyEndpoint := &rds.DBProxyEndpoint{
-		Endpoint:            aws.String("custom.proxy.rds.test"),
-		DBProxyEndpointName: aws.String("custom"),
-		DBProxyName:         aws.String("testproxy"),
-		DBProxyEndpointArn:  aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy-endpoint:prx-endpoint-abcdef"),
-		TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
+			dbProxyEndpoint := &rds.DBProxyEndpoint{
+				Endpoint:            aws.String("custom.proxy.rds.test"),
+				DBProxyEndpointName: aws.String("custom"),
+				DBProxyName:         aws.String("testproxy"),
+				DBProxyEndpointArn:  aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy-endpoint:prx-endpoint-abcdef"),
+				TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
+			}
+
+			tags := []*rds.Tag{{
+				Key:   aws.String("key"),
+				Value: aws.String("val"),
+			}}
+
+			t.Run("default endpoint", func(t *testing.T) {
+				expected, err := types.NewDatabaseV3(types.Metadata{
+					Name:        "testproxy",
+					Description: "RDS Proxy in ca-central-1",
+					Labels: map[string]string{
+						"key":                         "val",
+						types.DiscoveryLabelAccountID: "123456789012",
+						types.CloudLabel:              types.CloudAWS,
+						types.DiscoveryLabelRegion:    "ca-central-1",
+						types.DiscoveryLabelEngine:    test.engineFamily,
+						types.DiscoveryLabelVPCID:     "test-vpc-id",
+					},
+				}, types.DatabaseSpecV3{
+					Protocol: test.wantProtocol,
+					URI:      fmt.Sprintf("proxy.rds.test:%d", test.wantPort),
+					AWS: types.AWS{
+						Region:    "ca-central-1",
+						AccountID: "123456789012",
+						RDSProxy: types.RDSProxy{
+							ResourceID: "prx-abcdef",
+							Name:       "testproxy",
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				actual, err := NewDatabaseFromRDSProxy(dbProxy, tags)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(expected, actual))
+			})
+
+			t.Run("custom endpoint", func(t *testing.T) {
+				expected, err := types.NewDatabaseV3(types.Metadata{
+					Name:        "testproxy-custom",
+					Description: "RDS Proxy endpoint in ca-central-1",
+					Labels: map[string]string{
+						"key":                            "val",
+						types.DiscoveryLabelAccountID:    "123456789012",
+						types.CloudLabel:                 types.CloudAWS,
+						types.DiscoveryLabelRegion:       "ca-central-1",
+						types.DiscoveryLabelEngine:       test.engineFamily,
+						types.DiscoveryLabelVPCID:        "test-vpc-id",
+						types.DiscoveryLabelEndpointType: "READ_ONLY",
+					},
+				}, types.DatabaseSpecV3{
+					Protocol: test.wantProtocol,
+					URI:      fmt.Sprintf("custom.proxy.rds.test:%d", test.wantPort),
+					AWS: types.AWS{
+						Region:    "ca-central-1",
+						AccountID: "123456789012",
+						RDSProxy: types.RDSProxy{
+							ResourceID:         "prx-abcdef",
+							Name:               "testproxy",
+							CustomEndpointName: "custom",
+						},
+					},
+					TLS: types.DatabaseTLS{
+						ServerName: "proxy.rds.test",
+					},
+				})
+				require.NoError(t, err)
+
+				actual, err := NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, dbProxyEndpoint, tags)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(expected, actual))
+			})
+		})
 	}
-
-	tags := []*rds.Tag{{
-		Key:   aws.String("key"),
-		Value: aws.String("val"),
-	}}
-
-	t.Run("default endpoint", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "testproxy",
-			Description: "RDS Proxy in ca-central-1",
-			Labels: map[string]string{
-				"key":                         "val",
-				types.DiscoveryLabelAccountID: "123456789012",
-				types.CloudLabel:              types.CloudAWS,
-				types.DiscoveryLabelRegion:    "ca-central-1",
-				types.DiscoveryLabelEngine:    "MYSQL",
-				types.DiscoveryLabelVPCID:     "test-vpc-id",
-			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "proxy.rds.test:9999",
-			AWS: types.AWS{
-				Region:    "ca-central-1",
-				AccountID: "123456789012",
-				RDSProxy: types.RDSProxy{
-					ResourceID: "prx-abcdef",
-					Name:       "testproxy",
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		actual, err := NewDatabaseFromRDSProxy(dbProxy, port, tags)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
-
-	t.Run("custom endpoint", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "testproxy-custom",
-			Description: "RDS Proxy endpoint in ca-central-1",
-			Labels: map[string]string{
-				"key":                            "val",
-				types.DiscoveryLabelAccountID:    "123456789012",
-				types.CloudLabel:                 types.CloudAWS,
-				types.DiscoveryLabelRegion:       "ca-central-1",
-				types.DiscoveryLabelEngine:       "MYSQL",
-				types.DiscoveryLabelVPCID:        "test-vpc-id",
-				types.DiscoveryLabelEndpointType: "READ_ONLY",
-			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "custom.proxy.rds.test:9999",
-			AWS: types.AWS{
-				Region:    "ca-central-1",
-				AccountID: "123456789012",
-				RDSProxy: types.RDSProxy{
-					ResourceID:         "prx-abcdef",
-					Name:               "testproxy",
-					CustomEndpointName: "custom",
-				},
-			},
-			TLS: types.DatabaseTLS{
-				ServerName: "proxy.rds.test",
-			},
-		})
-		require.NoError(t, err)
-
-		actual, err := NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, dbProxyEndpoint, port, tags)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
 }
 
 func TestAuroraMySQLVersion(t *testing.T) {

--- a/lib/srv/db/cloud/resource_checker_url_aws_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws_test.go
@@ -60,10 +60,10 @@ func TestURLChecker_AWS(t *testing.T) {
 
 	// RDS Proxy.
 	rdsProxy := mocks.RDSProxy("rds-proxy", region, "some-vpc")
-	rdsProxyDB, err := services.NewDatabaseFromRDSProxy(rdsProxy, 1234, nil)
+	rdsProxyDB, err := services.NewDatabaseFromRDSProxy(rdsProxy, nil)
 	require.NoError(t, err)
 	rdsProxyCustomEndpoint := mocks.RDSProxyCustomEndpoint(rdsProxy, "my-custom", region)
-	rdsProxyCustomEndpointDB, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyCustomEndpoint, 1234, nil)
+	rdsProxyCustomEndpointDB, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyCustomEndpoint, nil)
 	require.NoError(t, err)
 	testCases = append(testCases, rdsProxyDB, rdsProxyCustomEndpointDB)
 

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -78,14 +78,6 @@ func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConf
 			continue
 		}
 
-		// rds.DBProxy has no port information. An extra SDK call is made to
-		// find the port from its targets.
-		port, err := getRDSProxyTargetPort(ctx, rdsClient, dbProxy.DBProxyName)
-		if err != nil {
-			cfg.Log.Debugf("Failed to get port for RDS Proxy %v: %v.", aws.StringValue(dbProxy.DBProxyName), err)
-			continue
-		}
-
 		// rds.DBProxy has no tags information. An extra SDK call is made to
 		// fetch the tags. If failed, keep going without the tags.
 		tags, err := listRDSResourceTags(ctx, rdsClient, dbProxy.DBProxyArn)
@@ -94,7 +86,7 @@ func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConf
 		}
 
 		// Add a database from RDS Proxy (default endpoint).
-		database, err := services.NewDatabaseFromRDSProxy(dbProxy, port, tags)
+		database, err := services.NewDatabaseFromRDSProxy(dbProxy, tags)
 		if err != nil {
 			cfg.Log.Debugf("Could not convert RDS Proxy %q to database resource: %v.",
 				aws.StringValue(dbProxy.DBProxyName), err)
@@ -112,7 +104,7 @@ func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConf
 				continue
 			}
 
-			database, err = services.NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, customEndpoint, port, tags)
+			database, err = services.NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, customEndpoint, tags)
 			if err != nil {
 				cfg.Log.Debugf("Could not convert custom endpoint %q of RDS Proxy %q to database resource: %v.",
 					aws.StringValue(customEndpoint.DBProxyEndpointName),

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -154,25 +154,6 @@ func getRDSProxyCustomEndpoints(ctx context.Context, rdsClient rdsiface.RDSAPI, 
 	return customEndpointsByProxyName, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 }
 
-// getRDSProxyTargetPort gets the port number that the targets of the RDS Proxy
-// are using.
-func getRDSProxyTargetPort(ctx context.Context, rdsClient rdsiface.RDSAPI, dbProxyName *string) (int64, error) {
-	output, err := rdsClient.DescribeDBProxyTargetsWithContext(ctx, &rds.DescribeDBProxyTargetsInput{
-		DBProxyName: dbProxyName,
-	})
-	if err != nil {
-		return 0, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
-	}
-
-	// The proxy may have multiple targets but they should have the same port.
-	for _, target := range output.Targets {
-		if target.Port != nil {
-			return aws.Int64Value(target.Port), nil
-		}
-	}
-	return 0, trace.NotFound("RDS Proxy target port not found")
-}
-
 // listRDSResourceTags returns tags for provided RDS resource.
 func listRDSResourceTags(ctx context.Context, rdsClient rdsiface.RDSAPI, resourceName *string) ([]*rds.Tag, error) {
 	output, err := rdsClient.ListTagsForResourceWithContext(ctx, &rds.ListTagsForResourceInput{

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
@@ -68,7 +68,7 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 
 func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rds.DBProxy, types.Database) {
 	rdsProxy := mocks.RDSProxy(name, region, vpcID)
-	rdsProxyDatabase, err := services.NewDatabaseFromRDSProxy(rdsProxy, 9999, nil)
+	rdsProxyDatabase, err := services.NewDatabaseFromRDSProxy(rdsProxy, nil)
 	require.NoError(t, err)
 	common.ApplyAWSDatabaseNameSuffix(rdsProxyDatabase, types.AWSMatcherRDSProxy)
 	return rdsProxy, rdsProxyDatabase
@@ -76,7 +76,7 @@ func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rds.DBProxy, types
 
 func makeRDSProxyCustomEndpoint(t *testing.T, rdsProxy *rds.DBProxy, name, region string) (*rds.DBProxyEndpoint, types.Database) {
 	rdsProxyEndpoint := mocks.RDSProxyCustomEndpoint(rdsProxy, name, region)
-	rdsProxyEndpointDatabase, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyEndpoint, 9999, nil)
+	rdsProxyEndpointDatabase, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyEndpoint, nil)
 	require.NoError(t, err)
 	common.ApplyAWSDatabaseNameSuffix(rdsProxyEndpointDatabase, types.AWSMatcherRDSProxy)
 	return rdsProxyEndpoint, rdsProxyEndpointDatabase

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
@@ -42,9 +42,8 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 			name: "fetch all",
 			inputClients: &cloud.TestCloudClients{
 				RDS: &mocks.RDSMock{
-					DBProxies:         []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
-					DBProxyEndpoints:  []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
-					DBProxyTargetPort: 9999,
+					DBProxies:        []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
+					DBProxyEndpoints: []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherRDSProxy, "us-east-1", wildcardLabels),
@@ -54,9 +53,8 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 			name: "fetch vpc1",
 			inputClients: &cloud.TestCloudClients{
 				RDS: &mocks.RDSMock{
-					DBProxies:         []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
-					DBProxyEndpoints:  []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
-					DBProxyTargetPort: 9999,
+					DBProxies:        []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
+					DBProxyEndpoints: []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherRDSProxy, "us-east-1", map[string]string{"vpc-id": "vpc1"}),


### PR DESCRIPTION
Backport #35347 to branch/v14

changelog: IAM permissions for rds:DescribeDBProxyTargets are no longer required for RDS Proxy discovery.