### PR TITLE
[v12] use rds proxy port instead of proxy target port

### DIFF
--- a/docs/pages/database-access/reference/aws.mdx
+++ b/docs/pages/database-access/reference/aws.mdx
@@ -180,7 +180,6 @@ permissions if IAM authentication is already enabled.
               "Action": [
                   "rds:DescribeDBProxies",
                   "rds:DescribeDBProxyEndpoints",
-                  "rds:DescribeDBProxyTargets",
                   "rds:ListTagsForResource",
               ],
               "Resource": "*"
@@ -213,7 +212,6 @@ permissions if IAM authentication is already enabled.
               "Action": [
                   "rds:DescribeDBProxies",
                   "rds:DescribeDBProxyEndpoints",
-                  "rds:DescribeDBProxyTargets",
                   "rds:ListTagsForResource",
               ],
               "Resource": "*"

--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -51,12 +51,11 @@ func (m *STSMock) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdenti
 // RDSMock mocks AWS RDS API.
 type RDSMock struct {
 	rdsiface.RDSAPI
-	DBInstances       []*rds.DBInstance
-	DBClusters        []*rds.DBCluster
-	DBProxies         []*rds.DBProxy
-	DBProxyEndpoints  []*rds.DBProxyEndpoint
-	DBEngineVersions  []*rds.DBEngineVersion
-	DBProxyTargetPort int64
+	DBInstances      []*rds.DBInstance
+	DBClusters       []*rds.DBCluster
+	DBProxies        []*rds.DBProxy
+	DBProxyEndpoints []*rds.DBProxyEndpoint
+	DBEngineVersions []*rds.DBEngineVersion
 }
 
 func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
@@ -203,14 +202,6 @@ func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rd
 		return nil, trace.NotFound("proxy endpoint %v not found", aws.StringValue(input.DBProxyEndpointName))
 	}
 	return &rds.DescribeDBProxyEndpointsOutput{DBProxyEndpoints: endpoints}, nil
-}
-func (m *RDSMock) DescribeDBProxyTargetsWithContext(ctx aws.Context, input *rds.DescribeDBProxyTargetsInput, options ...request.Option) (*rds.DescribeDBProxyTargetsOutput, error) {
-	// only mocking to return a port here
-	return &rds.DescribeDBProxyTargetsOutput{
-		Targets: []*rds.DBProxyTarget{{
-			Port: aws.Int64(m.DBProxyTargetPort),
-		}},
-	}, nil
 }
 func (m *RDSMock) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
 	fn(&rds.DescribeDBProxiesOutput{

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -145,7 +145,6 @@ var (
 		discovery: []string{
 			"rds:DescribeDBProxies",
 			"rds:DescribeDBProxyEndpoints",
-			"rds:DescribeDBProxyTargets",
 			"rds:ListTagsForResource",
 		},
 		boundary:       []string{"rds-db:connect"},

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -565,7 +565,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
 					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
@@ -573,7 +573,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
@@ -596,7 +596,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			statements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
 					"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy",
@@ -604,7 +604,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
-					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource",
+					"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource",
 					"rds-db:connect",
 				}},
 				{Effect: awslib.EffectAllow, Resources: []string{userTarget.String()}, Actions: []string{
@@ -759,7 +759,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource"},
+						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 				},
 			},
@@ -845,7 +845,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					{
 						Effect:    awslib.EffectAllow,
 						Resources: awslib.SliceOrString{"*"},
-						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:DescribeDBProxyTargets", "rds:ListTagsForResource"},
+						Actions:   awslib.SliceOrString{"rds:DescribeDBProxies", "rds:DescribeDBProxyEndpoints", "rds:ListTagsForResource"},
 					},
 					{
 						Effect:    awslib.EffectAllow,

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -979,94 +979,122 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 }
 
 func TestDatabaseFromRDSProxy(t *testing.T) {
-	var port int64 = 9999
-	dbProxy := &rds.DBProxy{
-		DBProxyArn:   aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-abcdef"),
-		DBProxyName:  aws.String("testproxy"),
-		EngineFamily: aws.String(rds.EngineFamilyMysql),
-		Endpoint:     aws.String("proxy.rds.test"),
-		VpcId:        aws.String("test-vpc-id"),
+	tests := []struct {
+		desc         string
+		engineFamily string
+		wantProtocol string
+		wantPort     int
+	}{
+		{
+			desc:         "mysql",
+			engineFamily: rds.EngineFamilyMysql,
+			wantProtocol: "mysql",
+			wantPort:     3306,
+		},
+		{
+			desc:         "postgres",
+			engineFamily: rds.EngineFamilyPostgresql,
+			wantProtocol: "postgres",
+			wantPort:     5432,
+		},
+		{
+			desc:         "sqlserver",
+			engineFamily: rds.EngineFamilySqlserver,
+			wantProtocol: "sqlserver",
+			wantPort:     1433,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			dbProxy := &rds.DBProxy{
+				DBProxyArn:   aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-abcdef"),
+				DBProxyName:  aws.String("testproxy"),
+				EngineFamily: aws.String(test.engineFamily),
+				Endpoint:     aws.String("proxy.rds.test"),
+				VpcId:        aws.String("test-vpc-id"),
+			}
 
-	dbProxyEndpoint := &rds.DBProxyEndpoint{
-		Endpoint:            aws.String("custom.proxy.rds.test"),
-		DBProxyEndpointName: aws.String("custom"),
-		DBProxyName:         aws.String("testproxy"),
-		DBProxyEndpointArn:  aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy-endpoint:prx-endpoint-abcdef"),
-		TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
+			dbProxyEndpoint := &rds.DBProxyEndpoint{
+				Endpoint:            aws.String("custom.proxy.rds.test"),
+				DBProxyEndpointName: aws.String("custom"),
+				DBProxyName:         aws.String("testproxy"),
+				DBProxyEndpointArn:  aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy-endpoint:prx-endpoint-abcdef"),
+				TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
+			}
+
+			tags := []*rds.Tag{{
+				Key:   aws.String("key"),
+				Value: aws.String("val"),
+			}}
+
+			t.Run("default endpoint", func(t *testing.T) {
+				expected, err := types.NewDatabaseV3(types.Metadata{
+					Name:        "testproxy",
+					Description: "RDS Proxy in ca-central-1",
+					Labels: map[string]string{
+						"key":                         "val",
+						types.DiscoveryLabelAccountID: "123456789012",
+						types.CloudLabel:              types.CloudAWS,
+						types.DiscoveryLabelRegion:    "ca-central-1",
+						types.DiscoveryLabelEngine:    test.engineFamily,
+						types.DiscoveryLabelVPCID:     "test-vpc-id",
+					},
+				}, types.DatabaseSpecV3{
+					Protocol: test.wantProtocol,
+					URI:      fmt.Sprintf("proxy.rds.test:%d", test.wantPort),
+					AWS: types.AWS{
+						Region:    "ca-central-1",
+						AccountID: "123456789012",
+						RDSProxy: types.RDSProxy{
+							ResourceID: "prx-abcdef",
+							Name:       "testproxy",
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				actual, err := NewDatabaseFromRDSProxy(dbProxy, tags)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(expected, actual))
+			})
+
+			t.Run("custom endpoint", func(t *testing.T) {
+				expected, err := types.NewDatabaseV3(types.Metadata{
+					Name:        "testproxy-custom",
+					Description: "RDS Proxy endpoint in ca-central-1",
+					Labels: map[string]string{
+						"key":                            "val",
+						types.DiscoveryLabelAccountID:    "123456789012",
+						types.CloudLabel:                 types.CloudAWS,
+						types.DiscoveryLabelRegion:       "ca-central-1",
+						types.DiscoveryLabelEngine:       test.engineFamily,
+						types.DiscoveryLabelVPCID:        "test-vpc-id",
+						types.DiscoveryLabelEndpointType: "READ_ONLY",
+					},
+				}, types.DatabaseSpecV3{
+					Protocol: test.wantProtocol,
+					URI:      fmt.Sprintf("custom.proxy.rds.test:%d", test.wantPort),
+					AWS: types.AWS{
+						Region:    "ca-central-1",
+						AccountID: "123456789012",
+						RDSProxy: types.RDSProxy{
+							ResourceID:         "prx-abcdef",
+							Name:               "testproxy",
+							CustomEndpointName: "custom",
+						},
+					},
+					TLS: types.DatabaseTLS{
+						ServerName: "proxy.rds.test",
+					},
+				})
+				require.NoError(t, err)
+
+				actual, err := NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, dbProxyEndpoint, tags)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(expected, actual))
+			})
+		})
 	}
-
-	tags := []*rds.Tag{{
-		Key:   aws.String("key"),
-		Value: aws.String("val"),
-	}}
-
-	t.Run("default endpoint", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "testproxy",
-			Description: "RDS Proxy in ca-central-1",
-			Labels: map[string]string{
-				"key":                         "val",
-				types.DiscoveryLabelAccountID: "123456789012",
-				types.CloudLabel:              types.CloudAWS,
-				types.DiscoveryLabelRegion:    "ca-central-1",
-				types.DiscoveryLabelEngine:    "MYSQL",
-				types.DiscoveryLabelVPCID:     "test-vpc-id",
-			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "proxy.rds.test:9999",
-			AWS: types.AWS{
-				Region:    "ca-central-1",
-				AccountID: "123456789012",
-				RDSProxy: types.RDSProxy{
-					ResourceID: "prx-abcdef",
-					Name:       "testproxy",
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		actual, err := NewDatabaseFromRDSProxy(dbProxy, port, tags)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
-
-	t.Run("custom endpoint", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "testproxy-custom",
-			Description: "RDS Proxy endpoint in ca-central-1",
-			Labels: map[string]string{
-				"key":                            "val",
-				types.DiscoveryLabelAccountID:    "123456789012",
-				types.CloudLabel:                 types.CloudAWS,
-				types.DiscoveryLabelRegion:       "ca-central-1",
-				types.DiscoveryLabelEngine:       "MYSQL",
-				types.DiscoveryLabelVPCID:        "test-vpc-id",
-				types.DiscoveryLabelEndpointType: "READ_ONLY",
-			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "custom.proxy.rds.test:9999",
-			AWS: types.AWS{
-				Region:    "ca-central-1",
-				AccountID: "123456789012",
-				RDSProxy: types.RDSProxy{
-					ResourceID:         "prx-abcdef",
-					Name:               "testproxy",
-					CustomEndpointName: "custom",
-				},
-			},
-			TLS: types.DatabaseTLS{
-				ServerName: "proxy.rds.test",
-			},
-		})
-		require.NoError(t, err)
-
-		actual, err := NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, dbProxyEndpoint, port, tags)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
 }
 
 func TestAuroraMySQLVersion(t *testing.T) {

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -102,14 +102,6 @@ func (f *rdsDBProxyFetcher) getRDSProxyDatabases(ctx context.Context) (types.Dat
 			continue
 		}
 
-		// rds.DBProxy has no port information. An extra SDK call is made to
-		// find the port from its targets.
-		port, err := getRDSProxyTargetPort(ctx, f.cfg.RDS, dbProxy.DBProxyName)
-		if err != nil {
-			f.log.Debugf("Failed to get port for RDS Proxy %v: %v.", aws.StringValue(dbProxy.DBProxyName), err)
-			continue
-		}
-
 		// rds.DBProxy has no tags information. An extra SDK call is made to
 		// fetch the tags. If failed, keep going without the tags.
 		tags, err := listRDSResourceTags(ctx, f.cfg.RDS, dbProxy.DBProxyArn)
@@ -118,7 +110,7 @@ func (f *rdsDBProxyFetcher) getRDSProxyDatabases(ctx context.Context) (types.Dat
 		}
 
 		// Add a database from RDS Proxy (default endpoint).
-		database, err := services.NewDatabaseFromRDSProxy(dbProxy, port, tags)
+		database, err := services.NewDatabaseFromRDSProxy(dbProxy, tags)
 		if err != nil {
 			f.log.Debugf("Could not convert RDS Proxy %q to database resource: %v.",
 				aws.StringValue(dbProxy.DBProxyName), err)
@@ -136,7 +128,7 @@ func (f *rdsDBProxyFetcher) getRDSProxyDatabases(ctx context.Context) (types.Dat
 				continue
 			}
 
-			database, err = services.NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, customEndpoint, port, tags)
+			database, err = services.NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, customEndpoint, tags)
 			if err != nil {
 				f.log.Debugf("Could not convert custom endpoint %q of RDS Proxy %q to database resource: %v.",
 					aws.StringValue(customEndpoint.DBProxyEndpointName),
@@ -190,25 +182,6 @@ func getRDSProxyCustomEndpoints(ctx context.Context, rdsClient rdsiface.RDSAPI, 
 		},
 	)
 	return customEndpointsByProxyName, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
-}
-
-// getRDSProxyTargetPort gets the port number that the targets of the RDS Proxy
-// are using.
-func getRDSProxyTargetPort(ctx context.Context, rdsClient rdsiface.RDSAPI, dbProxyName *string) (int64, error) {
-	output, err := rdsClient.DescribeDBProxyTargetsWithContext(ctx, &rds.DescribeDBProxyTargetsInput{
-		DBProxyName: dbProxyName,
-	})
-	if err != nil {
-		return 0, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
-	}
-
-	// The proxy may have multiple targets but they should have the same port.
-	for _, target := range output.Targets {
-		if target.Port != nil {
-			return aws.Int64Value(target.Port), nil
-		}
-	}
-	return 0, trace.NotFound("RDS Proxy target port not found")
 }
 
 // listRDSResourceTags returns tags for provided RDS resource.

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
@@ -40,9 +40,8 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 
 	clients := &cloud.TestCloudClients{
 		RDS: &mocks.RDSMock{
-			DBProxies:         []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
-			DBProxyEndpoints:  []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
-			DBProxyTargetPort: 9999,
+			DBProxies:        []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
+			DBProxyEndpoints: []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
 		},
 	}
 

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
@@ -85,7 +85,7 @@ func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rds.DBProxy, types
 		Status:       aws.String("available"),
 	}
 
-	rdsProxyDatabase, err := services.NewDatabaseFromRDSProxy(rdsProxy, 9999, nil)
+	rdsProxyDatabase, err := services.NewDatabaseFromRDSProxy(rdsProxy, nil)
 	require.NoError(t, err)
 	return rdsProxy, rdsProxyDatabase
 }
@@ -99,7 +99,7 @@ func makeRDSProxyCustomEndpoint(t *testing.T, rdsProxy *rds.DBProxy, name, regio
 		TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
 		Status:              aws.String("available"),
 	}
-	rdsProxyEndpointDatabase, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyEndpoint, 9999, nil)
+	rdsProxyEndpointDatabase, err := services.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyEndpoint, nil)
 	require.NoError(t, err)
 	return rdsProxyEndpoint, rdsProxyEndpointDatabase
 }


### PR DESCRIPTION
Backport #35347 to branch/v12.

changelog: IAM permissions for rds:DescribeDBProxyTargets are no longer required for RDS Proxy discovery.