### PR TITLE
Attempt to fix `TestCreateResources` flakiness

### DIFF
--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -42,7 +42,8 @@ func TestEditResources(t *testing.T) {
 	t.Parallel()
 	log := utils.NewLoggerForTests()
 	fc, fds := testhelpers.DefaultConfig(t)
-	_ = testhelpers.MakeAndRunTestAuthServer(t, log, fc, fds)
+	authServer := testhelpers.MakeAndRunTestAuthServer(t, log, fc, fds)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 	rootClient := testhelpers.MakeDefaultAuthClient(t, log, fc)
 
 	tests := []struct {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1348,7 +1348,8 @@ func TestCreateResources(t *testing.T) {
 	t.Parallel()
 
 	fc, fds := testhelpers.DefaultConfig(t)
-	_ = testhelpers.MakeAndRunTestAuthServer(t, utils.NewLoggerForTests(), fc, fds)
+	authServer := testhelpers.MakeAndRunTestAuthServer(t, utils.NewLoggerForTests(), fc, fds)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	tests := []struct {
 		kind   string


### PR DESCRIPTION
The auth process created in the test was not being closed before the test terminated leading to potentially writing data to the temporary directory generated from `t.TempDir` while the testing framework was trying to remove the directory. `TestEditResources` also exhibited the same behvarior and was fixed here as well.