### PR TITLE
Add types to api service in Web UI

### DIFF
--- a/web/packages/teleport/src/services/api/api.js
+++ b/web/packages/teleport/src/services/api/api.js
@@ -72,7 +72,7 @@ const api = {
   },
 
   async fetchJson(url, params) {
-    const response = await this.fetch(url, params);
+    const response = await api.fetch(url, params);
 
     let json;
     try {
@@ -106,7 +106,7 @@ const api = {
         }),
       },
     };
-    return this.fetchJson(url, paramsWithMfaHeader);
+    return api.fetchJson(url, paramsWithMfaHeader);
   },
 
   fetch(url, params = {}) {

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import api from './api';
+
+// The code below should guard us from changes to api.fetchJson which would cause it to lose type
+// information, for example by returning `any`.
+
+const fooService = {
+  doSomething() {
+    return api.fetchJson('/foo', {}).then(makeFoo);
+  },
+};
+
+const makeFoo = (): { foo: string } => {
+  return { foo: 'lorem ipsum' };
+};
+
+// This is a bogus test to satisfy Jest. We don't even need to execute the code that's in the async
+// function, we're interested only in the type system checking the code.
+test('fetchJson does not return any', () => {
+  async () => {
+    const result = await fooService.doSomething();
+    // Reading foo is correct. We add a bogus expect to satisfy Jest.
+    result.foo;
+
+    // @ts-expect-error If there's no error here, it means that api.fetchJson returns any, which it
+    // shouldn't.
+    result.bar;
+  };
+
+  expect(true).toBe(true);
+});

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -26,11 +26,11 @@ import parseError, { ApiError } from './parseError';
 const MFA_HEADER = 'Teleport-Mfa-Response';
 
 const api = {
-  get(url, abortSignal) {
+  get(url, abortSignal?) {
     return api.fetchJson(url, { signal: abortSignal });
   },
 
-  post(url, data, abortSignal) {
+  post(url, data?, abortSignal?) {
     return api.fetchJson(url, {
       body: JSON.stringify(data),
       method: 'POST',
@@ -57,7 +57,7 @@ const api = {
     throw new Error('data for body is not a type of FormData');
   },
 
-  delete(url, data) {
+  delete(url, data?) {
     return api.fetchJson(url, {
       body: JSON.stringify(data),
       method: 'DELETE',
@@ -71,7 +71,7 @@ const api = {
     });
   },
 
-  async fetchJson(url, params) {
+  async fetchJson(url, params): Promise<any> {
     const response = await api.fetch(url, params);
 
     let json;
@@ -127,7 +127,7 @@ const api = {
   },
 };
 
-const requestOptions = {
+const requestOptions: RequestInit = {
   credentials: 'same-origin',
   headers: {
     Accept: 'application/json',
@@ -155,13 +155,14 @@ export function getNoCacheHeaders() {
 }
 
 export const getXCSRFToken = () => {
-  const metaTag = document.querySelector('[name=grv_csrf_token]');
+  const metaTag = document.querySelector(
+    '[name=grv_csrf_token]'
+  ) as HTMLMetaElement;
   return metaTag ? metaTag.content : '';
 };
 
 export function getAccessToken() {
-  const bearerToken = storageService.getBearerToken() || {};
-  return bearerToken.accessToken;
+  return storageService.getBearerToken()?.accessToken;
 }
 
 export function getHostName() {


### PR DESCRIPTION
Lisa ran into a weird issue where this code [worked on master](https://github.com/gravitational/teleport.e/pull/2785/files#diff-18e02d6509d5301caf9f2b77ed32146724c3c120b83b97b1469e3a286896e087R41-R45):

```typescript
jest.spyOn(deviceService, 'fetchDevices').mockResolvedValue({ items: [] });
```

but was [failing on v14](https://github.com/gravitational/teleport.e/pull/2817/commits/ee955923d82ea7531ca543c01d5df35102d61494) and had to be changed to:

```typescript
jest.spyOn(deviceService, 'fetchDevices').mockResolvedValue({ items: [], startKey: '' });
```

After a short investigation, I found that #34814 changed the type of `api.fetchJson` to return `any` instead of `Promise<any>`. This resulted in all code utilizing `api.fetchJson` to lose type information as well. This is a substantial change as this method is used for all interactions with the backend.

Initially I thought it was a problem with [implicit this](https://github.com/gravitational/teleport/issues/34192), but it was not as simple. I realized that this service was actually just a JS file. It looks like TypeScript doesn't handle well async methods on objects. On v14, `fetchJson` is still just a regular function that returns a promise, on master it's an async method.

I renamed the file extension from `.js` to `.ts` and added an explicit `Promise<any>` type to bring back the old behavior.

---

This PR will not typecheck until we address those jest mocks in teleport.e mentioned above.