### PR TITLE
Allow Connect My Computer agent removal if cluster is down

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -32,6 +32,7 @@ import {
   makeRootCluster,
   makeServer,
 } from 'teleterm/services/tshd/testHelpers';
+import Logger, { NullService } from 'teleterm/logger';
 
 import {
   AgentCompatibilityError,
@@ -42,6 +43,10 @@ import {
 
 import type { IAppContext } from 'teleterm/ui/types';
 import type { Cluster } from 'teleterm/services/tshd/types';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
 
 function getMocks() {
   const rootCluster = makeRootCluster({
@@ -371,7 +376,7 @@ test('removing the agent shows a notification', async () => {
   expect(mockResourcesContext.requestResourcesRefresh).toHaveBeenCalledTimes(1);
 });
 
-test('when the user does not have permissions to remove node a custom notification is shown', async () => {
+test('when the request to remove the node fails a custom notification is shown', async () => {
   const { appContext, rootCluster } = getMocks();
   jest
     .spyOn(appContext.connectMyComputerService, 'removeConnectMyComputerNode')


### PR DESCRIPTION
When removing a Connect My Computer agent, we attempt to call `DeleteNode` in the cluster. This way the node disappears from the cache right after stopping the agent and the user does not have to wonder why the node is still visible in the cluster despite the agent removal.

We accounted for a scenario where the user does not have permissions to call `DeleteNode`. In that case we'd adjust the text of the notification being displayed, telling the user that the node might still be visible in the cluster for a few minutes.

However, we should have ignored any errors as calling `DeleteNode` is not crucial to this operation. If the cluster is down for example, at the moment it's impossible to remove the node as the call to that endpoint will fail.

---

Initially I tried to make it so that we ignore only [`PERMISSION_DENIED` and `UNAVAILABLE` gRPC codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html). However, I soon realized that:

* If the cluster is down, the gRPC code that the Electron app receives from tshd is `UNKNOWN` and not `UNAVAILABLE`. This is because technically the gRPC service handling Electron => tshd communication is available. It's the cluster that's down and any attempts to connect to it return `net.OpError` which we do not wrap into `trace.ConnectionProblemError`.
* It doesn't really matter what kind of error is returned by the cluster. Even if it returns `UNKNOWN` we don't want to prevent the user from removing the agent.

The downside of the solution I chose is that it ignores _all_ errors, even the ones that could potentially originate from the JS code. We should at least constrict this to "errors returned from the gRPC service", but at the moment it's not possible until we implement either #30753 or gravitational/teleport.e#853.