### PR TITLE
Show advanced search toggle only when its props are defined in search bar

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -1023,13 +1023,13 @@ interface AdvancedSearch {
 
 function ContentAndAdvancedSearch(
   props: React.PropsWithChildren<{
-    advancedSearch: AdvancedSearch;
+    advancedSearch: AdvancedSearch | undefined;
   }>
 ) {
   return (
     <Flex gap={2} justifyContent="space-between" alignItems="flex-start">
       {props.children}
-      {
+      {props.advancedSearch && (
         <AdvancedSearchToggle
           {...props.advancedSearch}
           css={`
@@ -1040,7 +1040,7 @@ function ContentAndAdvancedSearch(
             }
           `}
         />
-      }
+      )}
     </Flex>
   );
 }


### PR DESCRIPTION
In some places we set `advancedSearch` to `undefined`, but later we don't do anything with that. If props are not defined, we shouldn't show the toggle.