### PR TITLE
Attempt to deflake TestDiscovery

### DIFF
--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -148,7 +149,7 @@ func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnelclient.Ser
 		if err != nil {
 			return false
 		}
-		return cluster.GetTunnelsCount() >= expectedCount
+		return cluster.GetTunnelsCount() >= expectedCount && cluster.GetStatus() == teleport.RemoteClusterStatusOnline
 	},
 		30*time.Second,
 		time.Second,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4114,6 +4114,8 @@ func testDiscovery(t *testing.T, suite *integrationTestSuite) {
 	helpers.WaitForActiveTunnelConnections(t, main.Tunnel, "cluster-remote", 1)
 	helpers.WaitForActiveTunnelConnections(t, secondProxy, "cluster-remote", 1)
 
+	waitForNodesToRegister(t, main, "cluster-remote")
+
 	// execute the connection via first proxy
 	cfg := helpers.ClientConfig{
 		Login:   username,


### PR DESCRIPTION
Wait for the target to be registered before running any commands against it. All of the most recent errors seem to be caused by `direct dialing to nodes not found in inventory is not supported`. By waiting for the node to be present this should not longer be a possible failure scenario.