### PR TITLE
Properly identify user responsible for UpsertUser invocations

### DIFF
--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -382,7 +382,7 @@ func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest
 			Type: events.UserCreateEvent,
 			Code: events.UserCreateCode,
 		},
-		UserMetadata: authz.ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, upserted.GetCreatedBy().User.Name),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    upserted.GetName(),
 			Expires: upserted.Expiry(),

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -227,6 +227,9 @@ func TestCreateUser(t *testing.T) {
 	event := <-env.emitter.C()
 	assert.Equal(t, events.UserCreateEvent, event.GetType(), "unexpected event type")
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
+	createEvent, ok := event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "system", createEvent.UserMetadata.User)
 
 	user, err := types.NewUser("alpaca")
 	require.NoError(t, err, "creating user alpaca")
@@ -234,6 +237,9 @@ func TestCreateUser(t *testing.T) {
 	_, err = env.CreateUser(ctx, &userspb.CreateUserRequest{User: user.(*types.UserV2)})
 	assert.True(t, trace.IsNotFound(err), "expected a not found error, got %T", err)
 	require.Error(t, err, "user allowed to be created with a role that does not exist")
+	createEvent, ok = event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "system", createEvent.UserMetadata.User)
 }
 
 func TestDeleteUser(t *testing.T) {
@@ -360,6 +366,9 @@ func TestUpdateUser(t *testing.T) {
 	event := <-env.emitter.C()
 	assert.Equal(t, events.UserCreateEvent, event.GetType(), "unexpected event type")
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
+	createEvent, ok := event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "system", createEvent.UserMetadata.User)
 
 	// Attempt to update the user again.
 	created.User.SetLogins([]string{"alpaca"})
@@ -371,6 +380,9 @@ func TestUpdateUser(t *testing.T) {
 	event = <-env.emitter.C()
 	assert.Equal(t, events.UserUpdatedEvent, event.GetType(), "unexpected event type")
 	assert.Equal(t, events.UserUpdateCode, event.GetCode(), "unexpected event code")
+	createEvent, ok = event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "system", createEvent.UserMetadata.User)
 }
 
 func TestUpsertUser(t *testing.T) {
@@ -396,6 +408,9 @@ func TestUpsertUser(t *testing.T) {
 	event := <-env.emitter.C()
 	assert.Equal(t, events.UserCreateEvent, event.GetType(), "unexpected event type")
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
+	createEvent, ok := event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 
 	// Attempt to update the user again.
 	upserted.User.SetLogins([]string{"alpaca"})
@@ -407,6 +422,9 @@ func TestUpsertUser(t *testing.T) {
 	event = <-env.emitter.C()
 	assert.Equal(t, events.UserCreateEvent, event.GetType(), "unexpected event type")
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
+	createEvent, ok = event.(*apievents.UserCreate)
+	require.True(t, ok, "expected a UserCreate event got %T", event)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 }
 
 func TestListUsers(t *testing.T) {


### PR DESCRIPTION
Prior to this change the name of the user being updated was set in the audit event and not the user performing the update. This modifies upsert user to use the same code as create and update to populate the user metadata.

Changelog: Properly identify the Teleport user responsible for modifying user resources