### PR TITLE
Restrict IGS flag check to usage based plans only

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1119,6 +1119,7 @@ func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{
 			IdentityGovernanceSecurity: true,
+			IsUsageBasedBilling:        true,
 		},
 	})
 

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -73,6 +73,7 @@ func TestAccessRequest_WithAndWithoutLimit(t *testing.T) {
 
 	// Lift limit with IGS, expect no limit error.
 	s.features.IdentityGovernanceSecurity = true
+	s.features.IsUsageBasedBilling = true
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: s.features,
 	})

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -209,8 +209,9 @@ func (f Features) IsLegacy() bool {
 	return !f.IsUsageBasedBilling
 }
 
+// TODO(lisa): the isUsageBasedBilling check is temporary until nearing v15.0
 func (f Features) IGSEnabled() bool {
-	return f.IdentityGovernanceSecurity
+	return f.IsUsageBasedBilling && f.IdentityGovernanceSecurity
 }
 
 // AccessResourcesGetter is a minimal interface that is used to get access lists

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -524,7 +524,8 @@ func lockName(accessListName string) string {
 // Returns error if limit has been reached.
 func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, targetAccessListName string) error {
 	feature := modules.GetModules().Features()
-	if feature.IGSEnabled() {
+	// TODO(lisa): checking for legacy is temporary until nearing v15.
+	if feature.IsLegacy() || feature.IGSEnabled() {
 		return nil // unlimited
 	}
 

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1021,21 +1021,3 @@ func newAccessListReview(t *testing.T, accessList, name string) *accesslist.Revi
 
 	return review
 }
-
-func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Clock, igsEnabled bool) *AccessListService {
-	t.Helper()
-
-	modules.SetTestModules(t, &modules.TestModules{
-		TestFeatures: modules.Features{
-			IdentityGovernanceSecurity: igsEnabled,
-			AccessList: modules.AccessListFeature{
-				CreateLimit: 1,
-			},
-		},
-	})
-
-	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	return service
-}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -48,7 +48,8 @@ func TestAccessListCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -148,7 +149,8 @@ func TestAccessListCreate_UpsertAccessList_WithoutLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -172,6 +174,15 @@ func TestAccessListCreate_UpsertAccessList_WithoutLimit(t *testing.T) {
 // is limited to the limit defined in feature if IGS is NOT enabled.
 // Also tests "upserting" and deleting is allowed despite "create" limit reached.
 func TestAccessListCreate_UpsertAccessList_WithLimit(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			IsUsageBasedBilling: true,
+			AccessList: modules.AccessListFeature{
+				CreateLimit: 1,
+			},
+		},
+	})
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -181,7 +192,8 @@ func TestAccessListCreate_UpsertAccessList_WithLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, false /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -218,6 +230,14 @@ func TestAccessListCreate_UpsertAccessList_WithLimit(t *testing.T) {
 // with members, is limited to the limit defined in feature if IGS is NOT enabled.
 // Also tests "upserting" and deleting is allowed despite "create" limit reached.
 func TestAccessListCreate_UpsertAccessListWithMembers_WithLimit(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			IsUsageBasedBilling: true,
+			AccessList: modules.AccessListFeature{
+				CreateLimit: 1,
+			},
+		},
+	})
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -227,7 +247,8 @@ func TestAccessListCreate_UpsertAccessListWithMembers_WithLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, false /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -282,7 +303,8 @@ func TestAccessListCreate_UpsertAccessListWithMembers_WithoutLimit(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	accessList1 := newAccessList(t, "accessList1", clock)
 	accessList2 := newAccessList(t, "accessList2", clock)
@@ -315,7 +337,8 @@ func TestAccessListDedupeOwnersBackwardsCompat(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	// Put an unduplicated owners access list in the backend.
 	accessListDuplicateOwners := newAccessList(t, "accessListDuplicateOwners", clock)
@@ -343,7 +366,8 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -418,7 +442,8 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)
@@ -582,7 +607,8 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
 
 	// Create a couple access lists.
 	accessList1 := newAccessList(t, "accessList1", clock)


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/2317

Lifts IGS checking for legacy onprem and legacy cloud (non-usage based). I lost sight that EUB was for new customers and for cloud only.

IGS checking is for `usage based` plans only, which means Team or EUB