### PR TITLE
Clarify teleport-event-handler config

### DIFF
--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -1,8 +1,8 @@
 <Tabs>
-<TabItem label="Linux server">
+<TabItem label="Linux server - Splunk Enterprise">
 
-Earlier, we generated a file called `teleport-event-handler.toml` to configure
-the Fluentd event handler. This file includes setting similar to the following:
+This is an example of Splunk Enterprise configuration on a Linux server. Your 
+configured could be different depending on your [Splunk settings](https://docs.splunk.com/Documentation/Splunk/9.0.1/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector).
 
 ```toml
 storage = "./storage"
@@ -11,11 +11,39 @@ batch = 20
 namespace = "default"
 
 [forward.fluentd]
-ca = "/home/bob/event-handler/ca.crt"
-cert = "/home/bob/event-handler/client.crt"
-key = "/home/bob/event-handler/client.key"
-url = "https://fluentd.example.com:8888/test.log"
-session-url = "https://fluentd.example.com:8888/session"
+ca = "/home/teleport-logs/event-handler/ca.crt"
+cert = "/home/teleport-logs/event-handler/client.crt"
+key = "/home/teleport-logs/event-handler/client.key"
+url = "https://forwarder.<domain>.com:8088/services/collector/raw?token=<****>"
+session-url = "https://forwarder.<domain>.com:8088/services/collector/raw?token=<****>"
+
+[teleport]
+addr = "example.teleport.com:443"
+identity = "identity"
+```
+
+Modify the configuration to replace `fluentd.example.com` with the domain name
+of your Fluentd deployment.
+
+</TabItem>
+<Tabs>
+<TabItem label="Linux server - Splunk Cloud">
+
+This is an example of Splunk Cloud configuration on a Linux server. Your 
+configured could be different depending on your [Splunk settings](https://docs.splunk.com/Documentation/Splunk/9.0.1/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector).
+
+```toml
+storage = "./storage"
+timeout = "10s"
+batch = 20
+namespace = "default"
+
+[forward.fluentd]
+ca = "/home/teleport-logs/event-handler/ca.crt"
+cert = "/home/teleport-logs/event-handler/client.crt"
+key = "/home/teleport-logs/event-handler/client.key"
+url = "https://http-inputs-example.splunkcloud.com:443/services/collector/raw?token=<****>"
+session-url = "https://http-inputs-example.splunkcloud.com:443/services/collector/raw?token=<****>"
 
 [teleport]
 addr = "example.teleport.com:443"
@@ -56,4 +84,3 @@ persistentVolumeClaim:
 
 </TabItem>
 </Tabs>
-

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -286,13 +286,13 @@ Teleport cluster, then run the Teleport Event Handler.
 ### Configure the Teleport Event Handler
 
 In this section, you will configure the Teleport Event Handler for your
-environment.
+environment. 
 
-(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
+Earlier, we generated a file called `teleport-event-handler.toml` 
+to configure the Fluentd event handler. Make the following changes to the 
+`teleport-event-handler.toml` file:
 
-Update the configuration file as follows.
-
-Change `forward.fluentd.url` to the following:
+1. Change `forward.fluentd.url` to the following:
 
 ```text
 url = "https://localhost:9061/services/collector/raw?token=MYTOKEN"
@@ -307,7 +307,7 @@ Forwarder. If you are running the Universal Forwarder and Event Handler on
 separate hosts, replace `localhost` with your Universal Forwarder's IP address
 or domain name.
 
-Change `forward.fluentd.session-url` to the same value as `forward.fluentd.url`,
+2. Change `forward.fluentd.session-url` to the same value as `forward.fluentd.url`,
 but with the query parameter key `&noop=` appended to the end:
 
 ```text
@@ -320,7 +320,7 @@ Adding the `noop` query parameter causes the Teleport Event Handler to append
 the routing information as the parameter's value so the Universal Forwarder can
 discard it.
 
-Next, edit the `teleport` section of the configuration as follows:
+3. Next, edit the `teleport` section of the configuration as follows:
 
 (!docs/pages/includes/plugins/config-toml-teleport.mdx!)
 
@@ -329,6 +329,10 @@ Ensure that the Teleport Event Handler can read the identity file:
 ```code
 $ chmod +r auth.pem
 ```
+The following is an example `teleport-event-handler.toml` to review before 
+you start the Teleport Event Handler.
+
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
 
 ### Start the Teleport Event Handler
 


### PR DESCRIPTION
Some users are using the example config before reading through the changes that need to be made to it. This PR moves the example config to come after the change instructions as well as adds examples for Splunk Enterprise vs. Splunk Cloud.