### PR TITLE
[v14] Properly identify user responsible for modifying user resource

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -514,7 +514,7 @@ func (s *APIServer) upsertUser(auth *ServerWithRoles, w http.ResponseWriter, r *
 	if err := services.ValidateUserRoles(r.Context(), user, auth); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.UpsertUser(user)
+	err = auth.UpsertUser(r.Context(), user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -763,52 +763,6 @@ func TestUpdateConfig(t *testing.T) {
 	}}))
 }
 
-func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
-	t.Parallel()
-	s := newAuthSuite(t)
-
-	user, err := types.NewUser("some-user")
-	require.NoError(t, err)
-
-	ctx := context.Background()
-
-	// test create user, happy path
-	user.SetCreatedBy(types.CreatedBy{
-		User: types.UserRef{Name: "some-auth-user"},
-	})
-	err = s.a.CreateUser(ctx, user)
-	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserCreateEvent)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, "some-auth-user")
-	s.mockEmitter.Reset()
-
-	// test create user with existing user
-	err = s.a.CreateUser(ctx, user)
-	require.True(t, trace.IsAlreadyExists(err))
-	require.Nil(t, s.mockEmitter.LastEvent())
-
-	// test createdBy gets set to default
-	user2, err := types.NewUser("some-other-user")
-	require.NoError(t, err)
-	err = s.a.CreateUser(ctx, user2)
-	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, teleport.UserSystem)
-	s.mockEmitter.Reset()
-
-	// test update on non-existent user
-	user3, err := types.NewUser("non-existent-user")
-	require.NoError(t, err)
-	err = s.a.UpdateUser(ctx, user3)
-	require.True(t, trace.IsNotFound(err))
-	require.Nil(t, s.mockEmitter.LastEvent())
-
-	// test update user
-	err = s.a.UpdateUser(ctx, user)
-	require.NoError(t, err)
-	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserUpdatedEvent)
-	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, teleport.UserSystem)
-}
-
 func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 	t.Parallel()
 	s := newAuthSuite(t)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3361,7 +3361,7 @@ func (a *ServerWithRoles) UpdateUser(ctx context.Context, user types.User) error
 	return a.authServer.UpdateUser(ctx, user)
 }
 
-func (a *ServerWithRoles) UpsertUser(u types.User) error {
+func (a *ServerWithRoles) UpsertUser(ctx context.Context, u types.User) error {
 	if err := a.action(apidefaults.Namespace, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -3380,7 +3380,37 @@ func (a *ServerWithRoles) UpsertUser(u types.User) error {
 			User: types.UserRef{Name: a.context.User.GetName()},
 		})
 	}
-	return a.authServer.UpsertUser(u)
+
+	if err := a.authServer.UpsertUser(u); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Emitting the audit event is done here and not within [Server.UpsertUser] because
+	// the UserMetadata for the event cannot be derived without the [context.Context].
+	var connectorName string
+	if u.GetCreatedBy().Connector == nil {
+		connectorName = constants.LocalConnector
+	} else {
+		connectorName = u.GetCreatedBy().Connector.ID
+	}
+
+	if err := a.authServer.emitter.EmitAuditEvent(ctx, &apievents.UserCreate{
+		Metadata: apievents.Metadata{
+			Type: events.UserCreateEvent,
+			Code: events.UserCreateCode,
+		},
+		UserMetadata: authz.ClientUserMetadata(ctx),
+		ResourceMetadata: apievents.ResourceMetadata{
+			Name:    u.GetName(),
+			Expires: u.Expiry(),
+		},
+		Connector: connectorName,
+		Roles:     u.GetRoles(),
+	}); err != nil {
+		log.WithError(err).Warn("Failed to emit user upsert event.")
+	}
+
+	return nil
 }
 
 // UpdateAndSwapUser exists on [ServerWithRoles] only for compatibility with
@@ -6920,7 +6950,7 @@ func checkOktaOrigin(authzCtx *authz.Context, user types.User) error {
 
 // checkOktaAccessByName gates access to update operations on user records
 // based on the origin label on the supplied user record.
-func checkOktaAccessByName(authzCtx *authz.Context, users services.UsersService, existingUsername string, verb string) error {
+func checkOktaAccessByName(authzCtx *authz.Context, users *Server, existingUsername string, verb string) error {
 	existingUser, err := users.GetUser(existingUsername, false)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -199,7 +199,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 			user, err := types.NewUser(t.Name())
 			require.NoError(t, err)
 
-			err = authWithOktaRole.UpsertUser(user)
+			err = authWithOktaRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -218,7 +218,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.SetTraits(map[string][]string{"foo": {"bar", "baz"}})
 
-			err = authWithOktaRole.UpsertUser(user)
+			err = authWithOktaRole.UpsertUser(ctx, user)
 			require.NoError(t, err)
 		})
 
@@ -231,7 +231,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.SetOrigin(types.OriginOkta)
 
-			err = authWithOktaRole.UpsertUser(user)
+			err = authWithOktaRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsAccessDenied(err), "Expected access denied, got %T: %s", err, err.Error())
 		})
@@ -244,14 +244,14 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.SetOrigin(types.OriginDynamic)
 
-			err = authWithOktaRole.UpsertUser(user)
+			err = authWithOktaRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
 
 		t.Run("non-okta service creating okta user is an error", func(t *testing.T) {
 			user := newOktaUser(t)
-			err := authWithAdminRole.UpsertUser(user)
+			err := authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -264,7 +264,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.SetOrigin(types.OriginDynamic)
 
-			err = authWithAdminRole.UpsertUser(user)
+			err = authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})
@@ -277,7 +277,7 @@ func TestOktaServiceUserCRUD(t *testing.T) {
 
 			user.AddRole(teleport.PresetAccessRoleName)
 
-			err = authWithAdminRole.UpsertUser(user)
+			err = authWithAdminRole.UpsertUser(ctx, user)
 			require.Error(t, err)
 			require.Truef(t, trace.IsBadParameter(err), "Expected bad parameter, got %T: %s", err, err.Error())
 		})

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5777,6 +5777,75 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 	}
 }
 
+func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	m := &eventstest.MockAuditLog{
+		Emitter: &eventstest.MockRecorderEmitter{},
+	}
+	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir(), AuditLog: m})
+	require.NoError(t, err)
+
+	// Server used to create users and roles.
+	setupAuthContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestAdmin().I))
+	require.NoError(t, err)
+	setupServer := &ServerWithRoles{
+		authServer: srv.AuthServer,
+		alog:       srv.AuditLog,
+		context:    *setupAuthContext,
+	}
+
+	user, err := types.NewUser("some-user")
+	require.NoError(t, err)
+
+	localUser := authz.LocalUser{Username: "test", Identity: tlsca.Identity{Username: "test"}}
+
+	// test create user, happy path
+	err = setupServer.CreateUser(authz.ContextWithUser(ctx, localUser), user)
+	require.NoError(t, err)
+	require.Equal(t, events.UserCreateEvent, m.Emitter.LastEvent().GetType())
+	require.Equal(t, "test", m.Emitter.LastEvent().(*apievents.UserCreate).User)
+	m.Emitter.Reset()
+
+	// test create user with existing user
+	err = setupServer.CreateUser(ctx, user)
+	require.True(t, trace.IsAlreadyExists(err))
+	require.Nil(t, m.Emitter.LastEvent())
+
+	// test createdBy gets set to default
+	user2, err := types.NewUser("some-other-user")
+	require.NoError(t, err)
+	err = setupServer.CreateUser(ctx, user2)
+	require.NoError(t, err)
+	require.Equal(t, teleport.UserSystem, m.Emitter.LastEvent().(*apievents.UserCreate).User)
+	m.Emitter.Reset()
+
+	// test update on non-existent user
+	user3, err := types.NewUser("non-existent-user")
+	require.NoError(t, err)
+	err = setupServer.UpdateUser(ctx, user3)
+	require.True(t, trace.IsNotFound(err))
+	require.Nil(t, m.Emitter.LastEvent())
+
+	// test update user
+	err = setupServer.UpdateUser(authz.ContextWithUser(ctx, localUser), user)
+	require.NoError(t, err)
+	require.Equal(t, events.UserUpdatedEvent, m.Emitter.LastEvent().GetType())
+	require.Equal(t, "test", m.Emitter.LastEvent().(*apievents.UserCreate).User)
+
+	err = setupServer.UpsertUser(authz.ContextWithUser(ctx, localUser), user)
+	require.NoError(t, err)
+	require.Equal(t, events.UserCreateEvent, m.Emitter.LastEvent().GetType())
+	require.Equal(t, "test", m.Emitter.LastEvent().(*apievents.UserCreate).User)
+	m.Emitter.Reset()
+
+	err = setupServer.UpsertUser(ctx, user)
+	require.NoError(t, err)
+	require.Equal(t, events.UserCreateEvent, m.Emitter.LastEvent().GetType())
+	require.Equal(t, teleport.UserSystem, m.Emitter.LastEvent().(*apievents.UserCreate).User)
+	m.Emitter.Reset()
+}
+
 func TestGenerateCertAuthorityCRL(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -5793,7 +5862,10 @@ func TestGenerateCertAuthorityCRL(t *testing.T) {
 	}
 
 	// Create a test user.
-	_, err = CreateUser(setupServer, "username")
+	user, err := types.NewUser("username")
+	require.NoError(t, err)
+
+	err = setupServer.CreateUser(ctx, user)
 	require.NoError(t, err)
 
 	for _, tc := range []struct {


### PR DESCRIPTION
Prior to this change the name of the user being updated was set in the audit event and not the user performing the update. This modifies upsert user to use the same code as create and update to populate the user metadata.

This started as a backport #35428 to branch/v14 but the user service is slightly different in release branches so the changes were manually made.

Changelog: Properly identify the Teleport user responsible for modifying user resources