### PR TITLE
Export agent metadata

### DIFF
--- a/lib/automaticupgrades/export.go
+++ b/lib/automaticupgrades/export.go
@@ -1,0 +1,236 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package automaticupgrades
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/kubernetes"
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+const (
+	// kubeSchedKey is the key under which the kube controller schedule is exported
+	kubeSchedKey = "agent-maintenance-schedule"
+
+	// kubeMetadataKey is the key under which the kube controller metadata is exported
+	kubeMetadataKey = "agent-metadata"
+
+	// unitScheduleFile is the name of the file to which the unit schedule is exported.
+	unitScheduleFile = "schedule"
+
+	// unitMetadataFile is the name of the file to which the metadata is exported.
+	unitMetadataFile = "metadata"
+
+	// unitConfigDir is the configuration directory of the teleport-upgrade unit.
+	unitConfigDir = "/etc/teleport-upgrade.d"
+)
+
+// AgentMetadata contains agent metadata to exported to an external upgrader.
+type AgentMetadata struct {
+	UUID     string `json:"uuid,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+// Driver represents a type capable of exporting the maintenance window schedule
+// or agent metadata to an external upgrader, such as the teleport-upgrade systemd
+// timer or the kube-updater controller.
+type Driver interface {
+	// Kind gets the upgrader kind associated with this export driver.
+	Kind() string
+
+	// SyncSchedule exports the appropriate maintenance window schedule if one is present, or
+	// resets/clears the maintenance window if the schedule response returns no viable scheduling
+	// info.
+	SyncSchedule(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error
+
+	// SyncMetadata exports the agent metadata.
+	SyncMetadata(ctx context.Context, metadata AgentMetadata) error
+
+	// ResetSchedule forcibly clears any previously exported maintenance window values. This should be
+	// called if teleport experiences prolonged loss of auth connectivity, which may be an indicator
+	// that the control plane has been upgraded s.t. this agent is no longer compatible.
+	ResetSchedule(ctx context.Context) error
+}
+
+// NewDriver sets up a new export driver corresponding to the specified upgrader kind.
+func NewDriver(kind string) (Driver, error) {
+	switch kind {
+	case types.UpgraderKindKubeController:
+		return NewKubeControllerDriver(KubeControllerDriverConfig{})
+	case types.UpgraderKindSystemdUnit:
+		return NewSystemdUnitDriver(SystemdUnitDriverConfig{})
+	default:
+		return nil, trace.BadParameter("unsupported upgrader kind: %q", kind)
+	}
+}
+
+type KubeControllerDriverConfig struct {
+	// Backend is an optional backend. Must be an instance of the kuberenets shared-state backend
+	// if not nil.
+	Backend KubernetesBackend
+}
+
+// KubernetesBackend interface for kube shared storage backend.
+type KubernetesBackend interface {
+	// Put puts value into backend (creates if it does not
+	// exists, updates it otherwise)
+	Put(ctx context.Context, i backend.Item) (*backend.Lease, error)
+}
+
+type kubeDriver struct {
+	cfg KubeControllerDriverConfig
+}
+
+func NewKubeControllerDriver(cfg KubeControllerDriverConfig) (Driver, error) {
+	if cfg.Backend == nil {
+		var err error
+		cfg.Backend, err = kubernetes.NewShared()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &kubeDriver{cfg: cfg}, nil
+}
+
+func (e *kubeDriver) Kind() string {
+	return types.UpgraderKindKubeController
+}
+
+func (e *kubeDriver) SyncSchedule(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+	if rsp.KubeControllerSchedule == "" {
+		return e.ResetSchedule(ctx)
+	}
+	return trace.Wrap(e.sync(ctx, kubeSchedKey, []byte(rsp.GetKubeControllerSchedule())))
+}
+
+func (e *kubeDriver) SyncMetadata(ctx context.Context, metadata AgentMetadata) error {
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(e.sync(ctx, kubeMetadataKey, b))
+}
+
+func (e *kubeDriver) sync(ctx context.Context, dst string, data []byte) error {
+	_, err := e.cfg.Backend.Put(ctx, backend.Item{
+		Key:   []byte(dst),
+		Value: data,
+	})
+
+	return trace.Wrap(err)
+}
+
+func (e *kubeDriver) ResetSchedule(ctx context.Context) error {
+	// kube backend doesn't support deletes right now, so just set
+	// the key to empty.
+	_, err := e.cfg.Backend.Put(ctx, backend.Item{
+		Key:   []byte(kubeSchedKey),
+		Value: []byte{},
+	})
+
+	return trace.Wrap(err)
+}
+
+type SystemdUnitDriverConfig struct {
+	// ConfigDir is the directory from which the teleport-upgrade periodic loads its
+	// configuration parameters. Most notably, the 'schedule' file.
+	ConfigDir string
+}
+
+type systemdDriver struct {
+	cfg SystemdUnitDriverConfig
+}
+
+func NewSystemdUnitDriver(cfg SystemdUnitDriverConfig) (Driver, error) {
+	if cfg.ConfigDir == "" {
+		cfg.ConfigDir = unitConfigDir
+	}
+
+	return &systemdDriver{cfg: cfg}, nil
+}
+
+func (e *systemdDriver) Kind() string {
+	return types.UpgraderKindSystemdUnit
+}
+
+func (e *systemdDriver) SyncSchedule(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+	if len(rsp.SystemdUnitSchedule) == 0 {
+		// treat an empty schedule value as equivalent to a reset
+		return e.ResetSchedule(ctx)
+	}
+	return trace.Wrap(e.sync(ctx, e.scheduleFile(), []byte(rsp.GetSystemdUnitSchedule())))
+}
+
+func (e *systemdDriver) SyncMetadata(ctx context.Context, metadata AgentMetadata) error {
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(e.sync(ctx, e.metadataFile(), b))
+}
+
+func (e *systemdDriver) sync(ctx context.Context, dst string, data []byte) error {
+	// ensure config dir exists. if created it is set to 755, which is reasonably safe and seems to
+	// be the standard choice for config dirs like this in /etc/.
+	if err := os.MkdirAll(e.cfg.ConfigDir, defaults.DirectoryPermissions); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// export file. if created it is set to 644, which is reasonable for a sensitive but non-secret config value.
+	if err := os.WriteFile(dst, data, defaults.FilePermissions); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (e *systemdDriver) ResetSchedule(_ context.Context) error {
+	if _, err := os.Stat(e.scheduleFile()); os.IsNotExist(err) {
+		return nil
+	}
+
+	// note that we blank the file rather than deleting it, this is intended to allow us to
+	// preserve custom file permissions, such as those that might be used in a scenario where
+	// teleport is operating with limited privileges.
+	if err := os.WriteFile(e.scheduleFile(), []byte{}, teleport.FileMaskOwnerOnly); err != nil {
+		return trace.Errorf("failed to reset schedule file: %v", err)
+	}
+
+	return nil
+}
+
+func (e *systemdDriver) scheduleFile() string {
+	return filepath.Join(e.cfg.ConfigDir, unitScheduleFile)
+}
+
+func (e *systemdDriver) metadataFile() string {
+	return filepath.Join(e.cfg.ConfigDir, unitMetadataFile)
+}

--- a/lib/automaticupgrades/export_test.go
+++ b/lib/automaticupgrades/export_test.go
@@ -1,0 +1,275 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package automaticupgrades
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+type fakeKubeBackend struct {
+	data map[string]string
+}
+
+func newFakeKubeBackend() *fakeKubeBackend {
+	return &fakeKubeBackend{
+		data: make(map[string]string),
+	}
+}
+
+func (b *fakeKubeBackend) Put(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	b.data[string(item.Key)] = string(item.Value)
+	return nil, nil
+}
+
+// TestKubeControllerDriverSchedule verifies the schedule export behavior of the
+// kube controller driver.
+func TestKubeControllerDriverSchedule(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newFakeKubeBackend()
+
+	driver, err := NewKubeControllerDriver(KubeControllerDriverConfig{
+		Backend: bk,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "kube", driver.Kind())
+
+	// verify basic schedule creation
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule",
+	})
+	require.NoError(t, err)
+
+	key := "agent-maintenance-schedule"
+
+	require.Equal(t, "fake-schedule", bk.data[key])
+
+	// verify overwrite of existing schedule
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule-2",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-2", bk.data[key])
+
+	// verify reset of schedule
+	err = driver.ResetSchedule(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+
+	// verify reset of empty schedule has no effect
+	err = driver.ResetSchedule(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+
+	// setup another fake schedule
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule-3",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-3", bk.data[key])
+
+	// verify that empty schedule is equivalent to reset
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{})
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+}
+
+// TestSystemdUnitDriverSchedule verifies the schedule export behavior of the
+// systemd unit driver.
+func TestSystemdUnitDriverSchedule(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// use a sub-directory of a temp dir in order to verify that
+	// driver creates dir when needed.
+	dir := filepath.Join(t.TempDir(), "config")
+
+	driver, err := NewSystemdUnitDriver(SystemdUnitDriverConfig{
+		ConfigDir: dir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "unit", driver.Kind())
+
+	// verify basic schedule creation
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule",
+	})
+	require.NoError(t, err)
+
+	schedPath := filepath.Join(dir, "schedule")
+
+	sb, err := os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule", string(sb))
+
+	// verify overwrite of existing schedule
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule-2",
+	})
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-2", string(sb))
+
+	// verify reset/deletion of schedule
+	err = driver.ResetSchedule(ctx)
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+	require.Equal(t, "", string(sb))
+
+	// verify that duplicate resets succeed
+	err = driver.ResetSchedule(ctx)
+	require.NoError(t, err)
+
+	// set up another schedule
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule-3",
+	})
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-3", string(sb))
+
+	// verify that an empty schedule value is treated equivalent to a reset
+	err = driver.SyncSchedule(ctx, proto.ExportUpgradeWindowsResponse{})
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+	require.Equal(t, "", string(sb))
+}
+
+// TestKubeControllerDriverMetadata verifies metadata export behavior of the kube
+// controller driver.
+func TestKubeControllerDriverMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newFakeKubeBackend()
+
+	driver, err := NewKubeControllerDriver(KubeControllerDriverConfig{
+		Backend: bk,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "kube", driver.Kind())
+
+	var out AgentMetadata
+
+	// verify metadata creation
+	md1 := AgentMetadata{
+		UUID:     "uuid-1",
+		Hostname: "hostname-1",
+		Version:  "14.2.1",
+	}
+	require.NoError(t, driver.SyncMetadata(ctx, md1))
+
+	require.NoError(t, json.Unmarshal([]byte(bk.data[kubeMetadataKey]), &out))
+	require.Equal(t, md1, out)
+
+	// verify overwrite of existing metadata
+	md2 := AgentMetadata{
+		UUID:     "uuid-2",
+		Hostname: "hostname-2",
+		Version:  "14.2.2",
+	}
+	require.NoError(t, driver.SyncMetadata(ctx, md2))
+
+	require.NoError(t, json.Unmarshal([]byte(bk.data[kubeMetadataKey]), &out))
+	require.Equal(t, md2, out)
+}
+
+// TestSystemdUnitDriverMetadata verifies the metadata export behavior of the systemd
+// unit driver.
+func TestSystemdUnitDriverMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// use a sub-directory of a temp dir in order to verify that
+	// driver creates dir when needed.
+	dir := filepath.Join(t.TempDir(), "config")
+
+	driver, err := NewSystemdUnitDriver(SystemdUnitDriverConfig{
+		ConfigDir: dir,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "unit", driver.Kind())
+
+	var out AgentMetadata
+	metadataPath := filepath.Join(dir, unitMetadataFile)
+
+	// verify metadata creation
+	md1 := AgentMetadata{
+		UUID:     "uuid-1",
+		Hostname: "hostname-1",
+		Version:  "14.2.1",
+	}
+	require.NoError(t, driver.SyncMetadata(ctx, md1))
+
+	b, err := os.ReadFile(metadataPath)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(b, &out))
+	require.Equal(t, md1, out)
+
+	// verify overwrite of existing metadata
+	md2 := AgentMetadata{
+		UUID:     "uuid-2",
+		Hostname: "hostname-2",
+		Version:  "14.2.2",
+	}
+	require.NoError(t, driver.SyncMetadata(ctx, md2))
+
+	b, err = os.ReadFile(metadataPath)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(b, &out))
+	require.Equal(t, md2, out)
+}


### PR DESCRIPTION
Teleport agents will now export metadata about it self to the external upgrader. This will allow the teleport-upgrader to send agent metadata when making a request to the automatic upgrades version server. The additional metadata provided in the request can be used by the proxy to determine which versions to serve.

Currently, three pieces of agent information will be exported:
```
// AgentMetadata contains agent metadata to exported to an external upgrader.
type AgentMetadata struct {
	UUID     string `json:"uuid,omitempty"`
	Hostname string `json:"hostname,omitempty"`
	Version  string `json:"version,omitempty"`
}
```