### PR TITLE
[v14] Fix panic on nil value in `getPresetRoles()`

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -769,16 +769,7 @@ func GetPresetRoles() []types.Role {
 	// Certain `New$FooRole()` functions will return a nil role if the
 	// corresponding feature is disabled. They should be filtered out as they
 	// are not actually made available on the cluster.
-	filtered := make([]types.Role, 0, len(presets))
-	for _, role := range presets {
-		if role == nil {
-			continue
-		}
-
-		filtered = append(filtered, role)
-	}
-
-	return filtered
+	return slices.DeleteFunc(presets, func(r types.Role) bool { return r == nil })
 }
 
 // createPresetRoles creates preset role resources

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -753,7 +753,7 @@ type PresetRoleManager interface {
 // GetPresetRoles returns a list of all preset roles expected to be available on
 // this cluster.
 func GetPresetRoles() []types.Role {
-	return []types.Role{
+	presets := []types.Role{
 		services.NewPresetGroupAccessRole(),
 		services.NewPresetEditorRole(),
 		services.NewPresetAccessRole(),
@@ -765,6 +765,20 @@ func GetPresetRoles() []types.Role {
 		services.NewPresetDeviceEnrollRole(),
 		services.NewPresetRequireTrustedDeviceRole(),
 	}
+
+	// Certain `New$FooRole()` functions will return a nil role if the
+	// corresponding feature is disabled. They should be filtered out as they
+	// are not actually made available on the cluster.
+	filtered := make([]types.Role, 0, len(presets))
+	for _, role := range presets {
+		if role == nil {
+			continue
+		}
+
+		filtered = append(filtered, role)
+	}
+
+	return filtered
 }
 
 // createPresetRoles creates preset role resources


### PR DESCRIPTION
Backport #35458 to branch/v14

changelog: Fix panic on potential nil value when requesting `/webapi/presetroles`
