### PR TITLE
MFA for Admin Actions: `CreateResetPasswordToken`

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3122,6 +3122,10 @@ func (a *ServerWithRoles) CreateResetPasswordToken(ctx context.Context, req Crea
 		return nil, trace.AccessDenied("access denied")
 	}
 
+	if err := authz.AuthorizeAdminAction(ctx, &a.context); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return a.authServer.CreateResetPasswordToken(ctx, req)
 }
 

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -87,6 +87,12 @@ func (s *adminActionTestSuite) testAdminActionMFA_Users(t *testing.T) {
 			setup:      createUser,
 			cleanup:    deleteUser,
 		},
+		"tctl users reset": {
+			command:    "users reset teleuser",
+			cliCommand: &tctl.UserCommand{},
+			setup:      createUser,
+			cleanup:    deleteUser,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			s.runTestCase(t, ctx, tc)

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -97,12 +97,22 @@ const api = {
     if (!shouldRetry) {
       throw new ApiError(parseError(json), response);
     }
+
+    let webauthnResponse;
+    try {
+      webauthnResponse = await auth.getWebauthnResponse();
+    } catch (err) {
+      throw new Error(
+        'Failed to fetch webauthn credentials, please connect a registered hardware key and try again. If you do not have a hardware key registered, you can add one from your account settings page.'
+      );
+    }
+
     const paramsWithMfaHeader = {
       ...params,
       headers: {
         ...params.headers,
         [MFA_HEADER]: JSON.stringify({
-          webauthnAssertionResponse: await auth.getWebauthnResponse(),
+          webauthnAssertionResponse: webauthnResponse,
         }),
       },
     };


### PR DESCRIPTION
Require MFA for `CreateResetPasswordToken`.

Part of [RFD 131](https://github.com/gravitational/teleport/blob/6b998a78ddd76c0c9eb7d966086f984b01144de7/rfd/0131-adminitrative-actions-mfa.md#administrative-actions).

Based off https://github.com/gravitational/teleport/pull/35386 to use the same test helpers.