### PR TITLE
Build libbpf with fPIC

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -80,6 +80,10 @@ RUN apt-get update -y --fix-missing && \
         libelf-dev
 
 ARG LIBBPF_VERSION
+# BUILD_STATIC_ONLY - builds only static libraries without shared ones
+# EXTRA_CFLAGS - additional CFLAGS to pass to the compiler. fPIC is required so the library code can be moved around in memory
+# DESTDIR - where to install the library
+# V=1 - verbose build
 RUN mkdir -p /opt && cd /opt &&  \
     curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -83,8 +83,7 @@ ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt &&  \
     curl -fsSL https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    make &&  \
-    BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install install_uapi_headers
+    BUILD_STATIC_ONLY=y EXTRA_CFLAGS=-fPIC DESTDIR=/opt/libbpf V=1 make install install_uapi_headers
 
 ## BUILDBOX ###################################################################
 #


### PR DESCRIPTION
Fixes `/usr/bin/ld: /usr/libbpf-1.2.2/lib64//libbpf.a(libbpf.o): relocation R_X86_64_PC32 against symbol 'stderr@@GLIBC_2.2.5' can not be used when making a PDE object; recompile with -fPIE` error when running tests. 

Example from GHA: https://github.com/gravitational/teleport/actions/runs/7123089784/job/19395150812?pr=35465