### PR TITLE
Use automatic preset-react runtime in teleterm

### DIFF
--- a/web/packages/teleterm/babel.config.js
+++ b/web/packages/teleterm/babel.config.js
@@ -2,7 +2,7 @@ const baseCfg = require('@gravitational/build/.babelrc');
 
 baseCfg.presets = [
   ['@babel/preset-env', { targets: { node: 'current' } }],
-  '@babel/preset-react',
+  ['@babel/preset-react', { runtime: 'automatic' }],
   '@babel/preset-typescript',
 ];
 


### PR DESCRIPTION
#35037 added automatic runtime to our Babel config, but I missed the fact that teleterm overwrites Babel presets.