### PR TITLE
Improve UserMetadata used in User audit events

### DIFF
--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -98,7 +98,8 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 		Identity: &authz.LocalUser{
 			Username: "alice",
 			Identity: tlsca.Identity{
-				Groups: []string{"dev"},
+				Groups:   []string{"dev"},
+				Username: "alice",
 			},
 		},
 	}, nil
@@ -229,7 +230,7 @@ func TestCreateUser(t *testing.T) {
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
 	createEvent, ok := event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
-	assert.Equal(t, "system", createEvent.UserMetadata.User)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 
 	user, err := types.NewUser("alpaca")
 	require.NoError(t, err, "creating user alpaca")
@@ -239,7 +240,7 @@ func TestCreateUser(t *testing.T) {
 	require.Error(t, err, "user allowed to be created with a role that does not exist")
 	createEvent, ok = event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
-	assert.Equal(t, "system", createEvent.UserMetadata.User)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 }
 
 func TestDeleteUser(t *testing.T) {
@@ -368,7 +369,7 @@ func TestUpdateUser(t *testing.T) {
 	assert.Equal(t, events.UserCreateCode, event.GetCode(), "unexpected event code")
 	createEvent, ok := event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
-	assert.Equal(t, "system", createEvent.UserMetadata.User)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 
 	// Attempt to update the user again.
 	created.User.SetLogins([]string{"alpaca"})
@@ -382,7 +383,7 @@ func TestUpdateUser(t *testing.T) {
 	assert.Equal(t, events.UserUpdateCode, event.GetCode(), "unexpected event code")
 	createEvent, ok = event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
-	assert.Equal(t, "system", createEvent.UserMetadata.User)
+	assert.Equal(t, "alice", createEvent.UserMetadata.User)
 }
 
 func TestUpsertUser(t *testing.T) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -196,6 +196,12 @@ type Context struct {
 	adminActionAuthorized bool
 }
 
+// GetUserMetadata returns information about the authenticated identity
+// to be included in audit events.
+func (c *Context) GetUserMetadata() apievents.UserMetadata {
+	return c.Identity.GetIdentity().GetUserMetadata()
+}
+
 // LockTargets returns a list of LockTargets inferred from the context's
 // Identity and UnmappedIdentity.
 func (c *Context) LockTargets() []types.LockTarget {

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -174,6 +174,7 @@ func testEditUser(t *testing.T, fc *config.FileConfig, clt auth.ClientI) {
 
 		expected.SetRevision(created.GetRevision())
 		expected.SetLogins([]string{"abcdef"})
+		expected.SetCreatedBy(created.GetCreatedBy())
 
 		collection := &userCollection{users: []types.User{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())


### PR DESCRIPTION
Ensures that the metadata always contains the identity of the user performing the action and stops falling back to the user that last created the resource. Also adds a helper function to the authz.Context to make getting the UserMetadata from the already retrieved identity easier.