### PR TITLE
remove double quotes in instance single starter example Makefile

### DIFF
--- a/examples/aws/terraform/starter-cluster/Makefile
+++ b/examples/aws/terraform/starter-cluster/Makefile
@@ -47,7 +47,7 @@ TF_VAR_enable_postgres_listener ?= false
 TF_VAR_s3_bucket_name ?=
 
 # AWS instance type to provision for running this Teleport cluster
-TF_VAR_cluster_instance_type = "t3.micro"
+TF_VAR_cluster_instance_type = t3.micro
 
 # Email of your support org, used for Let's Encrypt cert registration process.
 TF_VAR_email ?=


### PR DESCRIPTION
the `"` causes an issue.

```
╷
│ Error: creating EC2 Instance: InvalidParameterValue: Invalid value '"t3.micro"' for InstanceType.
│ 	status code: 400, request id: a48e58d2-410e-4059-ab56-dce4b3357ff3
│
│   with aws_instance.cluster,
│   on cluster.tf line 2, in resource "aws_instance" "cluster":
│    2: resource "aws_instance" "cluster" {
│
╵
```

Changelog: fix default ec2 size in aws terraform starter cluster