### PR TITLE
EC2 Auto-Discovery: EICE support

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -747,6 +747,8 @@ const (
 	DiscoveredResourceKubernetes = "k8s"
 	// DiscoveredResourceAgentlessNode identifies a discovered agentless SSH node.
 	DiscoveredResourceAgentlessNode = "node.openssh"
+	// DiscoveredResourceEICENode identifies a discovered AWS EC2 Instance using the EICE access method.
+	DiscoveredResourceEICENode = "node.openssh-eice"
 	// DiscoveredResourceApp identifies a discovered Kubernetes App.
 	DiscoveredResourceApp = "app"
 

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -91,6 +91,14 @@ type Server interface {
 	// IsOpenSSHNode returns whether the connection to this Server must use OpenSSH.
 	// This returns true for SubKindOpenSSHNode and SubKindOpenSSHEICENode.
 	IsOpenSSHNode() bool
+
+	// IsEICE returns whether the Node is an EICE instance.
+	// Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
+	IsEICE() bool
+
+	// ServerInfoName returns the ServerInfo name for this resource.
+	// This name is used to match this instance against the ServerInfo resource.
+	ServerInfoName() string
 }
 
 // NewServer creates an instance of Server.
@@ -389,6 +397,42 @@ func (s *ServerV2) IsOpenSSHNode() bool {
 // OpenSSH daemon (instead of a Teleport Node).
 func IsOpenSSHNodeSubKind(subkind string) bool {
 	return subkind == SubKindOpenSSHNode || subkind == SubKindOpenSSHEICENode
+}
+
+// IsEICE returns whether the Node is an EICE instance.
+// Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
+func (s *ServerV2) IsEICE() bool {
+	if s.SubKind != SubKindOpenSSHEICENode {
+		return false
+	}
+
+	awsAccountID, _ := s.GetLabel(AWSAccountIDLabel)
+	awsInstanceID, _ := s.GetLabel(AWSInstanceIDLabel)
+
+	if awsMetadata := s.GetAWSInfo(); awsMetadata != nil && awsMetadata.AccountID != "" && awsMetadata.InstanceID != "" {
+		awsAccountID = awsMetadata.AccountID
+		awsInstanceID = awsMetadata.InstanceID
+	}
+
+	return awsAccountID != "" && awsInstanceID != ""
+}
+
+// ServerInfoName returns the ServerInfo name for this resource.
+// This name is used to match this instance against the ServerInfo resource.
+func (s *ServerV2) ServerInfoName() string {
+	awsAccountID, _ := s.GetLabel(AWSAccountIDLabel)
+	awsInstanceID, _ := s.GetLabel(AWSInstanceIDLabel)
+
+	if awsMetadata := s.GetAWSInfo(); awsMetadata != nil && awsMetadata.AccountID != "" && awsMetadata.InstanceID != "" {
+		awsAccountID = awsMetadata.AccountID
+		awsInstanceID = awsMetadata.InstanceID
+	}
+
+	if awsAccountID != "" && awsInstanceID != "" {
+		return ServerInfoNameFromAWS(awsAccountID, awsInstanceID)
+	}
+
+	return ServerInfoNameFromNodeName(s.GetName())
 }
 
 // openSSHNodeCheckAndSetDefaults are common validations for OpenSSH nodes.

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -96,9 +96,10 @@ type Server interface {
 	// Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
 	IsEICE() bool
 
-	// ServerInfoName returns the ServerInfo name for this resource.
-	// This name is used to match this instance against the ServerInfo resource.
-	ServerInfoName() string
+	// GetAWSInstanceID returns the AWS Instance ID if this node comes from an EC2 instance.
+	GetAWSInstanceID() string
+	// GetAWSAccountID returns the AWS Account ID if this node comes from an EC2 instance.
+	GetAWSAccountID() string
 }
 
 // NewServer creates an instance of Server.
@@ -399,6 +400,28 @@ func IsOpenSSHNodeSubKind(subkind string) bool {
 	return subkind == SubKindOpenSSHNode || subkind == SubKindOpenSSHEICENode
 }
 
+// GetAWSAccountID returns the AWS Account ID if this node comes from an EC2 instance.
+func (s *ServerV2) GetAWSAccountID() string {
+	awsAccountID, _ := s.GetLabel(AWSAccountIDLabel)
+
+	awsMetadata := s.GetAWSInfo()
+	if awsMetadata != nil && awsMetadata.AccountID != "" {
+		awsAccountID = awsMetadata.AccountID
+	}
+	return awsAccountID
+}
+
+// GetAWSInstanceID returns the AWS Instance ID if this node comes from an EC2 instance.
+func (s *ServerV2) GetAWSInstanceID() string {
+	awsInstanceID, _ := s.GetLabel(AWSInstanceIDLabel)
+
+	awsMetadata := s.GetAWSInfo()
+	if awsMetadata != nil && awsMetadata.InstanceID != "" {
+		awsInstanceID = awsMetadata.InstanceID
+	}
+	return awsInstanceID
+}
+
 // IsEICE returns whether the Node is an EICE instance.
 // Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
 func (s *ServerV2) IsEICE() bool {
@@ -406,33 +429,7 @@ func (s *ServerV2) IsEICE() bool {
 		return false
 	}
 
-	awsAccountID, _ := s.GetLabel(AWSAccountIDLabel)
-	awsInstanceID, _ := s.GetLabel(AWSInstanceIDLabel)
-
-	if awsMetadata := s.GetAWSInfo(); awsMetadata != nil && awsMetadata.AccountID != "" && awsMetadata.InstanceID != "" {
-		awsAccountID = awsMetadata.AccountID
-		awsInstanceID = awsMetadata.InstanceID
-	}
-
-	return awsAccountID != "" && awsInstanceID != ""
-}
-
-// ServerInfoName returns the ServerInfo name for this resource.
-// This name is used to match this instance against the ServerInfo resource.
-func (s *ServerV2) ServerInfoName() string {
-	awsAccountID, _ := s.GetLabel(AWSAccountIDLabel)
-	awsInstanceID, _ := s.GetLabel(AWSInstanceIDLabel)
-
-	if awsMetadata := s.GetAWSInfo(); awsMetadata != nil && awsMetadata.AccountID != "" && awsMetadata.InstanceID != "" {
-		awsAccountID = awsMetadata.AccountID
-		awsInstanceID = awsMetadata.InstanceID
-	}
-
-	if awsAccountID != "" && awsInstanceID != "" {
-		return ServerInfoNameFromAWS(awsAccountID, awsInstanceID)
-	}
-
-	return ServerInfoNameFromNodeName(s.GetName())
+	return s.GetAWSAccountID() != "" && s.GetAWSInstanceID() != ""
 }
 
 // openSSHNodeCheckAndSetDefaults are common validations for OpenSSH nodes.

--- a/api/types/server_info.go
+++ b/api/types/server_info.go
@@ -219,3 +219,25 @@ func ServerInfoNameFromAWS(accountID, instanceID string) string {
 func ServerInfoNameFromNodeName(name string) string {
 	return fmt.Sprintf("si-%v", name)
 }
+
+// ServerInfoForServer returns a ServerInfo from a Server
+func ServerInfoForServer(server Server) (ServerInfo, error) {
+	return NewServerInfo(
+		Metadata{
+			Name: serverInfoNameFromServer(server),
+		},
+		ServerInfoSpecV1{},
+	)
+}
+
+// serverInfoNameFromServer returns the ServerInfo name for this Server.
+func serverInfoNameFromServer(s Server) string {
+	awsAccountID := s.GetAWSAccountID()
+	awsInstanceID := s.GetAWSInstanceID()
+
+	if awsAccountID != "" && awsInstanceID != "" {
+		return ServerInfoNameFromAWS(awsAccountID, awsInstanceID)
+	}
+
+	return ServerInfoNameFromNodeName(s.GetName())
+}

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -633,59 +633,6 @@ func TestIsEICE(t *testing.T) {
 	}
 }
 
-func TestServerInfoName(t *testing.T) {
-	tests := []struct {
-		name   string
-		server *ServerV2
-		want   string
-	}{
-		{
-			name: "node with account and instance id labels uses the aws-<account-id>-<instance-id> format",
-			server: &ServerV2{
-				Metadata: Metadata{
-					Labels: map[string]string{
-						AWSAccountIDLabel:  "123456789012",
-						AWSInstanceIDLabel: "i-123",
-					},
-				},
-			},
-			want: "aws-123456789012-i-123",
-		},
-		{
-			name: "node with aws metadata uses the aws-<account-id>-<instance-id> format",
-			server: &ServerV2{
-				Metadata: Metadata{Labels: map[string]string{}},
-				Spec: ServerSpecV2{
-					CloudMetadata: &CloudMetadata{
-						AWS: &AWSInfo{
-							AccountID:  "123456789012",
-							InstanceID: "i-123",
-						},
-					},
-				},
-			},
-			want: "aws-123456789012-i-123",
-		},
-		{
-			name: "other nodes have their server info name following the si-<namen> format",
-			server: &ServerV2{
-				Metadata: Metadata{
-					Name:   "abcd",
-					Labels: map[string]string{},
-				},
-			},
-			want: "si-abcd",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.server.ServerInfoName(); got != tt.want {
-				t.Errorf("ServerInfoName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGetCloudMetadataAWS(t *testing.T) {
 	for _, tt := range []struct {
 		name     string

--- a/lib/auth/server_info.go
+++ b/lib/auth/server_info.go
@@ -88,6 +88,12 @@ func getServerInfoNames(node types.Server) []string {
 
 func (a *Server) setLabelsOnNodes(ctx context.Context, nodes []types.Server) (failedUpdates int, err error) {
 	for _, node := range nodes {
+		// EICE Node labels can't be updated using the Inventory Control Stream because there's no reverse tunnel.
+		// Labels are updated by the DiscoveryService during 'Server.handleEC2Instances'.
+		if node.GetSubKind() == types.SubKindOpenSSHEICENode {
+			continue
+		}
+
 		// Get the server infos that match this node.
 		serverInfoNames := getServerInfoNames(node)
 		serverInfos := make([]types.ServerInfo, 0, len(serverInfoNames))

--- a/lib/auth/server_info.go
+++ b/lib/auth/server_info.go
@@ -90,7 +90,8 @@ func (a *Server) setLabelsOnNodes(ctx context.Context, nodes []types.Server) (fa
 	for _, node := range nodes {
 		// EICE Node labels can't be updated using the Inventory Control Stream because there's no reverse tunnel.
 		// Labels are updated by the DiscoveryService during 'Server.handleEC2Instances'.
-		if node.GetSubKind() == types.SubKindOpenSSHEICENode {
+		// The same is valid for OpenSSH Nodes.
+		if node.IsOpenSSHNode() {
 			continue
 		}
 

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -24,6 +24,7 @@ import (
 	ec2TypesV2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
@@ -42,6 +43,7 @@ type ResourceTag interface {
 	//  here and use a type switch for now.
 	rdsTypesV2.Tag |
 		ec2TypesV2.Tag |
+		*ec2.Tag |
 		*rds.Tag |
 		*redshift.Tag |
 		*elasticache.Tag |
@@ -72,6 +74,8 @@ func TagsToLabels[Tag ResourceTag](tags []Tag) map[string]string {
 func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 	switch v := any(tag).(type) {
 	case *rds.Tag:
+		return aws.StringValue(v.Key), aws.StringValue(v.Value)
+	case *ec2.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *redshift.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)

--- a/lib/cloud/aws/tags_helpers_test.go
+++ b/lib/cloud/aws/tags_helpers_test.go
@@ -23,6 +23,7 @@ import (
 
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,32 @@ func TestTagsToLabels(t *testing.T) {
 
 	t.Run("rds", func(t *testing.T) {
 		inputTags := []*rds.Tag{
+			{
+				Key:   aws.String("Env"),
+				Value: aws.String("dev"),
+			},
+			{
+				Key:   aws.String("aws:cloudformation:stack-id"),
+				Value: aws.String("some-id"),
+			},
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("test"),
+			},
+		}
+
+		expectLabels := map[string]string{
+			"Name":                        "test",
+			"Env":                         "dev",
+			"aws:cloudformation:stack-id": "some-id",
+		}
+
+		actuallabels := TagsToLabels(inputTags)
+		require.Equal(t, expectLabels, actuallabels)
+	})
+
+	t.Run("ec2", func(t *testing.T) {
+		inputTags := []*ec2.Tag{
 			{
 				Key:   aws.String("Env"),
 				Value: aws.String("dev"),

--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -194,6 +194,7 @@ func TestListEC2(t *testing.T) {
 							"account-id":               "123456789012",
 							"region":                   "us-east-1",
 							"teleport.dev/instance-id": "i-123456789abcedf",
+							"teleport.dev/account-id":  "123456789012",
 						},
 						Namespace: "default",
 					},

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2V1 "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -443,6 +444,7 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 
 	instanceID := aws.ToString(instance.InstanceId)
 	labels[types.AWSInstanceIDLabel] = instanceID
+	labels[types.AWSAccountIDLabel] = awsCloudMetadata.AccountID
 
 	awsCloudMetadata.InstanceID = instanceID
 	awsCloudMetadata.VPCID = aws.ToString(instance.VpcId)
@@ -472,4 +474,31 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 	}
 
 	return server, nil
+}
+
+// NewAWSNodeFromEC2v1Instance creates a Node resource from an EC2 Instance.
+// It has a pre-populated spec which contains info that is not available in the ec2.Instance object.
+// Uses AWS SDK Go V1
+func NewAWSNodeFromEC2v1Instance(instance ec2V1.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
+	server, err := NewAWSNodeFromEC2Instance(ec2InstanceV1ToV2(instance), awsCloudMetadata)
+	return server, trace.Wrap(err)
+}
+
+func ec2InstanceV1ToV2(instance ec2V1.Instance) ec2Types.Instance {
+	tags := make([]ec2Types.Tag, 0, len(instance.Tags))
+	for _, tag := range instance.Tags {
+		tags = append(tags, ec2Types.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+
+	return ec2Types.Instance{
+		InstanceId:       instance.InstanceId,
+		VpcId:            instance.VpcId,
+		SubnetId:         instance.SubnetId,
+		PrivateIpAddress: instance.PrivateIpAddress,
+		PrivateDnsName:   instance.PrivateDnsName,
+		Tags:             tags,
+	}
 }

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	ec2V1 "github.com/aws/aws-sdk-go/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -435,7 +435,7 @@ func NodeHasMissedKeepAlives(s types.Server) bool {
 
 // NewAWSNodeFromEC2Instance creates a Node resource from an EC2 Instance.
 // It has a pre-populated spec which contains info that is not available in the ec2.Instance object.
-func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
+func NewAWSNodeFromEC2Instance(instance ec2types.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
 	labels := libaws.TagsToLabels(instance.Tags)
 	if labels == nil {
 		labels = make(map[string]string)
@@ -479,21 +479,21 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 // NewAWSNodeFromEC2v1Instance creates a Node resource from an EC2 Instance.
 // It has a pre-populated spec which contains info that is not available in the ec2.Instance object.
 // Uses AWS SDK Go V1
-func NewAWSNodeFromEC2v1Instance(instance ec2V1.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
+func NewAWSNodeFromEC2v1Instance(instance ec2v1.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
 	server, err := NewAWSNodeFromEC2Instance(ec2InstanceV1ToV2(instance), awsCloudMetadata)
 	return server, trace.Wrap(err)
 }
 
-func ec2InstanceV1ToV2(instance ec2V1.Instance) ec2Types.Instance {
-	tags := make([]ec2Types.Tag, 0, len(instance.Tags))
+func ec2InstanceV1ToV2(instance ec2v1.Instance) ec2types.Instance {
+	tags := make([]ec2types.Tag, 0, len(instance.Tags))
 	for _, tag := range instance.Tags {
-		tags = append(tags, ec2Types.Tag{
+		tags = append(tags, ec2types.Tag{
 			Key:   tag.Key,
 			Value: tag.Value,
 		})
 	}
 
-	return ec2Types.Instance{
+	return ec2types.Instance{
 		InstanceId:       instance.InstanceId,
 		VpcId:            instance.VpcId,
 		SubnetId:         instance.SubnetId,

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2V1 "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -80,6 +81,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
+						"teleport.dev/account-id":  "1234567889012",
 					},
 					Namespace: "default",
 				},
@@ -127,6 +129,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 						"region":                   "us-east-1",
 						"MyTag":                    "MyTagValue",
 						"teleport.dev/instance-id": "i-123456789abcedf",
+						"teleport.dev/account-id":  "1234567889012",
 					},
 					Namespace: "default",
 				},
@@ -224,6 +227,211 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := NewAWSNodeFromEC2Instance(tt.ec2Instance, tt.awsCloudMetadata)
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Empty(t, cmp.Diff(tt.expectedServer, s, cmpopts.IgnoreFields(types.ServerV2{}, "Metadata.Name")))
+		})
+	}
+}
+
+func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
+	isBadParameterErr := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	makeEC2Instance := func(fn func(*ec2V1.Instance)) ec2V1.Instance {
+		s := ec2V1.Instance{
+			PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
+			InstanceId:       aws.String("i-123456789abcedf"),
+			VpcId:            aws.String("vpc-abcd"),
+			SubnetId:         aws.String("subnet-123"),
+			PrivateIpAddress: aws.String("172.31.1.1"),
+			Tags: []*ec2V1.Tag{
+				{
+					Key:   aws.String("MyTag"),
+					Value: aws.String("MyTagValue"),
+				},
+			},
+		}
+		fn(&s)
+		return s
+	}
+
+	for _, tt := range []struct {
+		name             string
+		ec2Instance      ec2V1.Instance
+		awsCloudMetadata *types.AWSInfo
+		errCheck         require.ErrorAssertionFunc
+		expectedServer   types.Server
+	}{
+		{
+			name:        "valid",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: require.NoError,
+			expectedServer: &types.ServerV2{
+				Kind:    "node",
+				Version: "v2",
+				SubKind: "openssh-ec2-ice",
+				Metadata: types.Metadata{
+					Labels: map[string]string{
+						"account-id":               "1234567889012",
+						"region":                   "us-east-1",
+						"MyTag":                    "MyTagValue",
+						"teleport.dev/instance-id": "i-123456789abcedf",
+						"teleport.dev/account-id":  "1234567889012",
+					},
+					Namespace: "default",
+				},
+				Spec: types.ServerSpecV2{
+					Addr:     "172.31.1.1:22",
+					Hostname: "my-private-dns.compute.aws",
+					CloudMetadata: &types.CloudMetadata{
+						AWS: &types.AWSInfo{
+							AccountID:   "1234567889012",
+							InstanceID:  "i-123456789abcedf",
+							Region:      "us-east-1",
+							VPCID:       "vpc-abcd",
+							SubnetID:    "subnet-123",
+							Integration: "myintegration",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "instance metadata generated labels are not replaced by instance tags",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+				i.Tags = append(i.Tags, &ec2V1.Tag{
+					Key:   aws.String("region"),
+					Value: aws.String("evil"),
+				})
+				i.Tags = append(i.Tags, &ec2V1.Tag{
+					Key:   aws.String("account-id"),
+					Value: aws.String("evil"),
+				})
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: require.NoError,
+			expectedServer: &types.ServerV2{
+				Kind:    "node",
+				Version: "v2",
+				SubKind: "openssh-ec2-ice",
+				Metadata: types.Metadata{
+					Labels: map[string]string{
+						"account-id":               "1234567889012",
+						"region":                   "us-east-1",
+						"MyTag":                    "MyTagValue",
+						"teleport.dev/instance-id": "i-123456789abcedf",
+						"teleport.dev/account-id":  "1234567889012",
+					},
+					Namespace: "default",
+				},
+				Spec: types.ServerSpecV2{
+					Addr:     "172.31.1.1:22",
+					Hostname: "my-private-dns.compute.aws",
+					CloudMetadata: &types.CloudMetadata{
+						AWS: &types.AWSInfo{
+							AccountID:   "1234567889012",
+							InstanceID:  "i-123456789abcedf",
+							Region:      "us-east-1",
+							VPCID:       "vpc-abcd",
+							SubnetID:    "subnet-123",
+							Integration: "myintegration",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing ec2 private dns name",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+				i.PrivateDnsName = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 instance id",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+				i.InstanceId = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 vpc id",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+				i.VpcId = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 private ip address",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+				i.PrivateDnsName = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing account id",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing region",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing integration name",
+			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID: "1234567889012",
+				Region:    "us-east-1",
+			},
+			errCheck: isBadParameterErr,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewAWSNodeFromEC2v1Instance(tt.ec2Instance, tt.awsCloudMetadata)
 			tt.errCheck(t, err)
 			if err != nil {
 				return

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	ec2V1 "github.com/aws/aws-sdk-go/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -37,14 +37,14 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
 
-	makeEC2Instance := func(fn func(*ec2Types.Instance)) ec2Types.Instance {
-		s := ec2Types.Instance{
+	makeEC2Instance := func(fn func(*ec2types.Instance)) ec2types.Instance {
+		s := ec2types.Instance{
 			PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
 			InstanceId:       aws.String("i-123456789abcedf"),
 			VpcId:            aws.String("vpc-abcd"),
 			SubnetId:         aws.String("subnet-123"),
 			PrivateIpAddress: aws.String("172.31.1.1"),
-			Tags: []ec2Types.Tag{
+			Tags: []ec2types.Tag{
 				{
 					Key:   aws.String("MyTag"),
 					Value: aws.String("MyTagValue"),
@@ -57,14 +57,14 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 
 	for _, tt := range []struct {
 		name             string
-		ec2Instance      ec2Types.Instance
+		ec2Instance      ec2types.Instance
 		awsCloudMetadata *types.AWSInfo
 		errCheck         require.ErrorAssertionFunc
 		expectedServer   types.Server
 	}{
 		{
 			name:        "valid",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID:   "1234567889012",
 				Region:      "us-east-1",
@@ -103,12 +103,12 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name: "instance metadata generated labels are not replaced by instance tags",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
-				i.Tags = append(i.Tags, ec2Types.Tag{
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {
+				i.Tags = append(i.Tags, ec2types.Tag{
 					Key:   aws.String("region"),
 					Value: aws.String("evil"),
 				})
-				i.Tags = append(i.Tags, ec2Types.Tag{
+				i.Tags = append(i.Tags, ec2types.Tag{
 					Key:   aws.String("account-id"),
 					Value: aws.String("evil"),
 				})
@@ -151,7 +151,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 private dns name",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -163,7 +163,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 instance id",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {
 				i.InstanceId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -175,7 +175,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 vpc id",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {
 				i.VpcId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -187,7 +187,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 private ip address",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -199,7 +199,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name:        "missing account id",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				Region:      "us-east-1",
 				Integration: "myintegration",
@@ -208,7 +208,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name:        "missing region",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID:   "1234567889012",
 				Integration: "myintegration",
@@ -217,7 +217,7 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 		},
 		{
 			name:        "missing integration name",
-			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2types.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID: "1234567889012",
 				Region:    "us-east-1",
@@ -242,14 +242,14 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
 
-	makeEC2Instance := func(fn func(*ec2V1.Instance)) ec2V1.Instance {
-		s := ec2V1.Instance{
+	makeEC2Instance := func(fn func(*ec2v1.Instance)) ec2v1.Instance {
+		s := ec2v1.Instance{
 			PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
 			InstanceId:       aws.String("i-123456789abcedf"),
 			VpcId:            aws.String("vpc-abcd"),
 			SubnetId:         aws.String("subnet-123"),
 			PrivateIpAddress: aws.String("172.31.1.1"),
-			Tags: []*ec2V1.Tag{
+			Tags: []*ec2v1.Tag{
 				{
 					Key:   aws.String("MyTag"),
 					Value: aws.String("MyTagValue"),
@@ -262,14 +262,14 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 
 	for _, tt := range []struct {
 		name             string
-		ec2Instance      ec2V1.Instance
+		ec2Instance      ec2v1.Instance
 		awsCloudMetadata *types.AWSInfo
 		errCheck         require.ErrorAssertionFunc
 		expectedServer   types.Server
 	}{
 		{
 			name:        "valid",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID:   "1234567889012",
 				Region:      "us-east-1",
@@ -308,12 +308,12 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name: "instance metadata generated labels are not replaced by instance tags",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
-				i.Tags = append(i.Tags, &ec2V1.Tag{
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {
+				i.Tags = append(i.Tags, &ec2v1.Tag{
 					Key:   aws.String("region"),
 					Value: aws.String("evil"),
 				})
-				i.Tags = append(i.Tags, &ec2V1.Tag{
+				i.Tags = append(i.Tags, &ec2v1.Tag{
 					Key:   aws.String("account-id"),
 					Value: aws.String("evil"),
 				})
@@ -356,7 +356,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 private dns name",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -368,7 +368,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 instance id",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {
 				i.InstanceId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -380,7 +380,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 vpc id",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {
 				i.VpcId = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -392,7 +392,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name: "missing ec2 private ip address",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {
 				i.PrivateDnsName = nil
 			}),
 			awsCloudMetadata: &types.AWSInfo{
@@ -404,7 +404,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name:        "missing account id",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				Region:      "us-east-1",
 				Integration: "myintegration",
@@ -413,7 +413,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name:        "missing region",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID:   "1234567889012",
 				Integration: "myintegration",
@@ -422,7 +422,7 @@ func TestNewAWSNodeFromEC2v1Instance(t *testing.T) {
 		},
 		{
 			name:        "missing integration name",
-			ec2Instance: makeEC2Instance(func(i *ec2V1.Instance) {}),
+			ec2Instance: makeEC2Instance(func(i *ec2v1.Instance) {}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID: "1234567889012",
 				Region:    "us-east-1",

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1752,9 +1752,6 @@ type Node interface {
 	// IsEICE returns whether the Node is an EICE instance.
 	// Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
 	IsEICE() bool
-	// ServerInfoName returns the ServerInfo name for this resource.
-	// This name is used to match this instance against the ServerInfo resource.
-	ServerInfoName() string
 }
 
 // GetNodes allows callers to retrieve a subset of nodes that match the filter provided. The

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1749,6 +1749,12 @@ type Node interface {
 	GetUseTunnel() bool
 	// GetProxyIDs returns a list of proxy ids this server is connected to.
 	GetProxyIDs() []string
+	// IsEICE returns whether the Node is an EICE instance.
+	// Must be `openssh-ec2-ice` subkind and have the AccountID and InstanceID information (AWS Metadata or Labels).
+	IsEICE() bool
+	// ServerInfoName returns the ServerInfo name for this resource.
+	// This name is used to match this instance against the ServerInfo resource.
+	ServerInfoName() string
 }
 
 // GetNodes allows callers to retrieve a subset of nodes that match the filter provided. The
@@ -1770,31 +1776,6 @@ func (n *nodeCollector) GetNodes(ctx context.Context, fn func(n Node) bool) []ty
 	}
 
 	return matched
-}
-
-// FillNamesFromEC2Instances iterates over all nodes (cached) and fills in the fetchedEC2Instances value for nodes
-// that already exist in the cluster.
-// It uses the AWS AccountID/InstanceID labels to detect nodes already present.
-func (n *nodeCollector) FillNamesFromEC2Instances(ctx context.Context, fetchedEC2Instances map[string]string) {
-	// Attempt to freshen our data first.
-	n.refreshStaleNodes(ctx)
-
-	n.rw.RLock()
-	defer n.rw.RUnlock()
-
-	for _, server := range n.current {
-		labels := server.GetAllLabels()
-		accountID, accountOK := labels[types.AWSAccountIDLabel]
-		instanceID, instanceOK := labels[types.AWSInstanceIDLabel]
-		// Checking only for the subkind is not enough because users can manually remove labels from agentless nodes.
-		// Account/Instance IDs are required for comparing against new nodes, nodes without those labels are discarded.
-		if accountOK && instanceOK && server.GetSubKind() == types.SubKindOpenSSHEICENode {
-			nodeEC2Key := types.ServerInfoNameFromAWS(accountID, instanceID)
-			if _, found := fetchedEC2Instances[nodeEC2Key]; found {
-				fetchedEC2Instances[nodeEC2Key] = server.GetName()
-			}
-		}
-	}
 }
 
 // refreshStaleNodes attempts to reload nodes from the NodeGetter if

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -56,6 +56,7 @@ import (
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
+	"github.com/gravitational/teleport/lib/utils/spreadwork"
 )
 
 var errNoInstances = errors.New("all fetched nodes already enrolled")
@@ -741,18 +742,6 @@ func (s *Server) initGCPWatchers(ctx context.Context, matchers []types.GCPMatche
 	return nil
 }
 
-// existingEICENodes returns all the EICE Nodes
-func (s *Server) existingEICENodes() []types.Server {
-	return s.nodeWatcher.GetNodes(s.ctx, func(n services.Node) bool {
-		labels := n.GetAllLabels()
-		_, accountOK := labels[types.AWSAccountIDLabel]
-		_, instanceOK := labels[types.AWSInstanceIDLabel]
-		// Checking only for the subkind is not enough because users can manually remove labels from agentless nodes.
-		// Account/Instance IDs are required for comparing against new nodes, nodes without those labels are discarded.
-		return accountOK && instanceOK && n.GetSubKind() == types.SubKindOpenSSHEICENode
-	})
-}
-
 func (s *Server) filterExistingEC2Nodes(instances *server.EC2Instances) {
 	nodes := s.nodeWatcher.GetNodes(s.ctx, func(n services.Node) bool {
 		labels := n.GetAllLabels()
@@ -857,8 +846,13 @@ func (s *Server) handleEC2UsingEICE(instances *server.EC2Instances) {
 		Integration: instances.Integration,
 	}
 
-	existingEICENodes := s.existingEICENodes()
+	fetchedEC2Instances := make(map[string]string, len(instances.Instances))
+	for _, ec2Instance := range instances.Instances {
+		fetchedEC2Instances[types.ServerInfoNameFromAWS(instances.AccountID, ec2Instance.InstanceID)] = ""
+	}
+	s.nodeWatcher.FillNamesFromEC2Instances(s.ctx, fetchedEC2Instances)
 
+	nodesToUpsert := make([]types.Server, 0, len(instances.Instances))
 	// Add EC2 Instances using EICE method
 	for _, ec2Instance := range instances.Instances {
 		eiceNode, err := services.NewAWSNodeFromEC2v1Instance(ec2Instance.OriginalInstance, awsInfo)
@@ -869,23 +863,29 @@ func (s *Server) handleEC2UsingEICE(instances *server.EC2Instances) {
 		eiceNodeExpiration := s.clock.Now().Add(s.jitter(serverExpirationDuration))
 		eiceNode.SetExpiry(eiceNodeExpiration)
 
-		// Does the node exist already?
-		for _, existingEICENode := range existingEICENodes {
-			match := types.MatchLabels(existingEICENode, map[string]string{
-				types.AWSAccountIDLabel:  instances.AccountID,
-				types.AWSInstanceIDLabel: ec2Instance.InstanceID,
-			})
-			if match {
-				// Re-use the same Name so that `UpsertNode` replaces the node.
-				eiceNode.SetName(existingEICENode.GetName())
-				break
-			}
+		ec2InstanceServerInforName := types.ServerInfoNameFromAWS(instances.AccountID, ec2Instance.InstanceID)
+		// Re-use the same Name so that `UpsertNode` replaces the node.
+		if existingNodeName := fetchedEC2Instances[ec2InstanceServerInforName]; existingNodeName != "" {
+			eiceNode.SetName(existingNodeName)
 		}
 
+		nodesToUpsert = append(nodesToUpsert, eiceNode)
+	}
+
+	applyOverTimeConfig := spreadwork.ApplyOverTimeConfig{
+		MaxDuration: s.PollInterval,
+	}
+	err := spreadwork.ApplyOverTime(s.ctx, applyOverTimeConfig, nodesToUpsert, func(eiceNode types.Server) {
 		if _, err := s.AccessPoint.UpsertNode(s.ctx, eiceNode); err != nil {
-			s.Log.WithError(err).WithField("instance_id", ec2Instance.InstanceID).Warn("Error upserting as Node")
-			continue
+			var instanceID string
+			if awsInfo := eiceNode.GetAWSInfo(); awsInfo != nil {
+				instanceID = awsInfo.InstanceID
+			}
+			s.Log.WithError(err).WithField("instance_id", instanceID).Warn("Error upserting as Node")
 		}
+	})
+	if err != nil {
+		s.Log.WithError(err).Warn("Failed to upsert nodes.")
 	}
 }
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
@@ -153,6 +154,10 @@ type Config struct {
 	// clock is passed to watchers to handle poll intervals.
 	// Mostly used in tests.
 	clock clockwork.Clock
+
+	// jitter is a function which applies random jitter to a duration.
+	// It is used to add Expiration times to Resources that don't support Heartbeats (eg EICE Nodes).
+	jitter retryutils.Jitter
 }
 
 // AccessGraphConfig represents TAG server config.
@@ -241,6 +246,9 @@ kubernetes matchers are present.`)
 	}
 
 	c.Matchers.Azure = services.SimplifyAzureMatchers(c.Matchers.Azure)
+
+	c.jitter = retryutils.NewSeventhJitter()
+
 	return nil
 }
 
@@ -733,6 +741,16 @@ func (s *Server) initGCPWatchers(ctx context.Context, matchers []types.GCPMatche
 	return nil
 }
 
+// existingEICENodes returns all the EICE Nodes
+func (s *Server) existingEICENodes() []types.Server {
+	return s.nodeWatcher.GetNodes(s.ctx, func(n services.Node) bool {
+		labels := n.GetAllLabels()
+		_, accountOK := labels[types.AWSAccountIDLabel]
+		_, instanceOK := labels[types.AWSInstanceIDLabel]
+		return accountOK && instanceOK && n.GetSubKind() == types.SubKindOpenSSHEICENode
+	})
+}
+
 func (s *Server) filterExistingEC2Nodes(instances *server.EC2Instances) {
 	nodes := s.nodeWatcher.GetNodes(s.ctx, func(n services.Node) bool {
 		labels := n.GetAllLabels()
@@ -794,12 +812,6 @@ func genInstancesLogStr[T any](instances []T, getID func(T) string) string {
 
 func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	// TODO(marco): support AWS SSM Client backed by an integration
-	// TODO(gavin): support assume_role_arn for ec2.
-	ec2Client, err := s.CloudClients.GetAWSSSMClient(s.ctx, instances.Region, cloud.WithAmbientCredentials())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	serverInfos, err := instances.ServerInfos()
 	if err != nil {
 		return trace.Wrap(err)
@@ -809,11 +821,77 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	// instances.Rotation is true whenever the instances received need
 	// to be rotated, we don't want to filter out existing OpenSSH nodes as
 	// they all need to have the command run on them
-	if !instances.Rotation {
+	//
+	// Integration/EICE Nodes don't have heartbeat.
+	// Those Nodes must not be filtered, so that we can extend their expiration and sync labels.
+	if !instances.Rotation && instances.Integration == "" {
 		s.filterExistingEC2Nodes(instances)
 	}
 	if len(instances.Instances) == 0 {
 		return trace.NotFound("all fetched nodes already enrolled")
+	}
+
+	switch {
+	case instances.Integration != "":
+		s.handleEC2UsingEICE(instances)
+	default:
+		if err := s.handleEC2RemoteInstallation(instances); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if err := s.emitUsageEvents(instances.MakeEvents()); err != nil {
+		s.Log.WithError(err).Debug("Error emitting usage event.")
+	}
+
+	return nil
+}
+
+// handleEC2UsingEICE creates a Teleport Node (EICE subkind) from the instances list.
+func (s *Server) handleEC2UsingEICE(instances *server.EC2Instances) {
+	awsInfo := &types.AWSInfo{
+		AccountID:   instances.AccountID,
+		Region:      instances.Region,
+		Integration: instances.Integration,
+	}
+
+	existingEICENodes := s.existingEICENodes()
+
+	// Add EC2 Instances using EICE method
+	for _, ec2Instance := range instances.Instances {
+		eiceNode, err := services.NewAWSNodeFromEC2v1Instance(ec2Instance.OriginalInstance, awsInfo)
+		if err != nil {
+			s.Log.WithError(err).WithField("instance_id", ec2Instance.InstanceID).Warn("Error converting to Teleport EICE Node")
+			continue
+		}
+		eiceNodeExpiration := s.clock.Now().Add(s.jitter(serverExpirationDuration))
+		eiceNode.SetExpiry(eiceNodeExpiration)
+
+		// Does the node exist already?
+		for _, existingEICENode := range existingEICENodes {
+			match := types.MatchLabels(existingEICENode, map[string]string{
+				types.AWSAccountIDLabel:  instances.AccountID,
+				types.AWSInstanceIDLabel: ec2Instance.InstanceID,
+			})
+			if match {
+				// Re-use the same Name so that `UpsertNode` replaces the node.
+				eiceNode.SetName(existingEICENode.GetName())
+				break
+			}
+		}
+
+		if _, err := s.AccessPoint.UpsertNode(s.ctx, eiceNode); err != nil {
+			s.Log.WithError(err).WithField("instance_id", ec2Instance.InstanceID).Warn("Error upserting as Node")
+			continue
+		}
+	}
+}
+
+func (s *Server) handleEC2RemoteInstallation(instances *server.EC2Instances) error {
+	// TODO(gavin): support assume_role_arn for ec2.
+	ec2Client, err := s.CloudClients.GetAWSSSMClient(s.ctx, instances.Region, cloud.WithAmbientCredentials())
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	s.Log.Debugf("Running Teleport installation on these instances: AccountID: %s, Instances: %s",
@@ -829,9 +907,6 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	}
 	if err := s.ec2Installer.Run(s.ctx, req); err != nil {
 		return trace.Wrap(err)
-	}
-	if err := s.emitUsageEvents(instances.MakeEvents()); err != nil {
-		s.Log.WithError(err).Debug("Error emitting usage event.")
 	}
 	return nil
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -747,6 +747,8 @@ func (s *Server) existingEICENodes() []types.Server {
 		labels := n.GetAllLabels()
 		_, accountOK := labels[types.AWSAccountIDLabel]
 		_, instanceOK := labels[types.AWSInstanceIDLabel]
+		// Checking only for the subkind is not enough because users can manually remove labels from agentless nodes.
+		// Account/Instance IDs are required for comparing against new nodes, nodes without those labels are discarded.
 		return accountOK && instanceOK && n.GetSubKind() == types.SubKindOpenSSHEICENode
 	})
 }

--- a/lib/srv/discovery/reconciler.go
+++ b/lib/srv/discovery/reconciler.go
@@ -36,6 +36,10 @@ import (
 // instances.
 const minBatchSize = 5
 
+// serverExpirationDuration is the amount of time a Server should stay alive after being discovered.
+// To be used with a jitter when creating the non-Teleport Server's Expiration.
+const serverExpirationDuration = 90 * time.Minute
+
 type serverInfoUpserter interface {
 	UpsertServerInfo(ctx context.Context, si types.ServerInfo) error
 }
@@ -148,7 +152,7 @@ func (r *labelReconciler) queueServerInfos(serverInfos []types.ServerInfo) {
 			!utils.StringMapsEqual(si.GetNewLabels(), existingInfo.GetNewLabels()) ||
 			existingInfo.Expiry().Before(now.Add(30*time.Minute)) {
 
-			si.SetExpiry(now.Add(r.jitter(90 * time.Minute)))
+			si.SetExpiry(now.Add(r.jitter(serverExpirationDuration)))
 			r.discoveredServers[si.GetName()] = si
 			r.serverInfoQueue = append(r.serverInfoQueue, si)
 		}

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -62,19 +62,25 @@ type EC2Instances struct {
 	// Rotation is set so instances dont get filtered out for already
 	// existing in the teleport instance
 	Rotation bool
+
+	// Integration is the integration used to fetch the Instance and should be used to access it.
+	// Might be empty for instances that didn't use an Integration.
+	Integration string
 }
 
 // EC2Instance represents an AWS EC2 instance that has been
 // discovered.
 type EC2Instance struct {
-	InstanceID string
-	Tags       map[string]string
+	InstanceID       string
+	Tags             map[string]string
+	OriginalInstance ec2.Instance
 }
 
 func toEC2Instance(originalInst *ec2.Instance) EC2Instance {
 	inst := EC2Instance{
-		InstanceID: aws.StringValue(originalInst.InstanceId),
-		Tags:       make(map[string]string, len(originalInst.Tags)),
+		InstanceID:       aws.StringValue(originalInst.InstanceId),
+		Tags:             make(map[string]string, len(originalInst.Tags)),
+		OriginalInstance: *originalInst,
 	}
 	for _, tag := range originalInst.Tags {
 		if key := aws.StringValue(tag.Key); key != "" {
@@ -131,9 +137,14 @@ func WithPollInterval(interval time.Duration) Option {
 // MakeEvents generates ResourceCreateEvents for these instances.
 func (instances *EC2Instances) MakeEvents() map[string]*usageeventsv1.ResourceCreateEvent {
 	resourceType := types.DiscoveredResourceNode
-	if instances.DocumentName == types.AWSAgentlessInstallerDocument {
+
+	switch {
+	case instances.DocumentName == types.AWSAgentlessInstallerDocument:
 		resourceType = types.DiscoveredResourceAgentlessNode
+	case instances.Integration != "":
+		resourceType = types.DiscoveredResourceEICENode
 	}
+
 	events := make(map[string]*usageeventsv1.ResourceCreateEvent, len(instances.Instances))
 	for _, inst := range instances.Instances {
 		events[awsEventPrefix+inst.InstanceID] = &usageeventsv1.ResourceCreateEvent{
@@ -177,11 +188,12 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 			}
 
 			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
-				Matcher:   matcher,
-				Region:    region,
-				Document:  matcher.SSM.DocumentName,
-				EC2Client: ec2Client,
-				Labels:    matcher.Tags,
+				Matcher:     matcher,
+				Region:      region,
+				Document:    matcher.SSM.DocumentName,
+				EC2Client:   ec2Client,
+				Labels:      matcher.Tags,
+				Integration: matcher.Integration,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -193,11 +205,12 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 }
 
 type ec2FetcherConfig struct {
-	Matcher   types.AWSMatcher
-	Region    string
-	Document  string
-	EC2Client ec2iface.EC2API
-	Labels    types.Labels
+	Matcher     types.AWSMatcher
+	Region      string
+	Document    string
+	EC2Client   ec2iface.EC2API
+	Labels      types.Labels
+	Integration string
 }
 
 type ec2InstanceFetcher struct {
@@ -206,6 +219,7 @@ type ec2InstanceFetcher struct {
 	Region       string
 	DocumentName string
 	Parameters   map[string]string
+	Integration  string
 
 	// cachedInstances keeps all of the ec2 instances that were matched
 	// in the last run of GetInstances for use as a cache with
@@ -293,6 +307,7 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		Region:       cfg.Region,
 		DocumentName: cfg.Document,
 		Parameters:   parameters,
+		Integration:  cfg.Integration,
 		cachedInstances: &instancesCache{
 			instances: map[cachedInstanceKey]struct{}{},
 		},
@@ -307,9 +322,12 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(nodes []types.Server, rotation
 		DocumentName: f.DocumentName,
 		Parameters:   f.Parameters,
 		Rotation:     rotation,
+		Integration:  f.Integration,
 	}
 	for _, node := range nodes {
-		if node.GetSubKind() != types.SubKindOpenSSHNode {
+		// Heartbeating and expiration keeps Teleport Agents up to date, no need to consider those nodes.
+		// Agentless and EICE Nodes don't heartbeat, so they must be manually managed by the DiscoveryService.
+		if !types.IsOpenSSHNodeSubKind(node.GetSubKind()) {
 			continue
 		}
 		region, ok := node.GetLabel(types.AWSInstanceRegion)
@@ -358,6 +376,7 @@ func chunkInstances(insts EC2Instances) []Instances {
 			Parameters:   insts.Parameters,
 			Instances:    insts.Instances[i:end],
 			Rotation:     insts.Rotation,
+			Integration:  insts.Integration,
 		}
 		instColl = append(instColl, Instances{EC2: &inst})
 	}
@@ -386,6 +405,7 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 						Instances:    ToEC2Instances(res.Instances[i:end]),
 						Parameters:   f.Parameters,
 						Rotation:     rotation,
+						Integration:  f.Integration,
 					}
 					for _, ec2inst := range res.Instances[i:end] {
 						f.cachedInstances.add(ownerID, aws.StringValue(ec2inst.InstanceId))

--- a/lib/utils/spreadwork/spreadwork.go
+++ b/lib/utils/spreadwork/spreadwork.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package spreadwork
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// ApplyOverTimeConfig is the configuration values for the ApplyOverTime method.
+type ApplyOverTimeConfig struct {
+	// MaxDuration is the max duration for the operation to complete.
+	// It does not account for time spent in API calls.
+	MaxDuration time.Duration
+
+	// BatchInterval is the time spent between API calls to prevent server pressure.
+	// Defaults to 1 second.
+	BatchInterval time.Duration
+
+	// MinBatchSize is the min batch size per iteration.
+	// Defaults to 5 items.
+	MinBatchSize int
+
+	// clock is used for tests only.
+	clock clockwork.Clock
+}
+
+// CheckAndSetDefaults checks that the MaxDuration was set.
+func (c *ApplyOverTimeConfig) CheckAndSetDefaults() error {
+	if c.MaxDuration == 0 {
+		return trace.BadParameter("max duration is required")
+	}
+
+	if c.BatchInterval == 0 {
+		c.BatchInterval = time.Second
+	}
+
+	if c.MaxDuration < c.BatchInterval {
+		return trace.BadParameter("max interval must be greater than batch interval")
+	}
+
+	if c.MinBatchSize == 0 {
+		c.MinBatchSize = 5
+	}
+
+	if c.clock == nil {
+		c.clock = clockwork.NewRealClock()
+	}
+
+	return nil
+}
+
+// ApplyOverTime applies the applyFn to all elements of items during a period of time.
+func ApplyOverTime[T any](ctx context.Context, conf ApplyOverTimeConfig, items []T, applyFn func(T)) error {
+	if err := conf.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	maxBatches := int(conf.MaxDuration / conf.BatchInterval)
+	dynamicBatchSize := (len(items) / maxBatches) + 1
+	if dynamicBatchSize < conf.MinBatchSize {
+		dynamicBatchSize = conf.MinBatchSize
+	}
+
+	for {
+		if dynamicBatchSize > len(items) {
+			dynamicBatchSize = len(items)
+		}
+		chunk := items[0:dynamicBatchSize:dynamicBatchSize]
+		items = items[dynamicBatchSize:]
+
+		for _, c := range chunk {
+			// If ctx is Done, return without processing the other elements of the current chunk.
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				applyFn(c)
+			}
+		}
+		if len(items) == 0 {
+			return nil
+		}
+
+		select {
+		// If ctx is Done, return without processing the remaining chunks.
+		case <-ctx.Done():
+			return nil
+		case <-conf.clock.After(conf.BatchInterval):
+		}
+	}
+}

--- a/lib/utils/spreadwork/spreadwork_test.go
+++ b/lib/utils/spreadwork/spreadwork_test.go
@@ -1,0 +1,205 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package spreadwork
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyOverTime(t *testing.T) {
+	t.Run("all items at once", func(t *testing.T) {
+		ctx := context.Background()
+		fakeClock := clockwork.NewFakeClock()
+		items := []string{"1", "2", "3", "4", "5", "6"}
+		conf := ApplyOverTimeConfig{
+			MaxDuration: time.Second,
+			clock:       fakeClock,
+		}
+
+		var ops atomic.Uint64
+
+		go func() {
+			err := ApplyOverTime(ctx, conf, items, func(s string) {
+				ops.Add(1)
+			})
+			require.NoError(t, err)
+		}()
+
+		require.Eventually(t, func() bool {
+			return ops.Load() == uint64(len(items))
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("items processed in one chunks with some time left", func(t *testing.T) {
+		ctx := context.Background()
+		fakeClock := clockwork.NewFakeClock()
+		items := []string{"1", "2", "3", "4", "5", "6"}
+		conf := ApplyOverTimeConfig{
+			MaxDuration:   3 * time.Second,
+			BatchInterval: 2 * time.Second,
+			clock:         fakeClock,
+		}
+
+		var ops atomic.Uint64
+
+		go func() {
+			err := ApplyOverTime(ctx, conf, items, func(s string) {
+				ops.Add(1)
+			})
+			require.NoError(t, err)
+		}()
+
+		require.Eventually(t, func() bool {
+			fakeClock.Advance(100 * time.Millisecond)
+			return ops.Load() == uint64(len(items))
+		}, 1*time.Second, time.Millisecond)
+	})
+
+	t.Run("items processed in two chunks", func(t *testing.T) {
+		ctx := context.Background()
+		fakeClock := clockwork.NewFakeClock()
+		items := []string{"1", "2", "3", "4", "5", "6"}
+		conf := ApplyOverTimeConfig{
+			MaxDuration:   2 * time.Second,
+			BatchInterval: time.Second,
+			MinBatchSize:  1,
+			clock:         fakeClock,
+		}
+
+		var ops atomic.Uint64
+
+		go func() {
+			err := ApplyOverTime(ctx, conf, items, func(s string) {
+				ops.Add(1)
+			})
+			require.NoError(t, err)
+		}()
+
+		require.Eventually(t, func() bool {
+			fakeClock.Advance(100 * time.Millisecond)
+			return ops.Load() == uint64(len(items))
+		}, 1*time.Second, time.Millisecond)
+	})
+
+	t.Run("items processed in 3 chunks with uneven items", func(t *testing.T) {
+		ctx := context.Background()
+		fakeClock := clockwork.NewFakeClock()
+		items := []string{"1", "2", "3", "4", "5", "6", "7", "8"}
+		conf := ApplyOverTimeConfig{
+			MaxDuration:   3 * time.Second,
+			BatchInterval: time.Second,
+			MinBatchSize:  1,
+			clock:         fakeClock,
+		}
+
+		var ops atomic.Uint64
+
+		go func() {
+			err := ApplyOverTime(ctx, conf, items, func(s string) {
+				ops.Add(1)
+			})
+			require.NoError(t, err)
+		}()
+
+		require.Eventually(t, func() bool {
+			fakeClock.Advance(100 * time.Millisecond)
+			return ops.Load() == uint64(len(items))
+		}, 1*time.Second, time.Millisecond)
+	})
+
+	t.Run("cancel processing after three items", func(t *testing.T) {
+		ctx, cancelFn := context.WithCancel(context.Background())
+		fakeClock := clockwork.NewFakeClock()
+		items := []string{"1", "2", "3", "4", "5", "6", "7", "8"}
+		conf := ApplyOverTimeConfig{
+			MaxDuration:   3 * time.Second,
+			BatchInterval: time.Second,
+			MinBatchSize:  1,
+			clock:         fakeClock,
+		}
+
+		var ops atomic.Uint64
+		go func() {
+			err := ApplyOverTime(ctx, conf, items, func(s string) {
+				ops.Add(1)
+			})
+			require.NoError(t, err)
+		}()
+
+		require.Eventually(t, func() bool {
+			fakeClock.Advance(100 * time.Millisecond)
+			if ops.Load() == 3 {
+				cancelFn()
+				return true
+			}
+
+			return false
+		}, 1*time.Second, time.Millisecond)
+		require.Equal(t, uint64(3), ops.Load())
+	})
+
+	t.Run("check and set defaults", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			input    ApplyOverTimeConfig
+			errCheck require.ErrorAssertionFunc
+		}{
+			{
+				name: "minimal config",
+				input: ApplyOverTimeConfig{
+					MaxDuration: 3 * time.Second,
+				},
+				errCheck: require.NoError,
+			},
+			{
+				name: "all values set",
+				input: ApplyOverTimeConfig{
+					MaxDuration:   3 * time.Second,
+					BatchInterval: 2 * time.Second,
+				},
+				errCheck: require.NoError,
+			},
+			{
+				name: "invalid max duration",
+				input: ApplyOverTimeConfig{
+					MaxDuration: 0,
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "batch interval is greater than max duration",
+				input: ApplyOverTimeConfig{
+					MaxDuration:   time.Second,
+					BatchInterval: time.Minute,
+				},
+				errCheck: require.Error,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.errCheck(t, tt.input.CheckAndSetDefaults())
+			})
+		}
+	})
+}

--- a/lib/utils/spreadwork/spreadwork_test.go
+++ b/lib/utils/spreadwork/spreadwork_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +45,7 @@ func TestApplyOverTime(t *testing.T) {
 			err := ApplyOverTime(ctx, conf, items, func(s string) {
 				ops.Add(1)
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		require.Eventually(t, func() bool {
@@ -68,7 +69,7 @@ func TestApplyOverTime(t *testing.T) {
 			err := ApplyOverTime(ctx, conf, items, func(s string) {
 				ops.Add(1)
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		require.Eventually(t, func() bool {
@@ -94,7 +95,7 @@ func TestApplyOverTime(t *testing.T) {
 			err := ApplyOverTime(ctx, conf, items, func(s string) {
 				ops.Add(1)
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		require.Eventually(t, func() bool {
@@ -120,7 +121,7 @@ func TestApplyOverTime(t *testing.T) {
 			err := ApplyOverTime(ctx, conf, items, func(s string) {
 				ops.Add(1)
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		require.Eventually(t, func() bool {
@@ -145,7 +146,8 @@ func TestApplyOverTime(t *testing.T) {
 			err := ApplyOverTime(ctx, conf, items, func(s string) {
 				ops.Add(1)
 			})
-			require.NoError(t, err)
+
+			assert.ErrorIs(t, err, context.Canceled)
 		}()
 
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
Add support for EICE mode in EC2 Auto-Discovery

If an Integration is being used, then default to EICE mode.

Every time the Discovery finds EC2 instances, it will upsert them with an expiration of now+90m.
This ends up being something similar to a heartbeat that exists for Teleport SSH Nodes.
Labels are always in sync (it can lag as much time as the Discovery Service Poll Interval), and when an EC2 instance is removed or the Matcher no longer matches the instance, the Node is removed (it can lag up to 90 minutes, as per the expiration).

Pre-req:
Create an Integration and add your first EC2 instance (this ensures your permissions are correct) and the EC2 Instance Connect Endpoint is created for that VPC.
Now, start a DiscoveryService (no need if you are on cloud/dev) and then create the following DiscoveryConfig:
```yaml
kind: discovery_config
version: v1
metadata:
  name: dc001
spec:
  discovery_group: "prod-resources"
  aws:
    - types: ["ec2"]
      regions: ["eu-west-2"]
      tags:
        "*": "*"
      integration: teleportdev
```

Ensure the `discovery_group` is the same that you have running on the DiscoveryService (for cloud that's going to be `cloud-discovery-group`).

You should see the newly created Nodes (it can take up to five minutes).

Demo

![image](https://github.com/gravitational/teleport/assets/689271/b8f8d687-e866-4955-b49c-49342e9a844c)

```
2024-01-10T17:32:04Z DEBU [DISCOVERY] EC2 instances discovered (AccountID: 278576220453, Instances: [i-05723b41571a653e9]), starting installation pid:1137334.1 discovery/discovery.go:950
```

Fixes #34291