### PR TITLE
[v14] Don't include Stripe in CSP for enterprise usage-based products

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -187,7 +187,7 @@ var indexCSPStringCache *cspCache = newCSPCache()
 
 func getIndexContentSecurityPolicyString(cfg proto.Features, urlPath string) string {
 	// Check for result with this cfg and urlPath in cache
-	withStripe := cfg.GetCloud() && cfg.GetIsUsageBased()
+	withStripe := cfg.GetProductType() == proto.ProductType_PRODUCT_TYPE_TEAM
 	key := fmt.Sprintf("%v-%v", withStripe, urlPath)
 	if cspString, ok := indexCSPStringCache.get(key); ok {
 		return cspString

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -292,8 +292,8 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for cloud based usage (with stripe, no wasm)",
-			features: proto.Features{Cloud: true, IsUsageBased: true},
+			name:     "for cloud based usage, Team product (with stripe, no wasm)",
+			features: proto.Features{Cloud: true, IsUsageBased: true, ProductType: proto.ProductType_PRODUCT_TYPE_TEAM},
 			urlPath:  "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
@@ -303,6 +303,22 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 				"object-src":      "'none'",
 				"script-src":      "'self' https://js.stripe.com",
 				"frame-src":       "https://js.stripe.com",
+				"style-src":       "'self' 'unsafe-inline'",
+				"img-src":         "'self' data: blob:",
+				"font-src":        "'self' data:",
+				"connect-src":     "'self' wss:",
+			},
+		},
+		{
+			name:     "for cloud based usage, EUB product (no stripe or wasm)",
+			features: proto.Features{Cloud: true, IsUsageBased: true, ProductType: proto.ProductType_PRODUCT_TYPE_EUB},
+			urlPath:  "/web/index.js",
+			expectedCspVals: map[string]string{
+				"default-src":     "'self'",
+				"base-uri":        "'self'",
+				"form-action":     "'self'",
+				"frame-ancestors": "'none'",
+				"object-src":      "'none'",
 				"style-src":       "'self' 'unsafe-inline'",
 				"img-src":         "'self' data: blob:",
 				"font-src":        "'self' data:",
@@ -327,8 +343,8 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for cloud based usage & desktop session (with stripe, with wasm)",
-			features: proto.Features{Cloud: true, IsUsageBased: true},
+			name:     "for cloud based usage & desktop session, Team product (with stripe, with wasm)",
+			features: proto.Features{Cloud: true, IsUsageBased: true, ProductType: proto.ProductType_PRODUCT_TYPE_TEAM},
 			urlPath:  "/web/cluster/:clusterId/desktops/:desktopName/:username",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",


### PR DESCRIPTION
Backport #35456 to branch/v14

changelog: Content Security Policy will not allow accessing Stripe from the UI if the customer is using an enterprise usage-based billing plan, since it's not needed there.
