### PR TITLE
Rename the "Billing" nav item to "Usage & Billing"

### DIFF
--- a/web/packages/teleport/src/Navigation/categories.ts
+++ b/web/packages/teleport/src/Navigation/categories.ts
@@ -25,7 +25,7 @@ export enum ManagementSection {
   Access = 'Access Management',
   Identity = 'Identity Governance & Security',
   Activity = 'Activity',
-  Billing = 'Billing',
+  Billing = 'Usage & Billing',
   Clusters = 'Clusters',
   Permissions = 'Permissions Management',
 }


### PR DESCRIPTION
This better expresses the intent, since the pages here are more about usage tracking than actual billing for usage-based enterprise plans.

Updates gravitational/teleport.e#2861