### PR TITLE
[v14] User login state generator copies user labels.

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -30,8 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/api/types/header"
-	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/authz"
@@ -113,34 +111,7 @@ func createBotUser(
 		return nil, trace.Wrap(err)
 	}
 
-	uls, err := ulsFromUser(user)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if _, err := s.UserLoginStates.UpsertUserLoginState(ctx, uls); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return user, nil
-}
-
-func ulsFromUser(user types.User) (*userloginstate.UserLoginState, error) {
-	uls, err := userloginstate.New(header.Metadata{
-		Name: user.GetName(),
-		Labels: map[string]string{
-			types.BotLabel:           user.GetMetadata().Labels[types.BotLabel],
-			types.BotGenerationLabel: user.GetMetadata().Labels[types.BotGenerationLabel],
-		},
-	}, userloginstate.Spec{
-		Roles:  user.GetRoles(),
-		Traits: user.GetTraits(),
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return uls, nil
 }
 
 // createBot creates a new certificate renewal bot from a bot request.
@@ -436,22 +407,6 @@ func (a *Server) validateGenerationLabel(ctx context.Context, username string, c
 			// write. The request should be tried again - if it's malicious,
 			// someone will get a generation mismatch and trigger a lock.
 			return trace.CompareFailed("Database comparison failed, try the request again")
-		}
-
-		uls, err := a.GetUserLoginState(ctx, user.GetName())
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		if uls == nil {
-			uls, err = ulsFromUser(user)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-		}
-
-		uls.ResourceHeader.Metadata.Labels[types.BotGenerationLabel] = generation
-		if _, err := a.UpsertUserLoginState(ctx, uls); err != nil {
-			return trace.Wrap(err)
 		}
 
 		return nil

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -131,13 +131,17 @@ func (g *Generator) Generate(ctx context.Context, user types.User) (*userloginst
 		}
 	}
 
+	labels := make(map[string]string, len(user.GetAllLabels()))
+	for k, v := range user.GetAllLabels() {
+		labels[k] = v
+	}
+	labels[userloginstate.OriginalRolesAndTraitsSet] = "true"
+
 	// Create a new empty user login state.
 	uls, err := userloginstate.New(
 		header.Metadata{
-			Name: user.GetName(),
-			Labels: map[string]string{
-				userloginstate.OriginalRolesAndTraitsSet: "true",
-			},
+			Name:   user.GetName(),
+			Labels: labels,
 		}, userloginstate.Spec{
 			OriginalRoles:  utils.CopyStrings(user.GetRoles()),
 			OriginalTraits: originalTraits,

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -42,6 +42,10 @@ import (
 
 func TestAccessLists(t *testing.T) {
 	user, err := types.NewUser("user")
+	user.SetStaticLabels(map[string]string{
+		"label1": "value1",
+		"label2": "value2",
+	})
 	user.SetRoles([]string{"orole1"})
 	user.SetTraits(map[string][]string{
 		"otrait1": {"value1", "value2"},
@@ -70,6 +74,11 @@ func TestAccessLists(t *testing.T) {
 			cloud: true,
 			roles: []string{"orole1"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1"},
@@ -93,6 +102,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1", "role1", "role2"},
@@ -119,6 +133,11 @@ func TestAccessLists(t *testing.T) {
 			},
 			roles: []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1"},
@@ -142,6 +161,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1", "role1", "role2"},
@@ -165,6 +189,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1"},
@@ -188,6 +217,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "not-user")...),
 			roles:   []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1", "role1"},
@@ -207,6 +241,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2", "role3"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1", "role1", "role2", "role3"},
@@ -235,6 +274,11 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					"label1":                                 "value1",
+					"label2":                                 "value2",
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				[]string{"orole1"},
 				trait.Traits{"otrait1": {"value1", "value2"}},
 				[]string{"orole1"},
@@ -262,6 +306,9 @@ func TestAccessLists(t *testing.T) {
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"role1"},
 			expected: newUserLoginState(t, "user",
+				map[string]string{
+					userloginstate.OriginalRolesAndTraitsSet: "true",
+				},
 				nil,
 				nil,
 				[]string{"role1"},
@@ -421,15 +468,13 @@ func newAccessListMembers(t *testing.T, clock clockwork.Clock, accessList string
 	return alMembers
 }
 
-func newUserLoginState(t *testing.T, name string, originalRoles []string, originalTraits map[string][]string,
+func newUserLoginState(t *testing.T, name string, labels map[string]string, originalRoles []string, originalTraits map[string][]string,
 	roles []string, traits map[string][]string) *userloginstate.UserLoginState {
 	t.Helper()
 
 	uls, err := userloginstate.New(header.Metadata{
-		Name: name,
-		Labels: map[string]string{
-			userloginstate.OriginalRolesAndTraitsSet: "true",
-		},
+		Name:   name,
+		Labels: labels,
 	}, userloginstate.Spec{
 		OriginalRoles:  originalRoles,
 		OriginalTraits: originalTraits,

--- a/lib/auth/userloginstate/service_test.go
+++ b/lib/auth/userloginstate/service_test.go
@@ -68,8 +68,8 @@ func TestGetUserLoginStates(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, getResp.UserLoginStates)
 
-	uls1 := newUserLoginState(t, "1", stRoles, stTraits, stRoles, stTraits)
-	uls2 := newUserLoginState(t, "2", stRoles, stTraits, stRoles, stTraits)
+	uls1 := newUserLoginState(t, "1", nil, stRoles, stTraits, stRoles, stTraits)
+	uls2 := newUserLoginState(t, "2", nil, stRoles, stTraits, stRoles, stTraits)
 
 	_, err = svc.UpsertUserLoginState(ctx, &userloginstatev1.UpsertUserLoginStateRequest{UserLoginState: conv.ToProto(uls1)})
 	require.NoError(t, err)
@@ -94,8 +94,8 @@ func TestUpsertUserLoginStates(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, getResp.UserLoginStates)
 
-	uls1 := newUserLoginState(t, "1", stRoles, stTraits, stRoles, stTraits)
-	uls2 := newUserLoginState(t, "2", stRoles, stTraits, stRoles, stTraits)
+	uls1 := newUserLoginState(t, "1", nil, stRoles, stTraits, stRoles, stTraits)
+	uls2 := newUserLoginState(t, "2", nil, stRoles, stTraits, stRoles, stTraits)
 
 	_, err = svc.UpsertUserLoginState(ctx, &userloginstatev1.UpsertUserLoginStateRequest{UserLoginState: conv.ToProto(uls1)})
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestGetUserLoginState(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, getResp.UserLoginStates)
 
-	uls1 := newUserLoginState(t, "1", stRoles, stTraits, stRoles, stTraits)
+	uls1 := newUserLoginState(t, "1", nil, stRoles, stTraits, stRoles, stTraits)
 
 	_, err = svc.UpsertUserLoginState(ctx, &userloginstatev1.UpsertUserLoginStateRequest{UserLoginState: conv.ToProto(uls1)})
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestDeleteUserLoginState(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, getResp.UserLoginStates)
 
-	uls1 := newUserLoginState(t, "1", stRoles, stTraits, stRoles, stTraits)
+	uls1 := newUserLoginState(t, "1", nil, stRoles, stTraits, stRoles, stTraits)
 
 	_, err = svc.UpsertUserLoginState(ctx, &userloginstatev1.UpsertUserLoginStateRequest{UserLoginState: conv.ToProto(uls1)})
 	require.NoError(t, err)
@@ -170,8 +170,8 @@ func TestDeleteAllAccessLists(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, getResp.UserLoginStates)
 
-	uls1 := newUserLoginState(t, "1", stRoles, stTraits, stRoles, stTraits)
-	uls2 := newUserLoginState(t, "2", stRoles, stTraits, stRoles, stTraits)
+	uls1 := newUserLoginState(t, "1", nil, stRoles, stTraits, stRoles, stTraits)
+	uls2 := newUserLoginState(t, "2", nil, stRoles, stTraits, stRoles, stTraits)
 
 	_, err = svc.UpsertUserLoginState(ctx, &userloginstatev1.UpsertUserLoginStateRequest{UserLoginState: conv.ToProto(uls1)})
 	require.NoError(t, err)


### PR DESCRIPTION
Backport #35487 to branch/v14

changelog: Fix bot's unable to view or approve access requests due to ULS overwriting.
