### PR TITLE
Reduce the size of Dockerfile-centos7 image

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -36,7 +36,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
 
@@ -82,7 +82,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* && \
+        ${DEVTOOLSET}-gcc && \
     yum clean all
 
 # Install libudev-zero.
@@ -160,7 +160,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
 
@@ -203,7 +203,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* && \
+        ${DEVTOOLSET}-gcc && \
     yum clean all
 
 # Install libpcsclite - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -266,7 +266,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-gcc    \
         ${DEVTOOLSET}-make && \
     yum clean all
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -266,7 +266,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc    \
+        ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -203,7 +203,8 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc && \
+        ${DEVTOOLSET}-gcc \
+        ${DEVTOOLSET}-gcc-c++ && \
     yum clean all
 
 # Install libpcsclite - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -267,6 +268,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
+        ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
 

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -29,7 +29,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
 
@@ -97,7 +97,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
 

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -30,6 +30,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
+        ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
 
@@ -98,6 +99,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
+        ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
 


### PR DESCRIPTION
The Dockerfile for centos7 has been updated to refine the package installation process. The wildcard (*) in the DEVTOOLSET-gcc statement used for 'yum install' command has been removed, targeting a specific version rather than installing any available DEVTOOLSET-gcc packages. It aims to gain more control over the build environment and minimize unintentional side effects.

This path reduces the size from 5.8GB to 4.0GB