### PR TITLE
[v14] build: Revert Debian 12 bump for arm (32-bit) buildbox

### DIFF
--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
 
-# This Dockerfile is used to build Teleport on ARM only.
-# We are using the official Debian 12 image as a base image
-# because the final binary must be compatible with distroless
-# images that are also Debian 12 based: https://github.com/GoogleContainerTools/distroless
-FROM docker.io/library/debian:12
+# This Dockerfile is used to build Teleport on ARM (32-bit) only.
+# The binaries produced need to be able to run on all the linux
+# distributions we support. See https://goteleport.com/docs/installation/
+# The binaries also run in the OCI containers we produce,
+# both "heavy" and distroless.
+#
+FROM docker.io/library/debian:11
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile


### PR DESCRIPTION
Revert part of #31620 that updated the arm 32-bit buildbox from Debian
11 to Debian 12, rolling back to Debian 11. This increased the required
version of glibc above what we say we support. The update of the
distroless image is fine as that is self-contained. The buildbox builds
the stand-alone binaries and OS packages so must be conservative in that
it uses.

Reverts: https://github.com/gravitational/teleport/pull/31620 (partial)
Issue: https://github.com/gravitational/teleport/issues/35476
Backport: https://github.com/gravitational/teleport/pull/35536
Changelog: Reverted build of ARM 32-bit binaries to Debian 11, bringing back support for glibc 2.31.