### PR TITLE
[v14] Fix client IP propagation from the Proxy to the Auth during IdP initiated SSO

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -513,7 +513,7 @@ type IdentityService interface {
 	// CreateSAMLAuthRequest creates SAML AuthnRequest
 	CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRequest) (*types.SAMLAuthRequest, error)
 	// ValidateSAMLResponse validates SAML auth response
-	ValidateSAMLResponse(ctx context.Context, re string, connectorID string) (*SAMLAuthResponse, error)
+	ValidateSAMLResponse(ctx context.Context, samlResponse, connectorID, clientIP string) (*SAMLAuthResponse, error)
 	// GetSAMLAuthRequest returns SAML auth request if found
 	GetSAMLAuthRequest(ctx context.Context, authRequestID string) (*types.SAMLAuthRequest, error)
 

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -810,10 +810,11 @@ func (c *HTTPClient) ValidateOIDCAuthCallback(ctx context.Context, q url.Values)
 }
 
 // ValidateSAMLResponse validates response returned by SAML identity provider
-func (c *HTTPClient) ValidateSAMLResponse(ctx context.Context, re string, connectorID string) (*SAMLAuthResponse, error) {
+func (c *HTTPClient) ValidateSAMLResponse(ctx context.Context, samlResponse, connectorID, clientIP string) (*SAMLAuthResponse, error) {
 	out, err := c.PostJSON(ctx, c.Endpoint("saml", "requests", "validate"), ValidateSAMLResponseReq{
-		Response:    re,
+		Response:    samlResponse,
 		ConnectorID: connectorID,
+		ClientIP:    clientIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Backport #35397 to branch/v14

changelog: Fixed client IP propagation from the Proxy to the Auth during IdP initiated SSO.
