### PR TITLE
[v14] remove double quotes in instance single starter example Makefile

### DIFF
--- a/examples/aws/terraform/starter-cluster/Makefile
+++ b/examples/aws/terraform/starter-cluster/Makefile
@@ -47,7 +47,7 @@ TF_VAR_enable_postgres_listener ?= false
 TF_VAR_s3_bucket_name ?=
 
 # AWS instance type to provision for running this Teleport cluster
-TF_VAR_cluster_instance_type = "t3.micro"
+TF_VAR_cluster_instance_type = t3.micro
 
 # Email of your support org, used for Let's Encrypt cert registration process.
 TF_VAR_email ?=


### PR DESCRIPTION
Backport #35495 to branch/v14

changelog: fix default ec2 size in aws terraform starter cluster
