### PR TITLE
Prevent flakiness in TestOutput

### DIFF
--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -183,7 +183,7 @@ func TestOutput(t *testing.T) {
 				slogTime, err := time.Parse(time.RFC3339, slogMatches[1])
 				assert.NoError(t, err, "invalid slog timestamp found %s", slogMatches[1])
 
-				assert.InDelta(t, logrusTime.UnixNano(), slogTime.UnixNano(), 10)
+				assert.InDelta(t, logrusTime.Unix(), slogTime.Unix(), 10)
 
 				// Match level, and component: DEBU [TEST]
 				assert.Empty(t, cmp.Diff(logrusMatches[2], slogMatches[2]), "level, and component to be identical")
@@ -321,7 +321,7 @@ func TestOutput(t *testing.T) {
 				slogTime, err := time.Parse(time.RFC3339, slogTimestamp)
 				assert.NoError(t, err, "invalid slog timestamp %s", slogTimestamp)
 
-				assert.InDelta(t, logrusTime.UnixNano(), slogTime.UnixNano(), 10)
+				assert.InDelta(t, logrusTime.Unix(), slogTime.Unix(), 10)
 
 				require.Empty(t,
 					cmp.Diff(


### PR DESCRIPTION
Tests were failing if too much time had passed between the output of each logger being generated. The InDelta assertion was supposed to prevent this, but because it used nanoseconds the delta of 10 was always exceeded and resulted in errors like below.

```
Max difference between 1701993842000000000 and 1701993843000000000 allowed is 10, but difference was -1e+09
```

To avoid this the assertion is now using Unix instead of UnixNano so that we allow up to 10 seconds of drift in the timestamps.