### PR TITLE
Add helper method to preserve resource identifiers

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1668,15 +1668,7 @@ func MarshalAccessRequest(accessRequest types.AccessRequest, opts ...MarshalOpti
 
 	switch accessRequest := accessRequest.(type) {
 	case *types.AccessRequestV3:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *accessRequest
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			accessRequest = &copy
-		}
-		return utils.FastMarshal(accessRequest)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, accessRequest))
 	default:
 		return nil, trace.BadParameter("unrecognized access request type: %T", accessRequest)
 	}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -67,13 +67,7 @@ func MarshalApp(app types.Application, opts ...MarshalOption) ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *app
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			app = &copy
-		}
-		return utils.FastMarshal(app)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, app))
 	default:
 		return nil, trace.BadParameter("unsupported app resource %T", app)
 	}
@@ -128,13 +122,7 @@ func MarshalAppServer(appServer types.AppServer, opts ...MarshalOption) ([]byte,
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *appServer
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			appServer = &copy
-		}
-		return utils.FastMarshal(appServer)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, appServer))
 	default:
 		return nil, trace.BadParameter("unsupported app server resource %T", appServer)
 	}

--- a/lib/services/audit.go
+++ b/lib/services/audit.go
@@ -83,15 +83,7 @@ func MarshalClusterAuditConfig(auditConfig types.ClusterAuditConfig, opts ...Mar
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *auditConfig
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			auditConfig = &copy
-		}
-		return utils.FastMarshal(auditConfig)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, auditConfig))
 	default:
 		return nil, trace.BadParameter("unrecognized cluster audit config version %T", auditConfig)
 	}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -510,15 +510,7 @@ func MarshalCertAuthority(certAuthority types.CertAuthority, opts ...MarshalOpti
 
 	switch certAuthority := certAuthority.(type) {
 	case *types.CertAuthorityV2:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *certAuthority
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			certAuthority = &copy
-		}
-		return utils.FastMarshal(certAuthority)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, certAuthority))
 	default:
 		return nil, trace.BadParameter("unrecognized certificate authority version %T", certAuthority)
 	}

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -83,15 +83,7 @@ func MarshalClusterName(clusterName types.ClusterName, opts ...MarshalOption) ([
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *clusterName
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			clusterName = &copy
-		}
-		return utils.FastMarshal(clusterName)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, clusterName))
 	default:
 		return nil, trace.BadParameter("unrecognized cluster name version %T", clusterName)
 	}

--- a/lib/services/connection_diagnostic.go
+++ b/lib/services/connection_diagnostic.go
@@ -63,16 +63,7 @@ func MarshalConnectionDiagnostic(s types.ConnectionDiagnostic, opts ...MarshalOp
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *s
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			s = &copy
-		}
-
-		return utils.FastMarshal(s)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, s))
 	}
 
 	return nil, trace.BadParameter("unrecognized connection diagnostic version %T", s)

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -96,15 +96,7 @@ func MarshalDatabase(database types.Database, opts ...MarshalOption) ([]byte, er
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *database
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			database = &copy
-		}
-		return utils.FastMarshal(database)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, database))
 	default:
 		return nil, trace.BadParameter("unsupported database resource %T", database)
 	}

--- a/lib/services/databaseserver.go
+++ b/lib/services/databaseserver.go
@@ -38,15 +38,7 @@ func MarshalDatabaseServer(databaseServer types.DatabaseServer, opts ...MarshalO
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *databaseServer
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			databaseServer = &copy
-		}
-		return utils.FastMarshal(databaseServer)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, databaseServer))
 	default:
 		return nil, trace.BadParameter("unrecognized database server version %T", databaseServer)
 	}

--- a/lib/services/databaseservice.go
+++ b/lib/services/databaseservice.go
@@ -52,15 +52,7 @@ func MarshalDatabaseService(databaseService types.DatabaseService, opts ...Marsh
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *databaseService
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			databaseService = &copy
-		}
-		return utils.FastMarshal(databaseService)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, databaseService))
 	default:
 		return nil, trace.BadParameter("unrecognized DatabaseService version %T", databaseService)
 	}

--- a/lib/services/desktop.go
+++ b/lib/services/desktop.go
@@ -57,15 +57,7 @@ func MarshalWindowsDesktop(s types.WindowsDesktop, opts ...MarshalOption) ([]byt
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *s
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			s = &copy
-		}
-		return utils.FastMarshal(s)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, s))
 	default:
 		return nil, trace.BadParameter("unrecognized windows desktop version %T", s)
 	}
@@ -120,15 +112,7 @@ func MarshalWindowsDesktopService(s types.WindowsDesktopService, opts ...Marshal
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *s
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			s = &copy
-		}
-		return utils.FastMarshal(s)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, s))
 	default:
 		return nil, trace.BadParameter("unrecognized windows desktop service version %T", s)
 	}

--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -186,16 +186,7 @@ func MarshalOSSGithubConnector(githubConnector types.GithubConnector, opts ...Ma
 			githubConnector.Spec.EndpointURL != "" {
 			return nil, fmt.Errorf("GitHub endpoint URL is set: %w", ErrRequiresEnterprise)
 		}
-
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *githubConnector
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			githubConnector = &copy
-		}
-		return utils.FastMarshal(githubConnector)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, githubConnector))
 	default:
 		return nil, trace.BadParameter("unrecognized github connector version %T", githubConnector)
 	}

--- a/lib/services/installer.go
+++ b/lib/services/installer.go
@@ -69,15 +69,7 @@ func MarshalInstaller(installer types.Installer, opts ...MarshalOption) ([]byte,
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *installer
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			installer = &copy
-		}
-		return utils.FastMarshal(installer)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, installer))
 	default:
 		return nil, trace.BadParameter("unrecognized installer version %T", installer)
 	}

--- a/lib/services/integration.go
+++ b/lib/services/integration.go
@@ -67,13 +67,7 @@ func MarshalIntegration(ig types.Integration, opts ...MarshalOption) ([]byte, er
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *g
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			g = &copy
-		}
-		return utils.FastMarshal(g)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, g))
 	default:
 		return nil, trace.BadParameter("unsupported integration resource %T", g)
 	}

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -76,13 +76,7 @@ func MarshalKubeServer(kubeServer types.KubeServer, opts ...MarshalOption) ([]by
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *server
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			server = &copy
-		}
-		return utils.FastMarshal(server)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, server))
 	default:
 		return nil, trace.BadParameter("unsupported kube server resource %T", server)
 	}
@@ -137,13 +131,7 @@ func MarshalKubeCluster(kubeCluster types.KubeCluster, opts ...MarshalOption) ([
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *cluster
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			cluster = &copy
-		}
-		return utils.FastMarshal(cluster)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, cluster))
 	default:
 		return nil, trace.BadParameter("unsupported kube cluster resource %T", cluster)
 	}

--- a/lib/services/lock.go
+++ b/lib/services/lock.go
@@ -123,15 +123,7 @@ func MarshalLock(lock types.Lock, opts ...MarshalOption) ([]byte, error) {
 		if version := lock.GetVersion(); version != types.V2 {
 			return nil, trace.BadParameter("mismatched lock version %v and type %T", version, lock)
 		}
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *lock
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			lock = &copy
-		}
-		return utils.FastMarshal(lock)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, lock))
 	default:
 		return nil, trace.BadParameter("unrecognized lock version %T", lock)
 	}

--- a/lib/services/namespace.go
+++ b/lib/services/namespace.go
@@ -35,15 +35,7 @@ func MarshalNamespace(resource types.Namespace, opts ...MarshalOption) ([]byte, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !cfg.PreserveResourceID {
-		// avoid modifying the original object
-		// to prevent unexpected data races
-		copy := resource
-		copy.SetResourceID(0)
-		copy.SetRevision("")
-		resource = copy
-	}
-	return utils.FastMarshal(resource)
+	return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, &resource))
 }
 
 // UnmarshalNamespace unmarshals the Namespace resource from JSON.

--- a/lib/services/networking.go
+++ b/lib/services/networking.go
@@ -72,15 +72,7 @@ func MarshalClusterNetworkingConfig(netConfig types.ClusterNetworkingConfig, opt
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *netConfig
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			netConfig = &copy
-		}
-		return utils.FastMarshal(netConfig)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, netConfig))
 	default:
 		return nil, trace.BadParameter("unrecognized cluster networking config version %T", netConfig)
 	}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -150,15 +150,7 @@ func MarshalOIDCConnector(oidcConnector types.OIDCConnector, opts ...MarshalOpti
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *oidcConnector
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			oidcConnector = &copy
-		}
-		return utils.FastMarshal(oidcConnector)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, oidcConnector))
 	default:
 		return nil, trace.BadParameter("unrecognized OIDC connector version %T", oidcConnector)
 	}

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -93,13 +93,7 @@ func MarshalOktaImportRule(importRule types.OktaImportRule, opts ...MarshalOptio
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *i
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			i = &copy
-		}
-		return utils.FastMarshal(i)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, i))
 	default:
 		return nil, trace.BadParameter("unsupported Okta import rule resource %T", i)
 	}
@@ -154,13 +148,7 @@ func MarshalOktaAssignment(assignment types.OktaAssignment, opts ...MarshalOptio
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *a
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			a = &copy
-		}
-		return utils.FastMarshal(a)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, a))
 	default:
 		return nil, trace.BadParameter("unsupported Okta assignment resource %T", a)
 	}

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -54,15 +54,7 @@ func MarshalPluginData(pluginData types.PluginData, opts ...MarshalOption) ([]by
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			cp := *pluginData
-			cp.SetResourceID(0)
-			cp.SetRevision("")
-			pluginData = &cp
-		}
-		return utils.FastMarshal(pluginData)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, pluginData))
 	default:
 		return nil, trace.BadParameter("unrecognized plugin data type: %T", pluginData)
 	}

--- a/lib/services/plugin_static_credentials.go
+++ b/lib/services/plugin_static_credentials.go
@@ -55,13 +55,7 @@ func MarshalPluginStaticCredentials(pluginStaticCredentials types.PluginStaticCr
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *pluginStaticCredentials
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			pluginStaticCredentials = &copy
-		}
-		data, err := protojson.Marshal(protoadapt.MessageV2Of(pluginStaticCredentials))
+		data, err := protojson.Marshal(protoadapt.MessageV2Of(maybeResetProtoResourceID(cfg.PreserveResourceID, pluginStaticCredentials)))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/plugins.go
+++ b/lib/services/plugins.go
@@ -54,14 +54,8 @@ func MarshalPlugin(plugin types.Plugin, opts ...MarshalOption) ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *plugin
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			plugin = &copy
-		}
 		var buf bytes.Buffer
-		err := (&jsonpb.Marshaler{}).Marshal(&buf, plugin)
+		err := (&jsonpb.Marshaler{}).Marshal(&buf, maybeResetProtoResourceID(cfg.PreserveResourceID, plugin))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -124,14 +124,7 @@ func MarshalProvisionToken(provisionToken types.ProvisionToken, opts ...MarshalO
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *provisionToken
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			provisionToken = &copy
-		}
+		provisionToken = maybeResetProtoResourceID(cfg.PreserveResourceID, provisionToken)
 		if cfg.GetVersion() == types.V1 {
 			return utils.FastMarshal(provisionToken.V1())
 		}

--- a/lib/services/remotecluster.go
+++ b/lib/services/remotecluster.go
@@ -73,15 +73,7 @@ func MarshalRemoteCluster(remoteCluster types.RemoteCluster, opts ...MarshalOpti
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *remoteCluster
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			remoteCluster = &copy
-		}
-		return utils.FastMarshal(remoteCluster)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, remoteCluster))
 	default:
 		return nil, trace.BadParameter("unrecognized remote cluster version %T", remoteCluster)
 	}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -26,8 +26,10 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/protoadapt"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // MarshalConfig specifies marshaling options
@@ -729,4 +731,24 @@ func setResourceName(overrideLabels []string, meta types.Metadata, firstNamePart
 	meta.Name = strings.Join(nameParts, "-")
 
 	return meta
+}
+
+type resetProtoResource interface {
+	protoadapt.MessageV1
+	SetResourceID(int64)
+	SetRevision(string)
+}
+
+// maybeResetProtoResourceID returns a clone of [r] with the identifiers
+// reset to default values if preserveResourceID is true, otherwise
+// this is a nop, and the original value is returned unaltered.
+func maybeResetProtoResourceID[T resetProtoResource](preserveResourceID bool, r T) T {
+	if preserveResourceID {
+		return r
+	}
+
+	cp := utils.CloneProtoMsg(r)
+	cp.SetResourceID(0)
+	cp.SetRevision("")
+	return cp
 }

--- a/lib/services/restrictions.go
+++ b/lib/services/restrictions.go
@@ -93,15 +93,7 @@ func MarshalNetworkRestrictions(restrictions types.NetworkRestrictions, opts ...
 
 	switch restrictions := restrictions.(type) {
 	case *types.NetworkRestrictionsV4:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *restrictions
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			restrictions = &copy
-		}
-		return utils.FastMarshal(restrictions)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, restrictions))
 	default:
 		return nil, trace.BadParameter("unrecognized network restrictions version %T", restrictions)
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -3210,15 +3210,7 @@ func MarshalRole(role types.Role, opts ...MarshalOption) ([]byte, error) {
 
 	switch role := role.(type) {
 	case *types.RoleV6:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *role
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			role = &copy
-		}
-		return utils.FastMarshal(role)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, role))
 	default:
 		return nil, trace.BadParameter("unrecognized role version %T", role)
 	}

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -327,15 +327,7 @@ func MarshalSAMLConnector(samlConnector types.SAMLConnector, opts ...MarshalOpti
 
 	switch samlConnector := samlConnector.(type) {
 	case *types.SAMLConnectorV2:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *samlConnector
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			samlConnector = &copy
-		}
-		return utils.FastMarshal(samlConnector)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, samlConnector))
 	default:
 		return nil, trace.BadParameter("unrecognized SAML connector version %T", samlConnector)
 	}

--- a/lib/services/saml_idp_service_provider.go
+++ b/lib/services/saml_idp_service_provider.go
@@ -61,13 +61,7 @@ func MarshalSAMLIdPServiceProvider(serviceProvider types.SAMLIdPServiceProvider,
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *sp
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			sp = &copy
-		}
-		return utils.FastMarshal(sp)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, sp))
 	default:
 		return nil, trace.BadParameter("unsupported SAML IdP service provider resource %T", sp)
 	}

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -327,15 +327,7 @@ func MarshalSemaphore(semaphore types.Semaphore, opts ...MarshalOption) ([]byte,
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *semaphore
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			semaphore = &copy
-		}
-		return utils.FastMarshal(semaphore)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, semaphore))
 	default:
 		return nil, trace.BadParameter("unrecognized resource version %T", semaphore)
 	}

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -394,15 +394,7 @@ func MarshalServer(server types.Server, opts ...MarshalOption) ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *server
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			server = &copy
-		}
-		return utils.FastMarshal(server)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, server))
 	default:
 		return nil, trace.BadParameter("unrecognized server version %T", server)
 	}

--- a/lib/services/server_info.go
+++ b/lib/services/server_info.go
@@ -73,15 +73,7 @@ func MarshalServerInfo(si types.ServerInfo, opts ...MarshalOption) ([]byte, erro
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *si
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			si = &copy
-		}
-		bytes, err := utils.FastMarshal(si)
+		bytes, err := utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, si))
 		return bytes, trace.Wrap(err)
 	default:
 		return nil, trace.BadParameter("unrecognized server info version %T", si)

--- a/lib/services/session.go
+++ b/lib/services/session.go
@@ -80,15 +80,7 @@ func MarshalWebSession(webSession types.WebSession, opts ...MarshalOption) ([]by
 		if version := webSession.GetVersion(); version != types.V2 {
 			return nil, trace.BadParameter("mismatched web session version %v and type %T", version, webSession)
 		}
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *webSession
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			webSession = &copy
-		}
-		return utils.FastMarshal(webSession)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, webSession))
 	default:
 		return nil, trace.BadParameter("unrecognized web session version %T", webSession)
 	}
@@ -107,15 +99,7 @@ func MarshalWebToken(webToken types.WebToken, opts ...MarshalOption) ([]byte, er
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *webToken
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			webToken = &copy
-		}
-		return utils.FastMarshal(webToken)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, webToken))
 	default:
 		return nil, trace.BadParameter("unrecognized web token version %T", webToken)
 	}

--- a/lib/services/sessionrecording.go
+++ b/lib/services/sessionrecording.go
@@ -84,15 +84,7 @@ func MarshalSessionRecordingConfig(recConfig types.SessionRecordingConfig, opts 
 		if version := recConfig.GetVersion(); version != types.V2 {
 			return nil, trace.BadParameter("mismatched session recording config version %v and type %T", version, recConfig)
 		}
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *recConfig
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			recConfig = &copy
-		}
-		return utils.FastMarshal(recConfig)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, recConfig))
 	default:
 		return nil, trace.BadParameter("unrecognized session recording config version %T", recConfig)
 	}

--- a/lib/services/statictokens.go
+++ b/lib/services/statictokens.go
@@ -70,15 +70,7 @@ func MarshalStaticTokens(staticToken types.StaticTokens, opts ...MarshalOption) 
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *staticToken
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			staticToken = &copy
-		}
-		return utils.FastMarshal(staticToken)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, staticToken))
 	default:
 		return nil, trace.BadParameter("unrecognized static token version %T", staticToken)
 	}

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -189,15 +189,7 @@ func MarshalTrustedCluster(trustedCluster types.TrustedCluster, opts ...MarshalO
 
 	switch trustedCluster := trustedCluster.(type) {
 	case *types.TrustedClusterV2:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *trustedCluster
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			trustedCluster = &copy
-		}
-		return utils.FastMarshal(trustedCluster)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, trustedCluster))
 	default:
 		return nil, trace.BadParameter("unrecognized trusted cluster version %T", trustedCluster)
 	}

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -92,15 +92,7 @@ func MarshalReverseTunnel(reverseTunnel types.ReverseTunnel, opts ...MarshalOpti
 
 	switch reverseTunnel := reverseTunnel.(type) {
 	case *types.ReverseTunnelV2:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *reverseTunnel
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			reverseTunnel = &copy
-		}
-		return utils.FastMarshal(reverseTunnel)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, reverseTunnel))
 	default:
 		return nil, trace.BadParameter("unrecognized reverse tunnel version %T", reverseTunnel)
 	}

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -108,15 +108,7 @@ func MarshalTunnelConnection(tunnelConnection types.TunnelConnection, opts ...Ma
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *tunnelConnection
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			tunnelConnection = &copy
-		}
-		return utils.FastMarshal(tunnelConnection)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, tunnelConnection))
 	default:
 		return nil, trace.BadParameter("unrecognized tunnel connection version %T", tunnelConnection)
 	}

--- a/lib/services/ui_config.go
+++ b/lib/services/ui_config.go
@@ -68,15 +68,7 @@ func MarshalUIConfig(uiconfig types.UIConfig, opts ...MarshalOption) ([]byte, er
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *uiconfig
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			uiconfig = &copy
-		}
-		return utils.FastMarshal(uiconfig)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, uiconfig))
 	default:
 		return nil, trace.BadParameter("unrecognized uiconfig version %T", uiconfig)
 	}

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -133,15 +133,7 @@ func MarshalUser(user types.User, opts ...MarshalOption) ([]byte, error) {
 
 	switch user := user.(type) {
 	case *types.UserV2:
-		if !cfg.PreserveResourceID {
-			// avoid modifying the original object
-			// to prevent unexpected data races
-			copy := *user
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			user = &copy
-		}
-		return utils.FastMarshal(user)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, user))
 	default:
 		return nil, trace.BadParameter("unrecognized user version %T", user)
 	}

--- a/lib/services/usergroup.go
+++ b/lib/services/usergroup.go
@@ -56,13 +56,7 @@ func MarshalUserGroup(group types.UserGroup, opts ...MarshalOption) ([]byte, err
 			return nil, trace.Wrap(err)
 		}
 
-		if !cfg.PreserveResourceID {
-			copy := *g
-			copy.SetResourceID(0)
-			copy.SetRevision("")
-			g = &copy
-		}
-		return utils.FastMarshal(g)
+		return utils.FastMarshal(maybeResetProtoResourceID(cfg.PreserveResourceID, g))
 	default:
 		return nil, trace.BadParameter("unsupported user group resource %T", g)
 	}


### PR DESCRIPTION
Attempts to reduce some of the boilerplate required to marshal a resource by moving common resource idenfitier handling to a utility method. This currently only works for resources that are proto in nature and not plain structs(access lists, secreports, discovery config, etc.).