### PR TITLE
[v14] Notify requester of access request and subsequent updates via Slack.

### DIFF
--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -124,7 +124,8 @@ func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []com
 	var data accessrequest.SentMessages
 	var errors []error
 
-	// Fetch the user as a recipient.
+	// Fetch the user as a recipient. The user is expected to be an e-mail here, as should be
+	// the case with most SSO setups.
 	userRecipient, err := b.FetchRecipient(ctx, reqData.User)
 	if err != nil {
 		log.Warningf("Unable to find user %s in Slack, will not be able to notify.", reqData.User)

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -127,17 +127,14 @@ func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []com
 	// Fetch the user as a recipient.
 	userRecipient, err := b.FetchRecipient(ctx, reqData.User)
 	if err != nil {
-		log.Errorf("Unable to find user %s in Slack, will not be able to notify.", reqData.User)
+		log.Warningf("Unable to find user %s in Slack, will not be able to notify.", reqData.User)
 	}
 
 	// Include the user in the list of recipients if it exists.
-	var allRecipients []common.Recipient
-	if userRecipient == nil {
-		allRecipients = recipients
-	} else {
-		allRecipients = make([]common.Recipient, len(recipients)+1)
-		copy(allRecipients[1:], recipients)
-		allRecipients[0] = *userRecipient
+	allRecipients := make([]common.Recipient, len(recipients), len(recipients)+1)
+	copy(allRecipients, recipients)
+	if userRecipient != nil {
+		allRecipients = append(allRecipients, *userRecipient)
 	}
 
 	for _, recipient := range allRecipients {

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -124,7 +124,23 @@ func (b Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []com
 	var data accessrequest.SentMessages
 	var errors []error
 
-	for _, recipient := range recipients {
+	// Fetch the user as a recipient.
+	userRecipient, err := b.FetchRecipient(ctx, reqData.User)
+	if err != nil {
+		log.Errorf("Unable to find user %s in Slack, will not be able to notify.", reqData.User)
+	}
+
+	// Include the user in the list of recipients if it exists.
+	var allRecipients []common.Recipient
+	if userRecipient == nil {
+		allRecipients = recipients
+	} else {
+		allRecipients = make([]common.Recipient, len(recipients)+1)
+		copy(allRecipients[1:], recipients)
+		allRecipients[0] = *userRecipient
+	}
+
+	for _, recipient := range allRecipients {
 		var result ChatMsgResponse
 		_, err := b.client.NewRequest().
 			SetContext(ctx).

--- a/integrations/access/slack/slack_test.go
+++ b/integrations/access/slack/slack_test.go
@@ -58,6 +58,7 @@ type SlackSuite struct {
 		reviewer2 string
 		plugin    string
 	}
+	requestorUser  User
 	raceNumber     int
 	fakeSlack      *FakeSlack
 	fakeStatusSink *fakeStatusSink
@@ -194,7 +195,7 @@ func (s *SlackSuite) SetupTest() {
 	s.fakeSlack = NewFakeSlack(User{Name: "slackbot"}, s.raceNumber)
 	t.Cleanup(s.fakeSlack.Close)
 
-	s.fakeSlack.StoreUser(User{Name: "Vladimir", Profile: UserProfile{Email: s.userNames.requestor}})
+	s.requestorUser = s.fakeSlack.StoreUser(User{Name: "Vladimir", Profile: UserProfile{Email: s.userNames.requestor}})
 
 	s.fakeStatusSink = &fakeStatusSink{}
 
@@ -281,30 +282,33 @@ func (s *SlackSuite) TestMessagePosting() {
 	reviewer2 := s.fakeSlack.StoreUser(User{Profile: UserProfile{Email: s.userNames.reviewer2}})
 
 	s.startApp()
+	const numMessages = 3
 	request := s.createAccessRequest([]User{reviewer2, reviewer1})
 
 	pluginData := s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
-	assert.Len(t, pluginData.SentMessages, 2)
+	assert.Len(t, pluginData.SentMessages, numMessages)
 
 	var messages []Message
 	messageSet := make(SlackDataMessageSet)
-	for i := 0; i < 2; i++ {
+	for i := 0; i < numMessages; i++ {
 		msg, err := s.fakeSlack.CheckNewMessage(s.Context())
 		require.NoError(t, err)
 		messageSet.Add(accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.Timestamp})
 		messages = append(messages, msg)
 	}
 
-	assert.Len(t, messageSet, 2)
-	assert.Contains(t, messageSet, pluginData.SentMessages[0])
-	assert.Contains(t, messageSet, pluginData.SentMessages[1])
+	assert.Len(t, messageSet, numMessages)
+	for i := 0; i < numMessages; i++ {
+		assert.Contains(t, messageSet, pluginData.SentMessages[i])
+	}
 
 	sort.Sort(SlackMessageSlice(messages))
 
-	assert.Equal(t, reviewer1.ID, messages[0].Channel)
-	assert.Equal(t, reviewer2.ID, messages[1].Channel)
+	assert.Equal(t, s.requestorUser.ID, messages[0].Channel)
+	assert.Equal(t, reviewer1.ID, messages[1].Channel)
+	assert.Equal(t, reviewer2.ID, messages[2].Channel)
 
 	msgUser, err := parseMessageField(messages[0], "User")
 	require.NoError(t, err)
@@ -336,38 +340,35 @@ func (s *SlackSuite) TestRecipientsConfig() {
 	}
 
 	s.startApp()
+	const numMessages = 3
 
 	request := s.createAccessRequest(nil)
 	pluginData := s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
-	assert.Len(t, pluginData.SentMessages, 2)
+	assert.Len(t, pluginData.SentMessages, numMessages)
 
-	var (
-		msg      Message
-		messages []Message
-	)
+	var messages []Message
 
 	messageSet := make(SlackDataMessageSet)
 
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	messageSet.Add(accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.Timestamp})
-	messages = append(messages, msg)
+	for i := 0; i < numMessages; i++ {
+		msg, err := s.fakeSlack.CheckNewMessage(s.Context())
+		require.NoError(t, err)
+		messageSet.Add(accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.Timestamp})
+		messages = append(messages, msg)
+	}
 
-	msg, err = s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	messageSet.Add(accessrequest.MessageData{ChannelID: msg.Channel, MessageID: msg.Timestamp})
-	messages = append(messages, msg)
-
-	assert.Len(t, messageSet, 2)
-	assert.Contains(t, messageSet, pluginData.SentMessages[0])
-	assert.Contains(t, messageSet, pluginData.SentMessages[1])
+	assert.Len(t, messageSet, numMessages)
+	for i := 0; i < numMessages; i++ {
+		assert.Contains(t, messageSet, pluginData.SentMessages[i])
+	}
 
 	sort.Sort(SlackMessageSlice(messages))
 
-	assert.Equal(t, reviewer1.ID, messages[0].Channel)
-	assert.Equal(t, reviewer2.ID, messages[1].Channel)
+	assert.Equal(t, s.requestorUser.ID, messages[0].Channel)
+	assert.Equal(t, reviewer1.ID, messages[1].Channel)
+	assert.Equal(t, reviewer2.ID, messages[2].Channel)
 }
 
 func (s *SlackSuite) TestApproval() {
@@ -378,21 +379,16 @@ func (s *SlackSuite) TestApproval() {
 	s.startApp()
 
 	req := s.createAccessRequest([]User{reviewer})
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
-	err = s.ruler().ApproveAccessRequest(s.Context(), req.GetName(), "okay")
+	err := s.ruler().ApproveAccessRequest(s.Context(), req.GetName(), "okay")
 	require.NoError(t, err)
 
-	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msgUpdate.Channel)
-	assert.Equal(t, msg.Timestamp, msgUpdate.Timestamp)
-
-	statusLine, err := getStatusLine(msgUpdate)
-	require.NoError(t, err)
-	assert.Equal(t, "*Status*: ✅ APPROVED\n*Resolution reason*: ```\nokay```", statusLine)
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ✅ APPROVED\n*Resolution reason*: ```\nokay```", statusLine)
+	})
 }
 
 func (s *SlackSuite) TestDenial() {
@@ -403,22 +399,17 @@ func (s *SlackSuite) TestDenial() {
 	s.startApp()
 
 	req := s.createAccessRequest([]User{reviewer})
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
 	// max size of request was decreased here: https://github.com/gravitational/teleport/pull/13298
-	err = s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay "+strings.Repeat("A", 4000))
+	err := s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay "+strings.Repeat("A", 4000))
 	require.NoError(t, err)
 
-	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msgUpdate.Channel)
-	assert.Equal(t, msg.Timestamp, msgUpdate.Timestamp)
-
-	statusLine, err := getStatusLine(msgUpdate)
-	require.NoError(t, err)
-	assert.Equal(t, "*Status*: ❌ DENIED\n*Resolution reason*: ```\nnot okay "+strings.Repeat("A", 491)+"``` (truncated)", statusLine)
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ❌ DENIED\n*Resolution reason*: ```\nnot okay "+strings.Repeat("A", 491)+"``` (truncated)", statusLine)
+	})
 }
 
 func (s *SlackSuite) TestReviewReplies() {
@@ -437,11 +428,9 @@ func (s *SlackSuite) TestReviewReplies() {
 		return len(data.SentMessages) > 0
 	})
 
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
-	err = s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
+	err := s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer1,
 		ProposedState: types.RequestState_APPROVED,
 		Created:       time.Now(),
@@ -449,13 +438,11 @@ func (s *SlackSuite) TestReviewReplies() {
 	})
 	require.NoError(t, err)
 
-	reply, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
-	assert.Contains(t, reply.Text, "Resolution: ✅ APPROVED", "reply must contain a proposed state")
-	assert.Contains(t, reply.Text, "Reason: ```\nokay```", "reply must contain a reason")
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
+		assert.Contains(t, reply.Text, "Resolution: ✅ APPROVED", "reply must contain a proposed state")
+		assert.Contains(t, reply.Text, "Reason: ```\nokay```", "reply must contain a reason")
+	})
 
 	err = s.reviewer2().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer2,
@@ -465,13 +452,11 @@ func (s *SlackSuite) TestReviewReplies() {
 	})
 	require.NoError(t, err)
 
-	reply, err = s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
-	assert.Contains(t, reply.Text, "Resolution: ❌ DENIED", "reply must contain a proposed state")
-	assert.Contains(t, reply.Text, "Reason: ```\nnot okay```", "reply must contain a reason")
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
+		assert.Contains(t, reply.Text, "Resolution: ❌ DENIED", "reply must contain a proposed state")
+		assert.Contains(t, reply.Text, "Reason: ```\nnot okay```", "reply must contain a reason")
+	})
 }
 
 func (s *SlackSuite) TestApprovalByReview() {
@@ -486,11 +471,9 @@ func (s *SlackSuite) TestApprovalByReview() {
 	s.startApp()
 
 	req := s.createAccessRequest([]User{reviewer})
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
-	err = s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
+	err := s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer1,
 		ProposedState: types.RequestState_APPROVED,
 		Created:       time.Now(),
@@ -498,11 +481,15 @@ func (s *SlackSuite) TestApprovalByReview() {
 	})
 	require.NoError(t, err)
 
-	reply, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
+	})
+
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ⏳ PENDING", statusLine)
+	})
 
 	err = s.reviewer2().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer2,
@@ -512,23 +499,15 @@ func (s *SlackSuite) TestApprovalByReview() {
 	})
 	require.NoError(t, err)
 
-	reply, err = s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
-	// When posting a review, the slack bot also updates the message to add the amount of reviewrs
-	// This update is soon superseded by the "access allowed" update
-	_, _ = s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
+	})
 
-	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msgUpdate.Channel)
-	assert.Equal(t, msg.Timestamp, msgUpdate.Timestamp)
-
-	statusLine, err := getStatusLine(msgUpdate)
-	require.NoError(t, err)
-	assert.Equal(t, "*Status*: ✅ APPROVED\n*Resolution reason*: ```\nfinally okay```", statusLine)
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ✅ APPROVED\n*Resolution reason*: ```\nfinally okay```", statusLine)
+	})
 }
 
 func (s *SlackSuite) TestDenialByReview() {
@@ -543,11 +522,9 @@ func (s *SlackSuite) TestDenialByReview() {
 	s.startApp()
 
 	req := s.createAccessRequest([]User{reviewer})
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
-	err = s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
+	err := s.reviewer1().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer1,
 		ProposedState: types.RequestState_DENIED,
 		Created:       time.Now(),
@@ -555,11 +532,15 @@ func (s *SlackSuite) TestDenialByReview() {
 	})
 	require.NoError(t, err)
 
-	reply, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
+	})
+
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ⏳ PENDING", statusLine)
+	})
 
 	err = s.reviewer2().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer2,
@@ -569,23 +550,15 @@ func (s *SlackSuite) TestDenialByReview() {
 	})
 	require.NoError(t, err)
 
-	reply, err = s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, msg.Channel, reply.Channel)
-	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
-	assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
-	// When posting a review, the slack bot also updates the message to add the amount of reviewrs
-	// This update is soon superseded by the "access allowed" update
-	_, _ = s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
+	s.checkNewMessages(t, msgs, matchByThreadTs, func(t *testing.T, reply Message) {
+		assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
+	})
 
-	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msgUpdate.Channel)
-	assert.Equal(t, msg.Timestamp, msgUpdate.Timestamp)
-
-	statusLine, err := getStatusLine(msgUpdate)
-	require.NoError(t, err)
-	assert.Equal(t, "*Status*: ❌ DENIED\n*Resolution reason*: ```\nfinally not okay```", statusLine)
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ❌ DENIED\n*Resolution reason*: ```\nfinally not okay```", statusLine)
+	})
 }
 
 func (s *SlackSuite) TestExpiration() {
@@ -596,25 +569,20 @@ func (s *SlackSuite) TestExpiration() {
 	s.startApp()
 
 	request := s.createAccessRequest([]User{reviewer})
-	msg, err := s.fakeSlack.CheckNewMessage(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msg.Channel)
+	msgs := s.checkNewMessages(t, channelsToMessages(s.requestorUser.ID, reviewer.ID), matchOnlyOnChannel)
 
 	s.checkPluginData(request.GetName(), func(data accessrequest.PluginData) bool {
 		return len(data.SentMessages) > 0
 	})
 
-	err = s.ruler().DeleteAccessRequest(s.Context(), request.GetName()) // simulate expiration
+	err := s.ruler().DeleteAccessRequest(s.Context(), request.GetName()) // simulate expiration
 	require.NoError(t, err)
 
-	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
-	require.NoError(t, err)
-	assert.Equal(t, reviewer.ID, msgUpdate.Channel)
-	assert.Equal(t, msg.Timestamp, msgUpdate.Timestamp)
-
-	statusLine, err := getStatusLine(msgUpdate)
-	require.NoError(t, err)
-	assert.Equal(t, "*Status*: ⌛ EXPIRED", statusLine)
+	s.checkNewMessageUpdateByAPI(t, msgs, matchByTimestamp, func(t *testing.T, msgUpdate Message) {
+		statusLine, err := getStatusLine(msgUpdate)
+		require.NoError(t, err)
+		assert.Equal(t, "*Status*: ⌛ EXPIRED", statusLine)
+	})
 }
 
 func (s *SlackSuite) TestAccessListReminder() {
@@ -723,13 +691,13 @@ func (s *SlackSuite) TestRace() {
 		})
 	}
 
-	// Having TWO suggested reviewers will post TWO messages for each request.
+	// Having TWO suggested reviewers will post THREE messages for each request (including the requestor).
 	// We also have approval threshold of TWO set in the role properties
 	// so lets simply submit the approval from each of the suggested reviewers.
 	//
-	// Multiplier SIX means that we handle TWO messages for each request and also
+	// Multiplier NINE means that we handle THREE messages for each request and also
 	// TWO comments for each message: 2 * (1 message + 2 comments).
-	for i := 0; i < 6*s.raceNumber; i++ {
+	for i := 0; i < 9*s.raceNumber; i++ {
 		process.SpawnCritical(func(ctx context.Context) error {
 			msg, err := s.fakeSlack.CheckNewMessage(ctx)
 			if err != nil {
@@ -755,6 +723,11 @@ func (s *SlackSuite) TestRace() {
 					return setRaceErr(trace.Wrap(err))
 				}
 
+				// The requestor can't submit reviews.
+				if user.ID == s.requestorUser.ID {
+					return nil
+				}
+
 				if err = s.clients[user.Profile.Email].SubmitAccessRequestReview(ctx, reqID, types.AccessReview{
 					Author:        user.Profile.Email,
 					ProposedState: types.RequestState_APPROVED,
@@ -777,8 +750,8 @@ func (s *SlackSuite) TestRace() {
 		})
 	}
 
-	// Multiplier TWO means that we handle the 2 updates for each of the two messages posted to reviewers.
-	for i := 0; i < 2*2*s.raceNumber; i++ {
+	// Multiplier THREE means that we handle the 2 updates for each of the two messages posted to reviewers.
+	for i := 0; i < 3*2*s.raceNumber; i++ {
 		process.SpawnCritical(func(ctx context.Context) error {
 			msg, err := s.fakeSlack.CheckMessageUpdateByAPI(ctx)
 			if err != nil {
@@ -799,7 +772,7 @@ func (s *SlackSuite) TestRace() {
 	<-process.Done()
 	require.NoError(t, raceErr)
 
-	assert.Equal(t, int32(2*s.raceNumber), threadMsgsCount)
+	assert.Equal(t, int32(3*s.raceNumber), threadMsgsCount)
 	threadMsgIDs.Range(func(key, value interface{}) bool {
 		next := true
 
@@ -863,4 +836,91 @@ func getStatusLine(msg Message) (string, error) {
 	}
 
 	return textBlock.GetText(), nil
+}
+
+// matchFns are functions that tell how to match two messages together after matching on the channel ID.
+type matchFn func(matchAgainst Message, newMsg Message) bool
+
+func matchOnlyOnChannel(_, _ Message) bool {
+	return true
+}
+
+func matchByTimestamp(matchAgainst, newMsg Message) bool {
+	return matchAgainst.Timestamp == newMsg.Timestamp
+}
+
+func matchByThreadTs(matchAgainst, newMsg Message) bool {
+	return matchAgainst.Timestamp == newMsg.ThreadTs
+}
+
+// checkMsgTestFn is a test function to run on a new message after it has been matched.
+type checkMsgTestFn func(*testing.T, Message)
+
+func (s *SlackSuite) checkNewMessages(t *testing.T, matchMessages []Message, matchBy matchFn, testFns ...checkMsgTestFn) []Message {
+	t.Helper()
+	return s.matchAndCallFn(t, matchMessages, matchBy, testFns, s.fakeSlack.CheckNewMessage)
+}
+
+func (s *SlackSuite) checkNewMessageUpdateByAPI(t *testing.T, matchMessages []Message, matchBy matchFn, testFns ...checkMsgTestFn) []Message {
+	t.Helper()
+	return s.matchAndCallFn(t, matchMessages, matchBy, testFns, s.fakeSlack.CheckMessageUpdateByAPI)
+}
+
+func (s *SlackSuite) checkNewMessageUpdateByResponding(t *testing.T, matchMessages []Message, matchBy matchFn, testFns ...checkMsgTestFn) []Message {
+	t.Helper()
+	return s.matchAndCallFn(t, matchMessages, matchBy, testFns, s.fakeSlack.CheckMessageUpdateByResponding)
+}
+
+func channelsToMessages(channels ...string) (messages []Message) {
+	for _, channel := range channels {
+		messages = append(messages, Message{BaseMessage: BaseMessage{Channel: channel}})
+	}
+
+	return messages
+}
+
+type slackCheckMessage func(context.Context) (Message, error)
+
+func (s *SlackSuite) matchAndCallFn(t *testing.T, matchMessages []Message, matchBy matchFn, testFns []checkMsgTestFn, slackCall slackCheckMessage) []Message {
+	matchingTimestamps := map[string]Message{}
+
+	for _, matchMessage := range matchMessages {
+		matchingTimestamps[matchMessage.Channel] = matchMessage
+	}
+
+	var messages []Message
+	var notMatchingMessages []Message
+
+	// Try for 5 seconds to get the expected messages
+	endTime := time.Now().Add(2 * time.Second)
+	for {
+		if time.Now().After(endTime) {
+			break
+		}
+		msg, err := slackCall(s.Context())
+		require.NoError(t, err, "matching messages: %d, not matching messages: %d", len(messages), len(notMatchingMessages))
+
+		if matchMsg, ok := matchingTimestamps[msg.Channel]; ok {
+			if !matchBy(matchMsg, msg) {
+				break
+			}
+			messages = append(messages, msg)
+		} else {
+			notMatchingMessages = append(notMatchingMessages, msg)
+		}
+
+		if len(messages) == len(matchMessages) {
+			break
+		}
+	}
+
+	require.Len(t, messages, len(matchMessages), "missing required messages, found %v", notMatchingMessages)
+
+	for _, testFn := range testFns {
+		for _, message := range messages {
+			testFn(t, message)
+		}
+	}
+
+	return messages
 }

--- a/integrations/access/slack/slack_test.go
+++ b/integrations/access/slack/slack_test.go
@@ -866,11 +866,6 @@ func (s *SlackSuite) checkNewMessageUpdateByAPI(t *testing.T, matchMessages []Me
 	return s.matchAndCallFn(t, matchMessages, matchBy, testFns, s.fakeSlack.CheckMessageUpdateByAPI)
 }
 
-func (s *SlackSuite) checkNewMessageUpdateByResponding(t *testing.T, matchMessages []Message, matchBy matchFn, testFns ...checkMsgTestFn) []Message {
-	t.Helper()
-	return s.matchAndCallFn(t, matchMessages, matchBy, testFns, s.fakeSlack.CheckMessageUpdateByResponding)
-}
-
 func channelsToMessages(channels ...string) (messages []Message) {
 	for _, channel := range channels {
 		messages = append(messages, Message{BaseMessage: BaseMessage{Channel: channel}})
@@ -892,27 +887,22 @@ func (s *SlackSuite) matchAndCallFn(t *testing.T, matchMessages []Message, match
 	var notMatchingMessages []Message
 
 	// Try for 5 seconds to get the expected messages
-	endTime := time.Now().Add(2 * time.Second)
-	for {
-		if time.Now().After(endTime) {
-			break
-		}
+	require.Eventually(t, func() bool {
 		msg, err := slackCall(s.Context())
-		require.NoError(t, err, "matching messages: %d, not matching messages: %d", len(messages), len(notMatchingMessages))
+		if err != nil {
+			return false
+		}
 
 		if matchMsg, ok := matchingTimestamps[msg.Channel]; ok {
-			if !matchBy(matchMsg, msg) {
-				break
+			if matchBy(matchMsg, msg) {
+				messages = append(messages, msg)
 			}
-			messages = append(messages, msg)
 		} else {
 			notMatchingMessages = append(notMatchingMessages, msg)
 		}
 
-		if len(messages) == len(matchMessages) {
-			break
-		}
-	}
+		return len(messages) == len(matchMessages)
+	}, 2*time.Second, 100*time.Millisecond)
 
 	require.Len(t, messages, len(matchMessages), "missing required messages, found %v", notMatchingMessages)
 


### PR DESCRIPTION
Backport #35394 to branch/v14

changelog: When using the Slack plugin, users will now be notified directly of access requests and their approvals or denials.
