### PR TITLE
desktop access: stop writing to the NTAuth store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,14 @@ the newer hardened Amazon Linux 2023 AMIs will be produced.
 The legacy AMIs will continue to be published for Teleport 13 and 14 throughout
 the remainder of these releases' lifecycle.
 
+#### `windows_desktop_service` no longer writes to the NTAuth store
+
+In Teleport 15, the process that periodically publishes Teleport's user CA to
+the Windows NTAuth store has been removed. It is not necessary for Teleport to
+perform this step since it must be done by an administrator at installation
+time. As a result, Teleport's service account can use more restrictive
+permissions.
+
 ## 14.0.0 (09/20/23)
 
 Teleport 14 brings the following new major features and improvements:

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -119,11 +119,11 @@ To create the service account:
    # Allow Teleport to write the certificateRevocationList property in the CDP/Teleport container.
    dsacls "CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,$DomainDN " /I:T /G "$($SamAccountName):WP;certificateRevocationList;"
 
-   # Allow Teleport to create and delete certificationAuthority objects in the NTAuthCertificates container.
-   dsacls "CN=Public Key Services,CN=Services,CN=Configuration,$DomainDN" /I:T /G "$($SamAccountName):CCDC;certificationAuthority;"
+   # Allow Teleport to read certificationAuthority objects in the NTAuthCertificates container.
+   dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DomainDN" /I:T /G "$($SamAccountName):GR;certificationAuthority;"
 
-   # Allow Teleport to write the cACertificate property in the NTAuthCertificates container.
-   dsacls "CN=Public Key Services,CN=Services,CN=Configuration,$DomainDN" /I:T /G "$($SamAccountName):WP;cACertificate;"
+   # Allow Teleport to read the cACertificate property in the NTAuthCertificates container.
+   dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DomainDN" /I:T /G "$($SamAccountName):RP;cACertificate;"
    ```
 
 1. Get the security identifier for the new service account.
@@ -197,16 +197,9 @@ logins.
 
 1. Repeat these steps for **Deny log on through Remote Desktop Services**.
 
-   For added security, you can disable username and password authentication completely.
-   If you disable username and password authentication, only the Teleport virtual smart
-   card can be used to access Windows computers in the domain.
-
-1. To ensure your GPO update takes effect immediately on this host,
-   open PowerShell and run the following command (optional):
-
-   ```powershell
-   gpupdate.exe /force
-   ```
+  For added security, you can disable username and password authentication completely.
+  If you disable username and password authentication, only the Teleport virtual smart
+  card can be used to access Windows computers in the domain.
 
 ## Step 3/7. Configure a GPO to allow Teleport connections
 
@@ -266,8 +259,8 @@ To configure the group policy object:
    ![AWS Managed AD OU Location](../../img/desktop-access/aws-managed-ad.png)
    </Figure>
 
-1. Open **Group Policy Management** and expand **`Forest > Domains > $YOUR_DOMAIN > Group Policy Objects`**
-   to locate the GPO you just created.
+1. Open **Group Policy Management** and expand Forest, Domains, your domain, and
+   Group Policy Objects to locate the GPO you just created.
 
 1. Select the new GPO—for example, `Teleport Access Policy`, right-click, then select **Edit**.
 
@@ -389,7 +382,8 @@ Next you need to configure policies that allow remote connections to domain comp
    Because the PIN is never provided to the Teleport user, the **Always prompt for password
    upon connection** policy must be **disabled** for authentication to succeed.
 
-1. Expand **`Computer Configuration > Policies > Windows Settings > Security Settings > Windows Firewall with Advanced Security`**.
+1. Expand Computer Configuration, Policies, Windows Settings, Security Settings to select
+   **Windows Firewall with Advanced Security**.
 
 1. Right-click **Inbound Rules**, select **New Rule**.
 
@@ -431,8 +425,8 @@ the performance of remote desktop connections.
 
 1. Again left-click **Remote Session Environment** in the left pane, and from the items in the right pane, right-click **Limit maximum color depth**, select **Edit**, select **Enabled**, then click **OK**.
 
-1. To ensure your GPO update takes effect immediately on this host,
-   open PowerShell and run the following command (optional):
+1. Open PowerShell and run the following command to update your Teleport
+   group policy object:
 
    ```powershell
    gpupdate.exe /force
@@ -443,14 +437,15 @@ the performance of remote desktop connections.
 The Teleport RDP client requires secure cryptographic algorithms to make
 TLS connections. However, Windows Server 2012 R2 doesn't support these algorithms
 by default.
-You can configure Windows Server 2012 R2 domain controllers to support the
+
+You can configure Windows Server 2012 R2 to support the
 required algorithms by doing the following:
 
 - Create a new certificate template that uses elliptic curve cryptography.
 - Update the Teleport group policy object to use the new certificate template
   when issuing certificates for remote desktop connections.
 
-If your domain controllers support the required algorithms, you can skip this step
+If your hosts support the required algorithms, you can skip this step
 and go to [Export your LDAP CA certificate](#step-57-export-your-ldap-ca-certificate).
 
 ### Create a certificate template
@@ -512,13 +507,14 @@ To update the Teleport group policy object to use the new certificate template:
    ![RDP Certificate Template](../../img/desktop-access/rdp-certificate-template.png)
    </Figure>
 
-1. Expand **`Computer Configuration > Policies > Windows Settings > Public Key Policies`**.
+1. Expand Computer Configuration, Policies, and Windows Settings to select
+   **Public Key Policies**.
 
 1. Double-click **Certificate Services Client - Auto-Enrollment**, then select
    **Enabled** in the Configuration Model.
 
-1. To ensure your GPO update takes effect immediately on this host,
-   open PowerShell and run the following command (optional):
+1. Open PowerShell and run the following command to update your Teleport
+   group policy object:
 
    ```powershell
    gpupdate.exe /force
@@ -676,8 +672,9 @@ To change the default domain policy:
 1. Open **Group Policy Management** and expand Forest, Domains, your domain, and
    Group Policy Objects.
 1. Right-click **Default Domain Controller Policy**, then select **Edit**.
-1. In the group policy editor, expand
-   **`Computer Configuration > Policies > Windows Settings > Security Settings > Local Policies > User Rights Assignment`**.
+1. In the group policy editor, expand Computer Configuration, Policies, Windows
+   Settings, Security Settings, Local Policies, and User Rights Assignment to select
+   **Add workstations to domain**.
 1. Double-click the  **Add workstations to domain** policy and ensure that the
    **Authenticated Users** group is not present.
 

--- a/lib/auth/windows/certificate_authority.go
+++ b/lib/auth/windows/certificate_authority.go
@@ -19,9 +19,7 @@
 package windows
 
 import (
-	"bytes"
 	"context"
-	"encoding/pem"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -30,11 +28,9 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 )
 
-// NewCertificateStoreClient returns a new structure for modifying windows certificates in a windows CA
+// NewCertificateStoreClient returns a new structure for modifying windows certificates in a Windows CA.
 func NewCertificateStoreClient(cfg CertificateStoreConfig) *CertificateStoreClient {
-	return &CertificateStoreClient{
-		cfg: cfg,
-	}
+	return &CertificateStoreClient{cfg: cfg}
 }
 
 // CertificateStoreClient implements access to a Windows Certificate Authority
@@ -56,112 +52,27 @@ type CertificateStoreConfig struct {
 	LC *LDAPClient
 }
 
-// Update publishes the certificate to the current cluster's certificate authority
+// Update publishes an empty certificate revocation list to LDAP.
 func (c *CertificateStoreClient) Update(ctx context.Context) error {
-	// Publish the CA cert for current cluster CA. For trusted clusters, their
-	// respective windows_desktop_services will publish their CAs so we don't
-	// have to do it here.
-	//
-	// TODO(zmb3): support multiple CA certs per cluster (such as with HSMs).
 	caType := types.UserCA
-	ca, err := c.cfg.AccessPoint.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       caType,
-		DomainName: c.cfg.ClusterName,
-	}, false)
-	if err != nil {
-		return trace.Wrap(err, "fetching Teleport CA")
-	}
 
-	keypairs := ca.GetTrustedTLSKeyPairs()
-	c.cfg.Log.Debugf("Teleport CA has %d trusted keypairs", len(keypairs))
-
-	// LDAP stores certs and CRLs in binary DER format, so remove the outer PEM
-	// wrapper.
-	caPEM := keypairs[0].Cert
-	caBlock, _ := pem.Decode(caPEM)
-	if caBlock == nil {
-		return trace.BadParameter("failed to decode CA PEM block")
-	}
-	caDER := caBlock.Bytes
-
-	crlDER, err := c.cfg.AccessPoint.GenerateCertAuthorityCRL(ctx, types.UserCA)
+	crlDER, err := c.cfg.AccessPoint.GenerateCertAuthorityCRL(ctx, caType)
 	if err != nil {
 		return trace.Wrap(err, "generating CRL")
 	}
 
+	// TODO(zmb3): check for the presence of Teleport's CA in the NTAuth store
+
 	// To make the CA trusted, we need 3 things:
-	// 1. put the CA cert into the Trusted Certification Authorities in the
-	//    Group Policy (done manually for now, see public docs)
+	// 1. put the CA cert into the Trusted Certification Authorities in Group Policy
 	// 2. put the CA cert into NTAuth store in LDAP
 	// 3. put the CRL of the CA into a dedicated LDAP entry
 	//
-	// Below we do #2 and #3.
-	if err := c.updateCAInNTAuthStore(ctx, caDER); err != nil {
-		return trace.Wrap(err, "updating NTAuth store over LDAP")
-	}
+	// #1 and #2 are done manually as part of the set up process (see public docs).
+	// Below we do #3.
 	if err := c.updateCRL(ctx, crlDER, caType); err != nil {
 		return trace.Wrap(err, "updating CRL over LDAP")
 	}
-	return nil
-}
-
-// updateCAInNTAuthStore records the Teleport user CA in the Windows store which records
-// CAs that are eligible to issue smart card login certificates and perform client
-// private key archival.
-//
-// This function is equivalent to running:
-//
-//	certutil –dspublish –f <PathToCertFile.cer> NTAuthCA
-//
-// You can confirm the cert is present by running:
-//
-//	certutil -viewstore "ldap:///CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,DC=example,DC=com>?caCertificate"
-//
-// Once the CA is published to LDAP, it should eventually sync and be present in the
-// machine's enterprise NTAuth store. You can check that with:
-//
-//	certutil -viewstore -enterprise NTAuth
-//
-// You can expedite the synchronization by running:
-//
-//	certutil -pulse
-func (c *CertificateStoreClient) updateCAInNTAuthStore(ctx context.Context, caDER []byte) error {
-	// Check if our CA is already in the store. The LDAP entry for NTAuth store
-	// is constant and it should always exist.
-	ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + c.cfg.LDAPConfig.DomainDN()
-	entries, err := c.cfg.LC.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
-	if err != nil {
-		return trace.Wrap(err, "fetching existing CAs")
-	}
-	if len(entries) != 1 {
-		return trace.BadParameter("expected exactly 1 NTAuthCertificates CA store at %q, but found %d", ntAuthDN, len(entries))
-	}
-	// TODO(zmb3): during CA rotation, find the old CA in NTAuthStore and remove it.
-	// Right now we just append the active CA and let the old ones hang around.
-	existingCAs := entries[0].GetRawAttributeValues("cACertificate")
-	for _, existingCADER := range existingCAs {
-		// CA already present.
-		if bytes.Equal(existingCADER, caDER) {
-			c.cfg.Log.Info("Teleport CA already present in NTAuthStore in LDAP")
-			return nil
-		}
-	}
-
-	c.cfg.Log.Debugf("None of the %d existing NTAuthCertificates matched Teleport's", len(existingCAs))
-
-	// CA is not in the store, append it.
-	updatedCAs := make([]string, 0, len(existingCAs)+1)
-	for _, existingCADER := range existingCAs {
-		updatedCAs = append(updatedCAs, string(existingCADER))
-	}
-	updatedCAs = append(updatedCAs, string(caDER))
-
-	if err := c.cfg.LC.Update(ntAuthDN, map[string][]string{
-		"cACertificate": updatedCAs,
-	}); err != nil {
-		return trace.Wrap(err, "updating CA entry")
-	}
-	c.cfg.Log.Info("Added Teleport CA to NTAuthStore via LDAP")
 	return nil
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -520,17 +520,6 @@ func (s *WindowsService) initializeLDAP() error {
 	conn.SetTimeout(ldapRequestTimeout)
 	s.lc.SetClient(conn)
 
-	// Note: admin still needs to import our CA into the Group Policy following
-	// https://docs.vmware.com/en/VMware-Horizon-7/7.13/horizon-installation/GUID-7966AE16-D98F-430E-A916-391E8EAAFE18.html
-	//
-	// We can find the group policy object via LDAP, but it only contains an
-	// SMB file path with the actual policy. See
-	// https://en.wikipedia.org/wiki/Group_Policy
-	//
-	// In theory, we could update the policy file(s) over SMB following
-	// https://docs.microsoft.com/en-us/previous-versions/windows/desktop/policy/registry-policy-file-format,
-	// but I'm leaving this for later.
-	//
 	if err := s.ca.Update(s.closeCtx); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -41,10 +41,10 @@ dsacls "CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /
 dsacls "CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /I:T /G "$($SAM_ACCOUNT_NAME):CCDC;cRLDistributionPoint;"
 # Gives Teleport the ability to write the certificateRevocationList property in the CDP/Teleport container.
 dsacls "CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN " /I:T /G "$($SAM_ACCOUNT_NAME):WP;certificateRevocationList;"
-# Gives Teleport the ability to create and delete certificationAuthority objects in the NTAuthCertificates container.
-dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /I:T /G "$($SAM_ACCOUNT_NAME):CCDC;certificationAuthority;"
-# Gives Teleport the ability to write the cACertificate property in the NTAuthCertificates container.
-dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /I:T /G "$($SAM_ACCOUNT_NAME):WP;cACertificate;"
+# Gives Teleport the ability to read certificationAuthority objects in the NTAuthCertificates container.
+dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /I:T /G "$($SAM_ACCOUNT_NAME):GR;certificationAuthority;"
+# Gives Teleport the ability to read the cACertificate property in the NTAuthCertificates container.
+dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,$DOMAIN_DN" /I:T /G "$($SAM_ACCOUNT_NAME):RP;cACertificate;"
 
 $SAM_ACCOUNT_SID=(Get-ADUser -Identity $SAM_ACCOUNT_NAME).SID.Value
 


### PR DESCRIPTION
In the original releases of desktop access (circa Teleport 8), Teleport itself authenticated to LDAP with a password. As a result, Teleport could publish its own certificate authority to the Windows NTAuth store, which made one less step for the user to do when setting up Teleport.

Some time later, we removed the password authentication, and Teleport started using a Teleport-issued certificate to connect to LDAP. A side effect of this change was that Teleport could no longer authenticate to LDAP and publish its own CA, because the cert-based authentication could not succeed until the CA was already trusted. At this time, it became necessary to write Teleport's CA to the NTAuth store at installation time.

Ever since then, Teleport has been periodically publishing its CA to NTAuth, even though it's guaranteed to be there already.

This commit removes the periodic write operation and updates the docs to use more restrictive permissions on the Teleport service account. The installation process remains exactly the same.