### PR TITLE
Add `insecure-drop` to host creation docs

### DIFF
--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -28,11 +28,19 @@ since it must execute these commands in order to create transient users:
 
 ## Step 1/3. Configure a role
 
-First, create a role with `create_host_user_mode` set to `drop` or `keep`.
+First, create a role with `create_host_user_mode` set to `drop`, `insecure-drop`, or `keep`.
 
-Setting the option to `drop` will create transient users that are deleted once the
-session ends. Setting it to `keep` will create permanent users on the host at
-login time.
+  - `drop` will create transient users that are deleted once the session ends.
+  - `insecure-drop` is the same as `drop` except it does not create a home directory for the user. 
+  - `keep` will create permanent users on the host at login time.
+
+Note that with the `drop` and `insecure-drop` modes, it is possible for a created
+user to get the same UID as a previously deleted user, which would give the new user
+access to all of the old user's files if they are not deleted.
+
+<Admonition type="note">
+  `drop` mode will be removed in Teleport 15.
+</Admonition>
 
 The following role specification will allow users to log in as `nginxrestarter` on
 any matching Node. The host user will be created and added to the groups listed in
@@ -79,7 +87,7 @@ of the Linux distribution being used. See [User/Group Name Syntax](https://syste
 
 When a Teleport user accesses an SSH Service instance, Teleport checks each of the
 user's roles that match the instance. If at least one role matches the instance
-but does not specify `create_host_user_mode` to be either `keep` or `drop`,
+but does not specify `create_host_user_mode` to be either `keep`, `drop`, or `insecure-drop`,
 automatic user creation will be disabled. Roles that do not match the server will
 not be checked.
 
@@ -197,8 +205,9 @@ returns an error if it cannot find the `useradd` binary. The `useradd` command
 creates a new home directory with the name of the new host user and adds the
 user to the groups specified in the Teleport user's roles.
 
-Aside from specifying a home directory and groups, the SSH Service executes
-`useradd` with the system defaults. For example, it associates the user with the
+The SSH Service executes
+`useradd --no-create-home --home-dir <home> <username> --groups <groups> --uid <uid> --gid <gid>`
+when adding a user, with all other options using system defaults. For example, it associates the user with the
 default login shell for the host, which you can specify by setting the `SHELL`
 field in `/etc/default/useradd`. See the `useradd` manual for your system for a
 full description of the default behavior.
@@ -208,7 +217,8 @@ contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
 The session can then proceed as usual, however once the SSH session ends, the user
-will be automatically removed and their home directory will be deleted, as the
+will be automatically removed and their home directory will be deleted with
+`userdel --remove <username>`, as the
 matching role specified they should be dropped. Files owned by the deleted user,
 created outside the home directory, will remain in place. Groups that were created
 will remain on the system after the session ends.

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -30,8 +30,10 @@ since it must execute these commands in order to create transient users:
 
 First, create a role with `create_host_user_mode` set to `drop`, `insecure-drop`, or `keep`.
 
-  - `drop` will create transient users that are deleted once the session ends.
-  - `insecure-drop` is the same as `drop` except it does not create a home directory for the user. 
+  - `insecure-drop` will create transient users that are deleted once the session ends.
+  - `drop` is the same as `insecure-drop` except it also creates a home directory for the user.
+    It exists only for backwards compatibility; newly configured services should use
+    `insecure-drop` instead.
   - `keep` will create permanent users on the host at login time.
 
 Note that with the `drop` and `insecure-drop` modes, it is possible for a created


### PR DESCRIPTION
This change adds documentation for the `insecure-drop` host user creation mode added in #35175.

Part of #34340.