### PR TITLE
Update Go/Rust interface section of README

### DIFF
--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -426,7 +426,6 @@ func TestSetRedirectPageContentSecurityPolicy(t *testing.T) {
 		expectedCspSubString := fmt.Sprintf("%s %s;", k, v)
 		require.Contains(t, actualCsp, expectedCspSubString)
 	}
-
 }
 
 func TestOriginLocalRedirectURI(t *testing.T) {

--- a/lib/srv/desktop/rdp/rdpclient/README.md
+++ b/lib/srv/desktop/rdp/rdpclient/README.md
@@ -28,10 +28,8 @@ Protocol (TDP) and RDP.
 ## Rust
 
 Rust code is under `src`. It uses several libraries (see `Cargo.toml`), but the
-main one is `rdp-rs`. `rdp-rs` is a pure Rust (partial) implementation of the
-RDP protocol. We forked that library at
-https://github.com/gravitational/rdp-rs/. Our fork implements several changes
-necessary to support smartcard emulation.
+main one is [`IronRDP`](https://github.com/Devolutions/IronRDP/). `IronRDP` is a
+pure Rust implementation of the RDP protocol.
 
 Notes on specific Rust modules:
 
@@ -41,9 +39,6 @@ Entrypoint of the library. This implements the CGO API surface and basic RDP
 connection establishment. During RDP connection, it negotiates the "rdpdr"
 static virtual channel, which is used for smartcard device "redirection" (read
 more below).
-
-Most of the protocol is implemented in the `rdp-rs` crate and the spec is
-https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPBCGR/%5bMS-RDPBCGR%5d.pdf
 
 ### rdpdr.rs
 
@@ -55,7 +50,7 @@ fake smartcard.
 The spec is at:
 https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPEFS/%5bMS-RDPEFS%5d.pdf
 
-### scard.rs
+### rdpdr/scard.rs
 
 The smartcard reader emulation layer. This is redirected over RDPDR. Smartcards
 typically connect to a computer via a reader, e.g. a USB card reader. The code
@@ -85,29 +80,31 @@ hops from one side to the other.
 
 ### Go/Rust Interface
 
-Each Go `rdpclient.Client` has a corresponding Rust `client::Client` (`client.rs`). The Go
-`rdpclient.Client` calls `client_run`, which calls `client::Client::run`, which creates the
-Rust `client::Client` in (Rust) memory where it fields incoming messages from the RDP server
-to convert to TDP and pass back into the Go `rdpclient.Client`, and waits for messages coming
-from Go (typically user input from the browser) which it sends on to the RDP server.
+Each Go `rdpclient.Client` (`client.go`) has a corresponding Rust `client::Client` (`client.rs`).
+When a desktop session is started, the Go client is created, and in turn creates and
+starts its corresponding Rust client.
 
-When the Rust [`client::Client` is created](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client.rs#L92),
-it is passed a `CgoHandle`, which is the pointer to it's corresponding Go `rdpclient.Client`.
-It also calls [`ClientHandle::new`](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client.rs#L112),
-which creates a `ClientHandle` (proxy to the `Sender` half of a channel) and `FunctionReceiver`
-(proxy to the `Receiver` half of a channel). It places this `ClientHandle` in a
-[global, static map](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client/global.rs#L43-L47) of `ClientHandle`s indexed by `CgoHandle`, and spawns
-[a loop that waits to receive messages on the `FunctionReceiver`](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client.rs#L300-L308).
+When the Rust client is created, it is passed a [`cgo.Handle`](https://pkg.go.dev/runtime/cgo#Handle)
+(`CgoHandle` in the Rust codebase) that points to the Go client that created it. A custom Rust type
+`ClientHandle`, which functions as a handle to the Rust `client::Client`, is then added to a global
+map indexed by `CgoHandle` (`global.rs`). In this way we maintain a mapping between corresponding objects
+in Rust and Go memory.
 
-Now, when the Go `rdpclient.Client` needs to call a function (such as communicate a mouse-click event) on it's corresponding Rust `client::Client`, it passes in it's own `CgoHandle`, which is used to find it's corresponding `ClientHandle` in the global
-cache, which is used to send the corresponding message (remember, `CgoHandle` is a proxy to a channel's `Sender` half) to the
-waiting `FunctionReceiver` (the channel's `Receiver` half), which then handles it accordingly. See [`client_write_rdp_pointer`](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/lib.rs#L377-L391)
-for an example.
+From that point on, whenever the Go client needs to call a function that the Rust client implements,
+it passes in it's own `cgo.Handle` (look for `pub unsafe extern "C" fn` in `lib.rs`), which tells Rust
+where to find the correct `ClientHandle`, and whenever the Rust client needs to call a function the Go
+client implements, it passes in the Go client's `CgoHandle` (look for functions with `//export funcname`
+comments), which Go uses to re-construct the `rdpclient.Client`.
+
+##### A note on "why not reconstruct the Rust client from a pointer as well?"
 
 While this may seem at first glance like a very indirect way of communicating between the Go and Rust halfs of the `Client`,
-it has the virtue of saving us a lot of Rust concurrency enforcement headaches as compared to passing a Rust pointer to the
-`client::Client` to and from Go. In this system, we only need a small piece of the global cache of channels to remain `Send + Sync` (see [the module level documentation for `global.rs`](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client/global.rs#L15-L32)),
-and can use the "automatic" synchronization inherent to message passing over channels to take care of many downstream
-concurrency concerns. In a previous iteration of the system where the Rust `client::Client` was reconstructed from a pointer
-shared between Go and Rust, we needed the entire `Client` to be `Send + Sync`, and therefore to concern ourselves with the
-manual use of various `Mutex`es and other more error prone concurrency primitives.
+it has the virtue of saving us a lot of Rust concurrency enforcement headaches as compared to passing a Rust pointer from Go.
+
+See a [previous iteration of this document](https://github.com/gravitational/teleport/pull/26874/commits/c2edddfcd84a41d4a5554c52fd0688e235128d7c)
+for a deeper exploration of all of the memory safety footguns we were dealing with in such a system.
+
+In this current system we have far less `unsafe` code, and we only need a small piece of the global cache of channels to remain
+`Send + Sync` (see [the module level documentation for `global.rs`](https://github.com/gravitational/teleport/blob/acb22584f5423f7b184cb1a8e30e2ada62bafb16/lib/srv/desktop/rdp/rdpclient/src/client/global.rs#L15-L32)).
+In this system we can use the "automatic" synchronization inherent to message passing over channels to take care of many downstream
+concurrency concerns.


### PR DESCRIPTION
Attempts to clarify the structure and reasoning for our new, channel-oriented Go/Rust system