### PR TITLE
Restructure Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "lib/srv/desktop/rdp/rdpclient",
@@ -12,3 +13,27 @@ lto = "off"
 [profile.release]
 debug = 1
 codegen-units = 1
+
+[workspace.dependencies]
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+
+# Uncomment the following lines to use local crates instead of the ones from github
+# ironrdp-connector = { path = "/path/to/local/IronRDP/crates/ironrdp-connector" }
+# ironrdp-tls = { path = "/path/to/local/IronRDP/crates/ironrdp-tls" }
+# ironrdp-session = { path = "/path/to/local/IronRDP/crates/ironrdp-session" }
+# ironrdp-pdu = { path = "/path/to/local/IronRDP/crates/ironrdp-pdu" }
+# ironrdp-tokio = { path = "/path/to/local/IronRDP/crates/ironrdp-tokio" }
+# ironrdp-rdpsnd = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpsnd" }
+# ironrdp-rdpdr = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpdr" }
+# ironrdp-svc = { path = "/path/to/local/IronRDP/crates/ironrdp-svc" }
+# ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
+# ironrdp-graphics = { path = "/path/to/local/IronRDP/crates/ironrdp-graphics" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,6 @@ edition = "2021"
 license = "AGPL-3.0-only"
 homepage = "https://github.com/gravitational/teleport"
 repository = "https://github.com/gravitational/teleport"
-authors = [
-    "Teleport <goteleport.com>",
-    "Andrew Lytvynov <andrew@awly.dev>",
-    "Zac Bergquist <zac@goteleport.com>",
-    "Isaiah Becker-Mayer <isaiah@goteleport.com>",
-    "Przemko Robakowski <przemko.robakowski@goteleport.com>"
-]
-keywords = ["teleport", "rdp", "desktop"]
 publish = false
 
 [profile.dev]
@@ -29,8 +21,8 @@ debug = 1
 codegen-units = 1
 
 [workspace.dependencies]
-byteorder = "1.5.0"
-bytes = "1.4.0"
+# Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
+# ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
 ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
@@ -41,15 +33,3 @@ ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f
 ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-# Uncomment the following lines to use local crates instead of the ones from github
-# ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-# ironrdp-connector = { path = "/path/to/local/IronRDP/crates/ironrdp-connector" }
-# ironrdp-graphics = { path = "/path/to/local/IronRDP/crates/ironrdp-graphics" }
-# ironrdp-pdu = { path = "/path/to/local/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-rdpdr = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpdr" }
-# ironrdp-rdpsnd = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpsnd" }
-# ironrdp-session = { path = "/path/to/local/IronRDP/crates/ironrdp-session" }
-# ironrdp-svc = { path = "/path/to/local/IronRDP/crates/ironrdp-svc" }
-# ironrdp-tls = { path = "/path/to/local/IronRDP/crates/ironrdp-tls" }
-# ironrdp-tokio = { path = "/path/to/local/IronRDP/crates/ironrdp-tokio" }
-log = "0.4.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,24 @@
 [workspace]
 resolver = "2"
-
 members = [
     "lib/srv/desktop/rdp/rdpclient",
     "web/packages/teleport/src/ironrdp"
 ]
+
+[workspace.package]
+edition = "2021"
+license = "AGPL-3.0-only"
+homepage = "https://github.com/gravitational/teleport"
+repository = "https://github.com/gravitational/teleport"
+authors = [
+    "Teleport <goteleport.com>",
+    "Andrew Lytvynov <andrew@awly.dev>",
+    "Zac Bergquist <zac@goteleport.com>",
+    "Isaiah Becker-Mayer <isaiah@goteleport.com>",
+    "Przemko Robakowski <przemko.robakowski@goteleport.com>"
+]
+keywords = ["teleport", "rdp", "desktop"]
+publish = false
 
 [profile.dev]
 debug = 1
@@ -15,25 +29,27 @@ debug = 1
 codegen-units = 1
 
 [workspace.dependencies]
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+byteorder = "1.5.0"
+bytes = "1.4.0"
 ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
 # Uncomment the following lines to use local crates instead of the ones from github
-# ironrdp-connector = { path = "/path/to/local/IronRDP/crates/ironrdp-connector" }
-# ironrdp-tls = { path = "/path/to/local/IronRDP/crates/ironrdp-tls" }
-# ironrdp-session = { path = "/path/to/local/IronRDP/crates/ironrdp-session" }
-# ironrdp-pdu = { path = "/path/to/local/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-tokio = { path = "/path/to/local/IronRDP/crates/ironrdp-tokio" }
-# ironrdp-rdpsnd = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpsnd" }
-# ironrdp-rdpdr = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpdr" }
-# ironrdp-svc = { path = "/path/to/local/IronRDP/crates/ironrdp-svc" }
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
+# ironrdp-connector = { path = "/path/to/local/IronRDP/crates/ironrdp-connector" }
 # ironrdp-graphics = { path = "/path/to/local/IronRDP/crates/ironrdp-graphics" }
+# ironrdp-pdu = { path = "/path/to/local/IronRDP/crates/ironrdp-pdu" }
+# ironrdp-rdpdr = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpdr" }
+# ironrdp-rdpsnd = { path = "/path/to/local/IronRDP/crates/ironrdp-rdpsnd" }
+# ironrdp-session = { path = "/path/to/local/IronRDP/crates/ironrdp-session" }
+# ironrdp-svc = { path = "/path/to/local/IronRDP/crates/ironrdp-svc" }
+# ironrdp-tls = { path = "/path/to/local/IronRDP/crates/ironrdp-tls" }
+# ironrdp-tokio = { path = "/path/to/local/IronRDP/crates/ironrdp-tokio" }
+log = "0.4.20"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -3,7 +3,6 @@ name = "rdp-client"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-authors.workspace = true
 publish.workspace = true
 
 [lib]
@@ -12,8 +11,8 @@ crate-type = ["staticlib"]
 [dependencies]
 bitflags = "2.4.1"
 boring = { version = "3.1.0", optional = true }
-byteorder.workspace = true
-bytes.workspace = true
+byteorder = "1.5.0"
+bytes = "1.4.0"
 env_logger = "0.10.1"
 ironrdp-cliprdr.workspace = true
 ironrdp-connector.workspace = true
@@ -27,7 +26,7 @@ ironrdp-tokio.workspace = true
 iso7816 = "0.1.2"
 iso7816-tlv = "0.4.3"
 libc = "0.2.150"
-log.workspace = true
+log = "0.4.20"
 num-derive = "0.4.1"
 num-traits = "0.2.17"
 parking_lot = "0.12.1"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -1,45 +1,47 @@
 [package]
 name = "rdp-client"
 version = "0.1.0"
-authors = ["Andrew Lytvynov <andrew@goteleport.com>", "Zac Bergquist <zac@goteleport.com>"]
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 
 [lib]
 crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.1"
-byteorder = "1.5.0"
+boring = { version = "3.1.0", optional = true }
+byteorder.workspace = true
+bytes.workspace = true
 env_logger = "0.10.1"
+ironrdp-cliprdr.workspace = true
+ironrdp-connector.workspace = true
+ironrdp-pdu.workspace = true
+ironrdp-rdpdr.workspace = true
+ironrdp-rdpsnd.workspace = true
+ironrdp-session.workspace = true
+ironrdp-svc.workspace = true
+ironrdp-tls.workspace = true
+ironrdp-tokio.workspace = true
 iso7816 = "0.1.2"
 iso7816-tlv = "0.4.3"
 libc = "0.2.150"
-log = "0.4.20"
+log.workspace = true
 num-derive = "0.4.1"
 num-traits = "0.2.17"
+parking_lot = "0.12.1"
+png = "0.17.10"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_chacha = "0.3.1"
 rsa = "0.9.6"
-uuid = { version = "1.6.1", features = ["v4"] }
-utf16string = "0.2.0"
-png = "0.17.10"
-parking_lot = "0.12.1"
-bytes = "1"
-tokio = { version = "1.32", features = ["full"] }
-x509-parser = "0.14"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
-ironrdp-connector.workspace = true
-ironrdp-tls.workspace = true
-ironrdp-session.workspace = true
-ironrdp-pdu.workspace = true
-ironrdp-tokio.workspace = true
-ironrdp-rdpsnd.workspace = true
-ironrdp-rdpdr.workspace = true
-ironrdp-svc.workspace = true
-ironrdp-cliprdr.workspace = true
+tokio = { version = "1.32", features = ["full"] }
 tokio-boring = { version = "3.1.0", optional = true }
-boring = { version = "3.1.0", optional = true }
+utf16string = "0.2.0"
+uuid = { version = "1.6.1", features = ["v4"] }
+x509-parser = "0.14"
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -24,41 +24,20 @@ uuid = { version = "1.6.1", features = ["v4"] }
 utf16string = "0.2.0"
 png = "0.17.10"
 parking_lot = "0.12.1"
-
 bytes = "1"
 tokio = { version = "1.32", features = ["full"] }
 x509-parser = "0.14"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
-
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-
-# Uncomment the following lines to use local crates instead of the ones from github
-# ironrdp-connector = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-connector" }
-# ironrdp-tls = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tls" }
-# ironrdp-session = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-session" }
-# ironrdp-pdu = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-tokio = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-tokio" }
-# ironrdp-rdpsnd = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpsnd" }
-# ironrdp-rdpdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-rdpdr" }
-# ironrdp-svc = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-svc" }
-# ironrdp-cliprdr = { path = "/Users/ibeckermayer/Devolutions/IronRDP/crates/ironrdp-cliprdr" }
-
-# Uncomment the following lines to use local crates instead of the ones from github
-# ironrdp-connector = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-connector" }
-# ironrdp-tls = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-tls" }
-# ironrdp-session = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-session" }
-# ironrdp-pdu = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-tokio = { path = "/Users/hesperus/work/IronRDP/crates/ironrdp-tokio" }
-
+ironrdp-connector.workspace = true
+ironrdp-tls.workspace = true
+ironrdp-session.workspace = true
+ironrdp-pdu.workspace = true
+ironrdp-tokio.workspace = true
+ironrdp-rdpsnd.workspace = true
+ironrdp-rdpdr.workspace = true
+ironrdp-svc.workspace = true
+ironrdp-cliprdr.workspace = true
 tokio-boring = { version = "3.1.0", optional = true }
 boring = { version = "3.1.0", optional = true }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rdp-client"
 version = "0.1.0"
 authors = ["Andrew Lytvynov <andrew@goteleport.com>", "Zac Bergquist <zac@goteleport.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["staticlib"]

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -40,6 +40,7 @@ use ironrdp_session::SessionErrorKind::Reason;
 use ironrdp_session::{reason_err, SessionError, SessionResult};
 use ironrdp_svc::{StaticVirtualChannelProcessor, SvcMessage, SvcProcessorMessages};
 use ironrdp_tokio::{Framed, TokioStream};
+use log::debug;
 use rand::{Rng, SeedableRng};
 use std::fmt::{Debug, Display, Formatter};
 use std::io::Error as IoError;

--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt::{Debug, Formatter};
-
+use crate::client::ClientHandle;
+use crate::util;
 use ironrdp_cliprdr::backend::CliprdrBackend;
 use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
@@ -24,10 +24,9 @@ use ironrdp_cliprdr::pdu::{
 use ironrdp_cliprdr::{Cliprdr, CliprdrSvcMessages};
 use ironrdp_pdu::PduResult;
 use ironrdp_svc::impl_as_any;
+use log::{debug, error, info, trace, warn};
 use static_init::dynamic;
-
-use crate::client::ClientHandle;
-use crate::util;
+use std::fmt::{Debug, Formatter};
 
 #[dynamic]
 static CF_UNICODETEXT: ClipboardFormat = ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT);

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -24,13 +24,11 @@
 //! - Structs for passing between the two (those prefixed with the `#[repr(C)]` macro
 //!   and whose name begins with `CGO`)
 
-#[macro_use]
-extern crate log;
-
 use crate::client::global::get_client_handle;
 use crate::client::Client;
 use crate::rdpdr::tdp::SharedDirectoryAnnounce;
 use client::{ClientHandle, ClientResult, ConnectParams};
+use log::{error, trace, warn};
 use rdpdr::path::UnixPath;
 use rdpdr::tdp::{
     FileSystemObject, FileType, SharedDirectoryAcknowledge, SharedDirectoryCreateResponse,

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -21,6 +21,7 @@ use iso7816::command::instruction::Instruction;
 use iso7816::command::Command;
 use iso7816::response::Status;
 use iso7816_tlv::ber::{Tag, Tlv, Value};
+use log::{debug, warn};
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
 use rsa::{BigUint, RsaPrivateKey};

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -27,6 +27,7 @@ use ironrdp_rdpdr::pdu::{
     efs::{self, NtStatus},
     esc,
 };
+use log::debug;
 use std::collections::HashMap;
 use std::convert::TryInto;
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -28,6 +28,7 @@ use ironrdp_rdpdr::pdu::esc::{
     WriteCacheCall,
 };
 use iso7816::Command as CardCommand;
+use log::{debug, warn};
 use std::collections::HashMap;
 use uuid::Uuid;
 

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "ironrdp"
 version = "0.1.0"
-publish = false
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,20 +12,20 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-bytes = "1.4.0"
-byteorder = "1.5.0"
-getrandom = { version = "0.2", features = ["js"] }
-js-sys = "0.3.61"
-log = "0.4.17"
-console_log = "0.2.2"
-wasm-bindgen = "0.2.84"
-wasm-logger = "0.2.0"
-web-sys = { version = "0.3.61", features = ["ImageData"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["time"] }
-tracing-web = "0.1.2"
-time = { version = "0.3", features = ["wasm-bindgen"] }
+bytes.workspace = true
+byteorder.workspace = true
 console_error_panic_hook = "0.1.7"
+console_log = "0.2.2"
+getrandom = { version = "0.2", features = ["js"] }
 ironrdp-session.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-graphics.workspace = true
+js-sys = "0.3.61"
+log.workspace = true
+time = { version = "0.3", features = ["wasm-bindgen"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["time"] }
+tracing-web = "0.1.2"
+wasm-bindgen = "0.2.84"
+wasm-logger = "0.2.0"
+web-sys = { version = "0.3.61", features = ["ImageData"] }

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ironrdp"
 version = "0.1.0"
 publish = false
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -3,7 +3,6 @@ name = "ironrdp"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-authors.workspace = true
 publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,8 +11,8 @@ publish.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-bytes.workspace = true
-byteorder.workspace = true
+byteorder = "1.5.0"
+bytes = "1.4.0"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.2"
 getrandom = { version = "0.2", features = ["js"] }
@@ -21,7 +20,7 @@ ironrdp-session.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-graphics.workspace = true
 js-sys = "0.3.61"
-log.workspace = true
+log = "0.4.20"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["time"] }

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -24,12 +24,6 @@ tracing-subscriber = { version = "0.3.16", features = ["time"] }
 tracing-web = "0.1.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 console_error_panic_hook = "0.1.7"
-
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-
-# Uncomment the following lines and comment out the ones above to use local crates instead of the ones from github
-# ironrdp-session = { path = "/path/to/your/local/IronRDP/crates/ironrdp-session" }
-# ironrdp-pdu = { path = "/path/to/your/local/IronRDP/crates/ironrdp-pdu" }
-# ironrdp-graphics = { path = "/path/to/your/local/IronRDP/crates/ironrdp-graphics" }
+ironrdp-session.workspace = true
+ironrdp-pdu.workspace = true
+ironrdp-graphics.workspace = true

--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -17,31 +17,18 @@
 // default trait not supported in wasm
 #![allow(clippy::new_without_default)]
 
-#[macro_use]
-extern crate log;
-extern crate byteorder;
-extern crate bytes;
-extern crate console_log;
-extern crate ironrdp_graphics;
-extern crate ironrdp_pdu;
-extern crate ironrdp_session;
-extern crate js_sys;
-extern crate tracing;
-extern crate tracing_subscriber;
-extern crate tracing_web;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_pdu::geometry::{InclusiveRectangle, Rectangle};
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_session::fast_path::UpdateKind;
 use ironrdp_session::image::DecodedImage;
+use ironrdp_session::ActiveStageOutput;
 use ironrdp_session::{
     fast_path::Processor as IronRdpFastPathProcessor,
-    fast_path::ProcessorBuilder as IronRdpFastPathProcessorBuilder, ActiveStageOutput,
+    fast_path::ProcessorBuilder as IronRdpFastPathProcessorBuilder,
 };
 use js_sys::Uint8Array;
+use log::{debug, warn};
 use std::convert::TryFrom;
 use wasm_bindgen::{prelude::*, Clamped};
 use web_sys::ImageData;
@@ -109,7 +96,7 @@ impl From<RDPFastPathPDU> for RustRDPFastPathPDU {
 }
 
 #[wasm_bindgen]
-struct BitmapFrame {
+pub struct BitmapFrame {
     top: u16,
     left: u16,
     image_data: ImageData,


### PR DESCRIPTION
- Consolidates packages used in common between the wasm and backend Rust into the workspace level Cargo.toml.
- Adds some common `workspace.package` values.
- Alphabetizes dependencies.
- Removes rust 2015/2018 style constructs (the whole workspace is 2021 now).
- Fixes linter warnings in `web/packages/teleport/src/ironrdp/src/lib.rs`.

(These are all organizational/stylistic changes.)