### PR TITLE
Support concurrent requests in `retryWithRelogin`

### DIFF
--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -52,11 +52,13 @@ export class ModalsService extends ImmutableStore<State> {
    *
    * Calling openRegularDialog while another regular dialog is displayed will simply overwrite the
    * old dialog with the new one.
+   * The old dialog is canceled, if possible.
    *
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
   openRegularDialog(dialog: Dialog): { closeDialog: () => void } {
+    this.state.regular['onCancel']?.();
     this.setState(draftState => {
       draftState.regular = dialog;
     });
@@ -80,11 +82,13 @@ export class ModalsService extends ImmutableStore<State> {
    *
    * Calling openImportantDialog while another important dialog is displayed will simply overwrite
    * the old dialog with the new one.
+   * The old dialog is canceled, if possible.
    *
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
   openImportantDialog(dialog: Dialog): { closeDialog: () => void } {
+    this.state.important['onCancel']?.();
     this.setState(draftState => {
       draftState.important = dialog;
     });

--- a/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
+++ b/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
@@ -22,6 +22,8 @@ import Logger from 'teleterm/logger';
 
 const logger = new Logger('retryWithRelogin');
 
+let pendingLogin: Promise<void> | undefined;
+
 /**
  * `retryWithRelogin` executes `actionToRetry`. If `actionToRetry` throws an error, it checks if the
  * error can be resolved by the user logging in, according to metadata returned from the tshd
@@ -30,6 +32,10 @@ const logger = new Logger('retryWithRelogin');
  * If that's the case, it checks if the user is still looking at the relevant UI (the `isUiActive`
  * argument) and if so, it shows a login modal. After the user successfully logs in, it calls
  * `actionToRetry` again.
+ *
+ * `retryWithRelogin` supports concurrent requests.
+ * If multiple actions need to show a login modal at the same time,
+ * it will be displayed only once, and other actions will wait for it to be resolved.
  *
  * Each place using `retryWithRelogin` must be able to show the error to the user in case the
  * relogin attempt fails. Each place should also offer the user a way to manually retry the action
@@ -75,7 +81,13 @@ export async function retryWithRelogin<T>(
 
   const rootClusterUri = routing.ensureRootClusterUri(resourceUri);
 
-  await login(appContext, rootClusterUri);
+  if (!pendingLogin) {
+    pendingLogin = login(appContext, rootClusterUri).finally(() => {
+      pendingLogin = undefined;
+    });
+  }
+
+  await pendingLogin;
 
   return await actionToRetry();
 }

--- a/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
+++ b/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
@@ -22,7 +22,7 @@ import Logger from 'teleterm/logger';
 
 const logger = new Logger('retryWithRelogin');
 
-let pendingLogin: Promise<void> | undefined;
+let pendingLoginDialog: Promise<void> | undefined;
 
 /**
  * `retryWithRelogin` executes `actionToRetry`. If `actionToRetry` throws an error, it checks if the
@@ -81,13 +81,13 @@ export async function retryWithRelogin<T>(
 
   const rootClusterUri = routing.ensureRootClusterUri(resourceUri);
 
-  if (!pendingLogin) {
-    pendingLogin = login(appContext, rootClusterUri).finally(() => {
-      pendingLogin = undefined;
+  if (!pendingLoginDialog) {
+    pendingLoginDialog = login(appContext, rootClusterUri).finally(() => {
+      pendingLoginDialog = undefined;
     });
   }
 
-  await pendingLogin;
+  await pendingLoginDialog;
 
   return await actionToRetry();
 }


### PR DESCRIPTION
This PR adds handling concurrent requests in `retryWithRelogin`.

Currently, when two requests want to show a login modal, this happens: the first request shows the modal and makes the request wait for it to resolve. Then another request hides the previous login modal and shows a new one. The previous request will never resolve.

The PR fixes that by storing the login promise, so the concurrent requests can wait for it to finish. 

This fix will be needed for https://github.com/gravitational/teleport/pull/35251 where we send two requests at the same time: for resources and for preferences. 