### PR TITLE
[v12] docs: fix link to GitHub connector

### DIFF
--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -364,16 +364,7 @@ spec:
 <TabItem label="GitHub">
 
 ```yaml
-kind: cluster_auth_preference
-metadata:
-  name: cluster-auth-preference
-spec:
-  type: github
-  webauthn:
-    # Replace with the address of your Teleport cluster
-    rp_id: 'example.teleport.sh'
-version: v2
-
+(!/examples/resources/github.yaml!)
 ```
 
 </TabItem>


### PR DESCRIPTION
Backport #35603 to branch/v12