### PR TITLE
static labels in kubernetesDiscovery

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -6399,6 +6399,8 @@ message KubernetesMatcher {
     (gogoproto.jsontag) = "labels,omitempty",
     (gogoproto.customtype) = "Labels"
   ];
+  // Labels added to discovered resources
+  map<string, string> StaticLabels = 4 [(gogoproto.jsontag) = "static_labels,omitempty"];
 }
 
 // OktaOptions specify options related to the Okta service.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1547,9 +1547,10 @@ kubernetes matchers are present`)
 	}
 	for _, matcher := range fc.Discovery.KubernetesMatchers {
 		serviceMatcher := types.KubernetesMatcher{
-			Types:      matcher.Types,
-			Namespaces: matcher.Namespaces,
-			Labels:     matcher.Labels,
+			Types:        matcher.Types,
+			Namespaces:   matcher.Namespaces,
+			Labels:       matcher.Labels,
+			StaticLabels: matcher.StaticLabels,
 		}
 		if err := serviceMatcher.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1671,6 +1671,8 @@ type KubernetesMatcher struct {
 	Namespaces []string `yaml:"namespaces,omitempty"`
 	// Labels are Kubernetes services labels to match.
 	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
+	// Labels added to discovered resources
+	StaticLabels map[string]string `yaml:"static_labels,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -179,7 +179,7 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 // NewApplicationFromKubeService creates application resources from kubernetes service.
 // It transforms service fields and annotations into appropriate Teleport app fields.
 // Service labels are copied to app labels.
-func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol string, port corev1.ServicePort) (types.Application, error) {
+func NewApplicationFromKubeService(service corev1.Service, staticLabels map[string]string, clusterName, protocol string, port corev1.ServicePort) (types.Application, error) {
 	appURI := buildAppURI(protocol, getServiceFQDN(service), port.Port)
 
 	rewriteConfig, err := getAppRewriteConfig(service.GetAnnotations())
@@ -193,7 +193,7 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 		return nil, trace.Wrap(err, "could not create app name for the service")
 	}
 
-	labels, err := getAppLabels(service.GetLabels(), clusterName)
+	labels, err := getAppLabels(service.GetLabels(), staticLabels, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not get labels for the service")
 	}
@@ -269,10 +269,17 @@ func getAppName(serviceName, namespace, clusterName, portName, nameAnnotation st
 	return fmt.Sprintf("%s-%s-%s", serviceName, namespace, clusterName), nil
 }
 
-func getAppLabels(serviceLabels map[string]string, clusterName string) (map[string]string, error) {
-	result := make(map[string]string, len(serviceLabels)+1)
+func getAppLabels(serviceLabels map[string]string, staticLabels map[string]string, clusterName string) (map[string]string, error) {
+	result := make(map[string]string, len(serviceLabels)+len(staticLabels)+1)
 
 	for k, v := range serviceLabels {
+		if !types.IsValidLabelKey(k) {
+			return nil, trace.BadParameter("invalid label key: %q", k)
+		}
+
+		result[k] = v
+	}
+	for k, v := range staticLabels {
 		if !types.IsValidLabelKey(k) {
 			return nil, trace.BadParameter("invalid label key: %q", k)
 		}

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -267,9 +267,10 @@ headers:
 
 func TestGetAppLabels(t *testing.T) {
 	tests := []struct {
-		labels      map[string]string
-		clusterName string
-		expected    map[string]string
+		labels        map[string]string
+		static_labels map[string]string
+		clusterName   string
+		expected      map[string]string
 	}{
 		{
 			labels:      map[string]string{"label1": "value1"},
@@ -277,14 +278,15 @@ func TestGetAppLabels(t *testing.T) {
 			expected:    map[string]string{"label1": "value1", types.KubernetesClusterLabel: "cluster1"},
 		},
 		{
-			labels:      map[string]string{"label1": "value1", "label2": "value2"},
-			clusterName: "cluster2",
-			expected:    map[string]string{"label1": "value1", "label2": "value2", types.KubernetesClusterLabel: "cluster2"},
+			labels:        map[string]string{"label1": "value1", "label2": "value2"},
+			static_labels: map[string]string{"env": "dev"},
+			clusterName:   "cluster2",
+			expected:      map[string]string{"label1": "value1", "label2": "value2", "env": "dev", types.KubernetesClusterLabel: "cluster2"},
 		},
 	}
 
 	for _, tt := range tests {
-		result, err := getAppLabels(tt.labels, tt.clusterName)
+		result, err := getAppLabels(tt.labels, tt.static_labels, tt.clusterName)
 		require.NoError(t, err)
 
 		require.Equal(t, tt.expected, result)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -442,6 +442,7 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 		fetcher, err := fetchers.NewKubeAppsFetcher(fetchers.KubeAppsFetcherConfig{
 			KubernetesClient: kubeClient,
 			FilterLabels:     matcher.Labels,
+			StaticLabels:     matcher.StaticLabels,
 			Namespaces:       matcher.Namespaces,
 			Log:              s.Log,
 			ClusterName:      s.DiscoveryGroup,

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -49,7 +49,8 @@ type KubeAppsFetcherConfig struct {
 	// FilterLabels are the filter criteria.
 	FilterLabels types.Labels
 	// Namespaces are the kubernetes namespaces in which to discover services
-	Namespaces []string
+	Namespaces   []string
+	StaticLabels map[string]string
 	// Log is a logger to use
 	Log logrus.FieldLogger
 	// ProtocolChecker inspects port to find your whether they are HTTP/HTTPS or not.
@@ -198,11 +199,12 @@ func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 				if len(portProtocols) == 1 {
 					port.Name = ""
 				}
-				newApp, err := services.NewApplicationFromKubeService(service, f.ClusterName, portProtocol, port)
+				newApp, err := services.NewApplicationFromKubeService(service, f.StaticLabels, f.ClusterName, portProtocol, port)
 				if err != nil {
 					f.Log.WithError(err).Warnf("Could not get app from a Kubernetes service %q, port %d", service.GetName(), port.Port)
 					return nil
 				}
+				newApp.GetStaticLabels()
 				newApps = append(newApps, newApp)
 			}
 			appsMu.Lock()


### PR DESCRIPTION
I'm proposing simple feature which allows defining static labels for resources auto discovered in kubernetes. Currently, resource labels are copied from the labels of detected k8s services - the format of these labels does not always suit us and we do not always have any influence on them.Proposed feature allows adding to each auto-discovered resource set of "fixed" labels e.g.:
```
kubernetesDiscovery:
  - types: ["app"]
    namespaces: ["dev-namespace"]
    static_labels:
      env: "dev"
    labels:
      "app.kubernetes.io/instance":
       - my-app*
```
The above configuration will add an "env" label to each detected resource.