### PR TITLE
[v14] Adapt types.Resource to Resource153

### DIFF
--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -26,6 +26,42 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func TestLegacyToResource153(t *testing.T) {
+	// user is an example of a legacy resource.
+	// Any other resource type would to.
+	user := &types.UserV2{
+		Kind: "user",
+		Metadata: types.Metadata{
+			Name: "llama",
+		},
+		Spec: types.UserSpecV2{
+			Roles: []string{"human", "camelidae"},
+		},
+	}
+
+	resource := types.LegacyToResource153(user)
+
+	// Unwrap gives the underlying resource back.
+	t.Run("unwrap", func(t *testing.T) {
+		unwrapped := resource.(interface{ Unwrap() types.Resource }).Unwrap()
+		if diff := cmp.Diff(user, unwrapped, protocmp.Transform()); diff != "" {
+			t.Errorf("Unwrap mismatch (-want +got)\n%s", diff)
+		}
+	})
+
+	// Marshaling as JSON marshals the underlying resource.
+	t.Run("marshal", func(t *testing.T) {
+		jsonBytes, err := json.Marshal(resource)
+		require.NoError(t, err, "Marshal")
+
+		user2 := &types.UserV2{}
+		require.NoError(t, json.Unmarshal(jsonBytes, user2), "Unmarshal")
+		if diff := cmp.Diff(user, user2, protocmp.Transform()); diff != "" {
+			t.Errorf("Marshal/Unmarshal mismatch (-want +got)\n%s", diff)
+		}
+	})
+}
+
 func TestResource153ToLegacy(t *testing.T) {
 	// fake153Resource is used here because, at the time of backport, there were
 	// no RFD 153 resources in this branch.


### PR DESCRIPTION
Backport #35568 to branch/v14

Allow the more desired conversion from legacy to new resource.

Related to #35559.