### PR TITLE
Add closeMenuOnSelect prop to Select component

### DIFF
--- a/web/packages/shared/components/Select/Select.tsx
+++ b/web/packages/shared/components/Select/Select.tsx
@@ -30,6 +30,7 @@ export default function Select(props: Props) {
     hasError = false,
     elevated = false,
     stylesConfig,
+    closeMenuOnSelect = false,
     ...restOfProps
   } = props;
   return (
@@ -41,6 +42,7 @@ export default function Select(props: Props) {
         clearable={false}
         isMulti={false}
         isSearchable={true}
+        closeMenuOnSelect={closeMenuOnSelect}
         placeholder="Select..."
         styles={stylesConfig}
         {...restOfProps}

--- a/web/packages/shared/components/Select/Select.tsx
+++ b/web/packages/shared/components/Select/Select.tsx
@@ -30,7 +30,7 @@ export default function Select(props: Props) {
     hasError = false,
     elevated = false,
     stylesConfig,
-    closeMenuOnSelect = false,
+    closeMenuOnSelect = true,
     ...restOfProps
   } = props;
   return (

--- a/web/packages/shared/components/Select/types.ts
+++ b/web/packages/shared/components/Select/types.ts
@@ -24,6 +24,7 @@ export type Props = {
   inputId?: string;
   hasError?: boolean;
   isClearable?: boolean;
+  closeMenuOnSelect?: boolean;
   isSimpleValue?: boolean;
   isSearchable?: boolean;
   isDisabled?: boolean;
@@ -38,7 +39,7 @@ export type Props = {
   autoFocus?: boolean;
   label?: string;
   placeholder?: string;
-  options: Option<any, any>[];
+  options: Option<any, any>[] | GroupOption[];
   width?: string | number;
   menuPlacement?: string;
   name?: string;
@@ -75,6 +76,11 @@ export type Option<T = string, S = string> = {
   value: T;
   // label is the value user sees in the select options dropdown.
   label: S;
+};
+
+export type GroupOption = {
+  label: string;
+  options: Option[];
 };
 
 export type ActionMeta = {


### PR DESCRIPTION
This adds an optional parameter to allow a select menu dropdown to stay open when selecting options. This improves the UX when working with multi-selects by not making the user reopen the dropdown everytime to add/remove options.

This also allows the [`GroupOption`](https://react-select.com/props#group) type to be passed to our `react-select` wrapper. 

Contributes to https://github.com/gravitational/teleport/issues/35174