### PR TITLE
Build elfutils and zlib with `fPIC`

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -154,7 +154,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
-        elfutils-libelf-devel-static \
         scl-utils && \
     yum clean all
 
@@ -163,6 +162,11 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
         ${DEVTOOLSET}-make && \
     yum clean all
+
+# Install custom package with -fPIC.
+COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
+RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm && \
+    rm -rf /opt/custom-packages
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
 # BUILD_STATIC_ONLY - builds only static libraries without shared ones
@@ -198,7 +202,7 @@ RUN yum groupinstall -y 'Development Tools' && \
         autoconf-archive \
         libudev-devel \
         scl-utils \
-        centos-release-scl \
+        centos-release-scl && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
@@ -250,8 +254,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum install -y \
     # required by libbpf
     centos-release-scl \
-    # required by libbpf
-    elfutils-libelf-devel-static \
     net-tools \
     # required by Teleport PAM support
     pam-devel \
@@ -259,9 +261,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     tree \
     # used by our Makefile
     which \
-    zip \
-    # required by libbpf
-    zlib-static && \
+    zip && \
     yum clean all && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8
 
@@ -271,6 +271,12 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
+
+# Install custom packages with -fPIC.
+COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
+RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm \
+        /opt/custom-packages/zlib-static.*.rpm && \
+    rm -rf /opt/custom-packages
 
 # Override the old git in /usr/local installed by yum. We need git 2+ on GitHub Actions.
 COPY --from=git2 /opt/git /

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -22,21 +22,10 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-        # required by libbpf, Clang
         centos-release-scl \
-        # required by Clang/LLVM
         cmake3 \
-        # required by libbpf
-        elfutils-libelf-devel \
-        # required by libbpf
-        elfutils-libelf-devel-static \
         git \
-        # required by libbpf, Clang
-        scl-utils \
-        # required by libbpf
-        zlib-devel \
-        # required by libbpf
-        zlib-static && \
+        scl-utils && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
@@ -74,9 +63,34 @@ make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-forma
     cd ../.. && \
     rm -rf llvm-project
 
-# Create the final image with Clang only. We're using this Docker image as a tar.gz mainly
-# because we want to keep our artifacts on GitHub, and GH doesn't support blobs, only Docker images.
+# Build custom packages with -fPIC for use with other dependencies.
+FROM centos-devtoolset as custom-packages
+
+# Create mockbuild user/group for building.
+RUN useradd --user-group --create-home --shell=/bin/bash mockbuild
+
+# Recompile and install libelf with -fPIC.
+RUN mkdir -p /opt/custom-builds && cd /opt && \
+    yumdownloader --source elfutils-libelf-devel-static && \
+    yum-builddep -y elfutils-libelf-devel-static && \
+    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" elfutils-*.src.rpm && \
+    if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
+    cp /root/rpmbuild/RPMS/${TARGETARCH}/elfutils-libelf-devel-static-*.el7.${TARGETARCH}.rpm /opt/custom-builds/
+
+# Recompile and install zlib with -fPIC.
+RUN mkdir -p /opt/custom-builds && cd /opt && \
+    yumdownloader --source zlib-static && \
+    yum-builddep -y zlib-static && \
+    rpmbuild --rebuild --define "optflags `rpm -E %{optflags}` -fPIC" zlib-*.src.rpm && \
+    if [ "${TARGETARCH}" = "arm64" ]; then export TARGETARCH="aarch64"; fi && \
+    cp /root/rpmbuild/RPMS/${TARGETARCH}/zlib-static-*.el7.${TARGETARCH}.rpm /opt/custom-builds/
+
+# Create the final image with Clang and custom builds only. We're using this Docker image as a tar.gz
+# mainly because we want to keep our artifacts on GitHub, and GH doesn't support blobs, only Docker images.
 FROM scratch AS buildbox-centos7-assets
 
 # Copy Clang into the final image.
 COPY --from=clang12 /opt/llvm /opt/llvm/
+
+# Copy custom packages into the final image.
+COPY --from=custom-packages /opt/custom-builds /opt/custom-builds/

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -23,7 +23,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
-        elfutils-libelf-devel-static \
         scl-utils && \
     yum clean all
 
@@ -33,6 +32,11 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
+
+# Install custom package with -fPIC.
+COPY --from=teleport-buildbox-centos7-assets /opt/custom-packages /opt/custom-packages
+RUN rpm -ivh /opt/custom-packages/elfutils-libelf-devel-static.*.rpm && \
+    rm -rf /opt/custom-packages
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
 # BUILD_STATIC_ONLY - builds only static libraries without shared ones
@@ -79,8 +83,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     centos-release-scl \
     # required by Clang/LLVM
     cmake3 \
-    # required by libbpf
-    elfutils-libelf-devel-static \
     git \
     net-tools \
     # required by boringssl
@@ -91,9 +93,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     tree \
     # used by our Makefile
     which \
-    zip \
-    # required by libbpf
-    zlib-static && \
+    zip && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.


### PR DESCRIPTION
Stop using the upstream `-static` packages for elfutils and zlib and compile our own custom versions that include `-fPIC`.

Ref #17101.