### PR TITLE
Describe required permissions for registering apps

### DIFF
--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -3,9 +3,36 @@ title: Dynamic App Registration
 description: Register/unregister apps without restarting Teleport.
 ---
 
-Dynamic app registration allows Teleport administrators to register new apps
-(or update/unregister existing ones) without having to update the static
-configuration and restarting Teleport Application Service instances.
+Dynamic app registration allows Teleport administrators to register new apps (or
+update/unregister existing ones) without having to update the static
+configuration files read by Teleport Application Service instances. 
+
+Application Service instances periodically query the Teleport Auth Service for
+`app` resources, each of which includes the information that the Application
+Service needs to proxy an application. 
+
+Dynamic registration is useful for [managing pools of Application Service
+instances](../../agents/deploy-agents-terraform.mdx). And behind the scenes, the
+Teleport Discovery Service uses dynamic registration to [register Kubernetes
+applications](../enroll-kubernetes-applications.mdx).
+
+## Required permissions
+
+In order to interact with dynamically registered applications, a user must have
+a Teleport role with permissions to manage `app` resources. 
+
+In the following example, a role allows a user to perform all possible
+operations against `app` resources:
+
+```yaml
+allow:
+  rules:
+    - resources:
+        - app
+      verbs: [list, create, read, update, delete]
+```
+
+## Enabling dynamic registration
 
 To enable dynamic registration, include a `resources` section in your Application
 Service configuration with a list of resource label selectors you'd like this
@@ -30,7 +57,12 @@ resources:
     "env": "test"
 ```
 
-Next define an application resource:
+## Creating an app resource
+
+Configure Teleport to proxy an application dynamically by creating an `app`
+resource. The following example configures Teleport to proxy the application
+called `example` at `localhost:4321`, making it available at the public address
+`test.example.com`:
 
 ```yaml
 kind: app
@@ -50,6 +82,7 @@ See the full app resource spec [reference](../reference.mdx#application-resource
 The user creating the dynamic registration needs to have a role with access to the 
 application labels and the `app` resource.  In this example role the user can only
 create and maintain application services labeled `env: test`.
+
 ```yaml
 kind: role
 metadata:


### PR DESCRIPTION
Closes #10136

- Describe how a role can allow a user to manage the `app` resource.
- Subdivide the dynamic app registration page to account for the new text.
- Edit the intro section to pave the way for the permissions section by introducing the `app` resource and, briefly, how it works architecturally.