### PR TITLE
Add more specific aws_role_arns templating info

### DIFF
--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -153,9 +153,27 @@ spec:
     - arn:aws:iam::1234567890:role/ExampleReadOnlyAccess
 ```
 
+<Details title="Configuring aws_role_arns">
+
 The `aws_role_arns` field supports template variables so they can be populated
-dynamically based on your users' identity provider attributes. See [Role
-Templates](../../access-controls/guides/role-templates.mdx) for details.
+dynamically when a user authenticates to Teleport.
+
+For example, you can configure your identity provider to define a SAML attribute
+or OIDC claim called `aws_role_arns`, then use this field to list each user's
+permitted AWS role ARNs on your IdP. If you define a Teleport role to mention
+the `{{external.aws_role_arns}}` variable, the Auth Service will fill in the
+user's permitted ARNs based on data from the IdP:
+
+```yaml
+    aws_role_arns:
+    - {{external.aws_role_arns}}
+```
+
+See the [Teleport Access Controls
+Reference](../../access-controls/reference.mdx#template-expressions-for-access-to-infrastructure-resources)
+for all of the variables and functions you can use in the `aws_role_arns` field.
+
+</Details>
 
 (!docs/pages/includes/add-role-to-user.mdx role="aws-console-access"!)
 


### PR DESCRIPTION
Closes #22378

Include an example of using template variables with the `aws_role_arns` field in the AWS Console guide. Also link to a more appropriate guide, which has specific information about this field.