### PR TITLE
Safer logging through defining `String()` in the interface of sensitive structs

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -243,6 +243,9 @@ type Role interface {
 	GetGroupLabels(RoleConditionType) Labels
 	// SetGroupLabels sets the map of group labels this role is allowed or denied access to.
 	SetGroupLabels(RoleConditionType, Labels)
+
+	// String provides a safe to log representation of the role
+	String() string
 }
 
 // NewRole constructs new standard V7 role.

--- a/api/types/tunnel.go
+++ b/api/types/tunnel.go
@@ -39,6 +39,8 @@ type ReverseTunnel interface {
 	SetType(TunnelType)
 	// GetDialAddrs returns list of dial addresses for this cluster
 	GetDialAddrs() []string
+	// String returns a safe to log representation of the tunnel
+	String() string
 }
 
 // NewReverseTunnel returns new version of reverse tunnel

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -165,7 +165,7 @@ func (a *ServerWithRoles) actionForListWithCondition(namespace, resource, identi
 	}
 	cond, err := a.context.Checker.ExtractConditionForIdentifier(&services.Context{User: a.context.User}, namespace, resource, types.VerbList, identifier)
 	if trace.IsAccessDenied(err) {
-		log.WithError(err).Infof("Access to %v %v in namespace %v denied to %v.", types.VerbList, resource, namespace, a.context.Checker)
+		log.WithError(err).Infof("Access to %v %v in namespace %v denied to %v.", types.VerbList, resource, namespace, a.context.Checker.String())
 		// Return the original AccessDenied to avoid leaking information.
 		return nil, trace.Wrap(origErr)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -355,7 +355,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		if _, err := asrv.UpsertRole(ctx, role); err != nil {
 			return trace.Wrap(err)
 		}
-		log.Infof("Created role: %v.", role)
+		log.Infof("Created role: %v.", role.String())
 	}
 	for i := range cfg.Authorities {
 		ca := cfg.Authorities[i]
@@ -380,7 +380,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		if err := asrv.UpsertReverseTunnel(tunnel); err != nil {
 			return trace.Wrap(err)
 		}
-		log.Infof("Created reverse tunnel: %v.", tunnel)
+		log.Infof("Created reverse tunnel: %v.", tunnel.String())
 	}
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -251,6 +251,9 @@ type AccessChecker interface {
 	//
 	// - types.KindWindowsDesktop
 	GetAllowedLoginsForResource(resource AccessCheckable) ([]string, error)
+
+	// String returns an identifier without any secrets for logging.
+	String() string
 }
 
 // AccessInfo hold information about an identity necessary to check whether that

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -186,7 +186,7 @@ func (a *dbAuth) GetRDSAuthToken(ctx context.Context, sessionCtx *Session) (stri
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating RDS auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating RDS auth token for %s.", sessionCtx.String())
 	token, err := rdsutils.BuildAuthToken(
 		sessionCtx.Database.GetURI(),
 		meta.Region,
@@ -250,7 +250,7 @@ Make sure that IAM role %q has a trust relationship with Teleport database agent
 	}
 
 	// Now make the API call to generate the temporary credentials.
-	a.cfg.Log.Debugf("Generating Redshift IAM role auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating Redshift IAM role auth token for %s.", sessionCtx.String())
 	resp, err := client.GetClusterCredentialsWithIAMWithContext(ctx, &redshift.GetClusterCredentialsWithIAMInput{
 		ClusterIdentifier: aws.String(meta.Redshift.ClusterID),
 		DbName:            aws.String(sessionCtx.DatabaseName),
@@ -281,7 +281,7 @@ func (a *dbAuth) getRedshiftDBUserAuthToken(ctx context.Context, sessionCtx *Ses
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating Redshift auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating Redshift auth token for %s.", sessionCtx.String())
 	resp, err := redshiftClient.GetClusterCredentialsWithContext(ctx, &redshift.GetClusterCredentialsInput{
 		ClusterIdentifier: aws.String(meta.Redshift.ClusterID),
 		DbUser:            aws.String(sessionCtx.DatabaseUser),
@@ -346,7 +346,7 @@ Make sure that IAM role %q has a trust relationship with Teleport database agent
 	}
 
 	// Now make the API call to generate the temporary credentials.
-	a.cfg.Log.Debugf("Generating Redshift Serverless auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating Redshift Serverless auth token for %s.", sessionCtx.String())
 	resp, err := client.GetCredentialsWithContext(ctx, &redshiftserverless.GetCredentialsInput{
 		WorkgroupName: aws.String(meta.RedshiftServerless.WorkgroupName),
 		DbName:        aws.String(sessionCtx.DatabaseName),
@@ -375,7 +375,7 @@ func (a *dbAuth) GetCloudSQLAuthToken(ctx context.Context, sessionCtx *Session) 
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating GCP auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating GCP auth token for %s.", sessionCtx.String())
 	resp, err := gcpIAM.GenerateAccessToken(ctx,
 		&gcpcredentialspb.GenerateAccessTokenRequest{
 			// From GenerateAccessToken docs:
@@ -416,7 +416,7 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating GCP user password for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating GCP user password for %s.", sessionCtx.String())
 	token, err := utils.CryptoRandomHex(libauth.TokenLenBytes)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -462,7 +462,7 @@ Make sure Teleport db service has "Cloud SQL Admin" GCP IAM role, or
 
 // GetAzureAccessToken generates Azure database access token.
 func (a *dbAuth) GetAzureAccessToken(ctx context.Context, sessionCtx *Session) (string, error) {
-	a.cfg.Log.Debugf("Generating Azure access token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating Azure access token for %s.", sessionCtx.String())
 	cred, err := a.cfg.Clients.GetAzureCredential()
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -489,7 +489,7 @@ func (a *dbAuth) GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Sessi
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating ElastiCache Redis auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating ElastiCache Redis auth token for %s.", sessionCtx.String())
 	tokenReq := &awsRedisIAMTokenRequest{
 		// For IAM-enabled ElastiCache users, the username and user id properties must be identical.
 		// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
@@ -514,7 +514,7 @@ func (a *dbAuth) GetMemoryDBToken(ctx context.Context, sessionCtx *Session) (str
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	a.cfg.Log.Debugf("Generating MemoryDB auth token for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating MemoryDB auth token for %s.", sessionCtx.String())
 	tokenReq := &awsRedisIAMTokenRequest{
 		userID:      sessionCtx.DatabaseUser,
 		targetID:    meta.MemoryDB.ClusterName,
@@ -865,7 +865,7 @@ func (a *dbAuth) getClientCert(ctx context.Context, sessionCtx *Session) (cert *
 	}
 	// TODO(r0mant): Cache database certificates to avoid expensive generate
 	// operation on each connection.
-	a.cfg.Log.Debugf("Generating client certificate for %s.", sessionCtx)
+	a.cfg.Log.Debugf("Generating client certificate for %s.", sessionCtx.String())
 	resp, err := a.cfg.AuthClient.GenerateDatabaseCert(ctx, &proto.DatabaseCertRequest{
 		CSR: csr,
 		TTL: proto.Duration(sessionCtx.Identity.Expires.Sub(a.cfg.Clock.Now())),

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -356,7 +356,7 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 			// We do not want to allow changing the connection user and instead
 			// force users to go through normal reconnect flow so log the
 			// attempt and close the client connection.
-			log.Warnf("Rejecting attempt to change user to %q for session %v.", pkt.User(), sessionCtx)
+			log.Warnf("Rejecting attempt to change user to %q for session %v.", pkt.User(), sessionCtx.String())
 			return
 		case *protocol.Quit:
 			return

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -1145,7 +1145,7 @@ func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 		LockTargets: authContext.LockTargets(),
 	}
 
-	s.log.Debugf("Session context: %+v.", sessionCtx)
+	s.log.Debugf("Session context: %+v.", sessionCtx.String())
 	return sessionCtx, nil
 }
 

--- a/lib/srv/regular/get_home_dir.go
+++ b/lib/srv/regular/get_home_dir.go
@@ -63,6 +63,10 @@ func (h *homeDirSubsys) Start(_ context.Context, serverConn *ssh.ServerConn, ch 
 	return trace.Wrap(err)
 }
 
+func (h *homeDirSubsys) String() string {
+	return "homeDir()"
+}
+
 func (h *homeDirSubsys) Wait() error {
 	<-h.done
 	return nil

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -178,6 +179,10 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	}()
 
 	return nil
+}
+
+func (s *sftpSubsys) String() string {
+	return fmt.Sprintf("sftp(%s)", s.serverCtx.String())
 }
 
 func (s *sftpSubsys) Wait() error {

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -53,7 +53,7 @@ func (t *proxySitesSubsys) Wait() error {
 // Start serves a request for "proxysites" custom SSH subsystem. It builds an array of
 // service.Site structures, and writes it serialized as JSON back to the SSH client
 func (t *proxySitesSubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
-	log.Debugf("proxysites.start(%v)", serverContext)
+	log.Debugf("proxysites.start(%v)", serverContext.String())
 	checker, err := t.srv.tunnelWithAccessChecker(serverContext)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1875,17 +1875,17 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 		serverContext.Warnf("Failed to parse subsystem request: %v: %v.", req, err)
 		return trace.Wrap(err)
 	}
-	serverContext.Debugf("Subsystem request: %v.", sb)
+	serverContext.Debugf("Subsystem request: %v.", sb.String())
 	// starting subsystem is blocking to the client,
 	// while collecting its result and waiting is not blocking
 	if err := sb.Start(ctx, serverContext.ServerConn, ch, req, serverContext); err != nil {
-		serverContext.Warnf("Subsystem request %v failed: %v.", sb, err)
+		serverContext.Warnf("Subsystem request %v failed: %v.", sb.String(), err)
 		serverContext.SendSubsystemResult(srv.SubsystemResult{Err: trace.Wrap(err)})
 		return trace.Wrap(err)
 	}
 	go func() {
 		err := sb.Wait()
-		s.Logger.Debugf("Subsystem %v finished with result: %v.", sb, err)
+		s.Logger.Debugf("Subsystem %v finished with result: %v.", sb.String(), err)
 		serverContext.SendSubsystemResult(srv.SubsystemResult{Err: trace.Wrap(err)})
 	}()
 	return nil

--- a/lib/srv/subsystem.go
+++ b/lib/srv/subsystem.go
@@ -41,4 +41,7 @@ type Subsystem interface {
 
 	// Wait is returned by subsystem when it's completed
 	Wait() error
+
+	// String provides a safe to log representation of the subsystem
+	String() string
 }


### PR DESCRIPTION
This commit adds `String()` to the interface of several structs which may contain sensitive data.  This is to provide compiler enforcement (and docs) around the need to ensure that sensitive values are not accidentally logged.

There was no cases of actual sensitive logging found, but this change will help ensure that regressions don't accidentally develop while also addressing the code scanning alerts recently found:
* https://github.com/gravitational/teleport/security/code-scanning/862
* https://github.com/gravitational/teleport/security/code-scanning/869
* https://github.com/gravitational/teleport/security/code-scanning/870
* https://github.com/gravitational/teleport/security/code-scanning/896
* https://github.com/gravitational/teleport/security/code-scanning/897
* https://github.com/gravitational/teleport/security/code-scanning/898