### PR TITLE
docs: remove released feature from upcoming releases page

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -24,10 +24,6 @@ explicitly.
 Users going through the Access Management flow to enroll RDS instances will be able
 to configure auto-discovery.
 
-#### Web UI SSH latency detector
-
-Teleport's web UI will detect and report on the latency of SSH sessions.
-
 #### Improved registration of static desktops
 
 Teleport's configuration schema will be updated to allow users to specify custom
@@ -36,11 +32,6 @@ hostnames and labels for static desktops.
 #### Automatic user provisioning for MongoDB
 
 Teleport will add support for MongoDB automatic user provisioning.
-
-#### Add Spacelift joining support for Machine ID
-
-Teleport Machine ID will support secretless infrastructure as code workflows
-with [Spacelift](https://spacelift.io/).
 
 ### 15.0.0
 


### PR DESCRIPTION
Spacelift joining, web UI latency detector, and device trust updates were all released in 14.2.2.