### PR TITLE
integrations/operator: fix standaloneHelm chart and guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -478,6 +478,15 @@ connectors are accepted, invalid are rejected with sensible error messages.
 - [ ] Test receiving a message via Teleport Slackbot
 - [ ] Test receiving a new Jira Ticket via Teleport Jira
 
+### Teleport Operator
+
+- [ ] Test deploying a Teleport cluster with the `teleport-cluster` Helm chart and the operator enabled
+- [ ] Test deploying a standalone operator against Teleport Cloud
+- [ ] Test that operator can reconcile
+  - [ ] TeleportUser
+  - [ ] TeleportRole
+  - [ ] TeleportProvisionToken
+
 ### AWS Node Joining
 [Docs](https://goteleport.com/docs/setup/guides/joining-nodes-aws/)
 - [ ] On EC2 instance with `ec2:DescribeInstances` permissions for local account:
@@ -488,7 +497,8 @@ connectors are accepted, invalid are rejected with sensible error messages.
 - [ ] IAM Join method in IoT mode with node and auth in different AWS accounts
 
 ### Kubernetes Node Joining
-- [ ] Join a Teleport node running in the same Kubernetes cluster via a Kubernetes ProvisionToken
+- [ ] Join a Teleport node running in the same Kubernetes cluster via a Kubernetes in-cluster ProvisionToken
+- [ ] Join a tbot instance running in a different Kubernetes cluster as Teleport with a Kubernetes JWKS ProvisionToken
 
 ### Azure Node Joining
 [Docs](https://goteleport.com/docs/agents/join-services-to-your-cluster/azure/)

--- a/docs/pages/management/dynamic-resources/teleport-operator-standalone.mdx
+++ b/docs/pages/management/dynamic-resources/teleport-operator-standalone.mdx
@@ -39,8 +39,8 @@ In this step we create the role the operator uses to interact with Teleport reso
 
 Download and apply the operator role manifest:
 
-```bash
-$ curl -L -O https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/integrations/operator/hack/fixture-operator-role.yaml
+```code
+$ curl -L -O https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/integrations/operator/hack/fixture-operator-role.yaml -o operator-role.yaml
 $ tctl create -f operator-role.yaml
 ```
 
@@ -57,11 +57,11 @@ The join token is used by the operator on each startup to join the Teleport clus
 To establish trust between the connecting operator and Teleport, we are delegating the authentication to Kubernetes. Kubernetes has its own internal CA which signs the ServiceAccount tokens that are mounted in the pods. In the following setup, Teleport will trust SA tokens signed by Kubernetes to join the cluster.
 
 1. Retrieve the Kubernetes JWKS (the keys Teleport can use to validate Kubernetes SA tokens)
-   ```shell
+   ```code
    $ export JWKS="$(kubectl get --raw /openid/v1/jwks)"
    ```
 1. Create the token manifest that allows serviceaccount teleport-iac-operator from the namespace teleport-iac to join the cluster as the operator.
-   ```shell
+   ```code
    $ cat <<EOF > operator-token.yaml   
    kind: token
    version: v2
@@ -78,12 +78,16 @@ To establish trust between the connecting operator and Teleport, we are delegati
          jwks: |
            $JWKS
        allow:
-       - service_account: "teleport-iac:teleport-iac-operator" # namespace:serviceaccount
+       - service_account: "teleport-iac:teleport-operator" # namespace:serviceaccount
    EOF
    ```
 1. Then, apply the token manifest:
-   ```shell
+   ```code
    $ tctl create -f operator-token.yaml
+   ```
+1. Finally, retrieve the Teleport cluster name that will be required to use the token:
+   ```code
+   $ export CLUSTER_NAME="$(tctl status | grep Cluster | sed 's/Cluster[[:space:]]*//)"'
    ```
 
 ### Step 3/4 - Create the operator bot
@@ -91,8 +95,8 @@ To establish trust between the connecting operator and Teleport, we are delegati
 In Teleport, a bot is a resource allowing a machine to access Teleport.
 Create a bot for the operator with the following command:
 
-```shell
-$ tctl bots add operator --token operator-bot --role operator
+```code
+$ tctl bots add operator --token operator-bot --roles operator
 ```
 
 ### Step 4/4 - Deploy the operator in the Kubernetes cluster
@@ -102,19 +106,19 @@ At this point you can configure and run the operator:
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 1. Create the Kubernetes namespace that will contain both the operator Pods and the CustomResources to configure Teleport:
-   ```shell
+   ```code
    $ kubectl create namespace teleport-iac
    ```
 1. Apply the strictest Pod Security Standard on the namespace:
-   ```shell
+   ```code
    $ kubectl label namespace teleport-iac 'pod-security.kubernetes.io/enforce=restricted'
    ```
 1. Deploy the operator with Helm:
-   ```shell
-   $ helm install teleport-iac teleport/teleport-operator -n teleport-iac --set authAddr=teleport.example.com:443 --set token operator-bot
+   ```code
+   $ helm install teleport-operator teleport/teleport-operator -n teleport-iac --set teleportAddress=teleport.example.com:443 --set "teleportClusterName=$CLUSTER_NAME" --set token=operator-bot 
    ```
 1. Validate that operator is running properly (the operator might take a few seconds to start):
-   ```
+   ```code
    $ kubectl get pods -n teleport-iac
    ```
 

--- a/docs/pages/management/dynamic-resources/teleport-operator-standalone.mdx
+++ b/docs/pages/management/dynamic-resources/teleport-operator-standalone.mdx
@@ -40,7 +40,7 @@ In this step we create the role the operator uses to interact with Teleport reso
 Download and apply the operator role manifest:
 
 ```code
-$ curl -L -O https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/integrations/operator/hack/fixture-operator-role.yaml -o operator-role.yaml
+$ curl -L https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/integrations/operator/hack/fixture-operator-role.yaml -o operator-role.yaml
 $ tctl create -f operator-role.yaml
 ```
 
@@ -87,7 +87,7 @@ To establish trust between the connecting operator and Teleport, we are delegati
    ```
 1. Finally, retrieve the Teleport cluster name that will be required to use the token:
    ```code
-   $ export CLUSTER_NAME="$(tctl status | grep Cluster | sed 's/Cluster[[:space:]]*//)"'
+   $ export CLUSTER_NAME="$(tctl status | awk '/Cluster/ {print $2}')"
    ```
 
 ### Step 3/4 - Create the operator bot

--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-operator.mdx
@@ -10,16 +10,16 @@
 - When `true`, the chart creates both the `CustomResourceDefinition` and operator `Deployment` Kubernetes resources.
 - When `false`, the chart creates the `CustomResourceDefinition` resources without the operator `Deployment`.
 
-## `authServer`
+## `teleportAddress`
 
 | Type | Default |
 |------|---------|
 | `string` | `""` |
 
-`authServer` is the address of the Teleport cluster whose resources are managed
-by the operator. The address must contain both the domain name and the port of
-the Teleport cluster. It can be either the address of the auth servers or the
-proxy servers.
+`teleportAddress` is the address of the Teleport cluster whose resources
+are managed by the operator. The address must contain both the domain name and
+the port of the Teleport cluster. It can be either the address of the Auth Service
+or the Proxy Service.
 
 For example:
   - joining a Proxy: `teleport.example.com:443` or `teleport.example.com:3080`
@@ -47,6 +47,16 @@ an Auth server directly (on port `3025`) and is ignored when joining through a P
 The operator does not store its Teleport-issued identity, it must be able to join the
 cluster again on each pod restart. To achieve this, it needs to use a delegated join
 method. `kubernetes` is the most common one.
+
+## `teleportClusterName`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`teleportClusterName` is the name of the joined Teleport cluster.
+Setting this value is required when joining via the
+[Kubernetes JWKS](../join-methods.mdx#kubernetes-jwks) join method.
 
 ## `token`
 
@@ -283,7 +293,7 @@ $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.p
 
 | Type | Default |
 |------|---------|
-| `object` | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":"RuntimeDefault"}` |
+| `object` | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` |
 
 `podSecurityContext` sets the pod security context for any pods created by the chart.
 See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)

--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-operator.mdx
@@ -56,7 +56,7 @@ method. `kubernetes` is the most common one.
 
 `teleportClusterName` is the name of the joined Teleport cluster.
 Setting this value is required when joining via the
-[Kubernetes JWKS](../join-methods.mdx#kubernetes-jwks) join method.
+[Kubernetes JWKS](../../join-methods.mdx#kubernetes-jwks) join method.
 
 ## `token`
 

--- a/docs/pages/reference/helm-reference/teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/teleport-operator.mdx
@@ -15,6 +15,9 @@ You can
 <Admonition type="note" title="Version requirement">
 The `teleport-operator` chart was introduced in Teleport 15. Prior versions don't
 support running the operator separately from the `teleport-cluster` chart.
+
+The `teleport-operator` chart requires Kubernetes 1.20+ with [projected volumes
+support](https://kubernetes.io/docs/concepts/storage/projected-volumes/).
 </Admonition>
 
 <Admonition type="warning" title="Version Compatibility">

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/annotations.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/annotations.yaml
@@ -8,3 +8,7 @@ annotations:
   serviceAccount:
     kubernetes.io/serviceaccount: "test-annotation"
     kubernetes.io/serviceaccount-different: 6
+
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/existing-tls-ca.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/existing-tls-ca.yaml
@@ -1,2 +1,6 @@
 tls:
   existingCASecretName: helm-lint-existing-tls-secret-ca
+
+teleportAddress: "teleport.example.com:3080"
+token: "my-operator-bot"
+teleportClusterName: "teleport.example.com"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/non-kubernetes-joining.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/non-kubernetes-joining.yaml
@@ -1,3 +1,3 @@
 teleportAddress: "example.teleport.sh:443"
 token: "my-operator-bot"
-teleportClusterName: "example.teleport.sh"
+joinMethod: "iam"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/resources.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/resources.yaml
@@ -7,3 +7,7 @@ resources:
   requests:
     cpu: 1
     memory: 2Gi
+
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
@@ -57,7 +57,15 @@ teleport.dev/majorVersion: '{{ include "teleport-cluster.majorVersion" . }}'
 
 {{/* Teleport auth or proxy address */}}
 {{- define "teleport-cluster.operator.teleportAddress" -}}
-{{ coalesce (include "teleport-cluster.auth.serviceFQDN" . | printf "%s:3025") .Values.authServer }}
+{{- $clusterAddr := include "teleport-cluster.auth.serviceFQDN" . -}}
+{{- if empty $clusterAddr -}}
+    {{- required "The `teleportAddress` value is mandatory when deploying a standalone operator." .Values.teleportAddress -}}
+    {{- if and (eq .Values.joinMethod "kubernetes") (empty .Values.teleportClusterName) (not (hasSuffix ":3025" .Values.teleportAddress)) -}}
+        {{- fail "When joining using the Kubernetes JWKS join method, you must set the value `teleportClusterName`" -}}
+    {{- end -}}
+{{- else -}}
+    {{- $clusterAddr | printf "%s:3025" -}}
+{{- end -}}
 {{- end -}}
 
 {{- /* This template is a placeholder.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.enabled }}
-{{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
-{{- $hasVolumes := or $projectedServiceAccountToken .Values.tls.existingCASecretName }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,23 +19,23 @@ spec:
     matchLabels: {{- include "teleport-cluster.operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- if .Values.annotations.pod }}
+  {{- if .Values.annotations.pod }}
       annotations: {{- toYaml .Values.annotations.pod | nindent 8 }}
-      {{- end }}
+  {{- end }}
       labels: {{- include "teleport-cluster.operator.labels" . | nindent 8 }}
     spec:
-    {{- if .Values.nodeSelector }}
+  {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+  {{- end }}
+  {{- if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+  {{- end }}
+  {{- if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
-    {{- end }}
-    {{- if .Values.imagePullSecrets }}
+  {{- end }}
+  {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 8 }}
-    {{- end }}
+  {{- end }}
       containers:
         - name: "operator"
           image: '{{ .Values.image }}:{{ include "teleport-cluster.version" . }}'
@@ -50,15 +48,21 @@ spec:
             - '{{ .Values.joinMethod }}'
             - -token
             - '{{ .Values.token }}'
-            {{- if .Values.caPins }}
+  {{- if .Values.caPins }}
             - -ca-pin
             - '{{ join "," .Values.caPins }}'
-            {{- end }}
-          {{- if .Values.tls.existingCASecretName }}
+  {{- end }}
+  {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) }}
           env:
+    {{- if .Values.tls.existingCASecretName }}
             - name: SSL_CERT_FILE
               value: /etc/teleport-tls-ca/ca.pem
-          {{- end }}
+    {{- end }}
+    {{- if .Values.teleportClusterName }}
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/teleport/serviceaccount/token
+    {{- end }}
+  {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -78,31 +82,28 @@ spec:
             - name: op-health
               containerPort: 8081
               protocol: TCP
-        {{- if .Values.securityContext }}
+  {{- if .Values.securityContext }}
           securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
-        {{- end }}
-        {{- if .Values.resources }}
+  {{- end }}
+  {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
-        {{- end }}
-        {{- if $hasVolumes }}
+  {{- end }}
           volumeMounts:
-          {{- if $projectedServiceAccountToken }}
           - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: operator-serviceaccount-token
             readOnly: true
-          {{- end }}
-          {{- if .Values.tls.existingCASecretName }}
+  {{- if .Values.teleportClusterName }}
+          - mountPath: /var/run/secrets/teleport/serviceaccount
+            name: bot-serviceaccount-token
+            readOnly: true
+  {{- end }}
+  {{- if .Values.tls.existingCASecretName }}
           - mountPath: /etc/teleport-tls-ca
             name: "teleport-tls-ca"
             readOnly: true
-          {{- end }}
-        {{- end }}
-      {{- if $projectedServiceAccountToken }}
+  {{- end }}
       automountServiceAccountToken: false
-      {{- end }}
-      {{- if $hasVolumes }}
       volumes:
-        {{- if $projectedServiceAccountToken }}
         # This projected token volume mimics the `automountServiceAccountToken`
         # behaviour but defaults to a 1h TTL instead of 1y.
         - name: operator-serviceaccount-token
@@ -120,18 +121,35 @@ spec:
                     - path: "namespace"
                       fieldRef:
                         fieldPath: metadata.namespace
-        {{- end }}
-        {{- if .Values.tls.existingCASecretName }}
+  {{- if .Values.teleportClusterName }}
+        - name: bot-serviceaccount-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: "{{ .Values.teleportClusterName }}"
+                  expirationSeconds: 600
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - path: "namespace"
+                      fieldRef:
+                        fieldPath: metadata.namespace
+  {{- end }}
+  {{- if .Values.tls.existingCASecretName }}
         - name: teleport-tls-ca
           secret:
             secretName: {{ .Values.tls.existingCASecretName }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.priorityClassName }}
+  {{- end }}
+  {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
-      {{- end }}
-      {{- if .Values.podSecurityContext }}
+  {{- end }}
+  {{- if .Values.podSecurityContext }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
+  {{- end }}
       serviceAccountName: {{ include "teleport-cluster.operator.serviceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -10,6 +10,8 @@ tests:
           count: 0
 
   - it: creates a deployment when operator is enabled
+    values:
+      - ../.lint/cloud-join.yaml
     asserts:
       - containsDocument:
           kind: Deployment
@@ -19,6 +21,8 @@ tests:
   - it: shortens fullname if .Release.Name == .Chart.Name
     release:
       name: teleport-operator
+    values:
+      - ../.lint/cloud-join.yaml
     asserts:
       - containsDocument:
           kind: Deployment
@@ -28,6 +32,8 @@ tests:
   - it: respects the nameOverride
     set:
       nameOverride: operator
+    values:
+      - ../.lint/cloud-join.yaml
     asserts:
       - containsDocument:
           kind: Deployment
@@ -75,10 +81,9 @@ tests:
             name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/ca.pem
 
-  - it: mounts tokens through projected volumes on newer Kubernetes versions
-    capabilities:
-      majorVersion: 1
-      minorVersion: 21
+  - it: mounts tokens through projected volumes
+    values:
+      - ../.lint/cloud-join.yaml
     asserts:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
@@ -108,16 +113,9 @@ tests:
             name: operator-serviceaccount-token
             readOnly: true
 
-  - it: mounts regular tokens on older Kubernetes versions
-    capabilities:
-      majorVersion: 1
-      minorVersion: 18
-    asserts:
-      - notEqual:
-          path: spec.template.spec.automountServiceAccountToken
-          value: false
-
   - it: should set imagePullPolicy when set in values
+    values:
+      - ../.lint/cloud-join.yaml
     set:
       imagePullPolicy: Always
     asserts:
@@ -143,6 +141,8 @@ tests:
           value: 2Gi
 
   - it: should set security contexts by default
+    values:
+      - ../.lint/cloud-join.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext
@@ -155,8 +155,45 @@ tests:
       - equal:
           path: spec.template.spec.securityContext
           value:
-            seccompProfile: RuntimeDefault
+            seccompProfile:
+              type: RuntimeDefault
             runAsUser: 65532
             runAsGroup: 65532
             fsGroup: 65532
             runAsNonRoot: true
+
+  - it: configures a dedicated token when kube JWKS joining
+    values:
+      - ../.lint/cloud-join.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: bot-serviceaccount-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    audience: example.teleport.sh
+                    expirationSeconds: 600
+                    path: token
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - fieldRef:
+                          fieldPath: metadata.namespace
+                        path: namespace
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /var/run/secrets/teleport/serviceaccount
+            name: bot-serviceaccount-token
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBERNETES_TOKEN_PATH
+            value: /var/run/secrets/teleport/serviceaccount/token

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -29,7 +29,7 @@ joinMethod: "kubernetes"
 
 # teleportClusterName(string) -- is the name of the joined Teleport cluster.
 # Setting this value is required when joining via the
-# [Kubernetes JWKS](../join-methods.mdx#kubernetes-jwks) join method.
+# [Kubernetes JWKS](../../join-methods.mdx#kubernetes-jwks) join method.
 teleportClusterName: ""
 
 # token(string) -- is the name of the token used by the operator to join the Teleport cluster.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -4,16 +4,16 @@
 # - When `false`, the chart creates the `CustomResourceDefinition` resources without the operator `Deployment`.
 enabled: true
 
-# authServer(string) -- is the address of the Teleport cluster whose resources are managed
-# by the operator. The address must contain both the domain name and the port of
-# the Teleport cluster. It can be either the address of the auth servers or the
-# proxy servers.
+# teleportAddress(string) -- is the address of the Teleport cluster whose resources
+# are managed by the operator. The address must contain both the domain name and
+# the port of the Teleport cluster. It can be either the address of the Auth Service
+# or the Proxy Service.
 #
 # For example:
 #   - joining a Proxy: `teleport.example.com:443` or `teleport.example.com:3080`
 #   - joining an Auth: `teleport-auth.example.com:3025`
 #   - joining a Cloud-hosted Teleport: `example.teleport.sh:443`
-authServer: ""
+teleportAddress: ""
 
 # caPins(list[string]) -- is a list of Teleport CA fingerprints that is used by the operator to
 # validate the identity of the Teleport Auth server. This is only used when joining
@@ -26,6 +26,11 @@ caPins: []
 # cluster again on each pod restart. To achieve this, it needs to use a delegated join
 # method. `kubernetes` is the most common one.
 joinMethod: "kubernetes"
+
+# teleportClusterName(string) -- is the name of the joined Teleport cluster.
+# Setting this value is required when joining via the
+# [Kubernetes JWKS](../join-methods.mdx#kubernetes-jwks) join method.
+teleportClusterName: ""
 
 # token(string) -- is the name of the token used by the operator to join the Teleport cluster.
 token: ""
@@ -175,7 +180,8 @@ tls:
 # The default value supports running under the `restricted`
 # [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 podSecurityContext:
-  seccompProfile: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
   runAsUser: 65532
   runAsGroup: 65532
   fsGroup: 65532


### PR DESCRIPTION
This PR addresses a few issues detected during the test plan:
- operator cannot join due to wrong audience on token: we now ask for the cluster name
- a few typos in the docs commands
- fix invalid seccomp profile

This PR brings the following UX improvements:
- rename `authAddr` to `teleportAddress`
- change the release name to `teleport-operator` and have simpler resource names (`deploy/teleport-operator` instead of `teleport-operator-teleport-iac`)

This PR also brings a breaking change: the operator chart requires Kubernetes clusters to support projected volumes (1.20+). This was made to simplify the configuration as the new kubernetes jwks join token depends on projected volumes. 1.20 is EOL since 2 years.

Finally, this PR adds a few items to the major version test plan covering operator basics.

Changelog: Deploying the Teleport Kubernetes Operator now requires Kubernetes 1.20 as the `teleport-operator` chart uses the ProjectedVolumes API.