### PR TITLE
[v14] Fix regression in Kube Address introduced by #34211

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -854,7 +854,7 @@ func (c *Config) ParseProxyHost(proxyHost string) error {
 
 // KubeProxyHostPort returns the host and port of the Kubernetes proxy.
 func (c *Config) KubeProxyHostPort() (string, int) {
-	if c.KubeProxyAddr != "" && !c.TLSRoutingEnabled {
+	if c.KubeProxyAddr != "" {
 		addr, err := utils.ParseAddr(c.KubeProxyAddr)
 		if err == nil {
 			return addr.Host(), addr.Port(defaults.KubeListenPort)
@@ -4315,8 +4315,8 @@ func (tc *TeleportClient) applyProxySettings(proxySettings webclient.ProxySettin
 					proxySettings.Kube.PublicAddr)
 			}
 			tc.KubeProxyAddr = proxySettings.Kube.PublicAddr
-		// ListenAddr is the second preference.
-		case proxySettings.Kube.ListenAddr != "":
+		// ListenAddr is the second preference unless TLS routing is enabled.
+		case proxySettings.Kube.ListenAddr != "" && !proxySettings.TLSRoutingEnabled:
 			addr, err := utils.ParseAddr(proxySettings.Kube.ListenAddr)
 			if err != nil {
 				return trace.BadParameter(

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -91,7 +91,7 @@ func TestKubeLogin(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, k)
 
-		require.Equal(t, k.Clusters[k.Contexts[k.CurrentContext].Cluster].Server, "https://"+expectedAddr)
+		require.Equal(t, "https://"+expectedAddr, k.Clusters[k.Contexts[k.CurrentContext].Cluster].Server)
 	}
 
 	t.Run("kube login with multiplex mode", func(t *testing.T) {


### PR DESCRIPTION
Backport #35623 to branch/v14

changelog: Fixed regression of Kubernetes Server Address when Teleport runs in multiplex mode.
