### PR TITLE
Add agent version header

### DIFF
--- a/integration/proxy/automaticupgrades_test.go
+++ b/integration/proxy/automaticupgrades_test.go
@@ -89,9 +89,9 @@ func TestVersionServer(t *testing.T) {
 	forwardPath := "/version-server/"
 
 	upstreamServer := basichttp.NewServerMock(forwardPath + constants.VersionPath)
-	upstreamServer.SetResponse(t, http.StatusOK, testVersion)
+	upstreamServer.SetResponse(t, http.StatusOK, testVersion, nil)
 	upstreamHighServer := basichttp.NewServerMock(forwardPath + constants.VersionPath)
-	upstreamHighServer.SetResponse(t, http.StatusOK, testVersionMajorTooHigh)
+	upstreamHighServer.SetResponse(t, http.StatusOK, testVersionMajorTooHigh, nil)
 
 	channels := automaticupgrades.Channels{
 		staticChannel: {

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -40,6 +40,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kubeversionupdater "github.com/gravitational/teleport/integrations/kube-agent-updater"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/constants"
 	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/controller"
 	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/img"
 	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/maintenance"
@@ -125,7 +126,11 @@ func main() {
 		ctrl.Log.Error(err, "failed to pasre version server URL, exiting")
 		os.Exit(1)
 	}
+
+	// Initialize the version getter and set the updater version header
 	versionGetter := version.NewBasicHTTPVersionGetter(versionServerURL)
+	versionGetter.SetHeader(constants.UpdaterVersionHeader, kubeversionupdater.Version)
+
 	maintenanceTriggers := maintenance.Triggers{
 		maintenance.NewBasicHTTPMaintenanceTrigger("critical update", versionServerURL),
 		maintenance.NewUnhealthyWorkloadTrigger("unhealthy pods", mgr.GetClient()),

--- a/integrations/kube-agent-updater/pkg/basichttp/client.go
+++ b/integrations/kube-agent-updater/pkg/basichttp/client.go
@@ -42,6 +42,26 @@ func (c *Client) GetContent(ctx context.Context, targetURL url.URL) ([]byte, err
 	if err != nil {
 		return []byte{}, trace.Wrap(err)
 	}
+	content, err := c.getContent(ctx, req)
+	return content, trace.Wrap(err)
+}
+
+// GetContentWithHeaders sends a GET HTTP request with extra headers.
+// Returns an error if the response is not 200.
+func (c *Client) GetContentWithHeaders(ctx context.Context, targetURL url.URL, extraHeaders map[string]string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL.String(), nil)
+	if err != nil {
+		return []byte{}, trace.Wrap(err)
+	}
+
+	for header, value := range extraHeaders {
+		req.Header.Set(header, value)
+	}
+	content, err := c.getContent(ctx, req)
+	return content, trace.Wrap(err)
+}
+
+func (c *Client) getContent(ctx context.Context, req *http.Request) ([]byte, error) {
 	res, err := c.Do(req)
 	if err != nil {
 		return []byte{}, trace.Wrap(err)

--- a/integrations/kube-agent-updater/pkg/basichttp/servermock.go
+++ b/integrations/kube-agent-updater/pkg/basichttp/servermock.go
@@ -36,18 +36,23 @@ type ServerMock struct {
 	code     int
 	response string
 	path     string
+	headers  map[string]string
 }
 
 // SetResponse sets the ServerMock's response.
-func (m *ServerMock) SetResponse(t *testing.T, code int, response string) {
+func (m *ServerMock) SetResponse(t *testing.T, code int, response string, headers map[string]string) {
 	m.t = t
 	m.code = code
 	m.response = response
+	m.headers = headers
 }
 
 // ServeHTTP implements the http.Handler interface.
 func (m *ServerMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	require.Equal(m.t, m.path, r.URL.Path)
+	for header, value := range m.headers {
+		require.Equal(m.t, r.Header.Get(header), value)
+	}
 	w.WriteHeader(m.code)
 	_, err := io.WriteString(w, m.response)
 	require.NoError(m.t, err)

--- a/integrations/kube-agent-updater/pkg/constants/constants.go
+++ b/integrations/kube-agent-updater/pkg/constants/constants.go
@@ -35,4 +35,10 @@ const (
 	// NoVersion is returned by the version endpoint when there is no valid target version.
 	// This can be caused by the target version being incompatible with the cluster version.
 	NoVersion = "none"
+
+	// AgentVersionHeader defines the header that contains the teleport agent version metadata.
+	AgentVersionHeader = "agent-version"
+
+	// UpdaterVersionHeader defines the header that contains the teleport updater version metadata.
+	UpdaterVersionHeader = "updater-version"
 )

--- a/integrations/kube-agent-updater/pkg/constants/constants.go
+++ b/integrations/kube-agent-updater/pkg/constants/constants.go
@@ -37,8 +37,8 @@ const (
 	NoVersion = "none"
 
 	// AgentVersionHeader defines the header that contains the teleport agent version metadata.
-	AgentVersionHeader = "agent-version"
+	AgentVersionHeader = "Agent-Version"
 
 	// UpdaterVersionHeader defines the header that contains the teleport updater version metadata.
-	UpdaterVersionHeader = "updater-version"
+	UpdaterVersionHeader = "Updater-Version"
 )

--- a/integrations/kube-agent-updater/pkg/controller/updater.go
+++ b/integrations/kube-agent-updater/pkg/controller/updater.go
@@ -72,6 +72,11 @@ func (r *VersionUpdater) GetVersion(ctx context.Context, obj client.Object, curr
 		return nil, trace.Wrap(err)
 	}
 
+	nextVersion, err = version.EnsureSemver(nextVersion)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	log.Info("New version candidate", "nextVersion", nextVersion)
 	if !version.ValidVersionChange(ctx, currentVersion, nextVersion) {
 		return nil, &version.NoNewVersionError{CurrentVersion: currentVersion, NextVersion: nextVersion}

--- a/integrations/kube-agent-updater/pkg/maintenance/basichttp_test.go
+++ b/integrations/kube-agent-updater/pkg/maintenance/basichttp_test.go
@@ -99,7 +99,7 @@ func Test_basicHTTPMaintenanceClient_Get(t *testing.T) {
 				baseURL: serverURL,
 				client:  &basichttp.Client{Client: mock.Srv.Client()},
 			}
-			mock.SetResponse(t, tt.statusCode, tt.response)
+			mock.SetResponse(t, tt.statusCode, tt.response, nil)
 			result, err := b.Get(ctx)
 			tt.assertErr(t, err)
 			require.Equal(t, tt.expected, result)

--- a/integrations/kube-agent-updater/pkg/version/basichttp_test.go
+++ b/integrations/kube-agent-updater/pkg/version/basichttp_test.go
@@ -46,6 +46,7 @@ func Test_basicHTTPVersionClient_Get(t *testing.T) {
 		statusCode int
 		response   string
 		expected   string
+		headers    map[string]string
 		assertErr  require.ErrorAssertionFunc
 	}{
 		{
@@ -87,14 +88,26 @@ func Test_basicHTTPVersionClient_Get(t *testing.T) {
 			expected:   "",
 			assertErr:  require.Error,
 		},
+		{
+			name:       "agent metadata headers",
+			statusCode: http.StatusOK,
+			response:   "14.2.0",
+			expected:   "v14.2.0",
+			headers: map[string]string{
+				constants.AgentVersionHeader:   "14.0.0",
+				constants.UpdaterVersionHeader: "14.1.0",
+			},
+			assertErr: require.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &basicHTTPVersionClient{
-				baseURL: serverURL,
-				client:  &basichttp.Client{Client: mock.Srv.Client()},
+				baseURL:      serverURL,
+				client:       &basichttp.Client{Client: mock.Srv.Client()},
+				extraHeaders: tt.headers,
 			}
-			mock.SetResponse(t, tt.statusCode, tt.response)
+			mock.SetResponse(t, tt.statusCode, tt.response, tt.headers)
 			result, err := b.Get(ctx)
 			tt.assertErr(t, err)
 			require.Equal(t, tt.expected, result)

--- a/integrations/kube-agent-updater/pkg/version/versionget.go
+++ b/integrations/kube-agent-updater/pkg/version/versionget.go
@@ -40,8 +40,7 @@ func ValidVersionChange(ctx context.Context, current, next string) bool {
 	// TODO: clarify rollback constraints regarding previous version and add a "previous" parameter
 	log := ctrllog.FromContext(ctx).V(1)
 	// Cannot upgrade to a non-valid version
-	next, err := EnsureSemver(next)
-	if err != nil {
+	if !semver.IsValid(next) {
 		log.Error(trace.BadParameter("next version is not following semver"), "version change is invalid", "nextVersion", next)
 		return false
 	}

--- a/integrations/kube-agent-updater/pkg/version/versionget.go
+++ b/integrations/kube-agent-updater/pkg/version/versionget.go
@@ -40,7 +40,8 @@ func ValidVersionChange(ctx context.Context, current, next string) bool {
 	// TODO: clarify rollback constraints regarding previous version and add a "previous" parameter
 	log := ctrllog.FromContext(ctx).V(1)
 	// Cannot upgrade to a non-valid version
-	if !semver.IsValid(next) {
+	next, err := EnsureSemver(next)
+	if err != nil {
 		log.Error(trace.BadParameter("next version is not following semver"), "version change is invalid", "nextVersion", next)
 		return false
 	}

--- a/lib/automaticupgrades/channel_test.go
+++ b/lib/automaticupgrades/channel_test.go
@@ -76,7 +76,7 @@ func Test_Channel_CheckAndSetDefaults(t *testing.T) {
 				ForwardURL: stableCloudVersionBaseURL,
 			},
 			assertError:                 require.NoError,
-			expectedVersionGetterType:   version.BasicHTTPVersionGetter{},
+			expectedVersionGetterType:   &version.BasicHTTPVersionGetter{},
 			expectedCriticalTriggerType: maintenance.BasicHTTPMaintenanceTrigger{},
 		},
 		{


### PR DESCRIPTION
Supports https://github.com/gravitational/cloud/issues/6773
Related https://github.com/gravitational/teleport.e/pull/2963

The kube-agent-updater will now include two header values when making a request to the automatic upgrades version server. `Agent-Version` and `Updater-Version`.

Including the teleport agent version in the request can give the proxy version server more control over what teleport version to serve, or prevent serving an incompatible teleport version. Example situations that we might run into:
- Upgrade requires an intermediate version upgrade to succeed
- Some agents are upgraded past target version by accident, and we can't downgrade, but need to upgrade other agents.

changelog: kube-agent-updater now includes agent/updater version in version requests