### PR TITLE
Packer AMI Builder: Tag as intentionally public

### DIFF
--- a/assets/aws/single-ami.json
+++ b/assets/aws/single-ami.json
@@ -49,7 +49,8 @@
       "BuildType": "production"
     },
     "run_tags": {
-      "Name": "{{user `ami_name`}}"
+      "Name": "{{user `ami_name`}}",
+      "teleport.dev/is_public": "true"
     },
     "run_volume_tags": {
       "Name": "{{user `ami_name`}}"
@@ -92,7 +93,8 @@
       "BuildType": "production-fips"
     },
     "run_tags": {
-      "Name": "{{user `fips_ami_name`}}"
+      "Name": "{{user `fips_ami_name`}}",
+      "teleport.dev/is_public": "true"
     },
     "run_volume_tags": {
       "Name": "{{user `fips_ami_name`}}"

--- a/assets/aws/single-ami.pkr.hcl
+++ b/assets/aws/single-ami.pkr.hcl
@@ -143,8 +143,9 @@ source "amazon-ebs" "teleport-aws-linux" {
     http_put_response_hop_limit = 2
   }
   run_tags = {
-    Name    = local.ami_name
-    purpose = local.resource_purpose_tag_value
+    Name                     = local.ami_name
+    purpose                  = local.resource_purpose_tag_value
+    "teleport.dev/is_public" = true
   }
   run_volume_tags = {
     Name = local.ami_name


### PR DESCRIPTION
Add a tag to mark the ephemeral Packer instance used in building AMIs as being intentionally exposed (so Github Actions runners can reach it)