### PR TITLE
MFA for Admin Actions: Bots

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3086,6 +3086,10 @@ func (a *ServerWithRoles) CreateBot(ctx context.Context, req *proto.CreateBotReq
 		return nil, trace.Wrap(err)
 	}
 
+	if err := authz.AuthorizeAdminAction(ctx, &a.context); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return a.authServer.createBot(ctx, req)
 }
 
@@ -3100,6 +3104,11 @@ func (a *ServerWithRoles) DeleteBot(ctx context.Context, botName string) error {
 	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbRead, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
+
+	if err := authz.AuthorizeAdminAction(ctx, &a.context); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return a.authServer.deleteBot(ctx, botName)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3090,7 +3090,7 @@ func (a *ServerWithRoles) CreateBot(ctx context.Context, req *proto.CreateBotReq
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.createBot(ctx, req)
+	return a.authServer.CreateBot(ctx, req)
 }
 
 // DeleteBot removes a certificate renewal bot by name.
@@ -3109,7 +3109,7 @@ func (a *ServerWithRoles) DeleteBot(ctx context.Context, botName string) error {
 		return trace.Wrap(err)
 	}
 
-	return a.authServer.deleteBot(ctx, botName)
+	return a.authServer.DeleteBot(ctx, botName)
 }
 
 // GetBotUsers fetches all users with bot labels. It does not fetch users with

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -117,8 +117,8 @@ func createBotUser(
 	return user, nil
 }
 
-// createBot creates a new certificate renewal bot from a bot request.
-func (a *Server) createBot(ctx context.Context, req *proto.CreateBotRequest) (*proto.CreateBotResponse, error) {
+// CreateBot creates a new certificate renewal bot from a bot request.
+func (a *Server) CreateBot(ctx context.Context, req *proto.CreateBotRequest) (*proto.CreateBotResponse, error) {
 	if req.Name == "" {
 		return nil, trace.BadParameter("bot name must not be empty")
 	}
@@ -234,7 +234,7 @@ func (a *Server) deleteBotRole(ctx context.Context, botName, resourceName string
 	return err
 }
 
-func (a *Server) deleteBot(ctx context.Context, botName string) error {
+func (a *Server) DeleteBot(ctx context.Context, botName string) error {
 	// Note: this does not remove any locks for the bot's user / role. That
 	// might be convenient in case of accidental bot locking but there doesn't
 	// seem to be any automatic deletion of locks in teleport today (other

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -138,7 +138,7 @@ func TestServerCreateBot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			res, err := srv.Auth().createBot(ctx, tt.request)
+			res, err := srv.Auth().CreateBot(ctx, tt.request)
 			if tt.checkErr != nil {
 				tt.checkErr(t, err)
 				return
@@ -213,7 +213,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new bot.
-	bot, err := srv.Auth().createBot(ctx, &proto.CreateBotRequest{
+	bot, err := srv.Auth().CreateBot(ctx, &proto.CreateBotRequest{
 		Name:  "test",
 		Roles: []string{"example"},
 	})
@@ -271,7 +271,7 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new bot.
-	bot, err := srv.Auth().createBot(ctx, &proto.CreateBotRequest{
+	bot, err := srv.Auth().CreateBot(ctx, &proto.CreateBotRequest{
 		Name:  "test",
 		Roles: []string{"example"},
 	})
@@ -344,7 +344,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 	require.NoError(t, err)
 
 	botName := "botty"
-	_, err = a.createBot(ctx, &proto.CreateBotRequest{
+	_, err = a.CreateBot(ctx, &proto.CreateBotRequest{
 		Name:  botName,
 		Roles: []string{roleName},
 	})


### PR DESCRIPTION
Require MFA for Bot CRUD.

Part of [RFD 131](https://github.com/gravitational/teleport/blob/6b998a78ddd76c0c9eb7d966086f984b01144de7/rfd/0131-adminitrative-actions-mfa.md#administrative-actions).

Based off https://github.com/gravitational/teleport/pull/35386 to use the same test helpers.