### PR TITLE
docs: update self-hosted upgrader to include teleport-upgrader install

### DIFF
--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -1,3 +1,4 @@
+{{ toinstall="teleport-ent" }}
 <Tabs>
 <TabItem label="Debian 9+/Ubuntu 16.04+ (apt)">
 
@@ -14,7 +15,7 @@ https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport
 | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
 $ sudo apt-get update
-$ sudo apt-get install teleport-ent
+$ sudo apt-get install {{ toinstall }}
 ```
 
 For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
@@ -36,7 +37,7 @@ $ source /etc/os-release
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo yum install -y yum-utils
 $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
-$ sudo yum install teleport-ent
+$ sudo yum install {{ toinstall }}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -61,7 +62,7 @@ $ source /etc/os-release
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 # Use zypper to add the teleport RPM repo
 $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
-$ sudo yum install teleport-ent
+$ sudo yum install {{ toinstall }}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -88,7 +89,7 @@ $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
 
 # Install teleport
-$ sudo dnf install teleport-ent
+$ sudo dnf install {{ toinstall }}
 
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -114,7 +115,7 @@ $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport-zypper.repo")
 
 # Install teleport
-$ sudo zypper install teleport-ent
+$ sudo zypper install {{ toinstall }}
 ```
 
 For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -1,4 +1,4 @@
-{{ toinstall="teleport-ent" }}
+{{ to-install="teleport-ent" }}
 <Tabs>
 <TabItem label="Debian 9+/Ubuntu 16.04+ (apt)">
 
@@ -15,7 +15,7 @@ https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport
 | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
 $ sudo apt-get update
-$ sudo apt-get install {{ toinstall }}
+$ sudo apt-get install {{ to-install }}
 ```
 
 For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
@@ -37,7 +37,7 @@ $ source /etc/os-release
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo yum install -y yum-utils
 $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
-$ sudo yum install {{ toinstall }}
+$ sudo yum install {{ to-install }}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -62,7 +62,7 @@ $ source /etc/os-release
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 # Use zypper to add the teleport RPM repo
 $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
-$ sudo yum install {{ toinstall }}
+$ sudo yum install {{ to-install }}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -89,7 +89,7 @@ $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
 
 # Install teleport
-$ sudo dnf install {{ toinstall }}
+$ sudo dnf install {{ to-install }}
 
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
@@ -115,7 +115,7 @@ $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport-zypper.repo")
 
 # Install teleport
-$ sudo zypper install {{ toinstall }}
+$ sudo zypper install {{ to-install }}
 ```
 
 For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:

--- a/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
@@ -395,7 +395,7 @@ Follow these instructions on each of your Teleport agents.
    does not include the upgrader, add the appropriate repository and reinstall
    Teleport.
    
-   (!docs/pages/includes/install-linux-ent-self-hosted.mdx toinstall="teleport-ent-updater" !)
+   (!docs/pages/includes/install-linux-ent-self-hosted.mdx to-install="teleport-ent-updater" !)
 
 ### Configure the upgrader
 

--- a/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
@@ -395,7 +395,7 @@ Follow these instructions on each of your Teleport agents.
    does not include the upgrader, add the appropriate repository and reinstall
    Teleport.
    
-   (!docs/pages/includes/install-linux-self-hosted.mdx!)
+   (!docs/pages/includes/install-linux-ent-self-hosted.mdx toinstall="teleport-ent-updater" !)
 
 ### Configure the upgrader
 


### PR DESCRIPTION
The Teleport upgrader was not included for the install and showed community install.