### PR TITLE
docs: update team ubuntu reference

### DIFF
--- a/docs/pages/choose-an-edition/teleport-team.mdx
+++ b/docs/pages/choose-an-edition/teleport-team.mdx
@@ -66,10 +66,10 @@ To spin up a new server using Docker:
 as a resource in your Teleport Team cluster:
    
    ```code
-   $ docker run --interactive --tty ubuntu /bin/bash
+   $ docker run --interactive --tty ubuntu:22.04 /bin/bash
    ```
    
-   This command starts a new shell session in the `ubuntu` container. 
+   This command starts a new shell session in the `ubuntu:22.04` container. 
 
 1. Run the following command to install `curl` and `telnet` from the package management repository:
    

--- a/docs/pages/choose-an-edition/teleport-team.mdx
+++ b/docs/pages/choose-an-edition/teleport-team.mdx
@@ -66,10 +66,10 @@ To spin up a new server using Docker:
 as a resource in your Teleport Team cluster:
    
    ```code
-   $ docker run --interactive --tty ubuntu:22.10 /bin/bash
+   $ docker run --interactive --tty ubuntu /bin/bash
    ```
    
-   This command starts a new shell session in the `ubuntu:22.10` container. 
+   This command starts a new shell session in the `ubuntu` container. 
 
 1. Run the following command to install `curl` and `telnet` from the package management repository:
    


### PR DESCRIPTION
`ubuntu:22.10` no longer has repos to update. Using `ubuntu:22.04` will pull down a LTS supported version.