### PR TITLE
Prevent blinking of the loading skeleton

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/LoadingCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/LoadingCard.tsx
@@ -16,11 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Flex, Box } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 
 export function LoadingCard() {
+  const [randomizedSize] = useState(() => ({
+    name: randomNum(100, 30),
+    description: randomNum(90, 40),
+    labels: new Array(randomNum(4, 0)),
+  }));
+
   return (
     <Flex gap={2} alignItems="start" height="106px" p={3}>
       {/* Checkbox */}
@@ -33,17 +39,21 @@ export function LoadingCard() {
           <ShimmerBox
             height="24px"
             css={`
-              flex-basis: ${randomNum(100, 30)}%;
+              flex-basis: ${randomizedSize.name}%;
             `}
           />
           {/* Action button */}
           <ShimmerBox height="24px" width="90px" />
         </Flex>
         {/* Description */}
-        <ShimmerBox height="16px" width={`${randomNum(90, 40)}%`} mb={2} />
+        <ShimmerBox
+          height="16px"
+          width={`${randomizedSize.description}%`}
+          mb={2}
+        />
         {/* Labels */}
         <Flex gap={2}>
-          {new Array(randomNum(4, 0)).fill(null).map((_, i) => (
+          {randomizedSize.labels.fill(null).map((_, i) => (
             <ShimmerBox key={i} height="16px" width="60px" />
           ))}
         </Flex>

--- a/web/packages/shared/components/UnifiedResources/ListView/LoadingListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/LoadingListItem.tsx
@@ -16,13 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 
 export function LoadingListItem() {
+  const [randomizedSize] = useState(() => ({
+    name: randomNum(95, 40),
+    description: randomNum(65, 25),
+    type: randomNum(80, 60),
+    address: randomNum(90, 50),
+  }));
+
   return (
     <LoadingListItemWrapper>
       {/* Image */}
@@ -41,15 +48,15 @@ export function LoadingListItem() {
           grid-area: name;
         `}
       >
-        <ShimmerBox height="14px" width={`${randomNum(95, 40)}%`} />
-        <ShimmerBox height="10px" width={`${randomNum(65, 25)}%`} />
+        <ShimmerBox height="14px" width={`${randomizedSize.name}%`} />
+        <ShimmerBox height="10px" width={`${randomizedSize.description}%`} />
       </Flex>
       <ShimmerBox
         css={`
           grid-area: type;
         `}
         height="18px"
-        width={`${randomNum(80, 60)}%`}
+        width={`${randomizedSize.type}%`}
       />
 
       <ShimmerBox
@@ -57,7 +64,7 @@ export function LoadingListItem() {
           grid-area: address;
         `}
         height="18px"
-        width={`${randomNum(90, 50)}%`}
+        width={`${randomizedSize.address}%`}
       />
 
       <ShimmerBox

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -242,6 +242,10 @@ export function ResourceListItem({
                     cursor: pointer;
                     height: 20px;
                     line-height: 19px;
+                    max-width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                   `}
                 >
                   {labelText}


### PR DESCRIPTION
The first commit in this PR fixes the issue found by Rafał:
>In the videos I added 5 seconds of sleep to the tshd handlers that deal with user prefs. The loading skeleton shifts many times over when opening a new tab and it's even worse when reopening the app. I suppose this is because the skeleton component randomizes the lengths each time it's rendered instead of only on the initial mount or something. Maybe this is something that could be worked around with the key prop?

https://private-user-images.githubusercontent.com/27113/289903362-d0795ab8-a191-484b-80b8-8a5f4c922903.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDI0ODMxNTAsIm5iZiI6MTcwMjQ4Mjg1MCwicGF0aCI6Ii8yNzExMy8yODk5MDMzNjItZDA3OTVhYjgtYTE5MS00ODRiLTgwYjgtOGE1ZjRjOTIyOTAzLm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFJV05KWUFYNENTVkVINTNBJTJGMjAyMzEyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjMxMjEzVDE1NTQxMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWE3Y2NjZmYxMzVmYTM3MzJiZDg2MjIxZjZkMzExM2E2NGIwMWZmN2U0OTZkMTIzYzYxNWMyOTVjOGVjN2JlNWQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.Gj_1lOm9UTI7Cvio7rCuAgZKZEbbRrJgSEesHzNwN1s

I think that `key` can't help, since it doesn't prevent child components from re-rendering. I fixed that by calculating the random values only once, when the component mounts. 

The second commit prevents long labels from overflow: 
<img width="703" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/630bf05a-7805-4eb7-b726-5b5d93194528">

After:
<img width="703" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/7ba20164-e37b-482a-9fdc-b1a106dc9043">
