### PR TITLE
Narrow error response conditional for unified resources fetch

### DIFF
--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -56,7 +56,11 @@ class ResourceService {
         // TODO (avatus) : a temporary check to catch unimplemented errors for unified resources
         // This is a quick hacky way to catch the error until we migrate completely to unified resources
         // DELETE IN 15.0
-        if (res.response?.status === 404 || res.response?.status === 501) {
+        if (
+          (res.response?.status === 404 &&
+            res.message?.includes('unknown method ListUnifiedResources')) ||
+          res.response?.status === 501
+        ) {
           localStorage.setItem(
             KeysEnum.UNIFIED_RESOURCES_NOT_SUPPORTED,
             'true'


### PR DESCRIPTION
Originally, we had checked only for 404/501 to distinguished if a cluster supported unified resources. This worked fine until we added unified resources to the access requests view. Access request (which append `search_as_roles` to the query) have a few extra checks that can also return 404. If `search_as_roles` is configured incorrectly or has invalid roles, it will return a 404 "role not found" error. This would flag our fetch conditional and trick the web UI into thinking unified resources weren't supported and would default to the old view.

I decided to check for the error message specifically since we don't have access to sending a more specific error code (it IS a 404, but the whole point is it doesn't exist on older servers. couldn't think of a better way)

The TODO comment is even more poignant now in terms of it's "hackiness" but this way we are only checking responses that truly mean `ListUnifiedResources` isn't supported. Should still be removed in 15

e side: https://github.com/gravitational/teleport.e/pull/2922

fixes: https://github.com/gravitational/teleport/issues/35673