### PR TITLE
Sort usergroups by their oktalabels if available

### DIFF
--- a/api/types/usergroup.go
+++ b/api/types/usergroup.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -112,11 +113,37 @@ func (g UserGroups) SortByCustom(sortBy SortBy) error {
 	switch sortBy.Field {
 	case ResourceMetadataName:
 		sort.SliceStable(g, func(i, j int) bool {
-			return stringCompare(g[i].GetName(), g[j].GetName(), isDesc)
+			groupA := g[i]
+			groupB := g[j]
+
+			groupAName := FriendlyName(groupA)
+			groupBName := FriendlyName(groupB)
+
+			if groupAName == "" {
+				groupAName = groupA.GetName()
+			}
+			if groupBName == "" {
+				groupBName = groupB.GetName()
+			}
+
+			return stringCompare(strings.ToLower(groupAName), strings.ToLower(groupBName), isDesc)
 		})
 	case ResourceSpecDescription:
 		sort.SliceStable(g, func(i, j int) bool {
-			return stringCompare(g[i].GetMetadata().Description, g[j].GetMetadata().Description, isDesc)
+			groupA := g[i]
+			groupB := g[j]
+
+			groupADescription := groupA.GetMetadata().Description
+			groupBDescription := groupB.GetMetadata().Description
+
+			if oktaDescription, ok := groupA.GetLabel(OktaGroupDescriptionLabel); ok {
+				groupADescription = oktaDescription
+			}
+			if oktaDescription, ok := groupB.GetLabel(OktaGroupDescriptionLabel); ok {
+				groupBDescription = oktaDescription
+			}
+
+			return stringCompare(strings.ToLower(groupADescription), strings.ToLower(groupBDescription), isDesc)
 		})
 
 	default:


### PR DESCRIPTION
For the webui we display user groups based on their okta label for description and friendly name for name. Because of this, the user group table sorting of these two columns wasn't reliable. This change sorts by those values if available and if not, goes back to the old way.

changelog: Fixed the sorting of name and description columns for user groups when creating an access request