### PR TITLE
Update `IronRDP` to latest, fix key log leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bitflags 2.4.1",
  "ironrdp-pdu",
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1257,12 +1257,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bitflags 2.4.1",
  "ironrdp-error",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bitflags 2.4.1",
  "ironrdp-connector",
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bitflags 2.4.1",
  "ironrdp-pdu",
@@ -1345,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377#6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377"
+source = "git+https://github.com/Devolutions/IronRDP?rev=d24000a2aeab74f2610a0b01c629f7a4ef3c77ef#d24000a2aeab74f2610a0b01c629f7a4ef3c77ef"
 dependencies = [
  "bytes",
  "ironrdp-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ codegen-units = 1
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "6588f7cdc71cbaa24ae6d18b7f8d0d3ed48c1377" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "d24000a2aeab74f2610a0b01c629f7a4ef3c77ef" }

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -27,7 +27,6 @@ use ironrdp_connector::{Config, ConnectorError, Credentials};
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent, KeyboardFlags};
 use ironrdp_pdu::input::mouse::PointerFlags;
 use ironrdp_pdu::input::{InputEventError, MousePdu};
-use ironrdp_pdu::nego::SecurityProtocol;
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_pdu::rdp::RdpError;
 use ironrdp_pdu::{custom_err, function, PduError, PduParsing};
@@ -1030,7 +1029,8 @@ type RdpWriteStream = Framed<TokioStream<WriteHalf<TlsStream<TokioTcpStream>>>>;
 fn create_config(width: u16, height: u16, pin: String) -> Config {
     Config {
         desktop_size: ironrdp_connector::DesktopSize { width, height },
-        security_protocol: SecurityProtocol::SSL,
+        enable_tls: true,
+        enable_credssp: false,
         credentials: Credentials::SmartCard { pin },
         domain: None,
         // Windows 10, Version 1909, same as FreeRDP as of October 5th, 2021.

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -57,8 +57,7 @@ impl std::fmt::Debug for ScardBackend {
             .field("cert_der", &util::vec_u8_debug(&self.cert_der))
             // Important we don't leak key_der to the logs.
             .field("key_der", &util::vec_u8_debug(&self.key_der))
-            // Out of an abundance of caution, don't leak the PIN to the logs.
-            .field("pin", &util::str_debug(&self.pin))
+            .field("pin", &self.pin)
             .finish()
     }
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::client::ClientHandle;
-use crate::piv;
+use crate::{piv, util};
 use ironrdp_pdu::utils::CharacterSet;
 use ironrdp_pdu::{custom_err, other_err, PduResult};
 use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
@@ -35,7 +35,6 @@ use uuid::Uuid;
 /// `ScardBackend` implements the smartcard device redirection backend as described in [\[MS-RDPESC\]: Remote Desktop Protocol: Smart Card Virtual Channel Extension]
 ///
 /// [\[MS-RDPESC\]: Remote Desktop Protocol: Smart Card Virtual Channel Extension]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/0428ca28-b4dc-46a3-97c3-01887fa44a90
-#[derive(Debug)]
 pub struct ScardBackend {
     client_handle: ClientHandle,
     /// contexts holds all the active contexts for the server, established using
@@ -47,6 +46,21 @@ pub struct ScardBackend {
     cert_der: Vec<u8>,
     key_der: Vec<u8>,
     pin: String,
+}
+
+impl std::fmt::Debug for ScardBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScardBackend")
+            .field("client_handle", &self.client_handle)
+            .field("contexts", &self.contexts)
+            .field("uuid", &self.uuid)
+            .field("cert_der", &util::vec_u8_debug(&self.cert_der))
+            // Important we don't leak key_der to the logs.
+            .field("key_der", &util::vec_u8_debug(&self.key_der))
+            // Out of an abundance of caution, don't leak the PIN to the logs.
+            .field("pin", &util::str_debug(&self.pin))
+            .finish()
+    }
 }
 
 impl ScardBackend {

--- a/lib/srv/desktop/rdp/rdpclient/src/util.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/util.rs
@@ -59,6 +59,10 @@ pub fn vec_u8_debug(v: &[u8]) -> String {
     format!("&[u8] of length {}", v.len())
 }
 
+pub fn str_debug(s: &str) -> String {
+    format!("&str of length {}", s.len())
+}
+
 /// # Safety
 ///
 /// s must be a C-style null terminated string.


### PR DESCRIPTION
Updates IronRDP to latest with the changes necessary to keep up with the changes in https://github.com/Devolutions/IronRDP/pull/328. We select the `"rustls"` feature explicitly now, this is in line with our implicit choice of it as [the default](https://github.com/Devolutions/IronRDP/pull/325/files#diff-1f64036f3e460819b2b1e954803b7f266feca0e2787ca0614ae1253323944f59L19) before these latest changes.

Also creates a custom debug for `ScardBackend` so as to not leak `key_der` in the logs.