### PR TITLE
docs: fix google cloud image for cloud api access

### DIFF
--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -191,7 +191,7 @@ $ gcloud compute instances create teleport-app-service \
    --service-account=teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
    --scopes=cloud-platform \
    --zone=<Var name="google-cloud-zone" /> \
-   --image=https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2210-kinetic-arm64-v20230113
+   --image=https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20231212
 ```
 
 You must use the `service-account` and `scopes` flags as we list them here,


### PR DESCRIPTION
Fixes #31577. This now refers to a bootable, LTS Linux release.