### PR TITLE
AWSOIDC: Fix Session generator based on AWS OIDC Token

### DIFF
--- a/lib/integrations/awsoidc/clientsv1.go
+++ b/lib/integrations/awsoidc/clientsv1.go
@@ -85,11 +85,14 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 		return nil, trace.Wrap(err)
 	}
 
-	token, err := client.GenerateAWSOIDCToken(ctx, types.GenerateAWSOIDCTokenRequest{
-		Issuer: issuer,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// AWS SDK calls FetchToken everytime the session is no longer valid (or there's no session).
+	// Generating a token here and using it as a Static would make this token valid for the Max Duration Session for the current AWS Role (usually, 1 hour).
+	// Instead, it generates a token everytime the Session's client requests a new token, ensuring it always receives a fresh one.
+	var integrationTokenFetcher IntegrationTokenFetcher = func(ctx context.Context) ([]byte, error) {
+		token, err := client.GenerateAWSOIDCToken(ctx, types.GenerateAWSOIDCTokenRequest{
+			Issuer: issuer,
+		})
+		return []byte(token), trace.Wrap(err)
 	}
 
 	stsSTS := sts.New(sess)
@@ -97,7 +100,7 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 		stsSTS,
 		awsOIDCIntegration.RoleARN,
 		"",
-		IdentityToken(token),
+		integrationTokenFetcher,
 	)
 	awsCredentials := credentials.NewCredentials(roleProvider)
 
@@ -115,4 +118,14 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 	}
 
 	return session, nil
+}
+
+// IntegrationTokenFetcher handles dynamic token generation using a callback function.
+// Useful to embed as a [stscreds.TokenFetcher].
+type IntegrationTokenFetcher func(context.Context) ([]byte, error)
+
+// FetchToken returns a token by calling the callback function.
+func (genFn IntegrationTokenFetcher) FetchToken(ctx context.Context) ([]byte, error) {
+	token, err := genFn(ctx)
+	return token, trace.Wrap(err)
 }

--- a/lib/integrations/awsoidc/clientsv1_test.go
+++ b/lib/integrations/awsoidc/clientsv1_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -31,8 +32,9 @@ import (
 )
 
 type mockIntegrationsTokenGenerator struct {
-	proxies      []types.Server
-	integrations map[string]types.Integration
+	proxies         []types.Server
+	integrations    map[string]types.Integration
+	tokenCallsCount int
 }
 
 // GetIntegration returns the specified integration resources.
@@ -51,7 +53,8 @@ func (m *mockIntegrationsTokenGenerator) GetProxies() ([]types.Server, error) {
 
 // GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
 func (m *mockIntegrationsTokenGenerator) GenerateAWSOIDCToken(ctx context.Context, req types.GenerateAWSOIDCTokenRequest) (string, error) {
-	return "token-goes-here", nil
+	m.tokenCallsCount++
+	return uuid.NewString(), nil
 }
 
 func TestNewSessionV1(t *testing.T) {
@@ -77,6 +80,7 @@ func TestNewSessionV1(t *testing.T) {
 		name             string
 		region           string
 		integration      string
+		tokenFetchCount  int
 		expectedErr      require.ErrorAssertionFunc
 		sessionValidator func(*testing.T, *session.Session)
 	}{
@@ -109,6 +113,7 @@ func TestNewSessionV1(t *testing.T) {
 			if tt.sessionValidator != nil {
 				tt.sessionValidator(t, awsSessionOut)
 			}
+			require.Zero(t, tt.tokenFetchCount)
 		})
 	}
 


### PR DESCRIPTION
The Session was being created with a static Token.
This means that it would work for short-lived contexts.

However, for long-lived clients (eg Auto-Discovery), this token must be regenerated every-time the SDK Service deems necessary
Eg, when it expires