### PR TITLE
fix: Make use of GetWebSessionRequest.User

### DIFF
--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -325,6 +325,11 @@ func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (
 		return nil, trace.Wrap(err)
 	}
 
+	// Make sure the requested user matches the session user.
+	if req.User != session.GetUser() {
+		return nil, trace.NotFound("session not found")
+	}
+
 	return session, trace.Wrap(err)
 }
 


### PR DESCRIPTION
The GetWebSessionRequest.User field is set by callers and required by [GetWebSessionRequest.Check()][1], but its contents are never actually used.

There are two possible avenues: remove the field or make use of its contents. This PR chooses the latter for an added check when reading sessions.

Changelog: Verify expected owner when reading sessions from storage.

[1]: https://github.com/gravitational/teleport/blob/435483e9a38143eaa48d8147e6304b168e463ffd/api/types/session.go#L661-L663