### PR TITLE
fix: Avoid redundant session lookups

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2067,7 +2067,6 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 	clientMeta := clientMetaFromReq(r)
 
 	var webSession types.WebSession
-
 	switch cap.GetSecondFactor() {
 	case constants.SecondFactorOff:
 		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, clientMeta)
@@ -2108,7 +2107,7 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.Wrap(err)
 	}
 
-	ctx, err := h.auth.newSessionContext(r.Context(), req.User, webSession.GetName())
+	ctx, err := h.auth.newSessionContextFromSession(r.Context(), webSession)
 	if err != nil {
 		h.log.WithError(err).Warnf("Access attempt denied for user %q.", req.User)
 		return nil, trace.AccessDenied("need auth")
@@ -2267,7 +2266,7 @@ func (h *Handler) changeUserAuthentication(w http.ResponseWriter, r *http.Reques
 	}
 
 	sess := res.WebSession
-	ctx, err := h.auth.newSessionContext(r.Context(), sess.GetUser(), sess.GetName())
+	ctx, err := h.auth.newSessionContextFromSession(r.Context(), sess)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2503,7 +2502,7 @@ func (h *Handler) mfaLoginFinishSession(w http.ResponseWriter, r *http.Request, 
 		return nil, trace.Wrap(err)
 	}
 
-	ctx, err := h.auth.newSessionContext(r.Context(), user, session.GetName())
+	ctx, err := h.auth.newSessionContextFromSession(r.Context(), session)
 	if err != nil {
 		return nil, trace.AccessDenied("need auth")
 	}


### PR DESCRIPTION
Avoid redundant session lookups when the webapi already holds a complete session.

In a handful of methods the webapi calls [newSessionContext][1] using the ID of a "complete" session it already holds. Those calls go all the way to Auth and [cause the session to be re-read from storage][1], for no apparent reason.

Changelog: Avoid redundant session lookups

[1]: https://github.com/gravitational/teleport/blob/435483e9a38143eaa48d8147e6304b168e463ffd/lib/web/sessions.go#L950
[2]: https://github.com/gravitational/teleport/blob/435483e9a38143eaa48d8147e6304b168e463ffd/lib/auth/methods.go#L544-L553