### PR TITLE
Adds Rust and wasm-pack to Dockerfile-arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1222,6 +1222,10 @@ enter/grpcbox:
 enter/node:
 	make -C build.assets enter/node
 
+.PHONY:enter/arm
+enter/arm:
+	make -C build.assets enter/arm
+
 BUF := buf
 
 # protos/all runs build, lint and format on all protos.

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -23,25 +23,25 @@ ARG BUILDARCH
 
 RUN apt-get -y update && \
     apt-get install -q -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        gzip \
-        libc6-dev \
-        libpam-dev \
-        locales \
-        pkg-config \
-        sudo \
-        unzip \
-        zip \
-        # ARM dependencies
-        gcc-arm-linux-gnueabihf \
-        libc6-dev-armhf-cross \
-        # ARM64 dependencies
-        gcc-aarch64-linux-gnu \
-        libc6-dev-arm64-cross \
-        && \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gzip \
+    libc6-dev \
+    libpam-dev \
+    locales \
+    pkg-config \
+    sudo \
+    unzip \
+    zip \
+    # ARM dependencies
+    gcc-arm-linux-gnueabihf \
+    libc6-dev-armhf-cross \
+    # ARM64 dependencies
+    gcc-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
@@ -73,7 +73,6 @@ ENV GOPATH="/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Add the CI user.
-# This images is not used in CI, but because we used to use it in CI, we keep the same UID/GID and name.
 ARG UID
 ARG GID
 RUN groupadd ci --gid="$GID" -o && \
@@ -82,3 +81,23 @@ RUN groupadd ci --gid="$GID" -o && \
     chown -R ci /var/lib/teleport
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]
+
+# Install Rust.
+ARG RUST_VERSION
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version
+
+# Install wasm-pack for targeting WebAssembly from Rust.
+ARG WASM_PACK_VERSION
+RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -191,8 +191,6 @@ buildbox-centos7-fips:
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds
-# ARM buildboxes use a regular Teleport buildbox as a base which already has a user
-# with the correct UID and GID created, so those arguments are not needed here.
 #
 .PHONY:buildbox-arm
 buildbox-arm:
@@ -206,6 +204,8 @@ buildbox-arm:
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -397,6 +397,14 @@ enter/grpcbox: grpcbox
 enter/node: buildbox-node
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
 		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_NODE) /bin/bash
+
+#
+# Starts shell inside the arm build container
+#
+.PHONY:enter/arm
+enter/arm: buildbox-arm
+	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_ARM) /bin/bash
 
 # #############################################################################
 # Architecture and variant (fips) specific release targets


### PR DESCRIPTION
In trying to integrate IronRDP with Teleport's CI, I've bumped into [this failure](https://github.com/gravitational/teleport.e/actions/runs/7204188324/job/19625223758#step:11:871) in `teleport-buildbox-arm`.

Of noote is that we're only using this Dockerfile to build Teleport without desktop access support, which means that before these IronRDP changes we didn't need Rust installed. However because our web client can't currently be broken down feature-by-feature, and because the desktop access part of the client now relies on Rust/wasm-pack, we now need to add this in order to get builds to succeed.