### PR TITLE
[v14] fix: Update TLS and SSH certificate proto comments

### DIFF
--- a/api/client/proto/certs.pb.go
+++ b/api/client/proto/certs.pb.go
@@ -25,9 +25,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Set of certificates corresponding to a single public key.
 type Certs struct {
-	// SSH X509 cert (PEM-encoded).
+	// SSH certificate marshaled in the authorized key format.
 	SSH []byte `protobuf:"bytes,1,opt,name=SSH,proto3" json:"ssh,omitempty"`
-	// TLS X509 cert (PEM-encoded).
+	// TLS X.509 certificate (PEM-encoded).
 	TLS []byte `protobuf:"bytes,2,opt,name=TLS,proto3" json:"tls,omitempty"`
 	// TLSCACerts is a list of TLS certificate authorities.
 	TLSCACerts [][]byte `protobuf:"bytes,3,rep,name=TLSCACerts,proto3" json:"tls_ca_certs,omitempty"`

--- a/api/proto/teleport/legacy/client/proto/certs.proto
+++ b/api/proto/teleport/legacy/client/proto/certs.proto
@@ -25,9 +25,9 @@ option (gogoproto.unmarshaler_all) = true;
 
 // Set of certificates corresponding to a single public key.
 message Certs {
-  // SSH X509 cert (PEM-encoded).
+  // SSH certificate marshaled in the authorized key format.
   bytes SSH = 1 [(gogoproto.jsontag) = "ssh,omitempty"];
-  // TLS X509 cert (PEM-encoded).
+  // TLS X.509 certificate (PEM-encoded).
   bytes TLS = 2 [(gogoproto.jsontag) = "tls,omitempty"];
   // TLSCACerts is a list of TLS certificate authorities.
   repeated bytes TLSCACerts = 3 [(gogoproto.jsontag) = "tls_ca_certs,omitempty"];

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -3585,11 +3585,12 @@ message WebSessionV2 {
 message WebSessionSpecV2 {
   // User is the identity of the user to which the web session belongs.
   string User = 1 [(gogoproto.jsontag) = "user"];
-  // Pub is the SSH certificate for the user.
+  // Pub is the SSH certificate for the user, marshaled in the authorized key
+  // format.
   bytes Pub = 2 [(gogoproto.jsontag) = "pub"];
   // Priv is the SSH private key for the user.
   bytes Priv = 3 [(gogoproto.jsontag) = "priv,omitempty"];
-  // TLSCert is the TLS certificate for the user.
+  // TLSCert is the X.509 certificate for the user (PEM-encoded).
   bytes TLSCert = 4 [(gogoproto.jsontag) = "tls_cert,omitempty"];
   // BearerToken is a token that is paired with the session cookie for
   // authentication. It is periodically rotated so a stolen cookie itself

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -9118,11 +9118,12 @@ var xxx_messageInfo_WebSessionV2 proto.InternalMessageInfo
 type WebSessionSpecV2 struct {
 	// User is the identity of the user to which the web session belongs.
 	User string `protobuf:"bytes,1,opt,name=User,proto3" json:"user"`
-	// Pub is the SSH certificate for the user.
+	// Pub is the SSH certificate for the user, marshaled in the authorized key
+	// format.
 	Pub []byte `protobuf:"bytes,2,opt,name=Pub,proto3" json:"pub"`
 	// Priv is the SSH private key for the user.
 	Priv []byte `protobuf:"bytes,3,opt,name=Priv,proto3" json:"priv,omitempty"`
-	// TLSCert is the TLS certificate for the user.
+	// TLSCert is the X.509 certificate for the user (PEM-encoded).
 	TLSCert []byte `protobuf:"bytes,4,opt,name=TLSCert,proto3" json:"tls_cert,omitempty"`
 	// BearerToken is a token that is paired with the session cookie for
 	// authentication. It is periodically rotated so a stolen cookie itself


### PR DESCRIPTION
Backport #35722 to branch/v14

Update and fix a few certificate-related comments.