### PR TITLE
[v12] Return the correct errors to users when an mfa ceremony fails

### DIFF
--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1176,6 +1177,10 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 		}
 	}
 
+	abortedChallenge := func(ctx context.Context, realOrigin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, _ *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+		return nil, "", errors.New("aborted challenge")
+	}
+
 	cases := []struct {
 		name            string
 		target          string
@@ -1388,6 +1393,30 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			},
 			mfaPromptCount: 1,
 			errAssertion:   require.Error,
+		},
+		{
+			name: "aborted ceremony when role requires per session mfa",
+			authPreference: &types.AuthPreferenceV2{
+				Spec: types.AuthPreferenceSpecV2{
+					Type:         constants.Local,
+					SecondFactor: constants.SecondFactorOptional,
+					Webauthn: &types.Webauthn{
+						RPID: "localhost",
+					},
+				},
+			},
+			proxyAddr:       rootProxyAddr.String(),
+			auth:            rootAuth.GetAuthServer(),
+			target:          sshHostID,
+			roles:           []string{perSessionMFARole.GetName()},
+			webauthnLogin:   abortedChallenge,
+			stdoutAssertion: require.Empty,
+			stderrAssertion: func(t require.TestingT, v any, i ...any) {
+				out, ok := v.(string)
+				require.True(t, ok, i...)
+				require.Contains(t, out, "failed to authenticate using all MFA devices", i...)
+			},
+			errAssertion: require.Error,
 		},
 		{
 			name: "mfa ceremony prevented when using headless auth",


### PR DESCRIPTION
Backport #35581 to branch/v12. There were some manual changes made here to accommodate for changes to lib/client.

changelog: Prevent tsh from re-authenticating if the mfa ceremony fails during tsh ssh