### PR TITLE
export all tls keypairs with tctl or webapi

### DIFF
--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -220,7 +220,7 @@ func exportAuth(ctx context.Context, client auth.ClientI, req ExportAuthoritiesR
 			case types.HostCA:
 				castr, err = hostCAFormat(ca, key.PublicKey, client)
 			default:
-				return "", trace.BadParameter("unknown user type: %q", ca.GetType())
+				return "", trace.BadParameter("unknown CA type: %q", ca.GetType())
 			}
 			if err != nil {
 				return "", trace.Wrap(err)

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -164,20 +164,6 @@ func TestExportAuthorities(t *testing.T) {
 				name: "fingerprint not found",
 				req: ExportAuthoritiesRequest{
 					AuthType:                   "user",
-					ExportAuthorityFingerprint: "not found fingerprint",
-				},
-				errorCheck: require.NoError,
-				assertNoSecrets: func(t *testing.T, output string) {
-					require.Empty(t, output)
-				},
-				assertSecrets: func(t *testing.T, output string) {
-					require.Empty(t, output)
-				},
-			},
-			{
-				name: "fingerprint not found",
-				req: ExportAuthoritiesRequest{
-					AuthType:                   "user",
 					ExportAuthorityFingerprint: "fake fingerprint",
 				},
 				errorCheck: require.NoError,

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -83,7 +83,7 @@ func TestExportAuthorities(t *testing.T) {
 	validateTLSCertificatesDERFunc := func(wantCount int) func(*testing.T, [][]byte) {
 		return func(t *testing.T, output [][]byte) {
 			t.Helper()
-			require.Equal(t, wantCount, len(output), "expected %v der encoded cert(s)", wantCount)
+			require.Len(t, wantCount, len(output), "expected %v der encoded cert(s)", wantCount)
 			for _, cert := range output {
 				validateTLSCert(t, cert)
 			}
@@ -114,7 +114,7 @@ func TestExportAuthorities(t *testing.T) {
 	validatePrivateKeysDERFunc := func(wantCount int) func(*testing.T, [][]byte) {
 		return func(t *testing.T, output [][]byte) {
 			t.Helper()
-			require.Equal(t, wantCount, len(output), "expected %v der encoded private key(s)", wantCount)
+			require.Len(t, wantCount, len(output), "expected %v der encoded private key(s)", wantCount)
 			for _, key := range output {
 				validatePrivateKey(t, key)
 			}

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -83,7 +83,7 @@ func TestExportAuthorities(t *testing.T) {
 	validateTLSCertificatesDERFunc := func(wantCount int) func(*testing.T, [][]byte) {
 		return func(t *testing.T, output [][]byte) {
 			t.Helper()
-			require.Len(t, wantCount, len(output), "expected %v der encoded cert(s)", wantCount)
+			require.Len(t, output, wantCount, "expected %v der encoded cert(s)", wantCount)
 			for _, cert := range output {
 				validateTLSCert(t, cert)
 			}
@@ -114,7 +114,7 @@ func TestExportAuthorities(t *testing.T) {
 	validatePrivateKeysDERFunc := func(wantCount int) func(*testing.T, [][]byte) {
 		return func(t *testing.T, output [][]byte) {
 			t.Helper()
-			require.Len(t, wantCount, len(output), "expected %v der encoded private key(s)", wantCount)
+			require.Len(t, output, wantCount, "expected %v der encoded private key(s)", wantCount)
 			for _, key := range output {
 				validatePrivateKey(t, key)
 			}

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -222,7 +222,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 	// dump user identity into a single file:
 	case FormatFile:
 		filesWritten = append(filesWritten, cfg.OutputPath)
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -265,7 +265,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		keyPath := cfg.OutputPath
 		certPath := keypaths.IdentitySSHCertPath(keyPath)
 		filesWritten = append(filesWritten, keyPath, certPath)
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -283,7 +283,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		for k, cert := range cfg.Key.WindowsDesktopCerts {
 			certPath := cfg.OutputPath + "." + k + ".der"
 			filesWritten = append(filesWritten, certPath)
-			if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, certPath); err != nil {
+			if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, certPath); err != nil {
 				return nil, trace.Wrap(err)
 			}
 
@@ -306,7 +306,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 		filesWritten = append(filesWritten, keyPath, certPath, casPath)
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -335,7 +335,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		certPath := cfg.OutputPath + ".crt"
 		casPath := cfg.OutputPath + ".cas"
 		filesWritten = append(filesWritten, certPath, casPath)
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		err = writer.WriteFile(certPath, append(cfg.Key.TLSCert, cfg.Key.PrivateKeyPEM()...), identityfile.FilePermissions)
@@ -356,7 +356,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		pubPath := cfg.OutputPath + ".pub"
 		filesWritten = append(filesWritten, pubPath)
 
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, pubPath); err != nil {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, pubPath); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -401,7 +401,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		filesWritten = append(filesWritten, cfg.OutputPath)
 		// If the user does not want to override, it will merge the previous kubeconfig
 		// with the new entry.
-		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil && !trace.IsAlreadyExists(err) {
+		if err := CheckOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil && !trace.IsAlreadyExists(err) {
 			return nil, trace.Wrap(err)
 		} else if err == nil {
 			// Clean up the existing file, if it exists.
@@ -642,7 +642,7 @@ func prepareCassandraKeystore(cfg WriteConfig) (*bytes.Buffer, error) {
 	return &buff, nil
 }
 
-func checkOverwrite(ctx context.Context, writer ConfigWriter, force bool, paths ...string) error {
+func CheckOverwrite(ctx context.Context, writer ConfigWriter, force bool, paths ...string) error {
 	var existingFiles []string
 	// Check if the destination file exists.
 	for _, path := range paths {

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -150,10 +150,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "valid --proxy URL with valid URL scheme",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				proxyAddr:     "https://proxy-from-flag.example.com",
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				proxyAddr:       "https://proxy-from-flag.example.com",
 			},
 			wantAddr:  "https://proxy-from-flag.example.com",
 			assertErr: require.NoError,
@@ -162,10 +162,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "valid --proxy URL with invalid URL scheme",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				proxyAddr:     "file://proxy-from-flag.example.com",
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				proxyAddr:       "file://proxy-from-flag.example.com",
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
 				require.Error(t, err)
@@ -176,10 +176,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "valid --proxy URL without URL scheme",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				proxyAddr:     "proxy-from-flag.example.com",
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				proxyAddr:       "proxy-from-flag.example.com",
 			},
 			wantAddr:  "https://proxy-from-flag.example.com",
 			assertErr: require.NoError,
@@ -188,10 +188,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "invalid --proxy URL",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				proxyAddr:     "1https://proxy-from-flag.example.com",
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				proxyAddr:       "1https://proxy-from-flag.example.com",
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
 				require.Error(t, err)
@@ -202,9 +202,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "k8s proxy running locally with public_addr",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{Kube: servicecfg.KubeProxyConfig{
 					Enabled:     true,
 					PublicAddrs: []utils.NetAddr{{Addr: "proxy-from-config.example.com:3026"}},
@@ -217,9 +217,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "k8s proxy running locally without public_addr",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{
 					Kube: servicecfg.KubeProxyConfig{
 						Enabled: true,
@@ -234,9 +234,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "k8s proxy from cluster info",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{
 					Kube: servicecfg.KubeProxyConfig{
 						Enabled: false,
@@ -251,10 +251,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "--kube-cluster specified with valid cluster",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				leafCluster:   remoteCluster.GetMetadata().Name,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				leafCluster:     remoteCluster.GetMetadata().Name,
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{
 					Kube: servicecfg.KubeProxyConfig{
 						Enabled: false,
@@ -270,10 +270,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "--kube-cluster specified with invalid cluster",
 			client: newSeparatedCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
-				leafCluster:   "doesnotexist.example.com",
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
+				leafCluster:     "doesnotexist.example.com",
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{
 					Kube: servicecfg.KubeProxyConfig{
 						Enabled: false,
@@ -290,9 +290,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "k8s proxy running locally in multiplex mode without public_addr",
 			client: newMultiplexCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
 				config: &servicecfg.Config{
 					Auth: servicecfg.AuthConfig{
 						NetworkingConfig: &types.ClusterNetworkingConfigV2{
@@ -313,9 +313,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			desc:   "k8s proxy from cluster info with multiplex mode",
 			client: newMultiplexCluster(),
 			ac: AuthCommand{
-				output:        filepath.Join(t.TempDir(), "kubeconfig"),
-				outputFormat:  identityfile.FormatKubernetes,
-				signOverwrite: true,
+				output:          filepath.Join(t.TempDir(), "kubeconfig"),
+				outputFormat:    identityfile.FormatKubernetes,
+				outputOverwrite: true,
 				config: &servicecfg.Config{Proxy: servicecfg.ProxyConfig{
 					Kube: servicecfg.KubeProxyConfig{
 						Enabled: false,
@@ -686,11 +686,11 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ac := AuthCommand{
-				output:        filepath.Join(test.inOutDir, test.inOutFile),
-				outputFormat:  test.inFormat,
-				signOverwrite: true,
-				genHost:       test.inHost,
-				genTTL:        time.Hour,
+				output:          filepath.Join(test.inOutDir, test.inOutFile),
+				outputFormat:    test.inFormat,
+				outputOverwrite: true,
+				genHost:         test.inHost,
+				genTTL:          time.Hour,
 			}
 
 			err = ac.generateDatabaseKeysForKey(context.Background(), authClient, key)
@@ -800,11 +800,11 @@ func TestGenerateAppCertificates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			output := filepath.Join(tc.outDir, tc.outFileBase)
 			ac := AuthCommand{
-				output:        output,
-				outputFormat:  identityfile.FormatTLS,
-				signOverwrite: true,
-				genTTL:        time.Hour,
-				appName:       tc.appName,
+				output:          output,
+				outputFormat:    identityfile.FormatTLS,
+				outputOverwrite: true,
+				genTTL:          time.Hour,
+				appName:         tc.appName,
 			}
 			err = ac.generateUserKeys(context.Background(), authClient)
 			tc.assertErr(t, err)
@@ -929,13 +929,13 @@ func TestGenerateDatabaseUserCertificates(t *testing.T) {
 			certsDir := t.TempDir()
 			output := filepath.Join(certsDir, test.dbService)
 			ac := AuthCommand{
-				output:        output,
-				outputFormat:  identityfile.FormatTLS,
-				signOverwrite: true,
-				genTTL:        time.Hour,
-				dbService:     test.dbService,
-				dbName:        test.dbName,
-				dbUser:        test.dbUser,
+				output:          output,
+				outputFormat:    identityfile.FormatTLS,
+				outputOverwrite: true,
+				genTTL:          time.Hour,
+				dbService:       test.dbService,
+				dbName:          test.dbName,
+				dbUser:          test.dbUser,
 			}
 
 			err = ac.generateUserKeys(ctx, authClient)
@@ -1028,11 +1028,11 @@ func TestGenerateAndSignKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ac := AuthCommand{
-				output:        filepath.Join(test.inOutDir, test.inOutFile),
-				outputFormat:  test.inFormat,
-				signOverwrite: true,
-				genHost:       test.inHost,
-				genTTL:        time.Hour,
+				output:          filepath.Join(test.inOutDir, test.inOutFile),
+				outputFormat:    test.inFormat,
+				outputOverwrite: true,
+				genHost:         test.inHost,
+				genTTL:          time.Hour,
 			}
 
 			err = ac.GenerateAndSignKeys(context.Background(), authClient)

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -165,10 +165,13 @@ func runUserCommand(t *testing.T, fc *config.FileConfig, args []string, opts ...
 	return runCommand(t, fc, command, args, opts...)
 }
 
-func runAuthCommand(t *testing.T, fc *config.FileConfig, args []string, opts ...optionsFunc) error {
-	command := &AuthCommand{}
+func runAuthCommand(t *testing.T, fc *config.FileConfig, args []string, opts ...optionsFunc) (*bytes.Buffer, error) {
+	var stdoutBuff bytes.Buffer
+	command := &AuthCommand{
+		stdout: &stdoutBuff,
+	}
 	args = append([]string{"auth"}, args...)
-	return runCommand(t, fc, command, args, opts...)
+	return &stdoutBuff, runCommand(t, fc, command, args, opts...)
 }
 
 func mustDecodeJSON[T any](t *testing.T, r io.Reader) T {
@@ -223,7 +226,7 @@ func mustAddUser(t *testing.T, fc *config.FileConfig, username string, roles ...
 
 func mustWriteIdentityFile(t *testing.T, fc *config.FileConfig, username string) string {
 	identityFilePath := filepath.Join(t.TempDir(), "identity")
-	err := runAuthCommand(t, fc, []string{"sign", "--user", username, "--out", identityFilePath})
+	_, err := runAuthCommand(t, fc, []string{"sign", "--user", username, "--out", identityFilePath})
 	require.NoError(t, err)
 	return identityFilePath
 }


### PR DESCRIPTION
fixes #35444

changelog: All trusted TLS certs for a given CA are now exported when using `tctl auth export --type=<ca>` or `curl https://<proxy>/webapi/auth/export?type=<ca>`, rather than only one active cert.

If you `tctl auth export` multiple certs/keys in der format, you must provide an `--out/-o=<filename>` flag, because concatenated DER doesn't make sense.
Similar to the `tctl auth sign` command, the path given as --out is used to build the full name of the output file(s), i.e.:
`tctl auth export --out=/path/to/filename` results in these files:
- `/path/to/filename-0.cer`
- `/path/to/filename-1.cer`

Whereas when there is only one file to output, it just adds the file extension like: `/path/to/filename.cer`.

With the webapi, when there are multiple DER format certs to export, it creates a compressed archive attachment.
For `db-der` and `tls-user-der`, that will be a .tar.gz file.
For windows, it's a .zip file.

The archive contents will be named as:
- `teleport-ca-0.cer`
- `teleport-ca-1.cer`
- ...etc...

Browsers get a normal download popup.
Curl needs -o or -OJ when downloading the DER attachments since they're binary.

