### PR TITLE
Increase enhanced recording `session.command` arguments max size.

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -373,7 +373,15 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 		}
 
 		argv := (*C.char)(unsafe.Pointer(&event.Argv))
-		buf = append(buf, C.GoString(argv))
+		argvStr := C.GoString(argv)
+		// Large arguments come in multiple events, those are tracked with a
+		// sequence number.
+		if event.Seq > 0 && len(buf) > 0 {
+			buf[len(buf)-1] += argvStr
+		} else {
+			buf = append(buf, argvStr)
+		}
+
 		s.argsCache.Set(strconv.FormatUint(event.PID, 10), buf, 24*time.Hour)
 	// The event has returned, emit the fully parsed event.
 	case eventRet:

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -68,6 +68,10 @@ type rawExecEvent struct {
 
 	// CgroupID is the internal cgroupv2 ID of the event.
 	CgroupID uint64
+
+	// Seq is the argument sequence number. This is used to keep track of large
+	// arguments.
+	Seq int32
 }
 
 type exec struct {


### PR DESCRIPTION
Closes #34686.

changelog: Increase the maximum size of `session.command` audit event's path and argv.

This PR changes the enhanced recording command path/arguments reading to increase their maximum size.

The updated BPF function `__submit_arg` now utilizes `bpf_probe_read_user_str` to read arguments. This function reads a string and returns the number of bytes read. With this information, we can determine if additional reads are necessary to obtain the full parameter. Each "slice" of the argument is sent as a separate event to Golang.

A sequence reference is used to keep track of large arguments. There is no need to track the argument position since the ring buffer events are delivered in order.

Note: Despite this change, we still need to establish a maximum argument size due to the constraints of BPF programs.

Tested systems (running and executing BPF tests):
- EC2 instance (ARM) with Ubuntu 22.04: `Linux xxx 6.2.0-1012-aws aarch64 aarch64 aarch64 GNU/Linux`
- EC2 instance with Ubuntu 22.04: `Linux xxx 6.2.0-1017-aws x86_64 x86_64 x86_64 GNU/Linux`