### PR TITLE
Add `vpc-id` label to RDS Auto-Discover converter

### DIFF
--- a/lib/cloud/mocks/aws_rds.go
+++ b/lib/cloud/mocks/aws_rds.go
@@ -322,10 +322,15 @@ func applyInstanceFilters(in []*rds.DBInstance, filters []*rds.Filter) ([]*rds.D
 	}
 	var out []*rds.DBInstance
 	efs := engineFilterSet(filters)
+	clusterIDs := clusterIdentifierFilterSet(filters)
 	for _, instance := range in {
-		if instanceEngineMatches(instance, efs) {
-			out = append(out, instance)
+		if len(efs) > 0 && !instanceEngineMatches(instance, efs) {
+			continue
 		}
+		if len(clusterIDs) > 0 && !instanceClusterIDMatches(instance, clusterIDs) {
+			continue
+		}
+		out = append(out, instance)
 	}
 	return out, nil
 }
@@ -347,9 +352,18 @@ func applyClusterFilters(in []*rds.DBCluster, filters []*rds.Filter) ([]*rds.DBC
 
 // engineFilterSet builds a string set of engine names from a list of RDS filters.
 func engineFilterSet(filters []*rds.Filter) map[string]struct{} {
+	return filterValues(filters, "engine")
+}
+
+// clusterIdentifierFilterSet builds a string set of ClusterIDs from a list of RDS filters.
+func clusterIdentifierFilterSet(filters []*rds.Filter) map[string]struct{} {
+	return filterValues(filters, "db-cluster-id")
+}
+
+func filterValues(filters []*rds.Filter, filterKey string) map[string]struct{} {
 	out := make(map[string]struct{})
 	for _, f := range filters {
-		if aws.StringValue(f.Name) != "engine" {
+		if aws.StringValue(f.Name) != filterKey {
 			continue
 		}
 		for _, v := range f.Values {
@@ -362,6 +376,12 @@ func engineFilterSet(filters []*rds.Filter) map[string]struct{} {
 // instanceEngineMatches returns whether an RDS DBInstance engine matches any engine name in a filter set.
 func instanceEngineMatches(instance *rds.DBInstance, filterSet map[string]struct{}) bool {
 	_, ok := filterSet[aws.StringValue(instance.Engine)]
+	return ok
+}
+
+// instanceClusterIDMatches returns whether an RDS DBInstance ClusterID matches any ClusterID in a filter set.
+func instanceClusterIDMatches(instance *rds.DBInstance, filterSet map[string]struct{}) bool {
+	_, ok := filterSet[aws.StringValue(instance.DBClusterIdentifier)]
 	return ok
 }
 

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -318,6 +318,7 @@ func TestListDatabases(t *testing.T) {
 							"engine-version":     "",
 							"region":             "",
 							"status":             "available",
+							"vpc-id":             "vpc-999",
 							"teleport.dev/cloud": "AWS",
 						},
 					},

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -698,6 +698,9 @@ func labelsFromRDSV2Instance(rdsInstance *rdsTypesV2.DBInstance, meta *types.AWS
 	labels[types.DiscoveryLabelEngineVersion] = aws.StringValue(rdsInstance.EngineVersion)
 	labels[types.DiscoveryLabelEndpointType] = string(RDSEndpointTypeInstance)
 	labels[types.DiscoveryLabelStatus] = aws.StringValue(rdsInstance.DBInstanceStatus)
+	if rdsInstance.DBSubnetGroup != nil {
+		labels[types.DiscoveryLabelVPCID] = aws.StringValue(rdsInstance.DBSubnetGroup.VpcId)
+	}
 	return addLabels(labels, libcloudaws.TagsToLabels(rdsInstance.TagList))
 }
 
@@ -720,7 +723,7 @@ func NewDatabaseFromRDSV2Cluster(cluster *rdsTypesV2.DBCluster, firstInstance *r
 	return types.NewDatabaseV3(
 		setAWSDBName(types.Metadata{
 			Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
-			Labels:      labelsFromRDSV2Cluster(cluster, metadata, RDSEndpointTypePrimary),
+			Labels:      labelsFromRDSV2Cluster(cluster, metadata, RDSEndpointTypePrimary, firstInstance),
 		}, aws.StringValue(cluster.DBClusterIdentifier)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
@@ -777,17 +780,20 @@ func MetadataFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster, rdsInstance *rds
 
 // labelsFromRDSV2Cluster creates database labels for the provided RDS cluster.
 // It uses aws sdk v2.
-func labelsFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster, meta *types.AWS, endpointType RDSEndpointType) map[string]string {
+func labelsFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster, meta *types.AWS, endpointType RDSEndpointType, memberInstance *rdsTypesV2.DBInstance) map[string]string {
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelEngine] = aws.StringValue(rdsCluster.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.StringValue(rdsCluster.EngineVersion)
 	labels[types.DiscoveryLabelEndpointType] = string(endpointType)
 	labels[types.DiscoveryLabelStatus] = aws.StringValue(rdsCluster.Status)
+	if memberInstance != nil && memberInstance.DBSubnetGroup != nil {
+		labels[types.DiscoveryLabelVPCID] = aws.StringValue(memberInstance.DBSubnetGroup.VpcId)
+	}
 	return addLabels(labels, libcloudaws.TagsToLabels(rdsCluster.TagList))
 }
 
 // NewDatabaseFromRDSCluster creates a database resource from an RDS cluster (Aurora).
-func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
+func NewDatabaseFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Database, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -799,7 +805,7 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
 	return types.NewDatabaseV3(
 		setAWSDBName(types.Metadata{
 			Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
-			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary, memberInstances),
 		}, aws.StringValue(cluster.DBClusterIdentifier)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
@@ -809,7 +815,7 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
 }
 
 // NewDatabaseFromRDSClusterReaderEndpoint creates a database resource from an RDS cluster reader endpoint (Aurora).
-func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Database, error) {
+func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Database, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -821,7 +827,7 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Data
 	return types.NewDatabaseV3(
 		setAWSDBName(types.Metadata{
 			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
-			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader, memberInstances),
 		}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
@@ -831,7 +837,7 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Data
 }
 
 // NewDatabasesFromRDSClusterCustomEndpoints creates database resources from RDS cluster custom endpoints (Aurora).
-func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Databases, error) {
+func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Databases, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -859,7 +865,7 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Da
 		database, err := types.NewDatabaseV3(
 			setAWSDBName(types.Metadata{
 				Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
-				Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
+				Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom, memberInstances),
 			}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointDetails.ClusterCustomEndpointName),
 			types.DatabaseSpecV3{
 				Protocol: protocol,
@@ -885,7 +891,7 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Da
 
 // NewDatabasesFromRDSCluster creates all database resources from an RDS Aurora
 // cluster.
-func NewDatabasesFromRDSCluster(cluster *rds.DBCluster) (types.Databases, error) {
+func NewDatabasesFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Databases, error) {
 	var errors []error
 	var databases types.Databases
 
@@ -906,7 +912,7 @@ func NewDatabasesFromRDSCluster(cluster *rds.DBCluster) (types.Databases, error)
 
 	// Add a database from primary endpoint, if any writer instances.
 	if cluster.Endpoint != nil && hasWriterInstance {
-		database, err := NewDatabaseFromRDSCluster(cluster)
+		database, err := NewDatabaseFromRDSCluster(cluster, memberInstances)
 		if err != nil {
 			errors = append(errors, err)
 		} else {
@@ -917,7 +923,7 @@ func NewDatabasesFromRDSCluster(cluster *rds.DBCluster) (types.Databases, error)
 	// Add a database from reader endpoint, if any reader instances.
 	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.Endpoints.html#Aurora.Endpoints.Reader
 	if cluster.ReaderEndpoint != nil && hasReaderInstance {
-		database, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
+		database, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster, memberInstances)
 		if err != nil {
 			errors = append(errors, err)
 		} else {
@@ -927,7 +933,7 @@ func NewDatabasesFromRDSCluster(cluster *rds.DBCluster) (types.Databases, error)
 
 	// Add databases from custom endpoints
 	if len(cluster.CustomEndpoints) > 0 {
-		customEndpointDatabases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster)
+		customEndpointDatabases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster, memberInstances)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -1626,15 +1632,21 @@ func labelsFromRDSInstance(rdsInstance *rds.DBInstance, meta *types.AWS) map[str
 	labels[types.DiscoveryLabelEngine] = aws.StringValue(rdsInstance.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.StringValue(rdsInstance.EngineVersion)
 	labels[types.DiscoveryLabelEndpointType] = string(RDSEndpointTypeInstance)
+	if rdsInstance.DBSubnetGroup != nil {
+		labels[types.DiscoveryLabelVPCID] = aws.StringValue(rdsInstance.DBSubnetGroup.VpcId)
+	}
 	return addLabels(labels, libcloudaws.TagsToLabels(rdsInstance.TagList))
 }
 
 // labelsFromRDSCluster creates database labels for the provided RDS cluster.
-func labelsFromRDSCluster(rdsCluster *rds.DBCluster, meta *types.AWS, endpointType RDSEndpointType) map[string]string {
+func labelsFromRDSCluster(rdsCluster *rds.DBCluster, meta *types.AWS, endpointType RDSEndpointType, memberInstances []*rds.DBInstance) map[string]string {
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelEngine] = aws.StringValue(rdsCluster.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.StringValue(rdsCluster.EngineVersion)
 	labels[types.DiscoveryLabelEndpointType] = string(endpointType)
+	if len(memberInstances) > 0 && memberInstances[0].DBSubnetGroup != nil {
+		labels[types.DiscoveryLabelVPCID] = aws.StringValue(memberInstances[0].DBSubnetGroup.VpcId)
+	}
 	return addLabels(labels, libcloudaws.TagsToLabels(rdsCluster.TagList))
 }
 

--- a/lib/srv/db/cloud/resource_checker_url_aws.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/gravitational/trace"
@@ -100,7 +101,7 @@ func (c *urlChecker) checkRDSCluster(ctx context.Context, database types.Databas
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	databases, err := services.NewDatabasesFromRDSCluster(rdsCluster)
+	databases, err := services.NewDatabasesFromRDSCluster(rdsCluster, []*rds.DBInstance{})
 	if err != nil {
 		c.log.Warnf("Could not convert RDS cluster %q to database resources: %v.",
 			aws.StringValue(rdsCluster.DBClusterIdentifier), err)

--- a/lib/srv/db/cloud/resource_checker_url_aws_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws_test.go
@@ -55,7 +55,7 @@ func TestURLChecker_AWS(t *testing.T) {
 		mocks.WithRDSClusterReader,
 		mocks.WithRDSClusterCustomEndpoint("my-custom"),
 	)
-	rdsClusterDBs, err := services.NewDatabasesFromRDSCluster(rdsCluster)
+	rdsClusterDBs, err := services.NewDatabasesFromRDSCluster(rdsCluster, []*rds.DBInstance{})
 	require.NoError(t, err)
 	require.Len(t, rdsClusterDBs, 3) // Primary, reader, custom.
 	testCases = append(testCases, append(rdsClusterDBs, rdsInstanceDB)...)

--- a/lib/srv/discovery/common/renaming_test.go
+++ b/lib/srv/discovery/common/renaming_test.go
@@ -378,7 +378,7 @@ func makeAuroraPrimaryDB(t *testing.T, name, region, accountID, overrideLabel st
 			overrideLabel: name,
 		}),
 	}
-	database, err := services.NewDatabaseFromRDSCluster(cluster)
+	database, err := services.NewDatabaseFromRDSCluster(cluster, []*rds.DBInstance{})
 	require.NoError(t, err)
 	return database
 }

--- a/lib/srv/discovery/fetchers/db/aws_rds_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_test.go
@@ -47,13 +47,13 @@ func TestRDSFetchers(t *testing.T) {
 	rdsInstanceUnavailable, _ := makeRDSInstance(t, "instance-5", "us-west-1", nil, withRDSInstanceStatus("stopped"))
 	rdsInstanceUnknownStatus, rdsDatabaseUnknownStatus := makeRDSInstance(t, "instance-5", "us-west-6", nil, withRDSInstanceStatus("status-does-not-exist"))
 
-	auroraCluster1, auroraDatabase1 := makeRDSCluster(t, "cluster-1", "us-east-1", envProdLabels)
-	auroraCluster2, auroraDatabases2 := makeRDSClusterWithExtraEndpoints(t, "cluster-2", "us-east-2", envDevLabels, true)
-	auroraCluster3, auroraDatabase3 := makeRDSCluster(t, "cluster-3", "us-east-2", envProdLabels)
-	auroraClusterUnsupported, _ := makeRDSCluster(t, "serverless", "us-east-1", nil, withRDSClusterEngineMode("serverless"))
-	auroraClusterUnavailable, _ := makeRDSCluster(t, "cluster-4", "us-east-1", nil, withRDSClusterStatus("creating"))
-	auroraClusterUnknownStatus, auroraDatabaseUnknownStatus := makeRDSCluster(t, "cluster-5", "us-east-1", nil, withRDSClusterStatus("status-does-not-exist"))
-	auroraClusterNoWriter, auroraDatabasesNoWriter := makeRDSClusterWithExtraEndpoints(t, "cluster-6", "us-east-1", envDevLabels, false)
+	auroraCluster1, auroraCluster1MemberInstance, auroraDatabase1 := makeRDSCluster(t, "cluster-1", "us-east-1", envProdLabels)
+	auroraCluster2, auroraCluster2MemberInstance, auroraDatabases2 := makeRDSClusterWithExtraEndpoints(t, "cluster-2", "us-east-2", envDevLabels, true)
+	auroraCluster3, auroraCluster3MemberInstance, auroraDatabase3 := makeRDSCluster(t, "cluster-3", "us-east-2", envProdLabels)
+	auroraClusterUnsupported, _, _ := makeRDSCluster(t, "serverless", "us-east-1", nil, withRDSClusterEngineMode("serverless"))
+	auroraClusterUnavailable, _, _ := makeRDSCluster(t, "cluster-4", "us-east-1", nil, withRDSClusterStatus("creating"))
+	auroraClusterUnknownStatus, auroraClusterUnknownStatusMemberInstance, auroraDatabaseUnknownStatus := makeRDSCluster(t, "cluster-5", "us-east-1", nil, withRDSClusterStatus("status-does-not-exist"))
+	auroraClusterNoWriter, auroraClusterMemberNoWriter, auroraDatabasesNoWriter := makeRDSClusterWithExtraEndpoints(t, "cluster-6", "us-east-1", envDevLabels, false)
 
 	tests := []awsFetcherTest{
 		{
@@ -61,12 +61,12 @@ func TestRDSFetchers(t *testing.T) {
 			inputClients: &cloud.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3},
+						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster1},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
 					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2},
+						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
@@ -94,12 +94,12 @@ func TestRDSFetchers(t *testing.T) {
 			inputClients: &cloud.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3},
+						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster1},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
 					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2},
+						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
@@ -127,12 +127,12 @@ func TestRDSFetchers(t *testing.T) {
 			inputClients: &cloud.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3},
+						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster1},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 					},
 					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2},
+						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
 						DBEngineVersions: []*rds.DBEngineVersion{postgresEngine},
 					},
@@ -157,6 +157,7 @@ func TestRDSFetchers(t *testing.T) {
 			inputClients: &cloud.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &mocks.RDSMock{
+						DBInstances:      []*rds.DBInstance{auroraCluster1MemberInstance},
 						DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnsupported},
 						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 					},
@@ -173,7 +174,7 @@ func TestRDSFetchers(t *testing.T) {
 			name: "skip unavailable databases",
 			inputClients: &cloud.TestCloudClients{
 				RDS: &mocks.RDSMock{
-					DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus},
+					DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus, auroraCluster1MemberInstance, auroraClusterUnknownStatusMemberInstance},
 					DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnavailable, auroraClusterUnknownStatus},
 					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 				},
@@ -190,6 +191,7 @@ func TestRDSFetchers(t *testing.T) {
 			inputClients: &cloud.TestCloudClients{
 				RDS: &mocks.RDSMock{
 					DBClusters:       []*rds.DBCluster{auroraClusterNoWriter},
+					DBInstances:      []*rds.DBInstance{auroraClusterMemberNoWriter},
 					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 				},
 			},
@@ -212,15 +214,29 @@ func makeRDSInstance(t *testing.T, name, region string, labels map[string]string
 	return instance, database
 }
 
-func makeRDSCluster(t *testing.T, name, region string, labels map[string]string, opts ...func(*rds.DBCluster)) (*rds.DBCluster, types.Database) {
+func makeRDSCluster(t *testing.T, name, region string, labels map[string]string, opts ...func(*rds.DBCluster)) (*rds.DBCluster, *rds.DBInstance, types.Database) {
 	cluster := mocks.RDSCluster(name, region, labels, opts...)
-	database, err := services.NewDatabaseFromRDSCluster(cluster)
+	dbInstanceMember := makeRDSMemberForCluster(t, name, region, "vpc-123", *cluster.Engine, labels)
+	database, err := services.NewDatabaseFromRDSCluster(cluster, []*rds.DBInstance{dbInstanceMember})
 	require.NoError(t, err)
 	common.ApplyAWSDatabaseNameSuffix(database, types.AWSMatcherRDS)
-	return cluster, database
+	return cluster, dbInstanceMember, database
 }
 
-func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels map[string]string, hasWriter bool) (*rds.DBCluster, types.Databases) {
+func makeRDSMemberForCluster(t *testing.T, name, region, vpcid, engine string, labels map[string]string) *rds.DBInstance {
+	instanceRDSMember, _ := makeRDSInstance(t, name+"-instance-1", region, labels, func(d *rds.DBInstance) {
+		if d.DBSubnetGroup == nil {
+			d.DBSubnetGroup = &rds.DBSubnetGroup{}
+		}
+		d.DBSubnetGroup.SetVpcId(vpcid)
+		d.DBClusterIdentifier = aws.String(name)
+		d.Engine = aws.String(engine)
+	})
+
+	return instanceRDSMember
+}
+
+func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels map[string]string, hasWriter bool) (*rds.DBCluster, *rds.DBInstance, types.Databases) {
 	cluster := mocks.RDSCluster(name, region, labels,
 		func(cluster *rds.DBCluster) {
 			// Disable writer by default. If hasWriter, writer endpoint will be added below.
@@ -233,28 +249,31 @@ func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels 
 
 	var databases types.Databases
 
+	instanceRDSMember := makeRDSMemberForCluster(t, name, region, "vpc-123", aws.StringValue(cluster.Engine), labels)
+	dbInstanceMembers := []*rds.DBInstance{instanceRDSMember}
+
 	if hasWriter {
 		cluster.DBClusterMembers = append(cluster.DBClusterMembers, &rds.DBClusterMember{
 			IsClusterWriter: aws.Bool(true), // Add writer.
 		})
 
-		primaryDatabase, err := services.NewDatabaseFromRDSCluster(cluster)
+		primaryDatabase, err := services.NewDatabaseFromRDSCluster(cluster, dbInstanceMembers)
 		require.NoError(t, err)
 		databases = append(databases, primaryDatabase)
 	}
 
-	readerDatabase, err := services.NewDatabaseFromRDSClusterReaderEndpoint(cluster)
+	readerDatabase, err := services.NewDatabaseFromRDSClusterReaderEndpoint(cluster, dbInstanceMembers)
 	require.NoError(t, err)
 	databases = append(databases, readerDatabase)
 
-	customDatabases, err := services.NewDatabasesFromRDSClusterCustomEndpoints(cluster)
+	customDatabases, err := services.NewDatabasesFromRDSClusterCustomEndpoints(cluster, dbInstanceMembers)
 	require.NoError(t, err)
 	databases = append(databases, customDatabases...)
 
 	for _, db := range databases {
 		common.ApplyAWSDatabaseNameSuffix(db, types.AWSMatcherRDS)
 	}
-	return cluster, databases
+	return cluster, instanceRDSMember, databases
 }
 
 // withRDSInstanceStatus returns an option function for makeRDSInstance to overwrite status.


### PR DESCRIPTION
This PR adds a new label to RDS Instances and RDS Clusters to identify its VPC ID.

For Clusters, an additional fetch was necessary because RDS DescribeDBCluster does not return its VPC. So, a DescribeDBInstance must be performed to obtain that information from one of its members.

This will allow us to deploy a DatabaseService in a specific VPC and only proxy the Databases that also belong to that VPC.

Demo:
Discover RDS
![image](https://github.com/gravitational/teleport/assets/689271/577ef9f7-c50b-4404-a103-b3ea6aab69ff)

Discover Aurora
![image](https://github.com/gravitational/teleport/assets/689271/010dc218-9428-4f9b-bb55-9e5b7abb0722)

Auto-Discover
```
2023-12-15T14:32:13Z DEBU [WATCH:RDS] Database(Name=marcodemodb01, Type=rds, Labels=map[Discover:Yes MarcoDiscover:sim account-id:278576220453 endpoint-type:instance engine:postgres engine-version:14.7 region:us-east-1 teleport.dev/cloud:AWS vpc-id:vpc-092c26a0e0e802e92]) doesn't match selector. credentials:integration:teleportdev labels:map[MarcoDiscover:[no-please]] region:us-east-1 role:{  {} [] 0} db/db.go:142
2023-12-15T14:32:13Z DEBU [WATCH:AUR] Database(Name=marcodbcluster, Type=rds, Labels=map[account-id:278576220453 endpoint-type:primary engine:aurora-postgresql engine-version:15.3 region:us-east-1 teleport.dev/cloud:AWS vpc-id:vpc-092c26a0e0e802e92]) doesn't match selector. credentials:integration:teleportdev labels:map[MarcoDiscover:[no-please]] region:us-east-1 role:{  {} [] 0} db/db.go:142


$ tctl get db | yq '.metadata.name + " on " + .metadata.labels."vpc-id"'
"marcodbcluster-rds-aurora-us-east-1-278576220453 on vpc-092c26a0e0e802e92"
"marcodemodb01-rds-us-east-1-278576220453 on vpc-092c26a0e0e802e92"
```

changelog: add vpc-id as a label to auto-discovered RDS databases