### PR TITLE
[v13] Minor fixes to the S3 uploader

### DIFF
--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path/filepath"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -366,11 +366,11 @@ func (h *Handler) path(sessionID session.ID) string {
 	if h.Path == "" {
 		return string(sessionID) + ".tar"
 	}
-	return strings.TrimPrefix(filepath.Join(h.Path, string(sessionID)+".tar"), "/")
+	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".tar"), "/")
 }
 
-func (h *Handler) fromPath(path string) session.ID {
-	return session.ID(strings.TrimSuffix(filepath.Base(path), ".tar"))
+func (h *Handler) fromPath(p string) session.ID {
+	return session.ID(strings.TrimSuffix(path.Base(p), ".tar"))
 }
 
 // ensureBucket makes sure bucket exists, and if it does not, creates it

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -15,6 +15,7 @@
 package s3sessions
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"testing"
@@ -114,4 +115,17 @@ func TestConfig_SetFromURL(t *testing.T) {
 			tt.cfgAssertion(t, tt.cfg)
 		})
 	}
+}
+
+func TestUploadMetadata(t *testing.T) {
+	handler, err := NewHandler(context.Background(), Config{
+		Region: "us-west-1",
+		Path:   "/test/",
+		Bucket: "teleport-unit-tests",
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	meta := handler.GetUploadMetadata("test-session-id")
+	require.Equal(t, "s3://teleport-unit-tests/test/test-session-id", meta.URL)
 }

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package s3sessions
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -39,10 +40,10 @@ func TestMain(m *testing.M) {
 
 // TestStreams tests various streaming upload scenarios
 func TestStreams(t *testing.T) {
-	handler, err := NewHandler(Config{
+	handler, err := NewHandler(context.Background(), Config{
 		Region: "us-west-1",
 		Path:   "/test/",
-		Bucket: fmt.Sprintf("teleport-unit-tests"),
+		Bucket: "teleport-unit-tests",
 	})
 	require.Nil(t, err)
 

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -264,8 +265,15 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 
 // GetUploadMetadata gets the metadata for session upload
 func (h *Handler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
+	sessionURL, err := url.JoinPath(teleport.SchemeS3+"://"+h.Bucket, h.Path, sessionID.String())
+	if err != nil {
+		// this should never happen, but if it does revert to legacy behavior
+		// which omitted h.Path
+		sessionURL = fmt.Sprintf("%v://%v/%v", teleport.SchemeS3, h.Bucket, sessionID)
+	}
+
 	return events.UploadMetadata{
-		URL:       fmt.Sprintf("%v://%v/%v", teleport.SchemeS3, h.Bucket, sessionID),
+		URL:       sessionURL,
 		SessionID: sessionID,
 	}
 }


### PR DESCRIPTION
Backport #35753 to branch/v13

changelog: Fixed session upload audit event sometimes containing an incorrect URL for the session recording.
