### PR TITLE
Make reconciler generic

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -675,3 +675,32 @@ func FriendlyName(resource ResourceWithLabels) string {
 
 	return ""
 }
+
+// GetOrigin returns the origin if one can be obtained.
+func GetOrigin(v any) string {
+	switch r := v.(type) {
+	case ResourceWithOrigin:
+		return r.Origin()
+	case ResourceMetadata:
+		meta := r.GetMetadata()
+		if meta.Labels == nil {
+			return ""
+		}
+		return meta.Labels[OriginLabel]
+	}
+
+	return ""
+}
+
+// GetKind returns the kind if one can be obtained.
+func GetKind(v any) string {
+	type kinder interface {
+		GetKind() string
+	}
+
+	if k, ok := v.(kinder); ok {
+		return k.GetKind()
+	}
+
+	return ""
+}

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -177,7 +177,7 @@ type TLSServer struct {
 	// kubeClusterWatcher monitors changes to kube cluster resources.
 	kubeClusterWatcher *services.KubeClusterWatcher
 	// reconciler reconciles proxied kube clusters with kube_clusters resources.
-	reconciler *services.Reconciler
+	reconciler *services.Reconciler[types.KubeCluster]
 	// monitoredKubeClusters contains all kube clusters the proxied kube_clusters are
 	// reconciled against.
 	monitoredKubeClusters monitoredKubeClusters

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // startReconciler starts reconciler that registers/unregisters proxied
@@ -37,7 +38,7 @@ func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
 		s.log.Debug("Not initializing Kube Cluster resource watcher.")
 		return nil
 	}
-	s.reconciler, err = services.NewReconciler(services.ReconcilerConfig{
+	s.reconciler, err = services.NewReconciler(services.ReconcilerConfig[types.KubeCluster]{
 		Matcher:             s.matcher,
 		GetCurrentResources: s.getResources,
 		GetNewResources:     s.monitoredKubeClusters.get,
@@ -122,36 +123,24 @@ func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*servi
 	return watcher, nil
 }
 
-func (s *TLSServer) getResources() (resources types.ResourcesWithLabelsMap) {
-	return s.fwd.kubeClusters().AsResources().ToMap()
+func (s *TLSServer) getResources() map[string]types.KubeCluster {
+	return utils.FromSlice(s.fwd.kubeClusters(), types.KubeCluster.GetName)
 }
 
-func (s *TLSServer) onCreate(ctx context.Context, resource types.ResourceWithLabels) error {
-	cluster, ok := resource.(types.KubeCluster)
-	if !ok {
-		return trace.BadParameter("expected types.KubeCluster, got %T", resource)
-	}
+func (s *TLSServer) onCreate(ctx context.Context, cluster types.KubeCluster) error {
 	return s.registerKubeCluster(ctx, cluster)
 }
 
-func (s *TLSServer) onUpdate(ctx context.Context, resource types.ResourceWithLabels) error {
-	cluster, ok := resource.(types.KubeCluster)
-	if !ok {
-		return trace.BadParameter("expected types.KubeCluster, got %T", resource)
-	}
+func (s *TLSServer) onUpdate(ctx context.Context, cluster types.KubeCluster) error {
 	return s.updateKubeCluster(ctx, cluster)
 }
 
-func (s *TLSServer) onDelete(ctx context.Context, resource types.ResourceWithLabels) error {
-	return s.unregisterKubeCluster(ctx, resource.GetName())
+func (s *TLSServer) onDelete(ctx context.Context, cluster types.KubeCluster) error {
+	return s.unregisterKubeCluster(ctx, cluster.GetName())
 }
 
-func (s *TLSServer) matcher(resource types.ResourceWithLabels) bool {
-	cluster, ok := resource.(types.KubeCluster)
-	if !ok {
-		return false
-	}
-	return services.MatchResourceLabels(s.ResourceMatchers, cluster)
+func (s *TLSServer) matcher(cluster types.KubeCluster) bool {
+	return services.MatchResourceLabels(s.ResourceMatchers, cluster.GetAllLabels())
 }
 
 // monitoredKubeClusters is a collection of clusters from different sources
@@ -174,10 +163,10 @@ func (m *monitoredKubeClusters) setResources(clusters types.KubeClusters) {
 	m.resources = clusters
 }
 
-func (m *monitoredKubeClusters) get() types.ResourcesWithLabelsMap {
+func (m *monitoredKubeClusters) get() map[string]types.KubeCluster {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return append(m.static, m.resources...).AsResources().ToMap()
+	return utils.FromSlice(append(m.static, m.resources...), types.KubeCluster.GetName)
 }
 
 func (s *TLSServer) buildClusterDetailsConfigForCluster(cluster types.KubeCluster) clusterDetailsConfig {

--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -24,16 +24,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
 // CompareResources compares two resources by all significant fields.
-func CompareResources(resA, resB types.Resource) int {
+func CompareResources[T any](resA, resB T) int {
 	equal := cmp.Equal(resA, resB,
 		ignoreProtoXXXFields(),
 		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
 		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
 		cmpopts.IgnoreFields(types.UserSpecV2{}, "Status"),
+		cmpopts.IgnoreUnexported(headerv1.Metadata{}),
 		cmpopts.EquateEmpty(),
 	)
 	if equal {

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -108,15 +108,15 @@ func SimplifyAzureMatchers(matchers []types.AzureMatcher) []types.AzureMatcher {
 }
 
 // MatchResourceLabels returns true if any of the provided selectors matches the provided database.
-func MatchResourceLabels(matchers []ResourceMatcher, resource types.ResourceWithLabels) bool {
+func MatchResourceLabels(matchers []ResourceMatcher, labels map[string]string) bool {
 	for _, matcher := range matchers {
 		if len(matcher.Labels) == 0 {
 			return false
 		}
-		match, _, err := MatchLabels(matcher.Labels, resource.GetAllLabels())
+		match, _, err := MatchLabels(matcher.Labels, labels)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to match labels %v: %v.",
-				matcher.Labels, resource)
+				matcher.Labels, labels)
 			return false
 		}
 		if match {

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -132,7 +132,7 @@ func TestMatchResourceLabels(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, test.match, MatchResourceLabels(test.selectors, database))
+			require.Equal(t, test.match, MatchResourceLabels(test.selectors, database.GetAllLabels()))
 		})
 	}
 }

--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -27,29 +27,34 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+// Reconciled holds the common information required by any subject of the Reconciler.
+type Reconciled interface {
+	GetName() string
+}
+
 // ReconcilerConfig is the resource reconciler configuration.
-type ReconcilerConfig struct {
+type ReconcilerConfig[T Reconciled] struct {
 	// Matcher is used to match resources.
-	Matcher Matcher
+	Matcher Matcher[T]
 	// GetCurrentResources returns currently registered resources.
-	GetCurrentResources func() types.ResourcesWithLabelsMap
+	GetCurrentResources func() map[string]T
 	// GetNewResources returns resources to compare current resources against.
-	GetNewResources func() types.ResourcesWithLabelsMap
+	GetNewResources func() map[string]T
 	// OnCreate is called when a new resource is detected.
-	OnCreate func(context.Context, types.ResourceWithLabels) error
+	OnCreate func(context.Context, T) error
 	// OnUpdate is called when an existing resource is updated.
-	OnUpdate func(context.Context, types.ResourceWithLabels) error
+	OnUpdate func(context.Context, T) error
 	// OnDelete is called when an existing resource is deleted.
-	OnDelete func(context.Context, types.ResourceWithLabels) error
+	OnDelete func(context.Context, T) error
 	// Log is the reconciler's logger.
 	Log logrus.FieldLogger
 }
 
 // Matcher is used by reconciler to match resources.
-type Matcher func(types.ResourceWithLabels) bool
+type Matcher[T any] func(T) bool
 
 // CheckAndSetDefaults validates the reconciler configuration and sets defaults.
-func (c *ReconcilerConfig) CheckAndSetDefaults() error {
+func (c *ReconcilerConfig[T]) CheckAndSetDefaults() error {
 	if c.Matcher == nil {
 		return trace.BadParameter("missing reconciler Matcher")
 	}
@@ -75,11 +80,11 @@ func (c *ReconcilerConfig) CheckAndSetDefaults() error {
 }
 
 // NewReconciler creates a new reconciler with provided configuration.
-func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
+func NewReconciler[T Reconciled](cfg ReconcilerConfig[T]) (*Reconciler[T], error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &Reconciler{
+	return &Reconciler[T]{
 		cfg: cfg,
 		log: cfg.Log,
 	}, nil
@@ -90,14 +95,14 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 //
 // It's used in combination with watchers by agents (app, database, desktop)
 // to enable dynamically registered resources.
-type Reconciler struct {
-	cfg ReconcilerConfig
+type Reconciler[T Reconciled] struct {
+	cfg ReconcilerConfig[T]
 	log logrus.FieldLogger
 }
 
 // Reconcile reconciles currently registered resources with new resources and
 // creates/updates/deletes them appropriately.
-func (r *Reconciler) Reconcile(ctx context.Context) error {
+func (r *Reconciler[T]) Reconcile(ctx context.Context) error {
 	currentResources := r.cfg.GetCurrentResources()
 	newResources := r.cfg.GetNewResources()
 
@@ -114,8 +119,8 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	// Add new resources if there are any or refresh those that were updated.
-	for _, new := range newResources {
-		if err := r.processNewResource(ctx, currentResources, new); err != nil {
+	for _, newResource := range newResources {
+		if err := r.processNewResource(ctx, currentResources, newResource); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
 	}
@@ -125,15 +130,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 // processRegisteredResource checks the specified registered resource against the
 // new list of resources.
-func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources types.ResourcesWithLabelsMap, registered types.ResourceWithLabels) error {
+func (r *Reconciler[T]) processRegisteredResource(ctx context.Context, newResources map[string]T, registered T) error {
+	name := registered.GetName()
 	// See if this registered resource is still present among "new" resources.
-	if new := newResources[registered.GetName()]; new != nil {
+	if _, ok := newResources[name]; ok {
 		return nil
 	}
 
-	r.log.Infof("%v %v removed, deleting.", registered.GetKind(), registered.GetName())
+	kind := types.GetKind(registered)
+	r.log.Infof("%v %v removed, deleting.", kind, name)
 	if err := r.cfg.OnDelete(ctx, registered); err != nil {
-		return trace.Wrap(err, "failed to delete  %v %v", registered.GetKind(), registered.GetName())
+		return trace.Wrap(err, "failed to delete  %v %v", kind, name)
 	}
 
 	return nil
@@ -141,46 +148,50 @@ func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources
 
 // processNewResource checks the provided new resource agsinst currently
 // registered resources.
-func (r *Reconciler) processNewResource(ctx context.Context, currentResources types.ResourcesWithLabelsMap, new types.ResourceWithLabels) error {
+func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources map[string]T, newT T) error {
+	name := newT.GetName()
 	// First see if the resource is already registered and if not, whether it
 	// matches the selector labels and should be registered.
-	registered := currentResources[new.GetName()]
-	if registered == nil {
-		if r.cfg.Matcher(new) {
-			r.log.Infof("%v %v matches, creating.", new.GetKind(), new.GetName())
-			if err := r.cfg.OnCreate(ctx, new); err != nil {
-				return trace.Wrap(err, "failed to create %v %v", new.GetKind(), new.GetName())
+	registered, ok := currentResources[name]
+	if !ok {
+		kind := types.GetKind(newT)
+		if r.cfg.Matcher(newT) {
+			r.log.Infof("%v %v matches, creating.", kind, name)
+			if err := r.cfg.OnCreate(ctx, newT); err != nil {
+				return trace.Wrap(err, "failed to create %v %v", kind, name)
 			}
 			return nil
 		}
-		r.log.Debugf("%v %v doesn't match, not creating.", new.GetKind(), new.GetName())
+		r.log.Debugf("%v %v doesn't match, not creating.", kind, name)
 		return nil
 	}
 
 	// Don't overwrite resource of a different origin (e.g., keep static resource from config and ignore dynamic resource)
-	if registered.Origin() != new.Origin() {
-		r.log.Warnf("%v has different origin (%v vs %v), not updating.", new.GetName(),
-			new.Origin(), registered.Origin())
+	registeredOrigin := types.GetOrigin(registered)
+	newOrigin := types.GetOrigin(newT)
+	if registeredOrigin != newOrigin {
+		r.log.Warnf("%v has different origin (%v vs %v), not updating.", name, newOrigin, registeredOrigin)
 		return nil
 	}
 
 	// If the resource is already registered but was updated, see if its
 	// labels still match.
-	if CompareResources(new, registered) != Equal {
-		if r.cfg.Matcher(new) {
-			r.log.Infof("%v %v updated, updating.", new.GetKind(), new.GetName())
-			if err := r.cfg.OnUpdate(ctx, new); err != nil {
-				return trace.Wrap(err, "failed to update %v %v", new.GetKind(), new.GetName())
+	kind := types.GetKind(registered)
+	if CompareResources(newT, registered) != Equal {
+		if r.cfg.Matcher(newT) {
+			r.log.Infof("%v %v updated, updating.", kind, name)
+			if err := r.cfg.OnUpdate(ctx, newT); err != nil {
+				return trace.Wrap(err, "failed to update %v %v", kind, name)
 			}
 			return nil
 		}
-		r.log.Infof("%v %v updated and no longer matches, deleting.", new.GetKind(), new.GetName())
+		r.log.Infof("%v %v updated and no longer matches, deleting.", kind, name)
 		if err := r.cfg.OnDelete(ctx, registered); err != nil {
-			return trace.Wrap(err, "failed to delete %v %v", new.GetKind(), new.GetName())
+			return trace.Wrap(err, "failed to delete %v %v", kind, name)
 		}
 		return nil
 	}
 
-	r.log.Debugf("%v %v is already registered.", new.GetKind(), new.GetName())
+	r.log.Debugf("%v %v is already registered.", kind, name)
 	return nil
 }

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -25,7 +25,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // TestReconciler makes sure appropriate callbacks are called during reconciliation.
@@ -33,47 +35,36 @@ func TestReconciler(t *testing.T) {
 	tests := []struct {
 		description         string
 		selectors           []ResourceMatcher
-		registeredResources types.ResourcesWithLabels
-		newResources        types.ResourcesWithLabels
-		onCreateCalls       types.ResourcesWithLabels
-		onUpdateCalls       types.ResourcesWithLabels
-		onDeleteCalls       types.ResourcesWithLabels
+		registeredResources []testResource
+		newResources        []testResource
+		onCreateCalls       []testResource
+		onUpdateCalls       []testResource
+		onDeleteCalls       []testResource
 	}{
 		{
 			description: "new matching resource should be registered",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"*": []string{"*"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
-			onCreateCalls: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
+			newResources:  []testResource{makeDynamicResource("res1", nil)},
+			onCreateCalls: []testResource{makeDynamicResource("res1", nil)},
 		},
 		{
 			description: "new non-matching resource should not be registered",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"env": []string{"prod"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "dev"}),
-			},
+			newResources: []testResource{makeDynamicResource("res1", map[string]string{"env": "dev"})},
 		},
 		{
 			description: "resources that equal don't overwrite each other ",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"*": []string{"*"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
-			newResources: types.ResourcesWithLabels{
+			registeredResources: []testResource{makeDynamicResource("res1", nil)},
+			newResources: []testResource{
 				makeDynamicResource("res1", nil, func(r *testResource) {
-					// XXX_unrecognized should be ignored by CompareResources.
-					r.Metadata.XXX_unrecognized = []byte{11, 0}
+					r.Metadata.Labels = map[string]string{"env": "dev"}
 				}),
 			},
 		},
@@ -82,69 +73,48 @@ func TestReconciler(t *testing.T) {
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"*": []string{"*"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeStaticResource("res1", nil),
-			},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
+			registeredResources: []testResource{makeStaticResource("res1", nil)},
+			newResources:        []testResource{makeDynamicResource("res1", nil)},
 		},
 		{
 			description: "resource that's no longer present should be removed",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"*": []string{"*"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
-			newResources: types.ResourcesWithLabels{},
-			onDeleteCalls: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
+			registeredResources: []testResource{makeDynamicResource("res1", nil)},
+			onDeleteCalls:       []testResource{makeDynamicResource("res1", nil)},
 		},
 		{
 			description: "resource with updated matching labels should be updated",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"*": []string{"*"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "dev"}),
-			},
-			onUpdateCalls: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "dev"}),
-			},
+			registeredResources: []testResource{makeDynamicResource("res1", nil)},
+			newResources:        []testResource{makeDynamicResource("res1", map[string]string{"env": "dev"})},
+			onUpdateCalls:       []testResource{makeDynamicResource("res1", map[string]string{"env": "dev"})},
 		},
 		{
 			description: "non-matching updated resource should be removed",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"env": []string{"prod"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "prod"}),
-			},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "dev"}),
-			},
-			onDeleteCalls: types.ResourcesWithLabels{
-				makeDynamicResource("res1", map[string]string{"env": "prod"}),
-			},
+			registeredResources: []testResource{makeDynamicResource("res1", map[string]string{"env": "prod"})},
+			newResources:        []testResource{makeDynamicResource("res1", map[string]string{"env": "dev"})},
+			onDeleteCalls:       []testResource{makeDynamicResource("res1", map[string]string{"env": "prod"})},
 		},
 		{
 			description: "complex scenario with multiple created/updated/deleted resources",
 			selectors: []ResourceMatcher{{
 				Labels: types.Labels{"env": []string{"prod"}},
 			}},
-			registeredResources: types.ResourcesWithLabels{
+			registeredResources: []testResource{
 				makeStaticResource("res0", nil),
 				makeDynamicResource("res1", map[string]string{"env": "prod"}),
 				makeDynamicResource("res2", map[string]string{"env": "prod"}),
 				makeDynamicResource("res3", map[string]string{"env": "prod"}),
 				makeDynamicResource("res4", map[string]string{"env": "prod"}),
 			},
-			newResources: types.ResourcesWithLabels{
+			newResources: []testResource{
 				makeDynamicResource("res0", map[string]string{"env": "prod"}),
 				makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
 				makeDynamicResource("res3", map[string]string{"env": "prod"}),
@@ -152,13 +122,13 @@ func TestReconciler(t *testing.T) {
 				makeDynamicResource("res5", map[string]string{"env": "prod"}),
 				makeDynamicResource("res6", map[string]string{"env": "dev"}),
 			},
-			onCreateCalls: types.ResourcesWithLabels{
+			onCreateCalls: []testResource{
 				makeDynamicResource("res5", map[string]string{"env": "prod"}),
 			},
-			onUpdateCalls: types.ResourcesWithLabels{
+			onUpdateCalls: []testResource{
 				makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
 			},
-			onDeleteCalls: types.ResourcesWithLabels{
+			onDeleteCalls: []testResource{
 				makeDynamicResource("res1", map[string]string{"env": "prod"}),
 				makeDynamicResource("res4", map[string]string{"env": "prod"}),
 			},
@@ -168,28 +138,32 @@ func TestReconciler(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			// Reconciler will record all callback calls in these lists.
-			var onCreateCalls, onUpdateCalls, onDeleteCalls types.ResourcesWithLabels
+			var onCreateCalls, onUpdateCalls, onDeleteCalls []testResource
 
-			reconciler, err := NewReconciler(ReconcilerConfig{
-				Matcher: func(rwl types.ResourceWithLabels) bool {
-					return MatchResourceLabels(test.selectors, rwl)
+			reconciler, err := NewReconciler[testResource](ReconcilerConfig[testResource]{
+				Matcher: func(tr testResource) bool {
+					return MatchResourceLabels(test.selectors, tr.GetMetadata().Labels)
 				},
-				GetCurrentResources: func() types.ResourcesWithLabelsMap {
-					return test.registeredResources.ToMap()
+				GetCurrentResources: func() map[string]testResource {
+					return utils.FromSlice[testResource](test.registeredResources, func(t testResource) string {
+						return t.Metadata.Name
+					})
 				},
-				GetNewResources: func() types.ResourcesWithLabelsMap {
-					return test.newResources.ToMap()
+				GetNewResources: func() map[string]testResource {
+					return utils.FromSlice[testResource](test.newResources, func(t testResource) string {
+						return t.Metadata.Name
+					})
 				},
-				OnCreate: func(ctx context.Context, r types.ResourceWithLabels) error {
-					onCreateCalls = append(onCreateCalls, r)
+				OnCreate: func(ctx context.Context, tr testResource) error {
+					onCreateCalls = append(onCreateCalls, tr)
 					return nil
 				},
-				OnUpdate: func(ctx context.Context, r types.ResourceWithLabels) error {
-					onUpdateCalls = append(onUpdateCalls, r)
+				OnUpdate: func(ctx context.Context, tr testResource) error {
+					onUpdateCalls = append(onUpdateCalls, tr)
 					return nil
 				},
-				OnDelete: func(ctx context.Context, r types.ResourceWithLabels) error {
-					onDeleteCalls = append(onDeleteCalls, r)
+				OnDelete: func(ctx context.Context, tr testResource) error {
+					onDeleteCalls = append(onDeleteCalls, tr)
 					return nil
 				},
 			})
@@ -205,56 +179,43 @@ func TestReconciler(t *testing.T) {
 	}
 }
 
-func makeStaticResource(name string, labels map[string]string) types.ResourceWithLabels {
+func makeStaticResource(name string, labels map[string]string) testResource {
 	return makeResource(name, labels, map[string]string{
 		types.OriginLabel: types.OriginConfigFile,
 	})
 }
 
-func makeDynamicResource(name string, labels map[string]string, opts ...func(*testResource)) types.ResourceWithLabels {
+func makeDynamicResource(name string, labels map[string]string, opts ...func(*testResource)) testResource {
 	return makeResource(name, labels, map[string]string{
 		types.OriginLabel: types.OriginDynamic,
 	}, opts...)
 }
 
-func makeResource(name string, labels map[string]string, additionalLabels map[string]string, opts ...func(*testResource)) types.ResourceWithLabels {
+func makeResource(name string, labels map[string]string, additionalLabels map[string]string, opts ...func(*testResource)) testResource {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 	maps.Copy(labels, additionalLabels)
-	r := &testResource{
-		Metadata: types.Metadata{
+	r := testResource{
+		Metadata: &headerv1.Metadata{
 			Name:   name,
 			Labels: labels,
 		},
 	}
 	for _, opt := range opts {
-		opt(r)
+		opt(&r)
 	}
 	return r
 }
 
 type testResource struct {
-	types.ResourceWithLabels
-	Metadata types.Metadata
+	Metadata *headerv1.Metadata
 }
 
-func (r *testResource) GetName() string {
-	return r.Metadata.Name
-}
-
-func (r *testResource) GetKind() string {
-	return "TestResource"
-}
-
-func (r *testResource) GetMetadata() types.Metadata {
+func (r testResource) GetMetadata() *headerv1.Metadata {
 	return r.Metadata
 }
 
-func (r *testResource) Origin() string {
-	return r.Metadata.Labels[types.OriginLabel]
-}
-
-func (r *testResource) GetAllLabels() map[string]string {
-	return r.Metadata.Labels
+func (r testResource) GetName() string {
+	return r.Metadata.GetName()
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -249,10 +249,10 @@ func (m *monitoredApps) setResources(apps types.Apps) {
 	m.resources = apps
 }
 
-func (m *monitoredApps) get() types.ResourcesWithLabelsMap {
+func (m *monitoredApps) get() map[string]types.Application {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return append(m.static, m.resources...).AsResources().ToMap()
+	return utils.FromSlice(append(m.static, m.resources...), types.Application.GetName)
 }
 
 // New returns a new application server.

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -33,7 +33,7 @@ import (
 // startReconciler starts reconciler that registers/unregisters proxied
 // apps according to the up-to-date list of application resources.
 func (s *Server) startReconciler(ctx context.Context) error {
-	reconciler, err := services.NewReconciler(services.ReconcilerConfig{
+	reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.Application]{
 		Matcher:             s.matcher,
 		GetCurrentResources: s.getResources,
 		GetNewResources:     s.monitoredApps.get,
@@ -160,34 +160,22 @@ func FindPublicAddr(client FindPublicAddrClient, appPublicAddr string, appName s
 	return fmt.Sprintf("%v.%v", appName, cn.GetClusterName()), nil
 }
 
-func (s *Server) getResources() (resources types.ResourcesWithLabelsMap) {
-	return s.getApps().AsResources().ToMap()
+func (s *Server) getResources() map[string]types.Application {
+	return utils.FromSlice(s.getApps(), types.Application.GetName)
 }
 
-func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels) error {
-	app, ok := resource.(types.Application)
-	if !ok {
-		return trace.BadParameter("expected types.Application, got %T", resource)
-	}
+func (s *Server) onCreate(ctx context.Context, app types.Application) error {
 	return s.registerApp(ctx, app)
 }
 
-func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels) error {
-	app, ok := resource.(types.Application)
-	if !ok {
-		return trace.BadParameter("expected types.Application, got %T", resource)
-	}
+func (s *Server) onUpdate(ctx context.Context, app types.Application) error {
 	return s.updateApp(ctx, app)
 }
 
-func (s *Server) onDelete(ctx context.Context, resource types.ResourceWithLabels) error {
-	return s.unregisterAndRemoveApp(ctx, resource.GetName())
+func (s *Server) onDelete(ctx context.Context, app types.Application) error {
+	return s.unregisterAndRemoveApp(ctx, app.GetName())
 }
 
-func (s *Server) matcher(resource types.ResourceWithLabels) bool {
-	app, ok := resource.(types.Application)
-	if !ok {
-		return false
-	}
-	return services.MatchResourceLabels(s.c.ResourceMatchers, app)
+func (s *Server) matcher(app types.Application) bool {
+	return services.MatchResourceLabels(s.c.ResourceMatchers, app.GetAllLabels())
 }

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -356,10 +356,10 @@ func (m *monitoredDatabases) isResource(database types.Database) bool {
 	return false
 }
 
-func (m *monitoredDatabases) get() types.ResourcesWithLabelsMap {
+func (m *monitoredDatabases) get() map[string]types.Database {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return append(append(m.static, m.resources...), m.cloud...).AsResources().ToMap()
+	return utils.FromSlice(append(append(m.static, m.resources...), m.cloud...), types.Database.GetName)
 }
 
 // New returns a new database server.

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -29,13 +29,14 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	discovery "github.com/gravitational/teleport/lib/srv/discovery/common"
 	dbfetchers "github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // startReconciler starts reconciler that registers/unregisters proxied
 // databases according to the up-to-date list of database resources and
 // databases imported from the cloud.
 func (s *Server) startReconciler(ctx context.Context) error {
-	reconciler, err := services.NewReconciler(services.ReconcilerConfig{
+	reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.Database]{
 		Matcher:             s.matcher,
 		GetCurrentResources: s.getResources,
 		GetNewResources:     s.monitoredDatabases.get,
@@ -156,17 +157,12 @@ func (s *Server) startCloudWatcher(ctx context.Context) error {
 }
 
 // getResources returns proxied databases as resources.
-func (s *Server) getResources() types.ResourcesWithLabelsMap {
-	return s.getProxiedDatabases().AsResources().ToMap()
+func (s *Server) getResources() map[string]types.Database {
+	return utils.FromSlice(s.getProxiedDatabases(), types.Database.GetName)
 }
 
 // onCreate is called by reconciler when a new database is created.
-func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("expected types.Database, got %T", resource)
-	}
-
+func (s *Server) onCreate(ctx context.Context, database types.Database) error {
 	// OnCreate receives a "new" resource from s.monitoredDatabases. Make a
 	// copy here so that any attribute changes to the proxied database will not
 	// affect database objects tracked in s.monitoredDatabases.
@@ -184,12 +180,7 @@ func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels
 }
 
 // onUpdate is called by reconciler when an already proxied database is updated.
-func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("expected types.Database, got %T", resource)
-	}
-
+func (s *Server) onUpdate(ctx context.Context, database types.Database) error {
 	// OnUpdate receives a "new" resource from s.monitoredDatabases. Make a
 	// copy here so that any attribute changes to the proxied database will not
 	// affect database objects tracked in s.monitoredDatabases.
@@ -199,21 +190,12 @@ func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels
 }
 
 // onDelete is called by reconciler when a proxied database is deleted.
-func (s *Server) onDelete(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("expected types.Database, got %T", resource)
-	}
+func (s *Server) onDelete(ctx context.Context, database types.Database) error {
 	return s.unregisterDatabase(ctx, database)
 }
 
 // matcher is used by reconciler to check if database matches selectors.
-func (s *Server) matcher(resource types.ResourceWithLabels) bool {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return false
-	}
-
+func (s *Server) matcher(database types.Database) bool {
 	// In the case of databases discovered by this database server, matchers
 	// should be skipped.
 	if s.monitoredDatabases.isCloud(database) {
@@ -222,7 +204,7 @@ func (s *Server) matcher(resource types.ResourceWithLabels) bool {
 
 	// Database resources created via CLI, API, or discovery service are
 	// filtered by resource matchers.
-	return services.MatchResourceLabels(s.cfg.ResourceMatchers, database)
+	return services.MatchResourceLabels(s.cfg.ResourceMatchers, database.GetAllLabels())
 }
 
 func applyResourceMatchersToDatabase(database types.Database, resourceMatchers []services.ResourceMatcher) {

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -41,12 +41,12 @@ import (
 // startDesktopDiscovery starts fetching desktops from LDAP, periodically
 // registering and unregistering them as necessary.
 func (s *WindowsService) startDesktopDiscovery() error {
-	reconciler, err := services.NewReconciler(services.ReconcilerConfig{
+	reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
 		// Use a matcher that matches all resources, since our desktops are
 		// pre-filtered by nature of using an LDAP search with filters.
-		Matcher: func(r types.ResourceWithLabels) bool { return true },
+		Matcher: func(d types.WindowsDesktop) bool { return true },
 
-		GetCurrentResources: func() types.ResourcesWithLabelsMap { return s.lastDiscoveryResults },
+		GetCurrentResources: func() map[string]types.WindowsDesktop { return s.lastDiscoveryResults },
 		GetNewResources:     s.getDesktopsFromLDAP,
 		OnCreate:            s.upsertDesktop,
 		OnUpdate:            s.upsertDesktop,
@@ -94,7 +94,7 @@ func (s *WindowsService) ldapSearchFilter() string {
 }
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
-func (s *WindowsService) getDesktopsFromLDAP() types.ResourcesWithLabelsMap {
+func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
 	if !s.ldapReady() {
 		s.cfg.Log.Warn("skipping desktop discovery: LDAP not yet initialized")
 		return nil
@@ -125,7 +125,7 @@ func (s *WindowsService) getDesktopsFromLDAP() types.ResourcesWithLabelsMap {
 
 	s.cfg.Log.Debugf("discovered %d Windows Desktops", len(entries))
 
-	result := make(types.ResourcesWithLabelsMap)
+	result := make(map[string]types.WindowsDesktop)
 	for _, entry := range entries {
 		desktop, err := s.ldapEntryToWindowsDesktop(s.closeCtx, entry, s.cfg.HostLabelsFn)
 		if err != nil {
@@ -141,19 +141,11 @@ func (s *WindowsService) getDesktopsFromLDAP() types.ResourcesWithLabelsMap {
 	return result
 }
 
-func (s *WindowsService) upsertDesktop(ctx context.Context, r types.ResourceWithLabels) error {
-	d, ok := r.(types.WindowsDesktop)
-	if !ok {
-		return trace.Errorf("upsert: expected a WindowsDesktop, got %T", r)
-	}
+func (s *WindowsService) upsertDesktop(ctx context.Context, d types.WindowsDesktop) error {
 	return s.cfg.AuthClient.UpsertWindowsDesktop(ctx, d)
 }
 
-func (s *WindowsService) deleteDesktop(ctx context.Context, r types.ResourceWithLabels) error {
-	d, ok := r.(types.WindowsDesktop)
-	if !ok {
-		return trace.Errorf("delete: expected a WindowsDesktop, got %T", r)
-	}
+func (s *WindowsService) deleteDesktop(ctx context.Context, d types.WindowsDesktop) error {
 	return s.cfg.AuthClient.DeleteWindowsDesktop(ctx, d.GetHostID(), d.GetName())
 }
 
@@ -251,7 +243,7 @@ func (s *WindowsService) lookupDesktop(ctx context.Context, hostname string) ([]
 
 // ldapEntryToWindowsDesktop generates the Windows Desktop resource
 // from an LDAP search result
-func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *ldap.Entry, getHostLabels func(string) map[string]string) (types.ResourceWithLabels, error) {
+func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *ldap.Entry, getHostLabels func(string) map[string]string) (types.WindowsDesktop, error) {
 	hostname := entry.GetAttributeValue(windows.AttrDNSHostName)
 	if hostname == "" {
 		attrs := make([]string, len(entry.Attributes))

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -124,7 +124,7 @@ type WindowsService struct {
 	// when desktop discovery is enabled.
 	// no synchronization is necessary because this is only read/written from
 	// the reconciler goroutine.
-	lastDiscoveryResults types.ResourcesWithLabelsMap
+	lastDiscoveryResults map[string]types.WindowsDesktop
 
 	// Windows hosts discovered via LDAP likely won't resolve with the
 	// default DNS resolver, so we need a custom resolver that will

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const databaseEventPrefix = "db/"
@@ -38,18 +39,18 @@ func (s *Server) startDatabaseWatchers() error {
 	}
 
 	var (
-		newDatabases types.ResourcesWithLabels
+		newDatabases []types.Database
 		mu           sync.Mutex
 	)
 
 	reconciler, err := services.NewReconciler(
-		services.ReconcilerConfig{
-			Matcher:             func(_ types.ResourceWithLabels) bool { return true },
+		services.ReconcilerConfig[types.Database]{
+			Matcher:             func(database types.Database) bool { return true },
 			GetCurrentResources: s.getCurrentDatabases,
-			GetNewResources: func() types.ResourcesWithLabelsMap {
+			GetNewResources: func() map[string]types.Database {
 				mu.Lock()
 				defer mu.Unlock()
-				return newDatabases.ToMap()
+				return utils.FromSlice(newDatabases, types.Database.GetName)
 			},
 			Log:      s.Log.WithField("kind", types.KindDatabase),
 			OnCreate: s.onDatabaseCreate,
@@ -79,8 +80,17 @@ func (s *Server) startDatabaseWatchers() error {
 		for {
 			select {
 			case newResources := <-watcher.ResourcesC():
+				dbs := make([]types.Database, 0, len(newResources))
+				for _, r := range newResources {
+					db, ok := r.(types.Database)
+					if !ok {
+						continue
+					}
+
+					dbs = append(dbs, db)
+				}
 				mu.Lock()
-				newDatabases = newResources
+				newDatabases = dbs
 				mu.Unlock()
 
 				if err := reconciler.Reconcile(s.ctx); err != nil {
@@ -113,21 +123,19 @@ func (s *Server) getAllDatabaseFetchers() []common.Fetcher {
 	return allFetchers
 }
 
-func (s *Server) getCurrentDatabases() types.ResourcesWithLabelsMap {
+func (s *Server) getCurrentDatabases() map[string]types.Database {
 	databases, err := s.AccessPoint.GetDatabases(s.ctx)
 	if err != nil {
 		s.Log.WithError(err).Warn("Failed to get databases from cache.")
 		return nil
 	}
 
-	return types.Databases(filterResources(databases, types.OriginCloud, s.DiscoveryGroup)).AsResources().ToMap()
+	return utils.FromSlice[types.Database](filterResources(databases, types.OriginCloud, s.DiscoveryGroup), func(database types.Database) string {
+		return database.GetName()
+	})
 }
 
-func (s *Server) onDatabaseCreate(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Database, received %T", database)
-	}
+func (s *Server) onDatabaseCreate(ctx context.Context, database types.Database) error {
 	s.Log.Debugf("Creating database %s.", database.GetName())
 	err := s.AccessPoint.CreateDatabase(ctx, database)
 	// If the resource already exists, it means that the resource was created
@@ -138,7 +146,7 @@ func (s *Server) onDatabaseCreate(ctx context.Context, resource types.ResourceWi
 	// the resource.
 	// TODO(tigrato): DELETE on 15.0.0
 	if trace.IsAlreadyExists(err) {
-		return trace.Wrap(s.onDatabaseUpdate(ctx, resource))
+		return trace.Wrap(s.onDatabaseUpdate(ctx, database))
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -160,20 +168,12 @@ func (s *Server) onDatabaseCreate(ctx context.Context, resource types.ResourceWi
 	return nil
 }
 
-func (s *Server) onDatabaseUpdate(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Database, received %T", database)
-	}
+func (s *Server) onDatabaseUpdate(ctx context.Context, database types.Database) error {
 	s.Log.Debugf("Updating database %s.", database.GetName())
 	return trace.Wrap(s.AccessPoint.UpdateDatabase(ctx, database))
 }
 
-func (s *Server) onDatabaseDelete(ctx context.Context, resource types.ResourceWithLabels) error {
-	database, ok := resource.(types.Database)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Database, received %T", database)
-	}
+func (s *Server) onDatabaseDelete(ctx context.Context, database types.Database) error {
 	s.Log.Debugf("Deleting database %s.", database.GetName())
 	return trace.Wrap(s.AccessPoint.DeleteDatabase(ctx, database.GetName()))
 }

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2615,43 +2615,18 @@ func TestServer_onCreate(t *testing.T) {
 			Log:         logrus.New(),
 		},
 	}
-	type args struct {
-		resource types.ResourceWithLabels
-		onCreate func(context.Context, types.ResourceWithLabels) error
-	}
-	tests := []struct {
-		name   string
-		args   args
-		verify func(t *testing.T, accessPoint *fakeAccessPoint)
-	}{
-		{
-			name: "onCreate update kube",
-			args: args{
-				resource: mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"),
-				onCreate: s.onKubeCreate,
-			},
-			verify: func(t *testing.T, accessPoint *fakeAccessPoint) {
-				require.True(t, accessPoint.updateKube)
-			},
-		},
-		{
-			name: "onCreate update database",
-			args: args{
-				resource: awsRedshiftDB,
-				onCreate: s.onDatabaseCreate,
-			},
-			verify: func(t *testing.T, accessPoint *fakeAccessPoint) {
-				require.True(t, accessPoint.updateDatabase)
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.args.onCreate(context.Background(), tt.args.resource)
-			require.NoError(t, err)
-			tt.verify(t, accessPoint)
-		})
-	}
+
+	t.Run("onCreate update kube", func(t *testing.T) {
+		err := s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"))
+		require.NoError(t, err)
+		require.True(t, accessPoint.updateKube)
+	})
+
+	t.Run("onCreate update database", func(t *testing.T) {
+		err := s.onDatabaseCreate(context.Background(), awsRedshiftDB)
+		require.NoError(t, err)
+		require.True(t, accessPoint.updateDatabase)
+	})
 }
 
 func TestEmitUsageEvents(t *testing.T) {

--- a/lib/srv/discovery/kube_services_watcher.go
+++ b/lib/srv/discovery/kube_services_watcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const appEventPrefix = "app/"
@@ -39,26 +40,26 @@ func (s *Server) startKubeAppsWatchers() error {
 	}
 
 	var (
-		appResources types.ResourcesWithLabels
+		appResources []types.Application
 		mu           sync.Mutex
 	)
 
 	reconciler, err := services.NewReconciler(
-		services.ReconcilerConfig{
-			Matcher: func(_ types.ResourceWithLabels) bool { return true },
-			GetCurrentResources: func() types.ResourcesWithLabelsMap {
+		services.ReconcilerConfig[types.Application]{
+			Matcher: func(_ types.Application) bool { return true },
+			GetCurrentResources: func() map[string]types.Application {
 				apps, err := s.AccessPoint.GetApps(s.ctx)
 				if err != nil {
 					s.Log.WithError(err).Warn("Unable to get applications from cache.")
 					return nil
 				}
 
-				return types.Apps(filterResources(apps, types.OriginDiscoveryKubernetes, s.DiscoveryGroup)).AsResources().ToMap()
+				return utils.FromSlice(filterResources(apps, types.OriginDiscoveryKubernetes, s.DiscoveryGroup), types.Application.GetName)
 			},
-			GetNewResources: func() types.ResourcesWithLabelsMap {
+			GetNewResources: func() map[string]types.Application {
 				mu.Lock()
 				defer mu.Unlock()
-				return appResources.ToMap()
+				return utils.FromSlice(appResources, types.Application.GetName)
 			},
 			Log:      s.Log.WithField("kind", types.KindApp),
 			OnCreate: s.onAppCreate,
@@ -86,8 +87,18 @@ func (s *Server) startKubeAppsWatchers() error {
 		for {
 			select {
 			case newResources := <-watcher.ResourcesC():
+				apps := make([]types.Application, 0, len(newResources))
+				for _, r := range newResources {
+					app, ok := r.(types.Application)
+					if !ok {
+						continue
+					}
+
+					apps = append(apps, app)
+				}
+
 				mu.Lock()
-				appResources = newResources
+				appResources = apps
 				mu.Unlock()
 
 				if err := reconciler.Reconcile(s.ctx); err != nil {
@@ -102,11 +113,7 @@ func (s *Server) startKubeAppsWatchers() error {
 	return nil
 }
 
-func (s *Server) onAppCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	app, ok := rwl.(types.Application)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
-	}
+func (s *Server) onAppCreate(ctx context.Context, app types.Application) error {
 	s.Log.Debugf("Creating app %s", app.GetName())
 	err := s.AccessPoint.CreateApp(ctx, app)
 	// If the resource already exists, it means that the resource was created
@@ -116,7 +123,7 @@ func (s *Server) onAppCreate(ctx context.Context, rwl types.ResourceWithLabels) 
 	// discovery group label to ensure the user doesn't have to manually delete
 	// the resource.
 	if trace.IsAlreadyExists(err) {
-		return trace.Wrap(s.onAppUpdate(ctx, rwl))
+		return trace.Wrap(s.onAppUpdate(ctx, app))
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -134,20 +141,12 @@ func (s *Server) onAppCreate(ctx context.Context, rwl types.ResourceWithLabels) 
 	return nil
 }
 
-func (s *Server) onAppUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	app, ok := rwl.(types.Application)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
-	}
+func (s *Server) onAppUpdate(ctx context.Context, app types.Application) error {
 	s.Log.Debugf("Updating app %s.", app.GetName())
 	return trace.Wrap(s.AccessPoint.UpdateApp(ctx, app))
 }
 
-func (s *Server) onAppDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
-	app, ok := rwl.(types.Application)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
-	}
+func (s *Server) onAppDelete(ctx context.Context, app types.Application) error {
 	s.Log.Debugf("Deleting app %s.", app.GetName())
 	return trace.Wrap(s.AccessPoint.DeleteApp(ctx, app.GetName()))
 }

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const kubeEventPrefix = "kube/"
@@ -37,26 +38,26 @@ func (s *Server) startKubeWatchers() error {
 		return nil
 	}
 	var (
-		kubeResources types.ResourcesWithLabels
+		kubeResources []types.KubeCluster
 		mu            sync.Mutex
 	)
 
 	reconciler, err := services.NewReconciler(
-		services.ReconcilerConfig{
-			Matcher: func(_ types.ResourceWithLabels) bool { return true },
-			GetCurrentResources: func() types.ResourcesWithLabelsMap {
+		services.ReconcilerConfig[types.KubeCluster]{
+			Matcher: func(_ types.KubeCluster) bool { return true },
+			GetCurrentResources: func() map[string]types.KubeCluster {
 				kcs, err := s.AccessPoint.GetKubernetesClusters(s.ctx)
 				if err != nil {
 					s.Log.WithError(err).Warn("Unable to get Kubernetes clusters from cache.")
 					return nil
 				}
 
-				return types.KubeClusters(filterResources(kcs, types.OriginCloud, s.DiscoveryGroup)).AsResources().ToMap()
+				return utils.FromSlice(filterResources(kcs, types.OriginCloud, s.DiscoveryGroup), types.KubeCluster.GetName)
 			},
-			GetNewResources: func() types.ResourcesWithLabelsMap {
+			GetNewResources: func() map[string]types.KubeCluster {
 				mu.Lock()
 				defer mu.Unlock()
-				return kubeResources.ToMap()
+				return utils.FromSlice(kubeResources, types.KubeCluster.GetName)
 			},
 			Log:      s.Log.WithField("kind", types.KindKubernetesCluster),
 			OnCreate: s.onKubeCreate,
@@ -84,8 +85,17 @@ func (s *Server) startKubeWatchers() error {
 		for {
 			select {
 			case newResources := <-watcher.ResourcesC():
+				clusters := make([]types.KubeCluster, 0, len(newResources))
+				for _, r := range newResources {
+					cluster, ok := r.(types.KubeCluster)
+					if !ok {
+						continue
+					}
+
+					clusters = append(clusters, cluster)
+				}
 				mu.Lock()
-				kubeResources = newResources
+				kubeResources = clusters
 				mu.Unlock()
 
 				if err := reconciler.Reconcile(s.ctx); err != nil {
@@ -100,11 +110,7 @@ func (s *Server) startKubeWatchers() error {
 	return nil
 }
 
-func (s *Server) onKubeCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
-	}
+func (s *Server) onKubeCreate(ctx context.Context, kubeCluster types.KubeCluster) error {
 	s.Log.Debugf("Creating kube_cluster %s.", kubeCluster.GetName())
 	err := s.AccessPoint.CreateKubernetesCluster(ctx, kubeCluster)
 	// If the resource already exists, it means that the resource was created
@@ -115,7 +121,7 @@ func (s *Server) onKubeCreate(ctx context.Context, rwl types.ResourceWithLabels)
 	// the resource.
 	// TODO(tigrato): DELETE on 15.0.0
 	if trace.IsAlreadyExists(err) {
-		return trace.Wrap(s.onKubeUpdate(ctx, rwl))
+		return trace.Wrap(s.onKubeUpdate(ctx, kubeCluster))
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -133,20 +139,12 @@ func (s *Server) onKubeCreate(ctx context.Context, rwl types.ResourceWithLabels)
 	return nil
 }
 
-func (s *Server) onKubeUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
-	}
+func (s *Server) onKubeUpdate(ctx context.Context, kubeCluster types.KubeCluster) error {
 	s.Log.Debugf("Updating kube_cluster %s.", kubeCluster.GetName())
 	return trace.Wrap(s.AccessPoint.UpdateKubernetesCluster(ctx, kubeCluster))
 }
 
-func (s *Server) onKubeDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
-	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
-	}
+func (s *Server) onKubeDelete(ctx context.Context, kubeCluster types.KubeCluster) error {
 	s.Log.Debugf("Deleting kube_cluster %s.", kubeCluster.GetName())
 	return trace.Wrap(s.AccessPoint.DeleteKubernetesCluster(ctx, kubeCluster.GetName()))
 }

--- a/lib/utils/slice.go
+++ b/lib/utils/slice.go
@@ -126,3 +126,19 @@ func (b *BufferSyncPool) Get() *bytes.Buffer {
 func (b *BufferSyncPool) Size() int64 {
 	return b.size
 }
+
+// FromSlice converts the provided slice to a map using the key function
+// to determine the appropriate key per entry. If any duplicates
+// exist in the slice, then the entry with the lowest index is used.
+func FromSlice[T any](r []T, key func(T) string) map[string]T {
+	out := make(map[string]T, len(r))
+
+	// there may be duplicate resources in the input list.
+	// by iterating from end to start, the first resource of given name wins.
+	for i := len(r) - 1; i >= 0; i-- {
+		res := r[i]
+		out[key(res)] = res
+	}
+
+	return out
+}


### PR DESCRIPTION
Converts services.Reconciler to be generic over any type instead of being confined to operating on a types.ResourceWithLabels. This allows decoupling of the two since there is nothing specific to resources required for the reconciler to operate.


Companion: https://github.com/gravitational/teleport.e/pull/2957