### PR TITLE
Re-add PIV to amd64 centos7 release builds

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -406,7 +406,7 @@ enter/node: buildbox-node
 # AMD64 builds are done on CentOS 7 build boxes for broader glibc compatibility.
 .PHONY: release-amd64
 release-amd64:
-	$(MAKE) release-centos7 ARCH=amd64 FIDO2=yes
+	$(MAKE) release-centos7 ARCH=amd64 FIDO2=yes PIV=yes
 
 .PHONY: release-amd64-fips
 release-amd64-fips:


### PR DESCRIPTION
PIV was accidentally removed from amd64 centos7 release builds in https://github.com/gravitational/teleport/pull/35026

Closes https://github.com/gravitational/teleport/issues/35787