### PR TITLE
Add label to DatabaseService when deploying using AWS OIDC

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -936,6 +936,9 @@ const (
 	// InstallMethodAWSOIDCDeployServiceEnvVar is the env var used to detect if the agent was installed
 	// using the DeployService action of the AWS OIDC integration.
 	InstallMethodAWSOIDCDeployServiceEnvVar = "TELEPORT_INSTALL_METHOD_AWSOIDC_DEPLOYSERVICE"
+
+	// AWSOIDCAgentLabel is a label that indicates that the service was deployed into ECS/Fargate using the AWS OIDC Integration.
+	AWSOIDCAgentLabel = TeleportNamespace + "/awsoidc-agent"
 )
 
 // CloudHostnameTag is the name of the tag in a cloud instance used to override a node's hostname.

--- a/lib/inventory/metadata/metadata.go
+++ b/lib/inventory/metadata/metadata.go
@@ -181,7 +181,7 @@ func (c *fetchConfig) fetchInstallMethods() []string {
 	if c.systemctlInstallMethod() {
 		installMethods = append(installMethods, "systemctl")
 	}
-	if c.awsoidcDeployServiceInstallMethod() {
+	if AWSOIDCDeployServiceInstallMethod() {
 		installMethods = append(installMethods, "awsoidc_deployservice")
 	}
 	return installMethods
@@ -205,11 +205,15 @@ func (c *fetchConfig) nodeScriptInstallMethod() bool {
 	return c.boolEnvIsTrue("TELEPORT_INSTALL_METHOD_NODE_SCRIPT")
 }
 
-// awsoidcDeployServiceInstallMethod returns true if the instance was installed using
+// AWSOIDCDeployServiceInstallMethod returns true if the instance was installed using
 // the DeployService action of the AWS OIDC integration.
 // This install method uses Amazon ECS with Fargate deployment method.
-func (c *fetchConfig) awsoidcDeployServiceInstallMethod() bool {
-	return c.boolEnvIsTrue(types.InstallMethodAWSOIDCDeployServiceEnvVar)
+func AWSOIDCDeployServiceInstallMethod() bool {
+	b, err := apiutils.ParseBool(os.Getenv(types.InstallMethodAWSOIDCDeployServiceEnvVar))
+	if err != nil {
+		return false
+	}
+	return b
 }
 
 // systemctlInstallMethod returns true if the instance is running using systemctl.

--- a/lib/inventory/metadata/metadata_test.go
+++ b/lib/inventory/metadata/metadata_test.go
@@ -32,10 +32,9 @@ import (
 )
 
 func TestFetchInstallMethods(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		desc        string
+		setupEnv    func(t *testing.T)
 		getenv      func(string) string
 		execCommand func(string, ...string) ([]byte, error)
 		expected    []string
@@ -88,10 +87,10 @@ func TestFetchInstallMethods(t *testing.T) {
 		{
 			desc: "awsoidc_deployservice if env var is present",
 			getenv: func(name string) string {
-				if name == types.InstallMethodAWSOIDCDeployServiceEnvVar {
-					return "true"
-				}
 				return ""
+			},
+			setupEnv: func(t *testing.T) {
+				t.Setenv(types.InstallMethodAWSOIDCDeployServiceEnvVar, "yes")
 			},
 			execCommand: func(name string, args ...string) ([]byte, error) {
 				return nil, trace.NotFound("command does not exist")
@@ -165,6 +164,9 @@ CGroup: /system.slice/teleport.service
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
 			c := &fetchConfig{
 				getenv:      tc.getenv,
 				execCommand: tc.execCommand,

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -40,6 +40,7 @@ import (
 	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/inventory/metadata"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -782,12 +783,18 @@ func (s *Server) Start(ctx context.Context) (err error) {
 
 // startServiceHeartbeat sends the current DatabaseService server info.
 func (s *Server) startServiceHeartbeat() error {
+	labels := make(map[string]string)
+	if metadata.AWSOIDCDeployServiceInstallMethod() {
+		labels[types.AWSOIDCAgentLabel] = types.True
+	}
+
 	getDatabaseServiceServerInfo := func() (types.Resource, error) {
 		expires := s.cfg.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL)
 		resource, err := types.NewDatabaseServiceV1(types.Metadata{
 			Name:      s.cfg.HostID,
 			Namespace: apidefaults.Namespace,
 			Expires:   &expires,
+			Labels:    labels,
 		}, types.DatabaseServiceSpecV1{
 			ResourceMatchers: services.ResourceMatchersToTypes(s.cfg.ResourceMatchers),
 		})


### PR DESCRIPTION
Demo
Running without the env var
`tctl get db_service`
```yaml
kind: db_service
metadata:
  expires: "2023-12-15T19:13:35Z"
  id: 1702667015285239168
  name: cc1d52cf-1cd4-4341-91e5-5beea5815cf8
spec:
  resources:
  - aws: {}
    labels:
      anyone: "no"
version: v1
```


Running with the env var (emulating a DatabaseService deployed via AWS OIDC)
`tctl get db_service`
```yaml
kind: db_service
metadata:
  expires: "2023-12-15T19:14:16Z"
  id: 1702667056790726293
  labels:
    teleport.dev/awsoidc-agent: "true"
  name: cc1d52cf-1cd4-4341-91e5-5beea5815cf8
spec:
  resources:
  - aws: {}
    labels:
      anyone: "no"
version: v1
```