### PR TITLE
Stop users from deleting their last passwordless device

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3170,8 +3170,13 @@ func (a *Server) DeleteMFADeviceSync(ctx context.Context, req *proto.DeleteMFADe
 	return trace.Wrap(err)
 }
 
-// deleteMFADeviceSafely deletes the user's mfa device while preventing users from deleting their last device
-// for clusters that require second factors, which prevents users from being locked out of their account.
+// deleteMFADeviceSafely deletes the user's mfa device while preventing users
+// from locking themselves out of their account.
+//
+// Deletes are not allowed in the following situations:
+//   - Last MFA device when the cluster requires MFA
+//   - Last resident key credential in a passwordless-capable cluster (avoids
+//     passwordless users from locking themselves out).
 func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName string) (*types.MFADevice, error) {
 	devs, err := a.Services.GetMFADevices(ctx, user, true)
 	if err != nil {
@@ -3191,6 +3196,11 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 	sfToCount := make(map[constants.SecondFactorType]int)
 	var knownDevices int
 	var deviceToDelete *types.MFADevice
+	var numResidentKeys int
+
+	isResidentKey := func(d *types.MFADevice) bool {
+		return d.GetWebauthn() != nil && d.GetWebauthn().ResidentKey
+	}
 
 	// Find the device to delete and count devices.
 	for _, d := range devs {
@@ -3210,6 +3220,10 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 
 		sfToCount[sf]++
 		knownDevices++
+
+		if isResidentKey(d) {
+			numResidentKeys++
+		}
 	}
 	if deviceToDelete == nil {
 		return nil, trace.NotFound("MFA device %q does not exist", deviceName)
@@ -3231,6 +3245,20 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 		}
 	default:
 		return nil, trace.BadParameter("unexpected second factor type: %s", sf)
+	}
+
+	// Stop users from deleting their last resident key. This prevents
+	// passwordless users from locking themselves out, at the cost of not letting
+	// regular users do it either.
+	//
+	// A better logic would be to apply this only to passwordless users, but we
+	// cannot distinguish users in that manner.
+	// See https://github.com/gravitational/teleport/issues/13219#issuecomment-1148255979.
+	//
+	// TODO(codingllama): Check if the last login type used was passwordless, if
+	//  not then we could let this device be deleted.
+	if authPref.GetAllowPasswordless() && numResidentKeys == 1 && isResidentKey(deviceToDelete) {
+		return nil, trace.BadParameter("cannot delete last passwordless credential for user")
 	}
 
 	if err := a.DeleteMFADevice(ctx, user, deviceToDelete.Id); err != nil {


### PR DESCRIPTION
Stop users from deleting their last passwordless device in a passwordless-capable cluster.

In certain situations, like clusters with "second_factor:optional", it's possible to delete all your MFA devices. A pure passwordless user could lock themselves out by doing so.

This PR makes it impossible to delete your last passwordless device (if the cluster allows passwordless logins), preventing those lockouts at the cost of being more restrictive for "normal" users.

#32690

Changelog: Stop users from deleting their last passwordless device