### PR TITLE
fix: headers rewrite example configuration

### DIFF
--- a/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
@@ -98,8 +98,7 @@ set by the annotation.
 ### `teleport.dev/app-rewrite`
 
 Controls rewrite configuration for Teleport app, if needed. It should
-contain full rewrite configuration in YAML format, same as one would put into `rewrite` config section of an
-app with dynamic registration (see [documentation](../guides/connecting-apps.mdx#rewrite-redirect)).
+contain full rewrite configuration in YAML format, same as one would use when configuring an app with dynamic registration syntax (see [documentation](../guides/connecting-apps.mdx#rewrite-redirect)).
 
 ```yaml
 annotations:

--- a/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
@@ -108,7 +108,9 @@ annotations:
     - "localhost"
     - "jenkins.internal.dev"
     headers:
-    - "X-Custom-Header: example"
-    - "Authorization: Bearer {{internal.jwt}}"
+    - name: "X-Custom-Header"
+      value: "example"
+    - name: "Authorization"
+      value: "Bearer {{internal.jwt}}"
 ```
 

--- a/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
@@ -99,7 +99,7 @@ set by the annotation.
 
 Controls rewrite configuration for Teleport app, if needed. It should
 contain full rewrite configuration in YAML format, same as one would put into `rewrite` config section of an
-app (see [documentation](../guides/connecting-apps.mdx#rewrite-redirect)).
+app with dynamic registration (see [documentation](../guides/connecting-apps.mdx#rewrite-redirect)).
 
 ```yaml
 annotations:


### PR DESCRIPTION
Closes #35816

Fix headers rewrite example configuration in teleport.dev/app-rewrite annotation for App discovery