### PR TITLE
DiscoveryService: poll on DiscoveryConfig events

### DIFF
--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -41,8 +41,8 @@ type WatcherConfig struct {
 	FetchersFn func() []Fetcher
 	// Interval is the interval between fetches.
 	Interval time.Duration
-	// PollTrigger can be used to force an instant Poll, instead of waiting for the next poll Interval.
-	PollTrigger chan struct{}
+	// TriggerFetchC can be used to force an instant Poll, instead of waiting for the next poll Interval.
+	TriggerFetchC chan struct{}
 	// Log is the watcher logger.
 	Log logrus.FieldLogger
 	// Clock is used to control time.
@@ -64,8 +64,8 @@ func (c *WatcherConfig) CheckAndSetDefaults() error {
 	if c.Interval == 0 {
 		c.Interval = 5 * time.Minute
 	}
-	if c.PollTrigger == nil {
-		c.PollTrigger = make(chan struct{})
+	if c.TriggerFetchC == nil {
+		c.TriggerFetchC = make(chan struct{})
 	}
 	if c.Log == nil {
 		c.Log = logrus.New()
@@ -114,7 +114,7 @@ func (w *Watcher) Start() {
 		select {
 		case <-ticker.Chan():
 			w.fetchAndSend()
-		case <-w.cfg.PollTrigger:
+		case <-w.cfg.TriggerFetchC:
 			w.fetchAndSend()
 		case <-w.ctx.Done():
 			w.cfg.Log.Infof("Watcher done.")

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -41,6 +41,8 @@ type WatcherConfig struct {
 	FetchersFn func() []Fetcher
 	// Interval is the interval between fetches.
 	Interval time.Duration
+	// PollTrigger can be used to force an instant Poll, instead of waiting for the next poll Interval.
+	PollTrigger chan struct{}
 	// Log is the watcher logger.
 	Log logrus.FieldLogger
 	// Clock is used to control time.
@@ -61,6 +63,9 @@ type WatcherConfig struct {
 func (c *WatcherConfig) CheckAndSetDefaults() error {
 	if c.Interval == 0 {
 		c.Interval = 5 * time.Minute
+	}
+	if c.PollTrigger == nil {
+		c.PollTrigger = make(chan struct{})
 	}
 	if c.Log == nil {
 		c.Log = logrus.New()
@@ -108,6 +113,8 @@ func (w *Watcher) Start() {
 	for {
 		select {
 		case <-ticker.Chan():
+			w.fetchAndSend()
+		case <-w.cfg.PollTrigger:
 			w.fetchAndSend()
 		case <-w.ctx.Done():
 			w.cfg.Log.Infof("Watcher done.")

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -66,7 +66,7 @@ func (s *Server) startDatabaseWatchers() error {
 		Log:            s.Log.WithField("kind", types.KindDatabase),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
-		PollTrigger:    s.newPollSubscription(),
+		TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
 		Origin:         types.OriginCloud,
 		Clock:          s.clock,
 	})

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -66,6 +66,7 @@ func (s *Server) startDatabaseWatchers() error {
 		Log:            s.Log.WithField("kind", types.KindDatabase),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
+		PollTrigger:    s.newPollSubscription(),
 		Origin:         types.OriginCloud,
 		Clock:          s.clock,
 	})

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -128,7 +128,7 @@ type Config struct {
 	// TriggerFetchC is a list of channels that must be notified when a off-band poll must be performed.
 	// This is used to start a polling iteration when a new DiscoveryConfig change is received.
 	TriggerFetchC  []chan struct{}
-	triggerFetchMu *sync.RWMutex
+	triggerFetchMu sync.RWMutex
 
 	// clock is passed to watchers to handle poll intervals.
 	// Mostly used in tests.
@@ -188,7 +188,7 @@ kubernetes matchers are present.`)
 	}
 
 	c.TriggerFetchC = make([]chan struct{}, 0)
-	c.triggerFetchMu = &sync.RWMutex{}
+	c.triggerFetchMu = sync.RWMutex{}
 
 	if c.clock == nil {
 		c.clock = clockwork.NewRealClock()

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -184,14 +184,14 @@ func genEC2Instances(n int) []*ec2.Instance {
 
 type mockSSMInstaller struct {
 	mu                 sync.Mutex
-	installedInstances []string
+	installedInstances map[string]struct{}
 }
 
 func (m *mockSSMInstaller) Run(_ context.Context, req server.SSMRunRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, inst := range req.Instances {
-		m.installedInstances = append(m.installedInstances, inst.InstanceID)
+		m.installedInstances[inst.InstanceID] = struct{}{}
 	}
 	return nil
 }
@@ -199,7 +199,11 @@ func (m *mockSSMInstaller) Run(_ context.Context, req server.SSMRunRequest) erro
 func (m *mockSSMInstaller) GetInstalledInstances() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.installedInstances
+	keys := make([]string, 0, len(m.installedInstances))
+	for k := range m.installedInstances {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestDiscoveryServer(t *testing.T) {
@@ -482,7 +486,9 @@ func TestDiscoveryServer(t *testing.T) {
 
 			logger := logrus.New()
 			reporter := &mockUsageReporter{}
-			installer := &mockSSMInstaller{}
+			installer := &mockSSMInstaller{
+				installedInstances: make(map[string]struct{}),
+			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				CloudClients:     testCloudClients,
@@ -501,13 +507,6 @@ func TestDiscoveryServer(t *testing.T) {
 			if tc.discoveryConfig != nil {
 				_, err := tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 				require.NoError(t, err)
-
-				// Wait for the DiscoveryConfig to be added to the dynamic matchers
-				require.Eventually(t, func() bool {
-					server.muDynamicServerAWSFetchers.RLock()
-					defer server.muDynamicServerAWSFetchers.RUnlock()
-					return len(server.dynamicServerAWSFetchers) > 0
-				}, 1*time.Second, 100*time.Millisecond)
 			}
 
 			go server.Start()
@@ -519,13 +518,14 @@ func TestDiscoveryServer(t *testing.T) {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
 					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
+
 				}, 5000*time.Millisecond, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
 					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
-			require.Equal(t, 1, reporter.DiscoveryFetchEventCount())
+			require.GreaterOrEqual(t, 1, reporter.DiscoveryFetchEventCount())
 		})
 	}
 }
@@ -1901,14 +1901,6 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 		_, err = tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
-		require.Eventually(t, func() bool {
-			srv.muDynamicDatabaseFetchers.RLock()
-			defer srv.muDynamicDatabaseFetchers.RUnlock()
-			return len(srv.dynamicDatabaseFetchers) == 0
-		}, 1*time.Second, 100*time.Millisecond)
-
-		// Advance clock to trigger a poll.
-		clock.Advance(5 * time.Minute)
 
 		// Reconcile should not have any databases
 		select {
@@ -1940,15 +1932,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 		_, err = tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
-		require.Eventually(t, func() bool {
-			srv.muDynamicDatabaseFetchers.RLock()
-			defer srv.muDynamicDatabaseFetchers.RUnlock()
-			return len(srv.dynamicDatabaseFetchers) > 0
-		}, 1*time.Second, 100*time.Millisecond)
-
 		require.Zero(t, reporter.DiscoveryFetchEventCount())
-		// Advance clock to trigger a poll.
-		clock.Advance(5 * time.Minute)
 
 		// Check for new resource in reconciler
 		expectDatabases := []types.Database{awsRDSDB}
@@ -1980,14 +1964,6 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			// Remove DiscoveryConfig
 			err = tlsServer.Auth().DiscoveryConfigClient().DeleteDiscoveryConfig(ctx, dc1.GetName())
 			require.NoError(t, err)
-			require.Eventually(t, func() bool {
-				srv.muDynamicDatabaseFetchers.RLock()
-				defer srv.muDynamicDatabaseFetchers.RUnlock()
-				return len(srv.dynamicDatabaseFetchers) == 0
-			}, 1*time.Second, 100*time.Millisecond)
-
-			// Advance clock to trigger a poll.
-			clock.Advance(5 * time.Minute)
 
 			// Existing databases must be removed.
 			select {
@@ -2103,14 +2079,14 @@ func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*a
 
 type mockAzureInstaller struct {
 	mu                 sync.Mutex
-	installedInstances []string
+	installedInstances map[string]struct{}
 }
 
 func (m *mockAzureInstaller) Run(_ context.Context, req server.AzureRunRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, inst := range req.Instances {
-		m.installedInstances = append(m.installedInstances, *inst.Name)
+		m.installedInstances[*inst.Name] = struct{}{}
 	}
 	return nil
 }
@@ -2118,7 +2094,11 @@ func (m *mockAzureInstaller) Run(_ context.Context, req server.AzureRunRequest) 
 func (m *mockAzureInstaller) GetInstalledInstances() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.installedInstances
+	keys := make([]string, 0, len(m.installedInstances))
+	for k := range m.installedInstances {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestAzureVMDiscovery(t *testing.T) {
@@ -2313,7 +2293,9 @@ func TestAzureVMDiscovery(t *testing.T) {
 			logger := logrus.New()
 			emitter := &mockEmitter{}
 			reporter := &mockUsageReporter{}
-			installer := &mockAzureInstaller{}
+			installer := &mockAzureInstaller{
+				installedInstances: make(map[string]struct{}),
+			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				CloudClients:     testCloudClients,
@@ -2387,14 +2369,14 @@ func (m *mockGCPClient) RemoveSSHKey(_ context.Context, _ *gcp.SSHKeyRequest) er
 
 type mockGCPInstaller struct {
 	mu                 sync.Mutex
-	installedInstances []string
+	installedInstances map[string]struct{}
 }
 
 func (m *mockGCPInstaller) Run(_ context.Context, req server.GCPRunRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, inst := range req.Instances {
-		m.installedInstances = append(m.installedInstances, inst.Name)
+		m.installedInstances[inst.Name] = struct{}{}
 	}
 	return nil
 }
@@ -2402,7 +2384,12 @@ func (m *mockGCPInstaller) Run(_ context.Context, req server.GCPRunRequest) erro
 func (m *mockGCPInstaller) GetInstalledInstances() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.installedInstances
+
+	keys := make([]string, 0, len(m.installedInstances))
+	for k := range m.installedInstances {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestGCPVMDiscovery(t *testing.T) {
@@ -2566,7 +2553,9 @@ func TestGCPVMDiscovery(t *testing.T) {
 			logger := logrus.New()
 			emitter := &mockEmitter{}
 			reporter := &mockUsageReporter{}
-			installer := &mockGCPInstaller{}
+			installer := &mockGCPInstaller{
+				installedInstances: make(map[string]struct{}),
+			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				CloudClients:     testCloudClients,

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -83,12 +83,12 @@ type azureClientGetter interface {
 func NewAzureWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...Option) (*Watcher, error) {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	watcher := Watcher{
-		fetchersFn:   fetchersFn,
-		ctx:          cancelCtx,
-		cancel:       cancelFn,
-		pollInterval: time.Minute,
-		pollTrigger:  make(<-chan struct{}),
-		InstancesC:   make(chan Instances),
+		fetchersFn:    fetchersFn,
+		ctx:           cancelCtx,
+		cancel:        cancelFn,
+		pollInterval:  time.Minute,
+		triggerFetchC: make(<-chan struct{}),
+		InstancesC:    make(chan Instances),
 	}
 	for _, opt := range opts {
 		opt(&watcher)

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -87,6 +87,7 @@ func NewAzureWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...O
 		ctx:          cancelCtx,
 		cancel:       cancelFn,
 		pollInterval: time.Minute,
+		pollTrigger:  make(<-chan struct{}),
 		InstancesC:   make(chan Instances),
 	}
 	for _, opt := range opts {

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -153,6 +153,7 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 		ctx:            cancelCtx,
 		cancel:         cancelFn,
 		pollInterval:   time.Minute,
+		pollTrigger:    make(<-chan struct{}),
 		InstancesC:     make(chan Instances),
 		missedRotation: missedRotation,
 	}

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -153,7 +153,7 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 		ctx:            cancelCtx,
 		cancel:         cancelFn,
 		pollInterval:   time.Minute,
-		pollTrigger:    make(<-chan struct{}),
+		triggerFetchC:  make(<-chan struct{}),
 		InstancesC:     make(chan Instances),
 		missedRotation: missedRotation,
 	}

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -74,12 +74,12 @@ func (instances *GCPInstances) MakeEvents() map[string]*usageeventsv1.ResourceCr
 func NewGCPWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...Option) (*Watcher, error) {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	watcher := Watcher{
-		fetchersFn:   fetchersFn,
-		ctx:          cancelCtx,
-		cancel:       cancelFn,
-		pollInterval: time.Minute,
-		pollTrigger:  make(<-chan struct{}),
-		InstancesC:   make(chan Instances),
+		fetchersFn:    fetchersFn,
+		ctx:           cancelCtx,
+		cancel:        cancelFn,
+		pollInterval:  time.Minute,
+		triggerFetchC: make(<-chan struct{}),
+		InstancesC:    make(chan Instances),
 	}
 
 	for _, opt := range opts {

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -71,15 +71,21 @@ func (instances *GCPInstances) MakeEvents() map[string]*usageeventsv1.ResourceCr
 }
 
 // NewGCPWatcher creates a new GCP watcher.
-func NewGCPWatcher(ctx context.Context, fetchersFn func() []Fetcher) (*Watcher, error) {
+func NewGCPWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...Option) (*Watcher, error) {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	watcher := Watcher{
 		fetchersFn:   fetchersFn,
 		ctx:          cancelCtx,
 		cancel:       cancelFn,
 		pollInterval: time.Minute,
+		pollTrigger:  make(<-chan struct{}),
 		InstancesC:   make(chan Instances),
 	}
+
+	for _, opt := range opts {
+		opt(&watcher)
+	}
+
 	return &watcher, nil
 }
 


### PR DESCRIPTION
DiscoveryService now supports dynamic matchers based on its DiscoveryGroup.

It uses the DiscoveryConfig resource to dynamically load the matchers.

In order to provide a better UX, we want to load the Matchers as soon as possible, instead of the current 5 minute (default) interval.

This PR adds a broadcast system to the DiscoveryService and its watchers.
When a DiscoveryConfig event is processed, it will notify all the Watchers and trigger a new resource polling.