### PR TITLE
[v13] charts/kube-agent: updater extraArgs

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -203,6 +203,14 @@ Cloud user, and manage your own version server.
 You can override this to use your own Teleport Kube Agent Updater image rather
 than a Teleport-published image.
 
+### `updater.extraArgs`
+
+| Type   | Default value | Required? |
+|--------|---------------|-----------|
+| `list` | `[]`          | No        |
+
+`extraArgs` contains additional arguments to pass to the updater binary.
+
 ## `roleBindingName`
 
 | Type     | Default value | Required? |

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -67,6 +67,9 @@ spec:
           - "--base-image={{ include "teleport-kube-agent.baseImage" . }}"
           - "--version-server={{ $updater.versionServer }}"
           - "--version-channel={{ $updater.releaseChannel }}"
+          {{- if .Values.updater.extraArgs }}
+            {{- toYaml .Values.updater.extraArgs | nindent 10 }}
+          {{- end }}
 {{- if $updater.securityContext }}
         securityContext: {{- toYaml $updater.securityContext | nindent 10 }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -225,3 +225,14 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: distinct-updater-sa
+  - it: sets extraArgs when set
+    values:
+      - ../.lint/updater.yaml
+    set:
+      updater:
+        extraArgs:
+          - "--foo=bar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--foo=bar"

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -153,6 +153,9 @@ updater:
   serviceAccount:
     # service account name defaults to "<kube agent sa name>-updater"
     name: ""
+  # extraArgs(list) -- contains additional arguments to pass to the updater
+  # binary.
+  extraArgs: []
 
 # If set, will use an existing volume mounted via extraVolumes
 # as the Teleport data directory.


### PR DESCRIPTION
Backport #35786 to branch/v13

changelog: the `teleport-kube-agent` chart supports passing extra arguments to the updater.
