### PR TITLE
[v13] Role implements resource with labels.

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -48,7 +48,7 @@ const (
 // Role contains a set of permissions or settings
 type Role interface {
 	// Resource provides common resource methods.
-	Resource
+	ResourceWithLabels
 
 	// SetMetadata sets role metadata
 	SetMetadata(meta Metadata)
@@ -1641,6 +1641,44 @@ func (r *RoleV6) SetLabelMatchers(rct RoleConditionType, kind string, labelMatch
 		return nil
 	}
 	return trace.BadParameter("can't set label matchers for resource kind %q", kind)
+}
+
+// GetLabel retrieves the label with the provided key.
+func (r *RoleV6) GetLabel(key string) (value string, ok bool) {
+	v, ok := r.Metadata.Labels[key]
+	return v, ok
+}
+
+// GetAllLabels returns all resource's labels.
+func (r *RoleV6) GetAllLabels() map[string]string {
+	return r.Metadata.Labels
+}
+
+// GetStaticLabels returns the resource's static labels.
+func (r *RoleV6) GetStaticLabels() map[string]string {
+	return r.Metadata.Labels
+}
+
+// SetStaticLabels sets the resource's static labels.
+func (r *RoleV6) SetStaticLabels(labels map[string]string) {
+	r.Metadata.Labels = labels
+}
+
+// Origin returns the origin value of the resource.
+func (r *RoleV6) Origin() string {
+	return r.Metadata.Origin()
+}
+
+// SetOrigin sets the origin value of the resource.
+func (r *RoleV6) SetOrigin(origin string) {
+	r.Metadata.SetOrigin(origin)
+}
+
+// MatchSearch goes through select field values of a resource
+// and tries to match against the list of search values.
+func (r *RoleV6) MatchSearch(values []string) bool {
+	fieldVals := append(utils.MapToStrings(r.GetAllLabels()), r.GetName())
+	return MatchSearch(fieldVals, values, nil)
 }
 
 // LabelMatcherKinds is the complete list of resource kinds that support label


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/35660 to branch/v13.

Note: This backport is manual because `HasLabelMatchers` doesn't exist in v13, which caused a conflict. Other than that this was pretty straightforward.