### PR TITLE
Sort CLI reference guides alphabetically

### DIFF
--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -18,56 +18,37 @@ The primary commands for `tbot` are as follows:
 | `tbot db` | Connects to databases using native clients and queries database information. Functions as a wrapper for `tsh`, and requires `tsh` installation. |
 | `tbot proxy` | Allows for access to Teleport resources on a cluster using TLS Routing. Functions as a wrapper for `tsh`, and requires `tsh` installation. |
 
-## tbot start
+## tbot db
 
-Starts the Machine ID client `tbot`, fetching and writing certificates to disk at a set interval.
+Connects to databases using native clients and queries database information. This is best used for testing and validation purposes;
+most users will likely prefer to connect their own databases to a local proxy using `tbot proxy db`.
+
+Note that `tsh` must be installed to make use of this command.
 
 ### Flags
 
-| Flag                 | Description                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------------|
-| `-d/--debug`         | Enable verbose logging to stderr.                                                              |
-| `-c/--config`        | Path to a Machine ID configuration file.                                                                  |
-| `-a/--auth-server`   | Address of the Teleport Auth Server (on-prem installs) or Teleport Cloud tenant.               |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
-| `--ca-pin`           | CA pin to validate the Teleport Auth Server; used on first connect.                            |
-| `--data-dir`         | Directory to store internal bot data. In production environments access to this directory should be limited only to an isolated linux user as an owner with `0600` permissions. |
-| `--destination-dir`  | Directory to write short-lived machine certificates.                                           |
-| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                       |
-| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
-| `--join-method`      | Method to use to join the cluster. Can be `token`, `azure`, `circleci`, `gcp`, `github`, `gitlab` or `iam`. |
-| `--oneshot`          | If set, quit after the first renewal.                                                          |
-| `--log-format`       | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.               |
+| Flag                | Description                                                                                              |
+|---------------------|----------------------------------------------------------------------------------------------------------|
+| `-d/--debug`        | Enable verbose logging to stderr.                                                                        |
+| `-c/--config`       | Path to a Machine ID configuration file. Required if not using other required configuration flags.                  |
+| `--destination-dir` | Path to the Machine ID destination dir that should be used for authentication. Required.                 |
+| `--proxy`           | The `host:port` of the Teleport Proxy Service to use to access resources. Required.                      |
+| `--cluster`         | The name of the cluster on which resources should be accessed. Extracted from the bot identity if unset. |
 
-### Examples
-<Tabs>
-  <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
+All other flags and arguments are passed directly to `tsh db ...`, along
+with authentication parameters to use the Machine ID identity to skip `tsh`'s
+login steps.
 
-```code
-$ tbot start \
-   --data-dir=/var/lib/teleport/bot \
-   --destination-dir=/opt/machine-id \
-   --token=00000000000000000000000000000000 \
-   --join-method=token \
-   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
-   --auth-server=example.teleport.sh:443
-```
+Note that certain CLI parameters, for example `--help`, may be captured by
+`tbot` even if intended to be passed to the wrapped `tsh`. A `--` argument can
+be used to ensure all following arguments are passed to `tsh` and ignored by
+`tbot`.
 
-  </TabItem>
-  <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
-
-```code
-$ tbot start \
-   --data-dir=/var/lib/teleport/bot \
-   --destination-dir=/opt/machine-id \
-   --token=00000000000000000000000000000000 \
-   --join-method=token \
-   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
-   --auth-server=auth.example.com:3025
-```
-
-  </TabItem>
-</Tabs>
+Additionally, be aware of the following limitations of `tbot db`:
+ - `tbot db connect` requires a `tbot db login` for certain database types,
+   like MySQL, so that additional connection parameters can be written to a
+   local configuration file.
+ - `tbot db env` is not fully supported.
 
 ## tbot init
 
@@ -116,38 +97,6 @@ $ tbot init \
     --bot-user=teleport \
     --reader-user=jenkins
 ```
-
-## tbot db
-
-Connects to databases using native clients and queries database information. This is best used for testing and validation purposes;
-most users will likely prefer to connect their own databases to a local proxy using `tbot proxy db`.
-
-Note that `tsh` must be installed to make use of this command.
-
-### Flags
-
-| Flag                | Description                                                                                              |
-|---------------------|----------------------------------------------------------------------------------------------------------|
-| `-d/--debug`        | Enable verbose logging to stderr.                                                                        |
-| `-c/--config`       | Path to a Machine ID configuration file. Required if not using other required configuration flags.                  |
-| `--destination-dir` | Path to the Machine ID destination dir that should be used for authentication. Required.                 |
-| `--proxy`           | The `host:port` of the Teleport Proxy Service to use to access resources. Required.                      |
-| `--cluster`         | The name of the cluster on which resources should be accessed. Extracted from the bot identity if unset. |
-
-All other flags and arguments are passed directly to `tsh db ...`, along
-with authentication parameters to use the Machine ID identity to skip `tsh`'s
-login steps.
-
-Note that certain CLI parameters, for example `--help`, may be captured by
-`tbot` even if intended to be passed to the wrapped `tsh`. A `--` argument can
-be used to ensure all following arguments are passed to `tsh` and ignored by
-`tbot`.
-
-Additionally, be aware of the following limitations of `tbot db`:
- - `tbot db connect` requires a `tbot db login` for certain database types,
-   like MySQL, so that additional connection parameters can be written to a
-   local configuration file.
- - `tbot db env` is not fully supported.
 
 ## tbot proxy
 
@@ -239,3 +188,54 @@ using database proxies.
 | `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
 | `--join-method`      | Method to use to join the cluster. Can be `token` or `iam`.                                    |
 | `--oneshot`          | If set, quit after the first renewal.                                                          |
+## tbot start
+
+Starts the Machine ID client `tbot`, fetching and writing certificates to disk at a set interval.
+
+### Flags
+
+| Flag                 | Description                                                                                    |
+|----------------------|------------------------------------------------------------------------------------------------|
+| `-d/--debug`         | Enable verbose logging to stderr.                                                              |
+| `-c/--config`        | Path to a Machine ID configuration file.                                                                  |
+| `-a/--auth-server`   | Address of the Teleport Auth Server (on-prem installs) or Teleport Cloud tenant.               |
+| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
+| `--ca-pin`           | CA pin to validate the Teleport Auth Server; used on first connect.                            |
+| `--data-dir`         | Directory to store internal bot data. In production environments access to this directory should be limited only to an isolated linux user as an owner with `0600` permissions. |
+| `--destination-dir`  | Directory to write short-lived machine certificates.                                           |
+| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                       |
+| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
+| `--join-method`      | Method to use to join the cluster. Can be `token`, `azure`, `circleci`, `gcp`, `github`, `gitlab` or `iam`. |
+| `--oneshot`          | If set, quit after the first renewal.                                                          |
+| `--log-format`       | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.               |
+
+### Examples
+<Tabs>
+  <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
+
+```code
+$ tbot start \
+   --data-dir=/var/lib/teleport/bot \
+   --destination-dir=/opt/machine-id \
+   --token=00000000000000000000000000000000 \
+   --join-method=token \
+   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+   --auth-server=example.teleport.sh:443
+```
+
+  </TabItem>
+  <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
+
+```code
+$ tbot start \
+   --data-dir=/var/lib/teleport/bot \
+   --destination-dir=/opt/machine-id \
+   --token=00000000000000000000000000000000 \
+   --join-method=token \
+   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+   --auth-server=auth.example.com:3025
+```
+
+  </TabItem>
+</Tabs>
+

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -109,350 +109,142 @@ which could result in the error,
 | `-i, --identity` | none | **string** filepath | Path to an identity file |
 | `--insecure` | none | none | When specifying a Proxy Service address in `--auth-server`, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker |
 
-## tctl help
+## tctl acl get
 
-Shows help:
+Gets and displays information about a particular access list.
 
 ```code
-$ tctl help
+$ tctl acl get <id>
 ```
 
-## tctl users add
+## tctl acl ls
 
-Generates a user invitation token:
+Lists Access Lists on the cluster.
 
 ```code
-$ tctl users add [<flags>] <account>
+$ tctl acl ls
+```
+
+## tctl acl users add
+
+Adds a user to an access list.
+
+```code
+$ tctl acl users add <access-list-name> <user> [<expires>] [<reason>]
+```
+
+## tctl acl users ls
+
+Lists the users in an access list.
+
+```code
+$ tctl acl users ls <access-list-name>
+```
+
+## tctl acl users rm
+
+Removes a user from an access list.
+
+```code
+$ tctl acl users rm <access-list-name> <user>
+```
+
+## tctl alerts ack
+
+Temporarily acknowledges a cluster alert, preventing the alert from being
+displayed to users. Acknowledgements last for 24 hours by default. Users
+will begin seeing the alert again when the acknowledgement expires.
+
+```code
+$ tctl alerts ack [<flags>] <id>
 ```
 
 ### Arguments
 
-- `<account>` - The Teleport user account name.
+- `<id>`: the ID of the cluster alert to acknowledge
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--roles` | none | Comma-separated strings | List of Teleport roles to assign to the new user |
-| `--logins` | none | Comma-separated strings | List of allowed SSH logins for the new user |
-| `--kubernetes-groups` | none | Comma-separated strings | Kubernetes groups to assign to a user, e.g. `system:masters` |
-| `--kubernetes-users` | none | Comma-separated strings | Kubernetes user to assign to a user, e.g. `jenkins` |
-| `--db-users` | none | Comma-separated strings | List of allowed database users for the new user |
-| `--db-names` | none | Comma-separated strings | List of allowed database names for the new user |
-| `--windows-logins` | none | Comma-separated strings | List of allowed Windows logins for the new user |
-| `--aws-role-arns` | none | Comma-separated strings | List of allowed AWS role ARNs for the new user |
-| `--gcp-service-accounts` | none | Comma-separated strings | List of allowed GCP service accounts for the new user |
-| `--azure-identities` | none | Comma-separated strings | List of Azure managed identities to allow the user to assume. Must be the full URIs of the identities |
-| `--ttl` | 1h | relative duration like 5s, 2m, or 3h, **maximum 48h** | Set expiration time for token |
-| `--host-user-uid` | none | Unix UID | UID for auto provisioned host users to use |
-| `--host-user-gid` | none | Unix GID | GID for auto provisioned host users to use |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config`. Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+| `--ttl` | 24h | Any duration | Time duration to acknowledge the alert for |
+| `--clear` | none | | Clear an existing alert acknowledgement |
+| `--reason` | none | | The reason for suppressing this alert |
 
 ### Examples
 
+Suppress the cluster alert notifying users that an upgrade is available:
+
 ```code
-# Adds teleport user "joe" with mappings to
-# OS users and {{ internal.logins }} to "joe" and "ubuntu"
-$ tctl users add joe --roles=access,requester joe,ubuntu
-# Adds Teleport user "joe" with mappings to the editor role
-$ tctl users add joe --roles=editor,reviewer
+$ tctl alerts ack --reason="upgrade scheduled" upgrade-suggestion
+Successfully acknowledged alert 'upgrade-suggestion'. Alerts with this ID won't be pushed for 24h0m0s.
 ```
 
-## tctl users update
-
-Update user account:
+Clear an existing alert acknowledgement:
 
 ```code
-$ tctl users update [<flags>] <account>
+$ tctl alerts ack --clear upgrade-suggestion
+```
+
+## tctl alerts ack ls
+
+Lists alert acknowledgements.
+
+```code
+$ tctl alerts ack ls
+ID                 Reason                 Expires
+------------------ ---------------------- --------------------
+upgrade-suggestion "upgrade is scheduled" Wed Apr 12 16:52 UTC
+```
+
+## tctl alerts create
+
+Creates cluster alerts. Cluster alerts can be displayed to Teleport users
+in the web UI or upon logging via `tsh`.
+
+```code
+$ tctl alerts create [<flags>] <message>
 ```
 
 ### Arguments
 
-- `<account>` - The Teleport user account name.
+- `<message>`: The message for the alert to display
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--set-roles` | none | Comma-separated list of roles for the user to assume. | Assigns the user's roles to the ones provided, replacing the user's current roles. |
-| `--set-azure-identities` | none | Comma-separated list of allowed Azure identity URIs. |  Assigns the user's allowed Azure identities to the ones provided, replacing the user's currently allowed Azure identities. |
+| `--severity` | `low` | `low`, `medium`, `high` | Alert severity |
+| `--ttl` | none | Any duration | Optional expiry for alert (alert does not expire if no TTL is specified) |
+| `--labels` | none | any | A list of labels to attach to the alert. |
 
-### Examples
+While any labels can be applied to an alert, there are several internal labels that can be used to configure
+the behavior of alerts:
 
-Set the user `joe`'s roles to `access` and `editor`:
+- `teleport.internal/alert-on-login: yes`: ensures that the alert is displayed to users upon login
+- `teleport.internal/alert-permit-all: yes`: ensures that the alert is displayed to all users
 
-```code
-$ tctl users update joe --set-roles=access,editor
-```
-
-Set the user `priya`'s Azure identities to `developer` and `dba`:
-
-```code
-$ tctl users update priya --set-azure-identities \
- `/subscriptions/${SUBSCRIPTION_ID?}/resourceGroups/${MY_RESOURCE_GROUP?}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/developer,\
- `/subscriptions/${SUBSCRIPTION_ID?}/resourceGroups/${MY_RESOURCE_GROUP?}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dba
-```
-
-## tctl users ls
-
-Lists all user accounts:
-
-```code
-$ tctl users ls [<flags>]
-```
-
-## tctl users rm
-
-Deletes user accounts:
-
-```code
-$ tctl users rm <logins>
-```
-
-### Arguments
-
-- `<logins>` - comma-separated list of Teleport users
+If no labels are specified, `tctl` will automatically add both of these labels.
 
 ### Examples
 
 ```code
-$ tctl users rm sally,tim
-# Removes users sally and tim
+$ tctl alerts create \
+    --severity=low \
+    --ttl=4h \
+    "The system is under maintenance, functionality may be limited."
 ```
 
-## tctl users reset
+## tctl alerts list
 
-Reset local user account password and any associated second factor with expiring link to populate values. **Usage**: `tctl users reset <account>`
-
-### Arguments
-
-- `<account>` - Teleport Local DB User
+Lists cluster alerts. This command can also be invoked as `tctl alerts ls`.
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--ttl` | `8h` | relative duration like `5s`, `2m`, or `3h` | Set the expiration time for token, default is `8h0m0s`, maximum is `24h0m0s` |
-
-### Examples
-
-```code
-$ tctl users reset jeff
-# User jeff has been reset. Share this URL with the user to complete password reset, the link is valid for 8h0m0s:
-# https://teleport.example.com:3080/web/reset/8a4a40bec3a31a28db44fa64c0c70ca3
-# Resets jeff's password and any associated second factor.  Jeff populates the password and confirms the token with the link.
-```
-
-## tctl request ls
-
-List of open requests:
-
-```code
-$ tctl request ls
-```
-
-### Examples
-
-```code
-$ tctl request ls
-
-# Token                                Requestor Metadata       Created At (UTC)    Status
-# ------------------------------------ --------- -------------- ------------------- -------
-# request-id-1                         alice     roles=dictator 07 Nov 19 19:38 UTC PENDING
-```
-
-## tctl request approve
-
-Approve a user's request:
-
-```code
-$ tctl request approve [token]
-```
-
-### Arguments
-
-- `<tokens>` - comma-separated list of Teleport tokens.
-
-### Examples
-
-```code
-$ tctl request approve request-id-1, request-id-2
-```
-
-## tctl request deny
-
-Denies a user's request:
-
-```code
-$ tctl request deny [token]
-```
-
-### Arguments
-
-- `<tokens>` - comma-separated list of Teleport tokens.
-
-### Examples
-
-```code
-$ tctl request deny request-id-1, request-id-2
-```
-
-## tctl request rm
-
-Delete a users role request:
-
-```code
-$ tctl request rm [token]
-```
-
-### Arguments
-
-- `<tokens>` - comma-separated list of Teleport tokens.
-
-### Examples
-
-```code
-$ tctl request rm request-id-1
-```
-
-## tctl nodes add
-
-Generate a node invitation token:
-
-```code
-$ tctl nodes add [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--roles` | `node` | `proxy, auth, node, db, app` or `windowsdesktop` | Comma-separated list of roles for the new node to assume |
-| `--ttl` | 30m | relative duration like 5s, 2m, or 3h | Time to live for a generated token |
-| `--token` | none | **string** token value | A custom token to use, auto-generated if not provided. Should match token set with `teleport start --token` |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config`. Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Examples
-
-```code
-# Generates a token that can be used by a node to join the cluster, default ttl is 30 minutes
-$ tctl nodes add
-# Generates a token that can be used to add an SSH node to the cluster.
-# The node will run both the proxy service and the node (ssh) service.
-# This token can be used within an hour.
-$ tctl nodes add --roles=node,proxy --ttl=1h
-```
-
-## tctl nodes ls
-
-List all active SSH nodes within the cluster:
-
-```code
-$ tctl nodes ls [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--namespace` | none | **string** namespace | Namespace of the nodes |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config`. Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-## tctl tokens add
-
-Create an invitation token:
-
-```code
-$ tctl tokens add --type=TYPE [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
-| `--labels` | none | `text` | Sets token labels |
-| `--ttl` | 1h | Duration like 5s, 2m, or 3h | Sets how long the token is valid for. |
-| `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
-| `--value` | none | **string** token value | Value of token to add |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config` . Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Examples
-
-```code
-# Generate an invite token for a trusted_cluster
-$ tctl tokens add --type=trusted_cluster --ttl=5m
-# Generate an invite token for a trusted_cluster with labels
-$ tctl tokens add --type=trusted_cluster --labels=env=prod,region=us-west
-# Generate an invite token for a node
-# This is equivalent to `tctl nodes add`
-$ tctl tokens add --type=node
-# Generate a join token for both a Node and the Database Service
-$ tctl tokens add --type=node,db
-# Generate an invite token for a kubernetes_service
-$ tctl tokens add --type=kube
-# Generate an invite token for an app_service
-$ tctl tokens add --type=app
-```
-
-## tctl tokens rm
-
-Delete/revoke an invitation token:
-
-```code
-$ tctl tokens rm [<token>]
-```
-
-### Arguments
-
-- `<token>` The full-length token string to delete
-
-## tctl tokens ls
-
-List node and user invitation tokens:
-
-```code
-$ tctl tokens ls [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--format` | none | `text`, `json`, `yaml` | Output format |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config` . Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Example
-
-```code
-$ tctl tokens ls
-
-# Token                            Type            Expiry Time (UTC)
-# -------------------------------- --------------- -------------------
-# (=presets.tokens.first=) Node            11 Oct 19 22:17 UTC
-# (=presets.tokens.second=) trusted_cluster 11 Oct 19 22:19 UTC
-# (=presets.tokens.third=) User signup     11 Oct 19 22:20 UTC
-```
+| `--verbose` (`-v`) | false |boolean | If set, display detailed alert info (including acknowledged alerts) |
+| `--labels` | none | Comma-separated strings | A list of labels to filter by |
 
 ## tctl auth export
 
@@ -490,6 +282,38 @@ $ tctl auth export
 $ tctl auth export --fingerprint=SHA256:8xu5kh1CbHCZRrGuitbQd4hM+d9V+I7YA1mUwA/2tAo
 # Export tls certs only
 $ tctl auth export --type tls
+```
+
+## tctl auth rotate
+
+Rotate certificate authorities in the cluster:
+
+```code
+$ tctl auth rotate [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--grace-period` | none | relative duration like 5s, 2m, or 3h | Grace period keeps previous certificate authorities signatures valid, if set to 0 will force users to log in again and nodes to re-register. |
+| `--manual` | none | none | Activate manual rotation, set rotation phases manually |
+| `--type` | `user,host` | `user` or `host` | Certificate authority to rotate |
+| `--phase` | | `init, standby, update_clients, update_servers, rollback` | Target rotation phase to set, used in manual rotation |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config` . Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+```code
+# Rotate only user certificates with a grace period of 200 hours:
+$ tctl auth rotate --type=user --grace-period=200h
+
+# Rotate only host certificates with a grace period of 8 hours:
+$ tctl auth rotate --type=host --grace-period=8h
 ```
 
 ## tctl auth sign
@@ -561,22 +385,186 @@ $ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes
 $ tctl auth sign --user=admin --out=identity.pem
 ```
 
-## tctl auth rotate
+## tctl create
 
-Rotate certificate authorities in the cluster:
+Create or update a Teleport resource from a YAML file.
+
+The supported resource types are: user, node, cluster, role, connector, and device.
+See the [Resources Reference](../resources.mdx) for complete docs on how to build these yaml files.
 
 ```code
-$ tctl auth rotate [<flags>]
+$ tctl create [<flags>] <filename>
+```
+
+### Arguments
+
+- `<filename>` resource definition file
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `-f, --force` | none | none | Overwrite the resource if already exists |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+```code
+# Update a user record
+$ tctl create -f joe.yaml
+# Add a trusted cluster
+$ tctl create cluster.yaml
+# Update a trusted cluster
+$ tctl create -f cluster.yaml
+```
+
+## tctl devices add
+
+Register a device.
+
+```code
+$ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
 ```
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--grace-period` | none | relative duration like 5s, 2m, or 3h | Grace period keeps previous certificate authorities signatures valid, if set to 0 will force users to log in again and nodes to re-register. |
-| `--manual` | none | none | Activate manual rotation, set rotation phases manually |
-| `--type` | `user,host` | `user` or `host` | Certificate authority to rotate |
-| `--phase` | | `init, standby, update_clients, update_servers, rollback` | Target rotation phase to set, used in manual rotation |
+| `--os` | none | `linux`, `macos`, `windows` | Device operating system |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+| `--enroll` | false | boolean | If set, creates a device enrollment token |
+
+### Examples
+
+```code
+$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=)
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
+
+$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=) --enroll
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
+```
+
+## tctl devices enroll
+
+Create an enrollment token for a device.
+
+```code
+$ tctl devices enroll [--device-id=ID] [--asset-tag=ASSET_TAG]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--device-id` | none | string | Teleport device identifier |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+
+One of `--device-id` or `--asset-tag` must be present.
+
+### Examples
+
+```code
+$ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
+Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
+
+$ tctl devices enroll --asset-tag=(=devicetrust.asset_tag=)
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
+```
+
+## tctl devices ls
+
+List registered devices.
+
+```code
+$ tctl devices ls
+```
+
+### Examples
+
+```code
+$ tctl devices ls
+
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+(=devicetrust.asset_tag=) macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
+```
+
+## tctl devices rm
+
+Removes a registered device.
+
+A removed device is not considered a trusted device for future device
+authentication attempts.
+
+```code
+$ tctl devices rm [--device-id=ID] [--asset-tag=ASSET_TAG]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--device-id` | none | string | Teleport device identifier |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+
+One of `--device-id` or `--asset-tag` must be present.
+
+### Examples
+
+```code
+$ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
+Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
+
+$ tctl devices rm --asset-tag=(=devicetrust.asset_tag=)
+Device "(=devicetrust.asset_tag=)" removed
+```
+
+## tctl edit
+
+Modify a Teleport resource using your preferred text editor.
+
+```code
+$ tctl edit <resource-type/resource-name>
+```
+
+The text editor is selected by checking the following, in order of precedence:
+
+- the `TELEPORT_EDITOR` environment variable
+- the `VISUAL` environment variable
+- the `EDITOR` environment variable
+- defaulting to `vi`
+
+`tctl` will fetch the resource from the backend and open it in the selected editor.
+When the editor process terminates, `tctl` will push the updates to the Teleport cluster.
+To abandon the edit, close the editor without saving the file.
+
+Some graphical editors like VS Code launch a background process rather than running
+in the foreground. This prevents `tctl` from properly detecting when the editor
+process terminates. To work around this, check whether your editor supports a "wait"
+option that waits for files to be closed before terminating. For example, to edit a
+Teleport resource with VS Code, you can set `TELEPORT_EDITOR="code --wait"`.
+
+**Note:** Renaming resources with `tctl edit` is not supported since Teleport resources
+often refer to other resources by name. To rename a resource, we recommend you:
+
+- fetch the resource with `tctl get` and redirect the output to a file
+- change the name of the resource in the file
+- save the new resource with `tctl create -f`
+- update any references to the old resource
+
+### Arguments
+
+- `<resource-type/resource-name>` The resource to edit
+  - `<resource type>` The type of the resource \[for example: `user,cluster,token`]
+  - `<resource name>` The name of the resource
 
 ### Global flags
 
@@ -586,93 +574,268 @@ These flags are available for all commands `--debug, --config` . Run
 ### Examples
 
 ```code
-# Rotate only user certificates with a grace period of 200 hours:
-$ tctl auth rotate --type=user --grace-period=200h
+# edit the sre role
+$ tctl edit role/sre
 
-# Rotate only host certificates with a grace period of 8 hours:
-$ tctl auth rotate --type=host --grace-period=8h
+# edit the alice user with the nano editor
+$ TELEPORT_EDITOR=nano tctl edit user/alice
 ```
 
-## tctl sso test
+## tctl get
 
-Perform an end-to-end test of an SSO authentication flow using the provided auth connector definition.
-
-The command supports all auth connector types: `github`, `oidc` and `saml`. The latter two require Teleport Enterprise.
+Print a YAML declaration of various Teleport resources:
 
 ```code
-$ tctl [<global-flags>] sso test [<auth-connector.yaml>]
+$ tctl get [<flags>] <resource-type/resource-name>,...
 ```
-
-The testing consists of running a single end-to-end authentication request using the provided auth connector definition.
-Once the request is finished, the results will be printed to standard output along with context-specific diagnostic information.
-The test process is safe from side effects in that:
-- it will not change the list of configured auth connectors
-- the audit log will clearly state the login attempts as "test" ones
-- there will be no certificates issued for the authenticated user
-
-<Admonition
-  type="note"
-  title="Important"
->
-  To use this command, you must have access to the `github_request`, `oidc_request`, and `saml_request` resources (depending on the type of connector being tested).
-
-  If you receive a "permission denied" error, ensure that you have access to the following resources in one of your Teleport roles:
-
-```yaml
-- resources: [github_request]
-  verbs: [list,create,read,update,delete]
-- resources: [oidc_request]
-  verbs: [list,create,read,update,delete]
-- resources: [saml_request]
-  verbs: [list,create,read,update,delete]
-```
-</Admonition>
 
 ### Arguments
 
-- `[<filename>]` Connector resource definition file. Optional. Empty for stdin.
+- `<resource-type/resource-name>` The resource to get
+  - `<resource type>` The type of the resource \[for example: `user,cluster,token,device`]
+  - `<resource name>` The name of the resource
 
 ### Flags
 
-This command defines no flags.
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--format` | | `yaml, json` or `text` | Output format |
+| `--with-secrets` | none | none | Include secrets in resources like certificate authorities or OIDC connectors |
 
 ### Global flags
 
-These flags are available for all commands: `--debug, --config`. Run
+These flags are available for all commands `--debug, --config` . Run
 `tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
 
 ### Examples
 
-Test the auth connector from `connector.yaml`:
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
-$ tctl sso test connector.yaml
+$ tctl get users
+# Dump the user definition into a file:
+$ tctl get user/joe > joe.yaml
+# Prints the trusted cluster 'east'
+$ tctl get cluster/east
+# Prints all trusted clusters and all users
+$ tctl get clusters,users
+# Dump all resources for backup into state.yaml
+$ tctl get all > state.yaml
 ```
 
-The command is designed to be used in conjunction with the `tctl sso configure` family of commands:
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
-$ tctl sso configure ... | tctl sso test
+$ tctl get users
+# Dump the user definition into a file:
+$ tctl get user/joe > joe.yaml
+# Prints the trusted cluster 'east'
+$ tctl get cluster/east
+# Prints all trusted clusters and all users
+$ tctl get clusters,users
 ```
 
-The pipeline may also utilize `tee` to capture the connector generated with `tctl sso configure`. This will save the connector in `connector.yaml`:
+</TabItem>
+
+</Tabs>
+
+## tctl help
+
+Shows help:
 
 ```code
-$ tctl sso configure ... | tee connector.yaml | tctl sso test
+$ tctl help
 ```
 
-You can test an existing auth connector by combining the command with `tctl get`:
+## tctl login_rule test
 
-```bsh
-$ tctl get saml/your-connector-name --with-secrets | tctl sso test
-````
+Test a Login Rule resource without installing it in the cluster.
 
-<Admonition
-  type="note"
-  title="Important"
->
-  Make sure to include `--with-secrets` flag, or the exported auth connector will not be testable.
-</Admonition>
+### Arguments
+
+- `<traits-file>` input traits file in JSON or YAML format. Empty for stdin.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--resource-file` | none | **string** filepath | Path to Login Rule resource path, can be repeated for multiple files |
+| `--load-from-cluster` | `false` | `true, false` | When true, all Login Rules currently installed in the cluster will be loaded for the test. Can be combined with `--resource-file` to test interactions. |
+| `--format` | `yaml` | `yaml, json` | Output format for traits |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+Test evaluation of the Login Rules from rule1.yaml and rule2.yaml with input traits from traits.json
+
+```code
+$tctl login_rule test --resource-file rule1.yaml --resource-file rule2.yaml traits.json
+```
+
+Test the Login Rule in rule.yaml along with all Login Rules already present in the cluster
+
+```code
+$ tctl login_rule test --resource-file rule.yaml --load-from-cluster traits.json
+```
+
+Read the input traits from stdin
+
+```code
+$ echo '{"groups": ["example"]}' | tctl login_rule test --resource-file rule.yaml
+```
+
+## tctl nodes add
+
+Generate a node invitation token:
+
+```code
+$ tctl nodes add [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--roles` | `node` | `proxy, auth, node, db, app` or `windowsdesktop` | Comma-separated list of roles for the new node to assume |
+| `--ttl` | 30m | relative duration like 5s, 2m, or 3h | Time to live for a generated token |
+| `--token` | none | **string** token value | A custom token to use, auto-generated if not provided. Should match token set with `teleport start --token` |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+```code
+# Generates a token that can be used by a node to join the cluster, default ttl is 30 minutes
+$ tctl nodes add
+# Generates a token that can be used to add an SSH node to the cluster.
+# The node will run both the proxy service and the node (ssh) service.
+# This token can be used within an hour.
+$ tctl nodes add --roles=node,proxy --ttl=1h
+```
+
+## tctl nodes ls
+
+List all active SSH nodes within the cluster:
+
+```code
+$ tctl nodes ls [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--namespace` | none | **string** namespace | Namespace of the nodes |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+## tctl request approve
+
+Approve a user's request:
+
+```code
+$ tctl request approve [token]
+```
+
+### Arguments
+
+- `<tokens>` - comma-separated list of Teleport tokens.
+
+### Examples
+
+```code
+$ tctl request approve request-id-1, request-id-2
+```
+
+## tctl request deny
+
+Denies a user's request:
+
+```code
+$ tctl request deny [token]
+```
+
+### Arguments
+
+- `<tokens>` - comma-separated list of Teleport tokens.
+
+### Examples
+
+```code
+$ tctl request deny request-id-1, request-id-2
+```
+
+## tctl request ls
+
+List of open requests:
+
+```code
+$ tctl request ls
+```
+
+### Examples
+
+```code
+$ tctl request ls
+
+# Token                                Requestor Metadata       Created At (UTC)    Status
+# ------------------------------------ --------- -------------- ------------------- -------
+# request-id-1                         alice     roles=dictator 07 Nov 19 19:38 UTC PENDING
+```
+
+## tctl request rm
+
+Delete a users role request:
+
+```code
+$ tctl request rm [token]
+```
+
+### Arguments
+
+- `<tokens>` - comma-separated list of Teleport tokens.
+
+### Examples
+
+```code
+$ tctl request rm request-id-1
+```
+
+## tctl rm
+
+Delete a resource:
+
+```code
+$ tctl rm <resource-type/resource-name>
+```
+
+### Arguments
+
+- `<resource-type/resource-name>` Resource to delete
+  - `<resource type>` Type of a resource \[for example: `saml,oidc,github,user,cluster,tokens,device`]
+  - `<resource name>` Resource name to delete
+
+### Examples
+
+```code
+# Delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# Delete a local user called "admin":
+$ tctl rm users/admin
+```
 
 ## tctl sso configure github
 
@@ -928,221 +1091,86 @@ $ tctl sso configure saml -p okta -r group,dev,access -e https://dev-123456.okta
 $ tctl sso configure saml -p okta -r group,developer,access -e entity-desc.xml | tctl sso test
 ```
 
-## tctl login_rule test
+## tctl sso test
 
-Test a Login Rule resource without installing it in the cluster.
+Perform an end-to-end test of an SSO authentication flow using the provided auth connector definition.
+
+The command supports all auth connector types: `github`, `oidc` and `saml`. The latter two require Teleport Enterprise.
+
+```code
+$ tctl [<global-flags>] sso test [<auth-connector.yaml>]
+```
+
+The testing consists of running a single end-to-end authentication request using the provided auth connector definition.
+Once the request is finished, the results will be printed to standard output along with context-specific diagnostic information.
+The test process is safe from side effects in that:
+- it will not change the list of configured auth connectors
+- the audit log will clearly state the login attempts as "test" ones
+- there will be no certificates issued for the authenticated user
+
+<Admonition
+  type="note"
+  title="Important"
+>
+  To use this command, you must have access to the `github_request`, `oidc_request`, and `saml_request` resources (depending on the type of connector being tested).
+
+  If you receive a "permission denied" error, ensure that you have access to the following resources in one of your Teleport roles:
+
+```yaml
+- resources: [github_request]
+  verbs: [list,create,read,update,delete]
+- resources: [oidc_request]
+  verbs: [list,create,read,update,delete]
+- resources: [saml_request]
+  verbs: [list,create,read,update,delete]
+```
+</Admonition>
 
 ### Arguments
 
-- `<traits-file>` input traits file in JSON or YAML format. Empty for stdin.
+- `[<filename>]` Connector resource definition file. Optional. Empty for stdin.
 
 ### Flags
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--resource-file` | none | **string** filepath | Path to Login Rule resource path, can be repeated for multiple files |
-| `--load-from-cluster` | `false` | `true, false` | When true, all Login Rules currently installed in the cluster will be loaded for the test. Can be combined with `--resource-file` to test interactions. |
-| `--format` | `yaml` | `yaml, json` | Output format for traits |
+This command defines no flags.
 
 ### Global flags
 
-These flags are available for all commands `--debug, --config`. Run
+These flags are available for all commands: `--debug, --config`. Run
 `tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
 
 ### Examples
 
-Test evaluation of the Login Rules from rule1.yaml and rule2.yaml with input traits from traits.json
+Test the auth connector from `connector.yaml`:
 
 ```code
-$tctl login_rule test --resource-file rule1.yaml --resource-file rule2.yaml traits.json
+$ tctl sso test connector.yaml
 ```
 
-Test the Login Rule in rule.yaml along with all Login Rules already present in the cluster
+The command is designed to be used in conjunction with the `tctl sso configure` family of commands:
 
 ```code
-$ tctl login_rule test --resource-file rule.yaml --load-from-cluster traits.json
+$ tctl sso configure ... | tctl sso test
 ```
 
-Read the input traits from stdin
+The pipeline may also utilize `tee` to capture the connector generated with `tctl sso configure`. This will save the connector in `connector.yaml`:
 
 ```code
-$ echo '{"groups": ["example"]}' | tctl login_rule test --resource-file rule.yaml
+$ tctl sso configure ... | tee connector.yaml | tctl sso test
 ```
 
-## tctl create
+You can test an existing auth connector by combining the command with `tctl get`:
 
-Create or update a Teleport resource from a YAML file.
+```bsh
+$ tctl get saml/your-connector-name --with-secrets | tctl sso test
+````
 
-The supported resource types are: user, node, cluster, role, connector, and device.
-See the [Resources Reference](../resources.mdx) for complete docs on how to build these yaml files.
-
-```code
-$ tctl create [<flags>] <filename>
-```
-
-### Arguments
-
-- `<filename>` resource definition file
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-f, --force` | none | none | Overwrite the resource if already exists |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config`. Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Examples
-
-```code
-# Update a user record
-$ tctl create -f joe.yaml
-# Add a trusted cluster
-$ tctl create cluster.yaml
-# Update a trusted cluster
-$ tctl create -f cluster.yaml
-```
-
-## tctl rm
-
-Delete a resource:
-
-```code
-$ tctl rm <resource-type/resource-name>
-```
-
-### Arguments
-
-- `<resource-type/resource-name>` Resource to delete
-  - `<resource type>` Type of a resource \[for example: `saml,oidc,github,user,cluster,tokens,device`]
-  - `<resource name>` Resource name to delete
-
-### Examples
-
-```code
-# Delete a SAML connector called "okta":
-$ tctl rm saml/okta
-
-# Delete a local user called "admin":
-$ tctl rm users/admin
-```
-
-## tctl get
-
-Print a YAML declaration of various Teleport resources:
-
-```code
-$ tctl get [<flags>] <resource-type/resource-name>,...
-```
-
-### Arguments
-
-- `<resource-type/resource-name>` The resource to get
-  - `<resource type>` The type of the resource \[for example: `user,cluster,token,device`]
-  - `<resource name>` The name of the resource
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--format` | | `yaml, json` or `text` | Output format |
-| `--with-secrets` | none | none | Include secrets in resources like certificate authorities or OIDC connectors |
-
-### Global flags
-
-These flags are available for all commands `--debug, --config` . Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Examples
-
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-```code
-$ tctl get users
-# Dump the user definition into a file:
-$ tctl get user/joe > joe.yaml
-# Prints the trusted cluster 'east'
-$ tctl get cluster/east
-# Prints all trusted clusters and all users
-$ tctl get clusters,users
-# Dump all resources for backup into state.yaml
-$ tctl get all > state.yaml
-```
-
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-
-```code
-$ tctl get users
-# Dump the user definition into a file:
-$ tctl get user/joe > joe.yaml
-# Prints the trusted cluster 'east'
-$ tctl get cluster/east
-# Prints all trusted clusters and all users
-$ tctl get clusters,users
-```
-
-</TabItem>
-
-</Tabs>
-
-## tctl edit
-
-Modify a Teleport resource using your preferred text editor.
-
-```code
-$ tctl edit <resource-type/resource-name>
-```
-
-The text editor is selected by checking the following, in order of precedence:
-
-- the `TELEPORT_EDITOR` environment variable
-- the `VISUAL` environment variable
-- the `EDITOR` environment variable
-- defaulting to `vi`
-
-`tctl` will fetch the resource from the backend and open it in the selected editor.
-When the editor process terminates, `tctl` will push the updates to the Teleport cluster.
-To abandon the edit, close the editor without saving the file.
-
-Some graphical editors like VS Code launch a background process rather than running
-in the foreground. This prevents `tctl` from properly detecting when the editor
-process terminates. To work around this, check whether your editor supports a "wait"
-option that waits for files to be closed before terminating. For example, to edit a
-Teleport resource with VS Code, you can set `TELEPORT_EDITOR="code --wait"`.
-
-**Note:** Renaming resources with `tctl edit` is not supported since Teleport resources
-often refer to other resources by name. To rename a resource, we recommend you:
-
-- fetch the resource with `tctl get` and redirect the output to a file
-- change the name of the resource in the file
-- save the new resource with `tctl create -f`
-- update any references to the old resource
-
-### Arguments
-
-- `<resource-type/resource-name>` The resource to edit
-  - `<resource type>` The type of the resource \[for example: `user,cluster,token`]
-  - `<resource name>` The name of the resource
-
-### Global flags
-
-These flags are available for all commands `--debug, --config` . Run
-`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
-
-### Examples
-
-```code
-# edit the sre role
-$ tctl edit role/sre
-
-# edit the alice user with the nano editor
-$ TELEPORT_EDITOR=nano tctl edit user/alice
-```
+<Admonition
+  type="note"
+  title="Important"
+>
+  Make sure to include `--with-secrets` flag, or the exported auth connector will not be testable.
+</Admonition>
 
 ## tctl status
 
@@ -1164,247 +1192,89 @@ $ tctl status \
     --identity=identity.pem
 ```
 
-## tctl alerts create
+## tctl tokens add
 
-Creates cluster alerts. Cluster alerts can be displayed to Teleport users
-in the web UI or upon logging via `tsh`.
+Create an invitation token:
 
 ```code
-$ tctl alerts create [<flags>] <message>
+$ tctl tokens add --type=TYPE [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
+| `--labels` | none | `text` | Sets token labels |
+| `--ttl` | 1h | Duration like 5s, 2m, or 3h | Sets how long the token is valid for. |
+| `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
+| `--value` | none | **string** token value | Value of token to add |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config` . Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+```code
+# Generate an invite token for a trusted_cluster
+$ tctl tokens add --type=trusted_cluster --ttl=5m
+# Generate an invite token for a trusted_cluster with labels
+$ tctl tokens add --type=trusted_cluster --labels=env=prod,region=us-west
+# Generate an invite token for a node
+# This is equivalent to `tctl nodes add`
+$ tctl tokens add --type=node
+# Generate a join token for both a Node and the Database Service
+$ tctl tokens add --type=node,db
+# Generate an invite token for a kubernetes_service
+$ tctl tokens add --type=kube
+# Generate an invite token for an app_service
+$ tctl tokens add --type=app
+```
+
+## tctl tokens ls
+
+List node and user invitation tokens:
+
+```code
+$ tctl tokens ls [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--format` | none | `text`, `json`, `yaml` | Output format |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config` . Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Example
+
+```code
+$ tctl tokens ls
+
+# Token                            Type            Expiry Time (UTC)
+# -------------------------------- --------------- -------------------
+# (=presets.tokens.first=) Node            11 Oct 19 22:17 UTC
+# (=presets.tokens.second=) trusted_cluster 11 Oct 19 22:19 UTC
+# (=presets.tokens.third=) User signup     11 Oct 19 22:20 UTC
+```
+
+## tctl tokens rm
+
+Delete/revoke an invitation token:
+
+```code
+$ tctl tokens rm [<token>]
 ```
 
 ### Arguments
 
-- `<message>`: The message for the alert to display
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--severity` | `low` | `low`, `medium`, `high` | Alert severity |
-| `--ttl` | none | Any duration | Optional expiry for alert (alert does not expire if no TTL is specified) |
-| `--labels` | none | any | A list of labels to attach to the alert. |
-
-While any labels can be applied to an alert, there are several internal labels that can be used to configure
-the behavior of alerts:
-
-- `teleport.internal/alert-on-login: yes`: ensures that the alert is displayed to users upon login
-- `teleport.internal/alert-permit-all: yes`: ensures that the alert is displayed to all users
-
-If no labels are specified, `tctl` will automatically add both of these labels.
-
-### Examples
-
-```code
-$ tctl alerts create \
-    --severity=low \
-    --ttl=4h \
-    "The system is under maintenance, functionality may be limited."
-```
-
-## tctl alerts list
-
-Lists cluster alerts. This command can also be invoked as `tctl alerts ls`.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--verbose` (`-v`) | false |boolean | If set, display detailed alert info (including acknowledged alerts) |
-| `--labels` | none | Comma-separated strings | A list of labels to filter by |
-
-## tctl alerts ack
-
-Temporarily acknowledges a cluster alert, preventing the alert from being
-displayed to users. Acknowledgements last for 24 hours by default. Users
-will begin seeing the alert again when the acknowledgement expires.
-
-```code
-$ tctl alerts ack [<flags>] <id>
-```
-
-### Arguments
-
-- `<id>`: the ID of the cluster alert to acknowledge
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--ttl` | 24h | Any duration | Time duration to acknowledge the alert for |
-| `--clear` | none | | Clear an existing alert acknowledgement |
-| `--reason` | none | | The reason for suppressing this alert |
-
-### Examples
-
-Suppress the cluster alert notifying users that an upgrade is available:
-
-```code
-$ tctl alerts ack --reason="upgrade scheduled" upgrade-suggestion
-Successfully acknowledged alert 'upgrade-suggestion'. Alerts with this ID won't be pushed for 24h0m0s.
-```
-
-Clear an existing alert acknowledgement:
-
-```code
-$ tctl alerts ack --clear upgrade-suggestion
-```
-
-## tctl alerts ack ls
-
-Lists alert acknowledgements.
-
-```code
-$ tctl alerts ack ls
-ID                 Reason                 Expires
------------------- ---------------------- --------------------
-upgrade-suggestion "upgrade is scheduled" Wed Apr 12 16:52 UTC
-```
-
-## tctl devices add
-
-Register a device.
-
-```code
-$ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--os` | none | `linux`, `macos`, `windows` | Device operating system |
-| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
-| `--enroll` | false | boolean | If set, creates a device enrollment token |
-
-### Examples
-
-```code
-$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=)
-Device (=devicetrust.asset_tag=)/macOS added to the inventory
-
-$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=) --enroll
-Device (=devicetrust.asset_tag=)/macOS added to the inventory
-Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
-tsh device enroll --token=(=devicetrust.enroll_token=)
-```
-
-## tctl devices enroll
-
-Create an enrollment token for a device.
-
-```code
-$ tctl devices enroll [--device-id=ID] [--asset-tag=ASSET_TAG]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--device-id` | none | string | Teleport device identifier |
-| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
-
-One of `--device-id` or `--asset-tag` must be present.
-
-### Examples
-
-```code
-$ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
-Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
-tsh device enroll --token=(=devicetrust.enroll_token=)
-
-$ tctl devices enroll --asset-tag=(=devicetrust.asset_tag=)
-Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
-tsh device enroll --token=(=devicetrust.enroll_token=)
-```
-
-## tctl devices ls
-
-List registered devices.
-
-```code
-$ tctl devices ls
-```
-
-### Examples
-
-```code
-$ tctl devices ls
-
-Asset Tag    OS    Enroll Status Device ID
------------- ----- ------------- ------------------------------------
-(=devicetrust.asset_tag=) macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
-```
-
-## tctl devices rm
-
-Removes a registered device.
-
-A removed device is not considered a trusted device for future device
-authentication attempts.
-
-```code
-$ tctl devices rm [--device-id=ID] [--asset-tag=ASSET_TAG]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--device-id` | none | string | Teleport device identifier |
-| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
-
-One of `--device-id` or `--asset-tag` must be present.
-
-### Examples
-
-```code
-$ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
-Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
-
-$ tctl devices rm --asset-tag=(=devicetrust.asset_tag=)
-Device "(=devicetrust.asset_tag=)" removed
-```
-
-### tctl acl ls
-
-Lists Access Lists on the cluster.
-
-```code
-$ tctl acl ls
-```
-
-### tctl acl get
-
-Gets and displays information about a particular access list.
-
-```code
-$ tctl acl get <id>
-```
-
-### tctl acl users add
-
-Adds a user to an access list.
-
-```code
-$ tctl acl users add <access-list-name> <user> [<expires>] [<reason>]
-```
-
-### tctl acl users rm
-
-Removes a user from an access list.
-
-```code
-$ tctl acl users rm <access-list-name> <user>
-```
-
-### tctl acl users ls
-
-Lists the users in an access list.
-
-```code
-$ tctl acl users ls <access-list-name>
-```
+- `<token>` The full-length token string to delete
 
 ## tctl top
 
@@ -1427,6 +1297,136 @@ $ tctl top [<diag-addr>] [<refresh>]
 $ sudo teleport start --diag-addr=127.0.0.1:3000
 # View stats with a refresh period of 5 seconds
 $ tctl top http://127.0.0.1:3000 5s
+```
+
+## tctl users add
+
+Generates a user invitation token:
+
+```code
+$ tctl users add [<flags>] <account>
+```
+
+### Arguments
+
+- `<account>` - The Teleport user account name.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--roles` | none | Comma-separated strings | List of Teleport roles to assign to the new user |
+| `--logins` | none | Comma-separated strings | List of allowed SSH logins for the new user |
+| `--kubernetes-groups` | none | Comma-separated strings | Kubernetes groups to assign to a user, e.g. `system:masters` |
+| `--kubernetes-users` | none | Comma-separated strings | Kubernetes user to assign to a user, e.g. `jenkins` |
+| `--db-users` | none | Comma-separated strings | List of allowed database users for the new user |
+| `--db-names` | none | Comma-separated strings | List of allowed database names for the new user |
+| `--windows-logins` | none | Comma-separated strings | List of allowed Windows logins for the new user |
+| `--aws-role-arns` | none | Comma-separated strings | List of allowed AWS role ARNs for the new user |
+| `--gcp-service-accounts` | none | Comma-separated strings | List of allowed GCP service accounts for the new user |
+| `--azure-identities` | none | Comma-separated strings | List of Azure managed identities to allow the user to assume. Must be the full URIs of the identities |
+| `--ttl` | 1h | relative duration like 5s, 2m, or 3h, **maximum 48h** | Set expiration time for token |
+| `--host-user-uid` | none | Unix UID | UID for auto provisioned host users to use |
+| `--host-user-gid` | none | Unix GID | GID for auto provisioned host users to use |
+
+### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+### Examples
+
+```code
+# Adds teleport user "joe" with mappings to
+# OS users and {{ internal.logins }} to "joe" and "ubuntu"
+$ tctl users add joe --roles=access,requester joe,ubuntu
+# Adds Teleport user "joe" with mappings to the editor role
+$ tctl users add joe --roles=editor,reviewer
+```
+
+## tctl users ls
+
+Lists all user accounts:
+
+```code
+$ tctl users ls [<flags>]
+```
+
+## tctl users reset
+
+Reset local user account password and any associated second factor with expiring link to populate values. **Usage**: `tctl users reset <account>`
+
+### Arguments
+
+- `<account>` - Teleport Local DB User
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--ttl` | `8h` | relative duration like `5s`, `2m`, or `3h` | Set the expiration time for token, default is `8h0m0s`, maximum is `24h0m0s` |
+
+### Examples
+
+```code
+$ tctl users reset jeff
+# User jeff has been reset. Share this URL with the user to complete password reset, the link is valid for 8h0m0s:
+# https://teleport.example.com:3080/web/reset/8a4a40bec3a31a28db44fa64c0c70ca3
+# Resets jeff's password and any associated second factor.  Jeff populates the password and confirms the token with the link.
+```
+
+## tctl users rm
+
+Deletes user accounts:
+
+```code
+$ tctl users rm <logins>
+```
+
+### Arguments
+
+- `<logins>` - comma-separated list of Teleport users
+
+### Examples
+
+```code
+$ tctl users rm sally,tim
+# Removes users sally and tim
+```
+
+## tctl users update
+
+Update user account:
+
+```code
+$ tctl users update [<flags>] <account>
+```
+
+### Arguments
+
+- `<account>` - The Teleport user account name.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--set-roles` | none | Comma-separated list of roles for the user to assume. | Assigns the user's roles to the ones provided, replacing the user's current roles. |
+| `--set-azure-identities` | none | Comma-separated list of allowed Azure identity URIs. |  Assigns the user's allowed Azure identities to the ones provided, replacing the user's currently allowed Azure identities. |
+
+### Examples
+
+Set the user `joe`'s roles to `access` and `editor`:
+
+```code
+$ tctl users update joe --set-roles=access,editor
+```
+
+Set the user `priya`'s Azure identities to `developer` and `dba`:
+
+```code
+$ tctl users update priya --set-azure-identities \
+ `/subscriptions/${SUBSCRIPTION_ID?}/resourceGroups/${MY_RESOURCE_GROUP?}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/developer,\
+ `/subscriptions/${SUBSCRIPTION_ID?}/resourceGroups/${MY_RESOURCE_GROUP?}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dba
 ```
 
 ## tctl version

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -18,19 +18,19 @@ The primary commands for the `teleport` CLI are as follows:
 
 | Command | Description |
 | - | - |
-| `teleport help` | Outputs guidance for using Teleport commands. |
-| `teleport start` | Starts the `teleport` process in the foreground using the current shell session, including any services configured by the [configuration YAML file](../config.mdx). |
-| `teleport status` | Prints the status of the current active Teleport SSH session. |
-| `teleport configure` | Generates and writes a [configuration YAML file](../config.mdx) for the Teleport service. This file should be customized in production to suit the needs of your environment, and the default output should only be used when testing. |
-| `teleport version` | Prints the current release version of the Teleport binary installed on your system. |
 | `teleport app start` | Starts the Teleport Application Service. |
-| `teleport db start` | Starts the Teleport Database Service. |
-| `teleport db configure create` | Generates a configuration YAML file for the Database Service. This file should be customized in production to suit the needs of your environment, and the default output should only be used when testing. |
-| `teleport db configure bootstrap` | Used to bootstrap a configuration to the Teleport Database Service by reading a provided configuration. |
-| `teleport db configure aws print-iam` | Generates and outputs current IAM policies for a Teleport-managed database. |
+| `teleport configure` | Generates and writes a [configuration YAML file](../config.mdx) for the Teleport service. This file should be customized in production to suit the needs of your environment, and the default output should only be used when testing. |
 | `teleport db configure aws create-iam` | Generates, creates, and attaches desired IAM policies to a Teleport-managed database. |
+| `teleport db configure aws print-iam` | Generates and outputs current IAM policies for a Teleport-managed database. |
+| `teleport db configure bootstrap` | Used to bootstrap a configuration to the Teleport Database Service by reading a provided configuration. |
+| `teleport db configure create` | Generates a configuration YAML file for the Database Service. This file should be customized in production to suit the needs of your environment, and the default output should only be used when testing. |
+| `teleport db start` | Starts the Teleport Database Service. |
+| `teleport help` | Outputs guidance for using Teleport commands. |
 | `teleport install systemd` | Creates a systemd unit file, used to configure and install a `teleport` service daemon. |
 | `teleport node configure` | Generates a configuration YAML file for a Teleport Node accessed via SSH. This file should be customized in production to suit the needs of your environment, and the default output should only be used when testing. |
+| `teleport start` | Starts the `teleport` process in the foreground using the current shell session, including any services configured by the [configuration YAML file](../config.mdx). |
+| `teleport status` | Prints the status of the current active Teleport SSH session. |
+| `teleport version` | Prints the current release version of the Teleport binary installed on your system. |
 
 <Notice type="tip">
 For more information on subcommands when working with the `teleport` cli, use the `--help` option or `teleport <subcommand> --help`.

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -7,6 +7,26 @@ description: Comprehensive reference of subcommands, flags, and arguments for th
 current and past sessions on the cluster, copy files to and from nodes, and list
 information about the cluster.
 
+## tsh environment variables
+
+Environment variables configure your tsh client and can help you avoid using flags repetitively.
+
+| Environment Variable | Description | Example Value |
+| - | - | - |
+| TELEPORT_AUTH | Name of a defined SAML, OIDC, or GitHub auth connector (or a local user) | okta |
+| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | otp |
+| TELEPORT_CLUSTER | Name of a Teleport root or leaf cluster | cluster.example.com |
+| TELEPORT_LOGIN | Login name to be used by default on the remote host | root |
+| TELEPORT_LOGIN_BIND_ADDR | Address in the form of host:port to bind to for login command webhook | host:port |
+| TELEPORT_LOGIN_BROWSER | Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser. | none |
+| TELEPORT_PROXY | Address of the Teleport proxy server | cluster.example.com:3080 |
+| TELEPORT_HOME | Home location for tsh configuration and data | /directory |
+| TELEPORT_USER | A Teleport user name | alice |
+| TELEPORT_ADD_KEYS_TO_AGENT | Specifies if the user certificate should be stored on the running SSH agent | yes, no, auto, only |
+| TELEPORT_USE_LOCAL_SSH_AGENT | Disable or enable local SSH agent integration | true, false |
+| TELEPORT_GLOBAL_TSH_CONFIG | Override location of global `tsh` config file from default `/etc/tsh.yaml` | /opt/teleport/tsh.yaml |
+| TELEPORT_HEADLESS | Use headless authentication | true, false, 1, 0 |
+
 ## tsh global flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
@@ -26,109 +46,45 @@ information about the cluster.
 | `--headless` | none | none | Use Headless WebAuthn for authentication |
 | `--mlock` | `auto` | `auto`, `off`, `best_effort`, `strict` | Lock process memory to protect client secrets stored in memory from being swapped to disk. |
 
-## tsh help
+## tsh apps ls
 
-Prints help:
-
-```code
-$ tsh help
-```
-
-## tsh version
-
-Prints the version of your `tsh` binary and the Teleport Proxy Service in the current `tsh` profile
+List all available applications:
 
 ```code
-$ tsh version [<flags>]
+$ tsh apps ls
 ```
 
-| Name           | Default Value(s) | Allowed Value(s) | Description                                        |
-|----------------|------------------|------------------|----------------------------------------------------|
-| `-f, --format` | `text`           | text, json, yaml | Format for version output                          |
-| `--client`     | none             | none             | Show the client version only (no server required). |
-
-### Examples
+## tsh clusters
 
 ```code
-$ tsh version
-Teleport v(=teleport.version=) git: go(=teleport.golang=)
-Proxy version: (=teleport.version=)
-Proxy: teleport.example.com:443
+$ tsh clusters [<flags>]
 ```
-
-Display in JSON format:
-
-```code
-$ tsh version --format=json
-```
-
-```json
-{
-  "version": "(=teleport.version=)",
-  "gitref": "",
-  "runtime": "go(=teleport.golang=)",
-  "proxyVersion": "(=teleport.version=)",
-  "proxyPublicAddress": "teleport.example.com:443"
-}
-```
-
-Only display the `tsh` binary version:
-
-```code
-$ tsh version --client
-Teleport v(=teleport.version=) git: go(=teleport.golang=)
-```
-
-## tsh ssh
-
-Run shell or execute a command on a remote SSH node:
-
-```code
-$ tsh ssh [<flags>] <[user@]host> [<command>...]
-```
-
-### Arguments
-
-`<[user@]host> [<command>...]`
-
-- `user` The login identity to use on the remote host. If `[user]` is not specified the user defaults to `$USER` or can be set with `--user`. If the flag `--user` and positional argument `[user]` are specified the arg `[user]` takes precedence.
-- `host` The `nodename` of a cluster Node or a label specification like `env=aws` to run on all matching hosts.
-- `command` The command to execute on a remote host.
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `-p, --port` | none | port | SSH port on a remote host |
-| `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
-| `-L, --forward` | none | none | Forward localhost connections to remote server |
-| `-D, --dynamic-forward` | none | none | Forward localhost connections to remote server using SOCKS5 |
-| `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
-| `--local` | none | | Execute command on localhost after connecting to SSH node |
-| `-t, --tty` | `file` | | Allocate TTY |
-| `--cluster` | none | | Specify the cluster to connect |
-| `-o, --option` | `local` | | OpenSSH options in the format used in the configuration file |
-| `--enable-escape-sequences` | | | Enable support for SSH escape sequences. Type `~?` during an SSH session to list supported sequences. |
-| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`) |
-| `-X, --x11-untrusted` | none | none | Requests untrusted (secure) X11 forwarding for this session. |
-| `-Y, --x11-trusted` | none | none | Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution. |
-| `--x11-untrusted-timeout` | 10m | duration | Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server. |
+| `-q, --quiet` | none | none | no headers in output |
 
 ### Global flags
 
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
 Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 ### Examples
 
 ```code
-# Log in to node `grav-00` as OS User `root` with Teleport User `teleport`
-$ tsh ssh --proxy proxy.example.com --user teleport -d root@grav-00
-# `tsh ssh` takes the same arguments as OpenSSH client:
-$ tsh ssh -o ForwardAgent=yes root@grav-00
-$ tsh ssh -o AddKeysToAgent=yes root@grav-00
-# Run `hostname` on all nodes with the `env: aws` label
-$ tsh ssh root@env=aws hostname
+$ tsh clusters
+
+# Cluster Name Status
+# ------------ ------
+# staging          online
+# production       offline
+
+$ tsh clusters --quiet
+
+# staging online
+# production offline
 ```
 
 ## tsh config
@@ -158,43 +114,27 @@ $ tsh config
 $ tsh config >> ~/.ssh/config
 ```
 
-## tsh puttyconfig
+## tsh device enroll
 
-Adds a PuTTY saved session to the Windows registry for the currently logged in Windows user.
+Enroll the current device as a trusted device.
 
-```
-$ tsh puttyconfig [--leaf <leaf-cluster-name>] [login@]hostname
+Requires a device enrollment token created via `tctl devices enroll`.
+
+```code
+$ tsh device enroll --token=TOKEN
 ```
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `-l, --login` | none | Linux username | Default Linux username to use. Will translate to SSH config's `User` option. |
-| `-p`, `--port` | 3022 | port | Default SSH port to use. Will translate to SSH config's `Port` option. |
-| `--leaf` | none | Leaf cluster name | Leaf cluster name to add to the saved session. |
+| `--token` | none | String | Device enrollment token |
 
 ### Examples
 
 ```code
-# Add a saved PuTTY session on 'node' for the user 'ec2-user'
-$ tsh puttyconfig ec2-user@node
-
-# Add a saved PuTTY session for the Teleport-registered OpenSSH node 'openssh' for the user 'ubuntu'
-$ tsh puttyconfig --port 22 ubuntu@openssh
-
-# Add a saved PuTTY session on leaf-node for the user 'ec2-user' on the leaf cluster 'example.teleport.sh'
-$ tsh puttyconfig --leaf example.teleport.sh ec2-user@leaf-node
-```
-
-See [full docs on `tsh puttyconfig` here](../../connect-your-client/putty-winscp.mdx).
-
-## tsh apps ls
-
-List all available applications:
-
-```code
-$ tsh apps ls
+$ tsh device enroll --token=(=devicetrust.enroll_token=)
+Device "(=devicetrust.asset_tag=)"/macOS enrolled
 ```
 
 ## tsh gcloud
@@ -261,6 +201,14 @@ Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags)
 $ tsh gsutil ls
 ```
 
+## tsh help
+
+Prints help:
+
+```code
+$ tsh help
+```
+
 ## tsh join
 
 Joins an active session:
@@ -294,518 +242,40 @@ Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags)
 $ tsh --user=joe --login=ec2-user join <session-id>
 ```
 
-## tsh recordings ls
+## tsh kube login
 
-List recorded sessions.
+Log into a Kubernetes cluster. Discover connected clusters by using [`tsh kube ls`](#tsh-kube-ls).
 
 ```code
-$ tsh recordings ls [<flags>]
+$ tsh kube login <kube-cluster>
+```
+
+```code
+# tsh kube login to k8s cluster (gke_bens-demos_us-central1-c_gks-demo)
+$ tsh kube login gke_bens-demos_us-central1-c_gks-demo
+# Logged into kubernetes cluster "gke_bens-demos_us-central1-c_gks-demo". Try 'kubectl version' to test the connection.
+
+# On login, kubeconfig is pointed at the first cluster (alphabetically)
+$ kubectl config current-context
+# aws-gke_bens-demos_us-central1-c_gks-demo
+
+# But all clusters are populated as contexts
+$ kubectl config get-contexts
+
+# CURRENT   NAME                                        CLUSTER                       AUTHINFO                                    NAMESPACE
+# *         aws-gke_bens-demos_us-central1-c_gks-demo   aws                           aws-gke_bens-demos_us-central1-c_gks-demo
+#          aws-microk8s                                aws                           aws-microk8s
 ```
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--from-utc` | 24 hours ago | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
-| `--to-utc` | current | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
-| `--limit` | 50 | number | Maximum number of recordings to show. |
-| `--last` | none | duration | Duration into the past from which session recordings should be listed. Format 5h30m40s |
-
-### Global flags
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-# get the recorded sessions from the last 24 hours
-$ tsh --proxy proxy.example.com recordings ls
-ID                                   Type Participants Hostname Timestamp
------------------------------------- ---- ------------ -------- -------------------
-b0a04442-70dc-4be8-9308-7b7901d2d600 ssh  jeff         dev       Nov 26 16:36:16 UTC
-c0a02222-70dc-4be8-9308-7b7901d2d600 kube alice                  Nov 26 20:36:16 UTC
-d0a04442-70dc-4be8-9308-7b7901d2d600 ssh  navin        test      Nov 26 16:36:16 UTC
-
-# The session can be played with tsh play
-$ tsh play c0a02222-70dc-4be8-9308-7b7901d2d60
-
-# List recorded sessions that occurred between Nov 1, 2022 to Nov 3, 2022
-$ tsh recordings ls --from-utc=2022-11-01 --to-utc=2022-11-3
-
-# Retrieve recorded sessions in the last 6 hours
-$ tsh recordings ls --last=6h0m0s
-```
-
-<Admonition
-  title="Recorded Sessions Availability"
-  scope={["oss", "enterprise"]} type="tip" scopeOnly
->
-
-Recorded sessions are linked from the audit events to session recordings files
-in their [storage backend](../../reference/backends.mdx).
-The following error can occur if a session recording file is not available or
-when employing multiple auth servers with directory storage backend for recorded
-sessions. When using a directory storage backend for audit logs and recorded sessions,
-only the auth server with that recorded session can retrieve it.
-
-```code
-$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b
-ERROR: Recording for session c8e1b2c5-322a-4095-89e3-391edfd2da9b not found.
-```
-
-Using a Security Information and Event Management (SIEM) service that combines
-the audit logs will help consolidate the list of available recordings.
-
-Downloaded recorded session are directly playable as a file.
-
-```code
-$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b.tar
-```
-
-</Admonition>
-
-## tsh recordings export
-
-Export recorded desktop sessions to video.
-
-```code
-$ tsh recordings export <session_id> [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--out` | `<session_id>.avi` | a filename | Override the output file name. |
-
-### Examples
-
-```code
-$ tsh recordings export c8e1b2c5-322a-4095-89e3-391edfd2da9b --out=recording.avi
-wrote recording to recording.avi
-```
-
-## tsh play
-
-Plays back a prior session:
-
-```code
-$ tsh play [<flags>] <session-id>
-```
-
-### Arguments
-
-`<session-id>`
-
-- `session-id` The UUID of a past Teleport Session obtained by `teleport status` within
-  the session or from the Web UI.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | a cluster_name | Specify the cluster to connect |
-| `--format`  | `pty`  | json, pty | Format for playback |
-
-### Global flags
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh --proxy proxy.example.com play <session-id>
-
-# Playing back a session using pty format using a downloaded session recording.
-$ tsh play --format=pty 1fe153d1-ce8b-4ef4-9908-6539457ba4ad.tar
-
-# Playing back a session in json format using jq to filter on events
-$ tsh play --format=json ~/play/0c0b81ed-91a9-4a2a-8d7c-7495891a6ca0.tar | jq '.event
-```
-
-## tsh proxy db
-
-Start a local TLS proxy for database connections when using Teleport with TLS
-Routing enabled. Clients can connect to a Teleport-registered database through
-the local proxy.
-
-```code
-$ tsh proxy db [<flags>] <db>
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | string | The name of the Teleport cluster to connect to. |
-| `--db-name` | see below | string | The database name to log in to. |
-| `--db-user` | see below | string | The database user to log in as. |
-| `--port` | none | string | Source port used by the local proxy.|
-| `--tunnel` | none | Boolean | Open an authenticated tunnel using a database's client certificate so clients don't need to authenticate. |
-
-(!docs/pages/includes/db-user-name-flags.mdx!)
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-### Examples
-
-Proxy a DB connection to a named database
-```code
-$ tsh proxy db <db>
-```
-
-Proxy a connection to mysql db on local port 10700:
-```code
-$ tsh proxy db --port 10700  mysql-db
-# Started DB proxy on 127.0.0.1:10700
-
-# Use following credentials to connect to the mysql-db proxy:
-#  ca_file=/Users/jeff/.tsh/keys/teleport.example.com/cas/teleport.example.com.pem
-#  cert_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff-db/tele1c/mysql-db-x509.pem
-#  key_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff
-```
-
-Proxy a connection to mysql db with no credentials required:
-```code
-$ tsh proxy db --tunnel mysql-db
-Started authenticated tunnel for the MySQL database "mysql-db" in cluster "teleport.example.com" on 127.0.0.1:49415.
-
-Use the following command to connect to the database:
-  $ mysql --port 49415 --host localhost --protocol TCP
-```
-
-## tsh proxy ssh
-
-Start a local TLS proxy for `ssh` connections when using Teleport in TLS Routing mode.
-This is typically used as part of the SSH client configuration to use `ssh` as a client
-through Teleport.  See the [OpenSSH Guide](../../server-access/guides/openssh.mdx) guide
-on configuring OpenSSH servers and clients.  The `tsh config` output will include `tsh proxy ssh`
-within a `ProxyCommand` directive.
-
-```code
-$ tsh proxy ssh [<flags>] <[user@]host>
-```
-
-### Arguments
-- `<[user@]host>` Remote hostname and the login to use
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | Teleport Cluster | The name of the Teleport cluster to connect to.|
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-### Examples
-
-Run the following command to generate an OpenSSH client configuration:
-
-```code
-$ tsh config
-```
-
-This command produces the following configuration:
-
-```
-# Common flags for all example.com hosts
-Host *.example.com example.com
-    UserKnownHostsFile "/Users/jeff/.tsh/known_hosts"
-    IdentityFile "/Users/jeff/.tsh/keys/enterprise.teleportdemo.com/jeff"
-    CertificateFile "/Users/jeff/.tsh/keys/example.com/jeff-ssh/example.com-cert.pub"
-    PubkeyAcceptedKeyTypes +ssh-rsa-cert-v01@openssh.com
-    HostKeyAlgorithms ssh-rsa-cert-v01@openssh.com
-
-# Flags for all example.com hosts except the proxy
-Host *.example.com !example.com
-    Port 3022
-    ProxyCommand "/usr/local/bin/tsh" proxy ssh --cluster=example.com --proxy=example.com %r@%h:%p
-```
-
-This output should be placed into the default SSH Config for environment, `~/.ssh/config` for Mac/Linux or
-`.ssh\config` in the Windows User home directory. You can use this as a standalone SSH config file too.
-
-When you run an `ssh` command against a host with a subdomain of your Proxy
-Service's domain, this SSH configuration will use the `ProxyCommand` to run `tsh
-proxy ssh`:
-
-```code
-$ ssh myuser@node1.example.com
-```
-
-## tsh proxy app
-
-Starts a local TLS proxy for Application Service connections.
-You can use this proxy to connect to an application repeatedly after a single login to your Teleport cluster,
-which is especially useful for interacting with an application via a CLI.
-
-```code
-$ tsh proxy app [<flags>] <app>
-```
-
-### Arguments
-`<app>`
-
-- `app` The name of the application to start the local proxy for. To see a list of available applications, run `tsh apps ls`.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-p, --port` | none | port number | Specify the source port for the local proxy |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-### Examples
-```code
-$ tsh proxy app <app>
-
-# Proxy a connection to grafana on local port 10700
-$ tsh proxy --port 10700 app grafana &
-# Proxying connections to grafana on 127.0.0.1:10700
-$ curl http://127.0.0.1:10700/api/users
-```
-
-## tsh proxy azure
-
-Starts a local proxy server that provides secure access to an Azure managed
-service identity endpoint. This is useful for managing access to Azure from
-custom client applications. The local proxy forwards traffic to the Teleport
-Application Service, which uses an Azure managed identity to fetch an
-authentication token from Azure.
-
-```code
-$ tsh proxy azure [<flags>]
-```
-
-The command will print the address of the local proxy server along with `export`
-commands for environment variables required to connect:
-
-```text
-Started Azure proxy on http://127.0.0.1:54330.
-To avoid port randomization, you can choose the listening port using the --port flag.
-
-Use the following credentials and HTTPS proxy setting to connect to the proxy:
-
-  export AZURE_CONFIG_DIR=/Users/myuser/.tsh/azure/my.teleport.cluster/azure
-  export HTTPS_PROXY=http://127.0.0.1:54330
-  export HTTP_PROXY=http://127.0.0.1:54330
-  export MSI_ENDPOINT=https://azure-msi.teleport.dev/eedfd5b55257c0aaa58f
-  export REQUESTS_CA_BUNDLE=/Users/myuser/.tsh/keys/teleport.example.com/myuser-app/teleport.example.com/azure-cli-localca.pem
-```
-
-<Notice type="tip">
-
-`tsh proxy azure` runs the local proxy in the foreground, so don't interrupt
-the process or exit the terminal where you ran the command until you're ready
-to close the local proxy.
-
-</Notice>
-
-Copy the `export` commands and paste them into a second terminal.
-
-To run the local proxy server, one of the user's roles must include the
-`spec.allow.azure_identities` field with one of the identities used by the
-Application Service. To learn how to set up secure access to Azure via
-Teleport, read [Protect the Azure CLI with Teleport Application
-Access](../../application-access/cloud-apis/azure.mdx).
-
-### Arguments
-
-This command does not accept any arguments.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. |
-| `--port` | none | port number | The port on `localhost` where the local proxy will listen for connections. |
-| `--format` | `powershell` if on Windows, `unix` otherwise | `text`, `unix`, `command-prompt`, or `powershell` | The format to use for listing environment variables for Azure client applications connecting to the local proxy. |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-## tsh proxy aws
-
-Start a local proxy for AWS access. The user must already be logged in to at
-least one AWS application via Teleport before the proxy can start.
-
-```code
-$ tsh proxy aws [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in AWS app | string | Optional name of the AWS application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
-| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as an AWS endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
-| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-### Examples
-
-```code
-# Proxy a connection to AWS with the default settings
-$ tsh apps login awsapp
-$ tsh proxy aws
-# Set env variables from output
-$ aws s3 ls
-
-# Proxying connections to AWS on 127.0.0.1:10700 to app awsapp2
-$ tsh apps logins awsapp2
-$ tsh proxy aws --port=10700 --app=awsapp2
-# Set env variables from output
-$ aws s3 ls
-```
-
-## tsh proxy gcloud
-
-Start a local proxy for Google Cloud API access. The user must already be logged
-in to at least one Google Cloud application via Teleport before the proxy can
-start.
-
-```code
-$ tsh proxy gcloud [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in Google Cloud app | string | Optional name of the Google Cloud application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
-| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as a Google Cloud endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
-| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the Google Cloud proxy |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
-Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
-
-### Examples
-
-```code
-$ tsh apps login google-cloud-app
-$ tsh proxy gcloud
-# Set env variables from output
-$ gcloud compute instances list
-$ gsutil ls
-```
-
-## tsh scp
-
-Copies files from source to dest:
-
-```code
-$ tsh scp [<flags>] <source>... <dest>
-```
-
-{/* TODO Confirm which flags are supported and whether supports multiple sources */}
-
-### Arguments
-
-- `<source>` - filepath to copy
-- `<dest>` - target destination
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | a cluster_name | Specify the cluster to connect |
-| `-r, --recursive` | none | none | Recursive copy of subdirectories |
-| `-P, --port` | none | port number | Port to connect to on the remote host |
-| `-q, --quiet` | none | none | Quiet mode |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh --proxy=proxy.example.com scp example.txt user@host:/destination/dir
-```
-
-<Admonition type="note">
-  `tsh scp` will not work from the CLI if the user requires session moderation. You can transfer files in a moderated session by joining the SSH session from the Web UI and requesting the file transfer there. Both the session initiator and moderators must be present in the Web UI in order to approve the file transfer request.
-</Admonition>
-
-## tsh ls
-
-List cluster nodes:
-
-```code
-$ tsh ls [<flags>] [<label>]
-```
-
-<Details title="Not seeing Nodes?">
-
-(!docs/pages/includes/node-logins.mdx!)
-
-</Details>
-
-### Arguments
-
-- `<labels>` - comma-separated list of `key=value` labels to filter nodes by,
-  e.g., `env=dev,host=foo`.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-v, --verbose` | none | none | also print Node ID |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh ls
-
-# Node Name Address            Labels
-# --------- ------------------ ------
-# grav-00   10.164.0.0:3022    os:linux
-# grav-01   10.156.0.2:3022    os:linux
-# grav-02   10.156.0.7:3022    os:osx
-
-$ tsh ls -v
-
-# Node Name Node ID                              Address            Labels
-# --------- ------------------------------------ ------------------ ------
-# grav-00   52e3e46a-372f-494b-bdd9-a1d25b9d6dec 10.164.0.0:3022    os:linux
-# grav-01   73d86fc7-7c4b-42e3-9a5f-c46e177a29e8 10.156.0.2:3022    os:linux
-# grav-02  24503590-e8ae-4a0a-ad7a-dd1865c04e30 10.156.0.7:3022     os:osx
-
-# Only show nodes with os label set to 'osx':
-$ tsh ls os=osx
-
-# Node Name Address            Labels
-# --------- ------------------ ------
-# grav-02   10.156.0.7:3022    os:osx
-```
+| `--all` | false | Boolean | Whether to generate a kubeconfig for every Kubernetes cluster the current Teleport user has access to. If this is false, `tsh` will only generate a kubeconfig for the cluster specified in the `tsh kube login` command.|
+| `--as` | none | string | The Kubernetes user that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target user. |
+| `--as-groups` | none | string | A Kubernetes group that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target group. <br /><br/>You can include this flag multiple times to enable impersonation of multiple Kubernetes groups. |
+| `--cluster` | none | string | Name of the Teleport cluster to log into in order to connect to the given Kubernetes cluster. |
+| `-n`, `--kube-namespace` | none | string | The name of the Kubernetes namespace to configure as the default within the cluster the user is logging into. |
 
 ## tsh kube ls
 
@@ -824,39 +294,6 @@ $ tsh kube ls
 # ------------------------------------- --------
 # gke_bens-demos_us-central1-c_gks-demo *
 # microk8s
-```
-
-## tsh clusters
-
-```code
-$ tsh clusters [<flags>]
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-q, --quiet` | none | none | no headers in output |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh clusters
-
-# Cluster Name Status
-# ------------ ------
-# staging          online
-# production       offline
-
-$ tsh clusters --quiet
-
-# staging online
-# production offline
 ```
 
 ## tsh login
@@ -934,41 +371,6 @@ $ tsh login --proxy=proxy.example.com --format=kubernetes -o kubeconfig
 $ tsh login --proxy=proxy.example.com --request-reason="I need to run a debug script on production"
 ```
 
-## tsh kube login
-
-Log into a Kubernetes cluster. Discover connected clusters by using [`tsh kube ls`](#tsh-kube-ls).
-
-```code
-$ tsh kube login <kube-cluster>
-```
-
-```code
-# tsh kube login to k8s cluster (gke_bens-demos_us-central1-c_gks-demo)
-$ tsh kube login gke_bens-demos_us-central1-c_gks-demo
-# Logged into kubernetes cluster "gke_bens-demos_us-central1-c_gks-demo". Try 'kubectl version' to test the connection.
-
-# On login, kubeconfig is pointed at the first cluster (alphabetically)
-$ kubectl config current-context
-# aws-gke_bens-demos_us-central1-c_gks-demo
-
-# But all clusters are populated as contexts
-$ kubectl config get-contexts
-
-# CURRENT   NAME                                        CLUSTER                       AUTHINFO                                    NAMESPACE
-# *         aws-gke_bens-demos_us-central1-c_gks-demo   aws                           aws-gke_bens-demos_us-central1-c_gks-demo
-#          aws-microk8s                                aws                           aws-microk8s
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--all` | false | Boolean | Whether to generate a kubeconfig for every Kubernetes cluster the current Teleport user has access to. If this is false, `tsh` will only generate a kubeconfig for the cluster specified in the `tsh kube login` command.|
-| `--as` | none | string | The Kubernetes user that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target user. |
-| `--as-groups` | none | string | A Kubernetes group that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target group. <br /><br/>You can include this flag multiple times to enable impersonation of multiple Kubernetes groups. |
-| `--cluster` | none | string | Name of the Teleport cluster to log into in order to connect to the given Kubernetes cluster. |
-| `-n`, `--kube-namespace` | none | string | The name of the Kubernetes namespace to configure as the default within the cluster the user is logging into. |
-
 ## tsh logout
 
 Deletes the client's cluster certificate:
@@ -977,37 +379,61 @@ Deletes the client's cluster certificate:
 $ tsh logout
 ```
 
-## tsh status
+## tsh ls
 
-Display the list of proxy servers and retrieved certificates:
+List cluster nodes:
 
 ```code
-$ tsh status
+$ tsh ls [<flags>] [<label>]
 ```
+
+<Details title="Not seeing Nodes?">
+
+(!docs/pages/includes/node-logins.mdx!)
+
+</Details>
+
+### Arguments
+
+- `<labels>` - comma-separated list of `key=value` labels to filter nodes by,
+  e.g., `env=dev,host=foo`.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `-v, --verbose` | none | none | also print Node ID |
+
+### Global flags
+
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 ### Examples
 
 ```code
-$ tsh status
+$ tsh ls
 
-# > Profile URL:  https://proxy.example.com:3080
-#   Logged in as:       benarent
-#   Cluster:            aws
-#   Roles:              access, editor, auditor
-#   Logins:             benarent, root, ec2-user, ubunutu
-#   Kubernetes:         enabled
-#   Kubernetes cluster: "gke_bens-demos_us-central1-c_gks-demo"
-#   Kubernetes groups:  system:masters
-#  Valid until:        2020-11-21 01:50:23 -0800 PST [valid for 11h52m0s]
-#  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
-```
+# Node Name Address            Labels
+# --------- ------------------ ------
+# grav-00   10.164.0.0:3022    os:linux
+# grav-01   10.156.0.2:3022    os:linux
+# grav-02   10.156.0.7:3022    os:osx
 
-## tsh mfa ls
+$ tsh ls -v
 
-List all registered Multi-Factor Authentication (MFA) devices:
+# Node Name Node ID                              Address            Labels
+# --------- ------------------------------------ ------------------ ------
+# grav-00   52e3e46a-372f-494b-bdd9-a1d25b9d6dec 10.164.0.0:3022    os:linux
+# grav-01   73d86fc7-7c4b-42e3-9a5f-c46e177a29e8 10.156.0.2:3022    os:linux
+# grav-02  24503590-e8ae-4a0a-ad7a-dd1865c04e30 10.156.0.7:3022     os:osx
 
-```code
-$ tsh mfa ls
+# Only show nodes with os label set to 'osx':
+$ tsh ls os=osx
+
+# Node Name Address            Labels
+# --------- ------------------ ------
+# grav-02   10.156.0.7:3022    os:osx
 ```
 
 ## tsh mfa add
@@ -1048,6 +474,14 @@ $ tsh mfa add
 # MFA device "android" added.
 ```
 
+## tsh mfa ls
+
+List all registered Multi-Factor Authentication (MFA) devices:
+
+```code
+$ tsh mfa ls
+```
+
 ## tsh mfa rm
 
 Remove a registered Multi-Factor Authentication (MFA) device. You can view your
@@ -1056,6 +490,454 @@ registered devices using [`tsh mfa ls`](#tsh-mfa-ls).
 ```code
 $ tsh mfa rm <device-name>
 ```
+
+## tsh play
+
+Plays back a prior session:
+
+```code
+$ tsh play [<flags>] <session-id>
+```
+
+### Arguments
+
+`<session-id>`
+
+- `session-id` The UUID of a past Teleport Session obtained by `teleport status` within
+  the session or from the Web UI.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--cluster` | none | a cluster_name | Specify the cluster to connect |
+| `--format`  | `pty`  | json, pty | Format for playback |
+
+### Global flags
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+
+### Examples
+
+```code
+$ tsh --proxy proxy.example.com play <session-id>
+
+# Playing back a session using pty format using a downloaded session recording.
+$ tsh play --format=pty 1fe153d1-ce8b-4ef4-9908-6539457ba4ad.tar
+
+# Playing back a session in json format using jq to filter on events
+$ tsh play --format=json ~/play/0c0b81ed-91a9-4a2a-8d7c-7495891a6ca0.tar | jq '.event
+```
+
+## tsh proxy app
+
+Starts a local TLS proxy for Application Service connections.
+You can use this proxy to connect to an application repeatedly after a single login to your Teleport cluster,
+which is especially useful for interacting with an application via a CLI.
+
+```code
+$ tsh proxy app [<flags>] <app>
+```
+
+### Arguments
+`<app>`
+
+- `app` The name of the application to start the local proxy for. To see a list of available applications, run `tsh apps ls`.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `-p, --port` | none | port number | Specify the source port for the local proxy |
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+### Examples
+```code
+$ tsh proxy app <app>
+
+# Proxy a connection to grafana on local port 10700
+$ tsh proxy --port 10700 app grafana &
+# Proxying connections to grafana on 127.0.0.1:10700
+$ curl http://127.0.0.1:10700/api/users
+```
+
+## tsh proxy aws
+
+Start a local proxy for AWS access. The user must already be logged in to at
+least one AWS application via Teleport before the proxy can start.
+
+```code
+$ tsh proxy aws [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--app` | Currently logged in AWS app | string | Optional name of the AWS application (as shown in `tsh apps ls`) to use if logged in to multiple |
+| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
+| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as an AWS endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
+| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+### Examples
+
+```code
+# Proxy a connection to AWS with the default settings
+$ tsh apps login awsapp
+$ tsh proxy aws
+# Set env variables from output
+$ aws s3 ls
+
+# Proxying connections to AWS on 127.0.0.1:10700 to app awsapp2
+$ tsh apps logins awsapp2
+$ tsh proxy aws --port=10700 --app=awsapp2
+# Set env variables from output
+$ aws s3 ls
+```
+
+## tsh proxy azure
+
+Starts a local proxy server that provides secure access to an Azure managed
+service identity endpoint. This is useful for managing access to Azure from
+custom client applications. The local proxy forwards traffic to the Teleport
+Application Service, which uses an Azure managed identity to fetch an
+authentication token from Azure.
+
+```code
+$ tsh proxy azure [<flags>]
+```
+
+The command will print the address of the local proxy server along with `export`
+commands for environment variables required to connect:
+
+```text
+Started Azure proxy on http://127.0.0.1:54330.
+To avoid port randomization, you can choose the listening port using the --port flag.
+
+Use the following credentials and HTTPS proxy setting to connect to the proxy:
+
+  export AZURE_CONFIG_DIR=/Users/myuser/.tsh/azure/my.teleport.cluster/azure
+  export HTTPS_PROXY=http://127.0.0.1:54330
+  export HTTP_PROXY=http://127.0.0.1:54330
+  export MSI_ENDPOINT=https://azure-msi.teleport.dev/eedfd5b55257c0aaa58f
+  export REQUESTS_CA_BUNDLE=/Users/myuser/.tsh/keys/teleport.example.com/myuser-app/teleport.example.com/azure-cli-localca.pem
+```
+
+<Notice type="tip">
+
+`tsh proxy azure` runs the local proxy in the foreground, so don't interrupt
+the process or exit the terminal where you ran the command until you're ready
+to close the local proxy.
+
+</Notice>
+
+Copy the `export` commands and paste them into a second terminal.
+
+To run the local proxy server, one of the user's roles must include the
+`spec.allow.azure_identities` field with one of the identities used by the
+Application Service. To learn how to set up secure access to Azure via
+Teleport, read [Protect the Azure CLI with Teleport Application
+Access](../../application-access/cloud-apis/azure.mdx).
+
+### Arguments
+
+This command does not accept any arguments.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. |
+| `--port` | none | port number | The port on `localhost` where the local proxy will listen for connections. |
+| `--format` | `powershell` if on Windows, `unix` otherwise | `text`, `unix`, `command-prompt`, or `powershell` | The format to use for listing environment variables for Azure client applications connecting to the local proxy. |
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+## tsh proxy db
+
+Start a local TLS proxy for database connections when using Teleport with TLS
+Routing enabled. Clients can connect to a Teleport-registered database through
+the local proxy.
+
+```code
+$ tsh proxy db [<flags>] <db>
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--cluster` | none | string | The name of the Teleport cluster to connect to. |
+| `--db-name` | see below | string | The database name to log in to. |
+| `--db-user` | see below | string | The database user to log in as. |
+| `--port` | none | string | Source port used by the local proxy.|
+| `--tunnel` | none | Boolean | Open an authenticated tunnel using a database's client certificate so clients don't need to authenticate. |
+
+(!docs/pages/includes/db-user-name-flags.mdx!)
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+### Examples
+
+Proxy a DB connection to a named database
+```code
+$ tsh proxy db <db>
+```
+
+Proxy a connection to mysql db on local port 10700:
+```code
+$ tsh proxy db --port 10700  mysql-db
+# Started DB proxy on 127.0.0.1:10700
+
+# Use following credentials to connect to the mysql-db proxy:
+#  ca_file=/Users/jeff/.tsh/keys/teleport.example.com/cas/teleport.example.com.pem
+#  cert_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff-db/tele1c/mysql-db-x509.pem
+#  key_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff
+```
+
+Proxy a connection to mysql db with no credentials required:
+```code
+$ tsh proxy db --tunnel mysql-db
+Started authenticated tunnel for the MySQL database "mysql-db" in cluster "teleport.example.com" on 127.0.0.1:49415.
+
+Use the following command to connect to the database:
+  $ mysql --port 49415 --host localhost --protocol TCP
+```
+
+## tsh proxy gcloud
+
+Start a local proxy for Google Cloud API access. The user must already be logged
+in to at least one Google Cloud application via Teleport before the proxy can
+start.
+
+```code
+$ tsh proxy gcloud [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--app` | Currently logged in Google Cloud app | string | Optional name of the Google Cloud application (as shown in `tsh apps ls`) to use if logged in to multiple |
+| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
+| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as a Google Cloud endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
+| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the Google Cloud proxy |
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+### Examples
+
+```code
+$ tsh apps login google-cloud-app
+$ tsh proxy gcloud
+# Set env variables from output
+$ gcloud compute instances list
+$ gsutil ls
+```
+
+## tsh proxy ssh
+
+Start a local TLS proxy for `ssh` connections when using Teleport in TLS Routing mode.
+This is typically used as part of the SSH client configuration to use `ssh` as a client
+through Teleport.  See the [OpenSSH Guide](../../server-access/guides/openssh.mdx) guide
+on configuring OpenSSH servers and clients.  The `tsh config` output will include `tsh proxy ssh`
+within a `ProxyCommand` directive.
+
+```code
+$ tsh proxy ssh [<flags>] <[user@]host>
+```
+
+### Arguments
+- `<[user@]host>` Remote hostname and the login to use
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--cluster` | none | Teleport Cluster | The name of the Teleport cluster to connect to.|
+
+### [Global Flags](#tsh-global-flags)
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
+
+### Examples
+
+Run the following command to generate an OpenSSH client configuration:
+
+```code
+$ tsh config
+```
+
+This command produces the following configuration:
+
+```
+# Common flags for all example.com hosts
+Host *.example.com example.com
+    UserKnownHostsFile "/Users/jeff/.tsh/known_hosts"
+    IdentityFile "/Users/jeff/.tsh/keys/enterprise.teleportdemo.com/jeff"
+    CertificateFile "/Users/jeff/.tsh/keys/example.com/jeff-ssh/example.com-cert.pub"
+    PubkeyAcceptedKeyTypes +ssh-rsa-cert-v01@openssh.com
+    HostKeyAlgorithms ssh-rsa-cert-v01@openssh.com
+
+# Flags for all example.com hosts except the proxy
+Host *.example.com !example.com
+    Port 3022
+    ProxyCommand "/usr/local/bin/tsh" proxy ssh --cluster=example.com --proxy=example.com %r@%h:%p
+```
+
+This output should be placed into the default SSH Config for environment, `~/.ssh/config` for Mac/Linux or
+`.ssh\config` in the Windows User home directory. You can use this as a standalone SSH config file too.
+
+When you run an `ssh` command against a host with a subdomain of your Proxy
+Service's domain, this SSH configuration will use the `ProxyCommand` to run `tsh
+proxy ssh`:
+
+```code
+$ ssh myuser@node1.example.com
+```
+
+## tsh puttyconfig
+
+Adds a PuTTY saved session to the Windows registry for the currently logged in Windows user.
+
+```
+$ tsh puttyconfig [--leaf <leaf-cluster-name>] [login@]hostname
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `-l, --login` | none | Linux username | Default Linux username to use. Will translate to SSH config's `User` option. |
+| `-p`, `--port` | 3022 | port | Default SSH port to use. Will translate to SSH config's `Port` option. |
+| `--leaf` | none | Leaf cluster name | Leaf cluster name to add to the saved session. |
+
+### Examples
+
+```code
+# Add a saved PuTTY session on 'node' for the user 'ec2-user'
+$ tsh puttyconfig ec2-user@node
+
+# Add a saved PuTTY session for the Teleport-registered OpenSSH node 'openssh' for the user 'ubuntu'
+$ tsh puttyconfig --port 22 ubuntu@openssh
+
+# Add a saved PuTTY session on leaf-node for the user 'ec2-user' on the leaf cluster 'example.teleport.sh'
+$ tsh puttyconfig --leaf example.teleport.sh ec2-user@leaf-node
+```
+
+See [full docs on `tsh puttyconfig` here](../../connect-your-client/putty-winscp.mdx).
+
+## tsh recordings export
+
+Export recorded desktop sessions to video.
+
+```code
+$ tsh recordings export <session_id> [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--out` | `<session_id>.avi` | a filename | Override the output file name. |
+
+### Examples
+
+```code
+$ tsh recordings export c8e1b2c5-322a-4095-89e3-391edfd2da9b --out=recording.avi
+wrote recording to recording.avi
+```
+
+## tsh recordings ls
+
+List recorded sessions.
+
+```code
+$ tsh recordings ls [<flags>]
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--from-utc` | 24 hours ago | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
+| `--to-utc` | current | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
+| `--limit` | 50 | number | Maximum number of recordings to show. |
+| `--last` | none | duration | Duration into the past from which session recordings should be listed. Format 5h30m40s |
+
+### Global flags
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost, --format`.
+Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+
+### Examples
+
+```code
+# get the recorded sessions from the last 24 hours
+$ tsh --proxy proxy.example.com recordings ls
+ID                                   Type Participants Hostname Timestamp
+------------------------------------ ---- ------------ -------- -------------------
+b0a04442-70dc-4be8-9308-7b7901d2d600 ssh  jeff         dev       Nov 26 16:36:16 UTC
+c0a02222-70dc-4be8-9308-7b7901d2d600 kube alice                  Nov 26 20:36:16 UTC
+d0a04442-70dc-4be8-9308-7b7901d2d600 ssh  navin        test      Nov 26 16:36:16 UTC
+
+# The session can be played with tsh play
+$ tsh play c0a02222-70dc-4be8-9308-7b7901d2d60
+
+# List recorded sessions that occurred between Nov 1, 2022 to Nov 3, 2022
+$ tsh recordings ls --from-utc=2022-11-01 --to-utc=2022-11-3
+
+# Retrieve recorded sessions in the last 6 hours
+$ tsh recordings ls --last=6h0m0s
+```
+
+<Admonition
+  title="Recorded Sessions Availability"
+  scope={["oss", "enterprise"]} type="tip" scopeOnly
+>
+
+Recorded sessions are linked from the audit events to session recordings files
+in their [storage backend](../../reference/backends.mdx).
+The following error can occur if a session recording file is not available or
+when employing multiple auth servers with directory storage backend for recorded
+sessions. When using a directory storage backend for audit logs and recorded sessions,
+only the auth server with that recorded session can retrieve it.
+
+```code
+$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b
+ERROR: Recording for session c8e1b2c5-322a-4095-89e3-391edfd2da9b not found.
+```
+
+Using a Security Information and Event Management (SIEM) service that combines
+the audit logs will help consolidate the list of available recordings.
+
+Downloaded recorded session are directly playable as a file.
+
+```code
+$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b.tar
+```
+
+</Admonition>
 
 ## tsh request create
 
@@ -1091,6 +973,20 @@ Use `--max-duration` to request access for longer than the maximum certificate
 lifetime.
 </Admonition>
 
+## tsh request drop
+
+Drop one or more access requests from current identity
+
+```code
+$ tsh request drop [<request-id>...]
+```
+
+### Arguments
+
+- `<request-id>` - IDs of requests to "drop" from the current identity so that
+  your certificate will lose elevated roles and/or resource restrictions.
+  If no request ID is given, the default is to drop all Access Requests.
+
 ## tsh request ls
 
 List Access Requests
@@ -1107,24 +1003,6 @@ $ tsh request ls
 | `--reviewable` | `false` | `true` or `false` | Only show requests reviewable by current user |
 | `--suggested` | `false` | `true` or `false` | Only show requests that suggest current user as reviewer |
 | `--my-requests` | `false` | `true` or `false` | Only show requests created by current user |
-
-## tsh request show
-
-Show Access Request details
-
-```code
-$ tsh request show <request-id>
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--format` | text | `text`, `json`, or `yaml` | Format output |
-
-### Arguments
-
-- `<request-id>` - ID of the target request
 
 ## tsh request review
 
@@ -1164,59 +1042,182 @@ $ tsh request search [<flags>]
 | `--query` | none | String | Query by [predicate language](../predicate-language.mdx#resource-filtering) enclosed in single quotes |
 | `--labels` | none | Comma-separated strings | List of comma-separated labels to filter by labels (e.g. `key=value1,key2=value2`) |
 
-## tsh request drop
+## tsh request show
 
-Drop one or more access requests from current identity
-
-```code
-$ tsh request drop [<request-id>...]
-```
-
-### Arguments
-
-- `<request-id>` - IDs of requests to "drop" from the current identity so that
-  your certificate will lose elevated roles and/or resource restrictions.
-  If no request ID is given, the default is to drop all Access Requests.
-
-## tsh device enroll
-
-Enroll the current device as a trusted device.
-
-Requires a device enrollment token created via `tctl devices enroll`.
+Show Access Request details
 
 ```code
-$ tsh device enroll --token=TOKEN
+$ tsh request show <request-id>
 ```
 
 ### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--token` | none | String | Device enrollment token |
+| `--format` | text | `text`, `json`, or `yaml` | Format output |
+
+### Arguments
+
+- `<request-id>` - ID of the target request
+
+## tsh scp
+
+Copies files from source to dest:
+
+```code
+$ tsh scp [<flags>] <source>... <dest>
+```
+
+{/* TODO Confirm which flags are supported and whether supports multiple sources */}
+
+### Arguments
+
+- `<source>` - filepath to copy
+- `<dest>` - target destination
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--cluster` | none | a cluster_name | Specify the cluster to connect |
+| `-r, --recursive` | none | none | Recursive copy of subdirectories |
+| `-P, --port` | none | port number | Port to connect to on the remote host |
+| `-q, --quiet` | none | none | Quiet mode |
+
+### Global flags
+
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 ### Examples
 
 ```code
-$ tsh device enroll --token=(=devicetrust.enroll_token=)
-Device "(=devicetrust.asset_tag=)"/macOS enrolled
+$ tsh --proxy=proxy.example.com scp example.txt user@host:/destination/dir
 ```
 
-## tsh environment variables
+<Admonition type="note">
+  `tsh scp` will not work from the CLI if the user requires session moderation. You can transfer files in a moderated session by joining the SSH session from the Web UI and requesting the file transfer there. Both the session initiator and moderators must be present in the Web UI in order to approve the file transfer request.
+</Admonition>
 
-Environment variables configure your tsh client and can help you avoid using flags repetitively.
+## tsh ssh
 
-| Environment Variable | Description | Example Value |
-| - | - | - |
-| TELEPORT_AUTH | Name of a defined SAML, OIDC, or GitHub auth connector (or a local user) | okta |
-| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | otp |
-| TELEPORT_CLUSTER | Name of a Teleport root or leaf cluster | cluster.example.com |
-| TELEPORT_LOGIN | Login name to be used by default on the remote host | root |
-| TELEPORT_LOGIN_BIND_ADDR | Address in the form of host:port to bind to for login command webhook | host:port |
-| TELEPORT_LOGIN_BROWSER | Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser. | none |
-| TELEPORT_PROXY | Address of the Teleport proxy server | cluster.example.com:3080 |
-| TELEPORT_HOME | Home location for tsh configuration and data | /directory |
-| TELEPORT_USER | A Teleport user name | alice |
-| TELEPORT_ADD_KEYS_TO_AGENT | Specifies if the user certificate should be stored on the running SSH agent | yes, no, auto, only |
-| TELEPORT_USE_LOCAL_SSH_AGENT | Disable or enable local SSH agent integration | true, false |
-| TELEPORT_GLOBAL_TSH_CONFIG | Override location of global `tsh` config file from default `/etc/tsh.yaml` | /opt/teleport/tsh.yaml |
-| TELEPORT_HEADLESS | Use headless authentication | true, false, 1, 0 |
+Run shell or execute a command on a remote SSH node:
+
+```code
+$ tsh ssh [<flags>] <[user@]host> [<command>...]
+```
+
+### Arguments
+
+`<[user@]host> [<command>...]`
+
+- `user` The login identity to use on the remote host. If `[user]` is not specified the user defaults to `$USER` or can be set with `--user`. If the flag `--user` and positional argument `[user]` are specified the arg `[user]` takes precedence.
+- `host` The `nodename` of a cluster Node or a label specification like `env=aws` to run on all matching hosts.
+- `command` The command to execute on a remote host.
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `-p, --port` | none | port | SSH port on a remote host |
+| `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
+| `-L, --forward` | none | none | Forward localhost connections to remote server |
+| `-D, --dynamic-forward` | none | none | Forward localhost connections to remote server using SOCKS5 |
+| `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
+| `--local` | none | | Execute command on localhost after connecting to SSH node |
+| `-t, --tty` | `file` | | Allocate TTY |
+| `--cluster` | none | | Specify the cluster to connect |
+| `-o, --option` | `local` | | OpenSSH options in the format used in the configuration file |
+| `--enable-escape-sequences` | | | Enable support for SSH escape sequences. Type `~?` during an SSH session to list supported sequences. |
+| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`) |
+| `-X, --x11-untrusted` | none | none | Requests untrusted (secure) X11 forwarding for this session. |
+| `-Y, --x11-trusted` | none | none | Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution. |
+| `--x11-untrusted-timeout` | 10m | duration | Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server. |
+
+### Global flags
+
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+
+### Examples
+
+```code
+# Log in to node `grav-00` as OS User `root` with Teleport User `teleport`
+$ tsh ssh --proxy proxy.example.com --user teleport -d root@grav-00
+# `tsh ssh` takes the same arguments as OpenSSH client:
+$ tsh ssh -o ForwardAgent=yes root@grav-00
+$ tsh ssh -o AddKeysToAgent=yes root@grav-00
+# Run `hostname` on all nodes with the `env: aws` label
+$ tsh ssh root@env=aws hostname
+```
+
+## tsh status
+
+Display the list of proxy servers and retrieved certificates:
+
+```code
+$ tsh status
+```
+
+### Examples
+
+```code
+$ tsh status
+
+# > Profile URL:  https://proxy.example.com:3080
+#   Logged in as:       benarent
+#   Cluster:            aws
+#   Roles:              access, editor, auditor
+#   Logins:             benarent, root, ec2-user, ubunutu
+#   Kubernetes:         enabled
+#   Kubernetes cluster: "gke_bens-demos_us-central1-c_gks-demo"
+#   Kubernetes groups:  system:masters
+#  Valid until:        2020-11-21 01:50:23 -0800 PST [valid for 11h52m0s]
+#  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+## tsh version
+
+Prints the version of your `tsh` binary and the Teleport Proxy Service in the current `tsh` profile
+
+```code
+$ tsh version [<flags>]
+```
+
+| Name           | Default Value(s) | Allowed Value(s) | Description                                        |
+|----------------|------------------|------------------|----------------------------------------------------|
+| `-f, --format` | `text`           | text, json, yaml | Format for version output                          |
+| `--client`     | none             | none             | Show the client version only (no server required). |
+
+### Examples
+
+```code
+$ tsh version
+Teleport v(=teleport.version=) git: go(=teleport.golang=)
+Proxy version: (=teleport.version=)
+Proxy: teleport.example.com:443
+```
+
+Display in JSON format:
+
+```code
+$ tsh version --format=json
+```
+
+```json
+{
+  "version": "(=teleport.version=)",
+  "gitref": "",
+  "runtime": "go(=teleport.golang=)",
+  "proxyVersion": "(=teleport.version=)",
+  "proxyPublicAddress": "teleport.example.com:443"
+}
+```
+
+Only display the `tsh` binary version:
+
+```code
+$ tsh version --client
+Teleport v(=teleport.version=) git: go(=teleport.golang=)
+```
+


### PR DESCRIPTION
Closes #21164

The CLI reference is a section of the docs in which each CLI tool has its own page, so this change sorts each page individually.

The change places H2 sections not related to individual commands (e.g., sections for global flags and environment variables) at the top of each guide, and sorts the sections following these.

In `teleport.mdx`, all commands except for `start` are only documented in a table at the beignning of the page, so this change sorts the table.