### PR TITLE
[v14] Re-add PIV to amd64 centos7 release builds

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -393,7 +393,7 @@ enter/grpcbox: grpcbox
 # AMD64 builds are done on CentOS 7 build boxes for broader glibc compatibility.
 .PHONY: release-amd64
 release-amd64:
-	$(MAKE) release-centos7 ARCH=amd64 FIDO2=yes
+	$(MAKE) release-centos7 ARCH=amd64 FIDO2=yes PIV=yes
 
 .PHONY: release-amd64-fips
 release-amd64-fips:


### PR DESCRIPTION
Backport #35791 to branch/v14