### PR TITLE
charts/teleport-cluster: namespaced CRB names

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/clusterrolebinding.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}
   labels: {{- include "teleport-cluster.auth.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -18,7 +18,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-auth
+  name: {{ .Release.Namespace}}-{{ .Release.Name }}-auth
   labels: {{- include "teleport-cluster.auth.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/35486

changelog: the `teleport-cluster` Helm chart ClusterRoleBindings now contain the release namespace in their names. Multiple releases with the same name can now be deployed in different namespaces of the same Kubernetes cluster.