### PR TITLE
[v12] Set PIV build tag on Windows native builds

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -343,7 +343,7 @@ function Build-Tsh {
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building tsh..."
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
-        go build -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
+        go build -tags piv -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
         Write-Host "::endgroup::"
 
         Write-Host "::group::Signing tsh..."


### PR DESCRIPTION
Backport #35863 to branch/v12

changelog: Fixed PIV not being available on Windows TSH binaries
