### PR TITLE
[v14] include expiration in audit log lock event

### DIFF
--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -143,6 +144,12 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 		return trace.Wrap(err)
 	}
 
+	var expiresTime time.Time
+	// leave as 0 if no lock expiration was set
+	if le := lock.LockExpiry(); le != nil {
+		expiresTime = le.UTC()
+	}
+
 	um := authz.ClientUserMetadata(ctx)
 	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.LockCreate{
 		Metadata: apievents.Metadata{
@@ -152,6 +159,7 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 		UserMetadata: um,
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:      lock.GetName(),
+			Expires:   expiresTime,
 			UpdatedBy: um.User,
 		},
 		Target: lock.Target(),

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -173,6 +173,8 @@ func TestUpsertDeleteLockEventsEmitted(t *testing.T) {
 		Target: types.LockTarget{MFADevice: "mfa-device-id"},
 	})
 	require.NoError(t, err)
+	futureTime := time.Now().UTC().Add(12 * time.Hour)
+	lock.SetLockExpiry(&futureTime)
 
 	// Creating a lock should emit a LockCreatedEvent.
 	err = p.a.UpsertLock(ctx, lock)
@@ -180,6 +182,7 @@ func TestUpsertDeleteLockEventsEmitted(t *testing.T) {
 	require.Equal(t, events.LockCreatedEvent, p.mockEmitter.LastEvent().GetType())
 	require.Equal(t, lock.GetName(), p.mockEmitter.LastEvent().(*apievents.LockCreate).Name)
 	require.Equal(t, lock.Target(), p.mockEmitter.LastEvent().(*apievents.LockCreate).Target)
+	require.Equal(t, lock.LockExpiry().UTC(), p.mockEmitter.LastEvent().(*apievents.LockCreate).Expires)
 	p.mockEmitter.Reset()
 
 	// When a lock update results in an error, no event should be emitted.


### PR DESCRIPTION
backport #26421 to branch/v14

changelog: Lock expiration time included in Audit Log Lock Create events