### PR TITLE
[v12] include expiration in audit log lock event

### DIFF
--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -18,6 +18,7 @@ package auth
 
 import (
 	"context"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -107,6 +108,12 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 		return trace.Wrap(err)
 	}
 
+	var expiresTime time.Time
+	// leave as 0 if no lock expiration was set
+	if le := lock.LockExpiry(); le != nil {
+		expiresTime = le.UTC()
+	}
+
 	um := authz.ClientUserMetadata(ctx)
 	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.LockCreate{
 		Metadata: apievents.Metadata{
@@ -116,6 +123,7 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 		UserMetadata: um,
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:      lock.GetName(),
+			Expires:   expiresTime,
 			UpdatedBy: um.User,
 		},
 		Target: lock.Target(),


### PR DESCRIPTION
backport  https://github.com/gravitational/teleport/pull/26421 to branch/v12

changelog: Lock expiration time included in Audit Log Lock Create events