### PR TITLE
Run CodeQL when the CodeQL workflow is changed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,31 @@
 name: "CodeQL"
 
 on:
+  # we want to run this once a day and on any PRs that change the workflow
   schedule:
     - cron: '0 13 * * *' # At 1:00 PM UTC every day
+  pull_request: {}
+  # merge_group is intentionally excluded, because we don't require this workflow
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      workflow-modified: ${{ steps.changes.outputs.workflow }}
+    steps:
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      id: changes
+      with:
+        filters: |
+          workflow:
+            - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
+    needs: changes
+    if: ${{ github.event_name == 'cron' || needs.changes.outputs.workflow-modified == 'true' }}
     runs-on: ubuntu-22.04-16core
     permissions:
       actions: read
@@ -17,14 +35,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'master' ] # release branches are scanned in teleport-sec-scan repos (see RFD 147)
         language: [ 'go', 'javascript' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        ref: ${{ matrix.branch }}
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,31 +1,16 @@
 name: "CodeQL"
 
 on:
-  # we want to run this once a day and on any PRs that change the workflow
   schedule:
     - cron: '0 13 * * *' # At 1:00 PM UTC every day
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/codeql.yml'
   # merge_group is intentionally excluded, because we don't require this workflow
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      workflow-modified: ${{ steps.changes.outputs.workflow }}
-    steps:
-    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
-      id: changes
-      with:
-        filters: |
-          workflow:
-            - '.github/workflows/codeql.yml'
-
   analyze:
     name: Analyze
-    needs: changes
-    if: ${{ github.event_name == 'cron' || needs.changes.outputs.workflow-modified == 'true' }}
     runs-on: ubuntu-22.04-16core
     permissions:
       actions: read


### PR DESCRIPTION
This PR modifies our CodeQL workflow to run on PRs iff the PR touches the CodeQL yaml file.  This is useful for double checking changes to the workflow don't introduce regressions the we wouldn't notice until the next cron run.

We're seeing less than 1 change a month, so this shouldn't introduce significant cost concerns due to running CodeQL on every PR revision.  There will be a degree of cost increase due to running paths-filter (another time) on every PR revision.

Of immediate interest, I'd like to validate https://github.com/gravitational/teleport/pull/35847.

### Testing
You can verify CodeQL was kicked off for this PR here:

https://github.com/gravitational/teleport/actions/runs/7280918904/job/19840349596?pr=35895

I have not yet verified the following cases:

* CodeQL is kicked off by cron
* CodeQL is not kicked off by PRs that do not touch `.github/workflows/codeql.yml`

I was planning on checking both of these post merge.  If you'd like to see either checked beforehand, I can set up a test harness -- though it will be difficult to do so for the cron condition.