### PR TITLE
AWS OIDC: DeployDatabaseService per VPC

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -56,7 +56,7 @@ func StatementForECSManageService() *Statement {
 		Effect: EffectAllow,
 		Actions: []string{
 			"ecs:DescribeClusters", "ecs:CreateCluster", "ecs:PutClusterCapacityProviders",
-			"ecs:DescribeServices", "ecs:CreateService", "ecs:UpdateService",
+			"ecs:DescribeServices", "ecs:CreateService", "ecs:UpdateService", "ecs:ListServices",
 			"ecs:RegisterTaskDefinition", "ecs:DescribeTaskDefinition", "ecs:DeregisterTaskDefinition",
 
 			// EC2 DescribeSecurityGroups is required so that the user can list the SG and then pick which ones they want to apply to the ECS Service.

--- a/lib/integrations/awsoidc/deploydatabaseservice.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice.go
@@ -1,0 +1,290 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// DeployDatabaseServiceRequest contains the required fields to deploy multiple Teleport Databases Services.
+// Each Service will proxy a specific set of Databases, based on their "account-id", "region" and "vpc-id" labels.
+type DeployDatabaseServiceRequest struct {
+	// Region is the AWS Region
+	Region string
+
+	// Deployments contains a list of services to be deployed.
+	Deployments []DeployDatabaseServiceRequestDeployment
+
+	// TaskRoleARN is the AWS Role's ARN used within the Task execution.
+	// Ensure the AWS Client has `iam:PassRole` for this Role's ARN.
+	TaskRoleARN string
+
+	// TeleportClusterName is the Teleport Cluster Name.
+	// Used to create names for Cluster and TaskDefinitions, and AWS resource tags.
+	TeleportClusterName string
+
+	// ProxyServerHostPort is the Teleport Proxy's Public.
+	// The Deployed services will connect to this service.
+	ProxyServerHostPort string
+
+	// IntegrationName is the integration name.
+	// Used for resource tagging when creating resources in AWS.
+	IntegrationName string
+
+	// TeleportVersionTag is the version of teleport to install.
+	// Ensure the tag exists in:
+	// public.ecr.aws/gravitational/teleport-distroless:<TeleportVersionTag>
+	// Eg, 13.2.0
+	// Optional. Defaults to the current version.
+	TeleportVersionTag string
+
+	// ResourceCreationTags is used to add tags when creating resources in AWS.
+	ResourceCreationTags AWSTags
+
+	// ecsClusterName is the ECS Cluster Name to be used.
+	// It is based on the Teleport Cluster's Name.
+	ecsClusterName string
+
+	// teleportIAMTokenNameForTask is the IAM Join Token name that the deployed service must use to join the cluster.
+	teleportIAMTokenNameForTask string
+
+	// accountID is the AWS Account ID.
+	// sts.GetCallerIdentity is used to obtain its value.
+	accountID string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (r *DeployDatabaseServiceRequest) CheckAndSetDefaults() error {
+	if r.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	if len(r.Deployments) == 0 {
+		return trace.BadParameter("at least one deployment is required")
+	}
+	for _, deployment := range r.Deployments {
+		if deployment.VPCID == "" {
+			return trace.BadParameter("vpcid is required in every deployment")
+		}
+		if len(deployment.SubnetIDs) == 0 {
+			return trace.BadParameter("at least one subnet is required in every deployment")
+		}
+	}
+
+	if r.TaskRoleARN == "" {
+		return trace.BadParameter("task role arn is required")
+	}
+
+	if r.TeleportClusterName == "" {
+		return trace.BadParameter("teleport cluster name is required")
+	}
+
+	if r.ProxyServerHostPort == "" {
+		return trace.BadParameter("proxy address is required")
+	}
+
+	if r.IntegrationName == "" {
+		return trace.BadParameter("integration name is required")
+	}
+
+	if r.TeleportVersionTag == "" {
+		r.TeleportVersionTag = teleport.Version
+	}
+
+	if r.ResourceCreationTags == nil {
+		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+	}
+
+	r.ecsClusterName = normalizeECSClusterName(r.TeleportClusterName)
+
+	r.teleportIAMTokenNameForTask = defaultTeleportIAMTokenName
+
+	return nil
+}
+
+// DeployDatabaseServiceRequestDeployment identifies the required fields to deploy a DatabaseService.
+type DeployDatabaseServiceRequestDeployment struct {
+	// VPCID is the VPCID where the service is going to be deployed.
+	VPCID string
+
+	// SubnetIDs are the subnets for the network configuration.
+	// They must belong to the VPCID above.
+	SubnetIDs []string
+
+	// SecurityGroupIDs are the SecurityGroups that should be applied to the ECS Service.
+	// Optional. If empty, uses the VPC's default SecurityGroup.
+	SecurityGroupIDs []string
+}
+
+// DeployDatabaseServiceResponse contains the ARNs of the Amazon resources used to deploy the Teleport Service.
+type DeployDatabaseServiceResponse struct {
+	// ClusterARN is the Amazon ECS Cluster ARN where the task was started.
+	ClusterARN string
+
+	// ClusterDashboardURL is a link to the Cluster's Dashboard URL in Amazon Console.
+	ClusterDashboardURL string
+}
+
+// DeployDatabaseService calls Amazon ECS APIs to deploy multiple Teleport DatabaseService.
+// Each DatabaseService is created per Deployment and proxies the DBs that match a specific set of labels.
+//
+// Those DatabaseServices join the cluster using an IAM Join Token, which is created if it doesn't exist yet.
+//
+// The following AWS ECS resources are created: Cluster, Services and Task Definition.
+//
+// A single ECS Cluster is created, named <teleport-cluster-name>-teleport
+// Eg, tenant_teleport_sh-teleport
+//
+// An ECS TaskDefinition is created per deployment.
+// It uses Teleport Image and is configured to start a DatabaseService proxying the
+// databases that match on `account-id`, `region` and `vpc-id`.
+// A new revision is created if it already exists.
+// Example of an ECS TaskDefinition name: tenant_teleport_sh-teleport-database-service-vpc-123:1
+//
+// An ECS Service is created per deployment/ECS TaskDefinition.
+// It will be configured to run on the VPC and have the Subnets and SecurityGroups defined in each deployment.
+// If no SecurityGroup is provided, it will be assigned the VPC's default SecurityGroup.
+// Its IAM access are the ones defined in the TaskRoleARN AWS IAM Role.
+// For the required permissions, see the method ConfigureDeployServiceIAM.
+// Example of an ECS Service name: database-service-vpc-123
+//
+// Each of those AWS ECS Resources will have the following set of tags:
+//
+// - teleport.dev/cluster: <clusterName>
+//
+// - teleport.dev/origin: aws-oidc-integration
+//
+// - teleport.dev/integration: <integrationName>
+//
+// If resources already exist, only resources with those tags will be updated.
+func DeployDatabaseService(ctx context.Context, clt DeployServiceClient, req DeployDatabaseServiceRequest) (*DeployDatabaseServiceResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	callerIdentity, err := clt.GetCallerIdentity(ctx, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.accountID = aws.ToString(callerIdentity.Account)
+
+	upsertTokenReq := upsertIAMJoinTokenRequest{
+		accountID:      req.accountID,
+		region:         req.Region,
+		iamRole:        req.TaskRoleARN,
+		deploymentMode: DatabaseServiceDeploymentMode,
+		tokenName:      req.teleportIAMTokenNameForTask,
+	}
+	if err := upsertIAMJoinToken(ctx, upsertTokenReq, clt); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"region":        req.Region,
+		"account-id":    req.accountID,
+		"integration":   req.IntegrationName,
+		"deployservice": DatabaseServiceDeploymentMode,
+		"ecs-cluster":   req.ecsClusterName,
+	})
+
+	log.Debug("Upsert ECS Cluster")
+	cluster, err := upsertCluster(ctx, clt, req.ecsClusterName, req.ResourceCreationTags)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, deployment := range req.Deployments {
+		teleportConfigString, err := generateTeleportConfigString(generateTeleportConfigParams{
+			ProxyServerHostPort:  req.ProxyServerHostPort,
+			TeleportIAMTokenName: req.teleportIAMTokenNameForTask,
+			DeploymentMode:       DatabaseServiceDeploymentMode,
+			DatabaseResourceMatcherLabels: types.Labels{
+				types.DiscoveryLabelRegion:    []string{req.Region},
+				types.DiscoveryLabelAccountID: []string{req.accountID},
+				types.DiscoveryLabelVPCID:     []string{deployment.VPCID},
+			},
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		taskName := ecsTaskName(req.TeleportClusterName, DatabaseServiceDeploymentMode, deployment.VPCID)
+		serviceName := ecsServiceName(DatabaseServiceDeploymentMode, deployment.VPCID)
+
+		log = log.WithFields(logrus.Fields{
+			"vpc-id":           deployment.VPCID,
+			"ecs-task-name":    taskName,
+			"ecs-service-name": serviceName,
+		})
+
+		upsertTaskReq := upsertTaskRequest{
+			TaskName:             taskName,
+			TaskRoleARN:          req.TaskRoleARN,
+			ClusterName:          req.ecsClusterName,
+			ServiceName:          serviceName,
+			TeleportVersionTag:   req.TeleportVersionTag,
+			ResourceCreationTags: req.ResourceCreationTags,
+			Region:               req.Region,
+			TeleportConfigB64:    teleportConfigString,
+		}
+		log.Debug("Upsert ECS TaskDefinition.")
+		taskDefinition, err := upsertTask(ctx, clt, upsertTaskReq)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		taskDefinitionARN := aws.ToString(taskDefinition.TaskDefinitionArn)
+
+		upsertServiceReq := upsertServiceRequest{
+			ServiceName:          serviceName,
+			ClusterName:          req.ecsClusterName,
+			ResourceCreationTags: req.ResourceCreationTags,
+			SubnetIDs:            deployment.SubnetIDs,
+			SecurityGroups:       deployment.SecurityGroupIDs,
+		}
+		log.Debug("Upsert ECS Service.")
+		if _, err := upsertService(ctx, clt, upsertServiceReq, taskDefinitionARN); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	clusterDashboardURL := fmt.Sprintf("https://%s.console.aws.amazon.com/ecs/v2/clusters/%s/services", req.Region, aws.ToString(cluster.ClusterName))
+
+	return &DeployDatabaseServiceResponse{
+		ClusterARN:          aws.ToString(cluster.ClusterArn),
+		ClusterDashboardURL: clusterDashboardURL,
+	}, nil
+}
+
+// ecsTaskName returns the normalized ECS TaskDefinition Family
+func ecsTaskName(teleportClusterName, deploymentMode, vpcid string) string {
+	return normalizeECSResourceName(fmt.Sprintf("%s-teleport-%s-%s", teleportClusterName, deploymentMode, vpcid))
+}
+
+// ecsServiceName returns the normalized ECS Service Family
+func ecsServiceName(deploymentMode, vpcid string) string {
+	return normalizeECSResourceName(fmt.Sprintf("%s-%s", deploymentMode, vpcid))
+}

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -1,0 +1,467 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	baseReqFn := func() DeployDatabaseServiceRequest {
+		return DeployDatabaseServiceRequest{
+			TeleportClusterName: "mycluster",
+			Region:              "r",
+			TaskRoleARN:         "arn",
+			ProxyServerHostPort: "proxy.example.com:3080",
+			IntegrationName:     "teleportdev",
+			Deployments: []DeployDatabaseServiceRequestDeployment{{
+				VPCID:            "vpc-123",
+				SubnetIDs:        []string{"subnet-1", "subnet-2"},
+				SecurityGroupIDs: []string{"sg-1", "sg-2"},
+			}},
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() DeployDatabaseServiceRequest
+		errCheck require.ErrorAssertionFunc
+		expected *DeployDatabaseServiceRequest
+	}{
+		{
+			name: "no fields",
+			req: func() DeployDatabaseServiceRequest {
+				return DeployDatabaseServiceRequest{}
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing teleport cluster name",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.TeleportClusterName = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing region",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.Region = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing task role",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.TaskRoleARN = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing integration name",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.IntegrationName = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "empty list of subnets",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.Deployments[0].SubnetIDs = []string{}
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "empty vpc id",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.Deployments[0].VPCID = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "empty deployment list",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.Deployments = []DeployDatabaseServiceRequestDeployment{}
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "fill defaults",
+			req:      baseReqFn,
+			errCheck: require.NoError,
+			expected: &DeployDatabaseServiceRequest{
+				TeleportClusterName: "mycluster",
+				TeleportVersionTag:  teleport.Version,
+				Region:              "r",
+				TaskRoleARN:         "arn",
+				IntegrationName:     "teleportdev",
+				ProxyServerHostPort: "proxy.example.com:3080",
+				ResourceCreationTags: AWSTags{
+					"teleport.dev/origin":      "integration_awsoidc",
+					"teleport.dev/cluster":     "mycluster",
+					"teleport.dev/integration": "teleportdev",
+				},
+				Deployments: []DeployDatabaseServiceRequestDeployment{{
+					VPCID:            "vpc-123",
+					SubnetIDs:        []string{"subnet-1", "subnet-2"},
+					SecurityGroupIDs: []string{"sg-1", "sg-2"},
+				}},
+				ecsClusterName:              "mycluster-teleport",
+				teleportIAMTokenNameForTask: "discover-aws-oidc-iam-token",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.req()
+			err := r.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+
+			if err != nil {
+				return
+			}
+			if tt.expected != nil {
+				require.Equal(t, *tt.expected, r)
+			}
+		})
+	}
+}
+
+type mockDeployServiceClient struct {
+	clusters        map[string]*ecsTypes.Cluster
+	taskDefinitions map[string]*ecsTypes.TaskDefinition
+	services        map[string]*ecsTypes.Service
+
+	accountId       *string
+	iamTokenMissing bool
+}
+
+// DescribeClusters lists ECS Clusters.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeClusters
+func (m *mockDeployServiceClient) DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
+	ret := []ecsTypes.Cluster{}
+
+	if cluster, found := m.clusters[params.Clusters[0]]; found {
+		ret = append(ret, *cluster)
+	}
+
+	return &ecs.DescribeClustersOutput{
+		Clusters: ret,
+	}, nil
+}
+
+// CreateCluster creates a new cluster.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.CreateCluster
+func (m *mockDeployServiceClient) CreateCluster(ctx context.Context, params *ecs.CreateClusterInput, optFns ...func(*ecs.Options)) (*ecs.CreateClusterOutput, error) {
+	cluster := &ecs.CreateClusterOutput{
+		Cluster: &ecsTypes.Cluster{
+			Status:      aws.String("ACTIVE"),
+			ClusterName: params.ClusterName,
+			ClusterArn:  aws.String("ARN" + aws.ToString(params.ClusterName)),
+		},
+	}
+	m.clusters[aws.ToString(params.ClusterName)] = cluster.Cluster
+	return cluster, nil
+}
+
+// PutClusterCapacityProviders sets the Capacity Providers available for services in a given cluster.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.PutClusterCapacityProviders
+func (m *mockDeployServiceClient) PutClusterCapacityProviders(ctx context.Context, params *ecs.PutClusterCapacityProvidersInput, optFns ...func(*ecs.Options)) (*ecs.PutClusterCapacityProvidersOutput, error) {
+	return &ecs.PutClusterCapacityProvidersOutput{
+		Cluster: &ecsTypes.Cluster{
+			Status:      aws.String("ACTIVE"),
+			ClusterName: params.Cluster,
+			ClusterArn:  aws.String("ARN" + aws.ToString(params.Cluster)),
+		},
+	}, nil
+}
+
+// DescribeServices lists the matching Services of a given Cluster.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeServices
+func (m *mockDeployServiceClient) DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+	ret := []ecsTypes.Service{}
+
+	if service, found := m.services[params.Services[0]]; found {
+		ret = append(ret, *service)
+	}
+
+	return &ecs.DescribeServicesOutput{
+		Services: ret,
+	}, nil
+}
+
+// ListServices returns a list of services. You can filter the results by cluster, launch type,
+// and scheduling strategy.
+func (m *mockDeployServiceClient) ListServices(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
+	return nil, nil
+}
+
+// UpdateService updates the service.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.UpdateService
+func (m *mockDeployServiceClient) UpdateService(ctx context.Context, params *ecs.UpdateServiceInput, optFns ...func(*ecs.Options)) (*ecs.UpdateServiceOutput, error) {
+	ret := &ecsTypes.Service{
+		ServiceName:          params.Service,
+		ServiceArn:           aws.String("ARN" + aws.ToString(params.Service)),
+		NetworkConfiguration: params.NetworkConfiguration,
+	}
+	m.services[aws.ToString(params.Service)] = ret
+
+	return &ecs.UpdateServiceOutput{
+		Service: ret,
+	}, nil
+}
+
+// CreateService starts a task within a cluster.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.CreateService
+func (m *mockDeployServiceClient) CreateService(ctx context.Context, params *ecs.CreateServiceInput, optFns ...func(*ecs.Options)) (*ecs.CreateServiceOutput, error) {
+	service := &ecs.CreateServiceOutput{
+		Service: &ecsTypes.Service{
+			ServiceName:          params.ServiceName,
+			NetworkConfiguration: params.NetworkConfiguration,
+		},
+	}
+
+	m.services[aws.ToString(service.Service.ServiceName)] = service.Service
+
+	return service, nil
+}
+
+// DescribeTaskDefinition describes the task definition.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeTaskDefinition
+func (m *mockDeployServiceClient) DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+	return nil, nil
+}
+
+// RegisterTaskDefinition registers a new task definition from the supplied family and containerDefinitions.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.RegisterTaskDefinition
+func (m *mockDeployServiceClient) RegisterTaskDefinition(ctx context.Context, params *ecs.RegisterTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.RegisterTaskDefinitionOutput, error) {
+	taskDef := &ecs.RegisterTaskDefinitionOutput{
+		TaskDefinition: &ecsTypes.TaskDefinition{
+			TaskDefinitionArn:    aws.String("arn-for-task-definition==" + aws.ToString(params.Family)),
+			ContainerDefinitions: params.ContainerDefinitions,
+		},
+	}
+	m.taskDefinitions[aws.ToString(params.Family)] = taskDef.TaskDefinition
+
+	return taskDef, nil
+}
+
+// DeregisterTaskDefinition deregisters the task definition.
+// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DeregisterTaskDefinition
+func (m *mockDeployServiceClient) DeregisterTaskDefinition(ctx context.Context, params *ecs.DeregisterTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DeregisterTaskDefinitionOutput, error) {
+	return nil, nil
+}
+
+// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
+func (m *mockDeployServiceClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: m.accountId,
+	}, nil
+}
+
+// GetToken returns a provision token by name.
+func (m *mockDeployServiceClient) GetToken(ctx context.Context, name string) (types.ProvisionToken, error) {
+	return nil, trace.NotFound("token not found")
+}
+
+// UpsertToken creates or updates a provision token.
+func (m *mockDeployServiceClient) UpsertToken(ctx context.Context, token types.ProvisionToken) error {
+	return nil
+}
+
+func TestDeployDatabaseService(t *testing.T) {
+	ctx := context.Background()
+	t.Run("fails to get account id", func(t *testing.T) {
+		_, err := DeployDatabaseService(ctx, &mockDeployServiceClient{}, DeployDatabaseServiceRequest{
+			Region:              "us-east-1",
+			TaskRoleARN:         "my-role",
+			TeleportClusterName: "cluster-name",
+			ProxyServerHostPort: "proxy.example.com:3080",
+			IntegrationName:     "my-integration",
+			Deployments: []DeployDatabaseServiceRequestDeployment{
+				{
+					VPCID:     "vpc-123",
+					SubnetIDs: []string{"subnet-1", "subnet-2"},
+				},
+			},
+		})
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %+v", err)
+	})
+	t.Run("nothing exists", func(t *testing.T) {
+		mockClient := &mockDeployServiceClient{
+			clusters:        map[string]*ecsTypes.Cluster{},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{},
+			services:        map[string]*ecsTypes.Service{},
+			accountId:       aws.String("123456789012"),
+			iamTokenMissing: true,
+		}
+		resp, err := DeployDatabaseService(ctx,
+			mockClient,
+			DeployDatabaseServiceRequest{
+				Region:              "us-east-1",
+				TaskRoleARN:         "my-role",
+				TeleportClusterName: "cluster-name",
+				ProxyServerHostPort: "proxy.example.com:3080",
+				IntegrationName:     "my-integration",
+				Deployments: []DeployDatabaseServiceRequestDeployment{
+					{
+						VPCID:     "vpc-123",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/cluster-name-teleport/services", resp.ClusterDashboardURL)
+		require.Equal(t, "ARNcluster-name-teleport", resp.ClusterARN)
+		require.Contains(t, mockClient.clusters, "cluster-name-teleport")
+		require.Contains(t, mockClient.services, "database-service-vpc-123")
+		require.Contains(t, mockClient.taskDefinitions, "cluster-name-teleport-database-service-vpc-123")
+	})
+
+	t.Run("nothing exists, multiple deployments", func(t *testing.T) {
+		mockClient := &mockDeployServiceClient{
+			clusters:        map[string]*ecsTypes.Cluster{},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{},
+			services:        map[string]*ecsTypes.Service{},
+			accountId:       aws.String("123456789012"),
+			iamTokenMissing: true,
+		}
+		resp, err := DeployDatabaseService(ctx,
+			mockClient,
+			DeployDatabaseServiceRequest{
+				Region:              "us-east-1",
+				TaskRoleARN:         "my-role",
+				TeleportClusterName: "cluster-name",
+				ProxyServerHostPort: "proxy.example.com:3080",
+				IntegrationName:     "my-integration",
+				Deployments: []DeployDatabaseServiceRequestDeployment{
+					{
+						VPCID:     "vpc-001",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+					{
+						VPCID:     "vpc-002",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+					{
+						VPCID:     "vpc-003",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+					{
+						VPCID:     "vpc-004",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/cluster-name-teleport/services", resp.ClusterDashboardURL)
+		require.Equal(t, "ARNcluster-name-teleport", resp.ClusterARN)
+		require.Contains(t, mockClient.clusters, "cluster-name-teleport")
+
+		require.Contains(t, mockClient.services, "database-service-vpc-001")
+		require.Contains(t, mockClient.taskDefinitions, "cluster-name-teleport-database-service-vpc-001")
+		require.Contains(t, mockClient.services, "database-service-vpc-002")
+		require.Contains(t, mockClient.taskDefinitions, "cluster-name-teleport-database-service-vpc-002")
+		require.Contains(t, mockClient.services, "database-service-vpc-003")
+		require.Contains(t, mockClient.taskDefinitions, "cluster-name-teleport-database-service-vpc-003")
+		require.Contains(t, mockClient.services, "database-service-vpc-004")
+		require.Contains(t, mockClient.taskDefinitions, "cluster-name-teleport-database-service-vpc-004")
+
+		serviceNetworkConfig := mockClient.services["database-service-vpc-001"].NetworkConfiguration.AwsvpcConfiguration
+		require.ElementsMatch(t, serviceNetworkConfig.Subnets, []string{"subnet-1", "subnet-2"})
+	})
+
+	t.Run("ecs cluster and service already exist", func(t *testing.T) {
+		resp, err := DeployDatabaseService(ctx,
+			&mockDeployServiceClient{
+				clusters: map[string]*ecsTypes.Cluster{
+					"cluster-name-teleport": {
+						ClusterArn: aws.String("abc"),
+						Status:     aws.String("ACTIVE"),
+						Tags: []ecsTypes.Tag{
+							{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+							{Key: aws.String("teleport.dev/cluster"), Value: aws.String("cluster-name")},
+							{Key: aws.String("teleport.dev/integration"), Value: aws.String("my-integration")},
+						},
+					},
+				},
+				taskDefinitions: map[string]*ecsTypes.TaskDefinition{},
+				services: map[string]*ecsTypes.Service{
+					"database-service-vpc-123": {
+						Status:     aws.String("ACTIVE"),
+						LaunchType: ecsTypes.LaunchTypeFargate,
+						Tags: []ecsTypes.Tag{
+							{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+							{Key: aws.String("teleport.dev/cluster"), Value: aws.String("cluster-name")},
+							{Key: aws.String("teleport.dev/integration"), Value: aws.String("my-integration")},
+						},
+					},
+				},
+				accountId:       aws.String("123456789012"),
+				iamTokenMissing: true,
+			},
+			DeployDatabaseServiceRequest{
+				Region:              "us-east-1",
+				TaskRoleARN:         "my-role",
+				TeleportClusterName: "cluster-name",
+				ProxyServerHostPort: "proxy.example.com:3080",
+				IntegrationName:     "my-integration",
+				Deployments: []DeployDatabaseServiceRequestDeployment{
+					{
+						VPCID:     "vpc-123",
+						SubnetIDs: []string{"subnet-1", "subnet-2"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/cluster-name-teleport/services", resp.ClusterDashboardURL)
+		require.Equal(t, "ARNcluster-name-teleport", resp.ClusterARN)
+	})
+}

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -43,23 +43,14 @@ var (
 	// requiredCapacityProviders contains the FARGATE type which is required to deploy a Teleport Service.
 	requiredCapacityProviders = []string{launchTypeFargateString}
 
-	// Ensure Cpu and Memory use one of the allowed combinations:
-	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
-	taskCPU = "2048"
-	taskMem = "4096"
-
-	// taskAgentContainerName is the name of the container to run within the Task.
-	// Each task supports multiple containers, but, currently, there's only one being used.
-	taskAgentContainerName = "teleport-service"
-
 	// oneAgent is used to define the desired agent count when creating a service.
 	oneAgent = int32(1)
-
-	// defaultTeleportIAMTokenName is the default Teleport IAM Token to use when it's not specified.
-	defaultTeleportIAMTokenName = "discover-aws-oidc-iam-token"
 )
 
 const (
+	// defaultTeleportIAMTokenName is the default Teleport IAM Token to use when it's not specified.
+	defaultTeleportIAMTokenName = "discover-aws-oidc-iam-token"
+
 	// distrolessTeleportOSS is the distroless image of the OSS version of Teleport
 	distrolessTeleportOSS = "public.ecr.aws/gravitational/teleport-distroless"
 	// distrolessTeleportEnt is the distroless image of the Enterprise version of Teleport
@@ -80,13 +71,22 @@ const (
 	serviceStatusActive = "ACTIVE"
 	// serviceStatusDraining is the string representing an DRAINING ECS Service.
 	serviceStatusDraining = "DRAINING"
-)
 
-var (
+	// Ensure Cpu and Memory use one of the allowed combinations:
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
+	taskCPU = "2048"
+	taskMem = "4096"
+
+	// taskAgentContainerName is the name of the container to run within the Task.
+	// Each task supports multiple containers, but, currently, there's only one being used.
+	taskAgentContainerName = "teleport-service"
+
 	// DatabaseServiceDeploymentMode is a deployment configuration for Deploying a Database Service.
 	// This mode starts a Database with the specificied Resource Matchers.
 	DatabaseServiceDeploymentMode = "database-service"
+)
 
+var (
 	// DeploymentModes has all the available deployment modes.
 	DeploymentModes = []string{
 		DatabaseServiceDeploymentMode,
@@ -132,7 +132,7 @@ type DeployServiceRequest struct {
 	// TeleportIAMTokenNameis the Teleport IAM Token to use in the deployed Service.
 	// Optional.
 	// Defaults to discover-aws-oidc-iam-token
-	TeleportIAMTokenName *string
+	TeleportIAMTokenName string
 
 	// ProxyServerHostPort is the Teleport Proxy's Public.
 	ProxyServerHostPort string
@@ -207,8 +207,8 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 		r.TeleportVersionTag = teleport.Version
 	}
 
-	if r.TeleportIAMTokenName == nil || *r.TeleportIAMTokenName == "" {
-		r.TeleportIAMTokenName = &defaultTeleportIAMTokenName
+	if r.TeleportIAMTokenName == "" {
+		r.TeleportIAMTokenName = defaultTeleportIAMTokenName
 	}
 
 	if r.DeploymentMode == "" {
@@ -297,6 +297,10 @@ type DeployServiceClient interface {
 	// DescribeServices lists the matching Services of a given Cluster.
 	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeServices
 	DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+
+	// ListServices returns a list of services. You can filter the results by cluster, launch type,
+	// and scheduling strategy.
+	ListServices(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
 
 	// UpdateService updates the service.
 	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.UpdateService
@@ -413,7 +417,7 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 	}
 
 	upsertTokenReq := upsertIAMJoinTokenRequest{
-		tokenName:      *req.TeleportIAMTokenName,
+		tokenName:      req.TeleportIAMTokenName,
 		accountID:      req.AccountID,
 		region:         req.Region,
 		iamRole:        req.TaskRoleARN,
@@ -423,48 +427,81 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 		return nil, trace.Wrap(err)
 	}
 
-	teleportConfigString, err := generateTeleportConfigString(req)
+	teleportConfigString, err := generateTeleportConfigString(generateTeleportConfigParams{
+		ProxyServerHostPort:           req.ProxyServerHostPort,
+		TeleportIAMTokenName:          req.TeleportIAMTokenName,
+		DeploymentMode:                req.DeploymentMode,
+		DatabaseResourceMatcherLabels: req.DatabaseResourceMatcherLabels,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	taskDefinition, err := upsertTask(ctx, clt, req, teleportConfigString)
+	upsertTaskReq := upsertTaskRequest{
+		TaskName:             aws.ToString(req.TaskName),
+		TaskRoleARN:          req.TaskRoleARN,
+		ClusterName:          aws.ToString(req.ClusterName),
+		ServiceName:          aws.ToString(req.ServiceName),
+		TeleportVersionTag:   req.TeleportVersionTag,
+		ResourceCreationTags: req.ResourceCreationTags,
+		Region:               req.Region,
+		TeleportConfigB64:    teleportConfigString,
+	}
+	taskDefinition, err := upsertTask(ctx, clt, upsertTaskReq)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	taskDefinitionARN := *taskDefinition.TaskDefinitionArn
+	taskDefinitionARN := aws.ToString(taskDefinition.TaskDefinitionArn)
 
-	cluster, err := upsertCluster(ctx, clt, req)
+	cluster, err := upsertCluster(ctx, clt, aws.ToString(req.ClusterName), req.ResourceCreationTags)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	service, err := upsertService(ctx, clt, req, taskDefinitionARN)
+	upsertServiceReq := upsertServiceRequest{
+		ServiceName:          aws.ToString(req.ServiceName),
+		ClusterName:          aws.ToString(req.ClusterName),
+		ResourceCreationTags: req.ResourceCreationTags,
+		SubnetIDs:            req.SubnetIDs,
+		SecurityGroups:       req.SecurityGroups,
+	}
+	service, err := upsertService(ctx, clt, upsertServiceReq, taskDefinitionARN)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	serviceDashboardURL := fmt.Sprintf("https://%s.console.aws.amazon.com/ecs/v2/clusters/%s/services/%s", req.Region, *req.ClusterName, *req.ServiceName)
+	serviceDashboardURL := fmt.Sprintf("https://%s.console.aws.amazon.com/ecs/v2/clusters/%s/services/%s", req.Region, aws.ToString(req.ClusterName), aws.ToString(req.ServiceName))
 
 	return &DeployServiceResponse{
-		ClusterARN:          *cluster.ClusterArn,
-		ServiceARN:          *service.ServiceArn,
+		ClusterARN:          aws.ToString(cluster.ClusterArn),
+		ServiceARN:          aws.ToString(service.ServiceArn),
 		TaskDefinitionARN:   taskDefinitionARN,
 		ServiceDashboardURL: serviceDashboardURL,
 	}, nil
 }
 
+type upsertTaskRequest struct {
+	TaskName             string
+	TaskRoleARN          string
+	ClusterName          string
+	ServiceName          string
+	TeleportVersionTag   string
+	ResourceCreationTags AWSTags
+	Region               string
+	TeleportConfigB64    string
+}
+
 // upsertTask ensures a TaskDefinition with TaskName exists
-func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest, configB64 string) (*ecsTypes.TaskDefinition, error) {
+func upsertTask(ctx context.Context, clt DeployServiceClient, req upsertTaskRequest) (*ecsTypes.TaskDefinition, error) {
 	taskAgentContainerImage := getDistrolessTeleportImage(req.TeleportVersionTag)
 
 	taskDefOut, err := clt.RegisterTaskDefinition(ctx, &ecs.RegisterTaskDefinitionInput{
-		Family: req.TaskName,
+		Family: aws.String(req.TaskName),
 		RequiresCompatibilities: []ecsTypes.Compatibility{
 			ecsTypes.CompatibilityFargate,
 		},
-		Cpu:    &taskCPU,
-		Memory: &taskMem,
+		Cpu:    aws.String(taskCPU),
+		Memory: aws.String(taskMem),
 
 		NetworkMode:      ecsTypes.NetworkModeAwsvpc,
 		TaskRoleArn:      &req.TaskRoleARN,
@@ -482,18 +519,18 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceR
 				"teleport",
 				"start",
 				"--config-string",
-				configB64,
+				req.TeleportConfigB64,
 			},
 			EntryPoint: []string{"/usr/bin/dumb-init"},
-			Image:      &taskAgentContainerImage,
-			Name:       &taskAgentContainerName,
+			Image:      aws.String(taskAgentContainerImage),
+			Name:       aws.String(taskAgentContainerName),
 			LogConfiguration: &ecsTypes.LogConfiguration{
 				LogDriver: ecsTypes.LogDriverAwslogs,
 				Options: map[string]string{
-					"awslogs-group":         "ecs-" + *req.ClusterName,
+					"awslogs-group":         "ecs-" + req.ClusterName,
 					"awslogs-region":        req.Region,
 					"awslogs-create-group":  "true",
-					"awslogs-stream-prefix": *req.ServiceName + "/" + *req.TaskName,
+					"awslogs-stream-prefix": req.ServiceName + "/" + req.TaskName,
 				},
 			},
 		}},
@@ -510,9 +547,9 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceR
 // It will re-create if its status is INACTIVE.
 // If the cluster status is not ACTIVE, an error is returned.
 // The cluster is returned.
-func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest) (*ecsTypes.Cluster, error) {
+func upsertCluster(ctx context.Context, clt DeployServiceClient, clusterName string, resourceCreationTags AWSTags) (*ecsTypes.Cluster, error) {
 	describeClustersResponse, err := clt.DescribeClusters(ctx, &ecs.DescribeClustersInput{
-		Clusters: []string{*req.ClusterName},
+		Clusters: []string{clusterName},
 		Include: []ecsTypes.ClusterField{
 			ecsTypes.ClusterFieldTags,
 		},
@@ -523,15 +560,15 @@ func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServi
 
 	if clusterMustBeCreated(describeClustersResponse.Clusters) {
 		createClusterResp, err := clt.CreateCluster(ctx, &ecs.CreateClusterInput{
-			ClusterName:       req.ClusterName,
+			ClusterName:       aws.String(clusterName),
 			CapacityProviders: requiredCapacityProviders,
-			Tags:              req.ResourceCreationTags.ToECSTags(),
+			Tags:              resourceCreationTags.ToECSTags(),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		if err := waitForActiveCluster(ctx, clt, req, createClusterResp.Cluster); err != nil {
+		if err := waitForActiveCluster(ctx, clt, clusterName, createClusterResp.Cluster); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -541,10 +578,10 @@ func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServi
 	// There's a cluster and it is not INACTIVE.
 	cluster := &describeClustersResponse.Clusters[0]
 
-	ownershipTags := req.ResourceCreationTags
+	ownershipTags := resourceCreationTags
 	if !ownershipTags.MatchesECSTags(cluster.Tags) {
 		return nil, trace.Errorf("ECS Cluster %q already exists but is not managed by Teleport. "+
-			"Add the following tags to allow Teleport to manage this cluster: %s", *req.ClusterName, req.ResourceCreationTags)
+			"Add the following tags to allow Teleport to manage this cluster: %s", clusterName, resourceCreationTags)
 	}
 
 	if slices.Contains(cluster.CapacityProviders, launchTypeFargateString) {
@@ -553,7 +590,7 @@ func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServi
 
 	// Ensure the required capacity provider (Fargate) is available.
 	putClusterCPResp, err := clt.PutClusterCapacityProviders(ctx, &ecs.PutClusterCapacityProvidersInput{
-		Cluster:           req.ClusterName,
+		Cluster:           aws.String(clusterName),
 		CapacityProviders: requiredCapacityProviders,
 		DefaultCapacityProviderStrategy: []ecsTypes.CapacityProviderStrategyItem{{
 			CapacityProvider: &launchTypeFargateString,
@@ -563,7 +600,7 @@ func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := waitForActiveCluster(ctx, clt, req, cluster); err != nil {
+	if err := waitForActiveCluster(ctx, clt, clusterName, cluster); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -578,13 +615,13 @@ func clusterMustBeCreated(clusters []ecsTypes.Cluster) bool {
 
 	cluster := clusters[0]
 
-	return *cluster.Status == clusterStatusInactive
+	return aws.ToString(cluster.Status) == clusterStatusInactive
 }
 
 // waitForActiveCluster waits until the Cluster is Active.
 // If the Cluster is Provisioning, then it waits at most clusterStatusProvisioningWaitTime (30 seconds) for it to become ready.
-func waitForActiveCluster(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest, cluster *ecsTypes.Cluster) error {
-	if cluster.Status != nil && *cluster.Status == clusterStatusActive {
+func waitForActiveCluster(ctx context.Context, clt DeployServiceClient, clusterName string, cluster *ecsTypes.Cluster) error {
+	if cluster.Status != nil && aws.ToString(cluster.Status) == clusterStatusActive {
 		return nil
 	}
 
@@ -597,51 +634,59 @@ func waitForActiveCluster(ctx context.Context, clt DeployServiceClient, req Depl
 
 	err = retry.For(retryCtx, func() error {
 		describeClustersResponse, err := clt.DescribeClusters(ctx, &ecs.DescribeClustersInput{
-			Clusters: []string{*req.ClusterName},
+			Clusters: []string{clusterName},
 		})
 		if err != nil {
 			return retryutils.PermanentRetryError(trace.Wrap(err))
 		}
 
 		if len(describeClustersResponse.Clusters) == 0 {
-			return retryutils.PermanentRetryError(trace.NotFound("cluster %q does not exist", *cluster.ClusterName))
+			return retryutils.PermanentRetryError(trace.NotFound("cluster %q does not exist", aws.ToString(cluster.ClusterName)))
 		}
 
 		cluster := describeClustersResponse.Clusters[0]
 		if cluster.Status == nil {
-			return retryutils.PermanentRetryError(trace.Errorf("cluster %q has an unknown (nil) status", *cluster.ClusterName))
+			return retryutils.PermanentRetryError(trace.Errorf("cluster %q has an unknown (nil) status", aws.ToString(cluster.ClusterName)))
 		}
 
-		if *cluster.Status == clusterStatusActive {
+		if aws.ToString(cluster.Status) == clusterStatusActive {
 			return nil
 		}
 
-		if *cluster.Status == clusterStatusProvisioning {
-			return trace.Errorf("cluster %q is provisioning...", *cluster.ClusterName)
+		if aws.ToString(cluster.Status) == clusterStatusProvisioning {
+			return trace.Errorf("cluster %q is provisioning...", aws.ToString(cluster.ClusterName))
 		}
 
-		return retryutils.PermanentRetryError(trace.Errorf("unexpected status %s for ECS Cluster %q", *cluster.ClusterName, *cluster.Status))
+		return retryutils.PermanentRetryError(trace.Errorf("unexpected status %s for ECS Cluster %q", aws.ToString(cluster.ClusterName), aws.ToString(cluster.Status)))
 	})
 
 	return trace.Wrap(err)
 }
 
-func deployServiceNetworkConfiguration(req DeployServiceRequest) *ecsTypes.NetworkConfiguration {
+func deployServiceNetworkConfiguration(subnetIDs, securityGroups []string) *ecsTypes.NetworkConfiguration {
 	return &ecsTypes.NetworkConfiguration{
 		AwsvpcConfiguration: &ecsTypes.AwsVpcConfiguration{
 			AssignPublicIp: ecsTypes.AssignPublicIpEnabled, // no internet connection otherwise
-			Subnets:        req.SubnetIDs,
-			SecurityGroups: req.SecurityGroups,
+			Subnets:        subnetIDs,
+			SecurityGroups: securityGroups,
 		},
 	}
 }
 
+type upsertServiceRequest struct {
+	ServiceName          string
+	ClusterName          string
+	ResourceCreationTags AWSTags
+	SubnetIDs            []string
+	SecurityGroups       []string
+}
+
 // upsertService creates or updates the service.
 // If the service exists but its LaunchType is not Fargate, then it gets re-created.
-func upsertService(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest, taskARN string) (*ecsTypes.Service, error) {
+func upsertService(ctx context.Context, clt DeployServiceClient, req upsertServiceRequest, taskARN string) (*ecsTypes.Service, error) {
 	describeServiceOut, err := clt.DescribeServices(ctx, &ecs.DescribeServicesInput{
-		Services: []string{*req.ServiceName},
-		Cluster:  req.ClusterName,
+		Services: []string{req.ServiceName},
+		Cluster:  aws.String(req.ClusterName),
 		Include: []ecsTypes.ServiceField{
 			ecsTypes.ServiceFieldTags,
 		},
@@ -655,32 +700,32 @@ func upsertService(ctx context.Context, clt DeployServiceClient, req DeployServi
 		service := &describeServiceOut.Services[0]
 
 		if service.Status == nil {
-			return nil, trace.Errorf("unknown status for ECS Service %q", *req.ServiceName)
+			return nil, trace.Errorf("unknown status for ECS Service %q", req.ServiceName)
 		}
 
-		if *service.Status == serviceStatusDraining {
+		if aws.ToString(service.Status) == serviceStatusDraining {
 			return nil, trace.Errorf("ECS Service is draining, please retry in a couple of minutes")
 		}
 
-		if *service.Status == serviceStatusActive {
+		if aws.ToString(service.Status) == serviceStatusActive {
 			ownershipTags := req.ResourceCreationTags
 			if !ownershipTags.MatchesECSTags(service.Tags) {
 				return nil, trace.Errorf("ECS Service %q already exists but is not managed by Teleport. "+
-					"Add the following tags to allow Teleport to manage this service: %s", *req.ServiceName, req.ResourceCreationTags)
+					"Add the following tags to allow Teleport to manage this service: %s", req.ServiceName, req.ResourceCreationTags)
 			}
 
 			// If the LaunchType is the required one, than we can update the current Service.
 			// Otherwise we have to delete it.
 			if service.LaunchType != ecsTypes.LaunchTypeFargate {
-				return nil, trace.Errorf("ECS Service %q already exists but has an invalid LaunchType %q. Delete the Service and try again.", *req.ServiceName, service.LaunchType)
+				return nil, trace.Errorf("ECS Service %q already exists but has an invalid LaunchType %q. Delete the Service and try again.", req.ServiceName, service.LaunchType)
 			}
 
 			updateServiceResp, err := clt.UpdateService(ctx, &ecs.UpdateServiceInput{
-				Service:              req.ServiceName,
+				Service:              aws.String(req.ServiceName),
 				DesiredCount:         &oneAgent,
 				TaskDefinition:       &taskARN,
-				Cluster:              req.ClusterName,
-				NetworkConfiguration: deployServiceNetworkConfiguration(req),
+				Cluster:              aws.String(req.ClusterName),
+				NetworkConfiguration: deployServiceNetworkConfiguration(req.SubnetIDs, req.SecurityGroups),
 				ForceNewDeployment:   true,
 				PropagateTags:        ecsTypes.PropagateTagsService,
 			})
@@ -693,12 +738,12 @@ func upsertService(ctx context.Context, clt DeployServiceClient, req DeployServi
 	}
 
 	createServiceOut, err := clt.CreateService(ctx, &ecs.CreateServiceInput{
-		ServiceName:          req.ServiceName,
+		ServiceName:          aws.String(req.ServiceName),
 		DesiredCount:         &oneAgent,
 		LaunchType:           ecsTypes.LaunchTypeFargate,
 		TaskDefinition:       &taskARN,
-		Cluster:              req.ClusterName,
-		NetworkConfiguration: deployServiceNetworkConfiguration(req),
+		Cluster:              aws.String(req.ClusterName),
+		NetworkConfiguration: deployServiceNetworkConfiguration(req.SubnetIDs, req.SecurityGroups),
 		Tags:                 req.ResourceCreationTags.ToECSTags(),
 		PropagateTags:        ecsTypes.PropagateTagsService,
 	})

--- a/lib/integrations/awsoidc/deployservice_config.go
+++ b/lib/integrations/awsoidc/deployservice_config.go
@@ -30,12 +30,19 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 )
 
+type generateTeleportConfigParams struct {
+	ProxyServerHostPort           string
+	TeleportIAMTokenName          string
+	DeploymentMode                string
+	DatabaseResourceMatcherLabels types.Labels
+}
+
 // generateTeleportConfigString creates a teleport.yaml configuration that the agent
 // deployed in a ECS Cluster (using Fargate) will use.
 //
 // Returns config as base64-encoded string suitable for passing to teleport process
 // via --config-string flag.
-func generateTeleportConfigString(req DeployServiceRequest) (string, error) {
+func generateTeleportConfigString(req generateTeleportConfigParams) (string, error) {
 	teleportConfig, err := config.MakeSampleFileConfig(config.SampleFlags{
 		Version:      defaults.TeleportConfigVersionV3,
 		ProxyAddress: req.ProxyServerHostPort,
@@ -64,7 +71,7 @@ func generateTeleportConfigString(req DeployServiceRequest) (string, error) {
 		}
 	*/
 	teleportConfig.JoinParams = config.JoinParams{
-		TokenName: *req.TeleportIAMTokenName,
+		TokenName: req.TeleportIAMTokenName,
 		Method:    types.JoinMethodIAM,
 	}
 

--- a/lib/integrations/awsoidc/deployservice_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_config_test.go
@@ -27,9 +27,9 @@ import (
 
 func TestDeployServiceConfig(t *testing.T) {
 	t.Run("ensure log level is set to debug", func(t *testing.T) {
-		base64Config, err := generateTeleportConfigString(DeployServiceRequest{
+		base64Config, err := generateTeleportConfigString(generateTeleportConfigParams{
 			ProxyServerHostPort:  "host:port",
-			TeleportIAMTokenName: stringPointer("iam-token"),
+			TeleportIAMTokenName: "iam-token",
 			DeploymentMode:       DatabaseServiceDeploymentMode,
 		})
 		require.NoError(t, err)

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -146,7 +146,7 @@ func TestDeployServiceRequest(t *testing.T) {
 				ClusterName:          stringPointer("mycluster-teleport"),
 				ServiceName:          stringPointer("mycluster-teleport-database-service"),
 				TaskName:             stringPointer("mycluster-teleport-database-service"),
-				TeleportIAMTokenName: stringPointer("discover-aws-oidc-iam-token"),
+				TeleportIAMTokenName: "discover-aws-oidc-iam-token",
 				IntegrationName:      "teleportdev",
 				ProxyServerHostPort:  "proxy.example.com:3080",
 				ResourceCreationTags: AWSTags{

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -65,8 +65,8 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 		RequiresCompatibilities: []ecsTypes.Compatibility{
 			ecsTypes.CompatibilityFargate,
 		},
-		Cpu:    &taskCPU,
-		Memory: &taskMem,
+		Cpu:    aws.String(taskCPU),
+		Memory: aws.String(taskMem),
 
 		NetworkMode:      ecsTypes.NetworkModeAwsvpc,
 		TaskRoleArn:      aws.String("task-role-arn"),
@@ -83,7 +83,7 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 			},
 			EntryPoint: []string{"teleport"},
 			Image:      aws.String("image-v1"),
-			Name:       &taskAgentContainerName,
+			Name:       aws.String(taskAgentContainerName),
 			LogConfiguration: &ecsTypes.LogConfiguration{
 				LogDriver: ecsTypes.LogDriverAwslogs,
 				Options: map[string]string{
@@ -104,8 +104,8 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 		RequiresCompatibilities: []ecsTypes.Compatibility{
 			ecsTypes.CompatibilityFargate,
 		},
-		Cpu:    &taskCPU,
-		Memory: &taskMem,
+		Cpu:    aws.String(taskCPU),
+		Memory: aws.String(taskMem),
 
 		NetworkMode:      ecsTypes.NetworkModeAwsvpc,
 		TaskRoleArn:      aws.String("task-role-arn"),
@@ -122,7 +122,7 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 			},
 			EntryPoint: []string{"teleport"},
 			Image:      aws.String("image-v2"),
-			Name:       &taskAgentContainerName,
+			Name:       aws.String(taskAgentContainerName),
 			LogConfiguration: &ecsTypes.LogConfiguration{
 				LogDriver: ecsTypes.LogDriverAwslogs,
 				Options: map[string]string{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -833,6 +833,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.GET("/webapi/scripts/integrations/configure/listdatabases-iam.sh", h.WithLimiter(h.awsOIDCConfigureListDatabasesIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deploydatabaseservice", h.WithClusterAuth(h.awsOIDCDeployDatabaseService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -833,7 +833,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.GET("/webapi/scripts/integrations/configure/listdatabases-iam.sh", h.WithLimiter(h.awsOIDCConfigureListDatabasesIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
-	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deploydatabaseservices", h.WithClusterAuth(h.awsOIDCDeployDatabaseService))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deploydatabaseservices", h.WithClusterAuth(h.awsOIDCDeployDatabaseServices))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -833,7 +833,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.GET("/webapi/scripts/integrations/configure/listdatabases-iam.sh", h.WithLimiter(h.awsOIDCConfigureListDatabasesIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
-	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deploydatabaseservice", h.WithClusterAuth(h.awsOIDCDeployDatabaseService))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deploydatabaseservices", h.WithClusterAuth(h.awsOIDCDeployDatabaseService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -196,6 +196,69 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 	}, nil
 }
 
+// awsOIDCDeployDatabaseService deploys a Database Service in Amazon ECS.
+func (h *Handler) awsOIDCDeployDatabaseService(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	var req ui.AWSOIDCDeployDatabaseServiceRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsClientReq, err := h.awsOIDCClientRequest(ctx, req.Region, p, sctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := sctx.GetUserClient(ctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	deployServiceClient, err := awsoidc.NewDeployServiceClient(ctx, awsClientReq, clt)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	teleportVersionTag := "14.2.3" //teleport.Version
+	if automaticUpgrades(h.ClusterFeatures) {
+		cloudStableVersion, err := h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		// cloudStableVersion has vX.Y.Z format, however the container image tag does not include the `v`.
+		teleportVersionTag = strings.TrimPrefix(cloudStableVersion, "v")
+	}
+
+	deployments := make([]awsoidc.DeployDatabaseServiceRequestDeployment, 0, len(req.Deployments))
+	for _, d := range req.Deployments {
+		deployments = append(deployments, awsoidc.DeployDatabaseServiceRequestDeployment{
+			VPCID:            d.VPCID,
+			SubnetIDs:        d.SubnetIDs,
+			SecurityGroupIDs: d.SecurityGroups,
+		})
+	}
+
+	deployServiceResp, err := awsoidc.DeployDatabaseService(ctx, deployServiceClient, awsoidc.DeployDatabaseServiceRequest{
+		Region:              req.Region,
+		TaskRoleARN:         req.TaskRoleARN,
+		ProxyServerHostPort: h.PublicProxyAddr(),
+		TeleportClusterName: h.auth.clusterName,
+		TeleportVersionTag:  teleportVersionTag,
+		IntegrationName:     awsClientReq.IntegrationName,
+		Deployments:         deployments,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.AWSOIDCDeployDatabaseServiceResponse{
+		ClusterARN:          deployServiceResp.ClusterARN,
+		ClusterDashboardURL: deployServiceResp.ClusterDashboardURL,
+	}, nil
+}
+
 // awsOIDCConfigureDeployServiceIAM returns a script that configures the required IAM permissions to enable the usage of DeployService action.
 func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	ctx := r.Context()

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -197,7 +197,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 }
 
 // awsOIDCDeployDatabaseService deploys a Database Service in Amazon ECS.
-func (h *Handler) awsOIDCDeployDatabaseService(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	ctx := r.Context()
 
 	var req ui.AWSOIDCDeployDatabaseServiceRequest
@@ -220,7 +220,7 @@ func (h *Handler) awsOIDCDeployDatabaseService(w http.ResponseWriter, r *http.Re
 		return nil, trace.Wrap(err)
 	}
 
-	teleportVersionTag := "14.2.3" //teleport.Version
+	teleportVersionTag := teleport.Version
 	if automaticUpgrades(h.ClusterFeatures) {
 		cloudStableVersion, err := h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
 		if err != nil {

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -191,6 +191,49 @@ type AWSOIDCDeployServiceResponse struct {
 	ServiceDashboardURL string `json:"serviceDashboardUrl"`
 }
 
+// AWSOIDCDeployDatabaseServiceRequest contains the required fields to perform a DeployService request.
+// Each deployed DatabaseService will be proxying the resources that match the following labels:
+// -region: <Region>
+// -account-id: <AccountID>
+// -vpc-id: <Deployments[].VPCID>
+type AWSOIDCDeployDatabaseServiceRequest struct {
+	// Region is the AWS Region for the Service.
+	Region string `json:"region"`
+
+	// TaskRoleARN is the AWS Role's ARN used within the Task execution.
+	// Ensure the AWS Client's Role has `iam:PassRole` for this Role's ARN.
+	// This can be either the ARN or the short name of the AWS Role.
+	TaskRoleARN string `json:"taskRoleArn"`
+
+	// Deployments is a list of Services to be deployed.
+	// If the target deployment already exists, the deployment is skipped.
+	Deployments []DeployDatabaseServiceDeployment `json:"deployments"`
+}
+
+// DeployDatabaseServiceDeployment identifies the required fields to deploy a DatabaseService.
+type DeployDatabaseServiceDeployment struct {
+	// VPCID is the VPCID where the service is going to be deployed.
+	VPCID string `json:"vpcid"`
+
+	// SubnetIDs are the subnets for the network configuration.
+	// They must belong to the VPCID above.
+	SubnetIDs []string `json:"subnetIds"`
+
+	// SecurityGroups are the SecurityGroup IDs to associate with this particular deployment.
+	// If empty, the default security group for the VPC is going to be used.
+	SecurityGroups []string `json:"securityGroups"`
+}
+
+// AWSOIDCDeployServiceDatabaseResponse contains links to the ECS Cluster Dashboard where the current status for each Service is displayed.
+type AWSOIDCDeployDatabaseServiceResponse struct {
+	// ClusterARN is the Amazon ECS Cluster ARN where the Services were started.
+	ClusterARN string `json:"clusterArn"`
+
+	// ClusterDashboardURL is the URL for the Cluster Dashbord.
+	// Users can open this link and see which Services are running.
+	ClusterDashboardURL string `json:"clusterDashboardUrl"`
+}
+
 // AWSOIDCListEC2Request is a request to ListEC2s using the AWS OIDC Integration.
 type AWSOIDCListEC2Request struct {
 	// Region is the AWS Region.

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -213,7 +213,7 @@ type AWSOIDCDeployDatabaseServiceRequest struct {
 // DeployDatabaseServiceDeployment identifies the required fields to deploy a DatabaseService.
 type DeployDatabaseServiceDeployment struct {
 	// VPCID is the VPCID where the service is going to be deployed.
-	VPCID string `json:"vpcid"`
+	VPCID string `json:"vpcId"`
 
 	// SubnetIDs are the subnets for the network configuration.
 	// They must belong to the VPCID above.


### PR DESCRIPTION
This PR adds a new method for deploying services using the AWS OIDC Integration.
It will deploy multiple, one per element in `deployments` array.

Each one will only proxy a subset of existing Databases, using the `account-id`, `region` and `vpc-id` labels to select them.

Demo

```
POST .../deploydatabaseservice
{
    "region": "us-east-1",
    "taskRoleARN": "TeleportMarcoTestRDSSingleDB",
    "deployments": [
        {"vpcId": "vpc-<redacted1>", "subnetIds":["subnet-1", "subnet-2"]},
        {"vpcId": "vpc-<redacted2>", "subnetIds":["subnet-1", "subnet-2"]}
    ]
}

<--
{
  "clusterArn": "arn:aws:ecs:us-east-1:278576220453:cluster/lenix-teleport",
  "clusterDashboardUrl": "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/lenix-teleport/services"
}
```

```log
2023-12-20T18:52:24Z DEBU             Upsert ECS Cluster account-id:278576220453 deployservice:database-service ecs-cluster:lenix-teleport integration:teleportdev region:us-east-1 awsoidc/deploydatabaseservice.go:214
2023-12-20T18:52:25Z DEBU             Upsert ECS TaskDefinition. account-id:278576220453 deployservice:database-service ecs-cluster:lenix-teleport ecs-service-name:database-service-vpc-<redacted1> ecs-task-name:lenix-teleport-database-service-vpc-<redacted1> integration:teleportdev region:us-east-1 vpc-id:vpc-<redacted1> awsoidc/deploydatabaseservice.go:254
2023-12-20T18:52:26Z DEBU             Upsert ECS Service. account-id:278576220453 deployservice:database-service ecs-cluster:lenix-teleport ecs-service-name:database-service-vpc-<redacted1> ecs-task-name:lenix-teleport-database-service-vpc-<redacted1> integration:teleportdev region:us-east-1 vpc-id:vpc-<redacted1> awsoidc/deploydatabaseservice.go:268
2023-12-20T18:52:27Z DEBU             Upsert ECS TaskDefinition. account-id:278576220453 deployservice:database-service ecs-cluster:lenix-teleport ecs-service-name:database-service-vpc-<redacted2> ecs-task-name:lenix-teleport-database-service-vpc-<redacted2> integration:teleportdev region:us-east-1 vpc-id:vpc-<redacted2> awsoidc/deploydatabaseservice.go:254
2023-12-20T18:52:27Z DEBU             Upsert ECS Service. account-id:278576220453 deployservice:database-service ecs-cluster:lenix-teleport ecs-service-name:database-service-vpc-<redacted2> ecs-task-name:lenix-teleport-database-service-vpc-<redacted2> integration:teleportdev region:us-east-1 vpc-id:vpc-<redacted2> awsoidc/deploydatabaseservice.go:268
```

Services running in ECS Cluster:
<img width="1419" alt="image" src="https://github.com/gravitational/teleport/assets/689271/df8d9c3c-4f69-4139-bf74-bbcdab241c46">

DB Services heartbeat back their labels `tctl get db_services`:
```yaml
kind: db_service
metadata:
  expires: "2023-12-20T19:07:15.537837586Z"
  id: 1703098635576820826
  name: 3999f6c0-6612-44b2-89f9-c837dc1bf039
  revision: f86f72c6-6181-40cb-9745-eed311782f9d
spec:
  resources:
  - aws: {}
    labels:
      account-id: "278576220453"
      region: us-east-1
      vpc-id: vpc-02xyz
version: v1
---
kind: db_service
metadata:
  expires: "2023-12-20T19:07:20.354861775Z"
  id: 1703098640393153666
  name: ff88fe75-0022-4963-8a80-c28571de2785
  revision: 1df4172c-f016-4875-9087-b1f4b1a144c1
spec:
  resources:
  - aws: {}
    labels:
      account-id: "278576220453"
      region: us-east-1
      vpc-id: vpc-09xyz
version: v1
```

We are able to use the DatabaseService and access the Database
```
$ tsh db connect marcodemodb01-rds-us-east-1-278576220453
psql (15.5, server 14.7)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256, compression: off)
Type "help" for help.

postgres=> select 1+1;
 ?column? 
----------
        2
(1 row)

postgres=> 
```

Logs from the DatabaseService:
<img width="1039" alt="image" src="https://github.com/gravitational/teleport/assets/689271/fb283002-790a-41bd-84a8-3f415259d466">
