### PR TITLE
MFA for Admin Actions: Cert Authority

### DIFF
--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -161,8 +161,12 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 
 // DeleteCertAuthority deletes the matching cert authority.
 func (s *Service) DeleteCertAuthority(ctx context.Context, req *trustpb.DeleteCertAuthorityRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, false, types.KindCertAuthority, types.VerbDelete)
+	authzCtx, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, false, types.KindCertAuthority, types.VerbDelete)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authz.AuthorizeAdminAction(ctx, authzCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -183,7 +187,12 @@ func (s *Service) UpsertCertAuthority(ctx context.Context, req *trustpb.UpsertCe
 		return nil, trace.Wrap(err)
 	}
 
-	if _, err := authz.AuthorizeResourceWithVerbs(ctx, s.logger, s.authorizer, false, req.CertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
+	authzCtx, err := authz.AuthorizeResourceWithVerbs(ctx, s.logger, s.authorizer, false, req.CertAuthority, types.VerbCreate, types.VerbUpdate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authz.AuthorizeAdminAction(ctx, authzCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -228,6 +237,8 @@ func (s *Service) GenerateHostCert(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// TODO (Joerger): in v16.0.0, this endpoint should require admin action authorization.
 
 	// Call through to the underlying implementation on auth.Server. At some
 	// point in the future, we may wish to pull more of that implementation

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -238,7 +238,8 @@ func (s *Service) GenerateHostCert(
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO (Joerger): in v16.0.0, this endpoint should require admin action authorization.
+	// TODO (Joerger): in v16.0.0, this endpoint should require admin action authorization
+	// once the deprecated http endpoint is removed in use.
 
 	// Call through to the underlying implementation on auth.Server. At some
 	// point in the future, we may wish to pull more of that implementation

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -68,7 +68,8 @@ type fakeAuthorizer struct {
 
 func (f *fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 	return &authz.Context{
-		Checker: f.checker,
+		Checker:               f.checker,
+		AdminActionAuthorized: true,
 	}, nil
 }
 
@@ -373,7 +374,6 @@ func TestRBAC(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.NotNil(t, ca)
-
 			},
 			authorizer: fakeAuthorizer{
 				checker: &fakeChecker{
@@ -392,7 +392,6 @@ func TestRBAC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-
 			p := newTestPack(t)
 
 			trust := local.NewCAService(p.mem)
@@ -654,7 +653,6 @@ func TestDeleteCertAuthority(t *testing.T) {
 				ca, err := service.GetCertAuthority(ctx, &trustpb.GetCertAuthorityRequest{Domain: "test", Type: string(types.HostCA)})
 				require.True(t, trace.IsNotFound(err), "got unexpected error retrieving a deleted ca: %v", err)
 				require.Nil(t, ca)
-
 			},
 		},
 	}
@@ -730,7 +728,6 @@ func TestUpsertCertAuthority(t *testing.T) {
 				// Validate that only the rotation was changed
 				require.Nil(t, hostCA.Spec.Rotation)
 				require.NotNil(t, ca.Spec.Rotation)
-
 			},
 		},
 	}

--- a/rfd/0131-adminitrative-actions-mfa.md
+++ b/rfd/0131-adminitrative-actions-mfa.md
@@ -96,10 +96,10 @@ actions which modify the following administrative resources.
     - `UpsertLoginRule`, `CreateLoginRule`, `DeleteLoginRule`
 - Certificates
   - CA management
-    - http: `rotateCertAuthority`, `rotateExternalCertAuthority`, `upsertCertAuthority`, `deleteCertAuthority`
+    - `UpsertCertAuthority`, `DeleteCertAuthority`
+    - http: `rotateCertAuthority`, `rotateExternalCertAuthority`
   - Host certs
-    - `GenerateHostCerts`
-    - http: `generateHostCert`
+    - `GenerateHostCerts`, `GenerateHostCert`
   - User certs
     - `GenerateUserCerts`
   - Web sessions

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -20,6 +20,7 @@ package common_test
 
 import (
 	"context"
+	"crypto/x509/pkix"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/teleport/lib/auth/native"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	libclient "github.com/gravitational/teleport/lib/client"
@@ -49,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	tctl "github.com/gravitational/teleport/tool/tctl/common"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -64,6 +67,7 @@ func TestAdminActionMFA(t *testing.T) {
 	t.Run("AccessRequests", s.testAccessRequests)
 	t.Run("Tokens", s.testTokens)
 	t.Run("UserGroups", s.testUserGroups)
+	t.Run("CertAuthority", s.testCertAuthority)
 	t.Run("OIDCConnector", s.testOIDCConnector)
 	t.Run("SAMLConnector", s.testSAMLConnector)
 	t.Run("GithubConnector", s.testGithubConnector)
@@ -376,6 +380,58 @@ func (s *adminActionTestSuite) testUserGroups(t *testing.T) {
 				return s.authServer.DeleteUserGroup(ctx, userGroup.GetName())
 			},
 		})
+	})
+}
+
+func (s *adminActionTestSuite) testCertAuthority(t *testing.T) {
+	ctx := context.Background()
+
+	priv, pub, err := native.GenerateKeyPair()
+	require.NoError(t, err)
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(pkix.Name{CommonName: "Host"}, nil, time.Minute)
+	require.NoError(t, err)
+
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.HostCA,
+		ClusterName: "clustername",
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{{
+				PrivateKey:     priv,
+				PrivateKeyType: types.PrivateKeyType_RAW,
+				PublicKey:      pub,
+			}},
+			TLS: []*types.TLSKeyPair{{
+				Cert: cert,
+				Key:  key,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	createCertAuthority := func() error {
+		return s.authServer.CreateCertAuthority(ctx, ca)
+	}
+
+	getCertAuthority := func() (types.Resource, error) {
+		return s.authServer.GetCertAuthority(ctx, ca.GetID(), false)
+	}
+
+	deleteCertAuthority := func() error {
+		return s.authServer.DeleteCertAuthority(ctx, ca.GetID())
+	}
+
+	s.testResourceCommand(t, ctx, resourceCommandTestCase{
+		resource:        ca,
+		resourceCreate:  createCertAuthority,
+		resourceCleanup: deleteCertAuthority,
+	})
+
+	s.testEditCommand(t, ctx, editCommandTestCase{
+		resourceRef:     getResourceRef(ca),
+		resourceCreate:  createCertAuthority,
+		resourceGet:     getCertAuthority,
+		resourceCleanup: deleteCertAuthority,
 	})
 }
 
@@ -1001,6 +1057,8 @@ func getResourceRef(r types.Resource) string {
 	case types.KindClusterAuthPreference, types.KindNetworkRestrictions, types.KindClusterNetworkingConfig, types.KindSessionRecordingConfig:
 		// singleton resources are referred to by kind alone.
 		return kind
+	case types.KindCertAuthority:
+		return fmt.Sprintf("%v/%v/%v", r.GetKind(), r.(types.CertAuthority).GetType(), r.GetName())
 	default:
 		return fmt.Sprintf("%v/%v", r.GetKind(), r.GetName())
 	}


### PR DESCRIPTION
Require MFA for CA CRUD.

Part of [RFD 131](https://github.com/gravitational/teleport/blob/6b998a78ddd76c0c9eb7d966086f984b01144de7/rfd/0131-adminitrative-actions-mfa.md#administrative-actions).