### PR TITLE
docs: remove athena warning

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -952,25 +952,9 @@ Config option priority is applied in the following order:
   are not supported in certain regions or environments or are only supported in GovCloud.
 </Admonition>
 
-## Athena 
+## Athena
 
 The Athena audit log back-end is available starting from Teleport v14.0.
-
-<Notice type="danger">
-
-If you are using the
-[Teleport-event-exporter](../management/export-audit-events/fluentd.mdx)
-or any other mechanism for polling of [SearchEvents
-API](https://pkg.go.dev/github.com/gravitational/teleport/api/client#Client.SearchEvents),
-you should not use the Athena audit back-end, as the preview release of this
-back-end is especially resource intensive when polling the Teleport Auth
-Service for audit events.
-
-A new version of the Teleport event handler is under development to address this
-issue.
-
-</Notice>
-
 
 If you are running Teleport on AWS, you can use an
 [Athena](https://aws.amazon.com/athena/)-based audit log system that manages


### PR DESCRIPTION
This commit removes a warning not to use the Athena backend if using an event exporter due to high resource usage.

This issue was fixed in https://github.com/gravitational/teleport/pull/32547