### PR TITLE
Fix data race in `HeartbeatV2` around `.Spec.CloudMetadata`

### DIFF
--- a/lib/srv/heartbeatv2_test.go
+++ b/lib/srv/heartbeatv2_test.go
@@ -20,6 +20,7 @@ package srv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -475,11 +476,24 @@ func (f *fakeDownstreamHandle) CloseContext() context.Context {
 func mockMetadataGetter() (metadataGetter, chan *metadata.Metadata) {
 	ch := make(chan *metadata.Metadata, 1)
 	return func(ctx context.Context) (*metadata.Metadata, error) {
-		meta := <-ch
-		if meta == nil {
-			return nil, fmt.Errorf("error fetching metadata")
+		select {
+		case meta := <-ch:
+			if meta == nil {
+				return nil, errors.New("error fetching metadata")
+			}
+			return meta, nil
+		default:
 		}
-		return meta, nil
+
+		select {
+		case meta := <-ch:
+			if meta == nil {
+				return nil, errors.New("error fetching metadata")
+			}
+			return meta, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}, ch
 }
 
@@ -527,11 +541,4 @@ func TestNewHeartbeatFetchMetadata(t *testing.T) {
 	meta := inner.getServer(ctx).GetCloudMetadata()
 	assert.NotNil(t, meta, "Heartbeat never got metadata")
 	assert.Equal(t, "foo", meta.AWS.InstanceID)
-
-	// Metadata won't be fetched more than once.
-	metaCh <- makeMetadata("bar")
-	time.Sleep(100 * time.Millisecond) // Wait for goroutines to complete
-	meta = inner.getServer(ctx).GetCloudMetadata()
-	assert.NotNil(t, meta, "Lost metadata")
-	assert.NotEqual(t, "bar", meta.AWS.InstanceID)
 }


### PR DESCRIPTION
#30528 added a data race by writing to a `*ServerV2` after returning it from the `getServer` closure, which can manifest as a rare out-of-bound slice access during protobuf marshaling. This PR removes the internal caching added by #30528 (since `metadata.Get()` already does its own caching and singleflighting), adding the `CloudMetadata` data to the heartbeat only if already available.

changelog: fixed potential panic during early phases of SSH service lifetime 