### PR TITLE
Discovery Fetch Event: fix expected events test

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -525,7 +525,7 @@ func TestDiscoveryServer(t *testing.T) {
 					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
-			require.GreaterOrEqual(t, 1, reporter.DiscoveryFetchEventCount())
+			require.GreaterOrEqual(t, reporter.DiscoveryFetchEventCount(), 1)
 		})
 	}
 }


### PR DESCRIPTION
The assertion was wrong.
We should expect at least 1 event, but on slow machines we might have another iteration because we have a `require.Eventually` that might run up to 5 seconds which can trigger another fetch.