### PR TITLE
[v13] Fix data race in `HeartbeatV2` around `.Spec.CloudMetadata` (#35912)

### DIFF
--- a/lib/inventory/metadata/get.go
+++ b/lib/inventory/metadata/get.go
@@ -32,11 +32,11 @@ var metadataReady = make(chan struct{})
 // fetched is used to ensure that the instance metadata is fetched at most once.
 var fetched atomic.Bool
 
-// Get fetches the instance metadata.
-// The first call can take some time as all metadata will be retrieved.
-// The resulting metadata is cached, so subsequent calls will be fast.
-// The return value of Get might be shared between callers and should not be
-// modified.
+// Get fetches the instance metadata. The first call can take some time as all
+// metadata will be retrieved. The resulting metadata is cached, so subsequent
+// calls will be fast. The return value of Get might be shared between callers
+// and should not be modified. If the cached metadata is ready, it will be
+// returned successfully even if the context is done.
 func Get(ctx context.Context) (*Metadata, error) {
 	if !fetched.Swap(true) {
 		// Spawn a goroutine responsible for fetching the metadata if we're the
@@ -49,6 +49,13 @@ func Get(ctx context.Context) (*Metadata, error) {
 			// Signal that the metadata is ready.
 			close(metadataReady)
 		}()
+	}
+
+	// if the metadata is ready we don't care if the context is already done
+	select {
+	case <-metadataReady:
+		return metadata, nil
+	default:
 	}
 
 	select {

--- a/lib/srv/heartbeatv2.go
+++ b/lib/srv/heartbeatv2.go
@@ -18,7 +18,6 @@ package srv
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -74,7 +73,6 @@ func NewSSHServerHeartbeat(cfg SSHServerHeartbeatConfig) (*HeartbeatV2, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	var metadataPtr atomic.Pointer[metadata.Metadata]
 	inner := &sshServerHeartbeatV2{
 		getMetadata: metadata.Get,
 		announcer:   cfg.Announcer,
@@ -82,20 +80,11 @@ func NewSSHServerHeartbeat(cfg SSHServerHeartbeatConfig) (*HeartbeatV2, error) {
 	inner.getServer = func(ctx context.Context) *types.ServerV2 {
 		server := cfg.GetServer()
 
-		if meta := metadataPtr.Load(); meta == nil {
-			go func() {
-				meta, err := inner.getMetadata(ctx)
-				if err != nil {
-					log.Warnf("Failed to get metadata: %v", err)
-				} else if meta != nil && meta.CloudMetadata != nil {
-					// Set the metadata immediately to give the heartbeat
-					// a chance to use it.
-					server.SetCloudMetadata(meta.CloudMetadata)
-					metadataPtr.CompareAndSwap(nil, meta)
-				}
-			}()
-		} else if meta.CloudMetadata != nil {
-			// Server isn't cached between heartbeats, so set the metadata again.
+		doneCtx, cancel := context.WithCancel(ctx)
+		cancel() // not a typo
+
+		meta, err := inner.getMetadata(doneCtx)
+		if err == nil && meta != nil && meta.CloudMetadata != nil {
 			server.SetCloudMetadata(meta.CloudMetadata)
 		}
 
@@ -457,6 +446,10 @@ type heartbeatV2Driver interface {
 	SupportsFallback() bool
 }
 
+// metadataGetter returns the instance metadata, unblocking with an error if
+// fetching the metadata takes longer than the context. If the metadata is
+// immediately available, it shall be returned even if the context passed in is
+// already done.
 type metadataGetter func(ctx context.Context) (*metadata.Metadata, error)
 
 // sshServerHeartbeatV2 is the heartbeatV2 implementation for ssh servers.


### PR DESCRIPTION
Backport #35912 to branch/v13

changelog: fixed potential panic during early phases of SSH service lifetime