### PR TITLE
Fix remote cluster active connection helper

### DIFF
--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -144,12 +145,18 @@ func WaitForNodeCount(ctx context.Context, t *TeleInstance, clusterName string, 
 
 // WaitForActiveTunnelConnections waits for remote cluster to report a minimum number of active connections
 func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, expectedCount int) {
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		cluster, err := tunnel.GetSite(clusterName)
-		if err != nil {
-			return false
+		if !assert.NoError(t, err, "site not found") {
+			return
 		}
-		return cluster.GetTunnelsCount() >= expectedCount && cluster.GetStatus() == teleport.RemoteClusterStatusOnline
+
+		assert.GreaterOrEqual(t, cluster.GetTunnelsCount(), expectedCount, "missing tunnels for site")
+
+		assert.Equal(t, teleport.RemoteClusterStatusOnline, cluster.GetStatus(), "cluster not online")
+
+		_, err = cluster.GetClient()
+		assert.NoError(t, err, "cluster not yet available")
 	},
 		30*time.Second,
 		time.Second,


### PR DESCRIPTION
WaitForActiveTunnelConnections would return if a the site was not fully discovered yet which would result in test failures with a message similar to the following:

```
failed connecting to host 127.0.0.1:35391: failed to receive cluster details response
        	            		failed to dial target host
        	            		unable to fetch node watcher, this proxy clusterPeer(TunnelConnection(name=00000000-0000-0000-0000-000000000000-cluster-remote, type=, cluster=cluster-remote, proxy=00000000-0000-0000-0000-000000000000)) has not been discovered yet, try again later
```

This occurred because the check was only verifying that the cluster existed and was online, however the clusterPeer placeholder reports a status of online even though it isn't usable. To prevent this the check now asserts that the cluster is both online and is usable by checking that the client for the site doesn't return an error. This will prevent any clusterPeer objects from being considered in the check since they always return an error when trying to get a client.