### PR TITLE
Make AccessListMember implement ResourceWithLabels.

### DIFF
--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -24,8 +24,13 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 )
+
+func TestAccessListImplementsResourceWithLabels(t *testing.T) {
+	require.Implements(t, (*types.ResourceWithLabels)(nil), &AccessList{})
+}
 
 func TestParseReviewFrequency(t *testing.T) {
 	t.Parallel()

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // AccessListMember is an access list member resource.
@@ -117,4 +118,11 @@ func (a *AccessListMember) CheckAndSetDefaults() error {
 // and should be removed when possible.
 func (a *AccessListMember) GetMetadata() types.Metadata {
 	return legacy.FromHeaderMetadata(a.Metadata)
+}
+
+// MatchSearch goes through select field values of a resource
+// and tries to match against the list of search values.
+func (a *AccessListMember) MatchSearch(values []string) bool {
+	fieldVals := append(utils.MapToStrings(a.GetAllLabels()), a.GetName())
+	return types.MatchSearch(fieldVals, values, nil)
 }

--- a/api/types/accesslist/member_test.go
+++ b/api/types/accesslist/member_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 )
 
+func TestAccessListMemberImplementsResourceWithLabels(t *testing.T) {
+	require.Implements(t, (*types.ResourceWithLabels)(nil), &AccessListMember{})
+}
+
 func TestAccessListMemberDefaults(t *testing.T) {
 	newValidAccessListMember := func() *AccessListMember {
 		accesslist := uuid.New().String()


### PR DESCRIPTION
AccessListMember now implements ResourceWithLabels. This will let it be used by the reconciler.