### PR TITLE
bump kube envtest version

### DIFF
--- a/integrations/operator/envtest.mk
+++ b/integrations/operator/envtest.mk
@@ -4,4 +4,4 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 $(ENVTEST):
 	GOBIN="$(LOCALBIN)" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-ENVTEST_K8S_VERSION = 1.25
+ENVTEST_K8S_VERSION = 1.26


### PR DESCRIPTION
We are observing flaky envtest runs in the CI. Kubernetes 1.25 envtest had a bug that was fixed and backported but setup-envtest mirrors are not serving versions containing the fix for 1.25. Bumping to 1.26 should fix the flakiness.

See also: 
- https://github.com/kubernetes-sigs/karpenter/issues/803