### PR TITLE
Use actions/download-artifact@v3 instead of master 

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: build
           path: ${{ github.workspace }}/build/


### PR DESCRIPTION
Forward compatibility is not guaranteed on master, but is on any semver major version.  We got lucky this didn't break last week when https://github.com/gravitational/teleport/pull/35845 came out.

I'll pick up the upgrade to v4 when https://github.com/gravitational/teleport/pull/35845 merges.

I did check that we didn't have any other `@master` versions in teleport when I found this:

```console
walt@vm:~/git/teleport/.github$ rg '@(master|main)'
workflows/terraform-lint.yaml
18:    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@main

workflows/post-release.yaml
49:    uses: gravitational/teleport/.github/workflows/update-ami-ids.yaml@master

workflows/dependency-review.yaml
9:    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@main

workflows/trivy.yaml
9:    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@main
```

I deemed all of these acceptable, since we're in control of the upstream, and can easily address/rollback breaking changes there.

