### PR TITLE
Enable ARM64 FIPS builds in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -711,6 +711,79 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
+name: push-build-linux-arm64-fips
+trigger:
+  event:
+    include:
+    - push
+    exclude:
+    - pull_request
+  repo:
+    include:
+    - gravitational/*
+  branch:
+    include:
+    - master
+    - branch/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  pull: if-not-exists
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - mkdir -pv /go/cache
+  - rm -f /root/.ssh/id_rsa
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
+  pull: if-not-exists
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "build-connect=false" -input "release-target=release-arm64-fips" '
+  environment:
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
+
+---
 kind: pipeline
 type: kubernetes
 name: teleport-docker-cron-ecr
@@ -1396,6 +1469,77 @@ image_pull_secrets:
 
 kind: pipeline
 type: kubernetes
+name: build-linux-arm64-fips
+trigger:
+  event:
+    include:
+    - tag
+  ref:
+    include:
+    - refs/tags/v*
+  repo:
+    include:
+    - gravitational/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  pull: if-not-exists
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - mkdir -pv /go/cache
+  - rm -f /root/.ssh/id_rsa
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
+  pull: if-not-exists
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=false" -input "build-os-packages=true" -input "release-artifacts=true"
+    -input "release-target=release-arm64-fips" '
+  environment:
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
 name: tag-build-windows-amd64
 trigger:
   event:
@@ -1556,6 +1700,7 @@ depends_on:
 - build-linux-amd64
 - build-linux-amd64-fips
 - build-linux-arm64
+- build-linux-arm64-fips
 - build-linux-arm
 steps:
 - name: Check out code
@@ -2501,6 +2646,7 @@ depends_on:
 - build-linux-amd64
 - build-linux-amd64-fips
 - build-linux-arm64
+- build-linux-arm64-fips
 - build-linux-arm
 steps:
 - name: Check out code
@@ -2853,7 +2999,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport:v15-arm and push it to Local Registry
+- name: Pull teleport:v15-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -2861,11 +3007,11 @@ steps:
     146628656107.dkr.ecr.us-west-2.amazonaws.com
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-arm
+    "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-arm drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    "/go/var/full-version")-arm64 drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
     DOCKERHUB_PASSWORD:
@@ -2886,7 +3032,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport:v15-arm64 and push it to Local Registry
+- name: Pull teleport:v15-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -2894,11 +3040,11 @@ steps:
     146628656107.dkr.ecr.us-west-2.amazonaws.com
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-arm64
+    "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-arm64 drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    "/go/var/full-version")-arm drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
     DOCKERHUB_PASSWORD:
@@ -2960,46 +3106,6 @@ steps:
     path: /var/run
   depends_on:
   - Pull teleport:v15-amd64 and push it to Local Registry
-- name: Tag and push image "teleport:v15-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
-    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
-    ] && echo "skipping" || echo "continuing"
-  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
-    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
-    ] && echo "skipping" || echo "continuing"
-  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Pull teleport:v15-arm and push it to Local Registry
 - name: Tag and push image "teleport:v15-arm64" to ECR - production
   image: docker
   commands:
@@ -3041,6 +3147,46 @@ steps:
     path: /var/run
   depends_on:
   - Pull teleport:v15-arm64 and push it to Local Registry
+- name: Tag and push image "teleport:v15-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Pull teleport:v15-arm and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
@@ -3054,8 +3200,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -3071,8 +3217,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v15-amd64" to ECR - production
-  - Tag and push image "teleport:v15-arm" to ECR - production
   - Tag and push image "teleport:v15-arm64" to ECR - production
+  - Tag and push image "teleport:v15-arm" to ECR - production
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
@@ -3086,8 +3232,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -3103,8 +3249,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v15-amd64" to ECR - production
-  - Tag and push image "teleport:v15-arm" to ECR - production
   - Tag and push image "teleport:v15-arm64" to ECR - production
+  - Tag and push image "teleport:v15-arm" to ECR - production
 - name: Create manifest and push "teleport:full" to ECR - production
   image: docker
   commands:
@@ -3116,8 +3262,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
     public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm && docker
     manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -3133,8 +3279,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v15-amd64" to ECR - production
-  - Tag and push image "teleport:v15-arm" to ECR - production
   - Tag and push image "teleport:v15-arm64" to ECR - production
+  - Tag and push image "teleport:v15-arm" to ECR - production
 - name: Pull teleport-ent:v15-amd64 and push it to Local Registry
   image: docker
   commands:
@@ -3168,7 +3314,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-ent:v15-arm and push it to Local Registry
+- name: Pull teleport-ent:v15-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -3176,11 +3322,11 @@ steps:
     146628656107.dkr.ecr.us-west-2.amazonaws.com
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm
+    "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    "/go/var/full-version")-arm64 drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
     DOCKERHUB_PASSWORD:
@@ -3201,7 +3347,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-ent:v15-arm64 and push it to Local Registry
+- name: Pull teleport-ent:v15-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -3209,11 +3355,11 @@ steps:
     146628656107.dkr.ecr.us-west-2.amazonaws.com
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64
+    "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    "/go/var/full-version")-arm drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
     DOCKERHUB_PASSWORD:
@@ -3276,47 +3422,6 @@ steps:
     path: /var/run
   depends_on:
   - Pull teleport-ent:v15-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-ent:v15-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
-    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
-    ] && echo "skipping" || echo "continuing"
-  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
-    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
-    ] && echo "skipping" || echo "continuing"
-  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Pull teleport-ent:v15-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v15-arm64" to ECR - production
   image: docker
   commands:
@@ -3359,6 +3464,47 @@ steps:
     path: /var/run
   depends_on:
   - Pull teleport-ent:v15-arm64 and push it to Local Registry
+- name: Tag and push image "teleport-ent:v15-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Pull teleport-ent:v15-arm and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
@@ -3372,8 +3518,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -3389,8 +3535,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v15-arm" to ECR - production
   - Tag and push image "teleport-ent:v15-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v15-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
@@ -3404,8 +3550,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -3421,8 +3567,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v15-arm" to ECR - production
   - Tag and push image "teleport-ent:v15-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v15-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:full" to ECR - production
   image: docker
   commands:
@@ -3434,8 +3580,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -3451,8 +3597,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v15-arm" to ECR - production
   - Tag and push image "teleport-ent:v15-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v15-arm" to ECR - production
 - name: Pull teleport-ent:v15-fips-amd64 and push it to Local Registry
   image: docker
   commands:
@@ -3467,6 +3613,40 @@ steps:
     "/go/var/full-version")-fips-amd64 drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - production AWS Role
+- name: Pull teleport-ent:v15-fips-arm64 and push it to Local Registry
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
   environment:
     AWS_PROFILE: ecr-staging
     DOCKERHUB_PASSWORD:
@@ -3529,6 +3709,48 @@ steps:
     path: /var/run
   depends_on:
   - Pull teleport-ent:v15-fips-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-ent:v15-fips-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64)
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Pull teleport-ent:v15-fips-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
@@ -3542,6 +3764,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -3557,6 +3780,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v15-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
@@ -3570,6 +3794,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -3585,6 +3810,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v15-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
   image: docker
   commands:
@@ -3596,6 +3822,7 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "public.ecr.aws"
   environment:
@@ -3611,6 +3838,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v15-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v15-fips-arm64" to ECR - production
 - name: Pull teleport-operator:v15-amd64 and push it to Local Registry
   image: docker
   commands:
@@ -4249,72 +4477,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v14-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v14-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v14-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v14-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v14-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v14-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v14-arm-builder" --config "/tmp/teleport-v14-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-v14-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v14-arm-builder"
-  - rm -rf "/tmp/teleport-v14-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v14-tag_arm.deb" artifacts from S3
 - name: Download "teleport_v14-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -4381,6 +4543,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v14-tag_arm64.deb" artifacts from S3
+- name: Download "teleport_v14-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v14-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v14-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v14-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v14-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v14-arm-builder" --config "/tmp/teleport-v14-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-v14-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v14-arm-builder"
+  - rm -rf "/tmp/teleport-v14-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v14-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport:v14-amd64" to ECR - staging
   image: docker
   commands:
@@ -4423,47 +4651,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v14-amd64"
-- name: Tag and push image "teleport:v14-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v14-arm"
 - name: Tag and push image "teleport:v14-arm64" to ECR - staging
   image: docker
   commands:
@@ -4506,6 +4693,47 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v14-arm64"
+- name: Tag and push image "teleport:v14-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v14-arm"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -4519,8 +4747,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -4536,8 +4764,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - staging
-  - Tag and push image "teleport:v14-arm" to ECR - staging
   - Tag and push image "teleport:v14-arm64" to ECR - staging
+  - Tag and push image "teleport:v14-arm" to ECR - staging
 - name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -4551,8 +4779,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -4568,8 +4796,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - staging
-  - Tag and push image "teleport:v14-arm" to ECR - staging
   - Tag and push image "teleport:v14-arm64" to ECR - staging
+  - Tag and push image "teleport:v14-arm" to ECR - staging
 - name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -4583,8 +4811,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -4600,8 +4828,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - staging
-  - Tag and push image "teleport:v14-arm" to ECR - staging
   - Tag and push image "teleport:v14-arm64" to ECR - staging
+  - Tag and push image "teleport:v14-arm" to ECR - staging
 - name: Tag and push image "teleport:v14-amd64" to ECR - production
   image: docker
   commands:
@@ -4635,38 +4863,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v14-amd64"
-- name: Tag and push image "teleport:v14-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v14-arm"
 - name: Tag and push image "teleport:v14-arm64" to ECR - production
   image: docker
   commands:
@@ -4700,6 +4896,38 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v14-arm64"
+- name: Tag and push image "teleport:v14-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v14-arm"
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
@@ -4709,8 +4937,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -4726,8 +4954,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - production
-  - Tag and push image "teleport:v14-arm" to ECR - production
   - Tag and push image "teleport:v14-arm64" to ECR - production
+  - Tag and push image "teleport:v14-arm" to ECR - production
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
@@ -4737,8 +4965,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -4754,8 +4982,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - production
-  - Tag and push image "teleport:v14-arm" to ECR - production
   - Tag and push image "teleport:v14-arm64" to ECR - production
+  - Tag and push image "teleport:v14-arm" to ECR - production
 - name: Create manifest and push "teleport:full" to ECR - production
   image: docker
   commands:
@@ -4767,8 +4995,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
     public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm && docker
     manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -4784,8 +5012,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v14-amd64" to ECR - production
-  - Tag and push image "teleport:v14-arm" to ECR - production
   - Tag and push image "teleport:v14-arm64" to ECR - production
+  - Tag and push image "teleport:v14-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
   pull: if-not-exists
@@ -4906,72 +5134,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v14-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v14-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v14-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v14-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v14-arm-builder" --config "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-ent-v14-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v14-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v14-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v14-tag_arm.deb" artifacts from S3
 - name: Download "teleport-ent_v14-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -5038,6 +5200,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v14-tag_arm64.deb" artifacts from S3
+- name: Download "teleport-ent_v14-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v14-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v14-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v14-arm-builder" --config "/tmp/teleport-ent-v14-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v14-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v14-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v14-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v14-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v14-amd64" to ECR - staging
   image: docker
   commands:
@@ -5080,48 +5308,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v14-amd64"
-- name: Tag and push image "teleport-ent:v14-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v14-arm"
 - name: Tag and push image "teleport-ent:v14-arm64" to ECR - staging
   image: docker
   commands:
@@ -5164,6 +5350,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v14-arm64"
+- name: Tag and push image "teleport-ent:v14-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v14-arm"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -5177,8 +5405,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5194,8 +5422,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
   - Tag and push image "teleport-ent:v14-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -5209,8 +5437,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5226,8 +5454,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
   - Tag and push image "teleport-ent:v14-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -5241,8 +5469,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5258,8 +5486,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
   - Tag and push image "teleport-ent:v14-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-arm" to ECR - staging
 - name: Tag and push image "teleport-ent:v14-amd64" to ECR - production
   image: docker
   commands:
@@ -5294,39 +5522,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v14-amd64"
-- name: Tag and push image "teleport-ent:v14-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v14-arm"
 - name: Tag and push image "teleport-ent:v14-arm64" to ECR - production
   image: docker
   commands:
@@ -5361,6 +5556,39 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v14-arm64"
+- name: Tag and push image "teleport-ent:v14-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v14-arm"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
@@ -5370,8 +5598,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -5387,8 +5615,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v14-arm" to ECR - production
   - Tag and push image "teleport-ent:v14-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v14-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
@@ -5398,8 +5626,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -5415,8 +5643,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v14-arm" to ECR - production
   - Tag and push image "teleport-ent:v14-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v14-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:full" to ECR - production
   image: docker
   commands:
@@ -5428,8 +5656,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -5445,8 +5673,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v14-arm" to ECR - production
   - Tag and push image "teleport-ent:v14-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v14-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
   pull: if-not-exists
@@ -5569,6 +5797,73 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v14-tag-fips_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v14-tag-fips_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")-fips_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent-fips
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent-fips
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
+- name: Build teleport-ent-fips image "teleport-ent:v14-fips-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v14-fips-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v14-fips-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v14-fips-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v14-fips-arm64-builder" --config "/tmp/teleport-ent-v14-fips-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v14-fips-arm64-builder" --target
+    "teleport-fips" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 --file "/go/build/Dockerfile-teleport-ent-fips"
+    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v14-fips-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v14-fips-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v14-tag-fips_arm64.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v14-fips-amd64" to ECR - staging
   image: docker
   commands:
@@ -5611,6 +5906,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v14-fips-amd64"
+- name: Tag and push image "teleport-ent:v14-fips-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v14-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -5623,7 +5960,8 @@ steps:
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5639,6 +5977,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -5651,7 +5990,8 @@ steps:
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5667,6 +6007,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -5679,7 +6020,8 @@ steps:
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -5695,6 +6037,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - staging
 - name: Tag and push image "teleport-ent:v14-fips-amd64" to ECR - production
   image: docker
   commands:
@@ -5729,6 +6072,40 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v14-fips-amd64"
+- name: Tag and push image "teleport-ent:v14-fips-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v14-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
@@ -5738,6 +6115,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -5753,6 +6131,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
@@ -5762,6 +6141,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -5777,6 +6157,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
   image: docker
   commands:
@@ -5788,6 +6169,7 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "public.ecr.aws"
   environment:
@@ -5803,6 +6185,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v14-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v14-fips-arm64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v14-amd64"
   image: docker
   commands:
@@ -6667,72 +7050,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v13-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v13-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v13-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v13-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v13-arm-builder" --config "/tmp/teleport-v13-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-v13-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v13-arm-builder"
-  - rm -rf "/tmp/teleport-v13-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v13-tag_arm.deb" artifacts from S3
 - name: Download "teleport_v13-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -6799,6 +7116,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_arm64.deb" artifacts from S3
+- name: Download "teleport_v13-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v13-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v13-arm-builder" --config "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-v13-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v13-arm-builder"
+  - rm -rf "/tmp/teleport-v13-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v13-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport:v13-amd64" to ECR - staging
   image: docker
   commands:
@@ -6841,47 +7224,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v13-amd64"
-- name: Tag and push image "teleport:v13-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v13-arm"
 - name: Tag and push image "teleport:v13-arm64" to ECR - staging
   image: docker
   commands:
@@ -6924,6 +7266,47 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v13-arm64"
+- name: Tag and push image "teleport:v13-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -6937,8 +7320,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -6954,8 +7337,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - staging
-  - Tag and push image "teleport:v13-arm" to ECR - staging
   - Tag and push image "teleport:v13-arm64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
 - name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -6969,8 +7352,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -6986,8 +7369,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - staging
-  - Tag and push image "teleport:v13-arm" to ECR - staging
   - Tag and push image "teleport:v13-arm64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
 - name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -7001,8 +7384,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -7018,8 +7401,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - staging
-  - Tag and push image "teleport:v13-arm" to ECR - staging
   - Tag and push image "teleport:v13-arm64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
 - name: Tag and push image "teleport:v13-amd64" to ECR - production
   image: docker
   commands:
@@ -7053,38 +7436,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v13-amd64"
-- name: Tag and push image "teleport:v13-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v13-arm"
 - name: Tag and push image "teleport:v13-arm64" to ECR - production
   image: docker
   commands:
@@ -7118,6 +7469,38 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v13-arm64"
+- name: Tag and push image "teleport:v13-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm"
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
@@ -7127,8 +7510,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -7144,8 +7527,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
-  - Tag and push image "teleport:v13-arm" to ECR - production
   - Tag and push image "teleport:v13-arm64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
@@ -7155,8 +7538,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -7172,8 +7555,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
-  - Tag and push image "teleport:v13-arm" to ECR - production
   - Tag and push image "teleport:v13-arm64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
 - name: Create manifest and push "teleport:full" to ECR - production
   image: docker
   commands:
@@ -7185,8 +7568,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
     public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm && docker
     manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -7202,8 +7585,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
-  - Tag and push image "teleport:v13-arm" to ECR - production
   - Tag and push image "teleport:v13-arm64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
   pull: if-not-exists
@@ -7324,72 +7707,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v13-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v13-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v13-arm-builder" --config "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-ent-v13-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v13-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v13-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
 - name: Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -7456,6 +7773,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v13-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-arm-builder" --config "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v13-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v13-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v13-amd64" to ECR - staging
   image: docker
   commands:
@@ -7498,48 +7881,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-amd64"
-- name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - staging
   image: docker
   commands:
@@ -7582,6 +7923,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm64"
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -7595,8 +7978,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -7612,8 +7995,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -7627,8 +8010,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -7644,8 +8027,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -7659,8 +8042,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -7676,8 +8059,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
 - name: Tag and push image "teleport-ent:v13-amd64" to ECR - production
   image: docker
   commands:
@@ -7712,39 +8095,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-amd64"
-- name: Tag and push image "teleport-ent:v13-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - production
   image: docker
   commands:
@@ -7779,6 +8129,39 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm64"
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
@@ -7788,8 +8171,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -7805,8 +8188,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v13-arm" to ECR - production
   - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
@@ -7816,8 +8199,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -7833,8 +8216,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v13-arm" to ECR - production
   - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:full" to ECR - production
   image: docker
   commands:
@@ -7846,8 +8229,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -7863,8 +8246,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v13-arm" to ECR - production
   - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
   pull: if-not-exists
@@ -7987,6 +8370,73 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag-fips_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")-fips_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent-fips
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent-fips
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
+- name: Build teleport-ent-fips image "teleport-ent:v13-fips-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-fips-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-fips-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-fips-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-fips-arm64-builder" --config "/tmp/teleport-ent-v13-fips-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v13-fips-arm64-builder" --target
+    "teleport-fips" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 --file "/go/build/Dockerfile-teleport-ent-fips"
+    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-fips-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-fips-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag-fips_arm64.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
   image: docker
   commands:
@@ -8029,6 +8479,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+- name: Tag and push image "teleport-ent:v13-fips-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -8041,7 +8533,8 @@ steps:
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -8057,6 +8550,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -8069,7 +8563,8 @@ steps:
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -8085,6 +8580,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -8097,7 +8593,8 @@ steps:
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -8113,6 +8610,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - staging
 - name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
   image: docker
   commands:
@@ -8147,6 +8645,40 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+- name: Tag and push image "teleport-ent:v13-fips-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
@@ -8156,6 +8688,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -8171,6 +8704,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
@@ -8180,6 +8714,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -8195,6 +8730,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
   image: docker
   commands:
@@ -8206,6 +8742,7 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "public.ecr.aws"
   environment:
@@ -8221,6 +8758,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-arm64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v13-amd64"
   image: docker
   commands:
@@ -9085,72 +9623,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v12-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v12-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v12-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v12-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v12-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v12-arm-builder" --config "/tmp/teleport-v12-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v12-arm-builder"
-  - rm -rf "/tmp/teleport-v12-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v12-tag_arm.deb" artifacts from S3
 - name: Download "teleport_v12-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -9217,6 +9689,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
+- name: Download "teleport_v12-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v12-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v12-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v12-arm-builder" --config "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v12-arm-builder"
+  - rm -rf "/tmp/teleport-v12-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v12-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport:v12-amd64" to ECR - staging
   image: docker
   commands:
@@ -9259,47 +9797,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v12-amd64"
-- name: Tag and push image "teleport:v12-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
   image: docker
   commands:
@@ -9342,6 +9839,47 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v12-arm64"
+- name: Tag and push image "teleport:v12-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -9355,8 +9893,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -9372,8 +9910,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
-  - Tag and push image "teleport:v12-arm" to ECR - staging
   - Tag and push image "teleport:v12-arm64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
 - name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -9387,8 +9925,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -9404,8 +9942,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
-  - Tag and push image "teleport:v12-arm" to ECR - staging
   - Tag and push image "teleport:v12-arm64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
 - name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -9419,8 +9957,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -9436,8 +9974,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
-  - Tag and push image "teleport:v12-arm" to ECR - staging
   - Tag and push image "teleport:v12-arm64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
 - name: Tag and push image "teleport:v12-amd64" to ECR - production
   image: docker
   commands:
@@ -9471,38 +10009,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v12-amd64"
-- name: Tag and push image "teleport:v12-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
   image: docker
   commands:
@@ -9536,6 +10042,38 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport image "teleport:v12-arm64"
+- name: Tag and push image "teleport:v12-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm"
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
@@ -9545,8 +10083,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -9562,8 +10100,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
-  - Tag and push image "teleport:v12-arm" to ECR - production
   - Tag and push image "teleport:v12-arm64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
@@ -9573,8 +10111,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -9590,8 +10128,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
-  - Tag and push image "teleport:v12-arm" to ECR - production
   - Tag and push image "teleport:v12-arm64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
 - name: Create manifest and push "teleport:full" to ECR - production
   image: docker
   commands:
@@ -9603,8 +10141,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
     public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm && docker
     manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -9620,8 +10158,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
-  - Tag and push image "teleport:v12-arm" to ECR - production
   - Tag and push image "teleport:v12-arm64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
   pull: if-not-exists
@@ -9742,72 +10280,6 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v12-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v12-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v12-arm-builder" --config "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v12-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v12-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
 - name: Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
@@ -9874,6 +10346,72 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
+- name: Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v12-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-arm-builder" --config "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v12-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   image: docker
   commands:
@@ -9916,48 +10454,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
-- name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
   image: docker
   commands:
@@ -10000,6 +10496,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
+- name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -10013,8 +10551,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10030,8 +10568,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -10045,8 +10583,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10062,8 +10600,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
   image: docker
   commands:
@@ -10077,8 +10615,8 @@ steps:
     skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10094,8 +10632,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-amd64" to ECR - production
   image: docker
   commands:
@@ -10130,39 +10668,6 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
-- name: Tag and push image "teleport-ent:v12-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
   image: docker
   commands:
@@ -10197,6 +10702,39 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
+- name: Tag and push image "teleport-ent:v12-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
@@ -10206,8 +10744,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -10223,8 +10761,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v12-arm" to ECR - production
   - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
@@ -10234,8 +10772,8 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "public.ecr.aws"
   environment:
@@ -10251,8 +10789,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v12-arm" to ECR - production
   - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
 - name: Create manifest and push "teleport-ent:full" to ECR - production
   image: docker
   commands:
@@ -10264,8 +10802,8 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
   - docker logout "public.ecr.aws"
   environment:
@@ -10281,8 +10819,8 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v12-arm" to ECR - production
   - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
   pull: if-not-exists
@@ -10405,6 +10943,73 @@ steps:
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v12-tag-fips_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")-fips_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent-fips
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent-fips
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
+- name: Build teleport-ent-fips image "teleport-ent:v12-fips-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-fips-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-fips-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-fips-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-fips-arm64-builder" --config "/tmp/teleport-ent-v12-fips-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker buildx build --push --builder "teleport-ent-v12-fips-arm64-builder" --target
+    "teleport-fips" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 --file "/go/build/Dockerfile-teleport-ent-fips"
+    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_arm64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-fips-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v12-fips-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag-fips_arm64.deb" artifacts from S3
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
   image: docker
   commands:
@@ -10447,6 +11052,48 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+- name: Tag and push image "teleport-ent:v12-fips-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v12-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -10459,7 +11106,8 @@ steps:
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10475,6 +11123,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -10487,7 +11136,8 @@ steps:
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10503,6 +11153,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
   image: docker
   commands:
@@ -10515,7 +11166,8 @@ steps:
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
     image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips)
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
@@ -10531,6 +11183,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
   image: docker
   commands:
@@ -10565,6 +11218,40 @@ steps:
     path: /var/run
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+- name: Tag and push image "teleport-ent:v12-fips-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v12-fips-arm64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
@@ -10574,6 +11261,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -10589,6 +11277,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
@@ -10598,6 +11287,7 @@ steps:
   - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-arm64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
@@ -10613,6 +11303,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
   image: docker
   commands:
@@ -10624,6 +11315,7 @@ steps:
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-arm64
     && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "public.ecr.aws"
   environment:
@@ -10639,6 +11331,7 @@ steps:
     path: /var/run
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-fips-arm64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
   image: docker
   commands:
@@ -11348,6 +12041,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 40eb5349c45d155829dd463233a1d3795c00c4ca7e97bb9bd81689f377c30416
+hmac: 5c3c71d2315d7d4b09e5bb67388d2e28239343a1c096f33fa961b54509ebf175
 
 ...

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -46,7 +46,7 @@ func NewTeleportProduct(isEnterprise, isFips bool, version *ReleaseVersion) *Pro
 	workingDirectory := "/go/build"
 	name := "teleport"
 	dockerfileTarget := "teleport"
-	supportedArches := []string{"amd64"}
+	supportedArches := []string{"amd64", "arm64"}
 
 	if isEnterprise {
 		name += "-ent"
@@ -55,7 +55,7 @@ func NewTeleportProduct(isEnterprise, isFips bool, version *ReleaseVersion) *Pro
 		dockerfileTarget += "-fips"
 		name += "-fips"
 	} else {
-		supportedArches = append(supportedArches, "arm", "arm64")
+		supportedArches = append(supportedArches, "arm")
 	}
 
 	setupSteps, dockerfilePath, downloadProfileName := getTeleportSetupSteps(name, workingDirectory, version.ShellVersion)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -49,6 +49,7 @@ func pushPipelines() []pipeline {
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "386", fips: false}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm64", fips: false}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm", fips: false}))
 	ps = append(ps, ghaWindowsPushPipeline())
 

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -39,7 +39,8 @@ func tagPipelines() []pipeline {
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "amd64", fips: false, centos7: true, buildConnect: true, buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "amd64", fips: true, centos7: true, buildConnect: false, buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "386", buildOSPkg: true}))
-	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", buildOSPkg: true}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", fips: false, buildOSPkg: true}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", fips: true, buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm", buildOSPkg: true}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
@@ -51,6 +52,7 @@ func tagPipelines() []pipeline {
 			"build-linux-amd64",
 			"build-linux-amd64-fips",
 			"build-linux-arm64",
+			"build-linux-arm64-fips",
 			"build-linux-arm",
 		},
 		workflows: []ghaWorkflow{
@@ -145,6 +147,7 @@ func tagPipelines() []pipeline {
 			"build-linux-amd64",
 			"build-linux-amd64-fips",
 			"build-linux-arm64",
+			"build-linux-arm64-fips",
 			"build-linux-arm",
 		},
 		workflows: []ghaWorkflow{


### PR DESCRIPTION
Now that #34950 and gravitational/teleport.e#2729 have landed, we can now release arm64-based FIPS builds. Add the appropriate magic to dronegen and run `make dronegen` to update `.drone.yml`.

Ref #5068.
Ref #10581.