### PR TITLE
[Web] Make Unified Resources page responsive

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -20,7 +20,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { ButtonBorder, ButtonPrimary, ButtonSecondary } from 'design/Button';
 import { SortDir } from 'design/DataTable/types';
-import { Text, Flex, Box } from 'design';
+import { Text, Flex } from 'design';
 import Menu, { MenuItem } from 'design/Menu';
 import { StyledCheckbox } from 'design/Checkbox';
 import {
@@ -64,6 +64,7 @@ interface FilterPanelProps {
   setCurrentViewMode: (viewMode: ViewMode) => void;
   expandAllLabels: boolean;
   setExpandAllLabels: (expandAllLabels: boolean) => void;
+  hideViewModeOptions: boolean;
 }
 
 export function FilterPanel({
@@ -77,6 +78,7 @@ export function FilterPanel({
   setCurrentViewMode,
   expandAllLabels,
   setExpandAllLabels,
+  hideViewModeOptions,
 }: FilterPanelProps) {
   const { sort, kinds } = params;
 
@@ -120,34 +122,39 @@ export function FilterPanel({
         />
       </Flex>
       <Flex gap={2} alignItems="center">
-        <Box mr={1}>{BulkActions}</Box>
-        {currentViewMode === ViewMode.VIEW_MODE_LIST && (
-          <ButtonBorder
-            size="small"
-            css={`
-              border: none;
-              color: ${props => props.theme.colors.text.slightlyMuted};
-              text-transform: none;
-              padding-left: ${props => props.theme.space[2]}px;
-              padding-right: ${props => props.theme.space[2]}px;
-              height: 22px;
-            `}
-            onClick={() => setExpandAllLabels(!expandAllLabels)}
-          >
-            <Flex alignItems="center" width="100%">
-              {expandAllLabels ? (
-                <ArrowsIn size="small" mr={1} />
-              ) : (
-                <ArrowsOut size="small" mr={1} />
-              )}
-              {expandAllLabels ? 'Collapse ' : 'Expand '} All Labels
-            </Flex>
-          </ButtonBorder>
+        <Flex mr={1}>{BulkActions}</Flex>
+        {!hideViewModeOptions && (
+          <>
+            {currentViewMode === ViewMode.VIEW_MODE_LIST && (
+              <ButtonBorder
+                size="small"
+                css={`
+                  border: none;
+                  color: ${props => props.theme.colors.text.slightlyMuted};
+                  text-transform: none;
+                  padding-left: ${props => props.theme.space[2]}px;
+                  padding-right: ${props => props.theme.space[2]}px;
+                  height: 22px;
+                  font-size: 12px;
+                `}
+                onClick={() => setExpandAllLabels(!expandAllLabels)}
+              >
+                <Flex alignItems="center" width="100%">
+                  {expandAllLabels ? (
+                    <ArrowsIn size="small" mr={1} />
+                  ) : (
+                    <ArrowsOut size="small" mr={1} />
+                  )}
+                  {expandAllLabels ? 'Collapse ' : 'Expand '} All Labels
+                </Flex>
+              </ButtonBorder>
+            )}
+            <ViewModeSwitch
+              currentViewMode={currentViewMode}
+              setCurrentViewMode={setCurrentViewMode}
+            />
+          </>
         )}
-        <ViewModeSwitch
-          currentViewMode={currentViewMode}
-          setCurrentViewMode={setCurrentViewMode}
-        />
         <SortMenu
           onDirChange={onSortOrderButtonClicked}
           onChange={onSortFieldChange}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -22,6 +22,7 @@ import React, {
   useCallback,
   Children,
   PropsWithChildren,
+  useRef,
 } from 'react';
 
 import styled from 'styled-components';
@@ -78,6 +79,10 @@ import { mapResourceToViewItem } from './shared/viewItemsFactory';
 const INITIAL_FETCH_SIZE = 48;
 // increment by 24 every fetch
 export const FETCH_MORE_SIZE = 24;
+
+// The breakpoint at which to force the card view. This is to improve responsiveness
+// since list view looks cluttered on narrow viewports.
+const FORCE_CARD_VIEW_BREAKPOINT = 800;
 
 export const PINNING_NOT_SUPPORTED_MESSAGE =
   'This cluster does not support pinning resources. To enable, upgrade to 14.1 or newer.';
@@ -173,11 +178,14 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     bulkActions = [],
   } = props;
 
+  const containerRef = useRef<HTMLDivElement>();
+
   const { setTrigger } = useInfiniteScroll({
     fetch: fetchResources,
   });
 
   const [selectedResources, setSelectedResources] = useState<string[]>([]);
+  const [forceCardView, setForceCardView] = useState(false);
 
   const pinnedResourcesGetter =
     pinning.kind === 'supported'
@@ -355,10 +363,27 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     unifiedResourcePreferences.labelsViewMode ===
     LabelsViewMode.LABELS_VIEW_MODE_EXPANDED;
 
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(entries => {
+      const container = entries[0];
+      if (container.contentRect.width <= FORCE_CARD_VIEW_BREAKPOINT) {
+        setForceCardView(true);
+      } else {
+        setForceCardView(false);
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   const ViewComponent =
-    unifiedResourcePreferences.viewMode === ViewMode.VIEW_MODE_LIST
-      ? ListView
-      : CardsView;
+    unifiedResourcePreferences.viewMode === ViewMode.VIEW_MODE_CARD ||
+    forceCardView
+      ? CardsView
+      : ListView;
 
   return (
     <div
@@ -367,7 +392,9 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         width: 100%;
         max-width: 1800px;
         margin: 0 auto;
+        min-width: 450px;
       `}
+      ref={containerRef}
     >
       <ErrorsContainer>
         {resourcesFetchAttempt.status === 'failed' && (
@@ -419,6 +446,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
               : LabelsViewMode.LABELS_VIEW_MODE_COLLAPSED
           );
         }}
+        hideViewModeOptions={forceCardView}
         BulkActions={
           <>
             {selectedResources.length > 0 && (
@@ -432,9 +460,12 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                         textTransform="none"
                         onClick={() => action(getSelectedResources())}
                         disabled={disabled}
+                        size="small"
                         css={`
                           border: none;
                           color: ${props => props.theme.colors.brand};
+                          height: 22px;
+                          font-size: 12px;
                         `}
                       >
                         <Icon size="small" color="brand" mr={2} />

--- a/web/packages/shared/components/UnifiedResources/unifiedStyles.css
+++ b/web/packages/shared/components/UnifiedResources/unifiedStyles.css
@@ -39,7 +39,8 @@
 
 .SearchPanel {
   width: 100%;
-  @container (min-width: 800px) {
+  @container (min-width: 801px) {
     width: 70%;
+    min-width: 800px;
   }
 }

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -22,6 +22,8 @@ import React, {
   useEffect,
   useMemo,
   useState,
+  createContext,
+  useContext,
 } from 'react';
 import styled from 'styled-components';
 import { Indicator } from 'design';
@@ -265,12 +267,34 @@ function FeatureRoutes({ lockedFeatures }: { lockedFeatures: LockedFeatures }) {
   return <Switch>{routes}</Switch>;
 }
 
-export const ContentMinWidth = styled.div`
-  min-width: 1250px;
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-`;
+// This context allows children components to disable this min-width in case they want to be able to shrink smaller.
+type MinWidthContextState = {
+  setEnforceMinWidth: (enforceMinWidth: boolean) => void;
+};
+
+const ContentMinWidthContext = createContext<MinWidthContextState>(null);
+
+export const useContentMinWidthContext = () =>
+  useContext(ContentMinWidthContext);
+
+const ContentMinWidth = ({ children }: { children: ReactNode }) => {
+  const [enforceMinWidth, setEnforceMinWidth] = useState(true);
+
+  return (
+    <ContentMinWidthContext.Provider value={{ setEnforceMinWidth }}>
+      <div
+        css={`
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          ${enforceMinWidth ? 'min-width: 1250px;' : ''}
+        `}
+      >
+        {children}
+      </div>
+    </ContentMinWidthContext.Provider>
+  );
+};
 
 export const HorizontalSplit = styled.div`
   display: flex;

--- a/web/packages/teleport/src/Main/index.ts
+++ b/web/packages/teleport/src/Main/index.ts
@@ -18,7 +18,7 @@
 
 export {
   Main as default,
-  ContentMinWidth,
+  useContentMinWidthContext,
   HorizontalSplit,
   StyledIndicator,
 } from './Main';

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 
 import { Flex } from 'design';
 
@@ -40,6 +40,7 @@ import {
   FeatureHeaderTitle,
   FeatureBox,
 } from 'teleport/components/Layout';
+import { useContentMinWidthContext } from 'teleport/Main';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 import { SearchResource } from 'teleport/Discover/SelectResource';
 import { encodeUrlQueryParams } from 'teleport/components/hooks/useUrlFiltering';
@@ -100,6 +101,16 @@ function ClusterResources({
 }) {
   const teleCtx = useTeleport();
   const flags = teleCtx.getFeatureFlags();
+
+  const { setEnforceMinWidth } = useContentMinWidthContext();
+
+  useEffect(() => {
+    setEnforceMinWidth(false);
+
+    return () => {
+      setEnforceMinWidth(true);
+    };
+  }, []);
 
   const pinningNotSupported = storageService.arePinnedResourcesDisabled();
   const {


### PR DESCRIPTION
## Purpose

Makes the Unified Resources page in the Web UI responsive. If the window is resized to be narrow in list view, it will automatically force card view. This also fixes the responsiveness of the card view.

Also fixes a small visual bug with the bulk actions button not matching the size of the "Expand/Collapse all labels" button, and increases the font size to match the [Figma design](https://www.figma.com/file/JKd0Bgs30AnNfNCLUuzzc2/Unified-Resources?type=design&node-id=2135-54558&mode=design).

`e` counterpart: https://github.com/gravitational/teleport.e/pull/3025

## Implementation

This page wasn't responsive due to a `min-width` that we set on a wrapper that wraps all of our views, this was added in https://github.com/gravitational/webapps/pull/1178 to fix double horizontal scroll bars. This forced all views to never be able to shrink smaller than 1250px. To get around this without affecting all views and potentially introducing regressions, the `ContentMinWidth` wrapper now has a context which children can optionally use to disable the minimum width.

## Demo

### Before

https://github.com/gravitational/teleport/assets/56373201/b50ca3f8-c5ec-48ba-881c-8d537118a3f9

### After

https://github.com/gravitational/teleport/assets/56373201/79673796-b083-475c-b39f-9916263218fb

#### Button Fix

##### Before

![image](https://github.com/gravitational/teleport/assets/56373201/28aed425-68d6-47a7-8aeb-7ee5fc0f4e4c)

##### After

![image](https://github.com/gravitational/teleport/assets/56373201/f8b8d61e-c9e0-4ca0-84b1-cc776ae97a71)

changelog: Make Unified Resources page in Web UI responsive