### PR TITLE
Standardize buttons in login prompts in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptSsoStatus/PromptSsoStatus.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptSsoStatus/PromptSsoStatus.tsx
@@ -16,30 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, ButtonSecondary, Text, Flex } from 'design';
 
 import LinearProgress from 'teleterm/ui/components/LinearProgress';
 
 export default function PromptSsoStatus(props: Props) {
   return (
-    <Flex
-      flex="1"
-      minHeight="40px"
-      flexDirection="column"
-      justifyContent="space-between"
-      alignItems="center"
-      p={5}
-    >
-      <Box mb={4} style={{ position: 'relative' }}>
+    <Flex p={4} gap={4} flexDirection="column" alignItems="flex-start">
+      <Box style={{ position: 'relative' }}>
         <Text bold mb={2} textAlign="center">
           Please follow the steps in the new browser window to authenticate.
         </Text>
         <LinearProgress />
       </Box>
-      <ButtonSecondary width={120} size="small" onClick={props.onCancel}>
-        Cancel
-      </ButtonSecondary>
+      <ButtonSecondary onClick={props.onCancel}>Cancel</ButtonSecondary>
     </Flex>
   );
 }

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptWebauthn/PromptWebauthn.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptWebauthn/PromptWebauthn.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 import { Box, ButtonSecondary, ButtonPrimary, Text, Image, Flex } from 'design';
 import FieldInput from 'shared/components/FieldInput';
 import Validation from 'shared/components/Validation';
@@ -116,7 +116,7 @@ function PromptCredential({
 }
 
 function PromptPin({ onCancel, onUserResponse, processing }: Props) {
-  const [pin, setPin] = React.useState('');
+  const [pin, setPin] = useState('');
 
   return (
     <Validation>
@@ -163,11 +163,17 @@ function ActionButtons({
   };
 }) {
   return (
-    <Flex justifyContent="flex-end" mt={4}>
+    <Flex justifyContent="flex-start" mt={4}>
+      {/*
+        Generally, every other modal in the app with a "Cancel" button has the button to the right
+        of the button like "Next".
+
+        However, when using a hardware key with a PIN, the user goes through a series of steps where
+        the "Cancel" key is always present. The "Next" button is present only when entering the PIN,
+        so it makes sense to show it to the right of the "Cancel" button.
+      */}
       <ButtonSecondary
         type="button"
-        width={80}
-        size="small"
         onClick={onCancel}
         mr={nextButton.isVisible ? 3 : 0}
       >
@@ -176,12 +182,7 @@ function ActionButtons({
       {/* The caller of this component needs to handle wrapping
       this in a <form> element to handle `onSubmit` event on enter key*/}
       {nextButton.isVisible && (
-        <ButtonPrimary
-          type="submit"
-          width={80}
-          size="small"
-          disabled={nextButton.isDisabled}
-        >
+        <ButtonPrimary type="submit" disabled={nextButton.isDisabled}>
           Next
         </ButtonPrimary>
       )}


### PR DESCRIPTION
These two modals were outliers in terms of how the buttons looked like there. This PR makes it so they look like buttons in all the other modals that we have in the app.

| Before | After |
| --- | --- |
| ![image](https://github.com/gravitational/teleport/assets/27113/23a0ae5c-0ab3-4fc7-a7d8-c41fc9b34464) | ![image](https://github.com/gravitational/teleport/assets/27113/03b9f286-fdd0-4af2-99fc-43301b12965a) |
| ![image](https://github.com/gravitational/teleport/assets/27113/40f1c2f1-32f0-4319-8ca5-256e99dcb5ab) | ![image](https://github.com/gravitational/teleport/assets/27113/20a2defa-7734-40ef-93e2-e0f21e9c4ff2) |