### PR TITLE
AWS OIDC DeployDatabaseServices - implement AutoUpgrades

### DIFF
--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -20,12 +20,18 @@ package awsoidc
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	awsV1Http "github.com/aws/smithy-go/transport/http"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -171,17 +177,23 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 }
 
 type mockDeployServiceClient struct {
+	mu              sync.RWMutex
 	clusters        map[string]*ecsTypes.Cluster
 	taskDefinitions map[string]*ecsTypes.TaskDefinition
 	services        map[string]*ecsTypes.Service
 
 	accountId       *string
 	iamTokenMissing bool
+
+	iamAccessDeniedListServices bool
+	defaultTags                 AWSTags
 }
 
 // DescribeClusters lists ECS Clusters.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeClusters
 func (m *mockDeployServiceClient) DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	ret := []ecsTypes.Cluster{}
 
 	if cluster, found := m.clusters[params.Clusters[0]]; found {
@@ -196,6 +208,8 @@ func (m *mockDeployServiceClient) DescribeClusters(ctx context.Context, params *
 // CreateCluster creates a new cluster.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.CreateCluster
 func (m *mockDeployServiceClient) CreateCluster(ctx context.Context, params *ecs.CreateClusterInput, optFns ...func(*ecs.Options)) (*ecs.CreateClusterOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	cluster := &ecs.CreateClusterOutput{
 		Cluster: &ecsTypes.Cluster{
 			Status:      aws.String("ACTIVE"),
@@ -210,6 +224,8 @@ func (m *mockDeployServiceClient) CreateCluster(ctx context.Context, params *ecs
 // PutClusterCapacityProviders sets the Capacity Providers available for services in a given cluster.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.PutClusterCapacityProviders
 func (m *mockDeployServiceClient) PutClusterCapacityProviders(ctx context.Context, params *ecs.PutClusterCapacityProvidersInput, optFns ...func(*ecs.Options)) (*ecs.PutClusterCapacityProvidersOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return &ecs.PutClusterCapacityProvidersOutput{
 		Cluster: &ecsTypes.Cluster{
 			Status:      aws.String("ACTIVE"),
@@ -222,10 +238,14 @@ func (m *mockDeployServiceClient) PutClusterCapacityProviders(ctx context.Contex
 // DescribeServices lists the matching Services of a given Cluster.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeServices
 func (m *mockDeployServiceClient) DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	ret := []ecsTypes.Service{}
 
-	if service, found := m.services[params.Services[0]]; found {
-		ret = append(ret, *service)
+	for _, serviceName := range params.Services {
+		if service, found := m.services[serviceName]; found {
+			ret = append(ret, *service)
+		}
 	}
 
 	return &ecs.DescribeServicesOutput{
@@ -236,16 +256,48 @@ func (m *mockDeployServiceClient) DescribeServices(ctx context.Context, params *
 // ListServices returns a list of services. You can filter the results by cluster, launch type,
 // and scheduling strategy.
 func (m *mockDeployServiceClient) ListServices(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
-	return nil, nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.iamAccessDeniedListServices {
+		return nil, &awshttp.ResponseError{
+			ResponseError: &awsV1Http.ResponseError{
+				Response: &awsV1Http.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+					},
+				},
+				Err: fmt.Errorf("AccessDeniedException"),
+			},
+			RequestID: uuid.NewString(),
+		}
+	}
+
+	ret := []string{}
+
+	for _, service := range m.services {
+		if aws.ToString(service.ClusterArn) == aws.ToString(params.Cluster) {
+			ret = append(ret, aws.ToString(service.ServiceArn))
+		}
+	}
+
+	return &ecs.ListServicesOutput{
+		ServiceArns: ret,
+	}, nil
 }
 
 // UpdateService updates the service.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.UpdateService
 func (m *mockDeployServiceClient) UpdateService(ctx context.Context, params *ecs.UpdateServiceInput, optFns ...func(*ecs.Options)) (*ecs.UpdateServiceOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	ret := &ecsTypes.Service{
 		ServiceName:          params.Service,
 		ServiceArn:           aws.String("ARN" + aws.ToString(params.Service)),
 		NetworkConfiguration: params.NetworkConfiguration,
+		Status:               aws.String("ACTIVE"),
+		Deployments:          []ecsTypes.Deployment{{}},
+		DesiredCount:         1,
+		RunningCount:         1,
 	}
 	m.services[aws.ToString(params.Service)] = ret
 
@@ -257,6 +309,8 @@ func (m *mockDeployServiceClient) UpdateService(ctx context.Context, params *ecs
 // CreateService starts a task within a cluster.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.CreateService
 func (m *mockDeployServiceClient) CreateService(ctx context.Context, params *ecs.CreateServiceInput, optFns ...func(*ecs.Options)) (*ecs.CreateServiceOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	service := &ecs.CreateServiceOutput{
 		Service: &ecsTypes.Service{
 			ServiceName:          params.ServiceName,
@@ -272,12 +326,24 @@ func (m *mockDeployServiceClient) CreateService(ctx context.Context, params *ecs
 // DescribeTaskDefinition describes the task definition.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.DescribeTaskDefinition
 func (m *mockDeployServiceClient) DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
-	return nil, nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, taskDef := range m.taskDefinitions {
+		if aws.ToString(taskDef.Family) == aws.ToString(params.TaskDefinition) {
+			return &ecs.DescribeTaskDefinitionOutput{
+				TaskDefinition: taskDef,
+				Tags:           m.defaultTags.ToECSTags(),
+			}, nil
+		}
+	}
+	return nil, trace.NotFound("not found")
 }
 
 // RegisterTaskDefinition registers a new task definition from the supplied family and containerDefinitions.
 // https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.27.1#Client.RegisterTaskDefinition
 func (m *mockDeployServiceClient) RegisterTaskDefinition(ctx context.Context, params *ecs.RegisterTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.RegisterTaskDefinitionOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	taskDef := &ecs.RegisterTaskDefinitionOutput{
 		TaskDefinition: &ecsTypes.TaskDefinition{
 			TaskDefinitionArn:    aws.String("arn-for-task-definition==" + aws.ToString(params.Family)),

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -19,13 +19,16 @@
 package awsoidc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -139,4 +142,237 @@ func TestGenerateTaskDefinitionWithImage(t *testing.T) {
 	input, err := generateTaskDefinitionWithImage(taskDefinition, "image-v2", tags)
 	require.NoError(t, err)
 	require.Equal(t, expected, input)
+}
+
+func TestUpdateDeployServices(t *testing.T) {
+	ctx := context.Background()
+
+	clusterName := "my-cluster"
+	integrationName := "my-integration"
+	ownershipTags := defaultResourceCreationTags(clusterName, integrationName)
+	teleportVersion := teleport.Version
+	log := logrus.WithField("test", t.Name())
+
+	t.Run("only legacy service present", func(t *testing.T) {
+		m := &mockDeployServiceClient{
+			defaultTags: ownershipTags,
+			services: map[string]*ecsTypes.Service{
+				"my-cluster-teleport-database-service": {
+					ServiceName:    aws.String("my-cluster-teleport-database-service"),
+					ServiceArn:     aws.String("my-cluster-teleport-database-service"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+				},
+			},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{
+				"my-cluster-teleport-database-service": {
+					Family: aws.String("my-cluster-teleport-database-service"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+			},
+		}
+
+		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportClusterName: clusterName,
+			TeleportVersionTag:  teleportVersion,
+			OwnershipTags:       ownershipTags,
+		})
+		require.NoError(t, err)
+		newTaskDefinitionImage := aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+	})
+
+	t.Run("only legacy service present, and lacks permission to ecs:ListServices", func(t *testing.T) {
+		m := &mockDeployServiceClient{
+			defaultTags: ownershipTags,
+			services: map[string]*ecsTypes.Service{
+				"my-cluster-teleport-database-service": {
+					ServiceName:    aws.String("my-cluster-teleport-database-service"),
+					ServiceArn:     aws.String("my-cluster-teleport-database-service"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+				},
+			},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{
+				"my-cluster-teleport-database-service": {
+					Family: aws.String("my-cluster-teleport-database-service"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+			},
+			iamAccessDeniedListServices: true,
+		}
+
+		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportClusterName: clusterName,
+			TeleportVersionTag:  teleportVersion,
+			OwnershipTags:       ownershipTags,
+		})
+		require.NoError(t, err)
+		newTaskDefinitionImage := aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+	})
+
+	t.Run("only new services present", func(t *testing.T) {
+		ctx, cancelFn := context.WithCancel(ctx)
+		defer cancelFn()
+		m := &mockDeployServiceClient{
+			defaultTags: ownershipTags,
+			services: map[string]*ecsTypes.Service{
+				"database-service-vpc-123": {
+					ServiceName:    aws.String("database-service-vpc-123"),
+					ServiceArn:     aws.String("database-service-vpc-123"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service-vpc-123"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+					Deployments:    []ecsTypes.Deployment{{}},
+					DesiredCount:   1,
+					RunningCount:   1,
+				},
+				"database-service-vpc-345": {
+					ServiceName:    aws.String("database-service-vpc-345"),
+					ServiceArn:     aws.String("database-service-vpc-345"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service-vpc-345"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+					Deployments:    []ecsTypes.Deployment{{}},
+					DesiredCount:   1,
+					RunningCount:   1,
+				},
+			},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{
+				"my-cluster-teleport-database-service-vpc-123": {
+					Family: aws.String("my-cluster-teleport-database-service-vpc-123"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+				"my-cluster-teleport-database-service-vpc-345": {
+					Family: aws.String("my-cluster-teleport-database-service-vpc-345"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+			},
+		}
+
+		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportClusterName: clusterName,
+			TeleportVersionTag:  teleportVersion,
+			OwnershipTags:       ownershipTags,
+		})
+		require.NoError(t, err)
+
+		newTaskDefinitionImage := aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service-vpc-123"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+
+		newTaskDefinitionImage = aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service-vpc-345"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+	})
+
+	t.Run("new services and old service", func(t *testing.T) {
+		m := &mockDeployServiceClient{
+			defaultTags: ownershipTags,
+			services: map[string]*ecsTypes.Service{
+				"my-cluster-teleport-database-service": {
+					ServiceName:    aws.String("my-cluster-teleport-database-service"),
+					ServiceArn:     aws.String("my-cluster-teleport-database-service"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+				},
+				"database-service-vpc-123": {
+					ServiceName:    aws.String("database-service-vpc-123"),
+					ServiceArn:     aws.String("database-service-vpc-123"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service-vpc-123"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+				},
+				"database-service-vpc-345": {
+					ServiceName:    aws.String("database-service-vpc-345"),
+					ServiceArn:     aws.String("database-service-vpc-345"),
+					TaskDefinition: aws.String("my-cluster-teleport-database-service-vpc-345"),
+					ClusterArn:     aws.String("my-cluster-teleport"),
+					LaunchType:     ecsTypes.LaunchTypeFargate,
+					Tags:           ownershipTags.ToECSTags(),
+					Status:         aws.String("ACTIVE"),
+				},
+			},
+			taskDefinitions: map[string]*ecsTypes.TaskDefinition{
+				"my-cluster-teleport-database-service-vpc-123": {
+					Family: aws.String("my-cluster-teleport-database-service-vpc-123"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+				"my-cluster-teleport-database-service-vpc-345": {
+					Family: aws.String("my-cluster-teleport-database-service-vpc-345"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+				"my-cluster-teleport-database-service": {
+					Family: aws.String("my-cluster-teleport-database-service"),
+					ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+						Image: aws.String("myteleport-image:1.2.3"),
+					}},
+				},
+			},
+		}
+
+		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportClusterName: clusterName,
+			TeleportVersionTag:  teleportVersion,
+			OwnershipTags:       ownershipTags,
+		})
+		require.NoError(t, err)
+
+		newTaskDefinitionImage := aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+
+		newTaskDefinitionImage = aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service-vpc-123"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+
+		newTaskDefinitionImage = aws.ToString(m.taskDefinitions["my-cluster-teleport-database-service-vpc-345"].ContainerDefinitions[0].Image)
+		require.Contains(t, newTaskDefinitionImage, teleportVersion)
+		require.Contains(t, newTaskDefinitionImage, "public.ecr.aws/gravitational/teleport")
+	})
+
+	t.Run("no services running", func(t *testing.T) {
+		m := &mockDeployServiceClient{}
+
+		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportClusterName: clusterName,
+			TeleportVersionTag:  teleportVersion,
+			OwnershipTags:       ownershipTags,
+		})
+		require.NoError(t, err)
+
+		require.Empty(t, m.clusters)
+		require.Empty(t, m.services)
+		require.Empty(t, m.taskDefinitions)
+	})
 }

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -323,7 +323,7 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx conte
 	}()
 
 	updater.Log.Debugf("Updating AWS OIDC Deploy Service for integration %s in AWS region: %s", integration.GetName(), awsRegion)
-	if err := awsoidc.UpdateDeployService(ctx, awsOIDCDeployServiceClient, awsoidc.UpdateServiceRequest{
+	if err := awsoidc.UpdateDeployService(ctx, awsOIDCDeployServiceClient, updater.Log, awsoidc.UpdateServiceRequest{
 		TeleportClusterName: updater.TeleportClusterName,
 		TeleportVersionTag:  teleportVersion,
 		OwnershipTags:       ownershipTags,


### PR DESCRIPTION
The new DeployService adds some non-determenistic logic with regards to the deployed ECS Services.

Instead of looking for a specific ECS Service, we now iterate over all the ECS Services of a well-known ECS Cluster (same as before) and update the container image (as long as the tags are the Teleport ones).

Not everyone will have the new set of permissions which are created when using the new flow.
For those situations, we keep the old behaviour where we know the exact ECS Service name.

Demo

Previous version
![image](https://github.com/gravitational/teleport/assets/689271/e7526479-144f-40ab-80ec-d3bf5af39e7f)
With a custom version
![image](https://github.com/gravitational/teleport/assets/689271/a8d386f0-f67c-43c6-8e35-d292e3b6a3c1)

After running auto upgrade job
![image](https://github.com/gravitational/teleport/assets/689271/02c806f7-c3ce-4c71-ab04-2d0282b778f0)

<img width="1681" alt="image" src="https://github.com/gravitational/teleport/assets/689271/c805bbdb-259e-472d-9c78-8d995940e083">
