### PR TITLE
Improve the tsh prompt re: access list reviews

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4254,10 +4254,15 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 
 	if len(accessListsToReview) > 0 {
 		fmt.Printf("Access lists that need to be reviewed:\n")
-		now := time.Now()
-
 		for _, accessList := range accessListsToReview {
-			fmt.Printf("\t%s (%s left to review)\n", accessList.GetName(), accessList.Spec.Audit.NextAuditDate.Sub(now).Round(time.Second).String())
+			d := time.Until(accessList.Spec.Audit.NextAuditDate).Round(time.Minute)
+			var msg string
+			if d > 0 {
+				msg = fmt.Sprintf("%v left to review", d.String())
+			} else {
+				msg = fmt.Sprintf("review was required %v ago", (-d).String())
+			}
+			fmt.Printf("\t%s (%v)\n", accessList.Spec.Title, msg)
 		}
 		fmt.Println()
 	}


### PR DESCRIPTION
- Show the access list title instead of an arbitrary GUID
- Improve formatting for lists whose "next review" date is in the past

Closes #35427

changelog: Improve the formatting of access list notifications in tsh.