### PR TITLE
Remove notes that the default cap is blank

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -82,8 +82,6 @@ Obtain your existing `cluster_auth_preference` resource:
 $ tctl get cap > cap.yaml
 ```
 
-If you have not defined a `cluster_auth_preference`, `cap.yaml` will be blank.
-
 Ensure that `cap.yaml` contains the following content:
 
 ```yaml
@@ -112,8 +110,6 @@ Obtain your existing `cluster_auth_preference` resource:
 ```code
 $ tctl get cap > cap.yaml
 ```
-
-If you have not defined a `cluster_auth_preference`, `cap.yaml` will be blank.
 
 Ensure that `cap.yaml` contains the following content:
 

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -42,8 +42,6 @@ Obtain your existing `cluster_auth_preference` resource:
 $ tctl get cap > cap.yaml
 ```
 
-If you have not defined a `cluster_auth_preference`, `cap.yaml` will be blank.
-
 In `cap.yaml`, ensure that the value of `spec.second_factor` is `otp`,
 `webauthn`, or `on`:
 

--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -58,8 +58,6 @@ Obtain your existing `cluster_auth_preference` resource:
 $ tctl get cap > cap.yaml
 ```
 
-If you have not defined a `cluster_auth_preference`, `cap.yaml` will be blank.
-
 Ensure that `cap.yaml` includes the following content:
 
 ```yaml
@@ -96,8 +94,6 @@ Obtain your existing `cluster_auth_preference` resource:
 ```code
 $ tctl get cap > cap.yaml
 ```
-
-If you have not defined a `cluster_auth_preference`, `cap.yaml` will be blank.
 
 Ensure that `cap.yaml` includes the following content:
 


### PR DESCRIPTION
Closes #20993

This is inaccurate, as there are default `cap` values.