### PR TITLE
Replace "2FA" with "MFA" (and similar)

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -13,7 +13,7 @@ By default, `tsh`, Teleport Connect, and other Teleport clients store a user's k
 on their filesystem. If a user's filesystem is compromised, any of their active Teleport user keys and certificates
 would also be compromised.
 
-You can configure [per-session MFA](per-session-mfa.mdx) to require a second factor authentication check 
+You can configure [per-session MFA](per-session-mfa.mdx) to require a multi-factor authentication check 
 when users start new sessions with Teleport services, such as the SSH Service, Kubernetes Service, Database Service, and so on. 
 However, per-session MFA doesn't prevent compromised session credentials from taking other actions, such as 
 running administrative commands with `tctl`. 

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -700,7 +700,7 @@ NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users c
 
 </Tabs>
 
-Load the user creation link to create a password and set up 2-factor authentication for the Teleport user via the web UI.
+Load the user creation link to create a password and set up multi-factor authentication for the Teleport user via the web UI.
 
 ### High Availability
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/azure.mdx
@@ -282,7 +282,7 @@ NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users c
 </TabItem>
 </Tabs>
 
-Load the user creation link to create a password and set up 2-factor authentication for the Teleport user via the web UI.
+Load the user creation link to create a password and set up multi-factor authentication for the Teleport user via the web UI.
 
 ### High Availability
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -251,7 +251,7 @@ configured public address (specified using `public_addr` in your configuration)
 You must configure DNS properly using the methods described above for production workloads.
 </Admonition>
 
-Load the user creation link to create a password and set up 2-factor
+Load the user creation link to create a password and set up multi-factor
 authentication for the Teleport user via the web UI.
 
 ## Uninstalling the Helm chart

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -152,7 +152,7 @@ Copy the link shown after executing the above command and open the link in a web
   ![Set up user](../../../img/helm/digitalocean/setup-user.png)
 </Figure>
 
-After you complete the registration process by setting up a password and enrolling in two-factor authentication, you will be logged in to Teleport Web UI. 
+After you complete the registration process by setting up a password and enrolling in multi-factor authentication, you will be logged in to Teleport Web UI. 
 
 In this step, we created a user **tadmin** with roles `access, edit`. These are the default roles available in Teleport. However, to allow this user to access the Kubernetes cluster, we will need to assign **tadmin** a role authorized to access the Kubernetes cluster. So first, let's create a role named **member** with the Kubernetes privilege `system:master`.
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -442,7 +442,7 @@ NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users c
 
 </Tabs>
 
-Load the user creation link to create a password and set up 2-factor authentication for the Teleport user via the web UI.
+Load the user creation link to create a password and set up multi-factor authentication for the Teleport user via the web UI.
 
 ### High Availability
 

--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -2,7 +2,7 @@
 - [Role Templates](../access-controls/guides/role-templates.mdx): Set up Dynamic Access Policies with Role Templates.
 - [Impersonating Teleport Users](../access-controls/guides/impersonation.mdx): Create certificates for CI/CD with impersonation.
 - [Passwordless](../access-controls/guides/passwordless.mdx): Use passwordless authentication.
-- [Second Factor: WebAuthn](../access-controls/guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
+- [Multi-Factor: WebAuthn](../access-controls/guides/webauthn.mdx): Add multi-factor authentication through WebAuthn.
 - [Per-Session MFA](../access-controls/guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
 - [Locking](../access-controls/guides/locking.mdx): Lock access to active user sessions or hosts.
 - [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -71,7 +71,7 @@ Labs](https://goteleport.com/labs).
   Marketplace](https://marketplace.digitalocean.com/apps/teleport). Once your
   droplet is ready, SSH into the droplet and follow the configuration wizard.
 
-- A two-factor authenticator app such as [Authy](https://authy.com/download/),
+- A multi-factor authenticator app such as [Authy](https://authy.com/download/),
   [Google Authenticator](https://www.google.com/landing/2step/), or
   [1Password](https://support.1password.com/one-time-passwords/).
 
@@ -121,7 +121,7 @@ following:
 
 ![Teleport Welcome Screen](../img/quickstart/welcome.png)
 
-### Step 3/4. Create a Teleport user and set up two-factor authentication
+### Step 3/4. Create a Teleport user and set up multi-factor authentication
 
 In this step, we'll create a new Teleport user, `teleport-admin`, which is
 allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
@@ -163,8 +163,8 @@ Visit the provided URL in order to create your Teleport user.
 
 </Admonition>
 
-Teleport enforces the use of two-factor authentication by default. It supports
-one-time passwords (OTP) and second-factor authenticators (WebAuthn). In this
+Teleport enforces the use of multi-factor authentication by default. It supports
+one-time passwords (OTP) and multi-factor authenticators (WebAuthn). In this
 guide, you will need to enroll an OTP authenticator application using the QR
 code on the Teleport welcome screen.
 

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -58,7 +58,7 @@ NOTE: Make sure <proxy_host>:443 points at a Teleport proxy which users can acce
 ```
 
 The user completes registration by visiting this URL in their web browser,
-picking a password, and configuring second-factor authentication. If the
+picking a password, and configuring multi-factor authentication. If the
 credentials are correct, the Teleport Auth Server generates and signs a new
 certificate, and the client stores this key and will use it for subsequent
 logins. 

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -175,7 +175,7 @@ metadata:
 spec:
   # Sets the type of second factor to use.
   # Possible values: "on", "off", "otp", "webauthn" and "optional".
-  # If "on" is set, all 2FA protocols are supported.
+  # If "on" is set, all MFA protocols are supported.
   second_factor: "otp"
 
   # The name of the OIDC or SAML connector. if this is not set, the first connector in the backend is used.

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -148,7 +148,7 @@ $ tctl users add myuser --roles=editor,access --logins=root,ubuntu,ec2-user
 ```
 
 This will generate an initial login link where you can create a password and set
-up two-factor authentication for `myuser`.
+up multi-factor authentication for `myuser`.
 
 <Admonition type="note" title="Note">
 We've only given `myuser` the roles `editor` and `access` according to the

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -13,7 +13,7 @@ Teleport server access is designed for the following kinds of scenarios:
 - When up to a vast number of clusters must be managed using the command-line (`tsh`) or programmatically (through the Teleport API) and you want to simplify your stack, security, and configuration complexity.
 - When security team members must track and audit every user session. 
 - When Teleport users require a complete, dedicated, and secure SSH option (Teleport Node running in SSH mode) and more than a certificate authority (Teleport Auth) with proxy (Teleport Proxy).
-- When resource and network security must be maximized: SSH certificates over secret keys, Two-Factor Authentication (2FA), Single Sign-On (SSO), and short-lived certificates.
+- When resource and network security must be maximized: SSH certificates over secret keys, multi-factor authentication (MFA), Single Sign-On (SSO), and short-lived certificates.
 
 ## Getting started
 


### PR DESCRIPTION
This maintains consistency with Teleport's brand messaging.

This PR fulfills a request from @xinding33.