### PR TITLE
[v14] Temporarily rollback role version to v6 in kubernetes related docs.

### DIFF
--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -389,13 +389,13 @@ label:
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
       'env': 'staging'
     kubernetes_resources:
-      - kind: '*'
+      - kind: 'pod'
         namespace: '*'
         name: '*'
   deny: {}
@@ -413,7 +413,7 @@ namespace, and all pods in the `dev` namespace:
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -212,7 +212,7 @@ Save this role as `interns.yaml`:
 
 ```yaml
 kind: role
-version: v7
+version: v6
 metadata:
   name: interns
 spec:
@@ -228,10 +228,9 @@ spec:
     kubernetes_labels:
       'env': 'dev'
     kubernetes_resources:
-      - kind: *
+      - kind: 'pod'
         namespace: "*"
         name: "*"
-        verbs: ["*"]
     app_labels:
       'type': ['monitoring']
   # The deny rules always override allow rules.
@@ -243,8 +242,9 @@ spec:
     kubernetes_labels:
       'env': 'prod'
     kubernetes_resources:
-      - kind: "namespace"
-        name: "prod"
+      - kind: 'pod'
+        namespace: 'prod'
+        name: '*'
     db_labels:
       'env': 'prod'
     app_labels:

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -52,7 +52,7 @@ with the `auditor` role and the `moderator` mode present to start SSH or Kuberne
 kind: role
 metadata:
   name: prod-access
-version: v7
+version: v6
 spec:
   allow:
     require_session_join:
@@ -73,10 +73,9 @@ spec:
     kubernetes_users:
     - USER
     kubernetes_resources:
-    - kind: '*'
+    - kind: 'pod'
       name: '*'
       namespace: '*'
-      verbs: ['*']
 ```
 
 Because this sample policy requires that at least one user with the `auditor` role to be present

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -34,7 +34,7 @@ We can create two roles, one for each user in file `roles.yaml`:
 
 ```yaml
 kind: role
-version: v7
+version: v6
 metadata:
   name: alice
 spec:
@@ -46,10 +46,9 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: '*'
+      - kind: 'pod'
         namespace: '*'
         name: '*'
-        verbs: ['*']
 ---
 kind: role
 version: v7

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -235,7 +235,7 @@ Create a file called `sync-kubernetes-rbac.yaml` with the following content:
 
 ```yaml
 kind: role
-version: v7
+version: v6
 metadata:
   name: sync-kubernetes-rbac
 spec:
@@ -864,7 +864,7 @@ spec:
       default: best_effort
       desktop: true
     ssh_file_copy: true
-version: v7
+version: v6
 ```
 
 Compare this with the `minikube-pod-reader-app` role, which you can retrieve
@@ -911,7 +911,7 @@ spec:
       default: best_effort
       desktop: true
     ssh_file_copy: true
-version: v7
+version: v6
 ```
 
 Since role bindings are namespaced, this role only allows access to pods in the

--- a/docs/pages/includes/kubernetes-access/member-role.mdx
+++ b/docs/pages/includes/kubernetes-access/member-role.mdx
@@ -1,6 +1,6 @@
 ```yaml
 kind: role
-version: v7
+version: v6
 metadata:
   name: member
 spec:
@@ -9,8 +9,7 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: '*'
+      - kind: 'pod'
         namespace: '*'
         name: '*'
-        verbs: ['*']
 ```

--- a/docs/pages/includes/kubernetes-access/rbac.mdx
+++ b/docs/pages/includes/kubernetes-access/rbac.mdx
@@ -18,16 +18,15 @@ Create a file called `kube-access.yaml` with the following content, replacing
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: '*'
+      - kind: 'pod'
         namespace: '*'
         name: '*'
-        verbs: ['*']
     kubernetes_groups:
     - viewers
     kubernetes_users:

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -36,7 +36,7 @@ clusters:
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -482,7 +482,7 @@ specific resources in a Kubernetes cluster:
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -491,7 +491,6 @@ spec:
       - kind: pod
         namespace: "production"
         name: "webapp"
-        verbs: ['*']
     # ...
 ```
 
@@ -655,7 +654,7 @@ Let's say you have assigned the following three roles to a user:
 kind: role
 metadata:
   name: allow-dev-us-east-2
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -673,7 +672,7 @@ spec:
 kind: role
 metadata:
   name: allow-exec
-  version: v7
+  version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -688,7 +687,7 @@ spec:
 kind: role
 metadata:
   name: deny-redis-exec
-  version: v7
+  version: v6
 spec:
   deny:
     kubernetes_resources:
@@ -740,7 +739,7 @@ registered Kubernetes clusters, but only run `kubectl exec` or `kubectl logs` on
 kind: role
 metadata:
   name: kube-viewer
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -755,7 +754,7 @@ spec:
 kind: role
 metadata:
   name: nginx-exec
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:
@@ -801,7 +800,7 @@ group. This group can only view pods in the `default` namespace:
 kind: role
 metadata:
   name: kube-access-1
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_groups:
@@ -820,7 +819,7 @@ only to the `webapp` pod in the `default` namespace:
 ```yaml
 metadata:
   name: kube-access-2
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_groups:
@@ -856,7 +855,7 @@ permissions, restricting the user to pods in the `default` namespace:
 kind: role
 metadata:
   name: kube-access-1
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_groups:

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -130,16 +130,15 @@ one Kubernetes group named `viewers` and one Kubernetes user.
    kind: role
    metadata:
      name: kube-access
-   version: v7
+   version: v6
    spec:
      allow:
        kubernetes_labels:
          '*': '*'
        kubernetes_resources:
-         - kind: '*'
+         - kind: 'pod'
            namespace: '*'
            name: '*'
-           verbs: ['*']
        kubernetes_groups:
        - viewers
        kubernetes_users:

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -314,7 +314,7 @@ Create a file called `kube-access.yaml` with the following content:
 kind: role
 metadata:
   name: kube-access
-version: v7
+version: v6
 spec:
   allow:
     kubernetes_labels:


### PR DESCRIPTION
Context: https://gravitational.slack.com/archives/C01UV6NKQTS/p1703085368390109

Cloud users trying to use Kubernetes guides from the Teleport docs now have problems because of V7->V6 roles downgrading and can't make Kube access to work. This PR changes docs so if user takes role definition from there it should work correctly for them, even if they have Teleport v13 agents.

We'll revert it after v7 roles work properly for the cloud clients again.