### PR TITLE
Write handler config

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -375,12 +375,12 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		h.assistantLimiter = rate.NewLimiter(rate.Inf, 0)
 	}
 
-	if automaticUpgrades(cfg.ClusterFeatures) && cfg.AutomaticUpgradesChannels == nil {
-		cfg.AutomaticUpgradesChannels = automaticupgrades.Channels{}
+	if automaticUpgrades(cfg.ClusterFeatures) && h.cfg.AutomaticUpgradesChannels == nil {
+		h.cfg.AutomaticUpgradesChannels = automaticupgrades.Channels{}
 	}
 
-	if cfg.AutomaticUpgradesChannels != nil {
-		err := cfg.AutomaticUpgradesChannels.CheckAndSetDefaults(cfg.ClusterFeatures)
+	if h.cfg.AutomaticUpgradesChannels != nil {
+		err := h.cfg.AutomaticUpgradesChannels.CheckAndSetDefaults(cfg.ClusterFeatures)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Small follow up to https://github.com/gravitational/teleport/pull/35342

Check and set handler config for default channels to be enabled.

To reproduce, create a proxy server without the `automatic_upgrades_channels` config. The default channels are not configured.