### PR TITLE
Update auto discovery doc to include self-hosted web UI flow

### DIFF
--- a/docs/pages/database-access/guides/aws-discovery.mdx
+++ b/docs/pages/database-access/guides/aws-discovery.mdx
@@ -29,6 +29,10 @@ $ tctl tokens add --type=discovery
 
 ## Step 2/4. Configure the Discovery service
 
+<Admonition type="note">
+  If you’re following auto-discovery setup in Access Management web UI, use the template generated from the web UI instead.
+</Admonition>
+
 Enabling AWS database discovery requires that the `discovery_service.aws`
 section includes at least one entry and that `discovery_service.aws.types`
 includes one of database types listed in the sample YAML below. 
@@ -84,6 +88,10 @@ Adjust the keys under `discovery_service.aws` to match your AWS databases.
 (!docs/pages/kubernetes-access/discovery/includes/discovery-group.mdx!)
 
 ## Step 3/4. Bootstrap IAM permissions
+
+<Admonition type="note">
+  If you’re following auto-discovery setup in Access Management web UI, skip this step.
+</Admonition>
 
 Create an IAM role and attach it to the host that will run the Discovery
 Service.


### PR DESCRIPTION
Adds little notes to the `aws auto discovery` doc if user came from the web UI: https://github.com/gravitational/teleport/pull/36027

changed in: https://docs-2dew2l61w-goteleport.vercel.app/docs/database-access/guides/aws-discovery/

screenshot:
<img width="943" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/a1956ead-f9df-4200-870e-1ce39a456e12">

<img width="957" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/ce1c47cc-68ce-49e8-9c44-5d96064b2066">


