### PR TITLE
docs: incorporate variables in instructions for AWS EKS deployment

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -149,7 +149,7 @@ You'll need to replace these values in the policy example below:
 
 | Placeholder value | Replace with |
 | - | - |
-| `Z0159221358P96JYAUAA4` | Route 53 hosted zone ID for the domain hosting your Teleport cluster |
+| <Var name="Z0159221358P96JYAUAA4" /> | Route 53 hosted zone ID for the domain hosting your Teleport cluster |
 
 ```json
 {
@@ -166,7 +166,7 @@ You'll need to replace these values in the policy example below:
                 "route53:ChangeResourceRecordSets",
                 "route53:ListResourceRecordSets"
             ],
-            "Resource": "arn:aws:route53:::hostedzone/Z0159221358P96JYAUAA4"
+            "Resource": "arn:aws:route53:::hostedzone/<Var name="Z0159221358P96JYAUAA4" />"
         }
     ]
 }
@@ -193,10 +193,10 @@ You'll need to replace these values in the `Issuer` example below:
 
 | Placeholder value | Replace with |
 | - | - |
-| `email@address.com` | An email address to receive communications from Let's Encrypt |
-| `example.com` | The name of the Route 53 domain hosting your Teleport cluster |
-| `us-east-1` | AWS region where the cluster is running |
-| `Z0159221358P96JYAUAA4` | Route 53 hosted zone ID for the domain hosting your Teleport cluster |
+| <Var name="email@address.com" description="Email for Let's Encrypt" /> | An email address to receive communications from Let's Encrypt |
+| <Var name="example.com" description="Route 53 Hosted Zone" /> | The name of the Route 53 domain hosting your Teleport cluster |
+| <Var name="us-west-2" description="AWS Region"/> | AWS region where the cluster is running |
+| <Var name="Z0159221358P96JYAUAA4" description="Route 53 hosted zone id"/> | Route 53 hosted zone ID for the domain hosting your Teleport cluster |
 
 ```yaml
 cat << EOF > aws-issuer.yaml
@@ -207,18 +207,18 @@ metadata:
   namespace: teleport
 spec:
   acme:
-    email: email@address.com                                # Change this
+    email: <Var name="email@address.com" />
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt-production
     solvers:
     - selector:
         dnsZones:
-          - "example.com"                                  # Change this
+          - "<Var name="example.com" />"
       dns01:
         route53:
-          region: us-east-1                                # Change this
-          hostedZoneID: Z0159221358P96JYAUAA4              # Change this
+          region: <Var name="us-west-2" />
+          hostedZoneID: <Var name="Z0159221358P96JYAUAA4" />
 EOF
 ```
 
@@ -262,7 +262,7 @@ To use ACM to handle TLS, we will add annotations to the chart values in the sec
 the ACM certificate ARN to use, the port it should be served on and other ALB configuration
 parameters.
 
-Replace `arn:aws:acm:us-east-1:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece`
+Replace <Var name="arn:aws:acm:us-west-2:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"/>
 with your actual ACM certificate ARN.
 
 </TabItem>
@@ -318,14 +318,14 @@ a file called `aws-values.yaml` and write the values you've chosen above to it:
 <TabItem label="cert-manager">
 ```yaml
 chartMode: aws
-clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
 proxyListenerMode: multiplex
 aws:
-  region: us-west-2                               # AWS region
-  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
-  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  region: <Var name="us-west-2" />                # AWS region
+  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
+  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
   auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
   backups: true                                   # Whether or not to turn on DynamoDB backups
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:
@@ -350,16 +350,16 @@ with `tls.existingCASecretName` in the values file.
 <TabItem label="AWS Certificate Manager">
 ```yaml
 chartMode: aws
-clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
 proxyListenerMode: multiplex
 service:
   type: ClusterIP
 aws:
-  region: us-west-2                               # AWS region
-  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
-  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  region: <Var name="us-west-2" />                # AWS region
+  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
+  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
   auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
   backups: true                                   # Whether or not to turn on DynamoDB backups
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:
@@ -377,7 +377,7 @@ annotations:
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
     alb.ingress.kubernetes.io/success-codes: 200,301,302
     # Replace with your AWS certificate ARN
-    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"
+    alb.ingress.kubernetes.io/certificate-arn: "<Var name="arn:aws:acm:us-west-2:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"/>"
 # If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
 podSecurityPolicy:
   enabled: false
@@ -407,14 +407,14 @@ can also optionally provide these two values under `annotations.ingress`:
 <TabItem label="cert-manager">
 ```yaml
 chartMode: aws
-clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
 proxyListenerMode: multiplex
 aws:
-  region: us-west-2                               # AWS region
-  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
-  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  region: <Var name="us-west-2" />                # AWS region
+  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
+  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
   auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
   backups: true                                   # Whether or not to turn on DynamoDB backups
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:
@@ -440,16 +440,16 @@ with `tls.existingCASecretName` in the values file.
 <TabItem label="AWS Certificate Manager">
 ```yaml
 chartMode: aws
-clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
 proxyListenerMode: multiplex
 service:
   type: ClusterIP
 aws:
-  region: us-west-2                               # AWS region
-  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
-  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  region: <Var name="us-west-2" />                # AWS region
+  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
+  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
   auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings 
   backups: true                                   # Whether or not to turn on DynamoDB backups
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:
@@ -468,7 +468,7 @@ annotations:
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
     alb.ingress.kubernetes.io/success-codes: 200,301,302
     # Replace with your AWS certificate ARN
-    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"
+    alb.ingress.kubernetes.io/certificate-arn: "<Var name="arn:aws:acm:us-west-2:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"/>"
 # If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
 podSecurityPolicy:
   enabled: false
@@ -554,9 +554,9 @@ $ NAMESPACE='<Var name="namespace" />'
 $ RELEASE_NAME='<Var name="release-name" />'
 
 # DNS settings (change as necessary)
-$ MYZONE_DNS='example.com'
-$ MYDNS='teleport.example.com'
-$ MY_CLUSTER_REGION='us-west-2'
+$ MYZONE_DNS='<Var name="example.com"/>'
+$ MYDNS='<Var name="teleport.example.com"/>'
+$ MY_CLUSTER_REGION='<Var name="us-west-2"/>'
 
 # Find AWS Zone ID and ELB Zone ID
 $ MYZONE="$(aws route53 list-hosted-zones-by-name --dns-name="${MYZONE_DNS?}" | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)"
@@ -615,9 +615,9 @@ $ NAMESPACE='<Var name="namespace" />'
 $ RELEASE_NAME='<Var name="release-name" />'
 
 # DNS settings (change as necessary)
-$ MYZONE_DNS='example.com'
-$ MYDNS='teleport.example.com'
-$ MY_CLUSTER_REGION='us-west-2'
+$ MYZONE_DNS='<Var name="example.com"/>'
+$ MYDNS='<Var name="teleport.example.com"/>'
+$ MY_CLUSTER_REGION='<Var name="us-west-2"/>'
 
 # Find AWS Zone ID and Ingress Controller ALB Zone ID
 $ MYZONE="$(aws route53 list-hosted-zones-by-name --dns-name="${MYZONE_DNS?}" | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)"

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -60,10 +60,10 @@ You'll need to replace these values in the policy example below:
 
 | Placeholder value       | Replace with                                                                                       |
 |-------------------------|----------------------------------------------------------------------------------------------------|
-| `us-west-2`             | AWS region                                                                                         |
-| `1234567890`            | AWS account ID                                                                                     |
-| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend                                                |
-| `teleport-helm-events`  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
+| <Var name="us-west-2" description="AWS Region"/>             | AWS region                                                                                         |
+| <Var name="1234567890" description="AWS Account ID"/>            | AWS account ID                                                                                     |
+| <Var name="teleport-helm-backend" description="DynamoDB core Table name"/> | DynamoDB table name to use for the Teleport backend                                                |
+| <Var name="teleport-helm-events" description="DynamoDB events Table name" />  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
 
 ```json
 {
@@ -90,8 +90,8 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:UpdateContinuousBackups"
             ],
             "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend/stream/*"
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-backend" />",
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-backend" />/stream/*"
             ]
         },
         {
@@ -112,8 +112,8 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:UpdateContinuousBackups"
             ],
             "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events/index/*"
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-events" />",
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-events" />/index/*"
             ]
         }
     ]
@@ -130,10 +130,10 @@ You'll need to replace these values in the policy example below:
 
 | Placeholder value       | Replace with                                                                                       |
 |-------------------------|----------------------------------------------------------------------------------------------------|
-| `us-west-2`             | AWS region                                                                                         |
-| `1234567890`            | AWS account ID                                                                                     |
-| `teleport-backend` | DynamoDB table name to use for the Teleport backend                                                |
-| `teleport-events`  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
+| <Var name="us-west-2" description="AWS Region"/>             | AWS region                                                                                         |
+| <Var name="1234567890" description="AWS Account ID"/>            | AWS account ID                                                                                     |
+| <Var name="teleport-helm-backend" description="DynamoDB core Table name"/> | DynamoDB table name to use for the Teleport backend                                                |
+| <Var name="teleport-helm-events" description="DynamoDB events Table name" />  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
 
 ```json
 {
@@ -161,8 +161,8 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:UpdateContinuousBackups"
             ],
             "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-backend",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-backend/stream/*"
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-backend" />",
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-backend" />/stream/*"
             ]
         },
         {
@@ -184,8 +184,8 @@ You'll need to replace these values in the policy example below:
                 "dynamodb:UpdateContinuousBackups"
             ],
             "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-events",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-events/index/*"
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-events" />",
+                "arn:aws:dynamodb:<Var name="us-west-2" />:<Var name="1234567890" />:table/<Var name="teleport-helm-events" />/index/*"
             ]
         }
     ]

--- a/docs/pages/includes/s3-iam-policy.mdx
+++ b/docs/pages/includes/s3-iam-policy.mdx
@@ -17,7 +17,7 @@ You'll need to replace these values in the policy example below:
 
 | Placeholder value | Replace with |
 | - | - |
-| `your-sessions-bucket` | Name to use for the Teleport S3 session recording bucket |
+| <Var name="your-sessions-bucket" description="AWS Sessions Bucket"/> | Name to use for the Teleport S3 session recording bucket |
 
 ```json
 {
@@ -33,7 +33,7 @@ You'll need to replace these values in the policy example below:
                 "s3:GetEncryptionConfiguration",
                 "s3:GetBucketVersioning"
             ],
-            "Resource": "arn:aws:s3:::your-sessions-bucket"
+            "Resource": "arn:aws:s3:::<Var name="your-sessions-bucket" description="AWS Sessions Bucket"/>"
         },
         {
             "Sid": "ObjectActions",
@@ -46,7 +46,7 @@ You'll need to replace these values in the policy example below:
                 "s3:ListMultipartUploadParts",
                 "s3:AbortMultipartUpload"
             ],
-            "Resource": "arn:aws:s3:::your-sessions-bucket/*"
+            "Resource": "arn:aws:s3:::<Var name="your-sessions-bucket" description="AWS Sessions Bucket"/>/*"
         }
     ]
 }
@@ -59,7 +59,7 @@ You'll need to replace these values in the policy example below:
 
 | Placeholder value | Replace with |
 | - | - |
-| `your-sessions-bucket` | Name to use for the Teleport S3 session recording bucket |
+| <Var name="your-sessions-bucket" description="AWS Sessions Bucket"/> | Name to use for the Teleport S3 session recording bucket |
 
 ```json
 {
@@ -78,7 +78,7 @@ You'll need to replace these values in the policy example below:
                 "s3:GetBucketVersioning",
                 "s3:CreateBucket"
             ],
-            "Resource": "arn:aws:s3:::your-sessions-bucket"
+            "Resource": "arn:aws:s3:::<Var name="your-sessions-bucket" description="AWS Sessions Bucket"/>"
         },
         {
             "Sid": "ObjectActions",
@@ -90,7 +90,7 @@ You'll need to replace these values in the policy example below:
                 "s3:ListMultipartUploadParts",
                 "s3:AbortMultipartUpload"
             ],
-            "Resource": "arn:aws:s3:::your-sessions-bucket/*"
+            "Resource": "arn:aws:s3:::<Var name="your-sessions-bucket" description="AWS Sessions Bucket"/>/*"
         }
     ]
 }


### PR DESCRIPTION
Adds variables to allow for easier use of configuration content. This makes for single edits of settings like AWS region. Also make more consistent to use `us-west-2` instead of mixing that and `us-east-1`.