### PR TITLE
Convert the generic backend service to work with all resource types

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -676,7 +676,10 @@ func FriendlyName(resource ResourceWithLabels) string {
 	return ""
 }
 
-// GetOrigin returns the origin if one can be obtained.
+// GetOrigin returns the value set for the [OriginLabel].
+// If the label is missing, an empty string is returned.
+//
+// Works for both [ResourceWithOrigin] and [ResourceMetadata] instances.
 func GetOrigin(v any) string {
 	switch r := v.(type) {
 	case ResourceWithOrigin:
@@ -692,7 +695,10 @@ func GetOrigin(v any) string {
 	return ""
 }
 
-// GetKind returns the kind if one can be obtained.
+// GetKind returns the kind, if one can be obtained, otherwise
+// an empty string is returned.
+//
+// Works for both [Resource] and [ResourceMetadata] instances.
 func GetKind(v any) string {
 	type kinder interface {
 		GetKind() string
@@ -703,4 +709,65 @@ func GetKind(v any) string {
 	}
 
 	return ""
+}
+
+// GetRevision returns the revision, if one can be obtained, otherwise
+// an empty string is returned.
+//
+// Works for both [Resource] and [ResourceMetadata] instances.
+func GetRevision(v any) string {
+	switch r := v.(type) {
+	case Resource:
+		return r.GetRevision()
+	case ResourceMetadata:
+		return r.GetMetadata().Revision
+	}
+
+	return ""
+}
+
+// SetRevision updates the revision if v supports the concept of revisions.
+//
+// Works for both [Resource] and [ResourceMetadata] instances.
+func SetRevision(v any, revision string) {
+	switch r := v.(type) {
+	case Resource:
+		r.SetRevision(revision)
+	case ResourceMetadata:
+		r.GetMetadata().Revision = revision
+	}
+}
+
+// GetExpiry returns the expiration, if one can be obtained, otherwise returns
+// an empty time.
+//
+// Works for both [Resource] and [ResourceMetadata] instances.
+func GetExpiry(v any) time.Time {
+	switch r := v.(type) {
+	case Resource:
+		return r.Expiry()
+	case ResourceMetadata:
+		return r.GetMetadata().Expires.AsTime()
+	}
+
+	return time.Time{}
+}
+
+// GetResourceID returns the id, if one can be obtained, otherwise returns
+// zero.
+//
+// Works for both [Resource] and [ResourceMetadata] instances.
+//
+// Deprecated: GetRevision should be used instead.
+func GetResourceID(v any) int64 {
+	switch r := v.(type) {
+	case Resource:
+		//nolint:staticcheck // SA1019. Added for backward compatibility.
+		return r.GetResourceID()
+	case ResourceMetadata:
+		//nolint:staticcheck // SA1019. Added for backward compatibility.
+		return r.GetMetadata().Id
+	}
+
+	return 0
 }

--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -19,8 +19,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -95,5 +98,83 @@ func TestResource153ToLegacy(t *testing.T) {
 		if diff := cmp.Diff(bot, bot2, protocmp.Transform()); diff != "" {
 			t.Errorf("Marshal/Unmarshal mismatch (-want +got)\n%s", diff)
 		}
+	})
+}
+
+func TestResourceMethods(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	expiry := clock.Now().UTC()
+
+	// user is an example of a legacy resource.
+	// Any other resource type would to.
+	user := &types.UserV2{
+		Kind: "user",
+		Metadata: types.Metadata{
+			Name:     "llama",
+			Expires:  &expiry,
+			ID:       1234,
+			Revision: "alpaca",
+			Labels: map[string]string{
+				types.OriginLabel: "earth",
+			},
+		},
+		Spec: types.UserSpecV2{
+			Roles: []string{"human", "camelidae"},
+		},
+	}
+
+	// bot is an example of an RFD 153 "compliant" resource.
+	// Any other resource type would do.
+	bot := &machineidv1.Bot{
+		Kind:    "bot",
+		SubKind: "robot",
+		Metadata: &headerv1.Metadata{
+			Name:     "Bernard",
+			Expires:  timestamppb.New(expiry),
+			Id:       4567,
+			Revision: "tinman",
+			Labels: map[string]string{
+				types.OriginLabel: "mars",
+			},
+		},
+		Spec: &machineidv1.BotSpec{
+			Roles: []string{"robot", "human"},
+		},
+	}
+
+	t.Run("GetExpiry", func(t *testing.T) {
+		require.Equal(t, expiry, types.GetExpiry(user))
+		require.Equal(t, expiry, types.GetExpiry(bot))
+	})
+
+	t.Run("GetResourceID", func(t *testing.T) {
+		//nolint:staticcheck // SA1019. Added for backward compatibility.
+		require.Equal(t, user.GetResourceID(), types.GetResourceID(user))
+		//nolint:staticcheck // SA1019. Added for backward compatibility.
+		require.Equal(t, bot.GetMetadata().Id, types.GetResourceID(bot))
+	})
+
+	t.Run("GetRevision", func(t *testing.T) {
+		require.Equal(t, user.GetRevision(), types.GetRevision(user))
+		require.Equal(t, bot.GetMetadata().Revision, types.GetRevision(bot))
+	})
+
+	t.Run("SetRevision", func(t *testing.T) {
+		rev := uuid.NewString()
+		types.SetRevision(bot, rev)
+		types.SetRevision(user, rev)
+
+		require.Equal(t, rev, types.GetRevision(user))
+		require.Equal(t, rev, types.GetRevision(bot))
+	})
+
+	t.Run("GetKind", func(t *testing.T) {
+		require.Equal(t, types.KindUser, types.GetKind(user))
+		require.Equal(t, types.KindBot, types.GetKind(bot))
+	})
+
+	t.Run("GetOrigin", func(t *testing.T) {
+		require.Equal(t, user.Origin(), types.GetOrigin(user))
+		require.Equal(t, "mars", types.GetOrigin(bot))
 	})
 }

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -297,36 +297,35 @@ func RangeEnd(key []byte) []byte {
 	return nextKey(key)
 }
 
-// NextPaginationKey returns the next pagination key.
-// For resources that have the HostID in their keys, the next key will also
-// have the HostID part.
-func NextPaginationKey(r types.Resource) string {
-	switch resourceWithType := r.(type) {
-	case types.DatabaseServer:
-		return string(nextKey(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName())))
-	case types.AppServer:
-		return string(nextKey(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName())))
-	case types.KubeServer:
-		return string(nextKey(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName())))
-	default:
-		return string(nextKey([]byte(r.GetName())))
-	}
+// HostID is a derivation of a KeyedItem that allows the host id
+// to be included in the key.
+type HostID interface {
+	KeyedItem
+	GetHostID() string
 }
 
-// GetPaginationKey returns the pagination key given resource.
-func GetPaginationKey(r types.Resource) string {
-	switch resourceWithType := r.(type) {
-	case types.DatabaseServer:
-		return string(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName()))
-	case types.AppServer:
-		return string(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName()))
-	case types.KubeServer:
-		return string(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName()))
-	case types.WindowsDesktop:
-		return string(internalKey(resourceWithType.GetHostID(), resourceWithType.GetName()))
-	default:
-		return r.GetName()
+// KeyedItem represents an item from which a pagination key can be derived.
+type KeyedItem interface {
+	GetName() string
+}
+
+// NextPaginationKey returns the next pagination key.
+// For items that implement HostID, the next key will also
+// have the HostID part.
+func NextPaginationKey(ki KeyedItem) string {
+	key := GetPaginationKey(ki)
+	return string(nextKey([]byte(key)))
+}
+
+// GetPaginationKey returns the pagination key given item.
+// For items that implement HostID, the next key will also
+// have the HostID part.
+func GetPaginationKey(ki KeyedItem) string {
+	if h, ok := ki.(HostID); ok {
+		return string(internalKey(h.GetHostID(), h.GetName()))
 	}
+
+	return ki.GetName()
 }
 
 // MaskKeyName masks the given key name.


### PR DESCRIPTION
Modifies the type constraint on the generic backend service so that it can be used with legacy and new resource variants. A few additional helper methods were added to types to pull resource information from the correct location depending on the resource type.