### PR TITLE
Tests: check DiscoveryFetch events before creating resource

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1930,9 +1930,9 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		require.Zero(t, reporter.DiscoveryFetchEventCount())
 		_, err = tlsServer.Auth().DiscoveryConfigClient().CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
-		require.Zero(t, reporter.DiscoveryFetchEventCount())
 
 		// Check for new resource in reconciler
 		expectDatabases := []types.Database{awsRDSDB}


### PR DESCRIPTION
After creating a DiscoveryConfig with valid matchers, the DiscoveryService will fetch Cloud Resources and emit a DiscoveryFetchEvent.

The test was asserting that the number of FetchEvents was zero right after creating the DiscoveryConfig, but it might happen that between the CreateDiscoveryConfig and reading the DiscoveryFetchEventCount, the DiscoveryConfig was processed, a new fetch was triggered and an event emitted.

This PR moves the check to before the CreateDiscoveryConfig call.