### PR TITLE
Fix data race in `TestManagedConn/Basic`

### DIFF
--- a/lib/resumption/managedconn.go
+++ b/lib/resumption/managedconn.go
@@ -43,7 +43,7 @@ const (
 // connections actually return ECONNRESET on the first syscall experiencing the
 // error, then EPIPE afterwards; we don't bother emulating that detail and
 // always return EPIPE instead.
-var errBrokenPipe = syscall.EPIPE
+var errBrokenPipe error = syscall.EPIPE
 
 func newManagedConn() *managedConn {
 	c := new(managedConn)


### PR DESCRIPTION
`CloseIdleConnections` will synchronously close all idle connections but the connection we wanted to get closed could've not transitioned to an idle state in the internals of the `http.Transport`. Instead, we set the idle timeout to the lowest possible value and then we wait until the connection gets closed.
