### PR TITLE
Use app names when creating user_group for UI

### DIFF
--- a/lib/web/user_groups.go
+++ b/lib/web/user_groups.go
@@ -62,7 +62,7 @@ func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params h
 
 	appServerLookup := make(map[string]types.AppServer, len(appServers))
 	for _, appServer := range appServers {
-		appServerLookup[appServer.GetName()] = appServer
+		appServerLookup[appServer.GetApp().GetName()] = appServer
 	}
 
 	userGroupsToApps := map[string]types.Apps{}


### PR DESCRIPTION
When fetching user_groups, we would try to create a list of applications to include with each user_group, but we were comparing the wrong names. User groups contain the "app name", but we were searching for the app by its app server name later on. This made every user group have an empty applications field. This field was never needed in the UI so no one noticed. This supports an upcoming `e` pr related to https://github.com/gravitational/teleport.e/issues/3031

@mdwn can you double check this to make sure I'm not incorrect here.  If you checkout this PR, you should be able to inspect the result of a `fetchUserGroups` api request and see applications included. Let me know

e buddy: https://github.com/gravitational/teleport.e/pull/3040