### PR TITLE
Use the cache for user login state.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -451,8 +451,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	// Add in a login hook for generating state during user login.
 	as.ulsGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         log,
-		AccessLists: services,
-		Access:      services,
+		AccessLists: &as,
+		Access:      &as,
 		UsageEvents: &as,
 		Clock:       cfg.Clock,
 	})


### PR DESCRIPTION
It was discovered that the user login state isn't being used for the user login state generator. This means that role lookups are not being cached, which is an unnecessary performance burden, and any potential further cache updates would not be used. This has been fixed.

changelog: The user login state generator now uses the cache, which should reduce the number of calls to the backend.