### PR TITLE
Add v15 breaking CHANGELOG note about deb/rpm repo retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ or use PAM.
 `deb.releases.teleport.dev` and `rpm.rleases.teleport.dev` were deprecated in
 Teleport 11. Beginning in Teleport 15, Debian and RPM packages will no longer be
 published to these repos. Teleport 14 and prior packages will continue to be
-published to these repos for the remaidner of those releases' lifecycles.
+published to these repos for the remainder of those releases' lifecycles.
 
 All users are recommended to switch to `apt.releases.teleport.dev` and
 `yum.releases.teleport.dev` repositories as described in installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ or use PAM.
 
 ##### Packages no longer published to legacy Debian and RPM repos
 
-`deb.releases.teleport.dev` and `rpm.relases.teleport.dev` were deprecated in
+`deb.releases.teleport.dev` and `rpm.releases.teleport.dev` were deprecated in
 Teleport 11. Beginning in Teleport 15, Debian and RPM packages will no longer be
 published to these repos. Teleport 14 and prior packages will continue to be
 published to these repos for the remainder of those releases' lifecycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ or use PAM.
 
 ##### Packages no longer published to legacy Debian and RPM repos
 
-`deb.releases.teleport.dev` and `rpm.rleases.teleport.dev` were deprecated in
+`deb.releases.teleport.dev` and `rpm.relases.teleport.dev` were deprecated in
 Teleport 11. Beginning in Teleport 15, Debian and RPM packages will no longer be
 published to these repos. Teleport 14 and prior packages will continue to be
-published to these repos for the remainder of those releases' lifecycles.
+published to these repos for the remainder of those releases' lifecycle.
 
 All users are recommended to switch to `apt.releases.teleport.dev` and
 `yum.releases.teleport.dev` repositories as described in installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ by `insecure-drop`, which still creates temporary users but does not create a
 home directory. Users who need home directory creation should either wrap `useradd`/`userdel`
 or use PAM.
 
+##### Packages no longer published to legacy Debian and RPM repos
+
+`deb.releases.teleport.dev` and `rpm.rleases.teleport.dev` were deprecated in
+Teleport 11. Beginning in Teleport 15, Debian and RPM packages will no longer be
+published to these repos. Teleport 14 and prior packages will continue to be
+published to these repos for the remaidner of those releases' lifecycles.
+
+All users are recommended to switch to `apt.releases.teleport.dev` and
+`yum.releases.teleport.dev` repositories as described in installation
+[instructions](docs/pages/installation.mdx).
+
+The legacy package repos will be shut off in mid 2025 after Teleport 14
+has been out of support for many months.
+
 #### Container images
 
 Teleport 15 contains several breaking changes to improve the default security

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -85,17 +85,6 @@ Currently supported distributions (and `ID`) are:
 <Tabs>
 <TabItem scope="oss" label="Teleport Community Edition">
 
-<Details title="Using APT or YUM for versions prior to Teleport 10?" scopeOnly={false}>
-
-If you've previously installed Teleport via the APT
-repo at `https://deb.releases.teleport.dev/`, you can upgrade by
-re-running the "Debian/Ubuntu (DEB)" install instructions above.
-
-We will also continue to maintain the legacy APT repo at
-`https://deb.releases.teleport.dev/` for the foreseeable future.
-
-</Details>
-
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 


### PR DESCRIPTION
Similar to https://github.com/gravitational/teleport/pull/35452, this adds a breaking release note about our legacy deb/rpm repo retirement.  Fred had a minimal changelog in https://github.com/gravitational/teleport/pull/32172, but I thought it best to add a bigger note with instructions about what users should move to, and forewarning these repos will be removed eventually.

Contributes to https://github.com/gravitational/teleport/issues/32170

The (tenative) legacy deb/rpm repo brownout/retirement schedule is:

* 2024-01-XX - v15 released, no v15+ versions published
* 2024-09-01 - v14 is no longer supported, no new images published to these repos, retire related publishing IAM infra
* 2025-03-05 - brownout for 3 hours during a peak time
* 2025-04-02 - brownout for a day
* 2025-05-05 - brownout for a week
* 2025-06-02 - Turn off cloudfront/DNS, users can no longer access the repos
* 2026-06-XX - Delete the S3 buckets and all data therein
