### PR TITLE
delete obsolete FanoutSet

### DIFF
--- a/lib/services/fanout.go
+++ b/lib/services/fanout.go
@@ -21,7 +21,6 @@ package services
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/gravitational/trace"
 
@@ -424,100 +423,4 @@ func (w *fanoutWatcher) Error() error {
 	default:
 		return nil
 	}
-}
-
-// fanoutSetSize is the number of members in a fanout set.  selected based on some experimentation with
-// the FanoutSetRegistration benchmark.  This value keeps 100K concurrent registrations well under 1s.
-const fanoutSetSize = 128
-
-// FanoutSet is a collection of separate Fanout instances. It exposes an identical API, and "load balances"
-// watcher registration across the enclosed instances. In very large clusters it is possible for tens of
-// thousands of nodes to simultaneously request watchers. This can cause serious contention issues. FanoutSet is
-// a simple but effective solution to that problem.
-type FanoutSet struct {
-	// rw mutex is used to ensure that Close and Reset operations are exclusive,
-	// since these operations close watchers. Enforcing this property isn't strictly
-	// necessary, but it prevents a scenario where watchers might observe a reset/close,
-	// attempt re-registration, and observe the *same* reset/close again. This isn't
-	// necessarily a problem, but it might confuse attempts to debug other event-system
-	// issues, so we choose to avoid it.
-	rw      sync.RWMutex
-	counter atomic.Uint64
-	members []*Fanout
-}
-
-// NewFanoutSet creates a new FanoutSet instance in an uninitialized
-// state.  Until initialized, watchers will be queued but no
-// events will be sent.
-func NewFanoutSet() *FanoutSet {
-	members := make([]*Fanout, 0, fanoutSetSize)
-	for i := 0; i < fanoutSetSize; i++ {
-		members = append(members, NewFanout())
-	}
-	return &FanoutSet{
-		members: members,
-	}
-}
-
-// NewWatcher attaches a new watcher to a fanout instance.
-func (s *FanoutSet) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
-	s.rw.RLock() // see field-level docks for locking model
-	defer s.rw.RUnlock()
-	fi := int(s.counter.Add(1) % uint64(len(s.members)))
-	return s.members[fi].NewWatcher(ctx, watch)
-}
-
-// SetInit sets the Fanout instances into an initialized state, sending OpInit
-// events to any watchers which were added prior to initialization.
-// Takes a list of resource kinds confirmed by an upstream event source.
-// See Fanout.SetInit() for more details.
-func (s *FanoutSet) SetInit(confirmedKinds []types.WatchKind) {
-	s.rw.RLock() // see field-level docks for locking model
-	defer s.rw.RUnlock()
-	for _, f := range s.members {
-		f.SetInit(confirmedKinds)
-	}
-}
-
-// Emit broadcasts events to all matching watchers that have been attached
-// to this fanout set.
-func (s *FanoutSet) Emit(events ...types.Event) {
-	s.rw.RLock() // see field-level docks for locking model
-	defer s.rw.RUnlock()
-	for _, f := range s.members {
-		f.Emit(events...)
-	}
-}
-
-// Reset closes all attached watchers and places the fanout instances
-// into an uninitialized state.  Reset may be called on an uninitialized
-// fanout set to remove "queued" watchers.
-func (s *FanoutSet) Reset() {
-	s.rw.Lock() // see field-level docks for locking model
-	defer s.rw.Unlock()
-	var watcherMappings []map[string][]fanoutEntry
-	for _, f := range s.members {
-		watcherMappings = append(watcherMappings, f.takeAndReset())
-	}
-	go func() {
-		for _, watchers := range watcherMappings {
-			closeWatchers(watchers)
-		}
-	}()
-}
-
-// Close permanently closes the fanout.  Existing watchers will be
-// closed and no new watchers will be added.
-func (s *FanoutSet) Close() {
-	s.rw.Lock() // see field-level docks for locking model
-	defer s.rw.Unlock()
-	var watcherMappings []map[string][]fanoutEntry
-	for _, f := range s.members {
-		watcherMappings = append(watcherMappings, f.takeAndClose())
-	}
-	go func() {
-		for _, watchers := range watcherMappings {
-			closeWatchers(watchers)
-		}
-	}()
 }

--- a/lib/services/fanout_test.go
+++ b/lib/services/fanout_test.go
@@ -187,37 +187,3 @@ func BenchmarkFanoutRegistration(b *testing.B) {
 		wg.Wait()
 	}
 }
-
-/*
-goos: linux
-goarch: amd64
-pkg: github.com/gravitational/teleport/lib/services
-cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
-BenchmarkFanoutSetRegistration-16    	       3	 394211563 ns/op
-*/
-func BenchmarkFanoutSetRegistration(b *testing.B) {
-	const iterations = 100_000
-	ctx := context.Background()
-
-	for n := 0; n < b.N; n++ {
-		f := NewFanoutSet()
-		f.SetInit([]types.WatchKind{{Kind: "spam"}, {Kind: "eggs"}})
-
-		var wg sync.WaitGroup
-
-		for i := 0; i < iterations; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				w, err := f.NewWatcher(ctx, types.Watch{
-					Name:  "test",
-					Kinds: []types.WatchKind{{Kind: "spam"}, {Kind: "eggs"}},
-				})
-				require.NoError(b, err)
-				w.Close()
-			}()
-		}
-
-		wg.Wait()
-	}
-}


### PR DESCRIPTION
`FanoutSet` was obsoleted in https://github.com/gravitational/teleport/pull/32978 by `FanoutV2`.

It was only being used in a benchmark test and we no longer need it.

Confirmed with Forrest that this was ok to delete.