### PR TITLE
Fix drone's buildbox push logic to handle use of ghcr.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1858,11 +1858,12 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker tag ghcr.io/gravitational/teleport-buildbox:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
+  - docker tag ghcr.io/gravitational/teleport-buildbox:$BUILDBOX_VERSION public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
   - name: awsconfig
@@ -1880,12 +1881,12 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-arm
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker tag ghcr.io/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
+  - docker tag ghcr.io/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
   - name: awsconfig
@@ -1903,12 +1904,12 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
   - name: awsconfig
@@ -1926,12 +1927,14 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7-fips
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
+    public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
   - name: awsconfig
@@ -12041,6 +12044,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 5c3c71d2315d7d4b09e5bb67388d2e28239343a1c096f33fa961b54509ebf175
+hmac: 91cb6e78427c041c5e8a492e27c03a5214e3f6e23294a3d6e16b7cd80b658bc9
 
 ...

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -83,12 +83,14 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 			// Build buildbox image
 			fmt.Sprintf(`make -C build.assets %s`, buildboxName),
 			// Retag for staging registry
-			fmt.Sprintf(`docker tag %s/gravitational/teleport-%s:$BUILDBOX_VERSION %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, ProductionRegistry, buildboxName, StagingRegistry, buildboxName),
+			fmt.Sprintf(`docker tag %s/gravitational/teleport-%s:$BUILDBOX_VERSION %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, GitHubRegistry, buildboxName, StagingRegistry, buildboxName),
 			// Push to staging registry
 			fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, StagingRegistry, buildboxName),
 			// Authenticate to production registry
 			`docker logout ` + StagingRegistry,
 			`aws ecr-public get-login-password --profile production --region=us-east-1 | docker login -u="AWS" --password-stdin ` + ProductionRegistry,
+			// Retag for production registry
+			fmt.Sprintf(`docker tag %s/gravitational/teleport-%s:$BUILDBOX_VERSION %s/gravitational/teleport-%s:$BUILDBOX_VERSION`, GitHubRegistry, buildboxName, ProductionRegistry, buildboxName),
 			// Push to production registry
 			fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION`, ProductionRegistry, buildboxName),
 		},

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -33,6 +33,9 @@ const (
 	// ProductionRegistry is the production image registry that hosts are customer facing container images.
 	ProductionRegistry = "public.ecr.aws"
 
+	// GitHubRegistory is the GitHub container registry used for GitHub Actions.
+	GitHubRegistry = "ghcr.io"
+
 	// Go version used by internal tools
 	GoVersion = "1.18"
 


### PR DESCRIPTION
The default buildbox container image registry was changed from `public.ecr.aws` to `ghcr.io` in #34950. However, Drone still thinks that ECR Public is the default, causing the `build-buildboxes` step to fail. Adjust logic to use correct image tag name.

Example failure:
https://drone.platform.teleport.sh/gravitational/teleport/32084/9/6