### PR TITLE
Add known AWS STS regional endpoint in ca-west-1

### DIFF
--- a/lib/auth/sts_endpoints.go
+++ b/lib/auth/sts_endpoints.go
@@ -41,6 +41,7 @@ var (
 		"sts.ap-southeast-3.amazonaws.com",
 		"sts.ap-southeast-4.amazonaws.com",
 		"sts.ca-central-1.amazonaws.com",
+		"sts.ca-west-1.amazonaws.com",
 		"sts.cn-north-1.amazonaws.com.cn",
 		"sts.cn-northwest-1.amazonaws.com.cn",
 		"sts.eu-central-1.amazonaws.com",


### PR DESCRIPTION
This is a new AWS region as of 2023-12-20 : https://aws.amazon.com/blogs/aws/the-aws-canada-west-calgary-region-is-now-available/

If curious, here is previous discussion on using a static list vs referencing SDK or generating as a build step https://github.com/gravitational/teleport/pull/31217#issuecomment-1699618045

Changelog: Added support for the IAM join method in ca-west-1.