### PR TITLE
Fix user invites preventing tokens list

### DIFF
--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -965,3 +965,10 @@ func TestProvisionTokenV2_CaseInsensitiveRoles(t *testing.T) {
 		require.Equal(t, SystemRoles{RoleNode, RoleAuth}, tok.GetRoles())
 	})
 }
+
+func TestProvisionTokenV2_SignupRole(t *testing.T) {
+	t.Parallel()
+	tok, err := NewProvisionToken("token", SystemRoles{RoleSignup}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, SystemRoles{RoleSignup}, tok.GetRoles())
+}

--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -264,11 +264,11 @@ func (r *SystemRole) Set(v string) error {
 	return nil
 }
 
-// String returns debug-friendly representation of this teleport role.
+// String returns the system role string representation. Returned values must
+// match (case-insensitive) the role mappings; otherwise, the validation check
+// will fail.
 func (r *SystemRole) String() string {
 	switch *r {
-	case RoleSignup:
-		return "Password"
 	case RoleTrustedCluster:
 		return "trusted_cluster"
 	default:

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3339,3 +3339,25 @@ func TestInstallerCRUD(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err))
 }
+
+func TestGetTokens(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+	ctx := context.Background()
+
+	_, _, err := CreateUserAndRole(s.a, "username", []string{"username"}, nil)
+	require.NoError(t, err)
+	_, err = s.a.CreateResetPasswordToken(ctx, CreateUserTokenRequest{
+		Name: "username",
+		TTL:  time.Minute,
+		Type: UserTokenTypeResetPasswordInvite,
+	})
+	require.NoError(t, err)
+
+	for _, role := range types.LocalServiceMappings() {
+		generateTestToken(ctx, t, types.SystemRoles{role}, s.a.GetClock().Now().Add(time.Minute*30), s.a)
+	}
+
+	_, err = s.a.GetTokens(ctx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Closes #34387.

changelog: Fix user invites preventing listing tokens.

When initializing `types.SystemRoles` from a specification, the initializer converts the roles into strings using `StringSlice`, which utilizes the `String` method from `types.SystemRole`. However, the `RoleSignup` function may return a value that is not present in the system role mappings, causing a validation failure as shown in the issue.

Alternatively, we could add "password" to the `roleMapping` so that roles with this name would be correctly matched, and the returned value on `tctl get token` would still be `Password`.