### PR TITLE
[v12] Add known AWS STS regional endpoint in ca-west-1

### DIFF
--- a/lib/auth/sts_endpoints.go
+++ b/lib/auth/sts_endpoints.go
@@ -39,6 +39,7 @@ var (
 		"sts.ap-southeast-3.amazonaws.com",
 		"sts.ap-southeast-4.amazonaws.com",
 		"sts.ca-central-1.amazonaws.com",
+		"sts.ca-west-1.amazonaws.com",
 		"sts.cn-north-1.amazonaws.com.cn",
 		"sts.cn-northwest-1.amazonaws.com.cn",
 		"sts.eu-central-1.amazonaws.com",


### PR DESCRIPTION
Backport #36047 to branch/v12

changelog: Added support for the IAM join method in ca-west-1.
