### PR TITLE
Refactor os-compatiblity-test CI

### DIFF
--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -23,25 +23,24 @@ jobs:
     permissions:
       contents: read
 
-    container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport15-amd64
-      env:
-        GOCACHE: /tmp/gocache
-        WEBASSETS_SKIP_BUILD: 1
+    env:
+      GOCACHE: /tmp/gocache
 
     steps:
       - name: Checkout Teleport
-        uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+        uses: actions/checkout@v4
 
       - name: Prepare workspace
         uses: ./.github/actions/prepare-workspace
 
-      - name: Run make
+      - name: Build release binaries
+        env:
+          WEBASSETS_SKIP_BUILD: 1
         run: |
-          make -j"$(nproc)" binaries
+          make -C build.assets build-binaries
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: ${{ github.workspace }}/build/
@@ -59,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: ${{ github.workspace }}/build


### PR DESCRIPTION
We have make invoke the buildbox container instead of having GitHub actions invoke the container. This allows running only one step inside the container, which allows other parts of the workflow to use recent NodeJS versions that depend on a more recent GLIBC.