### PR TITLE
fix saml IdP service provider validation

### DIFF
--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -21,8 +21,6 @@ package local
 import (
 	"context"
 	"encoding/xml"
-	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -125,8 +123,19 @@ func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context
 		}
 	}
 
-	if err := validateSAMLIdPServiceProvider(sp); err != nil {
-		return trace.Wrap(err)
+	// verify that entity descriptor parses
+	ed, err := samlsp.ParseMetadata([]byte(sp.GetEntityDescriptor()))
+	if err != nil {
+		return trace.BadParameter("invalid entity descriptor for SAML IdP Service provider %q: %v", sp.GetEntityID(), err)
+	}
+
+	if ed.EntityID != sp.GetEntityID() {
+		return trace.BadParameter("entity ID parsed from the entity descriptor does not match the entity ID in the SAML IdP service provider object")
+	}
+
+	// ensure any filtering related issues get logged
+	if err := services.FilterSAMLEntityDescriptor(ed); err != nil {
+		s.log.Warnf("Entity descriptor for SAML IdP service provider %q may be malformed: %v", sp.GetEntityID(), err)
 	}
 
 	// embed attribute mapping in entity descriptor
@@ -155,8 +164,19 @@ func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context
 
 // UpdateSAMLIdPServiceProvider updates an existing SAML IdP service provider resource.
 func (s *SAMLIdPServiceProviderService) UpdateSAMLIdPServiceProvider(ctx context.Context, sp types.SAMLIdPServiceProvider) error {
-	if err := validateSAMLIdPServiceProvider(sp); err != nil {
-		return trace.Wrap(err)
+	// verify that entity descriptor parses
+	ed, err := samlsp.ParseMetadata([]byte(sp.GetEntityDescriptor()))
+	if err != nil {
+		return trace.BadParameter("invalid entity descriptor for SAML IdP Service provider %q: %v", sp.GetEntityID(), err)
+	}
+
+	if ed.EntityID != sp.GetEntityID() {
+		return trace.BadParameter("entity ID parsed from the entity descriptor does not match the entity ID in the SAML IdP service provider object")
+	}
+
+	// ensure any filtering related issues get logged
+	if err := services.FilterSAMLEntityDescriptor(ed); err != nil {
+		s.log.Warnf("Entity descriptor for SAML IdP service provider %q may be malformed: %v", sp.GetEntityID(), err)
 	}
 
 	// embed attribute mapping in entity descriptor
@@ -216,34 +236,6 @@ func (s *SAMLIdPServiceProviderService) ensureEntityIDIsUnique(ctx context.Conte
 		}
 		if nextToken == "" {
 			break
-		}
-	}
-
-	return nil
-}
-
-// validateSAMLIdPServiceProvider ensures that the entity ID in the entity descriptor is the same as the entity ID
-// in the [types.SAMLIdPServiceProvider] and that all AssertionConsumerServices defined are valid HTTPS endpoints.
-func validateSAMLIdPServiceProvider(sp types.SAMLIdPServiceProvider) error {
-	ed, err := samlsp.ParseMetadata([]byte(sp.GetEntityDescriptor()))
-	if err != nil {
-		switch {
-		case errors.Is(err, io.EOF):
-			return trace.BadParameter("missing entity descriptor: %s", err.Error())
-		default:
-			return trace.BadParameter(err.Error())
-		}
-	}
-
-	if ed.EntityID != sp.GetEntityID() {
-		return trace.BadParameter("entity ID parsed from the entity descriptor does not match the entity ID in the SAML IdP service provider object")
-	}
-
-	for _, descriptor := range ed.SPSSODescriptors {
-		for _, acs := range descriptor.AssertionConsumerServices {
-			if err := services.ValidateAssertionConsumerServicesEndpoint(acs.Location); err != nil {
-				return trace.Wrap(err)
-			}
 		}
 	}
 

--- a/lib/services/local/saml_idp_service_provider_test.go
+++ b/lib/services/local/saml_idp_service_provider_test.go
@@ -30,10 +30,8 @@ import (
 	"github.com/crewjam/saml/samlsp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -72,34 +70,6 @@ func TestSAMLIdPServiceProviderCRUD(t *testing.T) {
 			EntityID:         "sp2",
 		})
 	require.NoError(t, err)
-
-	// Try to create a service provider with an invalid acs.
-	invalidSP, err := types.NewSAMLIdPServiceProvider(
-		types.Metadata{
-			Name: "sp3",
-		},
-		types.SAMLIdPServiceProviderSpecV1{
-			EntityDescriptor: newInvalidACSEntityDescriptor("sp1"),
-			EntityID:         "sp1",
-		})
-	require.NoError(t, err)
-	err = service.CreateSAMLIdPServiceProvider(ctx, invalidSP)
-	assert.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "CreateSAMLIdPServiceProvider error mismatch, wanted BadParameter, got %q (%T)", err, trace.Unwrap(err))
-
-	// Try to create a service provider with a http acs.
-	invalidSP, err = types.NewSAMLIdPServiceProvider(
-		types.Metadata{
-			Name: "sp3",
-		},
-		types.SAMLIdPServiceProviderSpecV1{
-			EntityDescriptor: newHTTPACSEntityDescriptor("sp1"),
-			EntityID:         "sp1",
-		})
-	require.NoError(t, err)
-	err = service.CreateSAMLIdPServiceProvider(ctx, invalidSP)
-	assert.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "CreateSAMLIdPServiceProvider error mismatch, wanted BadParameter, got %q (%T)", err, trace.Unwrap(err))
 
 	// Initially we expect no service providers.
 	out, nextToken, err := service.ListSAMLIdPServiceProviders(ctx, 200, "")
@@ -200,20 +170,6 @@ func TestSAMLIdPServiceProviderCRUD(t *testing.T) {
 	err = service.UpdateSAMLIdPServiceProvider(ctx, sp)
 	require.Error(t, err)
 
-	// Update a service provider with an invalid acs.
-	invalidSP, err = service.GetSAMLIdPServiceProvider(ctx, sp1.GetName())
-	require.NoError(t, err)
-	invalidSP.SetEntityDescriptor(newInvalidACSEntityDescriptor(invalidSP.GetEntityID()))
-	err = service.UpdateSAMLIdPServiceProvider(ctx, invalidSP)
-	assert.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "CreateSAMLIdPServiceProvider error mismatch, wanted BadParameter, got %q (%T)", err, trace.Unwrap(err))
-
-	// Update a service provider with a http acs.
-	invalidSP.SetEntityDescriptor(newHTTPACSEntityDescriptor(invalidSP.GetEntityID()))
-	err = service.UpdateSAMLIdPServiceProvider(ctx, invalidSP)
-	assert.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "UpdateSAMLIdPServiceProvider error mismatch, wanted BadParameter, got %q (%T)", err, trace.Unwrap(err))
-
 	// Delete a service provider.
 	err = service.DeleteSAMLIdPServiceProvider(ctx, sp1.GetName())
 	require.NoError(t, err)
@@ -237,49 +193,6 @@ func TestSAMLIdPServiceProviderCRUD(t *testing.T) {
 	require.Empty(t, out)
 }
 
-func TestValidateSAMLIdPServiceProvider(t *testing.T) {
-	descriptor := newEntityDescriptor("IAMShowcase")
-
-	cases := []struct {
-		name         string
-		spec         types.SAMLIdPServiceProviderSpecV1
-		errAssertion require.ErrorAssertionFunc
-	}{
-		{
-			name: "valid provider",
-			spec: types.SAMLIdPServiceProviderSpecV1{
-				EntityDescriptor: descriptor,
-				EntityID:         "IAMShowcase",
-			},
-			errAssertion: require.NoError,
-		},
-		{
-			name: "invalid entity id",
-			spec: types.SAMLIdPServiceProviderSpecV1{
-				EntityDescriptor: descriptor,
-				EntityID:         uuid.NewString(),
-			},
-			errAssertion: require.Error,
-		},
-		{
-			name: "invalid acs",
-			spec: types.SAMLIdPServiceProviderSpecV1{
-				EntityDescriptor: newInvalidACSEntityDescriptor("IAMShowcase"),
-				EntityID:         "IAMShowcase",
-			},
-			errAssertion: require.Error,
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			sp, err := types.NewSAMLIdPServiceProvider(types.Metadata{Name: "sp"}, test.spec)
-			require.NoError(t, err)
-			test.errAssertion(t, validateSAMLIdPServiceProvider(sp))
-		})
-	}
-}
-
 func newEntityDescriptor(entityID string) string {
 	return fmt.Sprintf(testEntityDescriptor, entityID)
 }
@@ -291,36 +204,6 @@ const testEntityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
       <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
       <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
       <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sptest.iamshowcase.com/acs" index="0" isDefault="true"/>
-   </md:SPSSODescriptor>
-</md:EntityDescriptor>
-`
-
-func newInvalidACSEntityDescriptor(entityID string) string {
-	return fmt.Sprintf(invalidEntityDescriptor, entityID)
-}
-
-// A test entity descriptor from https://sptest.iamshowcase.com/testsp_metadata.xml with invalid ACS locations.
-const invalidEntityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="%s" validUntil="2025-12-09T09:13:31.006Z">
-   <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="javascript://sptest.iamshowcase.com/acs" index="0" isDefault="true"/>
-   </md:SPSSODescriptor>
-</md:EntityDescriptor>
-`
-
-func newHTTPACSEntityDescriptor(entityID string) string {
-	return fmt.Sprintf(httpEntityDescriptor, entityID)
-}
-
-// A test entity descriptor from https://sptest.iamshowcase.com/testsp_metadata.xml with a http ACS locations.
-const httpEntityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="%s" validUntil="2025-12-09T09:13:31.006Z">
-   <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://sptest.iamshowcase.com/acs" index="0" isDefault="true"/>
    </md:SPSSODescriptor>
 </md:EntityDescriptor>
 `

--- a/lib/services/saml_idp_service_provider.go
+++ b/lib/services/saml_idp_service_provider.go
@@ -21,8 +21,11 @@ package services
 import (
 	"context"
 	"net/url"
+	"slices"
 
+	"github.com/crewjam/saml"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
@@ -121,15 +124,67 @@ func GenerateIdPServiceProviderFromFields(name string, entityDescriptor string) 
 	return &s, nil
 }
 
+// supportedACSBindings is the set of AssertionConsumerService bindings that teleport supports.
+var supportedACSBindings = map[string]struct{}{
+	saml.HTTPPostBinding:     {},
+	saml.HTTPRedirectBinding: {},
+}
+
+// ValidateAssertionConsumerService checks if a given assertion consumer service is usable by teleport. Note that
+// it is permissible for a service provider to include acs endpoints that are not compatible with teleport, so long
+// as at least one _is_ compatible.
+func ValidateAssertionConsumerService(acs saml.IndexedEndpoint) error {
+	if _, ok := supportedACSBindings[acs.Binding]; !ok {
+		return trace.BadParameter("unsupported acs binding: %q", acs.Binding)
+	}
+
+	if acs.Location == "" {
+		return trace.BadParameter("acs location endpoint is missing or could not be decoded for %q binding", acs.Binding)
+	}
+
+	return trace.Wrap(ValidateAssertionConsumerServicesEndpoint(acs.Location))
+}
+
+// FilterSAMLEntityDescriptor performs a filter in place to remove unsupported and/or insecure fields from
+// a saml entity descriptor. Specifically, it removes acs endpoints that are either of an unsupported kind,
+// or are using a non-https endpoint. We perform filtering rather than outright rejection because it is generally
+// expected that a service provider will successfully support a given ACS so long as they have at least one
+// compatible binding.
+func FilterSAMLEntityDescriptor(ed *saml.EntityDescriptor) error {
+	var originalCount int
+	var filteredCount int
+	for i := range ed.SPSSODescriptors {
+		filtered := slices.DeleteFunc(ed.SPSSODescriptors[i].AssertionConsumerServices, func(acs saml.IndexedEndpoint) bool {
+			if err := ValidateAssertionConsumerService(acs); err != nil {
+				log.Warnf("AssertionConsumerService binding for entity %q is invalid and will be ignored: %v", ed.EntityID, err)
+				return true
+			}
+
+			return false
+		})
+
+		originalCount += len(ed.SPSSODescriptors[i].AssertionConsumerServices)
+		filteredCount += len(filtered)
+
+		ed.SPSSODescriptors[i].AssertionConsumerServices = filtered
+	}
+
+	if filteredCount == 0 && originalCount != 0 {
+		return trace.BadParameter("no AssertionConsumerService bindings for entity %q passed validation", ed.EntityID)
+	}
+
+	return nil
+}
+
 // ValidateAssertionConsumerServicesEndpoint ensures that the Assertion Consumer Service location
 // is a valid HTTPS endpoint.
 func ValidateAssertionConsumerServicesEndpoint(acs string) error {
 	endpoint, err := url.Parse(acs)
 	switch {
 	case err != nil:
-		return trace.Wrap(err)
+		return trace.BadParameter("acs location endpoint %q could not be parsed: %v", acs, err)
 	case endpoint.Scheme != "https":
-		return trace.BadParameter("the assertion consumer services location must be an https endpoint")
+		return trace.BadParameter("invalid scheme %q in acs location endpoint %q (must be 'https')", endpoint.Scheme, acs)
 	}
 
 	return nil

--- a/lib/services/saml_idp_service_provider_test.go
+++ b/lib/services/saml_idp_service_provider_test.go
@@ -19,8 +19,12 @@
 package services
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -61,6 +65,82 @@ func TestSAMLIdPServiceProviderMarshal(t *testing.T) {
 	actual, err := UnmarshalSAMLIdPServiceProvider(data)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+func TestFilterSAMLEntityDescriptor(t *testing.T) {
+	tts := []struct {
+		eds           string
+		ok            bool
+		before, after int
+		name          string
+	}{
+		{
+			eds: edBuilder().
+				ACS(saml.HTTPPostBinding, "https://one.example.com/acs").
+				ACS(saml.HTTPPostBinding, "https://two.example.com/acs").
+				Done(),
+			ok:     true,
+			before: 2,
+			after:  2,
+			name:   "no filtering",
+		},
+		{
+			eds: edBuilder().
+				ACS(saml.HTTPPostBinding, "https://example.com/acs").
+				ACS(saml.HTTPPostBinding, "http://example.com/acs").
+				Done(),
+			ok:     true,
+			before: 2,
+			after:  1,
+			name:   "scheme filtering",
+		},
+		{
+			eds: edBuilder().
+				ACS(saml.HTTPArtifactBinding, "https://example.com/acs").
+				ACS(saml.HTTPPostBinding, "https://example.com/acs").
+				Done(),
+			ok:     true,
+			before: 2,
+			after:  1,
+			name:   "binding filtering",
+		},
+		{
+			eds: edBuilder().
+				ACS(saml.HTTPArtifactBinding, "https://example.com/acs").
+				ACS(saml.HTTPPostBinding, "http://example.com/acs").
+				Done(),
+			ok:     false,
+			before: 2,
+			after:  0,
+			name:   "all invalid",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			ed, err := samlsp.ParseMetadata([]byte(tt.eds))
+			require.NoError(t, err)
+
+			require.Equal(t, tt.before, getACSCount(ed))
+
+			err = FilterSAMLEntityDescriptor(ed)
+			if !tt.ok {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tt.after, getACSCount(ed))
+		})
+	}
+}
+
+func getACSCount(ed *saml.EntityDescriptor) int {
+	var count int
+	for _, desc := range ed.SPSSODescriptors {
+		count += len(desc.AssertionConsumerServices)
+	}
+	return count
 }
 
 func TestValidateAssertionConsumerServicesEndpoint(t *testing.T) {
@@ -118,3 +198,41 @@ const testEntityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
    </md:SPSSODescriptor>
 </md:EntityDescriptor>
 `
+
+const edBuilderTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="IAMShowcase" validUntil="2025-12-09T09:13:31.006Z">
+   <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+	  %s
+   </md:SPSSODescriptor>
+</md:EntityDescriptor>
+`
+
+const edBuilderACSTemplate = `<md:AssertionConsumerService Binding="%s" Location="%s" index="%d" isDefault="true"/>`
+
+type entityDescriptorBuilder struct {
+	acs []struct {
+		binding, location string
+	}
+}
+
+func edBuilder() *entityDescriptorBuilder {
+	return &entityDescriptorBuilder{}
+}
+
+func (b *entityDescriptorBuilder) ACS(binding, location string) *entityDescriptorBuilder {
+	b.acs = append(b.acs, struct {
+		binding, location string
+	}{binding, location})
+	return b
+}
+
+func (b *entityDescriptorBuilder) Done() string {
+	var acss []string
+	for i, acs := range b.acs {
+		acss = append(acss, fmt.Sprintf(edBuilderACSTemplate, acs.binding, acs.location, i))
+	}
+
+	return fmt.Sprintf(edBuilderTemplate, strings.Join(acss, "\n      "))
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/crewjam/saml/samlsp"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 	log "github.com/sirupsen/logrus"
@@ -969,6 +970,18 @@ func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, cli
 	// Create services.SAMLIdPServiceProvider from raw YAML to extract the service provider name.
 	sp, err := services.UnmarshalSAMLIdPServiceProvider(raw.Raw)
 	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// verify that entity descriptor parses
+	ed, err := samlsp.ParseMetadata([]byte(sp.GetEntityDescriptor()))
+	if err != nil {
+		return trace.BadParameter("invalid entity descriptor for SAML IdP Service provider %q: %v", sp.GetEntityID(), err)
+	}
+
+	// try filtering the entity descriptor. if it can't be filtered down to a useable looking state, reject
+	// the creation attempt.
+	if err := services.FilterSAMLEntityDescriptor(ed); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Some recent SAML IdP validation changes started rejecting insecure SAML service provider descriptors.  This ended up causing issues for two reasons:

1. Validation was run during cache init, meaning that teleport could go into an infinite loop of failed cache initialization attempts if an existing SAML IdP configuration didn't meet the new requirements.
2. The validation would incorrectly reject configurations that *were* secure if they also supported insecure options (i.e. if a service provider supported both `http` and `https` the configuration would be rejected, instead of simply ignoring the `http` option always using the `https` option).

This PR is the first of two that will move us over to ignoring and warning about insecure IDP descriptors (a followup PR in `e` is needed to fully switch over to the new behavior).

These changes were manually tested against [samltest.id](https://samltest.id).

changelog: fixed an issue where valid saml entity descriptors could be rejected.