### PR TITLE
[v13] Clarify deprecation schedule for {rpm,deb}.releases.teleport.dev

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -91,8 +91,8 @@ If you've previously installed Teleport via the APT
 repo at `https://deb.releases.teleport.dev/`, you can upgrade by
 re-running the "Debian/Ubuntu (DEB)" install instructions above.
 
-We will also continue to maintain the legacy APT repo at
-`https://deb.releases.teleport.dev/` for the foreseeable future.
+The legacy APT repo at `https://deb.releases.teleport.dev/` will not receive updates
+past Teleport 14 and will be turned off after Teleport 14 is no longer supported.
 
 </Details>
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/36022 (or at least the relevant parts)

`{rpm,deb}.releases.teleport.dev` are going away, and we want customers to know that.

I grepped around to make sure nothing else needed updates:

```console
walt@vm:~/git/teleport$ rg '(rpm|deb).releases.teleport.dev'                    
e/tooling/os-package-repo-tool/src/yum_repo_tool.go
411:// https://rpm.releases.teleport.dev/teleport.repo

docs/pages/installation.mdx
91:repo at `https://deb.releases.teleport.dev/`, you can upgrade by
94:The legacy APT repo at `https://deb.releases.teleport.dev/` will not receive updates

CHANGELOG.md
1837:In Teleport 11, old deb/rpm repositories (deb.releases.teleport.dev and
1838:rpm.releases.teleport.dev) have been deprecated. Customers should use the new
2844:* Fixed an issue where DEB builds were not published to the [Teleport DEB repository](https://deb.releases.teleport.dev/).
3265:See https://rpm.releases.teleport.dev/ for more details.
```