### PR TITLE
[v14] Expose `tshd` in `IAppContext`

### DIFF
--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -41,6 +41,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ResourcesService } from 'teleterm/ui/services/resources';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { ConfigService } from 'teleterm/services/config';
+import { TshClient } from 'teleterm/services/tshd/types';
 import { IAppContext } from 'teleterm/ui/types';
 import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';
@@ -61,6 +62,7 @@ export default class AppContext implements IAppContext {
   connectionTracker: ConnectionTrackerService;
   fileTransferService: FileTransferService;
   resourcesService: ResourcesService;
+  tshd: TshClient;
   /**
    * subscribeToTshdEvent lets you add a listener that's going to be called every time a client
    * makes a particular RPC to the tshd events service. The listener receives the request converted
@@ -86,6 +88,7 @@ export default class AppContext implements IAppContext {
   constructor(config: ElectronGlobals) {
     const { tshClient, ptyServiceClient, mainProcessClient } = config;
     this.logger = new Logger('AppContext');
+    this.tshd = tshClient;
     this.subscribeToTshdEvent = config.subscribeToTshdEvent;
     this.mainProcessClient = mainProcessClient;
     this.notificationsService = new NotificationsService();

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -32,6 +32,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ConfigService } from 'teleterm/services/config';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { HeadlessAuthenticationService } from 'teleterm/ui/services/headlessAuthn/headlessAuthnService';
+import { TshClient } from 'teleterm/services/tshd/types';
 
 export interface IAppContext {
   clustersService: ClustersService;
@@ -53,6 +54,7 @@ export interface IAppContext {
   configService: ConfigService;
   connectMyComputerService: ConnectMyComputerService;
   headlessAuthenticationService: HeadlessAuthenticationService;
+  tshd: TshClient;
 
   pullInitialState(): Promise<void>;
 }


### PR DESCRIPTION
On master we can use `tshd` directly from the app context, this PR backports it to v14.