### PR TITLE
Improve Access Plugins/Audit Exporter docs flows

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -309,7 +309,8 @@ You configuration should resemble the following:
 # /etc/teleport-email.toml
 [teleport]
 addr = "example.com:443"
-identity = "/var/lib/teleport/plugins/email/auth_id"
+identity = "/var/lib/teleport/plugins/email/identity"
+refresh_identity = true
 
 [mailgun]
 domain = "sandbox123abc.mailgun.org" 
@@ -344,6 +345,7 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 teleport:
   address: "teleport.example.com:443"
   identitySecretName: teleport-plugin-email-identity
+  identitySecretPath: identity
 
 mailgun:
   domain: "sandbox123abc.mailgun.org" 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -227,7 +227,7 @@ The final configuration should look similar to this:
 # example mattermost configuration TOML file
 [teleport]
 auth_server = "myinstance.teleport.sh:443"                   # Teleport Cloud proxy HTTPS address
-identity = "/var/lib/teleport/plugins/mattermost/auth.pem"   # Identity file path
+identity = "/var/lib/teleport/plugins/mattermost/identity"   # Identity file path
 
 [mattermost]
 url = "https://mattermost.example.com" # Mattermost Server URL

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -228,6 +228,7 @@ The final configuration should look similar to this:
 [teleport]
 auth_server = "myinstance.teleport.sh:443"                   # Teleport Cloud proxy HTTPS address
 identity = "/var/lib/teleport/plugins/mattermost/identity"   # Identity file path
+refresh_identity = true                                      # Refresh identity file on a periodic basis
 
 [mattermost]
 url = "https://mattermost.example.com" # Mattermost Server URL

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -424,7 +424,8 @@ the host where you have Helm installed, create a file called
 ```yaml
 teleport:
   address: ""                 # Teleport Auth Server GRPC API address
-  identitySecretName: ""      # Identity file path
+  identitySecretName: ""      # Identity secret name
+  identitySecretPath: ""      # Identity secret path
 
 pagerduty:
   apiKey: ""                  # PagerDuty API Key

--- a/docs/pages/includes/plugins/config-toml-teleport.mdx
+++ b/docs/pages/includes/plugins/config-toml-teleport.mdx
@@ -21,6 +21,9 @@ or Teleport Enterprise Cloud tenant (e.g., `teleport.example.com:443` or
 **`identitySecretName`**: Fill in the `identitySecretName` field with the name
 of the Kubernetes secret you created earlier.
 
+**`identitySecretPath`**: Fill in the `identitySecretPath` field with the path
+of the identity file within the Kubernetes secret. If you have followed the
+instructions above, this will be `identity`.
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -40,6 +40,7 @@ eventHandler:
 teleport:
   address: "example.teleport.com:443"
   identitySecretName: teleport-event-handler-identity
+  identitySecretPath: identity
 
 fluentd:
   url: "https://fluentd.fluentd.svc.cluster.local/events.log"

--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -9,12 +9,12 @@ generates signed credentials, and writes an identity file to the local
 directory:
 
 ```code
-$ tctl auth sign --user={{ user }} --out=auth.pem
+$ tctl auth sign --user={{ user }} --out=identity
 ```
 
 The {{ client }} connects to the Teleport Auth Service's gRPC endpoint over TLS.
 
-The identity file, `auth.pem`, includes both TLS and SSH credentials. The 
+The identity file, `identity`, includes both TLS and SSH credentials. The
 {{ client }} uses the SSH credentials to connect to the Proxy Service, which
 establishes a reverse tunnel connection to the Auth Service. The {{ client }}
 uses this reverse tunnel, along with your TLS credentials, to connect to the
@@ -47,14 +47,14 @@ to hold certificate files for the {{ client }}:
 
 ```code
 $ sudo mkdir -p /var/lib/teleport/api-credentials
-$ sudo mv auth.* /var/lib/teleport/plugins/api-credentials
+$ sudo mv identity /var/lib/teleport/plugins/api-credentials
 ```
 
 If you are running the {{ client }} on Kubernetes, Create a Kubernetes secret
 that contains the Teleport identity file:
 
 ```code
-$ kubectl -n teleport create secret generic --from-file=auth.pem {{ secret }}
+$ kubectl -n teleport create secret generic --from-file=identity {{ secret }}
 ```
 
 Once the Teleport credentials expire, you will need to renew them by running the

--- a/docs/pages/includes/plugins/machine-id-exporter-config.mdx
+++ b/docs/pages/includes/plugins/machine-id-exporter-config.mdx
@@ -1,4 +1,4 @@
 If you are providing credentials to the Event Handler using a `tbot` binary that
 runs on a Linux server, make sure the value of `identity` in the Event Handler
 configuration is the same as the path of the identity file you configured `tbot`
-to generate, `/opt/machine-id`.
+to generate, `/opt/machine-id/identity`.

--- a/docs/pages/includes/plugins/refresh-plugin-identity.mdx
+++ b/docs/pages/includes/plugins/refresh-plugin-identity.mdx
@@ -1,6 +1,6 @@
 If you are providing credentials to the plugin using a `tbot` binary that runs
 on a Linux server, make sure the value of `identity` is the same as the path of
-the identity file you configured `tbot` to generate, `/opt/machine-id`.
+the identity file you configured `tbot` to generate, `/opt/machine-id/identity`.
 
 Configure the plugin to periodically reload the identity file, ensuring that it
 does not attempt to connect to the Teleport Auth Service with expired

--- a/examples/resources/plugins/teleport-discord-helm.yaml
+++ b/examples/resources/plugins/teleport-discord-helm.yaml
@@ -3,6 +3,8 @@ teleport:
   address: "teleport.example.com:443"
   # Secret containing identity
   identitySecretName: teleport-plugin-discord-identity
+  # Path within the secret containing the identity file.
+  identitySecretPath: identity
 
 discord:
   token: "XXXXXXXX"  # Discord Bot OAuth token

--- a/examples/resources/plugins/teleport-discord.toml
+++ b/examples/resources/plugins/teleport-discord.toml
@@ -10,7 +10,8 @@
 # Credentials generated with `tctl auth sign`.
 #
 # When using --format=file:
-# identity = "/var/lib/teleport/plugins/discord/auth_id"    # Identity file
+# identity = "/var/lib/teleport/plugins/discord/identity"    # Identity file
+# refresh_identity = true                                    # Refresh identity file on a periodic basis.
 #
 # When using --format=tls:
 # client_key = "/var/lib/teleport/plugins/discord/auth.key" # Teleport TLS secret key

--- a/examples/resources/plugins/teleport-email-helm.yaml
+++ b/examples/resources/plugins/teleport-email-helm.yaml
@@ -1,7 +1,7 @@
 teleport:
   address: teleport.example.com:443
-  identitySecretName: ""
   identitySecretName: teleport-plugin-email-identity
+  identitySecretPath: identity
 
 mailgun:
   enabled: false

--- a/examples/resources/plugins/teleport-jira-cloud.toml
+++ b/examples/resources/plugins/teleport-jira-cloud.toml
@@ -3,7 +3,9 @@
 # Proxy Service domain and HTTPS port
 auth_server = "myinstance.teleport.sh:443"
 # Teleport identity file location
-identity = "/var/lib/teleport/plugins/jira/auth.pem"
+identity = "/var/lib/teleport/plugins/jira/identity"
+# Refresh identity file on a periodic basis.
+refresh_identity = true
 
 [jira]
 url = "https://[my-jira].atlassian.net"    # JIRA URL

--- a/examples/resources/plugins/teleport-jira-helm-cloud.yaml
+++ b/examples/resources/plugins/teleport-jira-helm-cloud.yaml
@@ -4,6 +4,8 @@ teleport:
   address: "teleport.example.com:443"
   # Secret containing a Teleport identity document
   identityFromSecret: teleport-plugin-jira-identity
+  # Path within the secret containing the identity file.
+  identitySecretPath: identity
 
 jira:
   url: "https://[my-jira].atlassian.net"      # URL of the Jira instance

--- a/examples/resources/plugins/teleport-mattermost-cloud.toml
+++ b/examples/resources/plugins/teleport-mattermost-cloud.toml
@@ -1,7 +1,8 @@
 # example mattermost configuration TOML file
 [teleport]
 auth_server = "myinstance.teleport.sh:443"                   # Teleport Cloud proxy HTTPS address
-identity = "/var/lib/teleport/plugins/mattermost/auth.pem"   # Identity file path
+identity = "/var/lib/teleport/plugins/mattermost/identity"   # Identity file path
+refresh_identity = true                                      # Refresh identity file on a periodic basis.
 
 [mattermost]
 url = "https://mattermost.example.com" # Mattermost Server URL

--- a/examples/resources/plugins/teleport-mattermost-helm-cloud.yaml
+++ b/examples/resources/plugins/teleport-mattermost-helm-cloud.yaml
@@ -3,6 +3,8 @@ teleport:
   address: "teleport.example.com:443"
   # Secret containing identity
   identitySecretName: teleport-plugin-mattermost-identity
+  # Path within the secret containing the identity file.
+  identitySecretPath: identity
 
 mattermost:
   url: https://mattermost.example.com/  # URL of the Mattermost instance

--- a/examples/resources/plugins/teleport-msteams-helm.yaml
+++ b/examples/resources/plugins/teleport-msteams-helm.yaml
@@ -8,6 +8,7 @@
 teleport:
   address: "teleport.example.com:443"
   identitySecretName: teleport-plugin-msteams-identity
+  identitySecretPath: identity
 
 msTeams:
   appID: "APP_ID"

--- a/examples/resources/plugins/teleport-msteams.toml
+++ b/examples/resources/plugins/teleport-msteams.toml
@@ -17,7 +17,8 @@ preload = true
 # Credentials generated with `tctl auth sign`.
 #
 # When using --format=file:
-# identity = "/var/lib/teleport/plugins/msteams/auth_id"    # Identity file
+# identity = "/var/lib/teleport/plugins/msteams/identity"   # Identity file
+# refresh_identity = true                                   # Refresh identity file periodically
 #
 # When using --format=tls:
 # client_key = "/var/lib/teleport/plugins/msteams/auth.key" # Teleport TLS secret key
@@ -25,6 +26,7 @@ preload = true
 # root_cas = "/var/lib/teleport/plugins/msteams/auth.cas"   # Teleport CA certs
 addr = "localhost:3025"
 identity = "identity"
+refresh_identity = true
 
 [msapi]
 # MS API IDs. Please, check the documentation.

--- a/examples/resources/plugins/teleport-pagerduty-cloud.toml
+++ b/examples/resources/plugins/teleport-pagerduty-cloud.toml
@@ -1,7 +1,8 @@
 # example teleport-pagerduty configuration TOML file
 [teleport]
 auth_server = "myinstance.teleport.sh:443"                  # Teleport Cloud proxy HTTPS address
-identity = "/var/lib/teleport/plugins/pagerduty/auth.pem"   # Identity file path
+identity = "/var/lib/teleport/plugins/pagerduty/identity"   # Identity file path
+refresh_identity = true                                     # Refresh identity file periodically
 
 [pagerduty]
 api_key = "key"               # PagerDuty API Key

--- a/examples/resources/plugins/teleport-pagerduty-helm-cloud.yaml
+++ b/examples/resources/plugins/teleport-pagerduty-helm-cloud.yaml
@@ -3,6 +3,8 @@ teleport:
   address: "teleport.example.com:443"
   # Secret containing identity
   identitySecretName: teleport-plugin-pagerduty-identity
+  # Path within the secret containing the identity file.
+  identitySecretPath: identity
 
 pagerduty:
   apiKey: "key"                # PagerDuty API Key

--- a/examples/resources/plugins/teleport-pagerduty-helm.yaml
+++ b/examples/resources/plugins/teleport-pagerduty-helm.yaml
@@ -1,9 +1,0 @@
-teleport:
-  # Teleport HTTPS Proxy web address, for Teleport Enterprise Cloud should be in the form "your-account.teleport.sh:443"
-  address: "teleport.example.com:443"
-  # Secret containing identity
-  identitySecretName: teleport-plugin-pagerduty-identity
-
-pagerduty:
-  apiKey: "key"                # PagerDuty API Key
-  userEmail: "me@example.com"  # PagerDuty bot user email (Could be admin email)

--- a/examples/resources/plugins/teleport-slack-helm.yaml
+++ b/examples/resources/plugins/teleport-slack-helm.yaml
@@ -1,8 +1,10 @@
-teleport: {}
+teleport:
   # Teleport HTTPS Proxy Web Address, for Teleport Enterprise Cloud should be in the form "your-account.teleport.sh:443"
   address: "teleport.example.com:443"
   # Secret containing identity
   identitySecretName: teleport-plugin-slack-identity
+  # Path within the secret containing the identity file.
+  identitySecretPath: identity
 
 slack:
   token: "xoxb-11xx"  # Slack Bot OAuth token

--- a/examples/resources/plugins/teleport-slack.toml
+++ b/examples/resources/plugins/teleport-slack.toml
@@ -11,7 +11,8 @@
 # Credentials generated with `tctl auth sign`.
 #
 # When using --format=file:
-# identity = "/var/lib/teleport/plugins/slack/auth_id"    # Identity file
+# identity = "/var/lib/teleport/plugins/slack/identity"   # Identity file
+# refresh_identity = true                                 # Refresh identity file on a periodic basis
 #
 # When using --format=tls:
 # client_key = "/var/lib/teleport/plugins/slack/auth.key" # Teleport TLS secret key


### PR DESCRIPTION
Our access plugins guides have two "paths", Machine ID and Non-Machine ID. These used different file paths for the identity file and actually meant that the guides didn't really work in some combinations. I've unified everything to refer to the identity file as just `identity` rather than `auth.pem` or `auth_id`.

I've also deleted `examples/resources/plugins/teleport-pagerduty-helm.yaml` which looks like it was leftover from a bad refactor - it's not referenced anywhere.