### PR TITLE
atomic write api & etcd implementation

### DIFF
--- a/lib/backend/atomicwrite.go
+++ b/lib/backend/atomicwrite.go
@@ -1,0 +1,282 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package backend
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+)
+
+// ErrConditionFailed is returned from AtomicWrite when one or more conditions failed to hold.
+var ErrConditionFailed = &trace.CompareFailedError{Message: "condition failed, one or more resources were concurrently created|modified|deleted; please reload the current state and try again"}
+
+// ConditionKind marks the kind of condition to be evaluated.
+type ConditionKind int
+
+const (
+	// KindWhatever indicates that no condition should be evaluated.
+	KindWhatever ConditionKind = 1 + iota
+
+	// KindExists asserts that an item exists at the target key.
+	KindExists
+
+	// KindNotExists asserts that no item exists at the target key.
+	KindNotExists
+
+	// KindRevision asserts the exact current revision of the target key.
+	KindRevision
+)
+
+// Condition specifies some requirement that a backend item must meet.
+type Condition struct {
+	// Revision is a specific revision to be asserted (only used when Kind is KindRevision).
+	Revision string
+
+	// Kind is the kind of condition represented.
+	Kind ConditionKind
+}
+
+// IsZero checks if this condition appears unspecified.
+func (c *Condition) IsZero() bool {
+	return c.Kind == 0
+}
+
+// Check verifies that a the condition in well-formed.
+func (c *Condition) Check() error {
+	switch c.Kind {
+	case KindWhatever, KindExists, KindNotExists, KindRevision:
+	default:
+		return trace.BadParameter("unexpected condition kind %v", c.Kind)
+	}
+
+	return nil
+}
+
+// Whatever builds a condition that matches any current key state.
+func Whatever() Condition {
+	return Condition{
+		Kind: KindWhatever,
+	}
+}
+
+// Exists builds a condition that asserts the target key exists.
+func Exists() Condition {
+	return Condition{
+		Kind: KindExists,
+	}
+}
+
+// NotExists builds a condition that asserts the target key does not exist.
+func NotExists() Condition {
+	return Condition{
+		Kind: KindNotExists,
+	}
+}
+
+// Revision builds a condition that asserts the target key has the specified revision.
+func Revision(r string) Condition {
+	return Condition{
+		Kind:     KindRevision,
+		Revision: r,
+	}
+}
+
+// ActionKind marks the kind of an action to be taken.
+type ActionKind int
+
+const (
+	// KindNop indicates that no action should be taken.
+	KindNop ActionKind = 1 + iota
+
+	// KindPut indicates that the associated item should be written to the target key.
+	KindPut
+
+	// KindDelete indicates that any item at the target key should be removed.
+	KindDelete
+)
+
+// Action specifies an action to be taken against a backend item.
+type Action struct {
+	// Item is the item to be written (only used when Kind is Put).
+	Item Item
+
+	// Kind is the kind of action represented.
+	Kind ActionKind
+}
+
+// IsZero checks if this action appears unspecified.
+func (a *Action) IsZero() bool {
+	return a.Kind == 0
+}
+
+// Check verifies that the action is well-formed.
+func (a *Action) Check() error {
+	switch a.Kind {
+	case KindNop, KindDelete:
+	case KindPut:
+		if len(a.Item.Value) == 0 {
+			return trace.BadParameter("missing required put parameter Item.Value")
+		}
+	default:
+		return trace.BadParameter("unexpected action kind %v", a.Kind)
+	}
+
+	return nil
+}
+
+// IsWrite checks if this action performs a write.
+func (a *Action) IsWrite() bool {
+	switch a.Kind {
+	case KindPut, KindDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// Nop builds an action that does nothing.
+func Nop() Action {
+	return Action{
+		Kind: KindNop,
+	}
+}
+
+// Put builds an action that writes the provided item to the target key.
+func Put(item Item) Action {
+	return Action{
+		Kind: KindPut,
+		Item: item,
+	}
+}
+
+// Delete builds an action that removes the target key.
+func Delete() Action {
+	return Action{
+		Kind: KindDelete,
+	}
+}
+
+// ConditionalAction specifies a condition and an action associated with a given key. The condition
+// must hold for the action to be taken.
+type ConditionalAction struct {
+	// Key is the key against which the associated condition and action are to
+	// be applied.
+	Key []byte
+
+	// Condition must be one of Exists|NotExists|Revision(<revision>)|Whatever
+	Condition Condition
+
+	// Action must be one of Put(<item>)|Delete|Nop
+	Action Action
+}
+
+// Check validates the basic correctness of the conditional action.
+func (c *ConditionalAction) Check() error {
+	if len(c.Key) == 0 {
+		return trace.BadParameter("conditional action missing required parameter 'Key'")
+	}
+
+	if c.Condition.IsZero() {
+		return trace.BadParameter("conditional action for %q missing required parameter 'Condition'", c.Key)
+	}
+
+	if c.Action.IsZero() {
+		return trace.BadParameter("conditional action for %q missing required parameter 'Action'", c.Key)
+	}
+
+	if err := c.Condition.Check(); err != nil {
+		return trace.BadParameter("conditional action for key %q contains malformed condition: %v", c.Key, err)
+	}
+
+	if err := c.Action.Check(); err != nil {
+		return trace.BadParameter("conditional action for key %q contains malformed action: %v", c.Key, err)
+	}
+
+	if c.Condition.Kind == KindWhatever && c.Action.Kind == KindNop {
+		return trace.BadParameter("conditional action for %q is ineffectual (Condition=Whatever,Action=Nop)", c.Key)
+	}
+
+	return nil
+}
+
+const (
+	// MaxAtomicWriteSize is the maximum number of conditional actions that may
+	// be applied via a single atomic write. The exact number is subject to change
+	// but must always be less than the minimum value supported across all backends.
+	MaxAtomicWriteSize = 64
+)
+
+// AtomicWriter is a standalone interface for the AtomicWrite method. This interface will be deprecated
+// once all backends implement AtomicWrite.
+type AtomicWriter interface {
+	// AtomicWrite executes a batch of conditional actions atomically s.t. all actions happen if all
+	// conditions are met, but no actions happen if any condition fails to hold. If one or more conditions
+	// failed to hold, [ErrConditionFailed] is returned. The number of conditional actions must not
+	// exceed [MaxAtomicWriteSize] and no two conditional actions may point to the same key. If successful,
+	// the returned revision is the new revision associated with all [Put] actions that were part of the
+	// operation (the revision value has no meaning outside of the context of puts).
+	AtomicWrite(ctx context.Context, condacts []ConditionalAction) (revision string, err error)
+}
+
+// AtomicWriterBackend joins the AtomicWrite interface with the standard backend interface. This interface
+// will be deprecated once all backends implement AtomicWrite.
+type AtomicWriterBackend interface {
+	Backend
+	AtomicWriter
+}
+
+// ValidateAtomicWrite verifies that the supplied group of conditional actions are a valid input for atomic
+// application. This means both verifying that each individual conditional action is well-formed, and also
+// that no two conditional actions targets the same key.
+func ValidateAtomicWrite(condacts []ConditionalAction) error {
+	if len(condacts) > MaxAtomicWriteSize {
+		return trace.BadParameter("too many conditional actions for atomic application (len=%d, max=%d)", len(condacts), MaxAtomicWriteSize)
+	}
+
+	if len(condacts) == 0 {
+		return trace.BadParameter("empty conditional action list")
+	}
+
+	keys := make(map[string]struct{}, len(condacts))
+
+	var containsWrite bool
+
+	for i := range condacts {
+		if err := condacts[i].Check(); err != nil {
+			return trace.Wrap(err)
+		}
+
+		containsWrite = containsWrite || condacts[i].Action.IsWrite()
+
+		key := string(condacts[i].Key)
+
+		if _, ok := keys[key]; ok {
+			return trace.BadParameter("multiple conditional actions target key %q", key)
+		}
+
+		keys[key] = struct{}{}
+	}
+
+	if !containsWrite {
+		return trace.BadParameter("no conditional actions contain writes")
+	}
+
+	return nil
+}

--- a/lib/backend/atomicwrite_test.go
+++ b/lib/backend/atomicwrite_test.go
@@ -1,0 +1,196 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package backend
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicWriteValidation(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		condacts []ConditionalAction
+		ok       bool
+		desc     string
+		estr     string
+	}
+
+	tts := []testCase{
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Exists(),
+					Action: Put(Item{
+						Value: []byte("true"),
+					}),
+				},
+				{
+					Key:       []byte("/bin/baz"),
+					Condition: Revision("r1"),
+					Action:    Delete(),
+				},
+				{
+					Key:       []byte("/apples/oranges"),
+					Condition: NotExists(),
+					Action:    Nop(),
+				},
+				{
+					Key:       []byte("/up/down"),
+					Condition: Whatever(),
+					Action: Put(Item{
+						Value: []byte("v"),
+					}),
+				},
+			},
+			ok:   true,
+			desc: "basic case",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Revision(""), // empty revisions are allowed
+					Action:    Delete(),
+				},
+			},
+			ok:   true,
+			desc: "empty revision",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/singleton"),
+					Condition: Whatever(),
+					Action:    Delete(),
+				},
+			},
+			ok:   true,
+			desc: "singleton",
+		},
+		{
+			condacts: nil,
+			ok:       false,
+			desc:     "empty",
+			estr:     "empty conditional action list",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Exists(),
+					Action: Put(Item{
+						Value: []byte("true"),
+					}),
+				},
+				{
+					Key:       []byte("/foo/baz"),
+					Condition: Revision("r1"),
+					Action:    Delete(),
+				},
+				{
+					Key:       []byte("/apples/oranges"),
+					Condition: NotExists(),
+					Action:    Nop(),
+				},
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Revision("r2"),
+					Action:    Nop(),
+				},
+			},
+			ok:   false,
+			desc: "duplicate keys",
+			estr: "multiple conditional actions target key",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Exists(),
+					Action:    Put(Item{}),
+				},
+			},
+			ok:   false,
+			desc: "empty put",
+			estr: "missing required put parameter Item.Value",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Condition{},
+					Action:    Delete(),
+				},
+			},
+			ok:   false,
+			desc: "zero condition",
+			estr: "missing required parameter 'Condition'",
+		},
+		{
+			condacts: []ConditionalAction{
+				{
+					Key:       []byte("/foo/bar"),
+					Condition: Exists(),
+					Action:    Action{},
+				},
+			},
+			ok:   false,
+			desc: "zero action",
+			estr: "missing required parameter 'Action'",
+		},
+	}
+
+	var big []ConditionalAction
+	for i := 0; i < MaxAtomicWriteSize+1; i++ {
+		big = append(big, ConditionalAction{
+			Key:       []byte(fmt.Sprintf("/key-%d", i)),
+			Condition: Whatever(),
+			Action:    Delete(),
+		})
+	}
+
+	tts = append(tts, testCase{
+		condacts: big,
+		ok:       false,
+		desc:     "too big",
+	})
+
+	tts = append(tts, testCase{
+		condacts: big[:MaxAtomicWriteSize],
+		ok:       true,
+		desc:     "max",
+	})
+
+	for _, tt := range tts {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := ValidateAtomicWrite(tt.condacts)
+			if tt.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.estr)
+			}
+		})
+	}
+}

--- a/lib/backend/etcdbk/atomicwrite.go
+++ b/lib/backend/etcdbk/atomicwrite.go
@@ -1,0 +1,110 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package etcdbk implements Etcd powered backend
+package etcdbk
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+
+	"github.com/gravitational/trace"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+func (b *EtcdBackend) AtomicWrite(ctx context.Context, condacts []backend.ConditionalAction) (revision string, err error) {
+	if err := backend.ValidateAtomicWrite(condacts); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	var cmps []clientv3.Cmp
+	var ops []clientv3.Op
+	var includesPut bool
+
+	for _, ca := range condacts {
+		key := b.prependPrefix(ca.Key)
+
+		switch ca.Condition.Kind {
+		case backend.KindWhatever:
+			// no comparison to assert
+		case backend.KindExists:
+			cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(key), "!=", 0))
+		case backend.KindNotExists:
+			cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(key), "=", 0))
+		case backend.KindRevision:
+			rev, err := fromBackendRevision(ca.Condition.Revision)
+			if err != nil {
+				// malformed revisions are considered a kind of failed condition since they indicate that
+				// the supplied revision did not originate from a preceding read from this backend.
+				return "", trace.Wrap(backend.ErrConditionFailed)
+			}
+
+			cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(key), "!=", 0))
+			cmps = append(cmps, clientv3.Compare(clientv3.ModRevision(key), "=", rev))
+		default:
+			return "", trace.BadParameter("unexpected condition kind %v in conditional action against key %q", ca.Condition.Kind, ca.Key)
+		}
+
+		switch ca.Action.Kind {
+		case backend.KindNop:
+			// no action to be taken
+		case backend.KindPut:
+			includesPut = true
+			var opts []clientv3.OpOption
+			var lease backend.Lease
+			if !ca.Action.Item.Expires.IsZero() {
+				if err := b.setupLease(ctx, ca.Action.Item, &lease, &opts); err != nil {
+					return "", trace.Wrap(err)
+				}
+			}
+
+			ops = append(ops, clientv3.OpPut(key, base64.StdEncoding.EncodeToString(ca.Action.Item.Value), opts...))
+		case backend.KindDelete:
+			ops = append(ops, clientv3.OpDelete(key))
+		default:
+			return "", trace.BadParameter("unexpected action kind %v in conditional action against key %q", ca.Action.Kind, ca.Key)
+		}
+	}
+
+	start := b.clock.Now()
+	re, err := b.clients.Next().Txn(ctx).
+		If(cmps...).
+		Then(ops...).
+		Commit()
+	txLatencies.Observe(time.Since(start).Seconds())
+	txRequests.Inc()
+	if err != nil {
+		return "", trace.Wrap(convertErr(err))
+	}
+
+	if !re.Succeeded {
+		return "", trace.Wrap(backend.ErrConditionFailed)
+	}
+
+	// all etcd writes have a corresponding revision, but most other backends only
+	// have a concept of a put revision. in the interest of consistency, we explicitly
+	// omit returning revision from atomic writes that did not contain any puts.
+	if !includesPut {
+		return "", nil
+	}
+
+	return toBackendRevision(re.Header.Revision), nil
+}

--- a/lib/backend/etcdbk/atomicwrite_test.go
+++ b/lib/backend/etcdbk/atomicwrite_test.go
@@ -1,0 +1,77 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package etcdbk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/test"
+)
+
+// newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
+// it will be integrated into the main backend interface and we can get rid of this separate helper.
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+	opts, err := test.ApplyOptions(options)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if opts.MirrorMode {
+		return nil, nil, test.ErrMirrorNotSupported
+	}
+
+	// No need to check target backend - all Etcd backends create by this test
+	// point to the same datastore.
+
+	bk, err := New(context.Background(), commonEtcdParams, commonEtcdOptions...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// we can't fiddle with clocks inside the etcd client, so instead of creating
+	// and returning a fake clock, we wrap the real clock used by the etcd client
+	// in a FakeClock interface that sleeps instead of instantly advancing.
+	sleepingClock := test.BlockingFakeClock{Clock: bk.clock}
+
+	return bk, sleepingClock, nil
+}
+
+// TestAtomicWriteSuite runs the main atomic write test suite.
+func TestAtomicWriteSuite(t *testing.T) {
+	if !etcdTestEnabled() {
+		t.Skip("This test requires etcd, run `make run-etcd` and set TELEPORT_ETCD_TEST=yes in your environment")
+	}
+
+	test.RunAtomicWriteComplianceSuite(t, newAtomicWriteTestBackend)
+}
+
+// TestAtomicWriteShim runs the classic test suite using a shim that reimplements all single-item writes as calls
+// to AtomicWrite.
+func TestAtomicWriteShim(t *testing.T) {
+	if !etcdTestEnabled() {
+		t.Skip("This test requires etcd, run `make run-etcd` and set TELEPORT_ETCD_TEST=yes in your environment")
+	}
+
+	test.RunBackendComplianceSuiteWithAtomicWriteShim(t, newAtomicWriteTestBackend)
+}

--- a/lib/backend/test/atomicwrite.go
+++ b/lib/backend/test/atomicwrite.go
@@ -1,0 +1,691 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// AtomicWriteConstructor is equivalent to [Constructor], except that it includes the new AtomicWrite method. This type
+// will be deprecated once all backends implement AtomicWrite.
+type AtomicWriteConstructor func(options ...ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error)
+
+func RunAtomicWriteComplianceSuite(t *testing.T, newBackend AtomicWriteConstructor) {
+	t.Run("Move", func(t *testing.T) {
+		testAtomicWriteMove(t, newBackend)
+	})
+
+	t.Run("Lock", func(t *testing.T) {
+		testAtomicWriteLock(t, newBackend)
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		testAtomicWriteMax(t, newBackend)
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		testAtomicWriteConcurrent(t, newBackend)
+	})
+
+	t.Run("NonConflicting", func(t *testing.T) {
+		testAtomicWriteNonConflicting(t, newBackend)
+	})
+
+	t.Run("Other", func(t *testing.T) {
+		testAtomicWriteOther(t, newBackend)
+	})
+}
+
+// testAtomicWriteMove verifies the correct behavior of "move" operations.
+func testAtomicWriteMove(t *testing.T, newBackend AtomicWriteConstructor) {
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	fromKey, toKey, val := prefix("/src"), prefix("/dest"), []byte("val")
+
+	lease, err := bk.Put(ctx, backend.Item{
+		Key:   fromKey,
+		Value: val,
+	})
+	require.NoError(t, err)
+
+	// perform "move".
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fromKey,
+			Condition: backend.Revision(lease.Revision),
+			Action:    backend.Delete(),
+		},
+		{
+			Key:       toKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: val,
+			}),
+		},
+	})
+
+	require.NoError(t, err)
+
+	_, err = bk.Get(ctx, fromKey)
+	require.True(t, trace.IsNotFound(err), "err: %v", err)
+
+	item, err := bk.Get(ctx, toKey)
+	require.NoError(t, err)
+	require.Equal(t, val, item.Value)
+
+	// re-attempt now outdated "move".
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fromKey,
+			Condition: backend.Revision(lease.Revision),
+			Action:    backend.Delete(),
+		},
+		{
+			Key:       toKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: val,
+			}),
+		},
+	})
+	require.ErrorIs(t, err, backend.ErrConditionFailed)
+}
+
+// testAtomicWriteLock verifies correct behavior of various "lock" patterns (i.e. where some update on key X is conditional on
+// the state of key Y).
+func testAtomicWriteLock(t *testing.T, newBackend AtomicWriteConstructor) {
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	itemKey, lockKey := prefix("/item"), prefix("/lock")
+
+	// successful 'NotExists' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.NotExists(),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i1"),
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	firstLockLease, err := bk.Put(ctx, backend.Item{
+		Key:   lockKey,
+		Value: []byte("l1"),
+	})
+	require.NoError(t, err)
+
+	// failing 'NotExists' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.NotExists(),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i2"),
+			}),
+		},
+	})
+	require.ErrorIs(t, err, backend.ErrConditionFailed)
+
+	// verify that item value matches former successful put
+	item, err := bk.Get(ctx, itemKey)
+	require.NoError(t, err)
+	require.Equal(t, []byte("i1"), item.Value)
+
+	// successful 'Revision' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.Revision(firstLockLease.Revision),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i3"),
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	// update the lock
+	_, err = bk.Put(ctx, backend.Item{
+		Key:   lockKey,
+		Value: []byte("l2"),
+	})
+	require.NoError(t, err)
+
+	// unsuccessful 'Revision' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.Revision(firstLockLease.Revision),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i4"),
+			}),
+		},
+	})
+	require.ErrorIs(t, err, backend.ErrConditionFailed)
+
+	// verify that item value matches former successful put
+	item, err = bk.Get(ctx, itemKey)
+	require.NoError(t, err)
+	require.Equal(t, []byte("i3"), item.Value)
+
+	// delete the lock in prep for NotExists case
+	err = bk.Delete(ctx, lockKey)
+	require.NoError(t, err)
+
+	// successful 'NotExists' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.NotExists(),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i5"),
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	// recreate the lock
+	_, err = bk.Put(ctx, backend.Item{
+		Key:   lockKey,
+		Value: []byte("l3"),
+	})
+	require.NoError(t, err)
+
+	// unsuccessful 'NotExists' condition.
+	_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       lockKey,
+			Condition: backend.NotExists(),
+			Action:    backend.Nop(),
+		},
+		{
+			Key:       itemKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("i6"),
+			}),
+		},
+	})
+	require.ErrorIs(t, err, backend.ErrConditionFailed)
+
+	// verify that item value matches former successful put
+	item, err = bk.Get(ctx, itemKey)
+	require.NoError(t, err)
+	require.Equal(t, []byte("i5"), item.Value)
+}
+
+// testAtomicWriteMax verifies correct behavior of very large atomic writes.
+func testAtomicWriteMax(t *testing.T, newBackend AtomicWriteConstructor) {
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	keyOf := func(i int) []byte {
+		return prefix(fmt.Sprintf("/key-%d", i))
+	}
+
+	var condacts []backend.ConditionalAction
+
+	// set up one more conditional actions than should be permitted
+	for i := 0; i < backend.MaxAtomicWriteSize+1; i++ {
+		condacts = append(condacts, backend.ConditionalAction{
+			Key:       keyOf(i),
+			Condition: backend.NotExists(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("v1"),
+			}),
+		})
+	}
+
+	// atomic write should fail
+	_, err = bk.AtomicWrite(ctx, condacts)
+	require.Error(t, err)
+
+	// truncate to the allowed maximum
+	condacts = condacts[:backend.MaxAtomicWriteSize]
+
+	// atomic write should now succeed
+	rev1, err := bk.AtomicWrite(ctx, condacts)
+	require.NoError(t, err)
+
+	// verify that items were inserted as expected
+	for i := 0; i < backend.MaxAtomicWriteSize; i++ {
+		item, err := bk.Get(ctx, keyOf(i))
+		require.NoError(t, err, "i=%d", i)
+		require.Equal(t, rev1, item.Revision)
+		require.Equal(t, []byte("v1"), item.Value)
+	}
+
+	// update puts
+	for i := range condacts {
+		condacts[i].Action = backend.Put(backend.Item{
+			Value: []byte("v2"),
+		})
+	}
+
+	// re-attempt should fail due to conditions no-longer holding
+	_, err = bk.AtomicWrite(ctx, condacts)
+	require.ErrorIs(t, err, backend.ErrConditionFailed)
+
+	// verify that failed atomic write results in no changes
+	for i := 0; i < backend.MaxAtomicWriteSize; i++ {
+		item, err := bk.Get(ctx, keyOf(i))
+		require.NoError(t, err, "i=%d", i)
+		require.Equal(t, rev1, item.Revision)
+		require.Equal(t, []byte("v1"), item.Value)
+	}
+
+	// update conditional actions to assert revision
+	for i := range condacts {
+		condacts[i].Action = backend.Put(backend.Item{
+			Value: []byte("v3"),
+		})
+		condacts[i].Condition = backend.Revision(rev1)
+	}
+
+	// conditional actions should now succeed
+	rev2, err := bk.AtomicWrite(ctx, condacts)
+	require.NoError(t, err)
+
+	// verify that changes occurred as expected
+	for i := 0; i < backend.MaxAtomicWriteSize; i++ {
+		item, err := bk.Get(ctx, keyOf(i))
+		require.NoError(t, err, "i=%d", i)
+		require.Equal(t, rev2, item.Revision)
+		require.Equal(t, []byte("v3"), item.Value)
+	}
+}
+
+// testAtomicWriteConcurrent is a sanity-check intended to verify the correctness of AtomicWrite under high concurrency.
+func testAtomicWriteConcurrent(t *testing.T, newBackend AtomicWriteConstructor) {
+	const (
+		increments = 200
+		workers    = 20
+	)
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	counterKey := prefix("/counter")
+
+	_, err = bk.Put(ctx, backend.Item{
+		Key:   counterKey,
+		Value: []byte("0"),
+	})
+	require.NoError(t, err)
+
+	var eg errgroup.Group
+	for i := 0; i < workers; i++ {
+		eg.Go(func() error {
+			var localIncrements int
+
+			// note that we only attempt exactly 'increments' number of times, because we expect every iteration to
+			// succeed for at least one worker. this requirement only holds true if reads are *consistent*, weak reads
+			// *would* result in cases where all workers failed to perform an increment because they all observed an
+			// outdated state.
+			for j := 0; j < increments; j++ {
+				if localIncrements >= increments/workers {
+					return nil
+				}
+
+				item, err := bk.Get(ctx, counterKey)
+				if err != nil {
+					// should never happen unless test is malformed or backend is offline
+					return trace.Errorf("unexpected error loading counter: %v", err)
+				}
+
+				n, err := strconv.Atoi(string(item.Value))
+				if err != nil {
+					// should never happen unless test is malformed or backend is offline
+					return trace.Errorf("invalid counter value %q: %v", item.Value, err)
+				}
+
+				n++
+
+				_, err = bk.AtomicWrite(ctx, []backend.ConditionalAction{
+					{
+						Key:       counterKey,
+						Condition: backend.Revision(item.Revision),
+						Action: backend.Put(backend.Item{
+							Value: []byte(strconv.Itoa(n)),
+						}),
+					},
+				})
+
+				if err != nil {
+					if errors.Is(err, backend.ErrConditionFailed) {
+						continue
+					}
+
+					// should never happen unless test is malformed or backend is offline
+					return trace.Errorf("unexpected error writing counter: %v", err)
+				}
+
+				localIncrements++
+			}
+
+			if localIncrements < increments/workers {
+				// should never happen unless test is malformed or backend is offline
+				return trace.Errorf("worker halted with %d/%d local increments (this is a bug)", localIncrements, increments/workers)
+			}
+
+			return nil
+		})
+	}
+
+	require.NoError(t, eg.Wait())
+
+	counterItem, err := bk.Get(ctx, counterKey)
+	require.NoError(t, err)
+
+	n, err := strconv.Atoi(string(counterItem.Value))
+	require.NoError(t, err)
+	require.Equal(t, increments, n)
+}
+
+// testAtomicWriteNonConflicting verifies that non-conflicting but overlapping transactions all succeed
+// on the first attempt when running concurrently, meaning that backends that treat overlap as conflict (e.g. dynamo)
+// handle such conflicts internally.
+func testAtomicWriteNonConflicting(t *testing.T, newBackend AtomicWriteConstructor) {
+	const workers = 60
+
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	results := make(chan error, workers)
+
+	commonKey := prefix("/common")
+
+	itemKey := func(i int) []byte {
+		return prefix(fmt.Sprintf("/item-%d", i))
+	}
+
+	_, err = bk.Put(ctx, backend.Item{
+		Key:   commonKey,
+		Value: []byte("c1"),
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			_, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+				{
+					Key:       commonKey,
+					Condition: backend.Exists(),
+					Action:    backend.Nop(),
+				},
+				{
+					Key:       itemKey(i),
+					Condition: backend.Whatever(),
+					Action: backend.Put(backend.Item{
+						Value: []byte("v1"),
+					}),
+				},
+			})
+
+			results <- err
+		}(i)
+	}
+
+	timeout := time.After(time.Minute)
+
+	for i := 0; i < workers; i++ {
+		select {
+		case err := <-results:
+			require.NoError(t, err, trace.DebugReport(err))
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for workers to finish", "iteration=%d", i)
+		}
+	}
+
+	for i := 0; i < workers; i++ {
+		item, err := bk.Get(ctx, itemKey(i))
+		require.NoError(t, err)
+		require.Equal(t, []byte("v1"), item.Value)
+	}
+}
+
+// testAtomicWriteOther verifies some minor edge-cases that may not be covered by other tests. Specifically,
+// it verifies that Item.Key has no effect on writes or subsequent reads, and that ineffectual writes still
+// update the value of revision.
+func testAtomicWriteOther(t *testing.T, newBackend AtomicWriteConstructor) {
+	bk, _, err := newBackend()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prefix := MakePrefix()
+
+	fooKey, barKey, badKey := prefix("/foo"), prefix("/bar"), prefix("/bad")
+
+	fooVal, barVal := []byte("foo"), []byte("bar")
+
+	// set initial values. we include incorrect keys in the items passed to Put in
+	// order to verify that those keys are ignored as intended.
+	rev1, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fooKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Key:   badKey, // should be ignored
+				Value: fooVal,
+			}),
+		},
+		{
+			Key:       barKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Key:   badKey, // should be ignored
+				Value: barVal,
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	fooItem, err := bk.Get(ctx, fooKey)
+	require.NoError(t, err)
+	require.Equal(t, fooKey, fooItem.Key)
+	require.Equal(t, fooVal, fooItem.Value)
+	require.Equal(t, rev1, fooItem.Revision)
+
+	barItem, err := bk.Get(ctx, barKey)
+	require.NoError(t, err)
+	require.Equal(t, barKey, barItem.Key)
+	require.Equal(t, barVal, barItem.Value)
+	require.Equal(t, rev1, barItem.Revision)
+
+	// ensure that the key passed to item didn't cause anything to be written
+	// to that key.
+	_, err = bk.Get(ctx, badKey)
+	require.True(t, trace.IsNotFound(err), "err: %v", err)
+
+	// re-write the same values again to verify that revision is changed even when values are not.
+	rev2, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fooKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Key:   badKey, // should be ignored
+				Value: fooVal,
+			}),
+		},
+		{
+			Key:       barKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Key:   badKey, // should be ignored
+				Value: barVal,
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	fooItem, err = bk.Get(ctx, fooKey)
+	require.NoError(t, err)
+	require.Equal(t, fooVal, fooItem.Value)
+	require.Equal(t, rev2, fooItem.Revision)
+
+	barItem, err = bk.Get(ctx, barKey)
+	require.NoError(t, err)
+	require.Equal(t, barVal, barItem.Value)
+	require.Equal(t, rev2, barItem.Revision)
+
+	// perform partially-redundant write to ensure that revision is also changed for all items in that case.
+	rev3, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fooKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: fooVal,
+			}),
+		},
+		{
+			Key:       barKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: []byte("something-else"),
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	fooItem, err = bk.Get(ctx, fooKey)
+	require.NoError(t, err)
+	require.Equal(t, fooVal, fooItem.Value)
+	require.Equal(t, rev3, fooItem.Revision)
+
+	barItem, err = bk.Get(ctx, barKey)
+	require.NoError(t, err)
+	require.Equal(t, []byte("something-else"), barItem.Value)
+	require.Equal(t, rev3, barItem.Revision)
+
+	// mixed put and delete case
+	rev4, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fooKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: fooVal,
+			}),
+		},
+		{
+			Key:       barKey,
+			Condition: backend.Whatever(),
+			Action:    backend.Delete(),
+		},
+	})
+	require.NoError(t, err)
+
+	fooItem, err = bk.Get(ctx, fooKey)
+	require.NoError(t, err)
+	require.Equal(t, fooVal, fooItem.Value)
+	require.Equal(t, rev4, fooItem.Revision)
+
+	_, err = bk.Get(ctx, barKey)
+	require.True(t, trace.IsNotFound(err), "err: %v", err)
+
+	// mixed put and condition case
+	rev5, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       fooKey,
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: fooVal,
+			}),
+		},
+		{
+			Key:       barKey,
+			Condition: backend.NotExists(),
+			Action:    backend.Nop(),
+		},
+	})
+	require.NoError(t, err)
+
+	fooItem, err = bk.Get(ctx, fooKey)
+	require.NoError(t, err)
+	require.Equal(t, fooVal, fooItem.Value)
+	require.Equal(t, rev5, fooItem.Revision)
+
+	_, err = bk.Get(ctx, barKey)
+	require.True(t, trace.IsNotFound(err), "err: %v", err)
+}

--- a/lib/backend/test/atomicwrite_shim.go
+++ b/lib/backend/test/atomicwrite_shim.go
@@ -1,0 +1,244 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// RunBackendComplianceSuiteWithAtomicWriteShim runs the old backend compliance suite against the provided backend
+// with a shim that converts all calls to single-write methods (all write methods but DeleteRange) into calls to
+// AtomicWrite. This is done to ensure that the relationship between the conditional actions of AtomicWrite and the
+// single-write methods is well defined, and to improve overall coverage of AtomicWrite implementations via reuse.
+func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend AtomicWriteConstructor) {
+	RunBackendComplianceSuite(t, func(options ...ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
+		bk, clock, err := newBackend(options...)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		return atomicWriteShim{
+			AtomicWriterBackend: bk,
+			sentinel:            []byte(uuid.New().String()),
+		}, clock, nil
+	})
+}
+
+// atomciWriteShim reimplements all single-write backend methods as calls to AtomicWrite.
+type atomicWriteShim struct {
+	backend.AtomicWriterBackend
+	sentinel []byte
+}
+
+// sca builds a sentinel conditional action to be added to calls to AtomicWrite to force them to
+// all contain multiple conditional actions. This is a trick used to avoid being routed to an
+// optimized impl (e.g. translating a Whatever/Put into a standard Backend.Put).
+func (a atomicWriteShim) sca() backend.ConditionalAction {
+	return backend.ConditionalAction{
+		Key:       a.sentinel,
+		Condition: backend.NotExists(),
+		Action:    backend.Nop(),
+	}
+}
+
+// Create creates item if it does not exist
+func (a atomicWriteShim) Create(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       i.Key,
+			Condition: backend.NotExists(),
+			Action:    backend.Put(i),
+		},
+	})
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.AlreadyExists("already exists")
+		}
+		return nil, trace.Wrap(err)
+	}
+	return &backend.Lease{
+		Key:      i.Key,
+		Revision: rev,
+	}, nil
+}
+
+// Put puts value into backend (creates if it does not
+// exists, updates it otherwise)
+func (a atomicWriteShim) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       i.Key,
+			Condition: backend.Whatever(),
+			Action:    backend.Put(i),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &backend.Lease{
+		Key:      i.Key,
+		Revision: rev,
+	}, nil
+}
+
+// CompareAndSwap compares item with existing item
+// and replaces is with replaceWith item
+func (a atomicWriteShim) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
+	const casRetries = 16
+
+	for i := 0; i < casRetries; i++ {
+		existing, err := a.Get(ctx, replaceWith.Key)
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return nil, trace.CompareFailed("compare failed")
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		if !bytes.Equal(expected.Value, existing.Value) {
+			return nil, trace.CompareFailed("not equal")
+		}
+
+		rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+			a.sca(),
+			{
+				Key:       replaceWith.Key,
+				Condition: backend.Revision(existing.Revision),
+				Action:    backend.Put(replaceWith),
+			},
+		})
+
+		if err != nil {
+			if errors.Is(err, backend.ErrConditionFailed) {
+				// concurrent modification does not guarantee that the value was changed (may have been a redundant
+				// update or a keepalive), so we need to retry in order to determine wether or not the cas should
+				// succeed.
+				continue
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		return &backend.Lease{
+			Key:      replaceWith.Key,
+			Revision: rev,
+		}, nil
+	}
+
+	return nil, trace.Errorf("failed to perform CompareAndSwap, too much contention")
+}
+
+// Update updates value in the backend
+func (a atomicWriteShim) Update(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       i.Key,
+			Condition: backend.Exists(),
+			Action:    backend.Put(i),
+		},
+	})
+
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.NotFound("not found")
+		}
+
+		return nil, trace.Wrap(err)
+	}
+
+	return &backend.Lease{
+		Key:      i.Key,
+		Revision: rev,
+	}, nil
+}
+
+// Delete deletes item by key, returns NotFound error
+// if item does not exist
+func (a atomicWriteShim) Delete(ctx context.Context, key []byte) error {
+	_, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       key,
+			Condition: backend.Exists(),
+			Action:    backend.Delete(),
+		},
+	})
+
+	if errors.Is(err, backend.ErrConditionFailed) {
+		return trace.NotFound("not found")
+	}
+
+	return trace.Wrap(err)
+}
+
+// ConditionalUpdate updates the value in the backend if the revision of the [backend.Item] matches
+// the stored revision.
+func (a atomicWriteShim) ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       i.Key,
+			Condition: backend.Revision(i.Revision),
+			Action:    backend.Put(i),
+		},
+	})
+
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.Wrap(backend.ErrIncorrectRevision)
+		}
+
+		return nil, trace.Wrap(err)
+	}
+
+	return &backend.Lease{
+		Key:      i.Key,
+		Revision: rev,
+	}, nil
+}
+
+// ConditionalDelete deletes the item by key if the revision matches the stored revision.
+func (a atomicWriteShim) ConditionalDelete(ctx context.Context, key []byte, revision string) error {
+	_, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
+		a.sca(),
+		{
+			Key:       key,
+			Condition: backend.Revision(revision),
+			Action:    backend.Delete(),
+		},
+	})
+
+	if errors.Is(err, backend.ErrConditionFailed) {
+		return trace.Wrap(backend.ErrIncorrectRevision)
+	}
+
+	return trace.Wrap(err)
+}


### PR DESCRIPTION
This PR implements the core API and test suite for the new `AtomicWrite` method, as well as the first concrete implementation (etcd).

Once `AtomicWrite` is available for all backends it will allow us to perform consistent transaction-like operations across multiple keys atomically.  The `AtomicWrite` API allows callers to define a set of conditions and actions for various keys and apply them s.t. all actions happen if and only if all conditions are met.  Ex:

```golang
revision, err := bk.AtomicWrite(ctx, []backend.ConditionalAction{
    {
        Key:       []byte("new"),
        Condition: backend.NotExists(),
        Action: backend.Put(backend.Item{
            Value: []byte("val"),
        }),
    },
    {
        Key:       []byte("old"),
        Condition: backend.Exists(),
        Action: backend.Delete(),
    },
    {
        Key:       []byte("lock"),
        Condition: backend.Revision(rev),
        Action: backend.Nop(),
    },
})
```

The supported conditions are `Exists`, `NotExists`, `Revision(<revision>)`, and `Whatever`.  The supported actions are `Put(<item>)`, `Delete`, and `Nop`. The returned revision is the revision associated with any `Put` actions that were taken, and has no bearing toward any other keys involved in the write.

It is important to note that while this API is very powerful in terms of what it can achieve, it also has the potential to be significantly more slow/costly than classic methods (depending on the backend).  Especially in comparison to `Backend.Put` which is typically very fast/cheap.  Because of this, `AtomicWrite` is not suitable for use with presence resources and/or any automated action that doesn't have strong rate-limiting in place.  The best place for `AtomicWrite` is in ensuring consistent management of sensitive configuration state.