### PR TITLE
[testing] Check if os compat runs on a dependabot change to the workflow itself

### DIFF
--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Teleport
-        uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
+        uses: actions/checkout@v4
 
       - name: Prepare workspace
         uses: ./.github/actions/prepare-workspace
@@ -54,7 +54,7 @@ jobs:
           make -j"$(nproc)" binaries
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: ${{ github.workspace }}/build/
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: ${{ github.workspace }}/build


### PR DESCRIPTION
This is testing for https://github.com/gravitational/teleport/pull/36107