### PR TITLE
add openssh root login troubleshooting

### DIFF
--- a/docs/pages/server-access/troubleshooting-server.mdx
+++ b/docs/pages/server-access/troubleshooting-server.mdx
@@ -142,7 +142,7 @@ spec:
 For more information about moderated sessions and session sharing, see 
 [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx).
 
-## Unable to connect to Agentless OpenSSH server as root
+## Unable to connect to agentless OpenSSH server as root
 
 You should check your sshd configuration in `/etc/ssh/sshd_config` for a setting like
 `PermitRootLogin no` or `PermitRootLogin forced-commands-only` - either of these

--- a/docs/pages/server-access/troubleshooting-server.mdx
+++ b/docs/pages/server-access/troubleshooting-server.mdx
@@ -141,3 +141,16 @@ spec:
 
 For more information about moderated sessions and session sharing, see 
 [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx).
+
+## Unable to connect to Agentless OpenSSH server as root
+
+You should check sshd configuration in /etc/ssh/sshd_config for a setting like
+`PermitRootLogin no` or `PermitRootLogin forced-commands-only` - either of these
+settings will prevent login as root. 
+If you wish to login as root to an OpenSSH server via Teleport, we recommend
+changing this setting to `PermitRootLogin prohibit-password`.
+
+You will need to restart sshd for the change to take effect:
+```code
+$ sudo systemctl restart sshd
+```

--- a/docs/pages/server-access/troubleshooting-server.mdx
+++ b/docs/pages/server-access/troubleshooting-server.mdx
@@ -147,7 +147,7 @@ For more information about moderated sessions and session sharing, see
 You should check sshd configuration in /etc/ssh/sshd_config for a setting like
 `PermitRootLogin no` or `PermitRootLogin forced-commands-only` - either of these
 settings will prevent login as root. 
-If you wish to login as root to an OpenSSH server via Teleport, we recommend
+If you wish to log in as root to an OpenSSH server via Teleport, we recommend
 changing this setting to `PermitRootLogin prohibit-password`.
 
 You will need to restart sshd for the change to take effect:

--- a/docs/pages/server-access/troubleshooting-server.mdx
+++ b/docs/pages/server-access/troubleshooting-server.mdx
@@ -144,7 +144,7 @@ For more information about moderated sessions and session sharing, see
 
 ## Unable to connect to Agentless OpenSSH server as root
 
-You should check sshd configuration in /etc/ssh/sshd_config for a setting like
+You should check your sshd configuration in `/etc/ssh/sshd_config` for a setting like
 `PermitRootLogin no` or `PermitRootLogin forced-commands-only` - either of these
 settings will prevent login as root. 
 If you wish to log in as root to an OpenSSH server via Teleport, we recommend


### PR DESCRIPTION
This is a docs PR that adds a troubleshooting section for agentless openssh connections as root.

A customer had an issue where they could only login to their agentless openssh server as non-root users.
We discovered they had `PermitRootLogin no` in their sshd config.
The customer had no issue connecting as root to servers that were running a Teleport ssh agent, hence the confusion.

Maybe this section will help someone in the future 🤷‍♂️ 