### PR TITLE
dronegen: Add `-amd64` suffix to image tag to match what ghcr.io uses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1904,12 +1904,14 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7
-  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
-  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-amd64
+    public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
   - name: awsconfig
@@ -1927,13 +1929,13 @@ steps:
   - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
     -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7-fips
-  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-amd64
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
     login -u="AWS" --password-stdin public.ecr.aws
-  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
+  - docker tag ghcr.io/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-amd64
     public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
@@ -12044,6 +12046,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 362bdca89f7ae5fe897f6984533ff4d26993da5ed8084bbd64f3cf4991d2189b
+hmac: 4ebdea923dc76d4f2565d5462d5ee04db6dd9e9e273620fac44fcc34d3259808
 
 ...


### PR DESCRIPTION
Add an architecture-specific suffix to the image tag used by ghcr.io.

This will fix:
https://drone.platform.teleport.sh/gravitational/teleport/32161/9/8