### PR TITLE
Add support for hardened AMIs on arm64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2715,6 +2715,8 @@ depends_on:
 - clean-up-previous-build
 - build-linux-amd64
 - build-linux-amd64-fips
+- build-linux-arm64
+- build-linux-arm64-fips
 steps:
 - name: Check out code
   image: docker:git
@@ -12046,6 +12048,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 4ebdea923dc76d4f2565d5462d5ee04db6dd9e9e273620fac44fcc34d3259808
+hmac: 6037e6bdee3255d8eebea41cf0536df554378778bc536aeaf075eb65dcda82ff
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## 15.0.0 (xx/xx/24)
 
-### Breaking changes
+### New features
+
+#### FIPS now supported on ARM64
+
+Teleport 15 now provides FIPS-compliant Linux builds on ARM64. Users will now
+be able to run Teleport in FedRAMP/FIPS mode on ARM64.
+
+#### Hardened AMIs now produced for ARM64
+
+Teleport 15 now provides hardened AWS AMIs on ARM64.
+
+### Breaking changes and deprecations
 
 #### `tsh ssh`
 
@@ -36,7 +47,7 @@ has been out of support for many months.
 #### Container images
 
 Teleport 15 contains several breaking changes to improve the default security
-and usability of container images.
+and usability of Teleport-provided container images.
 
 ##### "Heavy" container images are discontinued
 
@@ -83,6 +94,20 @@ Teleport 8 will need to download any quay.io images they depend on and mirror
 them elsewhere before July 2024. Following brownouts in May and June, Teleport
 will disable pulls from all Teleport quay.io repositories on Wednesday July 3,
 2024.
+
+#### Amazon AMIs
+
+Teleport 15 contains several breaking changes to improve the default security
+and usability of Teleport-provided Amazon AMIs.
+
+##### Hardened AMIs
+
+Teleport-provided Amazon Linux 2023 previously only supported x86_64/amd64.
+Starting with Teleport 15, arm64-based AMIs will be produced. However, the
+naming scheme for these AMIs has been changed to include the architecture.
+
+- Previous naming scheme: `teleport-oss-14.0.0-$TIMESTAMP`
+- New naming scheme: `teleport-oss-15.0.0-x86_64-$TIMESTAMP`
 
 ## 14.0.0 (09/20/23)
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -352,8 +352,8 @@ from a trusted CA, e.g., Let's Encrypt.
 
 ## Amazon EC2
 
-We provide pre-built `amd64` Amazon Linux 2023 based EC2 AMIs with Teleport
-pre-installed.
+We provide pre-built `amd64` and `arm64` Amazon Linux 2023 based EC2 AMIs with
+Teleport pre-installed.
 
 These images are primarily intended for deploying a Teleport cluster using our
 [reference Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform).
@@ -367,14 +367,17 @@ the Teleport installation by setting configuration variables in the
 `/etc/teleport.d/conf` file on the EC2 instance. See the [Starter Cluster Configuration Template](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/starter-cluster/data.tpl)
 for a list of the available configuration options.
 
-The image names all include the build timestamp (shown as `$TIMESTAMP` in the table
-below), and are tagged for easier searching.
+The image names all include the build timestamp (shown as `$TIMESTAMP` in the
+table below), and are tagged for easier searching.
 
-| Image name | Edition | FIPS support | AMI Tags | Owner Account ID |
-| - | - | - | - | - |
-| `teleport-oss-(=teleport.version=)-$TIMESTAMP` | OSS | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: oss`, `TeleportFipsEnabled: false` | 146628656107 |
-| `teleport-ent-(=teleport.version=)-$TIMESTAMP` | Enterprise | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: false` | 146628656107 |
-| `teleport-ent-(=teleport.version=)-fips-$TIMESTAMP` | Enterprise | Yes | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: true` | 146628656107 |
+| Image name | Edition | Architecture | FIPS support | AMI Tags | Owner Account ID |
+| - | - | - | - | - | - |
+| `teleport-oss-(=teleport.version=)-x86_64-$TIMESTAMP` | OSS | amd64 | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: oss`, `TeleportFipsEnabled: false` | 146628656107 |
+| `teleport-oss-(=teleport.version=)-arm64-$TIMESTAMP` | OSS | arm64 | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: oss`, `TeleportFipsEnabled: false` | 146628656107 |
+| `teleport-ent-(=teleport.version=)-x86_64-$TIMESTAMP` | Enterprise | amd64 | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: false` | 146628656107 |
+| `teleport-ent-(=teleport.version=)-arm64-$TIMESTAMP` | Enterprise | arm64 | No | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: false` | 146628656107 |
+| `teleport-ent-(=teleport.version=)-x86_64-fips-$TIMESTAMP` | Enterprise | amd64 | Yes | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: true` | 146628656107 |
+| `teleport-ent-(=teleport.version=)-arm64-fips-$TIMESTAMP` | Enterprise | arm64 | Yes | `TeleportVersion: (=teleport.version=)`, `TeleportEdition: ent`, `TeleportFipsEnabled: true` | 146628656107 |
 
 All images are based on Amazon Linux 2023 and have been hardened using the
 Amazon EC2 ImageBuilder [STIG](https://public.cyber.mil/stigs/) hardening

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -74,6 +74,8 @@ func tagPipelines() []pipeline {
 			tagCleanupPipelineName,
 			"build-linux-amd64",
 			"build-linux-amd64-fips",
+			"build-linux-arm64",
+			"build-linux-arm64-fips",
 		},
 		workflows: []ghaWorkflow{
 			{


### PR DESCRIPTION
This is only for the newer AL2023 AMIs, not the old AL2 AMIs (which are deprecated).

Depends on gravitational/cloud-terraform#3920.

`e` companion -- gravitational/teleport.e#3058

Ref #36110.