### PR TITLE
Simplify single destination reverse tunnels

### DIFF
--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -142,8 +142,7 @@ type mockAgentInjection struct {
 	client SSHClient
 }
 
-func (m *mockAgentInjection) transport(context.Context, ssh.Channel, <-chan *ssh.Request, sshutils.Conn) *transport {
-	return &transport{}
+func (m *mockAgentInjection) handleTransport(context.Context, ssh.Channel, <-chan *ssh.Request, sshutils.Conn) {
 }
 
 func (m *mockAgentInjection) DialContext(context.Context, utils.NetAddr) (SSHClient, error) {
@@ -176,13 +175,13 @@ func testAgent(t *testing.T) (*agent, *mockSSHClient) {
 	}
 
 	agent, err := newAgent(agentConfig{
-		keepAlive:     time.Millisecond * 100,
-		addr:          addr,
-		transporter:   inject,
-		sshDialer:     inject,
-		versionGetter: inject,
-		tracker:       tracker,
-		lease:         lease,
+		keepAlive:        time.Millisecond * 100,
+		addr:             addr,
+		transportHandler: inject,
+		sshDialer:        inject,
+		versionGetter:    inject,
+		tracker:          tracker,
+		lease:            lease,
 	})
 	require.NoError(t, err, "Unexpected error during agent construction.")
 

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -37,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/defaults"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
@@ -464,7 +466,7 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 		addr:               *addr,
 		keepAlive:          p.runtimeConfig.keepAliveInterval,
 		sshDialer:          dialer,
-		transporter:        p,
+		transportHandler:   p,
 		versionGetter:      p,
 		tracker:            tracker,
 		lease:              lease,
@@ -515,8 +517,13 @@ func (p *AgentPool) getVersion(ctx context.Context) (string, error) {
 	return pong.ServerVersion, nil
 }
 
-// transport creates a new transport instance.
-func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) *transport {
+// handleTransport runs a new teleport-transport channel.
+func (p *AgentPool) handleTransport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) {
+	if !p.IsRemoteCluster {
+		p.handleLocalTransport(ctx, channel, requests, conn)
+		return
+	}
+
 	t := &transport{
 		closeContext:         ctx,
 		component:            p.Component,
@@ -540,11 +547,63 @@ func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests
 	// the leaf proxy to track sessions that are initiated via the root cluster. Without providing
 	// the user tracker the leaf cluster metrics will be incorrect and graceful shutdown will not
 	// wait for user sessions to be terminated prior to proceeding with the shutdown operation.
-	if p.IsRemoteCluster && p.ReverseTunnelServer != nil {
+	if p.ReverseTunnelServer != nil {
 		t.trackUserConnection = p.ReverseTunnelServer.TrackUserConnection
 	}
 
-	return t
+	t.start()
+}
+
+func (p *AgentPool) handleLocalTransport(ctx context.Context, channel ssh.Channel, reqC <-chan *ssh.Request, sconn sshutils.Conn) {
+	defer channel.Close()
+	go io.Copy(io.Discard, channel.Stderr())
+
+	// the only valid teleport-transport-dial request here is to reach the local service
+	var req *ssh.Request
+	select {
+	case <-ctx.Done():
+		go ssh.DiscardRequests(reqC)
+		return
+	case <-time.After(apidefaults.DefaultIOTimeout):
+		go ssh.DiscardRequests(reqC)
+		p.log.Warn("Timed out waiting for transport dial request.")
+		return
+	case r, ok := <-reqC:
+		if !ok {
+			return
+		}
+		go ssh.DiscardRequests(reqC)
+		req = r
+	}
+
+	// sconn should never be nil, but it's sourced from the agent state and
+	// starts as nil, and the original transport code checked against it
+	if sconn == nil || p.Server == nil {
+		p.log.Error("Missing client or server (this is a bug).")
+		fmt.Fprintf(channel.Stderr(), "internal server error")
+		req.Reply(false, nil)
+		return
+	}
+
+	if err := req.Reply(true, nil); err != nil {
+		p.log.Errorf("Failed to respond to dial request: %v.", err)
+		return
+	}
+
+	var conn net.Conn = sshutils.NewChConn(sconn, channel)
+
+	dialReq := parseDialReq(req.Payload)
+	switch dialReq.Address {
+	case reversetunnelclient.LocalNode, reversetunnelclient.LocalKubernetes, reversetunnelclient.LocalWindowsDesktop:
+	default:
+		p.log.WithField("address", dialReq.Address).
+			Warn("Received dial request for unexpected address, routing to the local service anyway.")
+	}
+	if src, err := utils.ParseAddr(dialReq.ClientSrcAddr); err == nil {
+		conn = utils.NewConnWithSrcAddr(conn, getTCPAddr(src))
+	}
+
+	p.Server.HandleConnection(conn)
 }
 
 // agentPoolRuntimeConfig contains configurations dynamically set and updated


### PR DESCRIPTION
Public release of private fix: https://github.com/gravitational/teleport-private/pull/1219
PR fixes: https://github.com/gravitational/teleport-private/issues/1197
Will be disclosed under advisory: https://github.com/gravitational/teleport/security/advisories/GHSA-hw4x-mcx5-9q36

This PR makes it so that teleport-transport channels in the reverse tunnel server (on the Teleport Proxy) will only connect the peer to the auth server, and that teleport-transport channels in the non-remote-cluster reverse tunnel agents (on the Teleport peripheral cluster components) will only connect the peer to the local service.

changelog: SSRF security fix documented under the advisory https://github.com/gravitational/teleport/security/advisories/GHSA-hw4x-mcx5-9q36