### PR TITLE
Better control on user injected environment values

### DIFF
--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -115,6 +115,23 @@ func TestOSCommandPrep(t *testing.T) {
 	require.Equal(t, expectedEnv, cmd.Env)
 }
 
+func TestConfigureCommand(t *testing.T) {
+	srv := newMockServer(t)
+	scx := newExecServerContext(t, srv)
+
+	unexpectedKey := "FOO"
+	unexpectedValue := "BAR"
+	// environment values in the server context should not be forwarded
+	scx.SetEnv(unexpectedKey, unexpectedValue)
+
+	cmd, err := ConfigureCommand(scx)
+	require.NoError(t, err)
+
+	require.NotNil(t, cmd)
+	require.Equal(t, "/proc/self/exe", cmd.Path)
+	require.NotContains(t, cmd.Env, unexpectedKey+"="+unexpectedValue)
+}
+
 // TestContinue tests if the process hangs if a continue signal is not sent
 // and makes sure the process continues once it has been sent.
 func TestContinue(t *testing.T) {

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -961,7 +961,6 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 
 	// build env for `teleport exec`
 	env := &envutils.SafeEnv{}
-	env.AddFullTrusted(cmdmsg.Environment...)
 	env.AddExecEnvironment()
 
 	// Build the "teleport exec" command.

--- a/lib/utils/envutils/environment.go
+++ b/lib/utils/envutils/environment.go
@@ -93,6 +93,7 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 
 var unsafeEnvironmentVars = map[string]struct{}{
 	// Linux
+	// values taken from 'man ld.so' https://man7.org/linux/man-pages/man8/ld.so.8.html
 	"LD_ASSUME_KERNEL":         {},
 	"LD_AUDIT":                 {},
 	"LD_BIND_NOW":              {},
@@ -108,8 +109,17 @@ var unsafeEnvironmentVars = map[string]struct{}{
 	"LD_RPATH":                 {},
 	"LD_USE_LOAD_BIAS":         {},
 	// macOS
-	"DYLD_INSERT_LIBRARIES": {},
-	"DYLD_LIBRARY_PATH":     {},
+	// values taken from 'man dyld' https://www.manpagez.com/man/1/dyld/
+	"DYLD_FRAMEWORK_PATH":           {},
+	"DYLD_FALLBACK_FRAMEWORK_PATH":  {},
+	"DYLD_VERSIONED_FRAMEWORK_PATH": {},
+	"DYLD_LIBRARY_PATH":             {},
+	"DYLD_FALLBACK_LIBRARY_PATH":    {},
+	"DYLD_VERSIONED_LIBRARY_PATH":   {},
+	"DYLD_IMAGE_SUFFIX":             {},
+	"DYLD_INSERT_LIBRARIES":         {},
+	"DYLD_SHARED_REGION":            {},
+	"DYLD_SHARED_CACHE_DIR:":        {},
 }
 
 // SafeEnv allows you to build a system environment while avoiding potentially dangerous environment conditions.  In
@@ -132,7 +142,7 @@ func (e *SafeEnv) AddUnique(k, v string) {
 func (e *SafeEnv) add(preventDuplicates bool, k, v string) {
 	k = strings.TrimSpace(k)
 	v = strings.TrimSpace(v)
-	if e.unsafeKey(preventDuplicates, k) {
+	if e.isUnsafeKey(preventDuplicates, k) {
 		return
 	}
 
@@ -158,7 +168,7 @@ func (e *SafeEnv) addFull(preventDuplicates bool, fullValues []string) {
 		kv = strings.TrimSpace(kv)
 
 		key := strings.SplitN(kv, "=", 2)[0]
-		if e.unsafeKey(preventDuplicates, key) {
+		if e.isUnsafeKey(preventDuplicates, key) {
 			continue
 		}
 
@@ -166,7 +176,7 @@ func (e *SafeEnv) addFull(preventDuplicates bool, fullValues []string) {
 	}
 }
 
-func (e *SafeEnv) unsafeKey(preventDuplicates bool, key string) bool {
+func (e *SafeEnv) isUnsafeKey(preventDuplicates bool, key string) bool {
 	if key == "" || key == "=" {
 		return false
 	}


### PR DESCRIPTION
Public release of private fix: https://github.com/gravitational/teleport-private/pull/1218
PR fixes: https://github.com/gravitational/teleport-private/issues/1214
Will be disclosed under advisory: https://github.com/gravitational/teleport/security/advisories/GHSA-vfxf-76hv-v4w4

This change expands the filtering done on environment variables so that possible code execution variables for macOS are excluded.  Additionally the user provided values are removed from a point of execution done under `root`.

This PR expands this protection further by filtering all `DYLD_` and `LD_` prefixed variables.  However this change will not be backported and instead is planned to be a release as a behavior change in v15.

changelog: macOS agent environment filtering documented under https://github.com/gravitational/teleport/security/advisories/GHSA-vfxf-76hv-v4w4