### PR TITLE
SSH server in proxy mode to only accept proxying subsystems

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7869,7 +7869,7 @@ func getRemoteAddrString(sshClientString string) string {
 
 func testSFTP(t *testing.T, suite *integrationTestSuite) {
 	// Create Teleport instance.
-	teleport := suite.newTeleport(t, []string{}, true)
+	teleport := suite.newTeleport(t, nil, true)
 	t.Cleanup(func() {
 		teleport.StopAll()
 	})
@@ -7891,15 +7891,11 @@ func testSFTP(t *testing.T, suite *integrationTestSuite) {
 		_ = clusterClient.Close()
 	})
 
-	nodes, err := clusterClient.CurrentCluster().GetNodes(ctx, teleportClient.Namespace)
-	require.NoError(t, err)
-	require.NotEmpty(t, nodes)
-
 	nodeClient, err := teleportClient.ConnectToNode(
 		ctx,
 		clusterClient,
 		client.NodeDetails{
-			Addr:      nodes[0].GetAddr(),
+			Addr:      teleport.Config.SSH.Addr.Addr,
 			Namespace: teleportClient.Namespace,
 			Cluster:   helpers.Site,
 		},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7893,7 +7893,7 @@ func testSFTP(t *testing.T, suite *integrationTestSuite) {
 
 	nodes, err := clusterClient.CurrentCluster().GetNodes(ctx, teleportClient.Namespace)
 	require.NoError(t, err)
-	require.Greater(t, len(nodes), 0)
+	require.NotEmpty(t, nodes)
 
 	nodeClient, err := teleportClient.ConnectToNode(
 		ctx,

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2108,11 +2108,18 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 		return nil, trace.BadParameter("failed to parse subsystem request: %v", err)
 	}
 
+	if s.proxyMode {
+		switch {
+		case strings.HasPrefix(r.Name, "proxy:"):
+			return parseProxySubsys(r.Name, s, ctx)
+		case strings.HasPrefix(r.Name, "proxysites"):
+			return parseProxySitesSubsys(r.Name, s)
+		default:
+			return nil, trace.BadParameter("unrecognized subsystem: %v", r.Name)
+		}
+	}
+
 	switch {
-	case s.proxyMode && strings.HasPrefix(r.Name, "proxy:"):
-		return parseProxySubsys(r.Name, s, ctx)
-	case s.proxyMode && strings.HasPrefix(r.Name, "proxysites"):
-		return parseProxySitesSubsys(r.Name, s)
 	// DELETE IN 15.0.0 (deprecated, tsh will not be using this anymore)
 	case r.Name == teleport.GetHomeDirSubsystem:
 		return newHomeDirSubsys(), nil

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -120,12 +120,12 @@ func newFixture(t *testing.T) *sshTestFixture {
 	return newCustomFixture(t, func(*auth.TestServerConfig) {})
 }
 
-func newFixtureWithoutDiskBasedLogging(t *testing.T) *sshTestFixture {
+func newFixtureWithoutDiskBasedLogging(t *testing.T, sshOpts ...ServerOption) *sshTestFixture {
 	t.Helper()
 
 	f := newCustomFixture(t, func(cfg *auth.TestServerConfig) {
 		cfg.Auth.AuditLog = events.NewDiscardAuditLog()
-	})
+	}, sshOpts...)
 
 	// use a sync recording mode because the disk-based uploader
 	// that runs in the background introduces races with test cleanup
@@ -2187,6 +2187,210 @@ func requireNoErrors(t *testing.T, errsCh <-chan []error) {
 
 	case <-timeoutCtx.Done():
 		require.Fail(t, "Timed out waiting for errors")
+	}
+}
+
+// TestParseSubsystemRequest verifies parseSubsystemRequest accepts the correct subsystems in depending on the runtime configuration.
+func TestParseSubsystemRequest(t *testing.T) {
+	ctx := context.Background()
+
+	// start a dummy listener; this will be needed for the proxy test to pass, otherwise nothing will be there to handle the call.
+	ln, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			// accept connections, but don't do anything else except for closing the connection on cleanup.
+			conn, _ := ln.Accept()
+			if conn != nil {
+				t.Cleanup(func() {
+					_ = conn.Close()
+				})
+			}
+		}
+	}()
+
+	agentlessSrv := types.ServerV2{
+		Kind:    types.KindNode,
+		SubKind: types.SubKindOpenSSHNode,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: uuid.NewString(),
+		},
+		Spec: types.ServerSpecV2{
+			Addr:     ln.Addr().String(),
+			Hostname: "agentless",
+		},
+	}
+
+	getNonProxySession := func(t *testing.T) *tracessh.Session {
+		f := newFixtureWithoutDiskBasedLogging(t, SetAllowFileCopying(true))
+		se, err := f.ssh.clt.NewSession(context.Background())
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = se.Close() })
+		return se
+	}
+
+	getProxySession := func(t *testing.T) *tracessh.Session {
+		f := newFixtureWithoutDiskBasedLogging(t)
+		listener, _ := mustListen(t)
+
+		proxyClient, _ := newProxyClient(t, f.testSrv)
+		lockWatcher := newLockWatcher(ctx, t, proxyClient)
+		nodeWatcher := newNodeWatcher(ctx, t, proxyClient)
+		caWatcher := newCertAuthorityWatcher(ctx, t, proxyClient)
+
+		reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
+			ClientTLS:                     proxyClient.TLSConfig(),
+			ID:                            hostID,
+			ClusterName:                   f.testSrv.ClusterName(),
+			Listener:                      listener,
+			HostSigners:                   []ssh.Signer{f.signer},
+			LocalAuthClient:               proxyClient,
+			LocalAccessPoint:              proxyClient,
+			NewCachingAccessPoint:         noCache,
+			NewCachingAccessPointOldProxy: noCache,
+			DataDir:                       t.TempDir(),
+			Emitter:                       proxyClient,
+			Log:                           logrus.StandardLogger(),
+			LockWatcher:                   lockWatcher,
+			NodeWatcher:                   nodeWatcher,
+			CertAuthorityWatcher:          caWatcher,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, reverseTunnelServer.Start())
+		t.Cleanup(func() { _ = reverseTunnelServer.Close() })
+
+		nodeClient, _ := newNodeClient(t, f.testSrv)
+
+		_, err = nodeClient.UpsertNode(ctx, &agentlessSrv)
+		require.NoError(t, err)
+
+		router, err := libproxy.NewRouter(libproxy.RouterConfig{
+			ClusterName:         f.testSrv.ClusterName(),
+			Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+			RemoteClusterGetter: proxyClient,
+			SiteGetter:          reverseTunnelServer,
+			TracerProvider:      tracing.NoopProvider(),
+		})
+		require.NoError(t, err)
+
+		sessionController, err := srv.NewSessionController(srv.SessionControllerConfig{
+			Semaphores:   proxyClient,
+			AccessPoint:  proxyClient,
+			LockEnforcer: lockWatcher,
+			Emitter:      proxyClient,
+			Component:    teleport.ComponentProxy,
+			ServerID:     hostID,
+		})
+		require.NoError(t, err)
+
+		proxy, err := New(
+			ctx,
+			utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
+			f.testSrv.ClusterName(),
+			[]ssh.Signer{f.signer},
+			proxyClient,
+			t.TempDir(),
+			"",
+			utils.NetAddr{},
+			proxyClient,
+			SetProxyMode("", reverseTunnelServer, proxyClient, router),
+			SetEmitter(nodeClient),
+			SetNamespace(apidefaults.Namespace),
+			SetPAMConfig(&servicecfg.PAMConfig{Enabled: false}),
+			SetBPF(&bpf.NOP{}),
+			SetRestrictedSessionManager(&restricted.NOP{}),
+			SetClock(f.clock),
+			SetLockWatcher(lockWatcher),
+			SetNodeWatcher(nodeWatcher),
+			SetSessionController(sessionController),
+		)
+		require.NoError(t, err)
+		require.NoError(t, proxy.Start())
+		t.Cleanup(func() { _ = proxy.Close() })
+
+		// set up SSH client using the user private key for signing
+		up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+		require.NoError(t, err)
+
+		sshConfig := &ssh.ClientConfig{
+			User:            f.user,
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
+			HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
+		}
+
+		_, err = newUpack(f.testSrv, "user1", []string{f.user}, wildcardAllow)
+		require.NoError(t, err)
+
+		// Connect SSH client to proxy
+		client, err := tracessh.Dial(ctx, "tcp", proxy.Addr(), sshConfig)
+
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		se, err := client.NewSession(ctx)
+		require.NoError(t, err)
+
+		return se
+	}
+
+	tests := []struct {
+		name                 string
+		subsystemOverride    string
+		wantErrInProxyMode   bool
+		wantErrInRegularMode bool
+	}{
+		{
+			name:                 "invalid",
+			wantErrInProxyMode:   true,
+			wantErrInRegularMode: true,
+		},
+		{
+			name:                 teleport.SFTPSubsystem,
+			wantErrInProxyMode:   true,
+			wantErrInRegularMode: false,
+		},
+		{
+			name:                 teleport.GetHomeDirSubsystem,
+			wantErrInProxyMode:   true,
+			wantErrInRegularMode: false,
+		},
+		{
+			name:                 "proxysites",
+			wantErrInProxyMode:   false,
+			wantErrInRegularMode: true,
+		},
+		{
+			name:                 "proxy:agentlessServer",
+			subsystemOverride:    "proxy:" + agentlessSrv.Spec.Addr,
+			wantErrInProxyMode:   false,
+			wantErrInRegularMode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subsystem := tt.name
+			if tt.subsystemOverride != "" {
+				subsystem = tt.subsystemOverride
+			}
+
+			err := getProxySession(t).RequestSubsystem(ctx, subsystem)
+			if tt.wantErrInProxyMode {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			err = getNonProxySession(t).RequestSubsystem(ctx, subsystem)
+			if tt.wantErrInRegularMode {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2201,11 +2201,14 @@ func TestParseSubsystemRequest(t *testing.T) {
 	go func() {
 		for {
 			// accept connections, but don't do anything else except for closing the connection on cleanup.
-			conn, _ := agentlessListener.Accept()
+			conn, err := agentlessListener.Accept()
 			if conn != nil {
 				t.Cleanup(func() {
 					_ = conn.Close()
 				})
+			}
+			if err != nil {
+				return
 			}
 		}
 	}()

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2202,14 +2202,12 @@ func TestParseSubsystemRequest(t *testing.T) {
 		for {
 			// accept connections, but don't do anything else except for closing the connection on cleanup.
 			conn, err := agentlessListener.Accept()
-			if conn != nil {
-				t.Cleanup(func() {
-					_ = conn.Close()
-				})
-			}
 			if err != nil {
 				return
 			}
+			t.Cleanup(func() {
+				_ = conn.Close()
+			})
 		}
 	}()
 


### PR DESCRIPTION
Public release of private fix: https://github.com/gravitational/teleport-private/pull/1215
PR fixes: https://github.com/gravitational/teleport-private/issues/1198
Will be disclosed under advisory: https://github.com/gravitational/teleport/security/advisories/GHSA-c9v7-wmwj-vf6x

changelog: Teleport Proxy now restricts SFTP for normal users as described under Advisory https://github.com/gravitational/teleport/security/advisories/GHSA-c9v7-wmwj-vf6x