### PR TITLE
integrations/operator: use unstructured objects for all controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
 	go.opentelemetry.io/proto/otlp v1.1.0
+	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 	golang.org/x/mod v0.14.0
@@ -464,7 +465,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/tools v0.16.1 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -63,15 +63,15 @@ func (r accessListClient) MutateExisting(new, existing *accesslist.AccessList) {
 }
 
 // NewAccessListReconciler instantiates a new Kubernetes controller reconciling access_list resources
-func NewAccessListReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList] {
+func NewAccessListReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	accessListClient := &accessListClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	resourceReconciler, err := NewTeleportResourceReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		client,
 		accessListClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/github_connector_controller.go
+++ b/integrations/operator/controllers/resources/github_connector_controller.go
@@ -58,15 +58,15 @@ func (r githubConnectorClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewGithubConnectorReconciler instantiates a new Kubernetes controller reconciling github_connector resources
-func NewGithubConnectorReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.GithubConnector, *resourcesv3.TeleportGithubConnector] {
+func NewGithubConnectorReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	githubClient := &githubConnectorClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.GithubConnector, *resourcesv3.TeleportGithubConnector](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.GithubConnector, *resourcesv3.TeleportGithubConnector](
 		client,
 		githubClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/global.go
+++ b/integrations/operator/controllers/resources/global.go
@@ -1,0 +1,117 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/gravitational/trace"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
+	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
+	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
+	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
+)
+
+// Scheme is a singleton scheme for all controllers
+var Scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(resourcesv5.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv3.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv2.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv1.AddToScheme(Scheme))
+
+	// Not needed to reconcile the teleport CRs, but needed for the controller manager.
+	// We are not doing something very kubernetes friendly, but it's easier to have a single
+	// scheme rather than having to build and propagate schemes in multiple places, which
+	// is error-prone and can lead to inconsistencies.
+	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+	utilruntime.Must(apiextv1.AddToScheme(Scheme))
+}
+
+type reconcilerFactory struct {
+	cr      string
+	factory func(kclient.Client, *client.Client) (Reconciler, error)
+}
+
+// Reconciler extends the reconcile.Reconciler interface by adding a
+// SetupWithManager function that creates a controller in the given manager.
+type Reconciler interface {
+	reconcile.Reconciler
+	SetupWithManager(mgr manager.Manager) error
+}
+
+func SetupAllControllers(log logr.Logger, mgr manager.Manager, teleportClient *client.Client, features *proto.Features) error {
+	reconcilers := []reconcilerFactory{
+		{"TeleportRole", NewRoleReconciler},
+		{"TeleportUser", NewUserReconciler},
+		{"TeleportGithubConnector", NewGithubConnectorReconciler},
+		{"TeleportProvisionToken", NewProvisionTokenReconciler},
+		{"TeleportOktaImportRule", NewOktaImportRuleReconciler},
+	}
+
+	if features.GetOIDC() {
+		reconcilers = append(reconcilers, reconcilerFactory{"TeleportOIDCConnector", NewOIDCConnectorReconciler})
+	} else {
+		log.Info("OIDC connectors are only available in Teleport Enterprise edition. TeleportOIDCConnector resources won't be reconciled")
+	}
+
+	if features.GetSAML() {
+		reconcilers = append(reconcilers, reconcilerFactory{"TeleportSAMLConnector", NewSAMLConnectorReconciler})
+	} else {
+		log.Info("SAML connectors are only available in Teleport Enterprise edition. TeleportSAMLConnector resources won't be reconciled")
+	}
+
+	// Login Rules are enterprise-only but there is no specific feature flag for them.
+	if features.GetOIDC() || features.GetSAML() {
+		reconcilers = append(reconcilers, reconcilerFactory{"TeleportLoginRule", NewLoginRuleReconciler})
+	} else {
+		log.Info("Login Rules are only available in Teleport Enterprise edition. TeleportLoginRule resources won't be reconciled")
+	}
+
+	// AccessLists are enterprise-only but there is no specific feature-flag for them.
+	if features.GetAdvancedAccessWorkflows() {
+		reconcilers = append(reconcilers, reconcilerFactory{"TeleportAccessList", NewAccessListReconciler})
+	} else {
+		log.Info("The cluster license does not contain advanced workflows. TeleportAccessList resources won't be reconciled")
+	}
+
+	kubeClient := mgr.GetClient()
+	for _, reconciler := range reconcilers {
+		r, err := reconciler.factory(kubeClient, teleportClient)
+		if err != nil {
+			return trace.Wrap(err, "failed to create controller for %s", reconciler.cr)
+		}
+		err = r.SetupWithManager(mgr)
+		if err != nil {
+			return trace.Wrap(err, "failed to setup controller for: %s", reconciler.cr)
+		}
+	}
+
+	return nil
+}

--- a/integrations/operator/controllers/resources/login_rule_controller.go
+++ b/integrations/operator/controllers/resources/login_rule_controller.go
@@ -61,15 +61,15 @@ func (l loginRuleClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewLoginRuleReconciler instantiates a new Kubernetes controller reconciling login_rule resources
-func NewLoginRuleReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule] {
+func NewLoginRuleReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	loginRuleClient := &loginRuleClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+	resourceReconciler, err := NewTeleportResourceReconciler[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
 		client,
 		loginRuleClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -58,15 +58,15 @@ func (r oidcConnectorClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewOIDCConnectorReconciler instantiates a new Kubernetes controller reconciling oidc_connector resources
-func NewOIDCConnectorReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector] {
+func NewOIDCConnectorReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	oidcClient := &oidcConnectorClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector](
 		client,
 		oidcClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/okta_import_rule_controller.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller.go
@@ -58,15 +58,15 @@ func (r oktaImportRuleClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewOktaImportRuleReconciler instantiates a new Kubernetes controller reconciling okta_import_rule resources
-func NewOktaImportRuleReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule] {
+func NewOktaImportRuleReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	oktaImportRuleClient := &oktaImportRuleClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](
 		client,
 		oktaImportRuleClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/provision_token_controller.go
+++ b/integrations/operator/controllers/resources/provision_token_controller.go
@@ -56,15 +56,15 @@ func (r provisionTokenClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewProvisionTokenReconciler instantiates a new Kubernetes controller reconciling provision token resources
-func NewProvisionTokenReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.ProvisionToken, *resourcesv2.TeleportProvisionToken] {
+func NewProvisionTokenReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	tokenClient := &provisionTokenClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](
 		client,
 		tokenClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/provision_token_controller_test.go
+++ b/integrations/operator/controllers/resources/provision_token_controller_test.go
@@ -197,7 +197,8 @@ github:
 
 	tokenName := validRandomResourceName("token-")
 
-	obj := resources.GetUnstructuredObjectFromGVK(teleportTokenGVK)
+	obj, err := resources.GetUnstructuredObjectFromGVK(teleportTokenGVK)
+	require.NoError(t, err)
 	obj.Object["spec"] = tokenManifest
 	obj.SetName(tokenName)
 	obj.SetNamespace(setup.Namespace.Name)

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -190,7 +190,8 @@ allow:
 
 			roleName := validRandomResourceName("role-")
 
-			obj := resources.GetUnstructuredObjectFromGVK(resources.TeleportRoleGVKV5)
+			obj, err := resources.GetUnstructuredObjectFromGVK(resources.TeleportRoleGVKV5)
+			require.NoError(t, err)
 			obj.Object["spec"] = roleManifest
 			obj.SetName(roleName)
 			obj.SetNamespace(setup.Namespace.Name)

--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -58,15 +58,15 @@ func (r samlConnectorClient) Delete(ctx context.Context, name string) error {
 }
 
 // NewSAMLConnectorReconciler instantiates a new Kubernetes controller reconciling saml_connector resources
-func NewSAMLConnectorReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector] {
+func NewSAMLConnectorReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	samlClient := &samlConnectorClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](
 		client,
 		samlClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -31,14 +31,16 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -56,7 +58,7 @@ import (
 
 // scheme is our own test-specific scheme to avoid using the global
 // unprotected scheme.Scheme that triggers the race detector
-var scheme = apiruntime.NewScheme()
+var scheme = resources.Scheme
 
 func init() {
 	utilruntime.Must(core.AddToScheme(scheme))
@@ -186,38 +188,17 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		// We enable cache to ensure the tests are close to how the manager is created when running in a real cluster
+		Client: ctrlclient.Options{Cache: &ctrlclient.CacheOptions{Unstructured: true}},
 	})
 	require.NoError(t, err)
 
-	err = (&resources.RoleReconciler{
-		Client:         s.K8sClient,
-		Scheme:         k8sManager.GetScheme(),
-		TeleportClient: s.TeleportClient,
-	}).SetupWithManager(k8sManager)
-	require.NoError(t, err)
+	setupLog := ctrl.Log.WithName("setup")
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
 
-	err = resources.NewUserReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
+	pong, err := s.TeleportClient.Ping(context.Background())
 	require.NoError(t, err)
-
-	err = resources.NewGithubConnectorReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewOIDCConnectorReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewSAMLConnectorReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewLoginRuleReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewProvisionTokenReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewOktaImportRuleReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
-	require.NoError(t, err)
-
-	err = resources.NewAccessListReconciler(s.K8sClient, s.TeleportClient).SetupWithManager(k8sManager)
+	err = resources.SetupAllControllers(setupLog, k8sManager, s.TeleportClient, pong.ServerFeatures)
 	require.NoError(t, err)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -65,15 +65,15 @@ func (r userClient) MutateExisting(newUser, existingUser types.User) {
 }
 
 // NewUserReconciler instantiates a new Kubernetes controller reconciling user resources
-func NewUserReconciler(client kclient.Client, tClient *client.Client) *TeleportResourceReconciler[types.User, *resourcesv2.TeleportUser] {
+func NewUserReconciler(client kclient.Client, tClient *client.Client) (Reconciler, error) {
 	userClient := &userClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler := NewTeleportResourceReconciler[types.User, *resourcesv2.TeleportUser](
+	resourceReconciler, err := NewTeleportResourceReconciler[types.User, *resourcesv2.TeleportUser](
 		client,
 		userClient,
 	)
 
-	return resourceReconciler
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -159,7 +159,8 @@ traits:
 
 			userName := validRandomResourceName("user-")
 
-			obj := resources.GetUnstructuredObjectFromGVK(teleportUserGVK)
+			obj, err := resources.GetUnstructuredObjectFromGVK(teleportUserGVK)
+			require.NoError(t, err)
 			obj.Object["spec"] = userManifest
 			obj.SetName(userName)
 			obj.SetNamespace(setup.Namespace.Name)

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -24,23 +24,17 @@ import (
 	"os"
 	"time"
 
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
-	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
-	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
-	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/embeddedtbot"
 )
@@ -49,18 +43,6 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
-
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(resourcesv5.AddToScheme(scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
-
-	utilruntime.Must(apiextv1.AddToScheme(scheme))
-}
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()
@@ -116,9 +98,11 @@ func main() {
 				config.namespace: {},
 			},
 		},
+		// All our controllers now use unstructured objects, we need to cache them.
+		Client: ctrlclient.Options{Cache: &ctrlclient.CacheOptions{Unstructured: true}},
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
+		setupLog.Error(err, "unable to create manager")
 		os.Exit(1)
 	}
 
@@ -127,76 +111,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&resources.RoleReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		TeleportClient: client,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TeleportRole")
+	if err = resources.SetupAllControllers(setupLog, mgr, client, pong.ServerFeatures); err != nil {
+		setupLog.Error(err, "failed to setup controllers")
 		os.Exit(1)
-	}
-
-	if err = resources.NewUserReconciler(mgr.GetClient(), client).
-		SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TeleportUser")
-		os.Exit(1)
-	}
-
-	if err = resources.NewGithubConnectorReconciler(mgr.GetClient(), client).
-		SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TeleportGithubConnector")
-		os.Exit(1)
-	}
-
-	if pong.ServerFeatures.OIDC {
-		if err = resources.NewOIDCConnectorReconciler(mgr.GetClient(), client).
-			SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "TeleportOIDCConnector")
-			os.Exit(1)
-		}
-	} else {
-		setupLog.Info("OIDC connectors are only available in Teleport Enterprise edition. TeleportOIDCConnector resources won't be reconciled")
-	}
-
-	if pong.ServerFeatures.SAML {
-		if err = resources.NewSAMLConnectorReconciler(mgr.GetClient(), client).
-			SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "TeleportSAMLConnector")
-			os.Exit(1)
-		}
-	} else {
-		setupLog.Info("SAML connectors are only available in Teleport Enterprise edition. TeleportSAMLConnector resources won't be reconciled")
-	}
-
-	// Login Rules are enterprise-only but there is no specific feature flag for them.
-	if pong.ServerFeatures.OIDC || pong.ServerFeatures.SAML {
-		if err := resources.NewLoginRuleReconciler(mgr.GetClient(), client).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "TeleportLoginRule")
-			os.Exit(1)
-		}
-	} else {
-		setupLog.Info("Login Rules are only available in Teleport Enterprise edition. TeleportLoginRule resources won't be reconciled")
-	}
-
-	if err = resources.NewProvisionTokenReconciler(mgr.GetClient(), client).
-		SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TeleportProvisionToken")
-		os.Exit(1)
-	}
-
-	if err = resources.NewOktaImportRuleReconciler(mgr.GetClient(), client).
-		SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TeleportOktaImportRule")
-		os.Exit(1)
-	}
-
-	// AccessLists are enterprise-only but there is no specific feature-flag for them.
-	if pong.ServerFeatures.AdvancedAccessWorkflows {
-		if err = resources.NewAccessListReconciler(mgr.GetClient(), client).
-			SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "TeleportAccessList")
-			os.Exit(1)
-		}
 	}
 
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
Goal of this PR: prepare everything for us to switch to a single reconciler for all resources. Part of https://github.com/gravitational/teleport/issues/21416

This PR does the following changes:
- setup controllers for the unstructured objects instead of the structured ones (like `Role` was doing). This is due to the bad behaviour of `utils.Strings` of serializing as a single string if the list contains a single element.
- use a single scheme for everything instead of multiple ones. We suffered from drifts between main and tests in the past.
- fetch the GVK for the unstructure objects from the scheme. This operation can fail and now a bunch of builder/init functions can return errors
- Introduce a new `Reconciler` interface to hide the controller internals
- unify how controllers are started in main and tests. This is not directly related to the PR goal (preparing the ground for a unified controller) but I was drawn into this when I made the constructors return errors.

This PR looks relatively large and complex, I can walk you through a call if you want. 

Blocked by: https://github.com/gravitational/teleport/pull/36215