### PR TITLE
[v13] Add `Architecture` tag to hardened AMIs

### DIFF
--- a/assets/aws/single-ami.pkr.hcl
+++ b/assets/aws/single-ami.pkr.hcl
@@ -165,6 +165,7 @@ source "amazon-ebs" "teleport-aws-linux" {
     BuildTimestamp      = var.ami_build_timestamp
     BuildType           = "production"
     Name                = local.ami_name
+    Architecture        = "x86_64"
     TeleportVersion     = var.teleport_version
     TeleportEdition     = var.teleport_type
     TeleportFipsEnabled = var.teleport_fips


### PR DESCRIPTION
Changes #36112 and #36153 update scripts under `assets/aws/cmd` to look for `tag:Architecture`. In order to make the addition of arm64 AMIs in #36110 easier, add a hardcoded `x86_64` value to older release branches.