### PR TITLE
Bump version(s) used for `teleport-lab` and `teleport-quickstart`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -808,9 +808,9 @@ steps:
       # increment these variables when a new major/minor version is released to bump the automatic builds
       # this only needs to be done on the master branch, as that's the branch that the Drone cron is configured for
       # build major version images which are just teleport:x
-      CURRENT_VERSION_ROOT: v12
-      PREVIOUS_VERSION_ONE_ROOT: v11
-      PREVIOUS_VERSION_TWO_ROOT: v10
+      CURRENT_VERSION_ROOT: v14
+      PREVIOUS_VERSION_ONE_ROOT: v13
+      PREVIOUS_VERSION_TWO_ROOT: v12
     commands:
       - apk --update --no-cache add curl go
       - mkdir -p /go/build && cd /go/build
@@ -12048,6 +12048,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 6037e6bdee3255d8eebea41cf0536df554378778bc536aeaf075eb65dcda82ff
+hmac: 4ebe6803bd4211a77094240d8e91c2cc9ac7e9b97956e277fbfa3b5e52962fdd
 
 ...

--- a/docker/teleport-lab.yml
+++ b/docker/teleport-lab.yml
@@ -3,7 +3,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: public.ecr.aws/gravitational/teleport-lab:12
+    image: public.ecr.aws/gravitational/teleport-lab:14
     container_name: teleport
     entrypoint: /bin/sh
     hostname: luna.teleport
@@ -24,7 +24,7 @@ services:
 
   # The bootstrap container generates certificates and then immediately exits.
   bootstrap:
-    image: public.ecr.aws/gravitational/teleport-lab:12
+    image: public.ecr.aws/gravitational/teleport-lab:14
     container_name: teleport-bootstrap
     entrypoint: /bin/sh
     command: -c "/etc/teleport.d/scripts/generate-certs.sh"
@@ -41,7 +41,7 @@ services:
   # openssh is a demo of openssh node
   #
   openssh:
-    image: public.ecr.aws/gravitational/teleport-lab:12
+    image: public.ecr.aws/gravitational/teleport-lab:14
     container_name: openssh
     hostname: mars.openssh.teleport
     entrypoint: /bin/sh
@@ -60,7 +60,7 @@ services:
   # term is a container with a terminal to try things out
   #
   term:
-    image: public.ecr.aws/gravitational/teleport-lab:12
+    image: public.ecr.aws/gravitational/teleport-lab:14
     hostname: term
     container_name: term
     entrypoint: /bin/sh

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -3,7 +3,7 @@ services:
   # The configure container starts, generates a config, writes it to
   # /etc/teleport/teleport.yaml and then immediately exits.
   configure:
-    image: public.ecr.aws/gravitational/teleport:12
+    image: public.ecr.aws/gravitational/teleport:14
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
@@ -14,7 +14,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: public.ecr.aws/gravitational/teleport:12
+    image: public.ecr.aws/gravitational/teleport:14
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -20,6 +20,6 @@ is published, since the PR will include an update to the plugins version as well
 - [ ] Update support matrix in docs FAQ page
 - [ ] Update `branchMajorVersion` const in Dronegen `/dronegen/container_images.go`, then run `make dronegen`
   - Example: https://github.com/gravitational/teleport/pull/4602
-- [ ] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml and docker/teleport-ent-quickstart.yml
+- [ ] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml
   - Example: https://github.com/gravitational/teleport/pull/4655
 - [ ] Create PR to update default Teleport image referenced in docker/teleport-lab.yml


### PR DESCRIPTION
The versions for `teleport-lab` / `teleport-quickstart` were still using Teleport 12. Bump them to Teleport 14.