### PR TITLE
kube-agent-updater: Add support for keyless signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,7 @@ require (
 	github.com/mdlayher/netlink v1.7.2
 	github.com/microsoft/go-mssqldb v0.0.0-00010101000000-000000000000 // replaced
 	github.com/miekg/pkcs11 v1.1.1
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/term v0.5.0
 	github.com/okta/okta-sdk-golang/v2 v2.20.0

--- a/go.sum
+++ b/go.sum
@@ -1124,6 +1124,8 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/integrations/kube-agent-updater/README.md
+++ b/integrations/kube-agent-updater/README.md
@@ -15,7 +15,7 @@ chart.
 
 This updater was designed first for cloud customers but can be adapter to run for on-prem users as well.
 
-See [the cloud update RFD](../../rfd/XXXX-change-me-once-merged.md) for more context.
+See [the cloud update RFD](../../rfd/0109-cloud-agent-upgrades.md) for more context.
 
 If an update goes wrong, a temporary downtime is acceptable until a correct
 version is pushed (this risk is mitigated by multi-replica deployments).

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/constants.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/constants.go
@@ -36,3 +36,12 @@ EuIXJJox2oAL7NzdSi9VIUYnEnx+2EtkU/spAFRR6i1BnT6aoIy3521B76wnmRr9
 atCSKjt6MdRxgj4htCjBWWJAGM9Z/avF4CYFmK7qiVxgpdrSM8Esbt2Ta+Lu3QMJ
 T8LjqFu3u3dxVOo9RuLk+BkCAwEAAQ==
 -----END PUBLIC KEY-----`)
+
+// teleportCertIdentityRegexp is a regular expression containing the GitHub
+// Actions workflow and associated git ref used as part of keyless signing
+// of Teleport distroless images.
+var teleportCertIdentityRegexp = "https://github\\.com/gravitational/teleport\\.e/\\.github/workflows/oci-image-build\\.yml@refs/tags/.+"
+
+// teleportCertOIDCIssuer is the GitHub Actions OIDC issuer used as part
+// of keyless signing of Teleport distroless images.
+var teleportCertOIDCIssuer = "https://token.actions.githubusercontent.com/teleport"

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -150,6 +150,13 @@ func main() {
 			os.Exit(1)
 		}
 		imageValidators = append(imageValidators, validator)
+
+		validator, err = img.NewCosignKeylessValidator(teleportCertIdentityRegexp, teleportCertOIDCIssuer, "cosign keyless signature validator")
+		if err != nil {
+			ctrl.Log.Error(err, "failed to build image validator, exiting")
+			os.Exit(1)
+		}
+		imageValidators = append(imageValidators, validator)
 	}
 
 	baseImage, err := reference.ParseNamed(baseImageName)

--- a/integrations/kube-agent-updater/hack/cosign-fixtures.go
+++ b/integrations/kube-agent-updater/hack/cosign-fixtures.go
@@ -495,7 +495,7 @@ func generateSignedManifest(scenario string, signer digestedRefSigner, keys ...*
 		return
 	}
 
-	// Singing the manifest
+	// Signing the manifest
 	sigLayers, sigManifest, err := makeSignature(manifestRef, signer, keys...)
 	if err != nil {
 		return nil, nil, v1.Hash{}, trace.Wrap(err)


### PR DESCRIPTION
Keyless signing is being added as an additional signature method in addition to the existing static signing key. Static key signatures will be deprecated at some future point, but we'll be supporting both for a while.

Also, we now publish signatures to the tlog due to upgrading to cosign 2.x, so stop ignoring it.