### PR TITLE
Use current year in `LICENSE.header` template

### DIFF
--- a/build.assets/LICENSE.header
+++ b/build.assets/LICENSE.header
@@ -1,5 +1,5 @@
 Teleport
-Copyright (C) 2023  Gravitational, Inc.
+Copyright (C) {{.Year}} Gravitational, Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
This isn't covered in the `addlicense` documentation, but we can use a year variable in license template https://github.com/google/addlicense/blob/4caba19b7ed7818bb86bc4cd20411a246aa4a524/tmpl.go#L104
instead of providing the value manually. 
Theoretically, the variable name could change in the future, but I think it's unlikely and easy to spot.

I also removed the double whitespace character after the year.

We don't need to backport it, because we have `LICENSE.header` only on master.