### PR TITLE
Update generic backend service to propagate revisions

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -163,6 +163,7 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 		}
 	}
 
+	var upserted *accesslist.AccessList
 	upsertWithLockFn := func() error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			oldAccessList, err := a.service.GetResource(ctx, accessList.GetName())
@@ -187,7 +188,9 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 				}
 				ownerMap[owner.Name] = struct{}{}
 			}
-			return trace.Wrap(a.service.UpsertResource(ctx, accessList))
+
+			upserted, err = a.service.UpsertResource(ctx, accessList)
+			return trace.Wrap(err)
 		})
 	}
 
@@ -207,7 +210,7 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 		return nil, trace.Wrap(err)
 	}
 
-	return accessList, nil
+	return upserted, nil
 }
 
 // DeleteAccessList removes the specified access list resource.
@@ -288,6 +291,7 @@ func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList 
 
 // UpsertAccessListMember creates or updates an access list member resource.
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	var upserted *accesslist.AccessListMember
 	err := a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		al, err := a.service.GetResource(ctx, member.Spec.AccessList)
 		if err != nil {
@@ -298,12 +302,13 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 			return services.ImplicitAccessListError{}
 		}
 
-		return trace.Wrap(a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member))
+		upserted, err = a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member)
+		return trace.Wrap(err)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return member, nil
+	return upserted, nil
 }
 
 // DeleteAccessListMember hard deletes the specified access list member resource.
@@ -392,19 +397,21 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 
 				for _, member := range members {
 					// If the member is not in the members map (request), delete it.
-					if _, ok := membersMap[member.GetName()]; !ok {
+					if existingMember, ok := membersMap[member.GetName()]; !ok {
 						err = a.memberService.WithPrefix(accessList.GetName()).DeleteResource(ctx, member.GetName())
 						if err != nil {
 							return trace.Wrap(err)
 						}
 					} else {
 						// Compare members and update if necessary.
-						if !cmp.Equal(member, membersMap[member.GetName()]) {
+						if !cmp.Equal(member, existingMember) {
 							// Update the member.
-							err = a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, membersMap[member.GetName()])
+							upserted, err := a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, existingMember)
 							if err != nil {
 								return trace.Wrap(err)
 							}
+
+							existingMember.SetRevision(upserted.GetRevision())
 						}
 					}
 
@@ -419,13 +426,15 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 
 			// Add any remaining members to the access list.
 			for _, member := range membersMap {
-				err = a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, member)
+				upserted, err := a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, member)
 				if err != nil {
 					return trace.Wrap(err)
 				}
+				member.SetRevision(upserted.GetRevision())
 			}
 
-			return trace.Wrap(a.service.UpsertResource(ctx, accessList))
+			accessList, err = a.service.UpsertResource(ctx, accessList)
+			return trace.Wrap(err)
 		})
 	}
 
@@ -515,7 +524,8 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 			}
 		}
 
-		if err := a.reviewService.WithPrefix(review.Spec.AccessList).CreateResource(ctx, createdReview); err != nil {
+		createdReview, err = a.reviewService.WithPrefix(review.Spec.AccessList).CreateResource(ctx, createdReview)
+		if err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -528,7 +538,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 			}
 		}
 
-		if err := a.service.UpdateResource(ctx, accessList); err != nil {
+		if _, err := a.service.UpdateResource(ctx, accessList); err != nil {
 			return trace.Wrap(err, "updating audit date in access list")
 		}
 

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -351,7 +351,7 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 	accessList1 := newAccessList(t, "accessList1", clock)
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(header.Metadata{}, "ID", "Revision"),
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
 	}
 
 	t.Run("create access list", func(t *testing.T) {
@@ -1188,7 +1188,7 @@ func TestDynamicAccessListMembersCRUD(t *testing.T) {
 		// AND a membership record fora user in that list (this can happen if an
 		// existing Explicit list is made Implicit)
 		m := newAccessListMember(t, implicitlist.GetName(), "scooby")
-		err = service.memberService.WithPrefix(m.Spec.AccessList).UpsertResource(ctx, m)
+		m, err = service.memberService.WithPrefix(m.Spec.AccessList).UpsertResource(ctx, m)
 		require.NoError(t, err)
 
 		// When I try to remove all the members of that list

--- a/lib/services/local/discoveryconfig.go
+++ b/lib/services/local/discoveryconfig.go
@@ -59,7 +59,7 @@ func NewDiscoveryConfigService(backend backend.Backend) (*DiscoveryConfigService
 	}, nil
 }
 
-// ListDiscoveryConfigss returns a paginated list of DiscoveryConfig resources.
+// ListDiscoveryConfigs returns a paginated list of DiscoveryConfig resources.
 func (s *DiscoveryConfigService) ListDiscoveryConfigs(ctx context.Context, pageSize int, pageToken string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
 	dcs, nextKey, err := s.svc.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
@@ -79,51 +79,42 @@ func (s *DiscoveryConfigService) GetDiscoveryConfig(ctx context.Context, name st
 	return dc, nil
 }
 
-// CreateDiscoveryConfigs creates a new DiscoveryConfig resource.
+// CreateDiscoveryConfig creates a new DiscoveryConfig resource.
 func (s *DiscoveryConfigService) CreateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
 	if err := dc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.svc.CreateResource(ctx, dc); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return dc, nil
+	created, err := s.svc.CreateResource(ctx, dc)
+	return created, trace.Wrap(err)
 }
 
-// UpdateDiscoveryConfigs updates an existing DiscoveryConfig resource.
+// UpdateDiscoveryConfig updates an existing DiscoveryConfig resource.
 func (s *DiscoveryConfigService) UpdateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
 	if err := dc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.svc.UpdateResource(ctx, dc); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return dc, nil
+	updated, err := s.svc.UpdateResource(ctx, dc)
+	return updated, trace.Wrap(err)
 }
 
-// UpsertDiscoveryConfigs upserts a DiscoveryConfig resource.
+// UpsertDiscoveryConfig upserts a DiscoveryConfig resource.
 func (s *DiscoveryConfigService) UpsertDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
 	if err := dc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.svc.UpsertResource(ctx, dc); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return dc, nil
+	upserted, err := s.svc.UpsertResource(ctx, dc)
+	return upserted, trace.Wrap(err)
 }
 
-// DeleteDiscoveryConfigs removes the specified DiscoveryConfig resource.
+// DeleteDiscoveryConfig removes the specified DiscoveryConfig resource.
 func (s *DiscoveryConfigService) DeleteDiscoveryConfig(ctx context.Context, name string) error {
 	return trace.Wrap(s.svc.DeleteResource(ctx, name))
 }
 
-// DeleteAllDiscoveryConfigss removes all DiscoveryConfig resources.
+// DeleteAllDiscoveryConfigs removes all DiscoveryConfig resources.
 func (s *DiscoveryConfigService) DeleteAllDiscoveryConfigs(ctx context.Context) error {
 	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }

--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -84,11 +84,8 @@ func (s *IntegrationsService) CreateIntegration(ctx context.Context, ig types.In
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.svc.CreateResource(ctx, ig); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return ig, nil
+	created, err := s.svc.CreateResource(ctx, ig)
+	return created, trace.Wrap(err)
 }
 
 // UpdateIntegration updates an existing Integration resource.
@@ -97,11 +94,8 @@ func (s *IntegrationsService) UpdateIntegration(ctx context.Context, ig types.In
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.svc.UpdateResource(ctx, ig); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return ig, nil
+	updated, err := s.svc.UpdateResource(ctx, ig)
+	return updated, trace.Wrap(err)
 }
 
 // DeleteIntegration removes the specified Integration resource.

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -97,7 +97,8 @@ func (o *OktaService) CreateOktaImportRule(ctx context.Context, importRule types
 	if err := validateOktaImportRuleRegexes(importRule); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return importRule, o.importRuleSvc.CreateResource(ctx, importRule)
+	created, err := o.importRuleSvc.CreateResource(ctx, importRule)
+	return created, trace.Wrap(err)
 }
 
 // UpdateOktaImportRule updates an existing Okta import rule resource.
@@ -105,7 +106,8 @@ func (o *OktaService) UpdateOktaImportRule(ctx context.Context, importRule types
 	if err := validateOktaImportRuleRegexes(importRule); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return importRule, o.importRuleSvc.UpdateResource(ctx, importRule)
+	updated, err := o.importRuleSvc.UpdateResource(ctx, importRule)
+	return updated, trace.Wrap(err)
 }
 
 // DeleteOktaImportRule removes the specified Okta import rule resource.
@@ -156,18 +158,20 @@ func (o *OktaService) GetOktaAssignment(ctx context.Context, name string) (types
 
 // CreateOktaAssignment creates a new Okta assignment resource.
 func (o *OktaService) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
-	return assignment, o.assignmentSvc.CreateResource(ctx, assignment)
+	created, err := o.assignmentSvc.CreateResource(ctx, assignment)
+	return created, trace.Wrap(err)
 }
 
 // UpdateOktaAssignment updates an existing Okta assignment resource.
 func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
-	return assignment, o.assignmentSvc.UpdateResource(ctx, assignment)
+	updated, err := o.assignmentSvc.UpdateResource(ctx, assignment)
+	return updated, trace.Wrap(err)
 }
 
 // UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
 // since the last transition.
 func (o *OktaService) UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error {
-	err := o.assignmentSvc.UpdateAndSwapResource(ctx, name, func(currentAssignment types.OktaAssignment) error {
+	_, err := o.assignmentSvc.UpdateAndSwapResource(ctx, name, func(currentAssignment types.OktaAssignment) error {
 		// Only update the status if the given duration has passed.
 		sinceLastTransition := o.clock.Since(currentAssignment.GetLastTransition())
 		if sinceLastTransition < timeHasPassed {

--- a/lib/services/local/plugin_static_credentials.go
+++ b/lib/services/local/plugin_static_credentials.go
@@ -58,12 +58,14 @@ func NewPluginStaticCredentialsService(backend backend.Backend) (*PluginStaticCr
 
 // CreatePluginStaticCredentials will create a new plugin static credentials resource.
 func (p *PluginStaticCredentialsService) CreatePluginStaticCredentials(ctx context.Context, pluginStaticCredentials types.PluginStaticCredentials) error {
-	return p.svc.CreateResource(ctx, pluginStaticCredentials)
+	_, err := p.svc.CreateResource(ctx, pluginStaticCredentials)
+	return trace.Wrap(err)
 }
 
 // GetPluginStaticCredentials will get a plugin static credentials resource by name.
 func (p *PluginStaticCredentialsService) GetPluginStaticCredentials(ctx context.Context, name string) (types.PluginStaticCredentials, error) {
-	return p.svc.GetResource(ctx, name)
+	creds, err := p.svc.GetResource(ctx, name)
+	return creds, trace.Wrap(err)
 }
 
 // GetPluginStaticCredentialsByLabels will get a list of plugin static credentials resource by matching labels.
@@ -84,7 +86,7 @@ func (p *PluginStaticCredentialsService) GetPluginStaticCredentialsByLabels(ctx 
 
 // DeletePluginStaticCredentials will delete a plugin static credentials resource.
 func (p *PluginStaticCredentialsService) DeletePluginStaticCredentials(ctx context.Context, name string) error {
-	return p.svc.DeleteResource(ctx, name)
+	return trace.Wrap(p.svc.DeleteResource(ctx, name))
 }
 
 var _ services.PluginStaticCredentials = (*PluginStaticCredentialsService)(nil)

--- a/lib/services/local/secreports.go
+++ b/lib/services/local/secreports.go
@@ -109,25 +109,26 @@ func NewSecReportsService(backend backend.Backend, clock clockwork.Clock) (*SecR
 
 // UpsertSecurityAuditQuery upserts audit query.
 func (s *SecReportsService) UpsertSecurityAuditQuery(ctx context.Context, in *secreports.AuditQuery) error {
-	if err := s.auditQuerySvc.UpsertResource(ctx, in); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.auditQuerySvc.UpsertResource(ctx, in)
+	return trace.Wrap(err)
 }
 
 // GetSecurityAuditQueries returns audit queries.
 func (s *SecReportsService) GetSecurityAuditQueries(ctx context.Context) ([]*secreports.AuditQuery, error) {
-	return s.auditQuerySvc.GetResources(ctx)
+	audits, err := s.auditQuerySvc.GetResources(ctx)
+	return audits, trace.Wrap(err)
 }
 
 // GetSecurityReports returns security reports.
 func (s *SecReportsService) GetSecurityReports(ctx context.Context) ([]*secreports.Report, error) {
-	return s.securityReportSvc.GetResources(ctx)
+	reports, err := s.securityReportSvc.GetResources(ctx)
+	return reports, trace.Wrap(err)
 }
 
 // GetSecurityReportsStates returns security report states.
 func (s *SecReportsService) GetSecurityReportsStates(ctx context.Context) ([]*secreports.ReportState, error) {
-	return s.securityReportStateSvc.GetResources(ctx)
+	states, err := s.securityReportStateSvc.GetResources(ctx)
+	return states, trace.Wrap(err)
 }
 
 // GetSecurityAuditQuery returns audit query by name.
@@ -155,10 +156,8 @@ func (s *SecReportsService) DeleteSecurityAuditQuery(ctx context.Context, name s
 
 // UpsertSecurityReport upserts security report.
 func (s *SecReportsService) UpsertSecurityReport(ctx context.Context, item *secreports.Report) error {
-	if err := s.securityReportSvc.UpsertResource(ctx, item); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.securityReportSvc.UpsertResource(ctx, item)
+	return trace.Wrap(err)
 }
 
 // GetSecurityReport returns security report by name.
@@ -181,10 +180,8 @@ func (s *SecReportsService) ListSecurityReports(ctx context.Context, i int, toke
 
 // UpsertSecurityReportsState upserts security report state.
 func (s *SecReportsService) UpsertSecurityReportsState(ctx context.Context, item *secreports.ReportState) error {
-	if err := s.securityReportStateSvc.UpsertResource(ctx, item); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.securityReportStateSvc.UpsertResource(ctx, item)
+	return trace.Wrap(err)
 }
 
 // GetSecurityReportState returns security report state by name.
@@ -231,10 +228,8 @@ func (s *SecReportsService) DeleteAllSecurityReportsStates(ctx context.Context) 
 
 // UpsertCostLimiter upserts cost limiter.
 func (s *SecReportsService) UpsertCostLimiter(ctx context.Context, item *secreports.CostLimiter) error {
-	if err := s.securityReportCostCostLimiterSvc.UpsertResource(ctx, item); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.securityReportCostCostLimiterSvc.UpsertResource(ctx, item)
+	return trace.Wrap(err)
 }
 
 // GetCostLimiter returns cost limiter by name.

--- a/lib/services/local/user_login_state.go
+++ b/lib/services/local/user_login_state.go
@@ -62,7 +62,8 @@ func NewUserLoginStateService(backend backend.Backend) (*UserLoginStateService, 
 
 // GetUserLoginStates returns the all user login state resources.
 func (u *UserLoginStateService) GetUserLoginStates(ctx context.Context) ([]*userloginstate.UserLoginState, error) {
-	return u.svc.GetResources(ctx)
+	states, err := u.svc.GetResources(ctx)
+	return states, trace.Wrap(err)
 }
 
 // GetUserLoginState returns the specified user login state resource.
@@ -73,10 +74,8 @@ func (u *UserLoginStateService) GetUserLoginState(ctx context.Context, name stri
 
 // UpsertUserLoginState creates or updates a user login state resource.
 func (u *UserLoginStateService) UpsertUserLoginState(ctx context.Context, userLoginState *userloginstate.UserLoginState) (*userloginstate.UserLoginState, error) {
-	if err := trace.Wrap(u.svc.UpsertResource(ctx, userLoginState)); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return userLoginState, nil
+	upserted, err := u.svc.UpsertResource(ctx, userLoginState)
+	return upserted, trace.Wrap(err)
 }
 
 // DeleteUserLoginState removes the specified user login state resource.

--- a/lib/services/local/usergroup.go
+++ b/lib/services/local/usergroup.go
@@ -58,32 +58,36 @@ func NewUserGroupService(backend backend.Backend) (*UserGroupService, error) {
 
 // ListUserGroups returns a paginated list of user group resources.
 func (s *UserGroupService) ListUserGroups(ctx context.Context, pageSize int, pageToken string) ([]types.UserGroup, string, error) {
-	return s.svc.ListResources(ctx, pageSize, pageToken)
+	groups, next, err := s.svc.ListResources(ctx, pageSize, pageToken)
+	return groups, next, trace.Wrap(err)
 }
 
 // GetUserGroup returns the specified user group resource.
 func (s *UserGroupService) GetUserGroup(ctx context.Context, name string) (types.UserGroup, error) {
-	return s.svc.GetResource(ctx, name)
+	group, err := s.svc.GetResource(ctx, name)
+	return group, trace.Wrap(err)
 }
 
 // CreateUserGroup creates a new user group resource.
 func (s *UserGroupService) CreateUserGroup(ctx context.Context, group types.UserGroup) error {
-	return s.svc.CreateResource(ctx, group)
+	_, err := s.svc.CreateResource(ctx, group)
+	return trace.Wrap(err)
 }
 
 // UpdateUserGroup updates an existing user group resource.
 func (s *UserGroupService) UpdateUserGroup(ctx context.Context, group types.UserGroup) error {
-	return s.svc.UpdateResource(ctx, group)
+	_, err := s.svc.UpdateResource(ctx, group)
+	return trace.Wrap(err)
 }
 
 // DeleteUserGroup removes the specified user group resource.
 func (s *UserGroupService) DeleteUserGroup(ctx context.Context, name string) error {
-	return s.svc.DeleteResource(ctx, name)
+	return trace.Wrap(s.svc.DeleteResource(ctx, name))
 }
 
 // DeleteAllUserGroups removes all user group resources.
 func (s *UserGroupService) DeleteAllUserGroups(ctx context.Context) error {
-	return s.svc.DeleteAllResources(ctx)
+	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }
 
 const (


### PR DESCRIPTION
Modifies Create, Update, Upsert, and UpdateAndSwapResource of the generic backend to return the modified resource. This allows any revision generated by the backend to be propagated back to the caller. Consumers of the generic backend were updated to use the returned resource where applicable.