### PR TITLE
Grant the Okta service permissions to manage access lists.

### DIFF
--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -24,15 +24,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"github.com/vulcand/predicate/builder"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
@@ -182,6 +187,790 @@ func TestUpsertDeleteDependentRoles(t *testing.T) {
 
 	// Deletion should succeed
 	require.NoError(t, p.a.DeleteRole(ctx, role.GetName()))
+}
+
+// newRole will create a new role for testing purposes.
+func newRole(t *testing.T, name string, labels map[string]string, allowRc types.RoleConditions, denyRc types.RoleConditions) types.Role {
+	t.Helper()
+
+	role, err := types.NewRole(name, types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow:   allowRc,
+		Deny:    denyRc,
+	})
+	require.NoError(t, err)
+	role.SetStaticLabels(labels)
+
+	return role
+}
+
+func rcWithRoleRule(verbs ...string) types.RoleConditions {
+	return rcWithRoleRuleWhere(verbs, "")
+}
+
+func rcWithRoleRuleWhere(verbs []string, where string) types.RoleConditions {
+	return types.RoleConditions{
+		Rules: []types.Rule{
+			{
+				Resources: []string{types.KindRole},
+				Verbs:     verbs,
+				Where:     where,
+			},
+		},
+	}
+}
+
+func TestCreateRole(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		userRole     types.Role
+		startingRole types.Role
+		createRole   types.Role
+		wantErr      require.ErrorAssertionFunc
+		want         types.Role
+	}{
+		{
+			name:       "create role",
+			userRole:   newRole(t, "urole", nil, rcWithRoleRule(types.VerbCreate), types.RoleConditions{}),
+			createRole: newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr:    require.NoError,
+			want:       newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name:       "create role denied",
+			userRole:   newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			createRole: newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:         "create role collision",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbCreate), types.RoleConditions{}),
+			startingRole: newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			createRole:   newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAlreadyExists(err))
+			},
+		},
+		{
+			name:         "create role collision with access denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			startingRole: newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			createRole:   newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "create role where clause",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbCreate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			createRole: newRole(t, "create", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: require.NoError,
+			want: newRole(t, "create", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name: "create role where clause denied",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbCreate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			createRole: newRole(t, "create", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Create a starting role if needed. This will be used to test collisions.
+			if test.startingRole != nil {
+				_, err := as.CreateRole(ctx, test.startingRole)
+				require.NoError(t, err)
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+
+			got, err := clt.CreateRole(ctx, test.createRole)
+			test.wantErr(t, err)
+			if test.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.Empty(t, cmp.Diff(test.want, got,
+					cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+				))
+			}
+		})
+	}
+}
+
+func TestUpdateRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		userRole     types.Role
+		startingRole types.Role
+		updateRole   types.Role
+		wantErr      require.ErrorAssertionFunc
+		want         types.Role
+	}{
+		{
+			name:         "update role",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbUpdate), types.RoleConditions{}),
+			startingRole: newRole(t, "update", nil, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole:   newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr:      require.NoError,
+			want:         newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name:         "update role denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			startingRole: newRole(t, "update", nil, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole:   newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:       "update role not found",
+			userRole:   newRole(t, "urole", nil, rcWithRoleRule(types.VerbUpdate), types.RoleConditions{}),
+			updateRole: newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				// This returns a compare failed instead of a NotFound. In the interests of not breaking anything,
+				// I'll maintain this for now.
+				require.True(t, trace.IsCompareFailed(err))
+			},
+		},
+		{
+			name:       "update role not found with access denied",
+			userRole:   newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole: newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role where clause",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "update", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole: newRole(t, "update", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: require.NoError,
+			want: newRole(t, "update", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name: "update role where clause denied",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "update", nil, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole:   newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role old role doesn't match where",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "update", nil, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole: newRole(t, "update", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role new role doesn't match where",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "update", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			updateRole: newRole(t, "update", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Create a starting role if needed. This will be used to test collisions.
+			var revision string
+			if test.startingRole != nil {
+				startingRole, err := as.CreateRole(ctx, test.startingRole)
+				require.NoError(t, err)
+				revision = startingRole.GetMetadata().Revision
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+			test.updateRole.SetRevision(revision)
+
+			got, err := clt.UpdateRole(ctx, test.updateRole)
+			test.wantErr(t, err)
+			if test.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.Empty(t, cmp.Diff(test.want, got,
+					cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+				))
+			}
+		})
+	}
+}
+
+func TestUpsertRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		userRole     types.Role
+		startingRole types.Role
+		upsertRole   types.Role
+		wantErr      require.ErrorAssertionFunc
+		want         types.Role
+	}{
+		{
+			name:       "create role",
+			userRole:   newRole(t, "urole", nil, rcWithRoleRule(types.VerbCreate), types.RoleConditions{}),
+			upsertRole: newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr:    require.NoError,
+			want:       newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name:         "update role",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbUpdate), types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", nil, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole:   newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr:      require.NoError,
+			want:         newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name:         "update role denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", nil, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole:   newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role where clause",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole: newRole(t, "upsert", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: require.NoError,
+			want: newRole(t, "upsert", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+		},
+		{
+			name: "update role where clause denied",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", nil, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole:   newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role old role doesn't match where",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", nil, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole: newRole(t, "upsert", map[string]string{
+				"label": "value",
+			}, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "update role new role doesn't match where",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbUpdate},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			startingRole: newRole(t, "upsert", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			upsertRole: newRole(t, "upsert", nil, rcWithRoleRule(services.RW()...), types.RoleConditions{}),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Create a starting role if needed. This will be used to test collisions.
+			var revision string
+			if test.startingRole != nil {
+				startingRole, err := as.CreateRole(ctx, test.startingRole)
+				require.NoError(t, err)
+				revision = startingRole.GetMetadata().Revision
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+			test.upsertRole.SetRevision(revision)
+
+			got, err := clt.UpsertRole(ctx, test.upsertRole)
+			test.wantErr(t, err)
+			if test.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.Empty(t, cmp.Diff(test.want, got,
+					cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+				))
+			}
+		})
+	}
+}
+
+func TestGetRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		userRole     types.Role
+		roleToCreate types.Role
+		roleToGet    string
+		wantErr      require.ErrorAssertionFunc
+		want         types.Role
+	}{
+		{
+			name:         "get role",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbRead), types.RoleConditions{}),
+			roleToCreate: newRole(t, "get", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToGet:    "get",
+			wantErr:      require.NoError,
+			want:         newRole(t, "get", nil, types.RoleConditions{}, types.RoleConditions{}),
+		},
+		{
+			name:         "get role denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToCreate: newRole(t, "get", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToGet:    "get",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:      "get role does not exist",
+			userRole:  newRole(t, "urole", nil, rcWithRoleRule(types.VerbRead), types.RoleConditions{}),
+			roleToGet: "get",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name:         "get role does not exist with access denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToCreate: newRole(t, "get", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToGet:    "get",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "get role where clause",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbRead},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			roleToCreate: newRole(t, "get", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			roleToGet: "get",
+			wantErr:   require.NoError,
+			want: newRole(t, "get", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+		},
+		{
+			name: "get role where clause denied",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbRead},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			roleToCreate: newRole(t, "get", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToGet:    "get",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Only create the role if it's been supplied.
+			if test.roleToCreate != nil {
+				_, err := as.CreateRole(ctx, test.roleToCreate)
+				require.NoError(t, err)
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+
+			got, err := clt.GetRole(ctx, test.roleToGet)
+			test.wantErr(t, err)
+			if test.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.Empty(t, cmp.Diff(test.want, got,
+					cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+				))
+			}
+		})
+	}
+}
+
+func TestGetRoles(t *testing.T) {
+	t.Parallel()
+
+	allRoles := func() []types.Role {
+		return []types.Role{
+			newRole(t, "1", nil, types.RoleConditions{}, types.RoleConditions{}),
+			newRole(t, "2", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			newRole(t, "3", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			newRole(t, "4", nil, types.RoleConditions{}, types.RoleConditions{}),
+			newRole(t, "5", nil, types.RoleConditions{}, types.RoleConditions{}),
+		}
+	}
+
+	tests := []struct {
+		name          string
+		userRole      types.Role
+		rolesToCreate []types.Role
+		wantErr       require.ErrorAssertionFunc
+		want          []types.Role
+	}{
+		{
+			name:          "get roles",
+			userRole:      newRole(t, "urole", nil, rcWithRoleRule(types.VerbList, types.VerbRead), types.RoleConditions{}),
+			rolesToCreate: allRoles(),
+			wantErr:       require.NoError,
+			want:          allRoles(),
+		},
+		{
+			name:          "get roles access denied",
+			userRole:      newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			rolesToCreate: allRoles(),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "get roles where",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbList, types.VerbRead},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			rolesToCreate: allRoles(),
+			wantErr:       require.NoError,
+			want: []types.Role{
+				newRole(t, "2", map[string]string{
+					"label": "value",
+				}, types.RoleConditions{}, types.RoleConditions{}),
+				newRole(t, "3", map[string]string{
+					"label": "value",
+				}, types.RoleConditions{}, types.RoleConditions{}),
+			},
+		},
+		{
+			name: "get roles where none found (access denied)",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbList, types.VerbRead},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["something-else"]`),
+					builder.String("non-existent"),
+				).String(),
+			), types.RoleConditions{}),
+			rolesToCreate: allRoles(),
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Only create the role if it's been supplied.
+			for _, role := range test.rolesToCreate {
+				_, err := as.CreateRole(ctx, role)
+				require.NoError(t, err)
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+
+			got, err := clt.GetRoles(ctx)
+			test.wantErr(t, err)
+			if test.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.Empty(t, cmp.Diff(test.want, got,
+					cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+					cmpopts.SortSlices(func(r1, r2 types.Role) bool {
+						return r1.GetName() < r2.GetName()
+					}),
+					// Ignore the user role and the default implicit role.
+					cmpopts.IgnoreSliceElements(func(r types.Role) bool {
+						return r.GetName() == test.userRole.GetName() ||
+							r.GetName() == constants.DefaultImplicitRole
+					}),
+				))
+			}
+		})
+	}
+}
+
+func TestDeleteRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		userRole     types.Role
+		roleToCreate types.Role
+		roleToDelete string
+		wantErr      require.ErrorAssertionFunc
+	}{
+		{
+			name:         "delete role",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbDelete), types.RoleConditions{}),
+			roleToCreate: newRole(t, "delete", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr:      require.NoError,
+		},
+		{
+			name:         "delete role denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToCreate: newRole(t, "delete", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:         "delete role does not exist",
+			userRole:     newRole(t, "urole", nil, rcWithRoleRule(types.VerbDelete), types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name:         "delete role does not exist with access denied",
+			userRole:     newRole(t, "urole", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToCreate: newRole(t, "delete", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "delete role where clause",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbDelete},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			roleToCreate: newRole(t, "delete", map[string]string{
+				"label": "value",
+			}, types.RoleConditions{}, types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr:      require.NoError,
+		},
+		{
+			name: "delete role where clause denied",
+			userRole: newRole(t, "urole", nil, rcWithRoleRuleWhere([]string{types.VerbDelete},
+				builder.Equals(
+					builder.Identifier(`resource.metadata.labels["label"]`),
+					builder.String("value"),
+				).String(),
+			), types.RoleConditions{}),
+			roleToCreate: newRole(t, "delete", nil, types.RoleConditions{}, types.RoleConditions{}),
+			roleToDelete: "delete",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			as := srv.AuthServer.AuthServer
+
+			// Only create the role if it's been supplied.
+			if test.roleToCreate != nil {
+				_, err := as.CreateRole(ctx, test.roleToCreate)
+				require.NoError(t, err)
+			}
+
+			user, err := types.NewUser("user")
+			require.NoError(t, err)
+			user.AddRole(test.userRole.GetName())
+
+			// Create a test user with the given user role.
+			_, err = as.CreateRole(ctx, test.userRole)
+			require.NoError(t, err)
+			_, err = as.CreateUser(ctx, user)
+			require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
+
+			test.wantErr(t, clt.DeleteRole(ctx, test.roleToDelete))
+		})
+	}
 }
 
 func TestUpsertDeleteLockEventsEmitted(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -77,6 +77,16 @@ func (a *ServerWithRoles) CloseContext() context.Context {
 	return a.authServer.closeCtx
 }
 
+// actionForResource will determine if a user has access to the given resource. This call respects where clauses.
+func (a *ServerWithRoles) actionForResource(resource types.Resource, kind string, verbs ...string) error {
+	sctx := &services.Context{User: a.context.User}
+	if resource != nil {
+		sctx.Resource = resource
+	}
+	return trace.Wrap(a.actionWithContext(sctx, apidefaults.Namespace, kind, verbs...))
+}
+
+// actionWithContext will determine if a user has access given a services.Context. This call respects where clauses.
 func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace, resource string, verbs ...string) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("no verbs provided for authorization check on resource %q", resource)
@@ -112,6 +122,7 @@ func (a *ServerWithRoles) withOptions(opts ...actionOption) actionConfig {
 	return cfg
 }
 
+// action will determine if a user has access to the given resource kind. This does not respect where clauses.
 func (c actionConfig) action(namespace, resource string, verbs ...string) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("no verbs provided for authorization check on resource %q", resource)
@@ -3970,10 +3981,31 @@ func (a *ServerWithRoles) DeleteNamespace(name string) error {
 
 // GetRoles returns a list of roles
 func (a *ServerWithRoles) GetRoles(ctx context.Context) ([]types.Role, error) {
-	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbList, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	authErr := a.action(apidefaults.Namespace, types.KindRole, types.VerbList, types.VerbRead)
+	if authErr == nil {
+		return a.authServer.GetRoles(ctx)
 	}
-	return a.authServer.GetRoles(ctx)
+
+	roles, err := a.authServer.GetRoles(ctx)
+	if err != nil {
+		// If we get an error here, let's return the previous auth error.
+		return nil, trace.Wrap(authErr)
+	}
+
+	var filteredRoles []types.Role
+	// See if the user has access to these roles through things like where clauses.
+	for _, role := range roles {
+		if err := a.actionForResource(role, types.KindRole, types.VerbList, types.VerbRead); err == nil {
+			filteredRoles = append(filteredRoles, role)
+		}
+	}
+
+	// If we found no roles, let's return the previous auth error.
+	if len(filteredRoles) == 0 {
+		return nil, trace.Wrap(authErr)
+	}
+
+	return filteredRoles, nil
 }
 
 func (a *ServerWithRoles) validateRole(ctx context.Context, role types.Role) error {
@@ -4006,7 +4038,7 @@ func (a *ServerWithRoles) validateRole(ctx context.Context, role types.Role) err
 
 // CreateRole creates a new role.
 func (a *ServerWithRoles) CreateRole(ctx context.Context, role types.Role) (types.Role, error) {
-	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbCreate); err != nil {
+	if err := a.actionForResource(role, types.KindRole, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -4024,7 +4056,21 @@ func (a *ServerWithRoles) CreateRole(ctx context.Context, role types.Role) (type
 
 // UpdateRole updates an existing role.
 func (a *ServerWithRoles) UpdateRole(ctx context.Context, role types.Role) (types.Role, error) {
-	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbUpdate); err != nil {
+	oldRole, getErr := a.authServer.GetRole(ctx, role.GetName())
+	oldRoleIsNotFound := trace.IsNotFound(getErr)
+	if getErr != nil && !oldRoleIsNotFound {
+		return nil, trace.Wrap(getErr)
+	}
+
+	// If oldRole is nil, this whole call will fail. However, we'll continue so that the rest of
+	// the call can return an appropriate error.
+	if oldRole != nil {
+		if err := a.actionForResource(oldRole, types.KindRole, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	if err := a.actionForResource(role, types.KindRole, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -4042,7 +4088,20 @@ func (a *ServerWithRoles) UpdateRole(ctx context.Context, role types.Role) (type
 
 // UpsertRole creates or updates role.
 func (a *ServerWithRoles) UpsertRole(ctx context.Context, role types.Role) (types.Role, error) {
-	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbCreate, types.VerbUpdate); err != nil {
+	oldRole, err := a.authServer.GetRole(ctx, role.GetName())
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	verbs := []string{types.VerbCreate}
+	if oldRole != nil {
+		verbs = []string{types.VerbUpdate}
+		if err := a.actionForResource(oldRole, types.KindRole, verbs...); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	if err := a.actionForResource(role, types.KindRole, verbs...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -4096,17 +4155,39 @@ func (a *ServerWithRoles) GetRole(ctx context.Context, name string) (types.Role,
 	// Current-user exception: we always allow users to read roles
 	// that they hold.  This requirement is checked first to avoid
 	// misleading denial messages in the logs.
-	if !slices.Contains(a.context.User.GetRoles(), name) {
-		if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbRead); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if slices.Contains(a.context.User.GetRoles(), name) {
+		return a.authServer.GetRole(ctx, name)
 	}
-	return a.authServer.GetRole(ctx, name)
+
+	authErr := a.action(apidefaults.Namespace, types.KindRole, types.VerbRead)
+	if authErr == nil {
+		return a.authServer.GetRole(ctx, name)
+	}
+
+	// See if the user has access to this individual role.
+	role, err := a.authServer.GetRole(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(authErr)
+	}
+
+	if err := a.actionForResource(role, types.KindRole, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return role, nil
 }
 
 // DeleteRole deletes role by name
 func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
-	if err := a.action(apidefaults.Namespace, types.KindRole, types.VerbDelete); err != nil {
+	// See if the user has access to this individual role. If this get fails,
+	// the delete will fail, but we'll leave it to the later call to send the appropriate
+	// error.
+	role, err := a.authServer.GetRole(ctx, name)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	if err := a.actionForResource(role, types.KindRole, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -4121,6 +4202,7 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	if modules.GetModules().BuildType() == modules.BuildOSS && name == teleport.AdminRoleName {
 		return trace.AccessDenied("can not delete system role %q", name)
 	}
+
 	return a.authServer.DeleteRole(ctx, name)
 }
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1043,6 +1043,23 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindClusterAuthPreference, services.RO()),
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindLock, services.RW()),
+						// Okta can manage access lists and roles it creates.
+						{
+							Resources: []string{types.KindRole},
+							Verbs:     services.RW(),
+							Where: builder.Equals(
+								builder.Identifier(`resource.metadata.labels["`+types.OriginLabel+`"]`),
+								builder.String(types.OriginOkta),
+							).String(),
+						},
+						{
+							Resources: []string{types.KindAccessList},
+							Verbs:     services.RW(),
+							Where: builder.Equals(
+								builder.Identifier(`resource.metadata.labels["`+types.OriginLabel+`"]`),
+								builder.String(types.OriginOkta),
+							).String(),
+						},
 					},
 				},
 			})


### PR DESCRIPTION
The Okta service will now be able to manage access lists and associated resources.