### PR TITLE
updates dependencies to use gravitational boring fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,8 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92667e5967bf826198f88dd3e43616973f8902769a6151616a65be1289a3c531"
+version = "4.2.0"
+source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
 dependencies = [
  "bitflags 2.4.1",
  "boring-sys",
@@ -247,9 +246,8 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04f5e0e2dc8315f68251391a4ac6da54793525c01d0206b10732b71139768cd"
+version = "4.2.0"
+source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2768,9 +2766,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2ca4142b3d45b579a45fc171a04d2f8dde1f5ff76290fd395286bcc5f82f4b"
+version = "4.2.0"
+source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "boring"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
+source = "git+https://github.com/gravitational/boring?rev=eb1296f580475ce77017c7169f3f59d0eca36a0d#eb1296f580475ce77017c7169f3f59d0eca36a0d"
 dependencies = [
  "bitflags 2.4.1",
  "boring-sys",
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
+source = "git+https://github.com/gravitational/boring?rev=eb1296f580475ce77017c7169f3f59d0eca36a0d#eb1296f580475ce77017c7169f3f59d0eca36a0d"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
+source = "git+https://github.com/gravitational/boring?rev=eb1296f580475ce77017c7169f3f59d0eca36a0d#eb1296f580475ce77017c7169f3f59d0eca36a0d"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "boring"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
+source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
 dependencies = [
  "bitflags 2.4.1",
  "boring-sys",
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
+source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "4.2.0"
-source = "git+https://github.com/gravitational/boring?rev=70e4c8051d4c276243f20f5f9e6457b714eb8717#70e4c8051d4c276243f20f5f9e6457b714eb8717"
+source = "git+https://github.com/gravitational/boring?rev=d1be1a42381476087ae1b154867d546e29d41f55#d1be1a42381476087ae1b154867d546e29d41f55"
 dependencies = [
  "boring",
  "boring-sys",

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -48,6 +48,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-gcc \
+        ${DEVTOOLSET}-gcc-c++ \
         ${DEVTOOLSET}-make && \
     yum clean all
 

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -22,17 +22,17 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum install -y centos-release-scl-rh && \
     yum install -y \
-        centos-release-scl \
-        cmake3 \
-        git \
-        scl-utils && \
+    centos-release-scl \
+    cmake3 \
+    git \
+    scl-utils && \
     yum clean all
 
 # As mentioned above, these packages are unsigned.
 RUN yum install --nogpgcheck -y \
-        ${DEVTOOLSET}-gcc \
-        ${DEVTOOLSET}-gcc-c++ \
-        ${DEVTOOLSET}-make && \
+    ${DEVTOOLSET}-gcc \
+    ${DEVTOOLSET}-gcc-c++ \
+    ${DEVTOOLSET}-make && \
     yum clean all
 
 # Use just created devtool image with newer GCC and Cmake
@@ -54,12 +54,12 @@ RUN git clone --branch llvmorg-14.0.6 --depth=1 https://github.com/llvm/llvm-pro
     [ "$(git rev-parse HEAD)" = 'f28c006a5895fc0e329fe15fead81e37457cb1d1' ] && \
     mkdir build && cd build/ && \
     scl enable ${DEVTOOLSET} 'bash -c "cmake3 \
--DCMAKE_BUILD_TYPE=Release \
--DCMAKE_INSTALL_PREFIX=/opt/llvm \
--DLLVM_ENABLE_PROJECTS=clang \
--DLLVM_BUILD_TOOLS=ON \
--G \"Unix Makefiles\" ../llvm && \
-make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang install-clang-resource-headers install-libclang"' && \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/llvm \
+    -DLLVM_ENABLE_PROJECTS=clang \
+    -DLLVM_BUILD_TOOLS=ON \
+    -G \"Unix Makefiles\" ../llvm && \
+    make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang install-clang-resource-headers install-libclang"' && \
     cd ../.. && \
     rm -rf llvm-project
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.1"
-boring = { git = "https://github.com/gravitational/boring", rev="d1be1a42381476087ae1b154867d546e29d41f55", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="eb1296f580475ce77017c7169f3f59d0eca36a0d", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.10.1"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { git = "https://github.com/gravitational/boring", rev="d1be1a42381476087ae1b154867d546e29d41f55", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="eb1296f580475ce77017c7169f3f59d0eca36a0d", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.6.1", features = ["v4"] }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.1"
-boring = { git = "https://github.com/gravitational/boring", rev="70e4c8051d4c276243f20f5f9e6457b714eb8717", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="d1be1a42381476087ae1b154867d546e29d41f55", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.10.1"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { git = "https://github.com/gravitational/boring", rev="70e4c8051d4c276243f20f5f9e6457b714eb8717", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="d1be1a42381476087ae1b154867d546e29d41f55", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.6.1", features = ["v4"] }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.1"
-boring = { version = "4.3.0", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="70e4c8051d4c276243f20f5f9e6457b714eb8717", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.10.1"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { version = "4.3.0", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="70e4c8051d4c276243f20f5f9e6457b714eb8717", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.6.1", features = ["v4"] }
 


### PR DESCRIPTION
depends on https://github.com/gravitational/teleport/pull/36166

Should not be merged before https://github.com/gravitational/boring/pull/2 is merged and the boring commit hashes in this PR are updated to the head of https://github.com/gravitational/boring/ 's `teleport` branch.