### PR TITLE
Remove deprecated migration from `tbot`

### DIFF
--- a/lib/tbot/identity/artifact.go
+++ b/lib/tbot/identity/artifact.go
@@ -62,12 +62,8 @@ func (a *Artifact) Matches(kinds ...ArtifactKind) bool {
 var artifacts = []Artifact{
 	// SSH artifacts
 	{
-		Key: SSHCertKey,
-
-		// DELETE IN: 12.0
-		// Migrate from old key "sshcert".
-		OldKey: "sshcert",
-		Kind:   KindAlways,
+		Key:  SSHCertKey,
+		Kind: KindAlways,
 		ToBytes: func(i *Identity) []byte {
 			return i.CertBytes
 		},


### PR DESCRIPTION
Long forgotten migration that should have been removed in V12

changelog: tbot will no longer attempt to load a SSH key from the legacy path.