### PR TITLE
[v13] Use the cache for user login state.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -418,8 +418,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	// Add in a login hook for generating state during user login.
 	as.ulsGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         log,
-		AccessLists: services,
-		Access:      services,
+		AccessLists: &as,
+		Access:      &as,
 		UsageEvents: &as,
 		Clock:       cfg.Clock,
 	})


### PR DESCRIPTION
Backport #36021 to branch/v13

changelog: The user login state generator now uses the cache, which should reduce the number of calls to the backend.
