### PR TITLE
Use cmp and cmpots properly in operator tests

### DIFF
--- a/integrations/operator/controllers/resources/github_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/github_connector_controller_test.go
@@ -116,15 +116,8 @@ func (g *githubTestingPrimitives) ModifyKubernetesResource(ctx context.Context, 
 }
 
 func (g *githubTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.GithubConnector, kubeResource *resourcesv3.TeleportGithubConnector) (bool, string) {
-	teleportMap, _ := teleportResourceToMap(tResource)
-	kubernetesMap, _ := teleportResourceToMap(kubeResource.ToTeleport())
-
-	equal := cmp.Equal(teleportMap["spec"], kubernetesMap["spec"])
-	if !equal {
-		return equal, cmp.Diff(teleportMap["spec"], kubernetesMap["spec"])
-	}
-
-	return equal, ""
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions()...)
+	return diff == "", diff
 }
 
 func TestGithubConnectorCreation(t *testing.T) {

--- a/integrations/operator/controllers/resources/oidc_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller_test.go
@@ -115,15 +115,8 @@ func (g *oidcTestingPrimitives) ModifyKubernetesResource(ctx context.Context, na
 }
 
 func (g *oidcTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.OIDCConnector, kubeResource *resourcesv3.TeleportOIDCConnector) (bool, string) {
-	teleportMap, _ := teleportResourceToMap(tResource)
-	kubernetesMap, _ := teleportResourceToMap(kubeResource.ToTeleport())
-
-	equal := cmp.Equal(teleportMap["spec"], kubernetesMap["spec"])
-	if !equal {
-		return equal, cmp.Diff(teleportMap["spec"], kubernetesMap["spec"])
-	}
-
-	return equal, ""
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions()...)
+	return diff == "", diff
 }
 
 func TestOIDCConnectorCreation(t *testing.T) {

--- a/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
@@ -153,15 +153,8 @@ func (g *oktaImportRuleTestingPrimitives) ModifyKubernetesResource(ctx context.C
 }
 
 func (g *oktaImportRuleTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.OktaImportRule, kubeResource *resourcesv1.TeleportOktaImportRule) (bool, string) {
-	teleportMap, _ := teleportResourceToMap(tResource)
-	kubernetesMap, _ := teleportResourceToMap(kubeResource.ToTeleport())
-
-	equal := cmp.Equal(teleportMap["spec"], kubernetesMap["spec"])
-	if !equal {
-		return equal, cmp.Diff(teleportMap["spec"], kubernetesMap["spec"])
-	}
-
-	return equal, ""
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions()...)
+	return diff == "", diff
 }
 
 func TestOktaImportRuleCreation(t *testing.T) {

--- a/integrations/operator/controllers/resources/provision_token_controller_test.go
+++ b/integrations/operator/controllers/resources/provision_token_controller_test.go
@@ -141,19 +141,8 @@ func (g *tokenTestingPrimitives) ModifyKubernetesResource(ctx context.Context, n
 }
 
 func (g *tokenTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.ProvisionToken, kubeResource *resourcesv2.TeleportProvisionToken) (bool, string) {
-	teleportMap, _ := teleportResourceToMap(tResource)
-	kubernetesMap, _ := teleportResourceToMap(kubeResource.ToTeleport())
-
-	equal := cmp.Equal(teleportMap["spec"], kubernetesMap["spec"])
-	if !equal {
-		return false, cmp.Diff(teleportMap["spec"], kubernetesMap["spec"])
-	}
-	// The operator does not support resource expiration, the token should not expire
-	// else we'll end up in an inconsistent state
-	if !tResource.Expiry().IsZero() {
-		return false, "Token expires on the Teleport side"
-	}
-	return true, ""
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions()...)
+	return diff == "", diff
 }
 
 func TestProvisionTokenCreation(t *testing.T) {

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -144,13 +144,7 @@ func (g *accessListTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 }
 
 func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tResource *accesslist.AccessList, kubeResource *resourcesv1.TeleportAccessList) (bool, string) {
-	opts := []cmp.Option{
-		cmpopts.IgnoreFields(header.Metadata{}, "ID", "Labels", "Revision"),
-		cmpopts.IgnoreFields(header.ResourceHeader{}, "Kind"),
-		cmpopts.EquateApproxTime(MaxTimeDiff),
-		// Notifications are set by CheckAndSetDefaults server-side most of the time
-		cmpopts.IgnoreFields(accesslist.Audit{}, "Notifications"),
-	}
+	opts := CompareOptions()
 	// If the kubernetes resource does not specify an audit date, it will be computed server-side
 	if kubeResource.Spec.Audit.NextAuditDate.IsZero() {
 		opts = append(opts, cmpopts.IgnoreFields(accesslist.Audit{}, "Notifications", "NextAuditDate"))

--- a/integrations/operator/controllers/resources/testlib/compare.go
+++ b/integrations/operator/controllers/resources/testlib/compare.go
@@ -1,0 +1,55 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testlib
+
+import (
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+)
+
+// MaxTimeDiff is used when writing tests comparing times. Timestamps suffer
+// from being serialized/deserialized with different precisions, the final value
+// might be a bit different from the initial one. If the difference is less than
+// MaxTimeDiff, we consider the values equal.
+const MaxTimeDiff = 2 * time.Millisecond
+
+var defaultCompareOpts = []cmp.Option{
+	// Ensures that a nil map equates initialized but empty map (depending on how the resource is sent over the
+	// wire, some local nil fields might come back from Teleport initialized but empty, and vice-versa.
+	cmpopts.EquateEmpty(),
+	// Fixes time precision issues that might be caused by serialization/deserialization
+	cmpopts.EquateApproxTime(MaxTimeDiff),
+	// New resource headers
+	cmpopts.IgnoreFields(header.Metadata{}, "ID", "Labels", "Revision"),
+	cmpopts.IgnoreFields(header.ResourceHeader{}, "Kind"),
+	// Legacy gogoproto resource headers
+	cmpopts.IgnoreFields(types.Metadata{}, "ID", "Labels", "Revision", "Namespace"),
+	cmpopts.IgnoreFields(types.ResourceHeader{}, "Kind"),
+}
+
+// CompareOptions builds comparison options by returning a slice of both default comparison options and optional
+// custom ones for the test/resource.
+func CompareOptions(customOpts ...cmp.Option) []cmp.Option {
+	return append(defaultCompareOpts, customOpts...)
+}

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -58,12 +58,6 @@ import (
 // unprotected scheme.Scheme that triggers the race detector
 var scheme = apiruntime.NewScheme()
 
-// MaxTimeDiff is used when writing tests comparing times. Timestamps suffer
-// from being serialized/deserialized with different precisions, the final value
-// might be a bit different from the initial one. If the difference is less than
-// MaxTimeDiff, we consider the values equal.
-const MaxTimeDiff = 2 * time.Millisecond
-
 func init() {
 	utilruntime.Must(core.AddToScheme(scheme))
 	utilruntime.Must(resourcesv1.AddToScheme(scheme))

--- a/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
@@ -137,8 +137,7 @@ func (l *loginRuleTestingPrimitives) CompareTeleportAndKubernetesResource(
 	tResource *resourcesv1.LoginRuleResource,
 	kubeResource *resourcesv1.TeleportLoginRule) (bool, string) {
 	diff := cmp.Diff(tResource, kubeResource.ToTeleport(),
-		cmpopts.IgnoreUnexported(loginrulepb.LoginRule{}),
-		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Labels"),
+		CompareOptions(cmpopts.IgnoreUnexported(loginrulepb.LoginRule{}))...,
 	)
 	return diff == "", diff
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -40,6 +40,7 @@ import (
 	v2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
 	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
 const teleportUserKind = "TeleportUser"
@@ -410,9 +411,10 @@ func getUserStatusConditionError(object map[string]interface{}) []metav1.Conditi
 }
 
 func compareRoles(expected, actual []string) bool {
+	opts := testlib.CompareOptions(cmpopts.SortSlices(func(a, b string) bool { return a < b }))
 	return cmp.Diff(
 		expected,
 		actual,
-		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+		opts...,
 	) == ""
 }


### PR DESCRIPTION
This PR creates a standard set of comparison options for all operator tests.

Default compare options handle the the common use cases:
- ignore ID, labels and other dynamic metadata
- apply sane time comparison by default
- equates nil maps and empty maps (caused by proto serialization)

This solves a couple of comparison issues I faced [in another PR](https://github.com/gravitational/teleport/pull/36142).