### PR TITLE
[v14] Relax Kubernetes CRD discovery when building cache

### DIFF
--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -117,7 +117,7 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 	}
 	var isClusterOffline bool
 	// Create the codec factory and the list of supported types for RBAC.
-	codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
+	codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(cfg.log, creds.getKubeClient())
 	if err != nil {
 		cfg.log.WithError(err).Warn("Failed to create cluster schema. Possibly the cluster is offline.")
 		// If the cluster is offline, we will not be able to create the codec factory
@@ -149,7 +149,7 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 			case <-ctx.Done():
 				return
 			case <-ticker.Chan():
-				codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
+				codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(cfg.log, creds.getKubeClient())
 				if err != nil {
 					cfg.log.WithError(err).Error("Failed to update cluster schema")
 					continue

--- a/lib/kube/proxy/scheme.go
+++ b/lib/kube/proxy/scheme.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,7 +100,7 @@ func newClientNegotiator(codecFactory *serializer.CodecFactory) runtime.ClientNe
 // This schema includes all well-known Kubernetes types and all namespaced
 // custom resources.
 // It also returns a map of resources that we support RBAC restrictions for.
-func newClusterSchemaBuilder(client kubernetes.Interface) (serializer.CodecFactory, rbacSupportedResources, error) {
+func newClusterSchemaBuilder(log logrus.FieldLogger, client kubernetes.Interface) (serializer.CodecFactory, rbacSupportedResources, error) {
 	kubeScheme := runtime.NewScheme()
 	kubeCodecs := serializer.NewCodecFactory(kubeScheme)
 	supportedResources := maps.Clone(defaultRBACResources)
@@ -112,19 +113,16 @@ func newClusterSchemaBuilder(client kubernetes.Interface) (serializer.CodecFacto
 	// register all namespaced custom resources
 	_, apiGroups, err := client.Discovery().ServerGroupsAndResources()
 	switch {
-	case errors.As(err, &discoveryErr) && len(discoveryErr.Groups) == 1:
-		// If the discovery error is of type `ErrGroupDiscoveryFailed` and it
-		// contains only one group, it it's possible that the group is the metrics
-		// group. If that's the case, we can ignore the error and continue.
-		// This is a workaround for the metrics group not being registered because
-		// the metrics pod is not running. It's common for Kubernetes clusters without
-		// nodes to not have the metrics pod running.
-		const metricsAPIGroup = "metrics.k8s.io"
-		for k := range discoveryErr.Groups {
-			if k.Group != metricsAPIGroup {
-				return serializer.CodecFactory{}, nil, trace.Wrap(err)
-			}
-		}
+	case errors.As(err, &discoveryErr):
+		// If the discovery of one or more API groups fails, we still want to
+		// register the well-known Kubernetes types.
+		// This is because the discovery of API groups can fail if the APIService
+		// is not available. Usually, this happens when the API service is not local
+		// to the cluster (e.g. when API is served by a pod) and the service is not
+		// reachable.
+		// In this case, we still want to register the other resources that are
+		// available in the cluster.
+		log.WithError(err).Debugf("Failed to discover some API groups: %v", maps.Keys(discoveryErr.Groups))
 	case err != nil:
 		return serializer.CodecFactory{}, nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/scheme_test.go
+++ b/lib/kube/proxy/scheme_test.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -28,7 +29,7 @@ import (
 // TestNewClusterSchemaBuilder tests that newClusterSchemaBuilder doesn't panic
 // when it's given types already registered in the global scheme.
 func Test_newClusterSchemaBuilder(t *testing.T) {
-	_, _, err := newClusterSchemaBuilder(&clientSet{})
+	_, _, err := newClusterSchemaBuilder(logrus.StandardLogger(), &clientSet{})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Backport #36214 to branch/v14

changelog: Safeguard against the disruption of cluster access caused by incorrect Kubernetes APIService configurations.
