### PR TITLE
Fix the access list reminder pagination loop.

### DIFF
--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -19,6 +19,11 @@ spec:
       - resources: ['access_plugin_data']
         verbs: ['update']
 
+      # In order to provide access list review reminders, permissions to access lists
+      # are necessary. This is currently only supported for a subset of plugins.
+      - resources: ['access_list']
+        verbs: ['list', 'read']
+
     # Optional: To display user-friendly names in resource-based Access
     # Requests instead of resource IDs, the plugin also needs permission
     # to list the resources being requested. Include this along with the

--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -19,7 +19,7 @@ spec:
       - resources: ['access_plugin_data']
         verbs: ['update']
 
-      # In order to provide access list review reminders, permissions to access lists
+      # In order to provide access list review reminders, permissions to list and read access lists
       # are necessary. This is currently only supported for a subset of plugins.
       - resources: ['access_list']
         verbs: ['list', 'read']

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -190,7 +190,8 @@ func (a *App) notifyForAccessListReviews(ctx context.Context, accessList *access
 
 	allRecipients := a.fetchRecipients(ctx, accessList, now, notificationStart)
 	if len(allRecipients) == 0 {
-		return trace.NotFound("no recipients could be fetched for access list %s", accessList.GetName())
+		// Don't return an error here to avoid generating a noisy log.
+		return nil
 	}
 
 	// Try to create base notification data with a zero notification date. If these objects already

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -137,14 +137,14 @@ func (a *App) run(ctx context.Context) error {
 			var err error
 			for {
 				var accessLists []*accesslist.AccessList
-				accessLists, nextToken, err = a.apiClient.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
+				accessLists, nextToken, err = a.apiClient.ListAccessLists(ctx, 0 /* default page size */, nextToken)
 				if err != nil {
 					if trace.IsNotImplemented(err) {
 						log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
 						return nil
 					}
 					log.Errorf("error listing access lists: %v", err)
-					continue
+					break
 				}
 
 				for _, accessList := range accessLists {

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
@@ -121,24 +122,18 @@ func (a *App) run(ctx context.Context) error {
 
 	a.job.SetReady(true)
 
-	select {
-	// Have a short first duration to wait for everything to settle before
-	// trying the first reminder.
-	case <-a.clock.After(30 * time.Second):
-		if err := a.remindIfNecessary(ctx); err != nil {
-			return trace.Wrap(err)
-		}
-	case <-ctx.Done():
-		log.Info("Access list monitor is finished")
-		return nil
-	}
+	jitter := retryutils.NewSeventhJitter()
+	timer := a.clock.NewTimer(jitter(30 * time.Second))
+	defer timer.Stop()
 
 	for {
 		select {
-		case <-a.clock.After(reminderInterval):
+		case <-timer.Chan():
 			if err := a.remindIfNecessary(ctx); err != nil {
 				return trace.Wrap(err)
 			}
+
+			timer.Reset(jitter(reminderInterval))
 		case <-ctx.Done():
 			log.Info("Access list monitor is finished")
 			return nil
@@ -163,8 +158,12 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 			if trace.IsNotImplemented(err) {
 				log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
 				return trace.Wrap(err)
+			} else if trace.IsAccessDenied(err) {
+				log.Warnf("Slack bot does not have permissions to list access lists. Please add access_list read and list permissions " +
+					"to the role associated with the Slack bot.")
+			} else {
+				log.Errorf("error listing access lists: %v", err)
 			}
-			log.Errorf("error listing access lists: %v", err)
 			break
 		}
 

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 type PluginConfiguration interface {
@@ -53,8 +53,8 @@ type wrappedClient struct {
 	*client.Client
 }
 
-func (w *wrappedClient) AccessListClient() services.AccessLists {
-	return w.Client.AccessListClient()
+func (w *wrappedClient) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+	return w.Client.AccessListClient().ListAccessLists(ctx, pageSize, pageToken)
 }
 
 // wrapAPIClient will wrap the API client such that it conforms to the Teleport plugin client interface.

--- a/integrations/access/common/teleport/client.go
+++ b/integrations/access/common/teleport/client.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // Client aggregates the parts of Teleport API client interface
@@ -38,5 +38,5 @@ type Client interface {
 	SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error)
 	SetAccessRequestState(ctx context.Context, params types.AccessRequestUpdate) error
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
-	AccessListClient() services.AccessLists
+	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 }


### PR DESCRIPTION
On error in the access list reminder pagination loop, the loop now breaks instead of continuing, which is the intended behavior. A test has been added to exercise this. This test will time out with the previous behavior. A light refactoring has been done to make it easier to mock the ListAccessLists response.

Users running their own Slack plugins (outside of cloud) were running into an issue here due to the plugin user not having permissions to read access lists. On cloud tenants, the plugins should have this access, so the impact there is minimal.

Additionally, the docs have been updated to include the access list permissions.

changelog: Fix spammy logging with access list reminders in Slack plugin when the plugin user lacks access list permissions.

Fixes https://github.com/gravitational/teleport/issues/36225