### PR TITLE
Reviewer bot should use the stable version of Go

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Checking reviewers
         run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"


### PR DESCRIPTION
The review bot was updated to use the slices package and requires Go 1.21. Have the check workflow use the stable version of Go rather than pulling from go.mod.