### PR TITLE
Warn about CPU limits in `teleport-cluster` Helm chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1823,11 +1823,12 @@ Resource requests/limits which should be configured for Teleport containers. The
 applied to `initContainers`.
 
 <Admonition type="danger">
-Setting CPU limits is an antipattern and is harmful in most cases. Unless you enabled
+Setting CPU limits is an anti-pattern and is harmful in most cases. Unless you enabled
 [the Static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy),
 a multithreaded workload with CPU limits will very likely not behave the way you expect when approaching its CPU limit.
 
 Teleport will become unstable once throttling starts. We recommend not to set CPU limits.
+See [the GitHub PR](https://github.com/gravitational/teleport/pull/36251) for technical details.
 </Admonition>
 
 `values.yaml` example:

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1822,6 +1822,14 @@ A `postStart` lifecycle handler to be configured on the main Teleport container.
 Resource requests/limits which should be configured for Teleport containers. These resource limits will also be
 applied to `initContainers`.
 
+<Admonition type="danger">
+Setting CPU limits is an antipattern and is harmful in most cases. Unless you enabled
+[the Static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy),
+a multithreaded workload with CPU limits will very likely not behave the way you expect when approaching its CPU limit.
+
+Teleport will become unstable once throttling starts. We recommend not to set CPU limits.
+</Admonition>
+
 `values.yaml` example:
 
   ```yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -658,9 +658,18 @@ postStart:
 
 # Resources to request for the teleport container
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+#
+# DANGER: Setting CPU limits is an antipattern and harmful in most cases.
+# Unless you enabled [the Static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy),
+# a multithreaded workload with CPU limits will very likely not behave the way
+# you expect when approaching its CPU limit.
+#
+# Teleport will become unstable once throttling starts. We recommend not to set CPU limits.
 resources: {}
 #  requests:
 #    cpu: "1"
+#    memory: "2Gi"
+#  limits:
 #    memory: "2Gi"
 
 # Security context to add to the container

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -659,12 +659,13 @@ postStart:
 # Resources to request for the teleport container
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 #
-# DANGER: Setting CPU limits is an antipattern and harmful in most cases.
+# DANGER: Setting CPU limits is an anti-pattern and harmful in most cases.
 # Unless you enabled [the Static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy),
 # a multithreaded workload with CPU limits will very likely not behave the way
 # you expect when approaching its CPU limit.
 #
 # Teleport will become unstable once throttling starts. We recommend not to set CPU limits.
+# See [the GitHub PR](https://github.com/gravitational/teleport/pull/36251) for technical details.
 resources: {}
 #  requests:
 #    cpu: "1"


### PR DESCRIPTION
Because people keep shooting themselves in the foot with CFS quotas and this causes S1s.

Technical explanation as to why cpu limits are not the best idea:
- you want to set limits to avoid side workloads to harm important workloads, setting limits on the Teleport cluster means that you want to degrade Teleport to protect something else in your Kube cluster. In the vast majority of setups, Teleport is the main workload in the cluster and the most important one, you don't want to degrade it and loose access to everything when under pressure.
- CFS quotas are misleading. If you set `requests.cpu:1`and `limits.cpu: 1` this absolutely does not mean that Teleport will run on a single CPU, nor that its CPU will be reserved. On an 8 core node, this means teleport will run 13% of the time on all CPUs, and then not be scheduled during the remaining 87% of the observed period. The Static CPU management policy does the thing people expect: it statically allocates CPUs to each workload (plus you get a nice CPU affinity that can help a lot with single-threaded workloads)
- Teleport is mainly doing IO; when throttling starts, latency will skyrocket, and the service will become unstable (you can safely expect everything to start timeouting: e.g. TLS handshakes)