### PR TITLE
feat: make tsh logout clear kubeconfig configurable

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -462,6 +462,9 @@ type CLIConf struct {
 	// It shouldn't be used outside testing.
 	KubeConfigPath string
 
+	// clearKubeConfig determines if kubectl config is cleared on tsh logout
+	clearKubeConfig bool
+
 	// Client only version display.  Skips checking proxy version.
 	clientOnlyVersionCheck bool
 
@@ -596,6 +599,7 @@ const (
 	awsKeystoreEnvVar        = "TELEPORT_AWS_KEYSTORE"
 	awsWorkgroupEnvVar       = "TELEPORT_AWS_WORKGROUP"
 	proxyKubeConfigEnvVar    = "TELEPORT_KUBECONFIG"
+	clearKubeConfigEnvVar    = "TELEPORT_LOGOUT_CLEAR_KUBECONFIG"
 
 	clusterHelp = "Specify the Teleport cluster to connect"
 	browserHelp = "Set to 'none' to suppress browser opening on login"
@@ -954,6 +958,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// logout deletes obtained session certificates in ~/.tsh
 	logout := app.Command("logout", "Delete a cluster certificate.")
+	logout.Flag("clear-kubeconfig", "Determines if kube config is cleared on logout. Default is enabled").
+		Envar(clearKubeConfigEnvVar).
+		Default("true").
+		BoolVar(&cf.clearKubeConfig)
 
 	// latency
 	latency := app.Command("latency", "Run latency diagnostics.").Hidden()
@@ -2038,11 +2046,13 @@ func onLogout(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		// Remove Teleport related entries from kubeconfig.
-		log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
-		err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
-		if err != nil {
-			return trace.Wrap(err)
+		if cf.clearKubeConfig {
+			// Remove Teleport related entries from kubeconfig.
+			log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
+			err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
+			if err != nil {
+				return trace.Wrap(err)
+			}
 		}
 
 		fmt.Printf("Logged out %v from %v.\n", cf.Username, proxyHost)
@@ -2053,17 +2063,19 @@ func onLogout(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
-		if err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr()); err != nil {
-			return trace.Wrap(err)
-		}
-
-		// Remove Teleport related entries from kubeconfig for all clusters.
-		for _, profile := range profiles {
-			log.Debugf("Removing Teleport related entries for cluster '%v' from kubeconfig.", profile.Cluster)
-			err = kubeconfig.RemoveByClusterName("", profile.Cluster)
-			if err != nil {
+		if cf.clearKubeConfig {
+			log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
+			if err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr()); err != nil {
 				return trace.Wrap(err)
+			}
+
+			// Remove Teleport related entries from kubeconfig for all clusters.
+			for _, profile := range profiles {
+				log.Debugf("Removing Teleport related entries for cluster '%v' from kubeconfig.", profile.Cluster)
+				err = kubeconfig.RemoveByClusterName("", profile.Cluster)
+				if err != nil {
+					return trace.Wrap(err)
+				}
 			}
 		}
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2917,6 +2917,39 @@ func TestEnvFlags(t *testing.T) {
 			},
 		}))
 	})
+
+	t.Run("tsh logout clear-kubeconfig env", func(t *testing.T) {
+		t.Run("nothing set", testEnvFlag(testCase{
+			outCLIConf: CLIConf{},
+		}))
+		t.Run("CLI flag is set", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				clearKubeConfig: true,
+			},
+			outCLIConf: CLIConf{
+				clearKubeConfig: true,
+			},
+		}))
+		t.Run("TELEPORT_LOGOUT_CLEAR_KUBECONFIG set", testEnvFlag(testCase{
+			envMap: map[string]string{
+				clearKubeConfigEnvVar: "true",
+			},
+			outCLIConf: CLIConf{
+				clearKubeConfig: true,
+			},
+		}))
+		t.Run("TELEPORT_LOGOUT_CLEAR_KUBECONFIG and CLI flag is set, prefer env", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				clearKubeConfig: false,
+			},
+			envMap: map[string]string{
+				clearKubeConfigEnvVar: "true",
+			},
+			outCLIConf: CLIConf{
+				clearKubeConfig: false,
+			},
+		}))
+	})
 }
 
 func TestKubeConfigUpdate(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/36261.

Adds in env var `TELEPORT_LOGOUT_CLEAR_KUBECONFIG` and flag `--[no-]clear-kubeconfig` which configures whether ones kubeconfig is cleared on `tsh logout`   

I have tested this locally on a custom build and works as expected for various scenarios 