### PR TITLE
Make UI part of tshd events service one-to-one

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -29,7 +29,6 @@
   "homepage": "https://goteleport.com",
   "dependencies": {
     "@types/tar-fs": "^2.0.1",
-    "emittery": "^1.0.1",
     "node-pty": "1.1.0-beta5",
     "strip-ansi": "^7.1.0",
     "tar-fs": "^3.0.3"

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -66,11 +66,13 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     credentials.shared,
     runtimeSettings
   );
-  const { subscribeToTshdEvent, resolvedAddress: tshdEventsServerAddress } =
-    await createTshdEventsServer(
-      runtimeSettings.tshdEvents.requestedNetworkAddress,
-      credentials.tshdEvents
-    );
+  const {
+    setupTshdEventContextBridgeService,
+    resolvedAddress: tshdEventsServerAddress,
+  } = await createTshdEventsServer(
+    runtimeSettings.tshdEvents.requestedNetworkAddress,
+    credentials.tshdEvents
+  );
 
   // Here we send to tshd the address of the tshd events server that we just created. This makes
   // tshd prepare a client for the server.
@@ -84,7 +86,7 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     mainProcessClient,
     tshClient,
     ptyServiceClient,
-    subscribeToTshdEvent,
+    setupTshdEventContextBridgeService,
   };
 }
 

--- a/web/packages/teleterm/src/services/tshd/middleware.ts
+++ b/web/packages/teleterm/src/services/tshd/middleware.ts
@@ -128,7 +128,7 @@ export const withLogging = (logger: Logger): UnaryInterceptor => {
   };
 };
 
-function filterSensitiveProperties(toFilter: object): object {
+export function filterSensitiveProperties(toFilter: object): object {
   const acc = {};
   const transformer = (result: object, value: any, key: any) => {
     if (

--- a/web/packages/teleterm/src/services/tshdEvents/index.ts
+++ b/web/packages/teleterm/src/services/tshdEvents/index.ts
@@ -166,6 +166,10 @@ function createService(logger: Logger): {
 
     logger.info(`got ${rpcName}`, filterSensitiveProperties(request));
 
+    call.on('cancelled', () => {
+      logger.error(`canceled by client ${rpcName}`);
+    });
+
     const onRequestCancelled = (callback: () => void) => {
       call.on('cancelled', callback);
     };
@@ -189,6 +193,10 @@ function createService(logger: Logger): {
       onRequestCancelled,
     }).then(
       response => {
+        if (call.cancelled) {
+          return;
+        }
+
         callback(null, mapResponseObjectToResponseInstance(response));
 
         logger.info(
@@ -197,6 +205,10 @@ function createService(logger: Logger): {
         );
       },
       error => {
+        if (call.cancelled) {
+          return;
+        }
+
         callback(error, null);
 
         logger.error(`replied with error to ${rpcName}`, error);

--- a/web/packages/teleterm/src/services/tshdEvents/index.ts
+++ b/web/packages/teleterm/src/services/tshdEvents/index.ts
@@ -16,14 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Emittery from 'emittery';
 import * as grpc from '@grpc/grpc-js';
 import * as api from 'gen-proto-js/teleport/lib/teleterm/v1/tshd_events_service_pb';
 import * as apiService from 'gen-proto-js/teleport/lib/teleterm/v1/tshd_events_service_grpc_pb';
+import * as protobuf from 'google-protobuf';
 
 import * as uri from 'teleterm/ui/uri';
 import Logger from 'teleterm/logger';
-import { SubscribeToTshdEvent } from 'teleterm/types';
+import { TshdEventContextBridgeService } from 'teleterm/types';
+import { filterSensitiveProperties } from 'teleterm/services/tshd/middleware';
 
 export interface ReloginRequest extends api.ReloginRequest.AsObject {
   rootClusterUri: uri.RootClusterUri;
@@ -51,15 +52,18 @@ export interface SendPendingHeadlessAuthenticationRequest
 
 /**
  * Starts tshd events server.
- * @return {Promise} Object containing the address the server is listening on and subscribeToEvent
- * function which lets UI code subscribe to events which are emitted when a client calls the server.
+ * @return {Promise} Object containing the address the server is listening on and
+ * setupTshdEventContextBridgeService function which lets UI code subscribe to events which are
+ * emitted when tshd calls the Electron app.
  */
 export async function createTshdEventsServer(
   requestedAddress: string,
   credentials: grpc.ServerCredentials
 ): Promise<{
   resolvedAddress: string;
-  subscribeToTshdEvent: SubscribeToTshdEvent;
+  setupTshdEventContextBridgeService: (
+    listener: TshdEventContextBridgeService
+  ) => void;
 }> {
   const logger = new Logger('tshd events');
   const { server, resolvedAddress } = await createServer(
@@ -67,7 +71,7 @@ export async function createTshdEventsServer(
     credentials,
     logger
   );
-  const { service, subscribeToTshdEvent } = createService(logger);
+  const { service, setupTshdEventContextBridgeService } = createService(logger);
 
   server.addService(
     apiService.TshdEventsServiceService,
@@ -81,7 +85,7 @@ export async function createTshdEventsServer(
     service
   );
 
-  return { resolvedAddress, subscribeToTshdEvent };
+  return { resolvedAddress, setupTshdEventContextBridgeService };
 }
 
 async function createServer(
@@ -118,100 +122,113 @@ async function createServer(
   });
 }
 
-// createService creates a service that can be added to tshd events server. It also
-// returns a function which lets UI code subscribe to events which are emitted when a client calls
-// this service.
-//
-// Why do we need to use an event emitter? The gRPC server is created in the preload script but we
-// need the UI to react to the events. We cannot create the service in the UI code because this
-// would mean that the service would need to cross the contextBridge. This is simply impossible
-// because the service is fed custom gRPC classes which can't be passed through the contextBridge.
-//
-// Instead, we create an event emitter and expose subscribeToEvent through the contextBridge.
-// subscribeToEvent lets UI code register a callback for a specific event. That callback receives
-// a simple JS object which can freely pass the contextBridge.
-//
-// # Async behavior
-//
-// The callback can return a promise. The service will not return a response until all callbacks
-// resolve. This lets us model behavior where tshd calls the Electron app and then blocks until it
-// receives a response, in case the Electron app needs to do some work before we want to unblock
-// tshd.
-//
-// If any of the callbacks return an error, the service will return that error immediately, without
-// waiting for other listeners.
+/**
+ * createService creates a service for the tshd events server. It sets up the preload part of the
+ * service and expects the UI to call setupTshdEventContextBridgeService to add the browser part of
+ * the service which interacts with the UI.
+ *
+ * See the JSDoc for TshdEventContextBridgeService for more details.
+ */
 function createService(logger: Logger): {
   service: apiService.ITshdEventsServiceServer;
-  subscribeToTshdEvent: SubscribeToTshdEvent;
+  setupTshdEventContextBridgeService: (
+    listener: TshdEventContextBridgeService
+  ) => void;
 } {
-  const emitter = new Emittery();
+  let contextBridgeService: TshdEventContextBridgeService;
 
-  const subscribeToTshdEvent: SubscribeToTshdEvent = (eventName, listener) => {
-    emitter.on(eventName, listener);
+  const setupTshdEventContextBridgeService = (
+    newListener: TshdEventContextBridgeService
+  ) => {
+    contextBridgeService = newListener;
   };
 
-  const service: apiService.ITshdEventsServiceServer = {
-    relogin: (call, callback) => {
-      const request = call.request.toObject();
+  /**
+   * processEvent is a helper function encapsulating common operations done before and after sending
+   * the event to the browser through the context bridge.
+   *
+   * The last argument is a function which maps the response object (received from the browser
+   * through the context bridge) to a class instance (as expected by grpc-js).
+   */
+  function processEvent<
+    RpcName extends keyof apiService.ITshdEventsServiceServer,
+    Request extends protobuf.Message,
+    Response extends protobuf.Message
+  >(
+    rpcName: RpcName,
+    call: grpc.ServerUnaryCall<Request, Response>,
+    callback: (error: Error, response: Response) => void,
+    mapResponseObjectToResponseInstance: (
+      responseObject: ReturnType<Response['toObject']>
+    ) => Response
+  ) {
+    const request = call.request.toObject();
 
-      logger.info('Emitting relogin', request);
+    logger.info(`got ${rpcName}`, filterSensitiveProperties(request));
 
-      const onCancelled = (callback: () => void) => {
-        call.on('cancelled', callback);
-      };
+    const onRequestCancelled = (callback: () => void) => {
+      call.on('cancelled', callback);
+    };
 
-      emitter.emit('relogin', { request, onCancelled }).then(
-        () => {
-          callback(null, new api.ReloginResponse());
-        },
-        error => {
-          callback(error);
-        }
+    if (!contextBridgeService) {
+      throw new Error(
+        'tshd events context bridge service has not been set up yet'
       );
-    },
-    sendNotification: (call, callback) => {
-      const request = call.request.toObject();
+    }
 
-      logger.info('Emitting sendNotification', request);
+    const contextBridgeHandler = contextBridgeService[rpcName];
 
-      const onCancelled = (callback: () => void) => {
-        call.on('cancelled', callback);
-      };
+    if (!contextBridgeHandler) {
+      throw new Error(`No context bridge handler for ${rpcName}`);
+    }
 
-      emitter.emit('sendNotification', { request, onCancelled }).then(
-        () => {
-          callback(null, new api.SendNotificationResponse());
-        },
-        error => {
-          callback(error);
-        }
-      );
-    },
-    sendPendingHeadlessAuthentication: (call, callback) => {
-      const request = call.request.toObject();
+    contextBridgeHandler({
+      // `as` is a workaround. We'd have to tell TypeScript somehow that `Request` is the same
+      // between `contextBridgeService` and `processEvent`, but it's not clear how to achieve that.
+      request: request as ReturnType<Request['toObject']>,
+      onRequestCancelled,
+    }).then(
+      response => {
+        callback(null, mapResponseObjectToResponseInstance(response));
 
-      logger.info('Emitting sendPendingHeadlessAuthentication', request);
-
-      const onCancelled = (callback: () => void) => {
-        call.on('cancelled', callback);
-      };
-
-      emitter
-        .emit('sendPendingHeadlessAuthentication', { request, onCancelled })
-        .then(
-          () => {
-            callback(null, new api.SendPendingHeadlessAuthenticationResponse());
-          },
-          error => {
-            callback(error);
-          }
+        logger.info(
+          `replied to ${rpcName}`,
+          filterSensitiveProperties(response)
         );
-    },
+      },
+      error => {
+        callback(error, null);
+
+        logger.error(`replied with error to ${rpcName}`, error);
+      }
+    );
+  }
+
+  const service: apiService.ITshdEventsServiceServer = {
+    relogin: (call, callback) =>
+      processEvent('relogin', call, callback, () => new api.ReloginResponse()),
+
+    sendNotification: (call, callback) =>
+      processEvent(
+        'sendNotification',
+        call,
+        callback,
+        () => new api.SendNotificationResponse()
+      ),
+
+    sendPendingHeadlessAuthentication: (call, callback) =>
+      processEvent(
+        'sendPendingHeadlessAuthentication',
+        call,
+        callback,
+        () => new api.SendPendingHeadlessAuthenticationResponse()
+      ),
+
     promptMFA: () => {
       // TODO (joerger): Handle MFA prompt with totp/webauthn modal.
       logger.info('Received prompt mfa request');
     },
   };
 
-  return { service, subscribeToTshdEvent };
+  return { service, setupTshdEventContextBridgeService };
 }

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -33,44 +33,79 @@ export type {
 };
 
 /**
- * SubscribeToTshdEvent is a type of the subscribeToTshdEvent function which gets exposed to the
- * renderer through the context bridge.
+ * TshdEventContextBridgeService is the part of the tshd events service running in the browser. It
+ * is a version of ITshdEventsServiceServer with properties mapped to values that can be passed
+ * through the context bridge.
  *
- * A typical implementation of a gRPC service looks something like this:
+ * The tshd events gRPC service itself is set up in preload.ts. A typical implementation of a
+ * handler for an RPC called "foo" of ITshdEventsServiceServer looks something like this:
  *
- *     {
- *       nameOfTheRpc: (call, callback) => {
- *         call.onCancelled(() => { … })
- *         const request = call.request.toObject()
- *         // Do something with the request fields…
- *       }
- *     }
+ * {
+ *   foo: (call, callback) => {
+ *     const result = processRequest(call.request)
+ *     callback(null, new api.FooResponse().setBar(result.bar))
+ *   }
+ * }
  *
- * subscribeToTshdEvent lets you add a listener that's going to be called every time a client makes
- * a particular RPC to the tshd events service. The listener receives the request converted to a
- * simple JS object since classes cannot be passed through the context bridge.
+ * However, we want the actual logic of tshd event handlers to interact with UI elements in the app.
+ * This means that the gRPC handlers need to run in the browser context, which in turns means that
+ * the gRPC handlers need to call functions that cross the context bridge.
  *
- * The SubscribeToTshdEvent type expresses all of this so that our subscribeToTshdEvent can stay
- * type safe.
+ * grpc-js expects that `call.request` and the second argument to `callback` are class instances.
+ * Unfortunately, class instances cannot be passed through the context bridge. This means that we
+ * have to cast them to simple objects first.
+ *
+ * This means that the gRPC handler on the preload.ts side needs to do something like this:
+ *
+ * {
+ *   foo: (call, callback) => {
+ *     const result = processRequestInBrowser(call.request.toObject())
+ *     callback(null, new api.FooResponse().setBar(result.bar))
+ *   }
+ * }
+ *
+ * …so that the implementation of TshdEventContextBridgeService can look like this:
+ *
+ * {
+ *   foo: async ({ request, onCancelled }) => {
+ *     doSomething(request)
+ *     return { bar: 1234 }
+ *   }
+ * }
+ *
+ * The functions always need to return something, even if technically the handler is not going to
+ * utilize the returned object. This helps with keeping type safety in cases where the handler
+ * actually uses the returned object.
  */
-export type SubscribeToTshdEvent = <
-  RpcName extends keyof ITshdEventsServiceServer,
-  RpcHandler extends ITshdEventsServiceServer[RpcName],
-  RpcHandlerServerCall extends Parameters<RpcHandler>[0],
-  RpcHandlerRequestObject extends ReturnType<
-    RpcHandlerServerCall['request']['toObject']
-  >
->(
-  eventName: RpcName,
-  listener: (eventData: {
-    request: RpcHandlerRequestObject;
-    onCancelled: (callback: () => void) => void;
-  }) => void | Promise<void>
-) => void;
+export type TshdEventContextBridgeService = {
+  [RpcName in keyof ITshdEventsServiceServer]: (args: {
+    /**
+     * request is the result of calling call.request.toObject() in a gRPC handler.
+     */
+    request: ReturnType<
+      Parameters<ITshdEventsServiceServer[RpcName]>[0]['request']['toObject']
+    >;
+    /**
+     * onRequestCancelled sets up a callback that is called when the request gets canceled by the
+     * client (tshd in this case).
+     */
+    onRequestCancelled: (callback: () => void) => void;
+  }) => Promise<
+    // The following type maps to the object version of the response type expected as the second
+    // argument to the callback function in a gRPC handler.
+    ReturnType<
+      Parameters<
+        Parameters<ITshdEventsServiceServer[RpcName]>[1]
+      >[1]['toObject']
+    >
+  >;
+};
 
 export type ElectronGlobals = {
   readonly mainProcessClient: MainProcessClient;
   readonly tshClient: TshClient;
   readonly ptyServiceClient: PtyServiceClient;
-  readonly subscribeToTshdEvent: SubscribeToTshdEvent;
+  readonly setupTshdEventContextBridgeService: (
+    listener: TshdEventContextBridgeService
+  ) => void;
 };

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -19,7 +19,7 @@
 import {
   MainProcessClient,
   ElectronGlobals,
-  SubscribeToTshdEvent,
+  TshdEventContextBridgeService,
 } from 'teleterm/types';
 import {
   ReloginRequest,
@@ -66,19 +66,16 @@ export default class AppContext implements IAppContext {
   resourcesService: ResourcesService;
   tshd: TshClient;
   /**
-   * subscribeToTshdEvent lets you add a listener that's going to be called every time a client
-   * makes a particular RPC to the tshd events service. The listener receives the request converted
-   * to a simple JS object since classes cannot be passed through the context bridge.
+   * setupTshdEventContextBridgeService adds a context-bridge-compatible version of a gRPC service
+   * that's going to be called every time a client makes a particular RPC to the tshd events
+   * service. The service receives requests converted to simple JS objects since classes cannot be
+   * passed through the context bridge.
    *
-   * @param {string} eventName - Name of the event.
-   * @param {function} listener - A function that gets called when a client calls the specific
-   * event. It accepts an object with two properties:
-   *
-   * - request is the request payload converted to a simple JS object.
-   * - onCancelled is a function which lets you register a callback which will be called when the
-   * request gets canceled by the client.
+   * See the JSDoc for TshdEventContextBridgeService for more details.
    */
-  subscribeToTshdEvent: SubscribeToTshdEvent;
+  setupTshdEventContextBridgeService: (
+    service: TshdEventContextBridgeService
+  ) => void;
   reloginService: ReloginService;
   tshdNotificationsService: TshdNotificationsService;
   headlessAuthenticationService: HeadlessAuthenticationService;
@@ -91,7 +88,8 @@ export default class AppContext implements IAppContext {
     const { tshClient, ptyServiceClient, mainProcessClient } = config;
     this.logger = new Logger('AppContext');
     this.tshd = tshClient;
-    this.subscribeToTshdEvent = config.subscribeToTshdEvent;
+    this.setupTshdEventContextBridgeService =
+      config.setupTshdEventContextBridgeService;
     this.mainProcessClient = mainProcessClient;
     this.notificationsService = new NotificationsService();
     this.configService = this.mainProcessClient.configService;
@@ -167,36 +165,45 @@ export default class AppContext implements IAppContext {
   }
 
   async pullInitialState(): Promise<void> {
-    this.setUpTshdEventSubscriptions();
+    this.setUpTshdEventService();
     this.subscribeToDeepLinkLaunch();
     this.clustersService.syncGatewaysAndCatchErrors();
     await this.clustersService.syncRootClustersAndCatchErrors();
   }
 
-  private setUpTshdEventSubscriptions() {
-    this.subscribeToTshdEvent('relogin', ({ request, onCancelled }) => {
-      // The handler for the relogin event should return only after the relogin procedure finishes.
-      return this.reloginService.relogin(
-        request as ReloginRequest,
-        onCancelled
-      );
-    });
-
-    this.subscribeToTshdEvent('sendNotification', ({ request }) => {
-      this.tshdNotificationsService.sendNotification(
-        request as SendNotificationRequest
-      );
-    });
-
-    this.subscribeToTshdEvent(
-      'sendPendingHeadlessAuthentication',
-      ({ request, onCancelled }) => {
-        return this.headlessAuthenticationService.sendPendingHeadlessAuthentication(
-          request as SendPendingHeadlessAuthenticationRequest,
-          onCancelled
+  private setUpTshdEventService() {
+    this.setupTshdEventContextBridgeService({
+      relogin: async ({ request, onRequestCancelled }) => {
+        await this.reloginService.relogin(
+          request as ReloginRequest,
+          onRequestCancelled
         );
-      }
-    );
+        return {};
+      },
+
+      sendNotification: async ({ request }) => {
+        this.tshdNotificationsService.sendNotification(
+          request as SendNotificationRequest
+        );
+
+        return {};
+      },
+
+      sendPendingHeadlessAuthentication: async ({
+        request,
+        onRequestCancelled,
+      }) => {
+        await this.headlessAuthenticationService.sendPendingHeadlessAuthentication(
+          request as SendPendingHeadlessAuthenticationRequest,
+          onRequestCancelled
+        );
+        return {};
+      },
+
+      promptMFA: async () => {
+        throw new Error('Not implemented yet');
+      },
+    });
   }
 
   private subscribeToDeepLinkLaunch() {

--- a/web/packages/teleterm/src/ui/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/ui/fixtures/mocks.ts
@@ -32,7 +32,7 @@ export class MockAppContext extends AppContext {
       mainProcessClient,
       tshClient: tshdClient,
       ptyServiceClient,
-      subscribeToTshdEvent: () => {},
+      setupTshdEventContextBridgeService: () => {},
     });
   }
 }

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -16,7 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MainProcessClient, SubscribeToTshdEvent } from 'teleterm/types';
+import {
+  MainProcessClient,
+  TshdEventContextBridgeService,
+} from 'teleterm/types';
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import { ModalsService } from 'teleterm/ui/services/modals';
 import { TerminalsService } from 'teleterm/ui/services/terminals';
@@ -49,7 +52,9 @@ export interface IAppContext {
   connectionTracker: ConnectionTrackerService;
   resourcesService: ResourcesService;
   fileTransferService: FileTransferService;
-  subscribeToTshdEvent: SubscribeToTshdEvent;
+  setupTshdEventContextBridgeService: (
+    service: TshdEventContextBridgeService
+  ) => void;
   reloginService: ReloginService;
   tshdNotificationsService: TshdNotificationsService;
   usageService: UsageService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,11 +7730,6 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-emittery@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/emittery/-/emittery-1.0.1.tgz#e0cf36e2d7eef94dbd025969f642d57ae50a56cd"
-  integrity sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
The previous implementation was one-to-many (using an event emitter) which had several drawbacks:

* Despite being one-to-many, we only ever had one listener for each gRPC handler.
* One-to-many means that the UI could not return a response to the gRPC handler without resorting to some unusual workarounds.

This PR makes the implementation one-to-one, where the UI part simply mirrors how the actual gRPC handler looks like. I feel like this is much easier to understand than the previous implementation. The types are still gnarly though, but to be honest it has more to do with TypeScript lack of ergonomics when it comes to writing generic types.

If you don't quite remember what this is all about, the JSDoc for `TshdEventContextBridgeService` should serve as a good reminder (please tell me if it's not!).

Now we have two objects, the gRPC service implementation that grpc-js expects from us:

```typescript
const service: apiService.ITshdEventsServiceServer = {
  relogin: (call, callback) =>
    processEvent('relogin', call, callback, () => new api.ReloginResponse()),

  sendNotification: (call, callback) =>
    processEvent(
      'sendNotification',
      call,
      callback,
      () => new api.SendNotificationResponse()
    ),

  sendPendingHeadlessAuthentication: (call, callback) =>
    processEvent(
      'sendPendingHeadlessAuthentication',
      call,
      callback,
      () => new api.SendPendingHeadlessAuthenticationResponse()
    ),

  promptMFA: () => {
    // TODO (joerger): Handle MFA prompt with totp/webauthn modal.
    logger.info('Received prompt mfa request');
  },
};
```

And the equivalent on the UI side:

```typescript
this.setupTshdEventContextBridgeService({
  relogin: async ({ request, onCancelled }) => {
    await this.reloginService.relogin(
      request as ReloginRequest,
      onCancelled
    );
    return {};
  },

  sendNotification: async ({ request }) => {
    this.tshdNotificationsService.sendNotification(
      request as SendNotificationRequest
    );

    return {};
  },

  sendPendingHeadlessAuthentication: async ({ request, onCancelled }) => {
    await this.headlessAuthenticationService.sendPendingHeadlessAuthentication(
      request as SendPendingHeadlessAuthenticationRequest,
      onCancelled
    );
    return {};
  },

  promptMFA: async () => {
    throw new Error('Not implemented yet');
  },
});
```

## Motivation

The motivation behind this change is that when tshd sends `PromptMFA`, we want to be able to respond with the TOTP that the user enters in the modal, in case they use TOTP MFA. This was not possible in the previous implementation but is natural with the new one.

## Testing

The easiest way to verify that the communication between tshd and the UI works as expected is to enable webauthn in the cluster and then make a headless auth request with Connect running:

```
tsh ls --headless --user=rav --proxy=teleport-local.dev:3090
```