### PR TITLE
Auto Discover tests: increment timeout for reconcile loops

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1849,6 +1849,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
 
 	waitForReconcile := make(chan struct{})
+	waitForReconcileTimeout := 5 * time.Second
 	reporter := &mockUsageReporter{}
 	tlsServer.Auth().SetUsageReporter(reporter)
 	srv, err := New(
@@ -1877,8 +1878,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		actualDatabases, err := tlsServer.Auth().GetDatabases(ctx)
 		require.NoError(t, err)
 		require.Empty(t, actualDatabases)
-	case <-time.After(time.Second):
-		t.Fatal("Didn't receive reconcile event after 1s")
+	case <-time.After(waitForReconcileTimeout):
+		t.Fatalf("Didn't receive reconcile event after %s", waitForReconcileTimeout)
 	}
 
 	require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is no fetchers actually being called")
@@ -1908,8 +1909,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			actualDatabases, err := tlsServer.Auth().GetDatabases(ctx)
 			require.NoError(t, err)
 			require.Empty(t, actualDatabases)
-		case <-time.After(time.Second):
-			t.Fatal("Didn't receive reconcile event after 1s")
+		case <-time.After(waitForReconcileTimeout):
+			t.Fatalf("Didn't receive reconcile event after %s", waitForReconcileTimeout)
 		}
 
 		require.Zero(t, reporter.DiscoveryFetchEventCount(), "a fetch event was emitted but there is no fetchers actually being called")
@@ -1944,8 +1945,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 				cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
 				cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "CACert"),
 			))
-		case <-time.After(time.Second):
-			t.Fatal("Didn't receive reconcile event after 1s")
+		case <-time.After(waitForReconcileTimeout):
+			t.Fatalf("Didn't receive reconcile event after %s", waitForReconcileTimeout)
 		}
 		require.Equal(t, 1, reporter.DiscoveryFetchEventCount())
 
@@ -1954,8 +1955,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		// Wait for the cycle to complete
 		select {
 		case <-waitForReconcile:
-		case <-time.After(time.Second):
-			t.Fatal("Didn't receive reconcile event after 1s")
+		case <-time.After(waitForReconcileTimeout):
+			t.Fatalf("Didn't receive reconcile event after %s", waitForReconcileTimeout)
 		}
 		// A new DiscoveryFetch event must have been emitted.
 		require.Equal(t, 2, reporter.DiscoveryFetchEventCount())
@@ -1971,8 +1972,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 				actualDatabases, err := tlsServer.Auth().GetDatabases(ctx)
 				require.NoError(t, err)
 				require.Empty(t, actualDatabases)
-			case <-time.After(time.Second):
-				t.Fatal("Didn't receive reconcile event after 1s")
+			case <-time.After(waitForReconcileTimeout):
+				t.Fatalf("Didn't receive reconcile event after %s", waitForReconcileTimeout)
 			}
 
 			// Given that no Fetch was issued, the counter should not increment.


### PR DESCRIPTION
Fix #36053

Just did 10 runs using the CI builder and it looks good :+1: 

![image](https://github.com/gravitational/teleport/assets/689271/c90e0ce6-5e3d-4c60-80c0-f5532b1f0c3f)
I was able to get a failure locally by running the test 1000 times with a `cpulimit -l 63`
It didn't fail after increasing the timeout