### PR TITLE
Wrap Reconnect in DocumentGatewayKube in Document

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
@@ -86,11 +86,13 @@ export const DocumentGatewayKube = (props: {
 
     case 'error': {
       return (
-        <Reconnect
-          kubeId={params.kubeId}
-          statusText={connectAttempt.statusText}
-          reconnect={createGateway}
-        />
+        <Document visible={visible} px={2}>
+          <Reconnect
+            kubeId={params.kubeId}
+            statusText={connectAttempt.statusText}
+            reconnect={createGateway}
+          />
+        </Document>
       );
     }
 


### PR DESCRIPTION
A top-level document must always return its content wrapped in `Document`. Otherwise the content won't be hidden, as is the case with `DocumentGatewayKube` today:

<img width="1251" alt="example" src="https://github.com/gravitational/teleport/assets/27113/dc75cc81-d05a-43b9-9ba0-e2e95ad83578">
