### PR TITLE
fix: bot workflows

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Assigning reviewers
         run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Backport PR
         run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -37,6 +37,6 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
       - name: Validate the changelog entry
         run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
         # Run "dismiss" subcommand on bot.
       - name: Dismiss
         run: cd .github/shared-workflows/bot && go run main.go -workflow=dismiss -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: .github/shared-workflows/bot/go.mod
+          go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Labeling PR
         run: cd .github/shared-workflows/bot && go run main.go -workflow=label -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"


### PR DESCRIPTION
Follow up to #36242. The review bot was updated to use the slices package and requires Go 1.21. Have all workflows use the stable version of Go rather than pulling from go.mod.