### PR TITLE
Fix `rdp-client` FIPS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
  "bitflags 2.4.1",
  "cexpr",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae1aba472e42d3cf45ac6d0a6c8fc3ddf743871209e1b40229aed9fbdf48ece"
+checksum = "92667e5967bf826198f88dd3e43616973f8902769a6151616a65be1289a3c531"
 dependencies = [
  "bitflags 2.4.1",
  "boring-sys",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceced5be0047c7c48d77599535fd7f0a81c1b0f0a1e97e7eece24c45022bb481"
+checksum = "f04f5e0e2dc8315f68251391a4ac6da54793525c01d0206b10732b71139768cd"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2852,12 +2852,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961385cffda2112d02c6e17169965ed604b9953078f2ec55740b8cf7b55c122e"
+checksum = "db2ca4142b3d45b579a45fc171a04d2f8dde1f5ff76290fd395286bcc5f82f4b"
 dependencies = [
  "boring",
  "boring-sys",
+ "once_cell",
  "tokio",
 ]
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -51,6 +51,9 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-make && \
     yum clean all
 
+# Needed for boring-rs
+ENV CMAKE=cmake3
+
 ## GIT2 ###################################################################
 
 # git2 packages are not available on ARM64, so we need to build it from source.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -307,5 +307,9 @@ COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 # Copy the pre-built CentOS 7 assets with clang. Needed to build BoringSSL and BPF tools.
 COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
 
+# Libclang is needed by boring-rs to generate bindings. libclang is kept in /opt/llvm/lib
+# and without this environment variable, boring-rs will not be able to find it.
+ENV LIBCLANG_PATH=/opt/llvm/lib/
+
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -59,7 +59,7 @@ RUN git clone --branch llvmorg-12.0.0 --depth=1 https://github.com/llvm/llvm-pro
 -DLLVM_ENABLE_PROJECTS=clang \
 -DLLVM_BUILD_TOOLS=ON \
 -G \"Unix Makefiles\" ../llvm && \
-make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang"' && \
+make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang install-clang-resource-headers install-libclang"' && \
     cd ../.. && \
     rm -rf llvm-project
 

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -34,6 +34,7 @@ RUN apt-get -y update && \
     build-essential \
     ca-certificates \
     git \
+    golang \
     libc6-dev \
     libssl-dev \
     locales \

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.1"
-boring = { version = "3.1.0", optional = true }
+boring = { version = "4.3.0", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.10.1"
@@ -37,7 +37,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { version = "3.1.0", optional = true }
+tokio-boring = { version = "4.3.0", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.6.1", features = ["v4"] }
 x509-parser = "0.15"


### PR DESCRIPTION
gravitational/teleport.e#3072 fixed building rdp-client with FIPS, but uncovered other problems.

* Set `CMAKE=cmake3`, as `boring-rs` (by way of `cmake-rs`) calls `cmake` (which isn't installed).
* Upgrade `boring` and `tokio-boring` to v4.3.0 to pick up build fixes.
* Install `clang-resource-headers` and `libclang` packages.
* Add `go` to node buildbox.
* Set `LIBCLANG_PATH`.