### PR TITLE
[v14] Remove outdated Details box in Installation

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -85,17 +85,6 @@ Currently supported distributions (and `ID`) are:
 <Tabs>
 <TabItem scope="oss" label="Teleport Community Edition">
 
-<Details title="Using APT or YUM for versions prior to Teleport 10?" scopeOnly={false}>
-
-If you've previously installed Teleport via the APT
-repo at `https://deb.releases.teleport.dev/`, you can upgrade by
-re-running the "Debian/Ubuntu (DEB)" install instructions above.
-
-The legacy APT repo at `https://deb.releases.teleport.dev/` will not receive updates
-past Teleport 14 and will be turned off after Teleport 14 is no longer supported.
-
-</Details>
-
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 


### PR DESCRIPTION
Closes #33008

The changes in #36022 removed a `Details` box with outdated information in the Installation page. This change backports that one. The instructions in the `Details` box refer to installation steps that we removed from the `install-linux.mdx` partial.

We will want to include more explicit instructions about using our DEB package repo at some point, but for now, this change prevents possible confusion.