### PR TITLE
Add UI for per-session MFA in Teleport Connect

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -264,6 +264,16 @@ func (s *Storage) makeDefaultClientConfig() *client.Config {
 	cfg.KeysDir = s.Dir
 	cfg.InsecureSkipVerify = s.InsecureSkipVerify
 	cfg.WebauthnLogin = s.WebauthnLogin
+	// Set AllowStdinHijack to true to enable daemon.mfaPrompt to ask for both TOTP and Webauthn at
+	// the same time if available.
+	//
+	// tsh sets AllowStdinHijack to true only during tsh login to avoid input swallowing bugs where
+	// calling a command would prompt for MFA and then expect some further data through stdin. tsh
+	// login does not ask for any further input after the MFA prompt.
+	//
+	// Since tsh daemon ran by Connect never expects data over stdin, it can always set this flag to
+	// true.
+	cfg.AllowStdinHijack = true
 
 	return cfg
 }

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -152,11 +152,8 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 		return nil, nil, trace.BadParameter("cluster directory is missing")
 	}
 
-	cfg := client.MakeDefaultConfig()
+	cfg := s.makeDefaultClientConfig()
 	cfg.WebProxyAddr = webProxyAddress
-	cfg.HomePath = s.Dir
-	cfg.KeysDir = s.Dir
-	cfg.InsecureSkipVerify = s.InsecureSkipVerify
 
 	profileName := parseName(webProxyAddress)
 	clusterURI := uri.NewClusterURI(profileName)
@@ -200,14 +197,10 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 
 	profileStore := client.NewFSProfileStore(s.Dir)
 
-	cfg := client.MakeDefaultConfig()
+	cfg := s.makeDefaultClientConfig()
 	if err := cfg.LoadProfile(profileStore, profileName); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	cfg.KeysDir = s.Dir
-	cfg.HomePath = s.Dir
-	cfg.InsecureSkipVerify = s.InsecureSkipVerify
-	cfg.WebauthnLogin = s.WebauthnLogin
 
 	if leafClusterName != "" {
 		clusterNameForKey = leafClusterName
@@ -262,6 +255,17 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 	}
 
 	return status, nil
+}
+
+func (s *Storage) makeDefaultClientConfig() *client.Config {
+	cfg := client.MakeDefaultConfig()
+
+	cfg.HomePath = s.Dir
+	cfg.KeysDir = s.Dir
+	cfg.InsecureSkipVerify = s.InsecureSkipVerify
+	cfg.WebauthnLogin = s.WebauthnLogin
+
+	return cfg
 }
 
 // parseName gets cluster name from cluster web proxy address

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -229,6 +229,8 @@ func (s *Service) ResolveClusterURI(uri uri.ResourceURI) (*clusters.Cluster, *cl
 		return nil, nil, trace.Wrap(err)
 	}
 
+	// Custom MFAPromptConstructor gets removed during the calls to Login and LoginPasswordless RPCs.
+	// Those RPCs assume that the default CLI prompt is in use.
 	clusterClient.MFAPromptConstructor = s.NewMFAPromptConstructor(cluster.URI.String())
 	return cluster, clusterClient, nil
 }

--- a/lib/teleterm/daemon/mfaprompt.go
+++ b/lib/teleterm/daemon/mfaprompt.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
@@ -73,6 +75,8 @@ func (p *mfaPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 
 	// Depending on the run opts, we may spawn a TOTP goroutine, webauth goroutine, or both.
 	spawnGoroutines := func(ctx context.Context, wg *sync.WaitGroup, respC chan<- libmfa.MFAGoroutineResponse) {
+		ctx, cancel := context.WithCancelCause(ctx)
+
 		// Fire App goroutine (TOTP).
 		wg.Add(1)
 		go func() {
@@ -80,6 +84,12 @@ func (p *mfaPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 
 			resp, err := p.promptMFA(ctx, chal, runOpts)
 			respC <- libmfa.MFAGoroutineResponse{Resp: resp, Err: err}
+
+			// If the user closes the modal in the Electron app, we need to be able to cancel the other
+			// goroutine as well so that we stop waiting for the hardware key tap.
+			if err != nil && status.Code(err) == codes.Aborted {
+				cancel(err)
+			}
 		}()
 
 		// Fire Webauthn goroutine.

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -31,6 +31,7 @@ import { assertUnreachable } from '../utils';
 
 import { UsageData } from './modals/UsageData';
 import { UserJobRole } from './modals/UserJobRole';
+import { ReAuthenticate } from './modals/ReAuthenticate';
 
 export default function ModalsHost() {
   const { modalsService } = useAppContext();
@@ -152,6 +153,22 @@ function renderDialog(dialog: Dialog, handleClose: () => void) {
           onSuccess={() => {
             handleClose();
             dialog.onSuccess();
+          }}
+        />
+      );
+    }
+
+    case 'reauthenticate': {
+      return (
+        <ReAuthenticate
+          promptMfaRequest={dialog.promptMfaRequest}
+          onSuccess={totpCode => {
+            handleClose();
+            dialog.onSuccess(totpCode);
+          }}
+          onCancel={() => {
+            handleClose();
+            dialog.onCancel();
           }}
         />
       );

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.story.tsx
@@ -1,0 +1,85 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+
+import { ReAuthenticate } from './ReAuthenticate';
+
+export default {
+  title: 'Teleterm/ModalsHost/ReAuthenticate',
+};
+
+const promptMfaRequest = {
+  reason: 'MFA is required to access Kubernetes cluster "minikube"',
+  rootClusterUri: makeRootCluster().uri,
+  webauthn: false,
+  totp: false,
+};
+
+export const WithWebauthn = () => (
+  <MockAppContextProvider>
+    <ReAuthenticate
+      promptMfaRequest={{ ...promptMfaRequest, webauthn: true }}
+      onCancel={() => {}}
+      onSuccess={() => {
+        window.alert(
+          'You somehow submitted a form while only Webauthn was available.'
+        );
+      }}
+    />
+  </MockAppContextProvider>
+);
+
+const showToken = (otpToken: string) =>
+  window.alert(`Submitted form with token: ${otpToken}`);
+
+export const WithTotp = () => (
+  <MockAppContextProvider>
+    <ReAuthenticate
+      promptMfaRequest={{ ...promptMfaRequest, totp: true }}
+      onCancel={() => {}}
+      onSuccess={showToken}
+    />
+  </MockAppContextProvider>
+);
+
+export const WithWebauthnAndTotp = () => (
+  <MockAppContextProvider>
+    <ReAuthenticate
+      promptMfaRequest={{ ...promptMfaRequest, webauthn: true, totp: true }}
+      onCancel={() => {}}
+      onSuccess={showToken}
+    />
+  </MockAppContextProvider>
+);
+
+export const MultilineTitle = () => (
+  <MockAppContextProvider>
+    <ReAuthenticate
+      promptMfaRequest={{
+        ...promptMfaRequest,
+        webauthn: true,
+        totp: true,
+        rootClusterUri: '/clusters/lorem.cloud.gravitational.io',
+      }}
+      onCancel={() => {}}
+      onSuccess={showToken}
+    />
+  </MockAppContextProvider>
+);

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -1,0 +1,217 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { FC, useState } from 'react';
+import DialogConfirmation, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from 'design/DialogConfirmation';
+import {
+  ButtonIcon,
+  ButtonPrimary,
+  ButtonSecondary,
+  Text,
+  Image,
+  Flex,
+  Box,
+} from 'design';
+import * as icons from 'design/Icon';
+import Validation from 'shared/components/Validation';
+import { requiredToken } from 'shared/components/Validation/rules';
+import FieldInput from 'shared/components/FieldInput';
+import FieldSelect from 'shared/components/FieldSelect';
+
+import { Option } from 'shared/components/Select';
+
+import { assertUnreachable } from 'shared/utils/assertUnreachable';
+
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { PromptMfaRequest } from 'teleterm/services/tshdEvents';
+import LinearProgress from 'teleterm/ui/components/LinearProgress';
+import svgHardwareKey from 'teleterm/ui/ClusterConnect/ClusterLogin/FormLogin/PromptWebauthn/hardware.svg';
+import { useLogger } from 'teleterm/ui/hooks/useLogger';
+import { routing } from 'teleterm/ui/uri';
+
+type MfaType = 'webauthn' | 'totp';
+
+export const ReAuthenticate: FC<{
+  promptMfaRequest: PromptMfaRequest;
+  onCancel: () => void;
+  onSuccess: (otp: string) => void;
+}> = props => {
+  const logger = useLogger('ReAuthenticate');
+  const { promptMfaRequest: req } = props;
+
+  // TODO(ravicious): At the moment it doesn't seem like it's possible for both Webauthn and TOTP to
+  // be available at the same time (see lib/client/mfa.PromptConfig/GetRunOptions). Whenever both
+  // Webauthn and TOTP are supported, Webauthn is preferred. Well, unless AllowStdinHijack is
+  // specified, but lib/teleterm doesn't do this and AllowStdinHijack has a scary comment next to it
+  // telling you not to use it.
+  //
+  // Alas, the data structure certainly allows for this so the modal was designed with supporting
+  // such scenario in mind.
+  const availableMfaTypes: MfaType[] = [];
+  // Add Webauthn first to prioritize it if both Webauthn and TOTP are available.
+  if (req.webauthn) {
+    availableMfaTypes.push('webauthn');
+  }
+  if (req.totp) {
+    availableMfaTypes.push('totp');
+  }
+  if (availableMfaTypes.length === 0) {
+    // This shouldn't happen but is technically allowed by the req data structure.
+    logger.warn('availableMfaTypes is empty, defaulting to webauthn and totp');
+    availableMfaTypes.push('webauthn', 'totp');
+  }
+
+  const [selectedMfaType, setSelectedMfaType] = useState(availableMfaTypes[0]);
+  const [otpToken, setOtpToken] = useState('');
+
+  const { rootClusterUri } = req;
+  const { clustersService } = useAppContext();
+  // TODO(ravicious): Use a profile name here from the URI and remove the dependency on
+  // clustersService. https://github.com/gravitational/teleport/issues/33733
+  const clusterName =
+    clustersService.findCluster(rootClusterUri)?.name ||
+    routing.parseClusterName(rootClusterUri);
+
+  return (
+    <DialogConfirmation
+      open={true}
+      onClose={props.onCancel}
+      dialogCss={() => ({
+        maxWidth: '400px',
+        width: '100%',
+      })}
+    >
+      <Validation>
+        {({ validator }) => (
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              validator.validate() && props.onSuccess(otpToken);
+            }}
+          >
+            <DialogHeader
+              justifyContent="space-between"
+              mb={0}
+              alignItems="baseline"
+            >
+              <Text typography="h4">
+                Verify your identity on <strong>{clusterName}</strong>
+              </Text>
+              <ButtonIcon
+                type="button"
+                onClick={props.onCancel}
+                color="text.slightlyMuted"
+              >
+                <icons.Cross size="medium" />
+              </ButtonIcon>
+            </DialogHeader>
+
+            <DialogContent mb={4}>
+              <Flex flexDirection="column" gap={4} alignItems="flex-start">
+                <Text typography="body1" color="text.slightlyMuted">
+                  {req.reason}
+                </Text>
+
+                <Flex width="100%" gap={3} flex-wrap="no-wrap">
+                  {availableMfaTypes.length > 1 && (
+                    <FieldSelect
+                      flex="1"
+                      label="Two-factor Type"
+                      value={mfaTypeToOption(selectedMfaType)}
+                      options={availableMfaTypes.map(mfaTypeToOption)}
+                      onChange={option =>
+                        setSelectedMfaType(
+                          (option as Option<string, string>).value as MfaType
+                        )
+                      }
+                      menuIsOpen={true}
+                    />
+                  )}
+
+                  {selectedMfaType === 'totp' ? (
+                    <FieldInput
+                      flex="1"
+                      autoFocus
+                      label="Authenticator Code"
+                      rule={requiredToken}
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      value={otpToken}
+                      onChange={e => setOtpToken(e.target.value)}
+                      placeholder="123 456"
+                      mb={0}
+                    />
+                  ) : (
+                    // Empty box to occupy hald of flex width if TOTP input is not shown.
+                    <Box flex="1" />
+                  )}
+                </Flex>
+
+                {selectedMfaType === 'webauthn' && (
+                  <>
+                    <Image width="200px" src={svgHardwareKey} mx="auto" />
+                    <Box
+                      width="100%"
+                      textAlign="center"
+                      style={{ position: 'relative' }}
+                    >
+                      <Text bold>Insert your security key and tap it</Text>
+                      <LinearProgress />
+                    </Box>
+                  </>
+                )}
+              </Flex>
+            </DialogContent>
+
+            <DialogFooter>
+              <Flex gap={3}>
+                {selectedMfaType === 'totp' && (
+                  <ButtonPrimary type="submit">Continue</ButtonPrimary>
+                )}
+                <ButtonSecondary type="button" onClick={props.onCancel}>
+                  Cancel
+                </ButtonSecondary>
+              </Flex>
+            </DialogFooter>
+          </form>
+        )}
+      </Validation>
+    </DialogConfirmation>
+  );
+};
+
+const mfaTypeToOption = (mfaType: MfaType): Option<string, string> => {
+  let label: string;
+
+  switch (mfaType) {
+    case 'webauthn':
+      label = 'Hardware Key';
+      break;
+    case 'totp':
+      label = 'Authenticator App';
+      break;
+    default:
+      assertUnreachable(mfaType);
+  }
+
+  return { value: mfaType, label };
+};

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/index.ts
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { ReAuthenticate } from './ReAuthenticate';

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -21,11 +21,6 @@ import {
   ElectronGlobals,
   TshdEventContextBridgeService,
 } from 'teleterm/types';
-import {
-  ReloginRequest,
-  SendNotificationRequest,
-  SendPendingHeadlessAuthenticationRequest,
-} from 'teleterm/services/tshdEvents';
 import Logger from 'teleterm/logger';
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import { ModalsService } from 'teleterm/ui/services/modals';
@@ -49,6 +44,7 @@ import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';
 
 import { CommandLauncher } from './commandLauncher';
+import { createTshdEventsContextBridgeService } from './tshdEvents';
 
 export default class AppContext implements IAppContext {
   private logger: Logger;
@@ -165,45 +161,13 @@ export default class AppContext implements IAppContext {
   }
 
   async pullInitialState(): Promise<void> {
-    this.setUpTshdEventService();
+    this.setupTshdEventContextBridgeService(
+      createTshdEventsContextBridgeService(this)
+    );
+
     this.subscribeToDeepLinkLaunch();
     this.clustersService.syncGatewaysAndCatchErrors();
     await this.clustersService.syncRootClustersAndCatchErrors();
-  }
-
-  private setUpTshdEventService() {
-    this.setupTshdEventContextBridgeService({
-      relogin: async ({ request, onRequestCancelled }) => {
-        await this.reloginService.relogin(
-          request as ReloginRequest,
-          onRequestCancelled
-        );
-        return {};
-      },
-
-      sendNotification: async ({ request }) => {
-        this.tshdNotificationsService.sendNotification(
-          request as SendNotificationRequest
-        );
-
-        return {};
-      },
-
-      sendPendingHeadlessAuthentication: async ({
-        request,
-        onRequestCancelled,
-      }) => {
-        await this.headlessAuthenticationService.sendPendingHeadlessAuthentication(
-          request as SendPendingHeadlessAuthenticationRequest,
-          onRequestCancelled
-        );
-        return {};
-      },
-
-      promptMFA: async () => {
-        throw new Error('Not implemented yet');
-      },
-    });
   }
 
   private subscribeToDeepLinkLaunch() {

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -22,6 +22,8 @@ import * as types from 'teleterm/services/tshd/types';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 
+import { PromptMfaRequest } from 'teleterm/services/tshdEvents';
+
 import { ImmutableStore } from '../immutableStore';
 
 import type * as uri from 'teleterm/ui/uri';
@@ -193,6 +195,13 @@ export interface DialogHeadlessAuthentication {
   onCancel(): void;
 }
 
+export interface DialogReAuthenticate {
+  kind: 'reauthenticate';
+  promptMfaRequest: PromptMfaRequest;
+  onSuccess(totpCode: string): void;
+  onCancel(): void;
+}
+
 export type Dialog =
   | DialogClusterConnect
   | DialogClusterLogout
@@ -201,4 +210,5 @@ export type Dialog =
   | DialogUserJobRole
   | DialogResourceSearchErrors
   | DialogHeadlessAuthentication
+  | DialogReAuthenticate
   | DialogNone;

--- a/web/packages/teleterm/src/ui/tshdEvents.ts
+++ b/web/packages/teleterm/src/ui/tshdEvents.ts
@@ -51,8 +51,37 @@ export function createTshdEventsContextBridgeService(
       return {};
     },
 
-    promptMFA: async () => {
-      throw new Error('Not implemented yet');
+    promptMFA: async ({ request, onRequestCancelled }) => {
+      const { totpCode, hasCanceledModal } = await new Promise<{
+        totpCode: string;
+        hasCanceledModal: boolean;
+      }>(resolve => {
+        const { closeDialog } = ctx.modalsService.openImportantDialog({
+          kind: 'reauthenticate',
+          promptMfaRequest: request as tshdEvents.PromptMfaRequest,
+          onSuccess: totpCode => resolve({ hasCanceledModal: false, totpCode }),
+          onCancel: () =>
+            resolve({ hasCanceledModal: true, totpCode: undefined }),
+        });
+
+        // If Webauthn is available, tshd starts two goroutines – one that sends this request and
+        // one that starts listening for a hardware key tap. When a tap is detected, tshd cancels
+        // this request.
+        onRequestCancelled(closeDialog);
+      });
+
+      if (hasCanceledModal) {
+        // Throwing an object here instead of an error to future-proof this code in case we need to
+        // return more than just the error name and message.
+        // Refer to processEvent in the preload part of tshd events service for more details.
+        throw {
+          isCrossContextError: true,
+          name: 'AbortError',
+          message: 'MFA modal closed by user',
+        };
+      }
+
+      return { totpCode };
     },
   };
 }

--- a/web/packages/teleterm/src/ui/tshdEvents.ts
+++ b/web/packages/teleterm/src/ui/tshdEvents.ts
@@ -1,0 +1,58 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TshdEventContextBridgeService } from 'teleterm/types';
+import { IAppContext } from 'teleterm/ui/types';
+import * as tshdEvents from 'teleterm/services/tshdEvents';
+
+export function createTshdEventsContextBridgeService(
+  ctx: IAppContext
+): TshdEventContextBridgeService {
+  return {
+    relogin: async ({ request, onRequestCancelled }) => {
+      await ctx.reloginService.relogin(
+        request as tshdEvents.ReloginRequest,
+        onRequestCancelled
+      );
+      return {};
+    },
+
+    sendNotification: async ({ request }) => {
+      ctx.tshdNotificationsService.sendNotification(
+        request as tshdEvents.SendNotificationRequest
+      );
+
+      return {};
+    },
+
+    sendPendingHeadlessAuthentication: async ({
+      request,
+      onRequestCancelled,
+    }) => {
+      await ctx.headlessAuthenticationService.sendPendingHeadlessAuthentication(
+        request as tshdEvents.SendPendingHeadlessAuthenticationRequest,
+        onRequestCancelled
+      );
+      return {};
+    },
+
+    promptMFA: async () => {
+      throw new Error('Not implemented yet');
+    },
+  };
+}


### PR DESCRIPTION
Closes #35361.

https://github.com/gravitational/teleport/assets/27113/cb2b50dc-480f-4e4f-8409-45a42d80c3a3

This PR utilizes the tshd events service RPC called `PromptMFA` added by Brian to show an MFA modal in Connect.

At the moment, it works for Kube access and during Connect My Computer setup (with a cluster on teleport master) when per-session MFA is enabled.

I added a new modal instead of attempting to reuse `PromptWebauthn` used in `ClusterLogin` since that modal also has to handle passwordless credential picker which isn't needed for this flow. The name of the modal is based on a modal in the Web UI which accomplishes the same thing (with the exception that TOTP MFA in the Web UI is not supported).

## Webauthn + TOTP

One thing I need to mention is that initially I assumed that the MFA prompt can have both Webauthn and TOTP at the same time as allowed MFA methods. Looking at [`lib/client/mfa.PromptConfig.GetRunOptions`](https://github.com/gravitational/teleport/blob/4dafecbc177c349090fa64314bb8c7b3119c4825/lib/client/mfa/prompt.go#L78-L109), I'm not sure if such situation is ever possible, at least in the context of Connect. Anyway, the data structure certainly allows for such scenario. I wrote the modal so that it supports such case as well so by now I just don't think it's worth removing that support. I'll ask Brian about that.

Edit: I now made it so that `AllowStdinHijack` is always set to true, enabling Connect to prompt for TOTP and Webauthn at the same time if both are available.

---

No changelog since #35772 already includes a line about per-session MFA support for Kube access in Connect.

Tag build: 15.0.0-dev.ravicious.7 on drone. It doesn't include `AllowStdinHijack` changes.