### PR TITLE
JoinScript: add DiscoveryService installation method

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -741,6 +741,11 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/scripts/:token/install-node.sh", h.WithLimiter(h.getNodeJoinScriptHandle))
 	h.GET("/scripts/:token/install-app.sh", h.WithLimiter(h.getAppJoinScriptHandle))
 	h.GET("/scripts/:token/install-database.sh", h.WithLimiter(h.getDatabaseJoinScriptHandle))
+
+	// Discovery installation script requires a query param to define the DiscoveryGroup:
+	// ?discoveryGroup=<group name>
+	h.GET("/scripts/:token/install-discovery.sh", h.WithLimiter(h.getDiscoveryJoinScriptHandle))
+
 	// web context
 	h.GET("/webapi/sites/:site/context", h.WithClusterAuth(h.getUserContext))
 	h.GET("/webapi/sites/:site/resources/check", h.WithClusterAuth(h.checkAccessToRegisteredResource))

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -78,6 +78,9 @@ type scriptSettings struct {
 	databaseInstallMode bool
 	installUpdater      bool
 
+	discoveryInstallMode bool
+	discoveryGroup       string
+
 	// automaticUpgradesVersion is the target automatic upgrades version.
 	// The version must be valid semver, with the leading 'v'. e.g. v15.0.0-dev
 	// Required when installUpdater is true.
@@ -339,6 +342,53 @@ func (h *Handler) getDatabaseJoinScriptHandle(w http.ResponseWriter, r *http.Req
 	return nil, nil
 }
 
+func (h *Handler) getDiscoveryJoinScriptHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params) (interface{}, error) {
+	httplib.SetScriptHeaders(w.Header())
+	queryValues := r.URL.Query()
+	discoveryGroupQueryParam := "discoveryGroup"
+
+	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
+	if err != nil {
+		w.Write(scripts.ErrorBashScript)
+		return nil, nil
+	}
+
+	discoveryGroup, err := url.QueryUnescape(queryValues.Get(discoveryGroupQueryParam))
+	if err != nil {
+		log.WithField("query-param", discoveryGroupQueryParam).WithError(err).Debug("Failed to return the discovery install script.")
+		w.Write(scripts.ErrorBashScript)
+		return nil, nil
+	}
+	if discoveryGroup == "" {
+		log.WithField("query-param", discoveryGroupQueryParam).Debug("Failed to return the discovery install script. Missing required fields.")
+		w.Write(scripts.ErrorBashScript)
+		return nil, nil
+	}
+
+	settings := scriptSettings{
+		token:                    params.ByName("token"),
+		discoveryInstallMode:     true,
+		discoveryGroup:           discoveryGroup,
+		installUpdater:           autoUpgrades,
+		automaticUpgradesVersion: autoUpgradesVersion,
+	}
+
+	script, err := getJoinScript(r.Context(), settings, h.GetProxyClient())
+	if err != nil {
+		log.WithError(err).Info("Failed to return the discovery install script.")
+		w.Write(scripts.ErrorBashScript)
+		return nil, nil
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintln(w, script); err != nil {
+		log.WithError(err).Debug("Failed to return the discovery install script.")
+		w.Write(scripts.ErrorBashScript)
+	}
+
+	return nil, nil
+}
+
 func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter) (string, error) {
 	switch types.JoinMethod(settings.joinMethod) {
 	case types.JoinMethodUnspecified, types.JoinMethodToken:
@@ -416,6 +466,12 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 		}
 	}
 
+	if settings.discoveryInstallMode {
+		if settings.discoveryGroup == "" {
+			return "", trace.BadParameter("discovery group is required")
+		}
+	}
+
 	packageName := types.PackageNameOSS
 	if modules.GetModules().BuildType() == modules.BuildEnterprise {
 		packageName = types.PackageNameEnt
@@ -463,6 +519,8 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 		"labels":                     strings.Join(labelsList, ","),
 		"databaseInstallMode":        strconv.FormatBool(settings.databaseInstallMode),
 		"db_service_resource_labels": dbServiceResourceLabels,
+		"discoveryInstallMode":       settings.discoveryInstallMode,
+		"discoveryGroup":             settings.discoveryGroup,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -345,7 +345,7 @@ func (h *Handler) getDatabaseJoinScriptHandle(w http.ResponseWriter, r *http.Req
 func (h *Handler) getDiscoveryJoinScriptHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params) (interface{}, error) {
 	httplib.SetScriptHeaders(w.Header())
 	queryValues := r.URL.Query()
-	discoveryGroupQueryParam := "discoveryGroup"
+	const discoveryGroupQueryParam = "discoveryGroup"
 
 	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
 	if err != nil {

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -764,6 +764,82 @@ db_service:
 	}
 }
 
+func TestGetDiscoveryJoinScript(t *testing.T) {
+	validToken := "f18da1c9f6630a51e8daf121e7451daa"
+
+	m := &mockedNodeAPIGetter{
+		mockGetProxyServers: func() ([]types.Server, error) {
+			var s types.ServerV2
+			s.SetPublicAddrs([]string{"test-host:12345678"})
+
+			return []types.Server{&s}, nil
+		},
+		mockGetClusterCACert: func(context.Context) (*proto.GetClusterCACertResponse, error) {
+			fakeBytes := []byte(fixtures.SigningCertPEM)
+			return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
+		},
+		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
+			provisionToken := &types.ProvisionTokenV2{
+				Metadata: types.Metadata{
+					Name: token,
+				},
+				Spec: types.ProvisionTokenSpecV2{},
+			}
+			if token == validToken {
+				return provisionToken, nil
+			}
+			return nil, trace.NotFound("token does not exist")
+		},
+	}
+
+	for _, test := range []struct {
+		desc            string
+		settings        scriptSettings
+		errAssert       require.ErrorAssertionFunc
+		extraAssertions func(t *testing.T, script string)
+	}{
+		{
+			desc: "valid",
+			settings: scriptSettings{
+				discoveryInstallMode: true,
+				discoveryGroup:       "my-group",
+				token:                validToken,
+			},
+			errAssert: require.NoError,
+			extraAssertions: func(t *testing.T, script string) {
+				require.Contains(t, script, validToken)
+				require.Contains(t, script, "test-host")
+				require.Contains(t, script, "sha256:")
+				require.Contains(t, script, "--labels ")
+				require.Contains(t, script, `
+discovery_service:
+  enabled: "yes"
+  discovery_group: "my-group"`)
+			},
+		},
+		{
+			desc: "fails when discovery group is not defined",
+			settings: scriptSettings{
+				discoveryInstallMode: true,
+				token:                validToken,
+			},
+			errAssert: require.Error,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			script, err := getJoinScript(context.Background(), test.settings, m)
+			test.errAssert(t, err)
+			if err != nil {
+				require.Empty(t, script)
+			}
+
+			if test.extraAssertions != nil {
+				test.extraAssertions(t, script)
+			}
+		})
+	}
+}
+
 func TestIsSameRuleSet(t *testing.T) {
 	tt := []struct {
 		name     string

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -765,7 +765,7 @@ db_service:
 }
 
 func TestGetDiscoveryJoinScript(t *testing.T) {
-	validToken := "f18da1c9f6630a51e8daf121e7451daa"
+	const validToken = "f18da1c9f6630a51e8daf121e7451daa"
 
 	m := &mockedNodeAPIGetter{
 		mockGetProxyServers: func() ([]types.Server, error) {


### PR DESCRIPTION
DiscoveryService can now be enabled using the JoinScript.

To generate a script, first create a token with `discovery` role.
You'll need a DiscoveryGroup (can be any string).
Then, build the URL as usual (it has a query parameter to indicate the DiscoveryGroup).

It should look like this:
```
https://127.0.0.1.nip.io:3080/scripts/592f8868de9d7dcb7538856552708a4e/install-discovery.sh?discoveryGroup=olamundo
```

Demo:
Generated `teleport.yaml`
![image](https://github.com/gravitational/teleport/assets/689271/ac77b6d3-b7f7-4b9d-bc61-51f2cb5926e9)

Inventory after the instance joins the cluster:
![image](https://github.com/gravitational/teleport/assets/689271/3eb0887b-0574-41e6-bf6c-7c70be423dd9)
