### PR TITLE
[v12] chore: Bump gci to v0.12.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -282,7 +282,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.11.0
+RUN go install github.com/daixiang0/gci@v0.12.1
 
 # Install golangci-lint.
 RUN VERSION='v1.55.2'; \


### PR DESCRIPTION
Backport #36284 to branch/v12

Keep up with latest releases.

Most of the changes since v0.11.0 are fairly inconsequential to us, but it seems like a reasonable idea to keep up with minor updates at least.

* https://github.com/daixiang0/gci/releases/tag/v0.12.1
* https://github.com/daixiang0/gci/releases/tag/v0.12.0
* https://github.com/daixiang0/gci/releases/tag/v0.11.2
* https://github.com/daixiang0/gci/releases/tag/v0.11.1