### PR TITLE
Sanitize backend keys with .. in them.

### DIFF
--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -19,7 +19,6 @@
 package backend
 
 import (
-	"bytes"
 	"context"
 	"regexp"
 	"time"
@@ -37,9 +36,9 @@ const errorMessage = "special characters are not allowed in resource names, plea
 var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
 
 // denyPattern matches some unallowed combinations
-var denyPatterns = []string{
-	"//",
-	"..",
+var denyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`//`),
+	regexp.MustCompile(`(^|/)\.\.?(/|$)`),
 }
 
 // isKeySafe checks if the passed in key conforms to whitelist
@@ -50,7 +49,7 @@ func isKeySafe(s []byte) bool {
 // denyPatternsMatch checks if the passed in key conforms to the deny patterns.
 func denyPatternsMatch(s []byte) bool {
 	for _, pattern := range denyPatterns {
-		if bytes.Contains(s, []byte(pattern)) {
+		if pattern.Match(s) {
 			return true
 		}
 	}

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -42,6 +42,10 @@ func TestSanitize(t *testing.T) {
 			assert: require.Error,
 		},
 		{
+			inKey:  []byte("/namespaces/.."),
+			assert: require.Error,
+		},
+		{
 			inKey:  RangeEnd([]byte("a-b/c:d/.e_f/01")),
 			assert: require.NoError,
 		},

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -46,6 +46,50 @@ func TestSanitize(t *testing.T) {
 			assert: require.Error,
 		},
 		{
+			inKey:  []byte("/namespaces/../params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/..params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("/namespaces/."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/./params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/.params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte(".."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("..params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("../params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte(".params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("./params"),
+			assert: require.Error,
+		},
+		{
 			inKey:  RangeEnd([]byte("a-b/c:d/.e_f/01")),
 			assert: require.NoError,
 		},


### PR DESCRIPTION
Backend keys with .. in them have been added to the regex for patterns in keys that are denied.

changelog: Resources named `.` and `..` are no longer allowed. Please review the resources in your Teleport instance and rename any resources with these names before upgrading.