### PR TITLE
Update Clang build to include system headers and libclang

### DIFF
--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -59,7 +59,7 @@ RUN git clone --branch llvmorg-12.0.0 --depth=1 https://github.com/llvm/llvm-pro
 -DLLVM_ENABLE_PROJECTS=clang \
 -DLLVM_BUILD_TOOLS=ON \
 -G \"Unix Makefiles\" ../llvm && \
-make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang"' && \
+make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang install-clang-resource-headers install-libclang"' && \
     cd ../.. && \
     rm -rf llvm-project
 


### PR DESCRIPTION
This commit updates the build command in Dockerfile-centos7 to install 'clang-resource-headers' and 'libclang'. These additions are needed by boring-rs library to build correctly. We're building it as a part of our FIPS build.