### PR TITLE
Use GetRole in the user login state generator, fail if not found.

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -224,25 +224,14 @@ func (g *Generator) postProcess(ctx context.Context, state *userloginstate.UserL
 		return nil
 	}
 
-	// Remove roles that don't exist in the backend so that we don't generate certs for non-existent roles.
-	// Doing so can prevent login from working properly. This could occur if access lists refer to roles that
-	// no longer exist, for example.
-	roles, err := g.access.GetRoles(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	roleLookup := map[string]bool{}
-	for _, role := range roles {
-		roleLookup[role.GetName()] = true
-	}
-
-	existingRoles := []string{}
+	// Make sure all the roles exist. If they don't, error out.
+	var existingRoles []string
 	for _, role := range state.Spec.Roles {
-		if roleLookup[role] {
+		_, err := g.access.GetRole(ctx, role)
+		if err == nil {
 			existingRoles = append(existingRoles, role)
 		} else {
-			g.log.Warnf("Role %s does not exist when trying to add user login state, will be skipped", role)
+			return trace.Wrap(err)
 		}
 	}
 	state.Spec.Roles = existingRoles

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -66,15 +67,17 @@ func TestAccessLists(t *testing.T) {
 		members            []*accesslist.AccessListMember
 		locks              []types.Lock
 		roles              []string
+		wantErr            require.ErrorAssertionFunc
 		expected           *userloginstate.UserLoginState
 		expectedRoleCount  int
 		expectedTraitCount int
 	}{
 		{
-			name:  "access lists are empty",
-			user:  user,
-			cloud: true,
-			roles: []string{"orole1"},
+			name:    "access lists are empty",
+			user:    user,
+			cloud:   true,
+			roles:   []string{"orole1"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -103,6 +106,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -133,7 +137,8 @@ func TestAccessLists(t *testing.T) {
 			locks: []types.Lock{
 				newUserLock(t, "test-lock", user.GetName()),
 			},
-			roles: []string{"orole1", "role1", "role2"},
+			roles:   []string{"orole1", "role1", "role2"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -162,6 +167,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -190,18 +196,9 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1"},
-			expected: newUserLoginState(t, "user",
-				map[string]string{
-					"label1":                                 "value1",
-					"label2":                                 "value2",
-					userloginstate.OriginalRolesAndTraitsSet: "true",
-				},
-				[]string{"orole1"},
-				trait.Traits{"otrait1": {"value1", "value2"}},
-				[]string{"orole1"},
-				trait.Traits{"otrait1": {"value1", "value2"}, "trait1": {"value1", "value2"}, "trait2": {"value3"}}),
-			expectedRoleCount:  0,
-			expectedTraitCount: 3,
+			wantErr: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.NotFound("role role1 is not found"))
+			},
 		},
 		{
 			name:  "access lists only a member of some lists",
@@ -218,6 +215,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "not-user")...),
 			roles:   []string{"orole1", "role1", "role2"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -242,6 +240,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1", "role1", "role2", "role3"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -275,6 +274,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"orole1"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					"label1":                                 "value1",
@@ -307,6 +307,7 @@ func TestAccessLists(t *testing.T) {
 			},
 			members: append(newAccessListMembers(t, clock, "1", "user"), newAccessListMembers(t, clock, "2", "user")...),
 			roles:   []string{"role1"},
+			wantErr: require.NoError,
 			expected: newUserLoginState(t, "user",
 				map[string]string{
 					userloginstate.OriginalRolesAndTraitsSet: "true",
@@ -358,7 +359,12 @@ func TestAccessLists(t *testing.T) {
 			}
 
 			state, err := svc.Generate(ctx, test.user)
-			require.NoError(t, err)
+			test.wantErr(t, err)
+
+			if err != nil {
+				return
+			}
+
 			require.Empty(t, cmp.Diff(test.expected, state,
 				cmpopts.SortSlices(func(str1, str2 string) bool {
 					return str1 < str2


### PR DESCRIPTION
The user login state generator will use GetRole instead of GetRoles to lookup roles. GetRole has a more robust fallback when unable to find things in the cache, so using it directly will make the user login state generator more robust in general.

Additionally, the user login state generator should not allow missing roles, so if a role is missing it will now throw an error.