### PR TITLE
[v14] Fix `rdp-client` FIPS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
  "bitflags 2.4.0",
  "cexpr",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae1aba472e42d3cf45ac6d0a6c8fc3ddf743871209e1b40229aed9fbdf48ece"
+checksum = "92667e5967bf826198f88dd3e43616973f8902769a6151616a65be1289a3c531"
 dependencies = [
  "bitflags 2.4.0",
  "boring-sys",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceced5be0047c7c48d77599535fd7f0a81c1b0f0a1e97e7eece24c45022bb481"
+checksum = "f04f5e0e2dc8315f68251391a4ac6da54793525c01d0206b10732b71139768cd"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "rdp-rs"
 version = "0.1.0"
-source = "git+https://github.com/gravitational/rdp-rs?rev=0ddb504e10051aaa8f0de57580a973d2853a5b7d#0ddb504e10051aaa8f0de57580a973d2853a5b7d"
+source = "git+https://github.com/gravitational/rdp-rs?rev=edfb5330a11d11eaf36d65e4300555368b4c6b02#edfb5330a11d11eaf36d65e4300555368b4c6b02"
 dependencies = [
  "boring",
  "bufstream",

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -145,5 +145,12 @@ COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 # Download pre-built CentOS 7 assets with clang needed to build BoringSSL and BPF tools.
 COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
 
+# Needed for boring-rs
+ENV CMAKE=cmake3
+
+# Libclang is needed by boring-rs to generate bindings. libclang is kept in /opt/llvm/lib
+# and without this environment variable, boring-rs will not be able to find it.
+ENV LIBCLANG_PATH=/opt/llvm/lib/
+
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-connect
+++ b/build.assets/Dockerfile-connect
@@ -29,6 +29,7 @@ RUN apt-get -y update && \
         build-essential \
         ca-certificates \
         git \
+        golang \
         libc6-dev \
         libssl-dev \
         locales \

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2.16"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_chacha = "0.3.1"
 rsa = "0.9.2"
-rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "0ddb504e10051aaa8f0de57580a973d2853a5b7d" }
+rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "edfb5330a11d11eaf36d65e4300555368b4c6b02" }
 uuid = { version = "1.4.1", features = ["v4"] }
 utf16string = "0.2.0"
 png = "0.17.10"


### PR DESCRIPTION
Backport of #36280.

gravitational/teleport.e#3072 fixed building rdp-client with FIPS, but uncovered other problems.

* Set `CMAKE=cmake3`, as `boring-rs` (by way of `cmake-rs`) calls `cmake` (which isn't installed).
* Upgrade `boring` and `tokio-boring` to v4.3.0 to pick up build fixes.
* Add `go` to node buildbox (wasn't handling our makefiles correctly).
* Set `LIBCLANG_PATH` to point to libclang file.