### PR TITLE
[v12] Update Rust version to 1.71.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@ GOLANG_VERSION ?= go1.20.12
 NODE_VERSION ?= 18.18.2
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.68.0
+RUST_VERSION ?= 1.71.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
Backport of #30281.

Depends on #36337.

The project's Rust version was updated from 1.68.0 to 1.71.1 in the versions.mk file.

This is needed to fix current `boring.rs` breakage -- https://github.com/gravitational/teleport.e/actions/runs/7418297613/job/20186050664.