### PR TITLE
[v14] Add clippy warning ignore for `arc_with_non_send_sync` in `rdpclient/src/lib.rs`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -612,6 +612,7 @@ fn connect_rdp_inner(go_ref: usize, params: ConnectParams) -> Result<Client, Con
     // will terminate the connection if the websocket disconnects.
     shared_tcp.tcp.set_read_timeout(None)?;
 
+    #[allow(clippy::arc_with_non_send_sync)]
     Ok(Client {
         rdp_client: Arc::new(Mutex::new(rdp_client)),
         tcp_fd,


### PR DESCRIPTION
Ignores the following warning:

> error: usage of an `Arc` that is not `Send` or `Sync`
>    --> lib/srv/desktop/rdp/rdpclient/src/lib.rs:616:21
>     |
> 616 |         rdp_client: Arc::new(Mutex::new(rdp_client)),
>     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     |
>     = note: the trait `Send` is not implemented for `Mutex<RdpClient<SharedStream>>`
>     = note: the trait `Sync` is not implemented for `Mutex<RdpClient<SharedStream>>`
>     = note: required for `Arc<Mutex<RdpClient<SharedStream>>>` to implement `Send` and `Sync`
>     = help: consider using an `Rc` instead or wrapping the inner type with a `Mutex`
>     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
>     = note: `-D clippy::arc-with-non-send-sync` implied by `-D warnings`
>     = help: to override `-D warnings` add `#[allow(clippy::arc_with_non_send_sync)]`