### PR TITLE
[v14] Fix incorrect audit log IP when using Kubernetes impersonation

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -693,7 +693,12 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = authz.ContextWithClientSrcAddr(ctx, clientSrcAddr)
 	}
 	ctx = authz.ContextWithUser(ctx, user)
-	a.Handler.ServeHTTP(w, r.WithContext(ctx))
+	r = r.WithContext(ctx)
+	// set remote address to the one that was passed in the header
+	// this is needed because impersonation reuses the same connection
+	// and the remote address is not updated from 0.0.0.0:0
+	r.RemoteAddr = remoteAddr
+	a.Handler.ServeHTTP(w, r)
 }
 
 // WrapContextWithUser enriches the provided context with the identity information

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -647,6 +647,7 @@ func (h *fakeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	clientSrcAddr, err := authz.ClientSrcAddrFromContext(r.Context())
 	require.NoError(h.t, err)
 	require.Equal(h.t, h.userIP, clientSrcAddr.String())
+	require.Equal(h.t, h.userIP, r.RemoteAddr)
 	// Ensure that the Teleport-Impersonate-User header is not set on the request
 	// after the middleware has run.
 	require.Empty(h.t, r.Header.Get(TeleportImpersonateUserHeader))


### PR DESCRIPTION
Backport #36322 to branch/v14

changelog: Fixed incorrect report of user's IP address in Kubernetes Audit Logs
