### PR TITLE
Remove support for the deprecated SSH tracing channel and request

### DIFF
--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -49,9 +49,9 @@ const (
 // NewClient creates a new Client.
 //
 // The server being connected to is probed to determine if it supports
-// ssh tracing. This is done by attempting to open a TracingChannel channel.
-// If the channel is successfully opened then all payloads delivered to the
-// server will be wrapped in an Envelope with tracing context. All Session
+// ssh tracing. This is done by inspecting the version the server provides
+// during the handshake, if it comes from a Teleport ssh server, then all
+// payloads will be wrapped in an Envelope with tracing context. All Session
 // and Channel created from the returned Client will honor the clients view
 // of whether they should provide tracing context.
 func NewClient(c ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request, opts ...tracing.Option) *Client {

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -50,7 +50,7 @@ func TestIsTracingSupported(t *testing.T) {
 			t.Cleanup(cancel)
 			errChan := make(chan error, 5)
 
-			srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+			srv := newServer(t, tt.expectedCapability, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
 				go ssh.DiscardRequests(requests)
 
 				for {
@@ -111,7 +111,7 @@ func TestSetEnvs(t *testing.T) {
 	// used to collect individual envs requests
 	envReqC := make(chan envReqParams, 3)
 
-	srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+	srv := newServer(t, tracingSupported, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
 		for {
 			select {
 			case <-ctx.Done():

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -36,14 +36,6 @@ const (
 	// See [EnvsReq] for the corresponding payload.
 	EnvsRequest = "envs@goteleport.com"
 
-	// TracingRequest is sent by clients to server to pass along tracing context.
-	// TODO(tross): DELETE in 15.0.0
-	TracingRequest = "tracing@goteleport.com"
-
-	// TracingChannel is a SSH channel used to indicate that servers support tracing.
-	// TODO(tross): DELETE in 15.0.0
-	TracingChannel = "tracing"
-
 	// instrumentationName is the name of this instrumentation package.
 	instrumentationName = "otelssh"
 )
@@ -206,7 +198,7 @@ func peerAttr(addr net.Addr) []attribute.KeyValue {
 }
 
 // Envelope wraps the payload of all ssh messages with
-// tracing context. Any servers that reply to a TracingChannel
+// tracing context. Any servers that support tracing propagation
 // will attempt to parse the Envelope for all received requests and
 // ensure that the original payload is provided to the handlers.
 type Envelope struct {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2119,11 +2119,6 @@ func x11Handler(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewCha
 		return nil
 	}
 
-	if nch.ChannelType() == tracessh.TracingChannel {
-		nch.Reject(ssh.UnknownChannelType, "")
-		return x11Handler(ctx, conn, chs)
-	}
-
 	if nch.ChannelType() != teleport.ChanSession {
 		return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -627,24 +627,6 @@ func (s *Server) HandleConnection(conn net.Conn) {
 				return
 			}
 
-			// This is a request from clients to determine if tracing is enabled.
-			// Handle here so that we always alert clients that we can handle tracing envelopes.
-			if nch.ChannelType() == tracessh.TracingChannel {
-				ch, _, err := nch.Accept()
-				if err != nil {
-					s.log.Warnf("Unable to accept channel: %v", err)
-					if err := nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err)); err != nil {
-						s.log.Warnf("Failed to reject channel: %v", err)
-					}
-					continue
-				}
-
-				if err := ch.Close(); err != nil {
-					s.log.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
-				}
-				continue
-			}
-
 			chanCtx, nch := tracessh.ContextFromNewChannel(nch)
 			ctx, span := s.tracerProvider.Tracer("ssh").Start(
 				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(chanCtx)),


### PR DESCRIPTION
Cleans up a few `TODO DELETE IN V15` related to old ssh tracing propagation detection mechanisms.