### PR TITLE
log lint error lines instead of making annotations

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,24 +44,27 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: api
+          args: --out-format=colored-line-number
           skip-cache: true
       - name: golangci-lint (teleport)
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --build-tags libfido2,piv
+          args: --out-format=colored-line-number --build-tags libfido2,piv
           skip-cache: true
       - name: golangci-lint (assets/backport)
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: assets/backport
+          args: --out-format=colored-line-number
           skip-cache: true
       - name: golangci-lint (build.assets/tooling)
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: build.assets/tooling
+          args: --out-format=colored-line-number
           skip-cache: true
 
       - uses: bufbuild/buf-setup-action@382440cdb8ec7bc25a68d7b4711163d95f7cc3aa # v1.28.1


### PR DESCRIPTION
This PR changes the lint actions to output the file/line information for each error in the logs, rather than creating github annotations in the PR's changed files.

We used to output affected lines in the logs, but that changed when we switched to using the github action instead of our own `make lint` - by default the action outputs file annotations.

IMO it's easier to just see the affected lines in the lint run's logs than browse the changed files and scroll.

I'll open up an `e` PR for the same if this is approved. Not sure if others prefer the annotations 🤷‍♂️ 