### PR TITLE
fix: add retries for AWS KMS

### DIFF
--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -137,14 +137,74 @@ func TestAWSKMS_WrongAccount(t *testing.T) {
 	require.ErrorIs(t, err, trace.BadParameter(`configured AWS KMS account "111111111111" does not match AWS account of ambient credentials "222222222222"`))
 }
 
+func TestAWSKMS_RetryWhilePending(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	kms := &fakeAWSKMSService{
+		clock:     clock,
+		account:   "111111111111",
+		region:    "us-west-2",
+		pageLimit: 1000,
+	}
+	cfg := Config{
+		AWSKMS: AWSKMSConfig{
+			Cluster:    "test-cluster",
+			AWSAccount: "111111111111",
+			AWSRegion:  "us-west-2",
+			CloudClients: &cloud.TestCloudClients{
+				KMS: kms,
+				STS: &fakeAWSSTSClient{
+					account: "111111111111",
+				},
+			},
+			clock: clock,
+		},
+	}
+	manager, err := NewManager(context.Background(), cfg)
+	require.NoError(t, err)
+
+	// Test with one retry required.
+	kms.keyPendingDuration = pendingKeyBaseRetryInterval
+	go func() {
+		clock.BlockUntil(2)
+		clock.Advance(kms.keyPendingDuration)
+	}()
+	_, err = manager.NewSSHKeyPair(ctx)
+	require.NoError(t, err)
+
+	// Test with two retries required.
+	kms.keyPendingDuration = 4 * pendingKeyBaseRetryInterval
+	go func() {
+		clock.BlockUntil(2)
+		clock.Advance(kms.keyPendingDuration / 2)
+		clock.BlockUntil(2)
+		clock.Advance(kms.keyPendingDuration / 2)
+	}()
+	_, err = manager.NewSSHKeyPair(ctx)
+	require.NoError(t, err)
+
+	// Test a timeout.
+	kms.keyPendingDuration = 2 * pendingKeyTimeout
+	go func() {
+		clock.BlockUntil(2)
+		clock.Advance(pendingKeyBaseRetryInterval)
+		clock.BlockUntil(2)
+		clock.Advance(pendingKeyTimeout)
+	}()
+	_, err = manager.NewSSHKeyPair(ctx)
+	require.Error(t, err)
+}
+
 type fakeAWSKMSService struct {
 	kmsiface.KMSAPI
 
-	keys      []*fakeAWSKMSKey
-	clock     clockwork.Clock
-	account   string
-	region    string
-	pageLimit int
+	keys               []*fakeAWSKMSKey
+	clock              clockwork.Clock
+	account            string
+	region             string
+	pageLimit          int
+	keyPendingDuration time.Duration
 }
 
 func newFakeAWSKMSService(t *testing.T, clock clockwork.Clock, account string, region string, pageLimit int) *fakeAWSKMSService {
@@ -172,11 +232,15 @@ func (f *fakeAWSKMSService) CreateKey(input *kms.CreateKeyInput) (*kms.CreateKey
 		AccountID: f.account,
 		Resource:  id,
 	}
+	state := "Enabled"
+	if f.keyPendingDuration > 0 {
+		state = "Pending"
+	}
 	f.keys = append(f.keys, &fakeAWSKMSKey{
 		arn:          a.String(),
 		tags:         input.Tags,
 		creationDate: f.clock.Now(),
-		state:        "Enabled",
+		state:        state,
 	})
 	return &kms.CreateKeyOutput{
 		KeyMetadata: &kms.KeyMetadata{
@@ -186,10 +250,10 @@ func (f *fakeAWSKMSService) CreateKey(input *kms.CreateKeyInput) (*kms.CreateKey
 	}, nil
 }
 
-func (f *fakeAWSKMSService) GetPublicKey(input *kms.GetPublicKeyInput) (*kms.GetPublicKeyOutput, error) {
-	key, ok := f.findKey(aws.StringValue(input.KeyId))
-	if !ok {
-		return nil, trace.NotFound("key %q not found", aws.StringValue(input.KeyId))
+func (f *fakeAWSKMSService) GetPublicKeyWithContext(ctx context.Context, input *kms.GetPublicKeyInput, opts ...request.Option) (*kms.GetPublicKeyOutput, error) {
+	key, err := f.findKey(aws.StringValue(input.KeyId))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	if key.state != "Enabled" {
 		return nil, trace.NotFound("key %q is not enabled", aws.StringValue(input.KeyId))
@@ -200,9 +264,9 @@ func (f *fakeAWSKMSService) GetPublicKey(input *kms.GetPublicKeyInput) (*kms.Get
 }
 
 func (f *fakeAWSKMSService) Sign(input *kms.SignInput) (*kms.SignOutput, error) {
-	key, ok := f.findKey(aws.StringValue(input.KeyId))
-	if !ok {
-		return nil, trace.NotFound("key %q not found", aws.StringValue(input.KeyId))
+	key, err := f.findKey(aws.StringValue(input.KeyId))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	if key.state != "Enabled" {
 		return nil, trace.NotFound("key %q is not enabled", aws.StringValue(input.KeyId))
@@ -230,9 +294,9 @@ func (f *fakeAWSKMSService) Sign(input *kms.SignInput) (*kms.SignOutput, error) 
 }
 
 func (f *fakeAWSKMSService) ScheduleKeyDeletion(input *kms.ScheduleKeyDeletionInput) (*kms.ScheduleKeyDeletionOutput, error) {
-	key, ok := f.findKey(aws.StringValue(input.KeyId))
-	if !ok {
-		return nil, trace.NotFound("key %q not found", aws.StringValue(input.KeyId))
+	key, err := f.findKey(aws.StringValue(input.KeyId))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	key.state = "PendingDeletion"
 	return &kms.ScheduleKeyDeletionOutput{}, nil
@@ -263,9 +327,9 @@ func (f *fakeAWSKMSService) ListKeysWithContext(ctx aws.Context, input *kms.List
 }
 
 func (f *fakeAWSKMSService) ListResourceTagsWithContext(ctx aws.Context, input *kms.ListResourceTagsInput, opts ...request.Option) (*kms.ListResourceTagsOutput, error) {
-	key, ok := f.findKey(aws.StringValue(input.KeyId))
-	if !ok {
-		return nil, trace.NotFound("key %q not found", aws.StringValue(input.KeyId))
+	key, err := f.findKey(aws.StringValue(input.KeyId))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return &kms.ListResourceTagsOutput{
 		Tags: key.tags,
@@ -273,9 +337,9 @@ func (f *fakeAWSKMSService) ListResourceTagsWithContext(ctx aws.Context, input *
 }
 
 func (f *fakeAWSKMSService) DescribeKeyWithContext(ctx aws.Context, input *kms.DescribeKeyInput, opts ...request.Option) (*kms.DescribeKeyOutput, error) {
-	key, ok := f.findKey(aws.StringValue(input.KeyId))
-	if !ok {
-		return nil, trace.NotFound("key %q not found", aws.StringValue(input.KeyId))
+	key, err := f.findKey(aws.StringValue(input.KeyId))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return &kms.DescribeKeyOutput{
 		KeyMetadata: &kms.KeyMetadata{
@@ -285,12 +349,24 @@ func (f *fakeAWSKMSService) DescribeKeyWithContext(ctx aws.Context, input *kms.D
 	}, nil
 }
 
-func (f *fakeAWSKMSService) findKey(arn string) (*fakeAWSKMSKey, bool) {
+func (f *fakeAWSKMSService) findKey(arn string) (*fakeAWSKMSKey, error) {
 	i := slices.IndexFunc(f.keys, func(k *fakeAWSKMSKey) bool { return k.arn == arn })
 	if i < 0 {
-		return nil, false
+		return nil, &kms.NotFoundException{
+			Message_: aws.String(fmt.Sprintf("key %q not found", arn)),
+		}
 	}
-	return f.keys[i], true
+	key := f.keys[i]
+	if key.state != "Pending" {
+		return key, nil
+	}
+	if f.clock.Now().Before(key.creationDate.Add(f.keyPendingDuration)) {
+		return nil, &kms.NotFoundException{
+			Message_: aws.String(fmt.Sprintf("key %q not found", arn)),
+		}
+	}
+	key.state = "Enabled"
+	return key, nil
 }
 
 type fakeAWSSTSClient struct {


### PR DESCRIPTION
AWS KMS is eventually-consistent. When trying to fetch the public key immediately after creating a new key, a few retries may be necessary.

In manual testing I observed errors without implementing the retries. After adding the retry logic, the keys always seem to be available very quickly (subsecond).