### PR TITLE
Update slog handlers to support configured extra_fields

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -723,6 +723,11 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 		return trace.BadParameter("unsupported logger severity: %q", loggerConfig.Severity)
 	}
 
+	configuredFields, err := logutils.ValidateFields(loggerConfig.Format.ExtraFields)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	sharedWriter := logutils.NewSharedWriter(w)
 	var slogLogger *slog.Logger
 	switch strings.ToLower(loggerConfig.Format.Output) {
@@ -731,7 +736,7 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 	case "text":
 		enableColors := trace.IsTerminal(os.Stderr)
 		formatter := &logutils.TextFormatter{
-			ExtraFields:  loggerConfig.Format.ExtraFields,
+			ExtraFields:  configuredFields,
 			EnableColors: enableColors,
 		}
 
@@ -742,15 +747,15 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 		logger.SetOutput(sharedWriter)
 		logger.SetFormatter(formatter)
 
-		slogLogger = slog.New(logutils.NewSlogTextHandler(sharedWriter, &logutils.SlogTextHandlerConfig{
-			Level:        level,
-			EnableColors: enableColors,
-			WithCaller:   true,
+		slogLogger = slog.New(logutils.NewSlogTextHandler(sharedWriter, logutils.SlogTextHandlerConfig{
+			Level:            level,
+			EnableColors:     enableColors,
+			ConfiguredFields: configuredFields,
 		}))
 		slog.SetDefault(slogLogger)
 	case "json":
 		formatter := &logutils.JSONFormatter{
-			ExtraFields: loggerConfig.Format.ExtraFields,
+			ExtraFields: configuredFields,
 		}
 
 		if err := formatter.CheckAndSetDefaults(); err != nil {
@@ -760,7 +765,10 @@ func applyLogConfig(loggerConfig Log, cfg *servicecfg.Config) error {
 		logger.SetFormatter(formatter)
 		logger.SetOutput(sharedWriter)
 
-		slogLogger = slog.New(logutils.NewSlogJSONHandler(sharedWriter, level))
+		slogLogger = slog.New(logutils.NewSlogJSONHandler(sharedWriter, logutils.SlogJSONHandlerConfig{
+			Level:            level,
+			ConfiguredFields: configuredFields,
+		}))
 		slog.SetDefault(slogLogger)
 	default:
 		return trace.BadParameter("unsupported log output format : %q", loggerConfig.Format.Output)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type testConfigFiles struct {
@@ -2944,62 +2943,6 @@ func TestDatabaseCLIFlags(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, []servicecfg.Database{tt.outDatabase}, config.Databases.Databases)
 			}
-		})
-	}
-}
-
-func TestTextFormatter(t *testing.T) {
-	tests := []struct {
-		comment      string
-		formatConfig []string
-		assertErr    require.ErrorAssertionFunc
-	}{
-		{
-			comment:      "invalid key (does not exist)",
-			formatConfig: []string{"level", "invalid key"},
-			assertErr:    require.Error,
-		},
-		{
-			comment:      "valid keys and formatting",
-			formatConfig: []string{"level", "component", "timestamp"},
-			assertErr:    require.NoError,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &logutils.TextFormatter{
-				ExtraFields: tt.formatConfig,
-			}
-			tt.assertErr(t, formatter.CheckAndSetDefaults())
-		})
-	}
-}
-
-func TestJSONFormatter(t *testing.T) {
-	tests := []struct {
-		comment     string
-		extraFields []string
-		assertErr   require.ErrorAssertionFunc
-	}{
-		{
-			comment:     "invalid key (does not exist)",
-			extraFields: []string{"level", "invalid key"},
-			assertErr:   require.Error,
-		},
-		{
-			comment:     "valid keys and formatting",
-			extraFields: []string{"level", "caller", "component", "timestamp"},
-			assertErr:   require.NoError,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &logutils.JSONFormatter{
-				ExtraFields: tt.extraFields,
-			}
-			tt.assertErr(t, formatter.CheckAndSetDefaults())
 		})
 	}
 }

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -128,14 +128,15 @@ func InitLogger(purpose LoggingPurpose, level slog.Level, opts ...LoggerOption) 
 		}
 
 		formatter = textFormatter
-		handler = logutils.NewSlogTextHandler(w, &logutils.SlogTextHandlerConfig{
+		handler = logutils.NewSlogTextHandler(w, logutils.SlogTextHandlerConfig{
 			Level:        level,
 			EnableColors: enableColors,
-			WithCaller:   true,
 		})
 	case LogFormatJSON:
 		formatter = &logutils.JSONFormatter{}
-		handler = logutils.NewSlogJSONHandler(w, level)
+		handler = logutils.NewSlogJSONHandler(w, logutils.SlogJSONHandlerConfig{
+			Level: level,
+		})
 	}
 
 	logrus.SetFormatter(formatter)
@@ -164,7 +165,7 @@ func InitLoggerForTests() {
 
 		output := logutils.NewSharedWriter(w)
 		logger.SetOutput(output)
-		slog.SetDefault(slog.New(logutils.NewSlogJSONHandler(output, level)))
+		slog.SetDefault(slog.New(logutils.NewSlogJSONHandler(output, logutils.SlogJSONHandlerConfig{Level: level})))
 	})
 }
 

--- a/lib/utils/log/logrus_formatter.go
+++ b/lib/utils/log/logrus_formatter.go
@@ -93,7 +93,7 @@ func NewDefaultTextFormatter(enableColors bool) *TextFormatter {
 	return &TextFormatter{
 		ComponentPadding: trace.DefaultComponentPadding,
 		FormatCaller:     formatCallerWithPathAndLine,
-		ExtraFields:      knownFormatFieldNames,
+		ExtraFields:      defaultFormatFields,
 		EnableColors:     enableColors,
 		callerEnabled:    true,
 		timestampEnabled: false,
@@ -113,24 +113,18 @@ func (tf *TextFormatter) CheckAndSetDefaults() error {
 	if tf.ExtraFields == nil {
 		tf.timestampEnabled = true
 		tf.callerEnabled = true
-		tf.ExtraFields = knownFormatFieldNames
+		tf.ExtraFields = defaultFormatFields
 		return nil
 	}
-	// parse input
-	res, err := parseInputFormat(tf.ExtraFields)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
-	if slices.Contains(res, timestampField) {
+	if slices.Contains(tf.ExtraFields, timestampField) {
 		tf.timestampEnabled = true
 	}
 
-	if slices.Contains(res, callerField) {
+	if slices.Contains(tf.ExtraFields, callerField) {
 		tf.callerEnabled = true
 	}
 
-	tf.ExtraFields = res
 	return nil
 }
 
@@ -146,7 +140,7 @@ func (tf *TextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 
 	for _, field := range tf.ExtraFields {
 		switch field {
-		case "level":
+		case levelField:
 			var color int
 			var level string
 			switch e.Level {
@@ -178,7 +172,7 @@ func (tf *TextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 			}
 
 			w.writeField(padMax(level, trace.DefaultLevelPadding), color)
-		case "component":
+		case componentField:
 			padding := trace.DefaultComponentPadding
 			if tf.ComponentPadding != 0 {
 				padding = tf.ComponentPadding
@@ -227,6 +221,9 @@ type JSONFormatter struct {
 	logrus.JSONFormatter
 
 	ExtraFields []string
+	// FormatCaller is a function to return (part) of source file path for output.
+	// Defaults to filePathAndLine() if unspecified
+	FormatCaller func() (caller string)
 
 	callerEnabled    bool
 	componentEnabled bool
@@ -236,24 +233,16 @@ type JSONFormatter struct {
 func (j *JSONFormatter) CheckAndSetDefaults() error {
 	// set log formatting
 	if j.ExtraFields == nil {
-		j.ExtraFields = knownFormatFieldNames
+		j.ExtraFields = defaultFormatFields
 	}
+	// set caller
+	j.FormatCaller = formatCallerWithPathAndLine
 
-	// parse input
-	res, err := parseInputFormat(j.ExtraFields)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if slices.Contains(res, timestampField) {
-		j.JSONFormatter.DisableTimestamp = true
-	}
-
-	if slices.Contains(res, callerField) {
+	if slices.Contains(j.ExtraFields, callerField) {
 		j.callerEnabled = true
 	}
 
-	if slices.Contains(res, componentField) {
+	if slices.Contains(j.ExtraFields, componentField) {
 		j.componentEnabled = true
 	}
 
@@ -264,6 +253,7 @@ func (j *JSONFormatter) CheckAndSetDefaults() error {
 			logrus.FieldKeyLevel: levelField,
 			logrus.FieldKeyMsg:   messageField,
 		},
+		DisableTimestamp: !slices.Contains(j.ExtraFields, timestampField),
 	}
 
 	return nil
@@ -272,7 +262,7 @@ func (j *JSONFormatter) CheckAndSetDefaults() error {
 // Format formats each log line as configured in teleport config file.
 func (j *JSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	if j.callerEnabled {
-		path := formatCallerWithPathAndLine()
+		path := j.FormatCaller()
 		e.Data[callerField] = path
 	}
 
@@ -457,7 +447,7 @@ func frameToTrace(frame runtime.Frame) trace.Trace {
 	}
 }
 
-var knownFormatFieldNames = []string{levelField, componentField, callerField, timestampField}
+var defaultFormatFields = []string{levelField, componentField, callerField, timestampField}
 
 var knownFormatFields = map[string]struct{}{
 	levelField:     {},
@@ -466,7 +456,7 @@ var knownFormatFields = map[string]struct{}{
 	timestampField: {},
 }
 
-func parseInputFormat(formatInput []string) (result []string, err error) {
+func ValidateFields(formatInput []string) (result []string, err error) {
 	for _, component := range formatInput {
 		component = strings.TrimSpace(component)
 		if _, ok := knownFormatFields[component]; !ok {

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -40,7 +40,14 @@ const TraceLevel = slog.LevelDebug - 1
 // SlogTextHandler is a [slog.Handler] that outputs messages in a textual
 // manner as configured by the Teleport configuration.
 type SlogTextHandler struct {
-	cfg       SlogTextHandlerConfig
+	cfg SlogTextHandlerConfig
+	// withCaller indicates whether the location the log was emitted from
+	// should be included in the output message.
+	withCaller bool
+	// withTimestamp indicates whether the times that the log was emitted at
+	// should be included in the output message.
+	withTimestamp bool
+	// component is the Teleport subcomponent that emitted the log.
 	component string
 	// preformatted data from previous calls to WithGroup and WithAttrs.
 	preformatted []byte
@@ -72,29 +79,34 @@ type SlogTextHandlerConfig struct {
 	EnableColors bool
 	// Padding to use for various components.
 	Padding int
-	// WithCaller indicates whether the source of the log should be
-	// included in output.
-	WithCaller bool
+	// ConfiguredFields are fields explicitly set by users to be included in
+	// the output message. If there are any entries configured, they will be honored.
+	// If empty, the default fields will be populated and included in the output.
+	ConfiguredFields []string
 	// ReplaceAttr is called to rewrite each non-group attribute before
 	// it is logged.
 	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
 }
 
 // NewSlogTextHandler creates a SlogTextHandler that writes messages to w.
-func NewSlogTextHandler(w io.Writer, cfg *SlogTextHandlerConfig) *SlogTextHandler {
-	if cfg == nil {
-		cfg = &SlogTextHandlerConfig{}
-	}
-
+func NewSlogTextHandler(w io.Writer, cfg SlogTextHandlerConfig) *SlogTextHandler {
 	if cfg.Padding == 0 {
 		cfg.Padding = trace.DefaultComponentPadding
 	}
 
-	return &SlogTextHandler{
-		cfg: *cfg,
-		out: w,
-		mu:  &sync.Mutex{},
+	handler := SlogTextHandler{
+		cfg:           cfg,
+		withCaller:    len(cfg.ConfiguredFields) == 0 || slices.Contains(cfg.ConfiguredFields, callerField),
+		withTimestamp: len(cfg.ConfiguredFields) == 0 || slices.Contains(cfg.ConfiguredFields, timestampField),
+		out:           w,
+		mu:            &sync.Mutex{},
 	}
+
+	if handler.cfg.ConfiguredFields == nil {
+		handler.cfg.ConfiguredFields = defaultFormatFields
+	}
+
+	return &handler
 }
 
 // Enabled returns whether the provided level will be included in output.
@@ -132,18 +144,39 @@ func (s *SlogTextHandler) appendAttr(buf []byte, a slog.Attr) []byte {
 			break
 		}
 
+		if a.Key == trace.ComponentFields {
+			switch fields := a.Value.Any().(type) {
+			case map[string]any:
+				for k, v := range fields {
+					buf = s.appendAttr(buf, slog.Any(k, v))
+				}
+			case logrus.Fields:
+				for k, v := range fields {
+					buf = s.appendAttr(buf, slog.Any(k, v))
+				}
+			}
+		}
+
 		if needsQuoting(value) {
-			if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == "caller" || a.Key == slog.MessageKey {
-				buf = fmt.Append(buf, " ")
+			if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
+				if len(buf) > 0 {
+					buf = fmt.Append(buf, " ")
+				}
 			} else {
-				buf = fmt.Appendf(buf, " %s%s:", s.groupPrefix, a.Key)
+				if len(buf) > 0 {
+					buf = fmt.Append(buf, " ")
+				}
+				buf = fmt.Appendf(buf, "%s%s:", s.groupPrefix, a.Key)
 			}
 			buf = strconv.AppendQuote(buf, value)
 			break
 		}
 
-		if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == "caller" || a.Key == slog.MessageKey {
-			buf = fmt.Appendf(buf, " %s", a.Value.String())
+		if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
+			if len(buf) > 0 {
+				buf = fmt.Append(buf, " ")
+			}
+			buf = fmt.Appendf(buf, "%s", a.Value.String())
 			break
 		}
 
@@ -222,7 +255,7 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 	buf := newBuffer()
 	defer buf.Free()
 
-	if !r.Time.IsZero() {
+	if s.withTimestamp && !r.Time.IsZero() {
 		if s.cfg.ReplaceAttr != nil {
 			*buf = s.appendAttr(*buf, slog.Time(slog.TimeKey, r.Time))
 		} else {
@@ -230,44 +263,79 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 		}
 	}
 
-	var color int
-	var level string
-	switch r.Level {
-	case TraceLevel:
-		level = "TRACE"
-		color = gray
-	case slog.LevelDebug:
-		level = "DEBUG"
-		color = gray
-	case slog.LevelInfo:
-		level = "INFO"
-		color = blue
-	case slog.LevelWarn:
-		level = "WARN"
-		color = yellow
-	case slog.LevelError:
-		level = "ERROR"
-		color = red
-	case slog.LevelError + 1:
-		level = "FATAL"
-		color = red
-	default:
-		color = blue
-		level = r.Level.String()
-	}
+	// Processing fields in this manner allows users to
+	// configure the level and component position in the output.
+	// This matches the behavior of the original logrus. All other
+	// fields location in the output message are static.
+	for _, field := range s.cfg.ConfiguredFields {
+		switch field {
+		case levelField:
+			var color int
+			var level string
+			switch r.Level {
+			case TraceLevel:
+				level = "TRACE"
+				color = gray
+			case slog.LevelDebug:
+				level = "DEBUG"
+				color = gray
+			case slog.LevelInfo:
+				level = "INFO"
+				color = blue
+			case slog.LevelWarn:
+				level = "WARN"
+				color = yellow
+			case slog.LevelError:
+				level = "ERROR"
+				color = red
+			case slog.LevelError + 1:
+				level = "FATAL"
+				color = red
+			default:
+				color = blue
+				level = r.Level.String()
+			}
 
-	if !s.cfg.EnableColors {
-		color = noColor
-	}
+			if !s.cfg.EnableColors {
+				color = noColor
+			}
 
-	level = padMax(level, trace.DefaultLevelPadding)
-	if color == noColor {
-		*buf = s.appendAttr(*buf, slog.String(slog.LevelKey, level))
-	} else {
-		*buf = fmt.Appendf(*buf, " \u001B[%dm%s\u001B[0m", color, level)
-	}
+			level = padMax(level, trace.DefaultLevelPadding)
+			if color == noColor {
+				*buf = s.appendAttr(*buf, slog.String(slog.LevelKey, level))
+			} else {
+				*buf = fmt.Appendf(*buf, " \u001B[%dm%s\u001B[0m", color, level)
+			}
+		case componentField:
+			component := s.component
+			// If there is no component for the handler check if one was provided with
+			// the attributes of the log message. If one is found, use that instead of
+			// an empty string and abort processing the component later. Note that if
+			// there are multiple components specified, the first one with the lowest index
+			// is used and the others are ignored.
+			if component == "" {
+				r.Attrs(func(attr slog.Attr) bool {
+					if attr.Key == trace.Component {
+						component = fmt.Sprintf("[%v]", attr.Value)
+						component = strings.ToUpper(padMax(component, s.cfg.Padding))
+						if component[len(component)-1] != ' ' {
+							component = component[:len(component)-1] + "]"
+						}
 
-	*buf = s.appendAttr(*buf, slog.String(trace.Component, s.component))
+						return false
+					}
+
+					return true
+				})
+			}
+
+			*buf = s.appendAttr(*buf, slog.String(trace.Component, component))
+		default:
+			if _, ok := knownFormatFields[field]; !ok {
+				return trace.BadParameter("invalid log format key: %v", field)
+			}
+		}
+	}
 
 	*buf = s.appendAttr(*buf, slog.String(slog.MessageKey, r.Message))
 
@@ -282,12 +350,17 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 		}
 
 		r.Attrs(func(a slog.Attr) bool {
+			// Skip adding any component attrs since they are processed above.
+			if a.Key == trace.Component {
+				return true
+			}
+
 			*buf = s.appendAttr(*buf, a)
 			return true
 		})
 	}
 
-	if r.PC != 0 && s.cfg.WithCaller {
+	if r.PC != 0 && s.withCaller {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
 		f, _ := fs.Next()
 
@@ -377,6 +450,20 @@ func (s *SlogTextHandler) WithGroup(name string) slog.Handler {
 	return &s2
 }
 
+// SlogJSONHandlerConfig allow the SlogJSONHandler functionality
+// to be tweaked.
+type SlogJSONHandlerConfig struct {
+	// Level is the minimum record level that will be logged.
+	Level slog.Leveler
+	// ConfiguredFields are fields explicitly set by users to be included in
+	// the output message. If there are any entries configured, they will be honored.
+	// If empty, the default fields will be populated and included in the output.
+	ConfiguredFields []string
+	// ReplaceAttr is called to rewrite each non-group attribute before
+	// it is logged.
+	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+}
+
 // SlogJSONHandler is a [slog.Handler] that outputs messages in a json
 // format per the config file.
 type SlogJSONHandler struct {
@@ -384,15 +471,23 @@ type SlogJSONHandler struct {
 }
 
 // NewSlogJSONHandler creates a SlogJSONHandler that outputs to w.
-func NewSlogJSONHandler(w io.Writer, level slog.Leveler) *SlogJSONHandler {
+func NewSlogJSONHandler(w io.Writer, cfg SlogJSONHandlerConfig) *SlogJSONHandler {
+	withCaller := len(cfg.ConfiguredFields) == 0 || slices.Contains(cfg.ConfiguredFields, callerField)
+	withComponent := len(cfg.ConfiguredFields) == 0 || slices.Contains(cfg.ConfiguredFields, componentField)
+	withTimestamp := len(cfg.ConfiguredFields) == 0 || slices.Contains(cfg.ConfiguredFields, timestampField)
+
 	return &SlogJSONHandler{
 		JSONHandler: slog.NewJSONHandler(w, &slog.HandlerOptions{
 			AddSource: true,
-			Level:     level,
+			Level:     cfg.Level,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				switch a.Key {
 				case trace.Component:
-					a.Key = "component"
+					if !withComponent {
+						return slog.Attr{}
+					}
+
+					a.Key = componentField
 				case slog.LevelKey:
 					var level string
 					switch lvl := a.Value.Any().(slog.Level); lvl {
@@ -414,18 +509,26 @@ func NewSlogJSONHandler(w io.Writer, level slog.Leveler) *SlogJSONHandler {
 
 					a.Value = slog.StringValue(level)
 				case slog.TimeKey:
+					if !withTimestamp {
+						return slog.Attr{}
+					}
+
 					t := a.Value.Time()
 					if t.IsZero() {
 						return a
 					}
 
-					a.Key = "timestamp"
+					a.Key = timestampField
 					a.Value = slog.StringValue(t.Format(time.RFC3339))
 				case slog.MessageKey:
-					a.Key = "message"
+					a.Key = messageField
 				case slog.SourceKey:
+					if !withCaller {
+						return slog.Attr{}
+					}
+
 					file, line := getCaller(a)
-					a = slog.String("caller", fmt.Sprintf("%s:%d", file, line))
+					a = slog.String(callerField, fmt.Sprintf("%s:%d", file, line))
 				}
 
 				return a

--- a/lib/utils/log/slog_handler_test.go
+++ b/lib/utils/log/slog_handler_test.go
@@ -46,8 +46,7 @@ func TestSlogTextHandler(t *testing.T) {
 	// the time to whatever time the fake clock has in UTC time. Since the timestamp
 	// is not important for this test overriding, it allows the regex to be simpler.
 	var buf bytes.Buffer
-	h := NewSlogTextHandler(&buf, &SlogTextHandlerConfig{
-		WithCaller: false,
+	h := NewSlogTextHandler(&buf, SlogTextHandlerConfig{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				a.Value = slog.StringValue(now)
@@ -62,7 +61,7 @@ func TestSlogTextHandler(t *testing.T) {
 	// Group 2: verbosity level of output
 	// Group 3: message contents
 	// Group 4: additional attributes
-	regex := fmt.Sprintf("^(?:(%s)?)\\s([A-Z]{4})\\s+(\\w+)(?:\\s(.*))?$", now)
+	regex := fmt.Sprintf("^(?:(%s)?)\\s?([A-Z]{4})\\s+(\\w+)(?:\\s(.*))?$", now)
 	lineRegex := regexp.MustCompile(regex)
 
 	results := func() []map[string]any {
@@ -76,6 +75,7 @@ func TestSlogTextHandler(t *testing.T) {
 			matches := lineRegex.FindSubmatch(line)
 			if len(matches) == 0 {
 				assert.Failf(t, "log output did not match regular expression", "regex: %s output: %s", regex, string(line))
+				ms = append(ms, m)
 				continue
 			}
 
@@ -147,7 +147,7 @@ func TestSlogTextHandler(t *testing.T) {
 func TestSlogJSONHandler(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	h := NewSlogJSONHandler(&buf, slog.LevelDebug)
+	h := NewSlogJSONHandler(&buf, SlogJSONHandlerConfig{Level: slog.LevelDebug})
 
 	results := func() []map[string]any {
 		var ms []map[string]any


### PR DESCRIPTION
In addition to configuring output format users can configure the fields which are included in log messages. Prior to this our slog handlers didn't support this feature and always output the default fields. Now, both the slog and logrus output is identical no matter the extra_fields configuration as verified by TestExtraFields. It was also found that due to the way the logurs json formatter was configuring itself in CheckAndSetDefaults the timestamp was always included in the final output even if it was not included in the configured extra_fields.