### PR TITLE
[v12] Ensure that login time is set for app sessions

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -213,7 +213,6 @@ func (ws *WebSessionV2) CheckAndSetDefaults() error {
 	if err := ws.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-
 	if ws.Spec.User == "" {
 		return trace.BadParameter("missing User")
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -107,6 +107,7 @@ func (a *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 		Priv:        privateKey,
 		Pub:         certs.SSH,
 		TLSCert:     certs.TLS,
+		LoginTime:   a.clock.Now(),
 		Expires:     a.clock.Now().Add(ttl),
 		BearerToken: bearer,
 	})


### PR DESCRIPTION
Backport #36365 to branch/v12

changelog: Ensure that the login time is populated for app sessions.
