### PR TITLE
Revert "Upgrade Rust to 1.75.0"

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -8,7 +8,7 @@ GOLANG_VERSION ?= go1.21.5
 NODE_VERSION ?= 18.18.2
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.75.0
+RUST_VERSION ?= 1.71.1
 WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport


### PR DESCRIPTION
This reverts commit ef6e0aa446b5a31617b3016183fdbe2c4c3f13eb.

Our CI builds are failing the WASM build with:

    rustc unexpectedly overflowed its stack! this is a bug
    maximum backtrace depth reached, frames may have been lost
    we would appreciate a report at https://github.com/rust-lang/rust