### PR TITLE
faq link fix in web ui

### DIFF
--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -184,7 +184,7 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
     adminGuide: withUTM(
       `https://goteleport.com/docs${docVer}/management/admin/`
     ),
-    faq: withUTM(`https://goteleport.com${docVer}/docs/faq`),
+    faq: withUTM(`https://goteleport.com/docs${docVer}/faq`),
     troubleshooting: withUTM(
       `https://goteleport.com/docs${docVer}/management/admin/troubleshooting/`
     ),

--- a/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/web/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`support Cloud 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -720,7 +720,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1238,7 +1238,7 @@ exports[`support Enterprise with CTA 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=e_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=e_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -1673,7 +1673,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >
@@ -2191,7 +2191,7 @@ exports[`support OSSWithCTA 1`] = `
         </a>
         <a
           class="c12"
-          href="https://goteleport.com/ver/13.x/docs/faq?product=teleport&version=oss_13.4.0-dev"
+          href="https://goteleport.com/docs/ver/13.x/faq?product=teleport&version=oss_13.4.0-dev"
           rel="noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
FAQ link had the wrong url in web ui. Only impacts master, v14 and v13 branches.

Currently:
https://goteleport.com/ver/14.x/docs/faq?product=teleport&version=e_14.3.0

Should be:

https://goteleport.com/docs/ver/14.x/faq?product=teleport&version=e_14.3.0

