### PR TITLE
Increase minimum password length and account lock interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,16 @@ and instance type has been changed to ARM64/Graviton.
 As a result of this modernization, the legacy monitoring stack configuration
 used with the legacy AMIs has been removed.
 
+### Other changes
+
+#### Increased password length
+
+The minimum password length has been increased to 12 characters.
+
+#### Increased account lockout interval
+
+The account lockout interval has been increased to 30 minutes.
+
 ## 14.0.0 (09/20/23)
 
 Teleport 14 brings the following new major features and improvements:

--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -124,7 +124,7 @@ A local user is blocked from attempting logins if, within a 30 minute window, a 
 - failed login attempts or
 - failed password resets
 
-The block lasts 20 minutes. After the block has expired the user may attempt to log in again.
+The block lasts 30 minutes. After the block has expired the user may attempt to log in again.
 
 Overriding a block is available to users with rights to maintain `user` resources,
 available in the built-in `editor` role. To turn off a block, update the user entry,

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1343,7 +1343,7 @@ type userAuthCreds struct {
 func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, error) {
 	ctx := context.Background()
 	username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
-	password := []byte("abc123")
+	password := []byte("abcdef123456")
 
 	// Enable second factors.
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -760,7 +760,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 
 	// Create user and initial WebAuthn device (MFA).
 	const user = "llama"
-	const password = "p@ssw0rd"
+	const password = "p@ssw0rd1234"
 	_, _, err = CreateUserAndRole(authServer, user, []string{"llama", "root"}, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(user, []byte(password)))

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -212,7 +212,7 @@ func TestSessions(t *testing.T) {
 	ctx := context.Background()
 
 	user := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	_, err := s.a.AuthenticateWebUser(ctx, AuthenticateUserRequest{
 		Username: user,
@@ -263,7 +263,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	require.NoError(t, s.a.CreateRemoteCluster(leaf))
 
 	user := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	// Try to login as an unknown user.
 	_, err = s.a.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
@@ -528,7 +528,7 @@ func TestUserLock(t *testing.T) {
 	ctx := context.Background()
 
 	username := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	_, err := s.a.AuthenticateWebUser(ctx, AuthenticateUserRequest{
 		Username: username,
@@ -556,7 +556,7 @@ func TestUserLock(t *testing.T) {
 	for i := 0; i <= defaults.MaxLoginAttempts; i++ {
 		_, err = s.a.AuthenticateWebUser(ctx, AuthenticateUserRequest{
 			Username: username,
-			Pass:     &PassCreds{Password: []byte("wrong pass")},
+			Pass:     &PassCreds{Password: []byte("wrong password")},
 		})
 		require.Error(t, err)
 	}
@@ -1069,7 +1069,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	ctx := context.Background()
 
 	const username = "llama"
-	const pass = "secret!!1!"
+	const pass = "secret!!1!!!"
 
 	// Use a >1 list of principals.
 	// This is enough to cause ordering issues between the TLS and SSH principal
@@ -1210,9 +1210,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	authServer := testServer.Auth()
 	ctx := context.Background()
 
-	const pass1 = "secret!!1!"
-	const pass2 = "secret!!2!"
-	const pass3 = "secret!!3!"
+	const pass1 = "secret!!1!!!"
+	const pass2 = "secret!!2!!!"
+	const pass3 = "secret!!3!!!"
 
 	// Prepare a few distinct users.
 	user1, _, err := CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
@@ -1659,7 +1659,7 @@ func TestGenerateUserCertIPPinning(t *testing.T) {
 
 	const pinnedUser = "pinnedUser"
 	const unpinnedUser = "unpinnedUser"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	// Create the user without IP pinning
 	_, _, err := CreateUserAndRole(s.a, unpinnedUser, []string{unpinnedUser}, nil)

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -107,7 +107,7 @@ func TestUserNotFound(t *testing.T) {
 
 	s := setupPasswordSuite(t)
 	username := "unknown-user"
-	password := "barbaz"
+	password := "feefiefoefum"
 
 	err := s.a.checkPasswordWOToken(username, []byte(password))
 	require.Error(t, err)
@@ -120,12 +120,12 @@ func TestChangePassword(t *testing.T) {
 	ctx := context.Background()
 
 	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user1", []byte("abc123"), constants.SecondFactorOff)
+	req, err := s.prepareForPasswordChange("user1", []byte("abcdef123456"), constants.SecondFactorOff)
 	require.NoError(t, err)
 
 	fakeClock := clockwork.NewFakeClock()
 	s.a.SetClock(fakeClock)
-	req.NewPassword = []byte("abce456")
+	req.NewPassword = []byte("defceba654321")
 
 	err = s.a.ChangePassword(ctx, req)
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestChangePassword(t *testing.T) {
 	// advance time and make sure we can login again
 	fakeClock.Advance(defaults.AccountLockInterval + time.Second)
 	req.OldPassword = req.NewPassword
-	req.NewPassword = []byte("abc5555")
+	req.NewPassword = []byte("123456abcdef")
 	err = s.a.ChangePassword(ctx, req)
 	require.NoError(t, err)
 }
@@ -145,7 +145,7 @@ func TestChangePasswordWithOTP(t *testing.T) {
 	t.Parallel()
 
 	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user2", []byte("abc123"), constants.SecondFactorOTP)
+	req, err := s.prepareForPasswordChange("user2", []byte("abcdef123456"), constants.SecondFactorOTP)
 	require.NoError(t, err)
 
 	fakeClock := clockwork.NewFakeClock()
@@ -162,7 +162,7 @@ func TestChangePasswordWithOTP(t *testing.T) {
 	require.NoError(t, err)
 
 	// change password
-	req.NewPassword = []byte("abce456")
+	req.NewPassword = []byte("defceba654321")
 	req.SecondFactorToken = validToken
 	err = s.a.ChangePassword(ctx, req)
 	require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestChangePasswordWithOTP(t *testing.T) {
 
 	validToken, _ = totp.GenerateCode(otpSecret, s.a.GetClock().Now())
 	req.OldPassword = req.NewPassword
-	req.NewPassword = []byte("abc5555")
+	req.NewPassword = []byte("123456abcdef")
 	req.SecondFactorToken = validToken
 	err = s.a.ChangePassword(ctx, req)
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
-					NewPassword: []byte("password1"),
+					NewPassword: []byte("password1357"),
 				}
 			},
 		},
@@ -304,7 +304,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
-					NewPassword:            []byte("password2"),
+					NewPassword:            []byte("password2468"),
 					NewMFARegisterResponse: registerSolved,
 				}
 			},
@@ -312,7 +312,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
-					NewPassword: []byte("password2"),
+					NewPassword: []byte("password2468"),
 					NewMFARegisterResponse: &proto.MFARegisterResponse{
 						Response: &proto.MFARegisterResponse_Webauthn{
 							Webauthn: &wanpb.CredentialCreationResponse{},
@@ -348,7 +348,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
-					NewPassword:            []byte("password3"),
+					NewPassword:            []byte("password3579"),
 					NewMFARegisterResponse: registerSolved,
 				}
 			},
@@ -356,7 +356,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
-					NewPassword: []byte("password3"),
+					NewPassword: []byte("password3579"),
 					NewMFARegisterResponse: &proto.MFARegisterResponse{
 						Response: &proto.MFARegisterResponse_TOTP{},
 					},
@@ -430,7 +430,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:                resetTokenID,
-					NewPassword:            []byte("password4"),
+					NewPassword:            []byte("password4680"),
 					NewMFARegisterResponse: registerSolved,
 					NewDeviceName:          "new-device",
 				}
@@ -439,7 +439,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 			getInvalidReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
-					NewPassword: []byte("password4"),
+					NewPassword: []byte("password4680"),
 				}
 			},
 		},
@@ -460,7 +460,7 @@ func TestChangeUserAuthentication(t *testing.T) {
 			getReq: func(t *testing.T, resetTokenID string) *proto.ChangeUserAuthenticationRequest {
 				return &proto.ChangeUserAuthenticationRequest{
 					TokenID:     resetTokenID,
-					NewPassword: []byte("password5"),
+					NewPassword: []byte("password5791"),
 				}
 			},
 		},
@@ -538,7 +538,7 @@ func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	validPassword := []byte("qweQWE1")
+	validPassword := []byte("qwertyQWERTY1")
 	validTokenID := token.GetName()
 
 	type testCase struct {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1287,7 +1287,7 @@ func TestPasswordCRUD(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
@@ -1318,7 +1318,7 @@ func TestOTPCRUD(t *testing.T) {
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
 	user := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
@@ -1372,7 +1372,7 @@ func TestWebSessionWithoutAccessRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	user := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
@@ -1462,7 +1462,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 
 	// Create user and roles.
 	username := "user"
-	password := []byte("hunter2")
+	password := []byte("hunter2hunter2")
 	baseRoleName := services.RoleNameForUser(username)
 	requestableRoleName := "requestable"
 	user, err := CreateUserRoleAndRequestable(clt, username, requestableRoleName)
@@ -1657,7 +1657,7 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	require.NoError(t, err)
 
 	user := "user2"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	newUser, err := CreateUserRoleAndRequestable(clt, user, "test-request-role")
 	require.NoError(t, err)
@@ -1770,7 +1770,7 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	require.NoError(t, err)
 
 	user := "user2"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	newUser, _, err := CreateUserAndRole(clt, user, nil, nil)
 	require.NoError(t, err)
@@ -1835,7 +1835,7 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 
 	const user = "user2"
 	const testRequestRole = "test-request-role"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	newUser, err := CreateUserRoleAndRequestable(adminClient, user, testRequestRole)
 	require.NoError(t, err)
@@ -2712,7 +2712,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 	require.NoError(t, err)
 
 	user := "ws-test"
-	pass := []byte("ws-abc123")
+	pass := []byte("ws-abcdef123456")
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
@@ -2745,7 +2745,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 	// authentication attempt fails with wrong password
 	_, err = proxy.AuthenticateWebUser(ctx, AuthenticateUserRequest{
 		Username: user,
-		OTP:      &OTPCreds{Password: []byte("wrong123"), Token: validToken},
+		OTP:      &OTPCreds{Password: []byte("wrong password"), Token: validToken},
 	})
 	require.True(t, trace.IsAccessDenied(err))
 
@@ -2797,7 +2797,7 @@ func TestLoginAttempts(t *testing.T) {
 	require.NoError(t, err)
 
 	user := "user1"
-	pass := []byte("abc123")
+	pass := []byte("abcdef123456")
 
 	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
@@ -2811,7 +2811,7 @@ func TestLoginAttempts(t *testing.T) {
 	req := AuthenticateUserRequest{
 		Username: user,
 		Pass: &PassCreds{
-			Password: []byte("bad pass"),
+			Password: []byte("wrong password"),
 		},
 	}
 	// authentication attempt fails with bad password
@@ -2886,7 +2886,7 @@ func TestChangeUserAuthenticationSettings(t *testing.T) {
 
 		_, err = testSrv.Auth().ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{
 			TokenID:                token.GetName(),
-			NewPassword:            []byte("qweqweqwe"),
+			NewPassword:            []byte("qweqweqweqwe"),
 			NewMFARegisterResponse: registerSolved,
 		})
 		require.NoError(t, err)
@@ -2919,7 +2919,7 @@ func TestChangeUserAuthenticationSettings(t *testing.T) {
 
 		_, err = testSrv.Auth().ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{
 			TokenID:                tokenID,
-			NewPassword:            []byte("qweqweqwe"),
+			NewPassword:            []byte("qweqweqweqwe"),
 			NewMFARegisterResponse: resp,
 		})
 		require.Error(t, err)
@@ -2939,7 +2939,7 @@ func TestLoginNoLocalAuth(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	user := "foo"
-	pass := []byte("barbaz")
+	pass := []byte("feefiefoefum")
 
 	// Create a local user.
 	clt, err := testSrv.NewClient(TestAdmin())

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -191,8 +191,10 @@ const (
 	// value is used.
 	ProvisioningTokenTTL = 30 * time.Minute
 
-	// MinPasswordLength is minimum password length
-	MinPasswordLength = 6
+	// MinPasswordLength is minimum password length.
+	// PCI DSS v4.0 control 8.3.6 requires a minimum password length of 12 characters.
+	// NIST SP 800-63B section 5.1.1.1 requires a minimum password length of 8 characters.
+	MinPasswordLength = 12
 
 	// MaxPasswordLength is maximum password length (for sanity)
 	MaxPasswordLength = 128
@@ -236,8 +238,9 @@ const (
 	MaxAccountRecoveryAttempts = 3
 
 	// AccountLockInterval defines a time interval during which a user account
-	// is locked after MaxLoginAttempts
-	AccountLockInterval = 20 * time.Minute
+	// is locked after MaxLoginAttempts.
+	// PCI DSS v4.0 control 8.3.4 requires a minimum lockout duration of 30 minutes.
+	AccountLockInterval = 30 * time.Minute
 
 	// AttemptTTL is TTL for login attempt
 	AttemptTTL = time.Minute * 30

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -445,7 +445,7 @@ func TestMux(t *testing.T) {
 		defer backend1.Close()
 
 		_, err = ssh.Dial("tcp", listener.Addr().String(), &ssh.ClientConfig{
-			Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
+			Auth:            []ssh.AuthMethod{ssh.Password("abcdef123456")},
 			Timeout:         time.Second,
 			HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 		})

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -58,7 +58,7 @@ func TestStartStop(t *testing.T) {
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
 		fn,
 		[]ssh.Signer{signer},
-		AuthMethods{Password: pass("abc123")},
+		AuthMethods{Password: pass("abcdef123456")},
 	)
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
@@ -73,7 +73,7 @@ func TestStartStop(t *testing.T) {
 	})
 
 	clientConfig := &ssh.ClientConfig{
-		Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
+		Auth:            []ssh.AuthMethod{ssh.Password("abcdef123456")},
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 	clt, err := ssh.Dial("tcp", srv.Addr(), clientConfig)
@@ -112,14 +112,14 @@ func TestShutdown(t *testing.T) {
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
 		fn,
 		[]ssh.Signer{signer},
-		AuthMethods{Password: pass("abc123")},
+		AuthMethods{Password: pass("abcdef123456")},
 		SetShutdownPollPeriod(10*time.Millisecond),
 	)
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
 	clientConfig := &ssh.ClientConfig{
-		Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
+		Auth:            []ssh.AuthMethod{ssh.Password("abcdef123456")},
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 	clt, err := ssh.Dial("tcp", srv.Addr(), clientConfig)
@@ -164,7 +164,7 @@ func TestConfigureCiphers(t *testing.T) {
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
 		fn,
 		[]ssh.Signer{signer},
-		AuthMethods{Password: pass("abc123")},
+		AuthMethods{Password: pass("abcdef123456")},
 		SetCiphers([]string{"aes128-ctr"}),
 	)
 	require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestConfigureCiphers(t *testing.T) {
 		Config: ssh.Config{
 			Ciphers: []string{"aes256-ctr"},
 		},
-		Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
+		Auth:            []ssh.AuthMethod{ssh.Password("abcdef123456")},
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 	_, err = ssh.Dial("tcp", srv.Addr(), &cc)
@@ -186,7 +186,7 @@ func TestConfigureCiphers(t *testing.T) {
 		Config: ssh.Config{
 			Ciphers: []string{"aes128-ctr"},
 		},
-		Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
+		Auth:            []ssh.AuthMethod{ssh.Password("abcdef123456")},
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 	clt, err := ssh.Dial("tcp", srv.Addr(), &cc)
@@ -246,7 +246,7 @@ func TestHostSignerFIPS(t *testing.T) {
 			utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
 			fn,
 			[]ssh.Signer{tt.inSigner},
-			AuthMethods{Password: pass("abc123")},
+			AuthMethods{Password: pass("abcdef123456")},
 			SetCiphers([]string{"aes128-ctr"}),
 			SetFIPS(tt.inFIPS),
 		)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2065,7 +2065,7 @@ func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
 //
 // POST /v1/webapi/sessions/web
 //
-// {"user": "alex", "pass": "abc123", "second_factor_token": "token", "second_factor_type": "totp"}
+// {"user": "alex", "pass": "abcdef123456", "second_factor_token": "token", "second_factor_type": "totp"}
 //
 // # Response
 //
@@ -2373,7 +2373,7 @@ func (h *Handler) getResetPasswordToken(ctx context.Context, tokenID string) (in
 //
 // POST /webapi/mfa/login/begin
 //
-// {"user": "alex", "pass": "abc123"}
+// {"user": "alex", "pass": "abcdef123456"}
 // {"passwordless": true}
 //
 // Successful response:

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -356,8 +356,8 @@ func configureClusterForMFA(t *testing.T, env *webPack, spec *types.AuthPreferen
 
 	// Create user.
 	const user = "llama"
-	const password = "password"
-	env.proxies[0].createUser(ctx, t, user, "root", "password", "" /* otpSecret */, nil /* roles */)
+	const password = "password1234"
+	env.proxies[0].createUser(ctx, t, user, "root", "password1234", "" /* otpSecret */, nil /* roles */)
 
 	// Register device.
 	clt, err := env.server.NewClient(auth.TestUser(user))

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -659,7 +659,7 @@ type authPack struct {
 // user, otp token, created web session and authenticated client.
 func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPack {
 	login := s.user
-	pass := "abc123"
+	pass := "abcdef123456"
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
@@ -711,7 +711,7 @@ func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPac
 }
 
 func (s *WebSuite) authPackWithMFA(t *testing.T, name string, roles ...types.Role) *authPack {
-	const password = "testing"
+	const password = "testing12345"
 	user, err := types.NewUser(name)
 	require.NoError(t, err)
 
@@ -941,7 +941,7 @@ func TestCSRF(t *testing.T) {
 
 	// create a valid user
 	user := "csrfuser"
-	pass := "abc123"
+	pass := "abcdef123456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte("def456"))
 	s.createUser(t, user, user, pass, otpSecret)
 
@@ -988,8 +988,8 @@ func TestPasswordChange(t *testing.T) {
 	require.NoError(t, err)
 
 	req := changePasswordReq{
-		OldPassword:       []byte("abc123"),
-		NewPassword:       []byte("abc1234"),
+		OldPassword:       []byte("abcdef123456"),
+		NewPassword:       []byte("fedcba654321"),
 		SecondFactorToken: validToken,
 	}
 
@@ -1023,7 +1023,7 @@ func TestWebSessionsBadInput(t *testing.T) {
 	t.Parallel()
 	s := newWebSuite(t)
 	user := "bob"
-	pass := "abc123"
+	pass := "abcdef123456"
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
@@ -2444,11 +2444,11 @@ func TestLogin_PrivateKeyEnabledError(t *testing.T) {
 	require.NoError(t, err)
 
 	// create user
-	s.createUser(t, "user1", "root", "password", "")
+	s.createUser(t, "user1", "root", "password1234", "")
 
 	loginReq, err := json.Marshal(CreateSessionReq{
 		User: "user1",
-		Pass: "password",
+		Pass: "password1234",
 	})
 	require.NoError(t, err)
 
@@ -2483,11 +2483,11 @@ func TestLogin(t *testing.T) {
 	require.NoError(t, err)
 
 	// create user
-	s.createUser(t, "user1", "root", "password", "")
+	s.createUser(t, "user1", "root", "password1234", "")
 
 	loginReq, err := json.Marshal(CreateSessionReq{
 		User: "user1",
-		Pass: "password",
+		Pass: "password1234",
 	})
 	require.NoError(t, err)
 
@@ -4810,7 +4810,7 @@ func TestGetAndDeleteMFADevices_WithRecoveryApprovedToken(t *testing.T) {
 
 	// Create a user with a TOTP device.
 	username := "llama"
-	proxy.createUser(ctx, t, username, "root", "password", "some-otp-secret", nil /* roles */)
+	proxy.createUser(ctx, t, username, "root", "password1234", "some-otp-secret", nil /* roles */)
 
 	// Enable second factor.
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -5418,7 +5418,7 @@ func TestChangeUserAuthentication_recoveryCodesReturnedForCloud(t *testing.T) {
 	clt := env.proxies[0].client
 	re, err := clt.ChangeUserAuthentication(ctx, &authproto.ChangeUserAuthenticationRequest{
 		TokenID:     resetToken.GetName(),
-		NewPassword: []byte("abc123"),
+		NewPassword: []byte("abcdef123456"),
 		NewMFARegisterResponse: &authproto.MFARegisterResponse{Response: &authproto.MFARegisterResponse_TOTP{
 			TOTP: &authproto.TOTPRegisterResponse{Code: totpCode},
 		}},
@@ -5449,7 +5449,7 @@ func TestChangeUserAuthentication_recoveryCodesReturnedForCloud(t *testing.T) {
 	// Test valid username (email) returns codes.
 	re, err = clt.ChangeUserAuthentication(ctx, &authproto.ChangeUserAuthenticationRequest{
 		TokenID:     resetToken.GetName(),
-		NewPassword: []byte("abc123"),
+		NewPassword: []byte("abcdef123456"),
 		NewMFARegisterResponse: &authproto.MFARegisterResponse{Response: &authproto.MFARegisterResponse_TOTP{
 			TOTP: &authproto.TOTPRegisterResponse{Code: totpCode},
 		}},
@@ -5511,7 +5511,7 @@ func TestChangeUserAuthentication_WithPrivacyPolicyEnabledError(t *testing.T) {
 	clt := env.proxies[0].newClient(t)
 	req := changeUserAuthenticationRequest{
 		SecondFactorToken: totpCode,
-		Password:          []byte("abc123"),
+		Password:          []byte("abcdef123456"),
 		TokenID:           resetToken.GetName(),
 	}
 	httpReqData, err := json.Marshal(req)
@@ -5577,7 +5577,7 @@ func TestChangeUserAuthentication_settingDefaultClusterAuthPreference(t *testing
 		name:                 "first cloud sign-in with password does not change connector",
 		cloud:                true,
 		numberOfUsers:        1,
-		password:             []byte("abc123"),
+		password:             []byte("abcdef123456"),
 		authPreferenceType:   constants.Local,
 		initialConnectorName: "",
 		resultConnectorName:  "",
@@ -7960,7 +7960,7 @@ type testProxy struct {
 func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Role) *authPack {
 	ctx := context.Background()
 	const (
-		pass      = "abc123"
+		pass      = "abcdef123456"
 		rawSecret = "def456"
 	)
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -92,7 +92,7 @@ import (
 )
 
 const (
-	mockHeadlessPassword = "password"
+	mockHeadlessPassword = "password1234"
 	staticToken          = "test-static-token"
 	// tshBinMainTestEnv allows to execute tsh main function from test binary.
 	tshBinMainTestEnv = "TSH_BIN_MAIN_TEST"

--- a/web/packages/shared/components/FormPassword/FormPassword.test.tsx
+++ b/web/packages/shared/components/FormPassword/FormPassword.test.tsx
@@ -39,7 +39,7 @@ const placeholdConfirm = /confirm password/i;
 
 const btnSubmitText = /update password/i;
 
-const inputValText = 'aaaaaa';
+const inputValText = 'aaaaaaaaaaaa';
 const inputVal = { target: { value: inputValText } };
 
 test('input validation error states', async () => {
@@ -60,7 +60,7 @@ test('input validation error states', async () => {
   expect(onChangePassWithWebauthn).not.toHaveBeenCalled();
 
   expect(screen.getByText(/current password is required/i)).toBeInTheDocument();
-  expect(screen.getByText(/enter at least 6 characters/i)).toBeInTheDocument();
+  expect(screen.getByText(/enter at least 12 characters/i)).toBeInTheDocument();
   expect(screen.getByText(/please confirm your password/i)).toBeInTheDocument();
   expect(screen.getByText(/token is required/i)).toBeInTheDocument();
 });

--- a/web/packages/shared/components/Validation/rules.test.ts
+++ b/web/packages/shared/components/Validation/rules.test.ts
@@ -54,7 +54,7 @@ describe('requiredToken', () => {
 });
 
 describe('requiredPassword', () => {
-  const errMsg = 'Enter at least 6 characters';
+  const errMsg = 'Enter at least 12 characters';
 
   test.each`
     password            | expected
@@ -107,12 +107,12 @@ describe('requiredConfirmedPassword', () => {
   const confirmError = 'Please confirm your password';
 
   test.each`
-    password       | confirmPassword | expected
-    ${'pwd123'}    | ${'pwd123'}     | ${{ valid: true }}
-    ${''}          | ${'mismatch'}   | ${{ valid: false, message: mismatchError }}
-    ${null}        | ${'mismatch'}   | ${{ valid: false, message: mismatchError }}
-    ${'mistmatch'} | ${null}         | ${{ valid: false, message: confirmError }}
-    ${null}        | ${null}         | ${{ valid: false, message: confirmError }}
+    password          | confirmPassword   | expected
+    ${'password1234'} | ${'password1234'} | ${{ valid: true }}
+    ${''}             | ${'mismatch'}     | ${{ valid: false, message: mismatchError }}
+    ${null}           | ${'mismatch'}     | ${{ valid: false, message: mismatchError }}
+    ${'mistmatch'}    | ${null}           | ${{ valid: false, message: confirmError }}
+    ${null}           | ${null}           | ${{ valid: false, message: confirmError }}
   `(
     'password: $password, confirmPassword: $confirmPassword',
     ({ password, confirmPassword, expected }) => {

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -60,10 +60,10 @@ const requiredToken: Rule = value => () => {
 };
 
 const requiredPassword: Rule = value => () => {
-  if (!value || value.length < 6) {
+  if (!value || value.length < 12) {
     return {
       valid: false,
-      message: 'Enter at least 6 characters',
+      message: 'Enter at least 12 characters',
     };
   }
 

--- a/web/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -134,15 +134,15 @@ describe('teleport/components/Welcome', () => {
     const pwdConfirmField = screen.getByPlaceholderText('Confirm Password');
 
     // fill out input boxes and trigger submit
-    fireEvent.change(pwdField, { target: { value: 'pwd_value' } });
-    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value' } });
+    fireEvent.change(pwdField, { target: { value: 'pwd_value_123' } });
+    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value_123' } });
     fireEvent.click(screen.getByRole('button'));
 
     expect(auth.resetPassword).toHaveBeenCalledWith(
       expect.objectContaining({
         req: {
           tokenId: '5182',
-          password: 'pwd_value',
+          password: 'pwd_value_123',
           otpCode: '',
           deviceName: '',
         },
@@ -161,8 +161,8 @@ describe('teleport/components/Welcome', () => {
     // Fill out password.
     const pwdField = await screen.findByPlaceholderText('Password');
     const pwdConfirmField = screen.getByPlaceholderText('Confirm Password');
-    fireEvent.change(pwdField, { target: { value: 'pwd_value' } });
-    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value' } });
+    fireEvent.change(pwdField, { target: { value: 'pwd_value_123' } });
+    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value_123' } });
 
     // Go to the next view.
     fireEvent.click(screen.getByText(/next/i));
@@ -176,7 +176,7 @@ describe('teleport/components/Welcome', () => {
       expect.objectContaining({
         req: {
           tokenId: '5182',
-          password: 'pwd_value',
+          password: 'pwd_value_123',
           otpCode: '2222',
           deviceName: 'otp-device',
         },
@@ -195,8 +195,8 @@ describe('teleport/components/Welcome', () => {
     // Fill out password.
     const pwdField = await screen.findByPlaceholderText('Password');
     const pwdConfirmField = screen.getByPlaceholderText('Confirm Password');
-    fireEvent.change(pwdField, { target: { value: 'pwd_value' } });
-    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value' } });
+    fireEvent.change(pwdField, { target: { value: 'pwd_value_123' } });
+    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value_123' } });
 
     // Go to the next view.
     fireEvent.click(screen.getByText(/next/i));
@@ -208,7 +208,7 @@ describe('teleport/components/Welcome', () => {
       expect.objectContaining({
         req: {
           tokenId: '5182',
-          password: 'pwd_value',
+          password: 'pwd_value_123',
           deviceName: 'webauthn-device',
         },
       })
@@ -279,8 +279,8 @@ describe('teleport/components/Welcome', () => {
     // Fill out password to get to the next screen.
     const pwdField = await screen.findByPlaceholderText('Password');
     const pwdConfirmField = screen.getByPlaceholderText('Confirm Password');
-    fireEvent.change(pwdField, { target: { value: 'pwd_value' } });
-    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value' } });
+    fireEvent.change(pwdField, { target: { value: 'pwd_value_123' } });
+    fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value_123' } });
     fireEvent.click(screen.getByText(/next/i));
 
     // Default radio selection should be webauthn.


### PR DESCRIPTION
* Increase `MinPasswordLength` from 6 to 12 characters
  - PCI DSS v4.0 control 8.3.6 requires a minimum password length of 12 characters.
  - NIST SP 800-63B section 5.1.1.1 requires a minimum password length of 8 characters.
  - Microsoft recommends a [minimum password length of 8 characters](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/minimum-password-length).

* Increase `AccountLockInterval` from 20 to 30 minutes
  - PCI DSS v4.0 control 8.3.4 requires a minimum lockout duration of 30 minutes.

This will contribute to better supporting customers to meet certain compliance requirements.

Ref #1936.
Ref #7687.