### PR TITLE
Add Annotations for TLS Skip Verify and Ignoring Services for Kubernetes App Discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -696,6 +696,10 @@ const (
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
 	DiscoveryAppNameLabel = TeleportNamespace + "/name"
+	// DiscoveryAppInsecureSkipVerify specifies the TLS verification enforcement for a discovered app created from Kubernetes service.
+	DiscoveryAppInsecureSkipVerify = TeleportNamespace + "/insecure-skip-verify"
+	// DiscoveryAppIgnore specifies if a Kubernetes service should be ignored by discovery service.
+	DiscoveryAppIgnore = TeleportNamespace + "/ignore"
 
 	// ReqAnnotationSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationSchedulesLabel = "/schedules"

--- a/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
+++ b/docs/pages/application-access/enroll-kubernetes-applications/reference.mdx
@@ -95,6 +95,28 @@ Controls resulting app name. If present it will override default app name patter
 as a suffix to the annotation value, as `$APP_NAME-$PORT1_NAME`, `$APP_NAME-$PORT2_NAME` etc, where `$APP_NAME` is the name
 set by the annotation.
 
+### `teleport.dev/insecure-skip-verify`
+
+Controls whether TLS certificate verification should be skipped for this app.
+If present and set to `true`, TLS certificate verification will be skipped.
+
+```yaml
+annotations:
+  teleport.dev/insecure-skip-verify: "true"
+```
+
+### `teleport.dev/ignore`
+
+Controls whether this service should be ignored by the Discovery Service.
+This annotation is useful when you want to exclude a service from being imported as an app
+when it matches the Discovery Service config. For example, you may want to exclude a service
+that shares the same labels as another services that you want to import as apps.
+
+```yaml
+annotations:
+  teleport.dev/ignore: "true"
+```
+
 ### `teleport.dev/app-rewrite`
 
 Controls rewrite configuration for Teleport app, if needed. It should

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -191,8 +191,9 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 		Description: fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName),
 		Labels:      labels,
 	}, types.AppSpecV3{
-		URI:     appURI,
-		Rewrite: rewriteConfig,
+		URI:                appURI,
+		Rewrite:            rewriteConfig,
+		InsecureSkipVerify: getTLSInsecureSkipVerify(service.GetAnnotations()),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "could not create an app from Kubernetes service")
@@ -233,6 +234,14 @@ func getAppRewriteConfig(annotations map[string]string) (*types.Rewrite, error) 
 	}
 
 	return &rw, nil
+}
+
+func getTLSInsecureSkipVerify(annotations map[string]string) bool {
+	val := annotations[types.DiscoveryAppInsecureSkipVerify]
+	if val == "" {
+		return false
+	}
+	return val == "true"
 }
 
 func getAppName(serviceName, namespace, clusterName, portName, nameAnnotation string) (string, error) {

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -290,3 +290,28 @@ func TestGetAppLabels(t *testing.T) {
 		require.Equal(t, tt.expected, result)
 	}
 }
+
+func TestInsecureSkipVerify(t *testing.T) {
+	tests := []struct {
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			annotations: map[string]string{types.DiscoveryAppInsecureSkipVerify: "true"},
+			expected:    true,
+		},
+		{
+			annotations: map[string]string{types.DiscoveryAppInsecureSkipVerify: "false"},
+			expected:    false,
+		},
+		{
+			annotations: map[string]string{},
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		result := getTLSInsecureSkipVerify(tt.annotations)
+		require.Equal(t, tt.expected, result)
+	}
+}

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -172,6 +172,11 @@ func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 			continue
 		}
 
+		// If the service is marked with the ignore annotation, skip it.
+		if v := service.GetAnnotations()[types.DiscoveryAppIgnore]; v == "true" {
+			continue
+		}
+
 		g.Go(func() error {
 			protocolAnnotation := service.GetAnnotations()[types.DiscoveryProtocolLabel]
 


### PR DESCRIPTION
This PR extends existing supported annotations to be able to import applications from Kubernetes that require disabling TLS verification.

It also adds `teleport.dev/ignore` annotation when users want to exclude single Kubernetes services from being imported when they share the same labels as other services that must be imported.

Fixes #36328
Fixes #36177

Changelog: Enhance Kubernetes App Discovery functionality to provide the ability to disable specific Service imports and configure the TLS Skip Verify option using an Annotation.