### PR TITLE
[v13] Sanitize backend keys with .. in them.

### DIFF
--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -17,7 +17,6 @@ limitations under the License.
 package backend
 
 import (
-	"bytes"
 	"context"
 	"regexp"
 	"time"
@@ -35,9 +34,9 @@ const errorMessage = "special characters are not allowed in resource names, plea
 var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
 
 // denyPattern matches some unallowed combinations
-var denyPatterns = []string{
-	"//",
-	"..",
+var denyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`//`),
+	regexp.MustCompile(`(^|/)\.\.?(/|$)`),
 }
 
 // isKeySafe checks if the passed in key conforms to whitelist
@@ -48,7 +47,7 @@ func isKeySafe(s []byte) bool {
 // denyPatternsMatch checks if the passed in key conforms to the deny patterns.
 func denyPatternsMatch(s []byte) bool {
 	for _, pattern := range denyPatterns {
-		if bytes.Contains(s, []byte(pattern)) {
+		if pattern.Match(s) {
 			return true
 		}
 	}

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backend
 
 import (
+	"bytes"
 	"context"
 	"regexp"
 	"time"
@@ -34,11 +35,25 @@ const errorMessage = "special characters are not allowed in resource names, plea
 var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
 
 // denyPattern matches some unallowed combinations
-var denyPattern = regexp.MustCompile(`//`)
+var denyPatterns = []string{
+	"//",
+	"..",
+}
 
 // isKeySafe checks if the passed in key conforms to whitelist
 func isKeySafe(s []byte) bool {
-	return allowPattern.Match(s) && !denyPattern.Match(s) && utf8.Valid(s)
+	return allowPattern.Match(s) && !denyPatternsMatch(s) && utf8.Valid(s)
+}
+
+// denyPatternsMatch checks if the passed in key conforms to the deny patterns.
+func denyPatternsMatch(s []byte) bool {
+	for _, pattern := range denyPatterns {
+		if bytes.Contains(s, []byte(pattern)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Sanitizer wraps a Backend implementation to make sure all values requested

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -42,6 +42,50 @@ func TestSanitize(t *testing.T) {
 			assert: require.Error,
 		},
 		{
+			inKey:  []byte("/namespaces/../params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/..params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("/namespaces/."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/./params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("/namespaces/.params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte(".."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("..params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("../params"),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte("."),
+			assert: require.Error,
+		},
+		{
+			inKey:  []byte(".params"),
+			assert: require.NoError,
+		},
+		{
+			inKey:  []byte("./params"),
+			assert: require.Error,
+		},
+		{
 			inKey:  RangeEnd([]byte("a-b/c:d/.e_f/01")),
 			assert: require.NoError,
 		},

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -38,6 +38,10 @@ func TestSanitize(t *testing.T) {
 			assert: require.Error,
 		},
 		{
+			inKey:  []byte("/namespaces/.."),
+			assert: require.Error,
+		},
+		{
 			inKey:  RangeEnd([]byte("a-b/c:d/.e_f/01")),
 			assert: require.NoError,
 		},


### PR DESCRIPTION
Backport #36303 to branch/v13

changelog: Resources named `.` and `..` are no longer allowed. Please review the resources in your Teleport instance and rename any resources with these names before upgrading.
