### PR TITLE
[v14] Fix the access list reminder pagination loop.

### DIFF
--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -19,6 +19,11 @@ spec:
       - resources: ['access_plugin_data']
         verbs: ['update']
 
+      # In order to provide access list review reminders, permissions to access lists
+      # are necessary. This is currently only supported for a subset of plugins.
+      - resources: ['access_list']
+        verbs: ['list', 'read']
+
     # Optional: To display user-friendly names in resource-based Access
     # Requests instead of resource IDs, the plugin also needs permission
     # to list the resources being requested. Include this along with the

--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -19,7 +19,7 @@ spec:
       - resources: ['access_plugin_data']
         verbs: ['update']
 
-      # In order to provide access list review reminders, permissions to access lists
+      # In order to provide access list review reminders, permissions to list and read access lists
       # are necessary. This is currently only supported for a subset of plugins.
       - resources: ['access_list']
         verbs: ['list', 'read']

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -182,14 +182,21 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 // notifyForAccessListReviews will notify if access list review dates are getting close. At the moment, this
 // only supports notifying owners.
 func (a *App) notifyForAccessListReviews(ctx context.Context, accessList *accesslist.AccessList) error {
+	log := logger.Get(ctx)
+
 	// Find the current notification window.
 	now := a.clock.Now()
 	notificationStart := accessList.Spec.Audit.NextAuditDate.Add(-accessList.Spec.Audit.Notifications.Start)
 
+	// If the current time before the notification start time, skip notifications.
+	if now.Before(notificationStart) {
+		log.Debugf("Access list %s is not ready for notifications, notifications start at %s", accessList.GetName(), notificationStart.Format(time.RFC3339))
+		return nil
+	}
+
 	allRecipients := a.fetchRecipients(ctx, accessList, now, notificationStart)
 	if len(allRecipients) == 0 {
-		// Don't return an error here to avoid generating a noisy log.
-		return nil
+		return trace.NotFound("no recipients could be fetched for access list %s", accessList.GetName())
 	}
 
 	// Try to create base notification data with a zero notification date. If these objects already
@@ -215,12 +222,6 @@ func (a *App) fetchRecipients(ctx context.Context, accessList *accesslist.Access
 	log := logger.Get(ctx)
 
 	allRecipients := make(map[string]common.Recipient, len(accessList.Spec.Owners))
-
-	// If the current time before the notification start time, skip notifications.
-	if now.Before(notificationStart) {
-		log.Debugf("Access list %s is not ready for notifications, notifications start at %s", accessList.GetName(), notificationStart.Format(time.RFC3339))
-		return nil
-	}
 
 	// Get the owners from the bot as recipients.
 	for _, owner := range accessList.Spec.Owners {

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -135,14 +135,14 @@ func (a *App) run(ctx context.Context) error {
 			var err error
 			for {
 				var accessLists []*accesslist.AccessList
-				accessLists, nextToken, err = a.apiClient.AccessListClient().ListAccessLists(ctx, 0 /* default page size */, nextToken)
+				accessLists, nextToken, err = a.apiClient.ListAccessLists(ctx, 0 /* default page size */, nextToken)
 				if err != nil {
 					if trace.IsNotImplemented(err) {
 						log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
 						return nil
 					}
 					log.Errorf("error listing access lists: %v", err)
-					continue
+					break
 				}
 
 				for _, accessList := range accessLists {

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -118,40 +118,66 @@ func (a *App) run(ctx context.Context) error {
 	log.Info("Access list monitor is running")
 
 	a.job.SetReady(true)
+
+	select {
+	// Have a short first duration to wait for everything to settle before
+	// trying the first reminder.
+	case <-a.clock.After(30 * time.Second):
+		if err := a.remindIfNecessary(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+	case <-ctx.Done():
+		log.Info("Access list monitor is finished")
+		return nil
+	}
+
 	for {
 		select {
 		case <-a.clock.After(reminderInterval):
-			log.Info("Looking for Access List Review reminders")
-
-			var nextToken string
-			var err error
-			for {
-				var accessLists []*accesslist.AccessList
-				accessLists, nextToken, err = a.apiClient.ListAccessLists(ctx, 0 /* default page size */, nextToken)
-				if err != nil {
-					if trace.IsNotImplemented(err) {
-						log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
-						return nil
-					}
-					log.Errorf("error listing access lists: %v", err)
-					break
-				}
-
-				for _, accessList := range accessLists {
-					if err := a.notifyForAccessListReviews(ctx, accessList); err != nil {
-						log.WithError(err).Warn("Error notifying for access list reviews")
-					}
-				}
-
-				if nextToken == "" {
-					break
-				}
+			if err := a.remindIfNecessary(ctx); err != nil {
+				return trace.Wrap(err)
 			}
 		case <-ctx.Done():
 			log.Info("Access list monitor is finished")
 			return nil
 		}
 	}
+}
+
+// remindIfNecessary will create and send reminders if necessary. The only error this returns is
+// notImplemented, which will cease looking for reminders if the auth server does not support
+// access lists.
+func (a *App) remindIfNecessary(ctx context.Context) error {
+	log := logger.Get(ctx)
+
+	log.Info("Looking for Access List Review reminders")
+
+	var nextToken string
+	var err error
+	for {
+		var accessLists []*accesslist.AccessList
+		accessLists, nextToken, err = a.apiClient.ListAccessLists(ctx, 0 /* default page size */, nextToken)
+		if err != nil {
+			if trace.IsNotImplemented(err) {
+				log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
+				return trace.Wrap(err)
+			}
+			log.Errorf("error listing access lists: %v", err)
+			break
+		}
+
+		for _, accessList := range accessLists {
+			if err := a.notifyForAccessListReviews(ctx, accessList); err != nil {
+				log.WithError(err).Warn("Error notifying for access list reviews")
+			}
+		}
+
+		if nextToken == "" {
+			break
+		}
+	}
+
+	return nil
 }
 
 // notifyForAccessListReviews will notify if access list review dates are getting close. At the moment, this

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -188,7 +188,8 @@ func (a *App) notifyForAccessListReviews(ctx context.Context, accessList *access
 
 	allRecipients := a.fetchRecipients(ctx, accessList, now, notificationStart)
 	if len(allRecipients) == 0 {
-		return trace.NotFound("no recipients could be fetched for access list %s", accessList.GetName())
+		// Don't return an error here to avoid generating a noisy log.
+		return nil
 	}
 
 	// Try to create base notification data with a zero notification date. If these objects already

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -25,14 +25,11 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
-	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
-	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/interval"
 )
 
 const (
@@ -40,6 +37,8 @@ const (
 	oneDay = 24 * time.Hour
 	// oneWeek is the number of days in a week.
 	oneWeek = oneDay * 7
+	// reminderInterval is the interval for sending access list reminders.
+	reminderInterval = 3 * time.Hour
 )
 
 // App is the access list application for plugins. This will notify access list owners
@@ -114,13 +113,6 @@ func (a *App) run(ctx context.Context) error {
 		return nil
 	})
 
-	remindInterval := interval.New(interval.Config{
-		Duration:      time.Hour * 3,
-		FirstDuration: utils.FullJitter(time.Second * 30),
-		Jitter:        retryutils.NewSeventhJitter(),
-		Clock:         a.clock,
-	})
-	defer remindInterval.Stop()
 	log := logger.Get(ctx)
 
 	log.Info("Access list monitor is running")
@@ -128,7 +120,7 @@ func (a *App) run(ctx context.Context) error {
 	a.job.SetReady(true)
 	for {
 		select {
-		case <-remindInterval.Next():
+		case <-a.clock.After(reminderInterval):
 			log.Info("Looking for Access List Review reminders")
 
 			var nextToken string

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -99,6 +99,9 @@ func TestAccessListReminders(t *testing.T) {
 	})
 	require.NoError(t, err)
 	as := server.Auth()
+	t.Cleanup(func() {
+		require.NoError(t, as.Close())
+	})
 
 	bot := &mockMessagingBot{
 		recipients: map[string]*common.Recipient{
@@ -110,7 +113,7 @@ func TestAccessListReminders(t *testing.T) {
 	app.Clock = clock
 	ctx := context.Background()
 	go func() {
-		require.NoError(t, app.Run(ctx))
+		app.Run(ctx)
 	}()
 
 	ready, err := app.WaitReady(ctx)
@@ -203,6 +206,9 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 	})
 	require.NoError(t, err)
 	as := server.Auth()
+	t.Cleanup(func() {
+		require.NoError(t, as.Close())
+	})
 
 	// Use this mock client so that we can force ListAccessLists to return an error.
 	client := &mockClient{
@@ -220,7 +226,7 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 	app.Clock = clock
 	ctx := context.Background()
 	go func() {
-		require.NoError(t, app.Run(ctx))
+		app.Run(ctx)
 	}()
 
 	ready, err := app.WaitReady(ctx)
@@ -239,7 +245,6 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 			return len(client.Calls) == i
 		}, 5*time.Second, 5*time.Millisecond, "timeout waiting for expected number of calls (%d/%d)", len(client.Calls), i)
 	}
-
 }
 
 func advanceAndLookForRecipients(t *testing.T,
@@ -266,8 +271,9 @@ func advanceAndLookForRecipients(t *testing.T,
 		}
 	}
 	clock.Advance(advance)
+	clock.BlockUntil(1)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
-	}, 5*time.Second, 5*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 }

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -94,7 +93,7 @@ func TestAccessListReminders(t *testing.T) {
 	server, err := auth.NewTestServer(auth.TestServerConfig{
 		Auth: auth.TestAuthServerConfig{
 			Dir:   t.TempDir(),
-			Clock: clock,
+			Clock: clockwork.NewFakeClock(),
 		},
 	})
 	require.NoError(t, err)
@@ -201,7 +200,7 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 	server, err := auth.NewTestServer(auth.TestServerConfig{
 		Auth: auth.TestAuthServerConfig{
 			Dir:   t.TempDir(),
-			Clock: clock,
+			Clock: clockwork.NewFakeClock(),
 		},
 	})
 	require.NoError(t, err)
@@ -239,11 +238,11 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 		require.NoError(t, app.Err())
 	})
 
+	clock.BlockUntil(1)
 	for i := 1; i <= 6; i++ {
-		clock.Advance(6 * time.Hour)
-		require.Eventuallyf(t, func() bool {
-			return len(client.Calls) == i
-		}, 5*time.Second, 5*time.Millisecond, "timeout waiting for expected number of calls (%d/%d)", len(client.Calls), i)
+		clock.Advance(3 * time.Hour)
+		clock.BlockUntil(1)
+		client.AssertNumberOfCalls(t, "ListAccessLists", i)
 	}
 }
 
@@ -273,7 +272,5 @@ func advanceAndLookForRecipients(t *testing.T,
 	clock.Advance(advance)
 	clock.BlockUntil(1)
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
-	}, 5*time.Second, 100*time.Millisecond)
+	require.ElementsMatch(t, expectedRecipients, bot.lastReminderRecipients)
 }

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -65,12 +66,12 @@ func (m *mockMessagingBot) SupportedApps() []common.App {
 }
 
 type mockPluginConfig struct {
-	as  *auth.Server
-	bot *mockMessagingBot
+	client teleport.Client
+	bot    *mockMessagingBot
 }
 
 func (m *mockPluginConfig) GetTeleportClient(ctx context.Context) (teleport.Client, error) {
-	return m.as, nil
+	return m.client, nil
 }
 
 func (m *mockPluginConfig) GetRecipients() common.RawRecipientsMap {
@@ -105,7 +106,7 @@ func TestAccessListReminders(t *testing.T) {
 			"owner2": {Name: "owner2"},
 		},
 	}
-	app := common.NewApp(&mockPluginConfig{as: as, bot: bot}, "test-plugin")
+	app := common.NewApp(&mockPluginConfig{client: as, bot: bot}, "test-plugin")
 	app.Clock = clock
 	ctx := context.Background()
 	go func() {
@@ -177,6 +178,68 @@ func TestAccessListReminders(t *testing.T) {
 		}
 		advanceAndLookForRecipients(t, bot, as, clock, 6*time.Hour, accessList, "owner1", "owner2")
 	}
+}
+
+type mockClient struct {
+	mock.Mock
+	teleport.Client
+}
+
+func (m *mockClient) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+	args := m.Called(ctx, pageSize, pageToken)
+	return args.Get(0).([]*accesslist.AccessList), args.String(1), args.Error(2)
+}
+
+func TestAccessListReminders_BadClient(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	server, err := auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			Dir:   t.TempDir(),
+			Clock: clock,
+		},
+	})
+	require.NoError(t, err)
+	as := server.Auth()
+
+	// Use this mock client so that we can force ListAccessLists to return an error.
+	client := &mockClient{
+		Client: as,
+	}
+	client.On("ListAccessLists", mock.Anything, mock.Anything, mock.Anything).Return(([]*accesslist.AccessList)(nil), "", trace.BadParameter("error"))
+
+	bot := &mockMessagingBot{
+		recipients: map[string]*common.Recipient{
+			"owner1": {Name: "owner1"},
+			"owner2": {Name: "owner2"},
+		},
+	}
+	app := common.NewApp(&mockPluginConfig{client: client, bot: bot}, "test-plugin")
+	app.Clock = clock
+	ctx := context.Background()
+	go func() {
+		require.NoError(t, app.Run(ctx))
+	}()
+
+	ready, err := app.WaitReady(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	t.Cleanup(func() {
+		app.Terminate()
+		<-app.Done()
+		require.NoError(t, app.Err())
+	})
+
+	for i := 1; i <= 6; i++ {
+		clock.Advance(6 * time.Hour)
+		require.Eventuallyf(t, func() bool {
+			return len(client.Calls) == i
+		}, 5*time.Second, 5*time.Millisecond, "timeout waiting for expected number of calls (%d/%d)", len(client.Calls), i)
+	}
+
 }
 
 func advanceAndLookForRecipients(t *testing.T,

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 type PluginConfiguration interface {
@@ -51,8 +51,8 @@ type wrappedClient struct {
 	*client.Client
 }
 
-func (w *wrappedClient) AccessListClient() services.AccessLists {
-	return w.Client.AccessListClient()
+func (w *wrappedClient) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+	return w.Client.AccessListClient().ListAccessLists(ctx, pageSize, pageToken)
 }
 
 // wrapAPIClient will wrap the API client such that it conforms to the Teleport plugin client interface.

--- a/integrations/access/common/teleport/client.go
+++ b/integrations/access/common/teleport/client.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // Client aggregates the parts of Teleport API client interface
@@ -34,5 +34,5 @@ type Client interface {
 	SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error)
 	SetAccessRequestState(ctx context.Context, params types.AccessRequestUpdate) error
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
-	AccessListClient() services.AccessLists
+	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 }


### PR DESCRIPTION
Backport #36228 to branch/v14

changelog: Fix spammy logging with access list reminders in Slack plugin when the plugin user lacks access list permissions.
