### PR TITLE
tty_playback: Fix `handlePlaybackAction` panic on unit16 overflow

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -122,6 +122,9 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/web \
     FuzzTdpMFACodecDecodeResponse fuzz_tdp_mfa_codec_decode_response
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/web \
+    FuzzHandlePlaybackAction fuzz_handle_playback_action
+
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
     FuzzReadProxyLineV1 fuzz_read_proxy_linec_v1
 

--- a/lib/web/tty_playback.go
+++ b/lib/web/tty_playback.go
@@ -266,7 +266,7 @@ func handlePlaybackAction(b []byte, p play) error {
 	msgType := b[0]
 	msgLen := binary.BigEndian.Uint16(b[1:])
 
-	if len(b) < int(msgLen+3) {
+	if len(b) < int(msgLen)+3 {
 		return trace.BadParameter("invalid message length")
 	}
 
@@ -349,7 +349,7 @@ This message is used to seek to a new position in the recording.
 
 ### 5 - Resize
 
-This message is used to indicate that the termina was resized.
+This message is used to indicate that the terminal was resized.
 
 - Message ID: 5
 - 2-byte width

--- a/lib/web/tty_playback_test.go
+++ b/lib/web/tty_playback_test.go
@@ -24,9 +24,16 @@ import (
 )
 
 func FuzzHandlePlaybackAction(f *testing.F) {
+	f.Add([]byte{0x3, 0x0, 0x1, 0x0})                                    // Play
+	f.Add([]byte{0x3, 0x0, 0x1, 0x1})                                    // Pause
+	f.Add([]byte{0x4, 0x0, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x0}) // Seek
+	f.Add([]byte{0x0, 0x0})                                              // Invalid length
+	f.Add([]byte{0x0, 0xF, 0x0, 0x0})                                    // Invalid encoded size
+	f.Add([]byte{0x30, 0xff, 0xff, 0x30})                                // Size uint16 overflow
+
 	player := nopPlayer{}
 	f.Fuzz(func(t *testing.T, b []byte) {
-		handlePlaybackAction(b, player)
+		_ = handlePlaybackAction(b, player)
 	})
 }
 


### PR DESCRIPTION
Panic fix followup from https://github.com/gravitational/teleport/pull/36168

Because the addition was happening prior to the `int` cast it was possible to bypass the length check and result in a panic.

In addition this case and others were added as fuzz seeds, and enabled in oss-fuzz.