### PR TITLE
API: Remove fallback support for `SearchUnstructuredEvents` and `StreamUnstructuredSessionEvents`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2489,40 +2489,10 @@ func (c *Client) SearchUnstructuredEvents(ctx context.Context, fromUTC, toUTC ti
 
 	response, err := c.grpc.GetUnstructuredEvents(ctx, request)
 	if err != nil {
-		err = trace.Wrap(err)
-		// If the server does not support the unstructured events API,
-		// fallback to the legacy API.
-		if trace.IsNotImplemented(err) {
-			return c.searchUnstructuredEventsFallback(ctx, fromUTC, toUTC, namespace, eventTypes, limit, order, startKey)
-		}
-		return nil, "", err
-	}
-
-	return response.Items, response.LastKey, nil
-}
-
-// searchUnstructuredEventsFallback is a fallback implementation of the
-// SearchUnstructuredEvents method that is used when the server does not
-// support the unstructured events API.
-// This method converts the events at event handler plugin side, which can cause
-// the plugin to miss some events if the plugin is not updated to the latest
-// version.
-// TODO(tigrato): DELETE IN 15.0.0
-func (c *Client) searchUnstructuredEventsFallback(ctx context.Context, fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, order types.EventOrder, startKey string) ([]*auditlogpb.EventUnstructured, string, error) {
-	eventsRcv, next, err := c.SearchEvents(ctx, fromUTC, toUTC, namespace, eventTypes, limit, order, startKey)
-	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	items := make([]*auditlogpb.EventUnstructured, 0, len(eventsRcv))
-	for _, evt := range eventsRcv {
-		item, err := events.ToUnstructured(evt)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		items = append(items, item)
-	}
-	return items, next, nil
+	return response.Items, response.LastKey, nil
 }
 
 // StreamUnstructuredSessionEvents streams audit events from a given session recording in an unstructured format.
@@ -2539,17 +2509,7 @@ func (c *Client) StreamUnstructuredSessionEvents(ctx context.Context, sessionID 
 
 	stream, err := c.grpc.StreamUnstructuredSessionEvents(ctx, request)
 	if err != nil {
-		if trace.IsNotImplemented(trace.Wrap(err)) {
-			// If the server does not support the unstructured events API,
-			// fallback to the legacy API.
-			// This code patch shouldn't be triggered because the server
-			// returns the error only if the client calls Recv() on the stream.
-			// However, we keep this code patch here just in case there is a bug
-			// on the client grpc side.
-			c.streamUnstructuredSessionEventsFallback(ctx, sessionID, startIndex, ch, e)
-		} else {
-			e <- trace.Wrap(trace.Wrap(err))
-		}
+		e <- trace.Wrap(trace.Wrap(err))
 		return ch, e
 	}
 	go func() {
@@ -2557,20 +2517,6 @@ func (c *Client) StreamUnstructuredSessionEvents(ctx context.Context, sessionID 
 			event, err := stream.Recv()
 			if err != nil {
 				if err != io.EOF {
-					// If the server does not support the unstructured events API, it will
-					// return an error with code Unimplemented. This error is received
-					// the first time the client calls Recv() on the stream.
-					// If the client receives this error, it should fallback to the legacy
-					// API that spins another goroutine to convert the events to the
-					// unstructured format and sends them to the channel ch.
-					// Once we decide to spin the goroutine, we can leave this loop without
-					// reporting any error to the caller.
-					if trace.IsNotImplemented(trace.Wrap(err)) {
-						// If the server does not support the unstructured events API,
-						// fallback to the legacy API.
-						go c.streamUnstructuredSessionEventsFallback(ctx, sessionID, startIndex, ch, e)
-						return
-					}
 					e <- trace.Wrap(trace.Wrap(err))
 				} else {
 					close(ch)
@@ -2588,61 +2534,6 @@ func (c *Client) StreamUnstructuredSessionEvents(ctx context.Context, sessionID 
 	}()
 
 	return ch, e
-}
-
-// streamUnstructuredSessionEventsFallback is a fallback implementation of the
-// StreamUnstructuredSessionEvents method that is used when the server does not
-// support the unstructured events API. This method uses the old API to stream
-// events from the server and converts them to the unstructured format. This
-// method converts the events at event handler plugin side, which can cause
-// the plugin to miss some events if the plugin is not updated to the latest
-// version.
-// TODO(tigrato): DELETE IN 15.0.0
-func (c *Client) streamUnstructuredSessionEventsFallback(ctx context.Context, sessionID string, startIndex int64, ch chan *auditlogpb.EventUnstructured, e chan error) {
-	request := &proto.StreamSessionEventsRequest{
-		SessionID:  sessionID,
-		StartIndex: int32(startIndex),
-	}
-
-	stream, err := c.grpc.StreamSessionEvents(ctx, request)
-	if err != nil {
-		e <- trace.Wrap(err)
-		return
-	}
-
-	go func() {
-		for {
-			oneOf, err := stream.Recv()
-			if err != nil {
-				if err != io.EOF {
-					e <- trace.Wrap(trace.Wrap(err))
-				} else {
-					close(ch)
-				}
-
-				return
-			}
-
-			event, err := events.FromOneOf(*oneOf)
-			if err != nil {
-				e <- trace.Wrap(trace.Wrap(err))
-				return
-			}
-
-			unstructedEvent, err := events.ToUnstructured(event)
-			if err != nil {
-				e <- trace.Wrap(err)
-				return
-			}
-
-			select {
-			case ch <- unstructedEvent:
-			case <-ctx.Done():
-				e <- trace.Wrap(ctx.Err())
-				return
-			}
-		}
-	}()
 }
 
 // SearchSessionEvents allows searching for session events with a full pagination support.


### PR DESCRIPTION
This PR removes the fallback introduced in Teleport 13 to deal with servers that do not support the new `UnstructureEvents` grpc service introduced in Teleport 13.

Once Teleport 15 is released, we no longer need to maintain Teleport 12 so this code can be removed.