### PR TITLE
Add command for configuring EKS IAM access for Discover

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -135,6 +135,22 @@ func StatementForEC2InstanceConnectEndpoint() *Statement {
 	}
 }
 
+// StatementForEKSAccess returns the statement that allows enrolling of EKS clusters into Teleport.
+func StatementForEKSAccess() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"eks:ListClusters",
+			"eks:DescribeCluster",
+			"eks:ListAccessEntries",
+			"eks:CreateAccessEntry",
+			"eks:DeleteAccessEntry",
+			"eks:AssociateAccessPolicy",
+		},
+		Resources: allResources,
+	}
+}
+
 // StatementForAWSOIDCRoleTrustRelationship returns the Trust Relationship to allow the OpenID Connect Provider
 // set up during the AWS OIDC Onboarding to assume this Role.
 func StatementForAWSOIDCRoleTrustRelationship(accountID, providerURL string, audiences []string) *Statement {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -211,6 +211,10 @@ type CommandLineFlags struct {
 	// `teleport integration configure eice-iam` command
 	IntegrationConfEICEIAMArguments IntegrationConfEICEIAM
 
+	// IntegrationConfEKSIAMArguments contains the arguments of
+	// `teleport integration configure eks-iam` command
+	IntegrationConfEKSIAMArguments IntegrationConfEKSIAM
+
 	// IntegrationConfAWSOIDCIdPArguments contains the arguments of
 	// `teleport integration configure awsoidc-idp` command
 	IntegrationConfAWSOIDCIdPArguments IntegrationConfAWSOIDCIdP
@@ -242,6 +246,15 @@ type IntegrationConfDeployServiceIAM struct {
 // IntegrationConfEICEIAM contains the arguments of
 // `teleport integration configure eice-iam` command
 type IntegrationConfEICEIAM struct {
+	// Region is the AWS Region used to set up the client.
+	Region string
+	// Role is the AWS Role associated with the Integration
+	Role string
+}
+
+// IntegrationConfEKSIAM contains the arguments of
+// `teleport integration configure eks-iam` command
+type IntegrationConfEKSIAM struct {
 	// Region is the AWS Region used to set up the client.
 	Region string
 	// Role is the AWS Role associated with the Integration

--- a/lib/integrations/awsoidc/clientsv1_test.go
+++ b/lib/integrations/awsoidc/clientsv1_test.go
@@ -97,7 +97,7 @@ func TestNewSessionV1(t *testing.T) {
 			name:        "not found error when integration is missing",
 			region:      "us-dummy-1",
 			integration: "not-found",
-			expectedErr: notFounCheck,
+			expectedErr: notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -39,7 +39,7 @@ var alreadyExistsCheck = func(t require.TestingT, err error, msgAndArgs ...inter
 	require.True(t, trace.IsAlreadyExists(err), `expected "already exists", but got %v`, err)
 }
 
-var notFounCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+var notFoundCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
 	require.True(t, trace.IsNotFound(err), `expected "not found", but got %v`, err)
 }
 
@@ -180,7 +180,7 @@ func TestDeployServiceIAMConfig(t *testing.T) {
 			mockExistingPolicies: []string{},
 			mockExistingRoles:    []string{},
 			req:                  baseReq,
-			errCheck:             notFounCheck,
+			errCheck:             notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/integrations/awsoidc/eice_iam_config_test.go
+++ b/lib/integrations/awsoidc/eice_iam_config_test.go
@@ -110,7 +110,7 @@ func TestEICEIAMConfig(t *testing.T) {
 			name:              "integration role does not exist",
 			mockExistingRoles: []string{},
 			req:               baseReq,
-			errCheck:          notFounCheck,
+			errCheck:          notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/integrations/awsoidc/eks_iam_config.go
+++ b/lib/integrations/awsoidc/eks_iam_config.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	// defaultPolicyNameForEKS is the default name for the Inline EKS Policy added to the IntegrationRole.
+	defaultPolicyNameForEKS = "EKSAccess"
+)
+
+// EKSIAMConfigureRequest is a request to configure the required Policies to use the EKS.
+type EKSIAMConfigureRequest struct {
+	// Region is the AWS Region.
+	// Used to set up the AWS SDK Client.
+	Region string
+
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+
+	// IntegrationRoleEKSPolicy is the Policy Name that is created to allow access to call AWS APIs.
+	// Defaults to "EKSAccess"
+	IntegrationRoleEKSPolicy string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *EKSIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.IntegrationRoleEKSPolicy == "" {
+		r.IntegrationRoleEKSPolicy = defaultPolicyNameForEKS
+	}
+
+	return nil
+}
+
+// EKSIAMConfigureClient describes the required methods to create the IAM Policies required for enrolling EKS clusters into Teleport.
+type EKSIAMConfigureClient interface {
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultEKSEIAMConfigureClient struct {
+	*iam.Client
+}
+
+// NewEKSIAMConfigureClient creates a new EKSIAMConfigureClient.
+func NewEKSIAMConfigureClient(ctx context.Context, region string) (EKSIAMConfigureClient, error) {
+	if region == "" {
+		return nil, trace.BadParameter("region is required")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultEKSEIAMConfigureClient{
+		Client: iam.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureEKSIAM sets up the roles required for enrolling EKS clusters into Teleport.
+// It creates an embedded policy with the following permissions:
+// - eks:ListClusters
+// - eks:DescribeCluster
+// - eks:ListAccessEntries
+// - eks:CreateAccessEntry
+// - eks:DeleteAccessEntry
+// - eks:AssociateAccessPolicy
+//
+// For more info about EKS access entries see:
+// https://aws.amazon.com/blogs/containers/a-deep-dive-into-simplified-amazon-eks-access-management-controls/
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - iam:PutRolePolicy
+func ConfigureEKSIAM(ctx context.Context, clt EKSIAMConfigureClient, req EKSIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	eksPolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForEKSAccess(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.IntegrationRoleEKSPolicy,
+		RoleName:       &req.IntegrationRole,
+		PolicyDocument: &eksPolicyDocument,
+	})
+	if err != nil {
+		if trace.IsNotFound(awslib.ConvertIAMv2Error(err)) {
+			return trace.NotFound("role %q not found.", req.IntegrationRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleEKSPolicy, req.IntegrationRole)
+	return nil
+}

--- a/lib/integrations/awsoidc/eks_iam_config_test.go
+++ b/lib/integrations/awsoidc/eks_iam_config_test.go
@@ -21,12 +21,12 @@ package awsoidc
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/stretchr/testify/require"
-	"slices"
 )
 
 func TestEKSIAMConfigReqDefaults(t *testing.T) {

--- a/lib/integrations/awsoidc/eks_iam_config_test.go
+++ b/lib/integrations/awsoidc/eks_iam_config_test.go
@@ -30,22 +30,18 @@ import (
 )
 
 func TestEKSIAMConfigReqDefaults(t *testing.T) {
-	baseReq := func() EKSIAMConfigureRequest {
-		return EKSIAMConfigureRequest{
-			Region:          "us-east-1",
-			IntegrationRole: "integrationRole",
-		}
-	}
-
 	for _, tt := range []struct {
 		name     string
-		req      func() EKSIAMConfigureRequest
+		req      EKSIAMConfigureRequest
 		errCheck require.ErrorAssertionFunc
 		expected EKSIAMConfigureRequest
 	}{
 		{
-			name:     "set defaults",
-			req:      baseReq,
+			name: "set defaults",
+			req: EKSIAMConfigureRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationRole",
+			},
 			errCheck: require.NoError,
 			expected: EKSIAMConfigureRequest{
 				Region:                   "us-east-1",
@@ -55,25 +51,21 @@ func TestEKSIAMConfigReqDefaults(t *testing.T) {
 		},
 		{
 			name: "missing region",
-			req: func() EKSIAMConfigureRequest {
-				req := baseReq()
-				req.Region = ""
-				return req
+			req: EKSIAMConfigureRequest{
+				IntegrationRole: "integrationRole",
 			},
 			errCheck: badParameterCheck,
 		},
 		{
 			name: "missing integration role",
-			req: func() EKSIAMConfigureRequest {
-				req := baseReq()
-				req.IntegrationRole = ""
-				return req
+			req: EKSIAMConfigureRequest{
+				Region: "us-east-1",
 			},
 			errCheck: badParameterCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			req := tt.req()
+			req := tt.req
 			err := req.CheckAndSetDefaults()
 			tt.errCheck(t, err)
 			if err != nil {
@@ -87,30 +79,30 @@ func TestEKSIAMConfigReqDefaults(t *testing.T) {
 
 func TestEKSAMConfig(t *testing.T) {
 	ctx := context.Background()
-	baseReq := func() EKSIAMConfigureRequest {
-		return EKSIAMConfigureRequest{
-			Region:          "us-east-1",
-			IntegrationRole: "integrationRole",
-		}
-	}
 
 	for _, tt := range []struct {
 		name              string
 		mockExistingRoles []string
-		req               func() EKSIAMConfigureRequest
+		req               EKSIAMConfigureRequest
 		errCheck          require.ErrorAssertionFunc
 	}{
 		{
-			name:              "valid",
-			req:               baseReq,
+			name: "valid",
+			req: EKSIAMConfigureRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationRole",
+			},
 			mockExistingRoles: []string{"integrationRole"},
 			errCheck:          require.NoError,
 		},
 		{
 			name:              "integration role does not exist",
 			mockExistingRoles: []string{},
-			req:               baseReq,
-			errCheck:          notFounCheck,
+			req: EKSIAMConfigureRequest{
+				Region:          "us-east-1",
+				IntegrationRole: "integrationRole",
+			},
+			errCheck: notFounCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,7 +110,7 @@ func TestEKSAMConfig(t *testing.T) {
 				existingRoles: tt.mockExistingRoles,
 			}
 
-			err := ConfigureEKSIAM(ctx, &clt, tt.req())
+			err := ConfigureEKSIAM(ctx, &clt, tt.req)
 			tt.errCheck(t, err)
 		})
 	}

--- a/lib/integrations/awsoidc/eks_iam_config_test.go
+++ b/lib/integrations/awsoidc/eks_iam_config_test.go
@@ -1,0 +1,140 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/require"
+	"slices"
+)
+
+func TestEKSIAMConfigReqDefaults(t *testing.T) {
+	baseReq := func() EKSIAMConfigureRequest {
+		return EKSIAMConfigureRequest{
+			Region:          "us-east-1",
+			IntegrationRole: "integrationRole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() EKSIAMConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected EKSIAMConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseReq,
+			errCheck: require.NoError,
+			expected: EKSIAMConfigureRequest{
+				Region:                   "us-east-1",
+				IntegrationRole:          "integrationRole",
+				IntegrationRoleEKSPolicy: "EKSAccess",
+			},
+		},
+		{
+			name: "missing region",
+			req: func() EKSIAMConfigureRequest {
+				req := baseReq()
+				req.Region = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration role",
+			req: func() EKSIAMConfigureRequest {
+				req := baseReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestEKSAMConfig(t *testing.T) {
+	ctx := context.Background()
+	baseReq := func() EKSIAMConfigureRequest {
+		return EKSIAMConfigureRequest{
+			Region:          "us-east-1",
+			IntegrationRole: "integrationRole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name              string
+		mockExistingRoles []string
+		req               func() EKSIAMConfigureRequest
+		errCheck          require.ErrorAssertionFunc
+	}{
+		{
+			name:              "valid",
+			req:               baseReq,
+			mockExistingRoles: []string{"integrationRole"},
+			errCheck:          require.NoError,
+		},
+		{
+			name:              "integration role does not exist",
+			mockExistingRoles: []string{},
+			req:               baseReq,
+			errCheck:          notFounCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockEKSIAMConfigClient{
+				existingRoles: tt.mockExistingRoles,
+			}
+
+			err := ConfigureEKSIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockEKSIAMConfigClient struct {
+	existingRoles []string
+}
+
+// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+func (m *mockEKSIAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
+		return nil, &iamTypes.NoSuchEntityException{
+			Message: &noSuchEntityMessage,
+		}
+	}
+	return nil, nil
+}

--- a/lib/integrations/awsoidc/eks_iam_config_test.go
+++ b/lib/integrations/awsoidc/eks_iam_config_test.go
@@ -102,7 +102,7 @@ func TestEKSAMConfig(t *testing.T) {
 				Region:          "us-east-1",
 				IntegrationRole: "integrationRole",
 			},
-			errCheck: notFounCheck,
+			errCheck: notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -86,7 +86,7 @@ func TestListDatabasesIAMConfig(t *testing.T) {
 			name:              "integration role does not exist",
 			mockExistingRoles: []string{},
 			req:               baseReq,
-			errCheck:          notFounCheck,
+			errCheck:          notFoundCheck,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -472,7 +472,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEICECmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Region)
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
 
-	integrationConfEKSCmd := integrationConfigureCmd.Command("eks-iam", "Adds required IAM permissions for enrollment of EKS clusters to Teleport..")
+	integrationConfEKSCmd := integrationConfigureCmd.Command("eks-iam", "Adds required IAM permissions for enrollment of EKS clusters to Teleport.")
 	integrationConfEKSCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Region)
 	integrationConfEKSCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Role)
 

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -472,6 +472,10 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEICECmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Region)
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
 
+	integrationConfEKSCmd := integrationConfigureCmd.Command("eks-iam", "Adds required IAM permissions for enrollment of EKS clusters to Teleport..")
+	integrationConfEKSCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Region)
+	integrationConfEKSCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Role)
+
 	integrationConfAWSOIDCIdPCmd := integrationConfigureCmd.Command("awsoidc-idp", "Creates an IAM IdP (OIDC) in your AWS account to allow the AWS OIDC Integration to access AWS APIs.")
 	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster name.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Cluster)
@@ -592,6 +596,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onIntegrationConfDeployService(ccf.IntegrationConfDeployServiceIAMArguments)
 	case integrationConfEICECmd.FullCommand():
 		err = onIntegrationConfEICEIAM(ccf.IntegrationConfEICEIAMArguments)
+	case integrationConfEKSCmd.FullCommand():
+		err = onIntegrationConfEKSIAM(ccf.IntegrationConfEKSIAMArguments)
 	case integrationConfAWSOIDCIdPCmd.FullCommand():
 		err = onIntegrationConfAWSOIDCIdP(ccf.IntegrationConfAWSOIDCIdPArguments)
 	case integrationConfListDatabasesCmd.FullCommand():
@@ -963,6 +969,25 @@ func onIntegrationConfEICEIAM(params config.IntegrationConfEICEIAM) error {
 	}
 
 	err = awsoidc.ConfigureEICEIAM(ctx, iamClient, awsoidc.EICEIAMConfigureRequest{
+		Region:          params.Region,
+		IntegrationRole: params.Role,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func onIntegrationConfEKSIAM(params config.IntegrationConfEKSIAM) error {
+	ctx := context.Background()
+
+	iamClient, err := awsoidc.NewEKSIAMConfigureClient(ctx, params.Region)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = awsoidc.ConfigureEKSIAM(ctx, iamClient, awsoidc.EKSIAMConfigureRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
 	})


### PR DESCRIPTION
This PR adds backend code for configuring EKS IAM access that will be used for automatic EKS clusters enrolment through the Discover.