### PR TITLE
lock: Remove deprecated lock per `node`

### DIFF
--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -210,13 +210,6 @@ func (c *LockV2) CheckAndSetDefaults() error {
 	if c.Spec.Target.IsEmpty() {
 		return trace.BadParameter("at least one target field must be set")
 	}
-	// If the user specifies a server ID but not a node, copy the server ID to the node
-	// field. This is for backwards compatibility with previous versions of Teleport
-	// so that locking a node still works.
-	// TODO: DELETE IN 15.0.0
-	if c.Spec.Target.ServerID != "" && c.Spec.Target.Node == "" {
-		c.Spec.Target.Node = c.Spec.Target.ServerID
-	}
 	return nil
 }
 

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -49,13 +49,6 @@ func (c *LockCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	c.mainCmd.Flag("user", "Name of a Teleport user to disable.").StringVar(&c.spec.Target.User)
 	c.mainCmd.Flag("role", "Name of a Teleport role to disable.").StringVar(&c.spec.Target.Role)
 	c.mainCmd.Flag("login", "Name of a local UNIX user to disable.").StringVar(&c.spec.Target.Login)
-	// Locking a node is now deprecated, but we still support it for backwards compatibility.
-	// Previously, locking a node would lock only the `ssh_service` from that node to
-	// access Teleport but didn't prevent any other roles that the same instance could run.
-	// Now, `tctl lock --server-id` should be used instead to lock the entire server
-	// and all roles that it runs (including the `ssh_service`) from accessing Teleport.
-	// TODO: DELETE IN 15.0.0
-	c.mainCmd.Flag("node", "UUID of a Teleport node to disable.").Hidden().StringVar(&c.spec.Target.Node)
 	c.mainCmd.Flag("mfa-device", "UUID of a user MFA device to disable.").StringVar(&c.spec.Target.MFADevice)
 	c.mainCmd.Flag("windows-desktop", "Name of a Windows desktop to disable.").StringVar(&c.spec.Target.WindowsDesktop)
 	c.mainCmd.Flag("access-request", "UUID of an access request to disable.").StringVar(&c.spec.Target.AccessRequest)
@@ -79,15 +72,6 @@ func (c *LockCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 // CreateLock creates a lock for the main `tctl lock` command.
 func (c *LockCommand) CreateLock(ctx context.Context, client auth.ClientI) error {
-	// Locking a node is now deprecated, but we still support it for backwards compatibility.
-	// Previously, locking a node would lock only the `ssh_service` from that node to
-	// access Teleport but didn't prevent any other roles that the same instance could run.
-	// Now, `tctl lock --server-id` should be used instead to lock the entire server.
-	// TODO: DELETE IN 15.0.0
-	if c.spec.Target.Node != "" {
-		c.config.Log.Warnf("`tctl lock --node <id>` is now deprecated. Please use `tctl lock --server-id <id>` instead.")
-	}
-
 	lockExpiry, err := computeLockExpiry(c.expires, c.ttl)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR removes the ability to configure locks for `ssh` services only. 

This code was deprecated in v13 when we introduce `--server-id` target and in Teleport 15 we remove the ability for users to create locks targeted to `nodes` but we still support existing lock targets.