### PR TITLE
Add web UI changes for configuring EKS IAM access for Discover

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -849,6 +849,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/securitygroups", h.WithClusterAuth(h.awsOIDCListSecurityGroups))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/requireddatabasesvpcs", h.WithClusterAuth(h.awsOIDCRequiredDatabasesVPCS))
 	h.GET("/webapi/scripts/integrations/configure/eice-iam.sh", h.WithLimiter(h.awsOIDCConfigureEICEIAM))
+	h.GET("/webapi/scripts/integrations/configure/eks-iam.sh", h.WithLimiter(h.awsOIDCConfigureEKSIAM))
 
 	// AWS OIDC Integration specific endpoints:
 	// Unauthenticated access to OpenID Configuration - used for AWS OIDC IdP integration

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -357,6 +357,41 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 	return nil, trace.Wrap(err)
 }
 
+// awsOIDCConfigureEKSIAM returns a script that configures the required IAM permissions to enroll EKS clusters into Teleport.
+func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+	queryParams := r.URL.Query()
+
+	awsRegion := queryParams.Get("awsRegion")
+	if err := aws.IsValidRegion(awsRegion); err != nil {
+		return nil, trace.BadParameter("invalid awsRegion")
+	}
+
+	role := queryParams.Get("role")
+	if err := aws.IsValidIAMRoleName(role); err != nil {
+		return nil, trace.BadParameter("invalid role %q", role)
+	}
+
+	// The script must execute the following command:
+	// "teleport integration configure eks-iam"
+	argsList := []string{
+		"integration", "configure", "eks-iam",
+		fmt.Sprintf("--aws-region=%s", awsRegion),
+		fmt.Sprintf("--role=%s", role),
+	}
+	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
+		TeleportArgs:   strings.Join(argsList, " "),
+		SuccessMessage: "Success! You can now go back to the browser to complete the EKS enrollment.",
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	httplib.SetScriptHeaders(w.Header())
+	_, err = fmt.Fprint(w, script)
+
+	return nil, trace.Wrap(err)
+}
+
 // awsOIDCListEC2 returns a list of EC2 Instances using the ListEC2 action of the AWS OIDC Integration.
 func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	ctx := r.Context()

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -363,7 +363,7 @@ func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request,
 
 	awsRegion := queryParams.Get("awsRegion")
 	if err := aws.IsValidRegion(awsRegion); err != nil {
-		return nil, trace.BadParameter("invalid awsRegion")
+		return nil, trace.BadParameter("invalid aws region")
 	}
 
 	role := queryParams.Get("role")

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
+	t.Parallel()
 	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
@@ -159,6 +160,7 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 }
 
 func TestBuildEICEConfigureIAMScript(t *testing.T) {
+	t.Parallel()
 	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
@@ -246,7 +248,97 @@ func TestBuildEICEConfigureIAMScript(t *testing.T) {
 	}
 }
 
+func TestBuildEKSConfigureIAMScript(t *testing.T) {
+	t.Parallel()
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+
+	// Unauthenticated client for script downloading.
+	publicClt := env.proxies[0].newClient(t)
+	pathVars := []string{
+		"webapi",
+		"scripts",
+		"integrations",
+		"configure",
+		"eks-iam.sh",
+	}
+	endpoint := publicClt.Endpoint(pathVars...)
+
+	tests := []struct {
+		name                 string
+		reqRelativeURL       string
+		reqQuery             url.Values
+		errCheck             require.ErrorAssertionFunc
+		expectedTeleportArgs string
+	}{
+		{
+			name: "valid",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure eks-iam " +
+				"--aws-region=us-east-1 " +
+				"--role=myRole",
+		},
+		{
+			name: "valid with symbols in role",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"Test+1=2,3.4@5-6_7"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure eks-iam " +
+				"--aws-region=us-east-1 " +
+				"--role=Test+1=2,3.4@5-6_7",
+		},
+		{
+			name: "missing aws-region",
+			reqQuery: url.Values{
+				"role": []string{"myRole"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing role",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "trying to inject escape sequence into query params",
+			reqQuery: url.Values{
+				"awsRegion": []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":      []string{"role"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			tc.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Contains(t, string(resp.Bytes()),
+				fmt.Sprintf("teleportArgs='%s'\n", tc.expectedTeleportArgs),
+			)
+		})
+	}
+}
+
 func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
+	t.Parallel()
 	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
@@ -560,6 +652,7 @@ func TestAWSOIDCRequiredVPCSHelper(t *testing.T) {
 }
 
 func TestAWSOIDCRequiredVPCSHelper_CombinedSubnetsForAVpcID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newWebPack(t, 1)
 	clt := env.proxies[0].client

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -322,7 +322,6 @@ func TestBuildEKSConfigureIAMScript(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
 			tc.errCheck(t, err)

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.story.tsx
@@ -34,6 +34,16 @@ export const Ec2 = () => {
   );
 };
 
+export const Eks = () => {
+  return (
+    <ConfigureIamPerms
+      kind="eks"
+      region="us-east-1"
+      integrationRoleArn="arn:aws:iam::123456789012:role/some-iam-role-name"
+    />
+  );
+};
+
 export const Rds = () => {
   return (
     <ConfigureIamPerms

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
@@ -28,7 +28,7 @@ import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { Regions } from 'teleport/services/integrations';
 import cfg from 'teleport/config';
 
-type AwsResourceKind = 'rds' | 'ec2';
+type AwsResourceKind = 'rds' | 'ec2' | 'eks';
 
 export function ConfigureIamPerms({
   region,
@@ -72,6 +72,43 @@ export function ConfigureIamPerms({
         "iam:CreateServiceLinkedRole",
         "ec2-instance-connect:SendSSHPublicKey",
         "ec2-instance-connect:OpenTunnel"
+      ],
+      "Resource": "*"
+    }
+  ]
+}`;
+
+      editor = (
+        <EditorWrapper $height={345}>
+          <TextEditor
+            readOnly={true}
+            data={[{ content: json, type: 'json' }]}
+            bg="levels.deep"
+          />
+        </EditorWrapper>
+      );
+      break;
+    }
+    case 'eks': {
+      iamPolicyName = 'EKSAccess';
+      msg = 'We were unable to list your EKS clusters.';
+      scriptUrl = cfg.getEksIamConfigureScriptUrl({
+        region,
+        iamRoleName,
+      });
+
+      const json = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:ListClusters",
+        "eks:DescribeCluster",
+        "eks:ListAccessEntries",
+        "eks:CreateAccessEntry",
+        "eks:DeleteAccessEntry",
+        "eks:AssociateAccessPolicy",
       ],
       "Resource": "*"
     }

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -273,6 +273,8 @@ const cfg = {
       '/webapi/scripts/integrations/configure/listdatabases-iam.sh?awsRegion=:region&role=:iamRoleName',
     awsConfigureIamScriptEc2InstanceConnectPath:
       '/v1/webapi/scripts/integrations/configure/eice-iam.sh?awsRegion=:region&role=:iamRoleName',
+    awsConfigureIamEksScriptPath:
+      '/v1/webapi/scripts/integrations/configure/eks-iam.sh?awsRegion=:region&role=:iamRoleName',
 
     awsRdsDbDeployServicesPath:
       '/webapi/sites/:clusterId/integrations/aws-oidc/:name/deploydatabaseservices',
@@ -962,6 +964,15 @@ const cfg = {
     return (
       cfg.baseUrl +
       generatePath(cfg.api.awsConfigureIamScriptEc2InstanceConnectPath, {
+        ...params,
+      })
+    );
+  },
+
+  getEksIamConfigureScriptUrl(params: UrlAwsConfigureIamScriptParams) {
+    return (
+      cfg.baseUrl +
+      generatePath(cfg.api.awsConfigureIamEksScriptPath, {
         ...params,
       })
     );


### PR DESCRIPTION
This PR adds Web UI-side of configuring EKS IAM access that will be used for automatic EKS clusters enrolment through the Discover.

Depends on #36417