### PR TITLE
Fix PIV custom slot re-login

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3974,10 +3974,6 @@ func (tc *TeleportClient) updatePrivateKeyPolicy(policy keys.PrivateKeyPolicy) e
 	// The current private key was rejected due to an unmet key policy requirement.
 	fmt.Fprintf(tc.Stderr, "Unmet private key policy %q.\n", policy)
 
-	if tc.PIVSlot != "" {
-		return trace.BadParameter("Private key in specified slot %q does not meet the private key policy requirement %q.", tc.PIVSlot, policy)
-	}
-
 	// Set the private key policy to the expected value and re-login.
 	tc.PrivateKeyPolicy = policy
 	return nil


### PR DESCRIPTION
Fix PIV relogin flow when hardware key requirement is set on the user's role and a PIV slot is specified by the server/client.

The removed line would be return an error when a custom PIV slot was provided but the hardware key requirement was not met. There should be no assumption that hardware key login has been attempted just because a custom piv slot was provided. Instead, this should be (and is) handled on the hardware key login level - when a yubikey private key is retrieved, we check if it satisfies the expected hardware key requirement. 