### PR TITLE
[v12] Revert "Ensure expiration of Webauthn sessions"

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -14,12 +14,5 @@
 
 package local
 
-import "github.com/jonboulle/clockwork"
-
 // SessionDataLimiter exports sdLimiter for tests.
 var SessionDataLimiter = sdLimiter
-
-// SetDesyncedClockForTesting sets its namesake clock in the identity service.
-func (s *IdentityService) SetDesyncedClockForTesting(clock clockwork.Clock) {
-	s.desyncedClockForTesting = clock
-}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -57,8 +57,6 @@ var GlobalSessionDataMaxEntries = 5000 // arbitrary
 type IdentityService struct {
 	backend.Backend
 	log logrus.FieldLogger
-	// desyncedClockForTesting is used in tests to desync the service clock from the backend clock.
-	desyncedClockForTesting clockwork.Clock
 }
 
 // NewIdentityService returns a new instance of IdentityService object
@@ -67,13 +65,6 @@ func NewIdentityService(backend backend.Backend) *IdentityService {
 		Backend: backend,
 		log:     logrus.WithField(trace.Component, "identity"),
 	}
-}
-
-func (s *IdentityService) getClock() clockwork.Clock {
-	if s.desyncedClockForTesting != nil {
-		return s.desyncedClockForTesting
-	}
-	return s.Backend.Clock()
 }
 
 // DeleteAllUsers deletes all users
@@ -730,21 +721,9 @@ func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sess
 	}
 
 	item, err := s.Get(ctx, sessionDataKey(user, sessionID))
-	if trace.IsNotFound(err) {
-		return nil, trace.NotFound("webauthn session data is not found")
-	} else if err != nil {
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	if !s.getClock().Now().Before(item.Expires) {
-		// Webauthn session already expired. Some backends do not clean up expired
-		// items in a timely manner, force delete.
-		if err := s.Delete(ctx, item.Key); err != nil && !trace.IsNotFound(err) {
-			s.log.WithError(err).Debug("Failed to delete expired webauthn session")
-		}
-		return nil, trace.NotFound("webauthn session data is not found")
-	}
-
 	sd := &wanpb.SessionData{}
 	return sd, trace.Wrap(json.Unmarshal(item.Value, sd))
 }

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -757,34 +757,6 @@ func TestIdentityService_GlobalWebauthnSessionDataCRUD(t *testing.T) {
 	}
 }
 
-func TestIdentityService_WebauthnSessionDataExpiry(t *testing.T) {
-	t.Parallel()
-	clock := clockwork.NewFakeClock()
-	identity := newIdentityService(t, clock)
-	identity.SetDesyncedClockForTesting(clock)
-
-	ctx := context.Background()
-	sessionData := &wanpb.SessionData{Challenge: []byte("challenge"), UserId: []byte("userid")}
-	err := identity.UpsertWebauthnSessionData(ctx, "user", "login", sessionData)
-	require.NoError(t, err)
-
-	got, err := identity.GetWebauthnSessionData(ctx, "user", "login")
-	require.NoError(t, err)
-	require.Equal(t, sessionData, got)
-
-	// If the session data is expired but not automatically removed from
-	// the backend, it should be manually deleted on retrieval attempt.
-	// Advance the identity service clock and not the backend clock to
-	// emulate this occurrence.
-	clock.Advance(10 * time.Minute)
-	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
-	require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
-
-	// Another retrieval should result in a not found error since it was deleted during the last get.
-	_, err = identity.GetWebauthnSessionData(ctx, "user", "login")
-	require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
-}
-
 func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) {
 	// Don't t.Parallel()!
 


### PR DESCRIPTION
Backport #36440 to branch/v12

Changelog: Fix a bug that caused Webauthn sessions to expire prematurely