### PR TITLE
[v13] Fix DynamicIdentityFileCreds being incompatible with L7 Loadbalancers

### DIFF
--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -364,14 +364,8 @@ func newTLSRoutingWithConnUpgradeDialer(ssh ssh.ClientConfig, params connectPara
 			},
 			ALPNConnUpgradeRequired: IsALPNConnUpgradeRequired(ctx, params.addr, insecure),
 			GetClusterCAs: func(_ context.Context) (*x509.CertPool, error) {
-				// TODO(noah): there's potentially a bug here when multiple
-				// credentials have been configured as the CAs are always
-				// retrieved from the first credential.
-				tlsConfig, err := params.cfg.Credentials[0].TLSConfig()
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				return tlsConfig.RootCAs, nil
+				// Uses the Root CAs from the TLS Config of the Credentials.
+				return params.tlsConfig.RootCAs, nil
 			},
 		})
 		if err != nil {

--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -364,6 +364,9 @@ func newTLSRoutingWithConnUpgradeDialer(ssh ssh.ClientConfig, params connectPara
 			},
 			ALPNConnUpgradeRequired: IsALPNConnUpgradeRequired(ctx, params.addr, insecure),
 			GetClusterCAs: func(_ context.Context) (*x509.CertPool, error) {
+				// TODO(noah): there's potentially a bug here when multiple
+				// credentials have been configured as the CAs are always
+				// retrieved from the first credential.
 				tlsConfig, err := params.cfg.Credentials[0].TLSConfig()
 				if err != nil {
 					return nil, trace.Wrap(err)

--- a/api/client/credentials.go
+++ b/api/client/credentials.go
@@ -486,6 +486,8 @@ func (d *DynamicIdentityFileCreds) Dialer(
 
 // TLSConfig returns TLS configuration. Implementing the Credentials interface.
 func (d *DynamicIdentityFileCreds) TLSConfig() (*tls.Config, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	// Build a "dynamic" tls.Config which can support a changing cert and root
 	// CA pool.
 	cfg := &tls.Config{
@@ -507,7 +509,10 @@ func (d *DynamicIdentityFileCreds) TLSConfig() (*tls.Config, error) {
 		},
 
 		// VerifyConnection is used instead of the static RootCAs field.
-		RootCAs: nil,
+		// However, there's some client code which relies on the static RootCAs
+		// field. So we set it to a copy of the current root CAs pool to support
+		// those - e.g ALPNDialerConfig.GetClusterCAs
+		RootCAs: d.tlsRootCAs.Clone(),
 		// InsecureSkipVerify is forced true to ensure that only our
 		// VerifyConnection callback is used to verify the server's presented
 		// certificate.
@@ -522,7 +527,7 @@ func (d *DynamicIdentityFileCreds) TLSConfig() (*tls.Config, error) {
 			opts := x509.VerifyOptions{
 				DNSName:       state.ServerName,
 				Intermediates: x509.NewCertPool(),
-				Roots:         d.tlsRootCAs,
+				Roots:         d.tlsRootCAs.Clone(),
 			}
 			for _, cert := range state.PeerCertificates[1:] {
 				// Whilst we don't currently use intermediate certs at

--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -421,6 +421,13 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, wantTLSCert, *gotTLSCert)
 
+	tlsCACertPEM, _ := pem.Decode(tlsCACert)
+	tlsCACertDER, err := x509.ParseCertificate(tlsCACertPEM.Bytes)
+	require.NoError(t, err)
+	wantCertPool := x509.NewCertPool()
+	wantCertPool.AddCert(tlsCACertDER)
+	require.True(t, wantCertPool.Equal(tlsConfig.RootCAs))
+
 	// Generate a new TLS certificate that contains the same private key as
 	// the original.
 	template := &x509.Certificate{

--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -426,7 +426,7 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	wantCertPool := x509.NewCertPool()
 	wantCertPool.AddCert(tlsCACertDER)
-	require.True(t, wantCertPool.Equal(tlsConfig.RootCAs))
+	require.True(t, wantCertPool.Equal(tlsConfig.RootCAs), "tlsconfig.RootCAs mismatch")
 
 	// Generate a new TLS certificate that contains the same private key as
 	// the original.


### PR DESCRIPTION
Backport #36411 to branch/v13

changelog: Fixes `refresh_identity = true` preventing Access Plugins connecting to Teleport using TLS routing with a L7 LB.
