### PR TITLE
Fix `mfa challenge is empty`  error

### DIFF
--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -58,6 +58,11 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		return nil, trace.Wrap(err)
 	}
 
+	// No prompt to run, no-op.
+	if !runOpts.PromptTOTP && !runOpts.PromptWebauthn {
+		return &proto.MFAAuthenticateResponse{}, nil
+	}
+
 	// Depending on the run opts, we may spawn a TOTP goroutine, webauth goroutine, or both.
 	spawnGoroutines := func(ctx context.Context, wg *sync.WaitGroup, respC chan<- MFAGoroutineResponse) {
 		// Use variables below to cancel OTP reads and make sure the goroutine exited.

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -47,6 +47,11 @@ func TestCLIPrompt(t *testing.T) {
 		expectResp   *proto.MFAAuthenticateResponse
 	}{
 		{
+			name:         "OK empty challenge",
+			expectStdOut: "",
+			challenge:    &proto.MFAAuthenticateChallenge{},
+			expectResp:   &proto.MFAAuthenticateResponse{},
+		}, {
 			name:         "OK webauthn",
 			expectStdOut: "Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -80,10 +80,6 @@ func (c PromptConfig) GetRunOptions(ctx context.Context, chal *proto.MFAAuthenti
 	promptTOTP := chal.TOTP != nil
 	promptWebauthn := chal.WebauthnChallenge != nil
 
-	if !promptTOTP && !promptWebauthn {
-		return RunOpts{}, trace.BadParameter("mfa challenge is empty")
-	}
-
 	// Does the current platform support hardware MFA? Adjust accordingly.
 	switch {
 	case !promptTOTP && !c.WebauthnSupported:
@@ -159,6 +155,10 @@ func HandleMFAPromptGoroutines(ctx context.Context, startGoroutines func(context
 
 		// Return successful response.
 		return resp.Resp, nil
+	}
+
+	if len(errs) == 0 {
+		return &proto.MFAAuthenticateResponse{}, nil
 	}
 
 	return nil, trace.Wrap(trace.NewAggregate(errs...), "failed to authenticate using available MFA devices")

--- a/lib/teleterm/daemon/mfaprompt.go
+++ b/lib/teleterm/daemon/mfaprompt.go
@@ -73,6 +73,11 @@ func (p *mfaPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		return nil, trace.Wrap(err)
 	}
 
+	// No prompt to run, no-op.
+	if !runOpts.PromptTOTP && !runOpts.PromptWebauthn {
+		return &proto.MFAAuthenticateResponse{}, nil
+	}
+
 	// Depending on the run opts, we may spawn a TOTP goroutine, webauth goroutine, or both.
 	spawnGoroutines := func(ctx context.Context, wg *sync.WaitGroup, respC chan<- libmfa.MFAGoroutineResponse) {
 		ctx, cancel := context.WithCancelCause(ctx)


### PR DESCRIPTION
Fix https://github.com/gravitational/teleport/issues/36482 by restoring behavior of empty mfa challenges resulting in a no-op prompt.

This bug was caused by my refactors in https://github.com/gravitational/teleport/pull/34087, which was not backported.