### PR TITLE
Fix goroutine leak in SSH service

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -665,7 +665,7 @@ type session struct {
 	fileTransferRequests map[string]*fileTransferRequest
 
 	io       *TermManager
-	inWriter io.Writer
+	inWriter io.WriteCloser
 
 	term Terminal
 
@@ -855,6 +855,11 @@ func (s *session) Stop() {
 	s.log.Info("Stopping session")
 
 	// Close io copy loops
+	if s.inWriter != nil {
+		if err := s.inWriter.Close(); err != nil {
+			s.log.WithError(err).Debug("Failed to close session writer")
+		}
+	}
 	s.io.Close()
 
 	// Make sure that the terminal has been closed

--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -19,6 +19,7 @@
 package srv
 
 import (
+	"errors"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -223,7 +224,9 @@ func (g *TermManager) AddReader(name string, r io.Reader) {
 			buf := make([]byte, 1024)
 			n, err := r.Read(buf)
 			if err != nil {
-				log.Warnf("Failed to read from remote terminal: %v", err)
+				if !errors.Is(err, io.EOF) {
+					log.Warnf("Failed to read from remote terminal: %v", err)
+				}
 				// Let term manager decide how to handle broken party readers.
 				if g.OnReadError != nil {
 					g.OnReadError(name, err)


### PR DESCRIPTION
The session object was never closing the write half of the io.Pipe that is created to propagate input of the session. This results in the goroutine responsible for reading from the pipe to block indefinitely. `(session) Stop` was updated to close the write half of the pipe which causes the read goroutine to terminate properly when the session is terminated.

Fixes #36487.

changelog: Fixed goroutine leak per ssh session