### PR TITLE
Enable the usage&billing page in self-hosted dashboards

### DIFF
--- a/lib/services/license.go
+++ b/lib/services/license.go
@@ -21,6 +21,7 @@ package services
 import (
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -73,4 +74,15 @@ func MarshalLicense(license types.License, opts ...MarshalOption) ([]byte, error
 	default:
 		return nil, trace.BadParameter("unrecognized license version %T", license)
 	}
+}
+
+// IsDashboard returns a bool indicating if the cluster is a
+// dashboard cluster.
+// Dashboard is a cluster running on cloud infrastructure that
+// isn't a Teleport Cloud cluster
+func IsDashboard(features proto.Features) bool {
+	// TODO(matheus): for now, we assume dashboard based on
+	// the presence of recovery codes, which are never enabled
+	// in OSS or self-hosted Teleport.
+	return !features.GetCloud() && features.GetRecoveryCodes()
 }

--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -112,6 +113,54 @@ func TestLicenseUnmarshal(t *testing.T) {
 		} else {
 			require.IsType(t, err, tc.err, comment)
 		}
+	}
+}
+
+func TestIsDashboard(t *testing.T) {
+	tt := []struct {
+		name     string
+		features proto.Features
+		expected bool
+	}{
+		{
+			name: "not cloud nor recovery codes is not dashboard",
+			features: proto.Features{
+				Cloud:         false,
+				RecoveryCodes: false,
+			},
+			expected: false,
+		},
+		{
+			name: "not cloud, with recovery codes is dashboard",
+			features: proto.Features{
+				Cloud:         false,
+				RecoveryCodes: true,
+			},
+			expected: true,
+		},
+		{
+			name: "cloud, with recovery codes is not dashboard",
+			features: proto.Features{
+				Cloud:         true,
+				RecoveryCodes: true,
+			},
+			expected: false,
+		},
+		{
+			name: "cloud, without recovery codes is not dashboard",
+			features: proto.Features{
+				Cloud:         true,
+				RecoveryCodes: false,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsDashboard(tc.features)
+			require.Equal(t, tc.expected, result)
+		})
 	}
 }
 

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -156,8 +156,12 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 		assistAccess = newAccess(userRoles, ctx, types.KindAssistant)
 	}
 
+	// The billing dashboards are available in cloud clusters or for
+	// self-hosted dashboards for usage-based subscriptions.
 	var billingAccess ResourceAccess
-	if features.Cloud {
+	isDashboard := IsDashboard(features)
+	isUsageBasedEnterprise := features.GetProductType() == proto.ProductType_PRODUCT_TYPE_EUB
+	if features.Cloud || (isDashboard && isUsageBasedEnterprise) {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1606,7 +1606,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		TunnelPublicAddress:            tunnelPublicAddr,
 		RecoveryCodesEnabled:           clusterFeatures.GetRecoveryCodes(),
 		UI:                             h.getUIConfig(r.Context()),
-		IsDashboard:                    isDashboard(clusterFeatures),
+		IsDashboard:                    services.IsDashboard(clusterFeatures),
 		IsUsageBasedBilling:            clusterFeatures.GetIsUsageBased(),
 		AutomaticUpgrades:              automaticUpgradesEnabled,
 		AutomaticUpgradesTargetVersion: automaticUpgradesTargetVersion,
@@ -4334,17 +4334,6 @@ func (h *Handler) authExportPublic(w http.ResponseWriter, r *http.Request, p htt
 	// ServeContent sets the correct headers: Content-Type, Content-Length and Accept-Ranges.
 	// It also handles the Range negotiation
 	http.ServeContent(w, r, "authorized_hosts.txt", time.Now(), reader)
-}
-
-// isDashboard returns a bool indicating if the cluster is a
-// dashboard cluster.
-// Dashboard is a cluster running on cloud infrastructure that
-// isn't a Teleport Cloud cluster
-func isDashboard(features proto.Features) bool {
-	// TODO(matheus): for now, we assume dashboard based on
-	// the presence of recovery codes, which are never enabled
-	// in OSS or self-hosted Teleport.
-	return !features.GetCloud() && features.GetRecoveryCodes()
 }
 
 const robots = `User-agent: *

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8953,54 +8953,6 @@ func TestLogout(t *testing.T) {
 	require.ErrorIs(t, err, trace.AccessDenied("need auth"))
 }
 
-func TestGetIsDashboard(t *testing.T) {
-	tt := []struct {
-		name     string
-		features authproto.Features
-		expected bool
-	}{
-		{
-			name: "not cloud nor recovery codes is not dashboard",
-			features: authproto.Features{
-				Cloud:         false,
-				RecoveryCodes: false,
-			},
-			expected: false,
-		},
-		{
-			name: "not cloud, with recovery codes is dashboard",
-			features: authproto.Features{
-				Cloud:         false,
-				RecoveryCodes: true,
-			},
-			expected: true,
-		},
-		{
-			name: "cloud, with recovery codes is not dashboard",
-			features: authproto.Features{
-				Cloud:         true,
-				RecoveryCodes: true,
-			},
-			expected: false,
-		},
-		{
-			name: "cloud, without recovery codes is not dashboard",
-			features: authproto.Features{
-				Cloud:         true,
-				RecoveryCodes: false,
-			},
-			expected: false,
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			result := isDashboard(tc.features)
-			require.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 // initGRPCServer creates a gRPC server serving on the provided listener.
 func initGRPCServer(t *testing.T, env *webPack, listener net.Listener) {
 	clusterName := env.server.ClusterName()


### PR DESCRIPTION
With the launch of self-hosted usage-based products, the billing page now needs to be available for:

- usage-based enterprise cloud
- dashboard tenants for usage-based self-hosted enterprise

The billing pages remain inaccessible in the actual Teleport clusters for self hosted customers, as well as for legacy cloud enterprise customers.