### PR TITLE
Update macOS build instructions

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -58,17 +58,23 @@ PRs with corrections and updates are welcome!
   * Install the required version
   
   ```shell
-  rustup toolchain install <version from build.assets/Makefile>
+  rustup toolchain install <version from build.assets/versions.mk>
   cd <teleport.git>
-  rustup override set <version from build.assets/Makefile>
+  rustup override set <version from build.assets/versions.mk>
   rustc --version
-  # rustc <version from build.assets/Makefile> (db9d1b20b 2022-01-20)
+  # rustc <version from build.assets/versions.mk>
   ```
 
-* To install `libfido2` (pulls `openssl 1.1.1` as dependency)
+* To install `libfido2` (pulls `openssl 3` as dependency)
 
   ```shell
   brew install libfido2
+  ```
+
+* To install `pkg-config`
+
+  ```shell
+  brew install pkg-config
   ```
 
 * To install `yarn` for building the UI

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ To build `tsh` with `libfido`:
   make build/tsh FIDO2=dynamic
   ```
 
-  * On a Mac, with `libfido` and `openssl 1.1` installed via `homebrew`
+  * On a Mac, with `libfido` and `openssl 3` installed via `homebrew`
 
     ```shell
-    export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig"
+    export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
     make build/tsh FIDO2=dynamic
     ```
 


### PR DESCRIPTION
While trying to build Teleport on new Apple M3 Pro (MacOS 14.2.1) I faced couple of issues and updated the instructions to resolve them:

- Updated location where rust version is set
- Had to explicitly install `pkg-config`
- `openssl@1.1` was missing, so used `openssl@3` instead:
    - seems like `libfido2` was updated to run on `openssl@3`: https://github.com/Homebrew/homebrew-core/commit/c26724ebbdeee0ba8c75bf8db5a5e8e7f21815cd
    - teleport was updated to work with OpenSSL3: https://github.com/gravitational/teleport/issues/23689