### PR TITLE
Fix example mysql grant all command

### DIFF
--- a/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
@@ -399,7 +399,7 @@ function DbEngineInstructions({
                 bash={false}
                 lines={[
                   {
-                    text: "GRANT ALL ON ` % `.* TO 'YOUR_USERNAME'@'%';",
+                    text: "GRANT ALL ON `%`.* TO 'YOUR_USERNAME'@'%';",
                   },
                 ]}
               />


### PR DESCRIPTION
Fixing example MySQL grant all command, because current one fails with `ERROR 1102 (42000): Incorrect database name ' % '` because of extra spaces around `%`:

How it currently looks on the UI:
![image](https://github.com/gravitational/teleport/assets/9948629/abc878fe-bb58-45c6-8d37-278705979282)

Screenshot from the UI after the change:

![image](https://github.com/gravitational/teleport/assets/9948629/a3b2b7ef-81a6-461e-949c-c7195f3a23e9)


---

MySQL command execution example:

```
mysql> GRANT ALL ON ` % `.* TO 'YOUR_USERNAME'@'%';
ERROR 1102 (42000): Incorrect database name ' % '
mysql> GRANT ALL ON `%`.* TO 'YOUR_USERNAME'@'%';
Query OK, 0 rows affected (0.01 sec)
```