### PR TITLE
Switch to the new account settings screen on OSS

### DIFF
--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -58,8 +58,7 @@ const Audit = lazy(() => import('./Audit'));
 const Nodes = lazy(() => import('./Nodes'));
 const Sessions = lazy(() => import('./Sessions'));
 const UnifiedResources = lazy(() => import('./UnifiedResources'));
-const Account = lazy(() => import('./Account'));
-const AccountNew = lazy(() => import('./Account/AccountNew'));
+const Account = lazy(() => import('./Account/AccountNew'));
 const Applications = lazy(() => import('./Apps'));
 const Kubes = lazy(() => import('./Kubes'));
 const Support = lazy(() => import('./Support'));
@@ -638,10 +637,7 @@ export class FeatureAccount implements TeleportFeature {
   route = {
     title: 'Account Settings',
     path: cfg.routes.account,
-    component:
-      localStorage.getItem('enableNewAccountSettingsScreen') == 'true'
-        ? AccountNew
-        : Account,
+    component: Account,
   };
 
   hasAccess() {


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/36231

![Screenshot 2024-01-10 at 19 14 20](https://github.com/gravitational/teleport/assets/9391503/cb9cd4b9-ffe9-4d34-b9c7-3f3ca49216b4)

Changelog: Implemented a new, redesigned account settings page.