### PR TITLE
accountrecovery.go: Unconditionally delete the token after use

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -488,11 +488,8 @@ func (a *Server) CreateAccountRecoveryCodes(ctx context.Context, req *proto.Crea
 		return nil, trace.AccessDenied(unableToCreateCodesMsg)
 	}
 
-	// If used as part of the recovery flow, getting new recovery codes marks the end of the flow in the UI.
-	if token.GetSubKind() == UserTokenTypeRecoveryApproved {
-		if err := a.deleteUserTokens(ctx, token.GetUser()); err != nil {
-			log.Error(trace.DebugReport(err))
-		}
+	if err := a.deleteUserTokens(ctx, token.GetUser()); err != nil {
+		log.Error(trace.DebugReport(err))
 	}
 
 	return newRecovery, nil

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1192,10 +1192,9 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	require.NoError(t, err)
 
 	cases := []struct {
-		name        string
-		wantErr     bool
-		forRecovery bool
-		getRequest  func() *proto.CreateAccountRecoveryCodesRequest
+		name       string
+		wantErr    bool
+		getRequest func() *proto.CreateAccountRecoveryCodesRequest
 	}{
 		{
 			name:    "invalid token type",
@@ -1231,8 +1230,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			},
 		},
 		{
-			name:        "recovery approved token",
-			forRecovery: true,
+			name: "recovery approved token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
 				token, err := srv.Auth().createRecoveryToken(ctx, "llama@example.com", UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
@@ -1271,12 +1269,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 
 				// Check token is deleted after success.
 				_, err = srv.Auth().GetUserToken(ctx, req.TokenID)
-				switch {
-				case c.forRecovery:
-					require.True(t, trace.IsNotFound(err))
-				default:
-					require.NoError(t, err)
-				}
+				require.True(t, trace.IsNotFound(err))
 			}
 		})
 	}


### PR DESCRIPTION
A conditional when using an account recovery generation token was allowing a replay attack on the recovery process.  Although discovery of this token is a high bar for an attacker, we should be able to unconditionally delete this token after it's used.

PR fixes report: https://github.com/gravitational/security-findings/issues/85