### PR TITLE
Update Toggle component styles

### DIFF
--- a/web/packages/design/src/Alert/Alert.jsx
+++ b/web/packages/design/src/Alert/Alert.jsx
@@ -42,7 +42,7 @@ const kind = props => {
       };
     case 'success':
       return {
-        background: theme.colors.success,
+        background: theme.colors.success.main,
         color: theme.colors.text.primaryInverse,
       };
     default:

--- a/web/packages/design/src/Alert/Alert.test.jsx
+++ b/web/packages/design/src/Alert/Alert.test.jsx
@@ -54,7 +54,7 @@ describe('design/Alert', () => {
   test('"kind" success renders bg == theme.colors.success', () => {
     const { container } = render(<Success />);
     expect(container.firstChild).toHaveStyle({
-      background: theme.colors.success,
+      background: theme.colors.success.main,
     });
   });
 });

--- a/web/packages/design/src/CardSuccess/__snapshots__/CardSuccess.test.jsx.snap
+++ b/web/packages/design/src/CardSuccess/__snapshots__/CardSuccess.test.jsx.snap
@@ -22,8 +22,13 @@ exports[`rendering of CardSuccess components 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #00BFA5;
   margin-bottom: 16px;
+}
+
+.c2 color {
+  main: #00BFA6;
+  hover: #33CCB8;
+  active: #66D9CA;
 }
 
 <div

--- a/web/packages/design/src/Label/Label.jsx
+++ b/web/packages/design/src/Label/Label.jsx
@@ -48,7 +48,7 @@ const kind = ({ kind, theme }) => {
 
   if (kind === 'success') {
     return {
-      backgroundColor: theme.colors.success,
+      backgroundColor: theme.colors.success.main,
       color: theme.colors.text.primaryInverse,
     };
   }

--- a/web/packages/design/src/LabelState/LabelState.jsx
+++ b/web/packages/design/src/LabelState/LabelState.jsx
@@ -45,7 +45,7 @@ const kinds = ({ theme, kind, shadow }) => {
   }
 
   if (kind === 'success') {
-    styles.background = theme.colors.success;
+    styles.background = theme.colors.success.main;
     styles.color = theme.colors.text.primaryInverse;
   }
 

--- a/web/packages/design/src/LabelState/LabelState.test.jsx
+++ b/web/packages/design/src/LabelState/LabelState.test.jsx
@@ -32,7 +32,7 @@ const colors = {
   info: theme.colors.spotBackground[0],
   warning: theme.colors.warning.main,
   danger: theme.colors.error.main,
-  success: theme.colors.success,
+  success: theme.colors.success.main,
 };
 
 describe('design/LabelState', () => {

--- a/web/packages/design/src/Toggle/Toggle.story.tsx
+++ b/web/packages/design/src/Toggle/Toggle.story.tsx
@@ -28,7 +28,16 @@ export default {
 };
 
 export const Default = () => {
-  const [toggled, setToggled] = useState(false);
+  return (
+    <Flex flexDirection="column" gap={4}>
+      <ToggleRow initialToggled={false} />
+      <ToggleRow initialToggled={true} />
+    </Flex>
+  );
+};
+
+const ToggleRow = (props: { initialToggled: boolean }) => {
+  const [toggled, setToggled] = useState(props.initialToggled);
 
   function toggle(): void {
     setToggled(wasToggled => !wasToggled);
@@ -43,6 +52,19 @@ export const Default = () => {
       <div>
         <Text>Disabled</Text>
         <Toggle disabled={true} onToggle={toggle} isToggled={toggled} />
+      </div>
+      <div>
+        <Text>Enabled (large)</Text>
+        <Toggle onToggle={toggle} isToggled={toggled} size="large" />
+      </div>
+      <div>
+        <Text>Disabled (large)</Text>
+        <Toggle
+          disabled={true}
+          onToggle={toggle}
+          isToggled={toggled}
+          size="large"
+        />
       </div>
     </Flex>
   );

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -25,12 +25,14 @@ export function Toggle({
   children,
   disabled,
   className,
+  size = 'small',
 }: {
   isToggled: boolean;
   onToggle: () => void;
   children?: ReactNode;
   disabled?: boolean;
   className?: string;
+  size?: 'small' | 'large';
 }) {
   return (
     <StyledWrapper disabled={disabled} className={className}>
@@ -38,8 +40,9 @@ export function Toggle({
         checked={isToggled}
         onChange={onToggle}
         disabled={disabled}
+        size={size}
       />
-      <StyledSlider />
+      <StyledSlider size={size} />
       {children}
     </StyledWrapper>
   );
@@ -56,23 +59,65 @@ const StyledWrapper = styled.label`
   }
 `;
 
+const size = props => {
+  switch (props.size) {
+    case 'large':
+      return {
+        track: {
+          width: 40,
+          height: 20,
+        },
+        circle: {
+          width: 14,
+          height: 14,
+          transform: 'translate(3px, -50%)',
+        },
+        translate: 'translate(23px, -50%)',
+      };
+    default:
+      // small
+      return {
+        track: {
+          width: 32,
+          height: 16,
+        },
+        circle: {
+          width: 12,
+          height: 12,
+          transform: 'translate(2px, -50%)',
+        },
+        translate: 'translate(18px, -50%)',
+      };
+  }
+};
+
 const StyledSlider = styled.div`
-  width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: ${props => props.theme.colors.levels.surface};
+  // the slider 'track'
+  ${props => size(props).track};
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: ${props => props.theme.colors.buttons.secondary.default};
+  transition: background 0.15s ease-in-out;
 
+  &:hover {
+    background: ${props => props.theme.colors.buttons.secondary.hover};
+  }
+
+  &:active {
+    background: ${props => props.theme.colors.buttons.secondary.active};
+  }
+
+  // the slider 'circle'
   &:before {
     content: '';
     position: absolute;
     top: 50%;
-    transform: translate(0, -50%);
-    width: 16px;
-    height: 16px;
-    border-radius: 16px;
-    background: ${props => props.theme.colors.brand};
+    ${props => size(props).circle};
+    border-radius: 14px;
+    background: ${props => props.theme.colors.interactionHandle};
+    box-shadow: ${props => props.theme.boxShadow[0]};
+    transition: transform 0.05s ease-in;
   }
 `;
 
@@ -80,20 +125,36 @@ const StyledInput = styled.input.attrs({ type: 'checkbox' })`
   opacity: 0;
   position: absolute;
   cursor: inherit;
+  z-index: -1;
 
   &:checked + ${StyledSlider} {
-    background: ${props => props.theme.colors.spotBackground[1]};
-
     &:before {
-      transform: translate(16px, -50%);
+      transform: ${props => size(props).translate};
+    }
+  }
+
+  &:enabled:checked + ${StyledSlider} {
+    background: ${props => props.theme.colors.success.main};
+
+    &:hover {
+      background: ${props => props.theme.colors.success.hover};
+    }
+
+    &:active {
+      background: ${props => props.theme.colors.success.active};
     }
   }
 
   &:disabled + ${StyledSlider} {
-    background: ${props => props.theme.colors.levels.surface};
+    background: ${props => props.theme.colors.spotBackground[0]};
 
     &:before {
-      background: ${props => props.theme.colors.grey[700]};
+      opacity: 0.36;
+      box-shadow: none;
     }
+  }
+
+  &:disabled:checked + ${StyledSlider} {
+    background: ${props => props.theme.colors.interactive.tonal.success[2]};
   }
 `;

--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -97,6 +97,11 @@ const colors: ThemeColors = {
         'rgba(255,160,40, 0.18)',
         'rgba(255,160,40, 0.25)',
       ],
+      success: [
+        'rgba(0, 162, 35, 0.1)',
+        'rgba(0, 162, 35, 0.18)',
+        'rgba(0, 162, 35, 0.25)',
+      ],
       neutral: neutralColors,
     },
   },
@@ -434,7 +439,12 @@ const colors: ThemeColors = {
   },
 
   link: '#66ABFF',
-  success: '#00BFA5',
+
+  success: {
+    main: '#00A223',
+    hover: '#35D655',
+    active: '#00851C',
+  },
 
   dataVisualisation: dataVisualisationColors,
 };

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -97,6 +97,11 @@ const colors: ThemeColors = {
         'rgba(159,133,255, 0.18)',
         'rgba(159,133,255, 0.25)',
       ],
+      success: [
+        'rgba(0, 191, 166, 0.1)',
+        'rgba(0, 191, 166, 0.18)',
+        'rgba(0, 191, 166, 0.25)',
+      ],
       neutral: neutralColors,
     },
   },
@@ -163,6 +168,12 @@ const colors: ThemeColors = {
     main: '#FF6257',
     hover: '#FF8179',
     active: '#FFA19A',
+  },
+
+  success: {
+    main: '#00BFA6',
+    hover: '#33CCB8',
+    active: '#66D9CA',
   },
 
   warning: {
@@ -434,7 +445,6 @@ const colors: ThemeColors = {
   },
 
   link: '#009EFF',
-  success: '#00BFA5',
 
   dataVisualisation: dataVisualisationColors,
 };

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -96,6 +96,11 @@ const colors: ThemeColors = {
         'rgba(81,47,201, 0.18)',
         'rgba(81,47,201, 0.25)',
       ],
+      success: [
+        'rgba(0, 125, 107, 0.1)',
+        'rgba(0, 125, 107, 0.18)',
+        'rgba(0, 125, 107, 0.25)',
+      ],
       neutral: neutralColors,
     },
   },
@@ -157,6 +162,12 @@ const colors: ThemeColors = {
   },
 
   progressBarColor: '#007D6B',
+
+  success: {
+    main: '#007D6B',
+    hover: '#006456',
+    active: '#004B40',
+  },
 
   error: {
     main: '#CC372D',
@@ -433,7 +444,6 @@ const colors: ThemeColors = {
   },
 
   link: '#0073BA',
-  success: '#007D6B',
 
   dataVisualisation: dataVisualisationColors,
 };

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -64,6 +64,7 @@ export const sharedStyles: SharedStyles = {
 export const sharedColors: SharedColors = {
   dark: '#000000',
   light: '#FFFFFF',
+  interactionHandle: '#FFFFFF',
   grey: {
     ...blueGrey,
   },

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -59,6 +59,7 @@ export type ThemeColors = {
     tonal: {
       primary: string[];
       neutral: string[];
+      success: string[];
     };
   };
 
@@ -136,6 +137,12 @@ export type ThemeColors = {
     active: string;
   };
 
+  success: {
+    main: string;
+    hover: string;
+    active: string;
+  };
+
   notice: {
     background: string;
   };
@@ -183,7 +190,6 @@ export type ThemeColors = {
   };
 
   link: string;
-  success: string;
 
   dataVisualisation: DataVisualisationColors;
   accessGraph: AccessGraphColors;
@@ -242,6 +248,7 @@ interface AccessGraphEdgeColors {
 export type SharedColors = {
   dark: string;
   light: string;
+  interactionHandle: string;
   grey: typeof blueGrey;
   subtle: string;
   bgTerminal: string;

--- a/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -666,44 +666,69 @@ exports[`failed state 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {
@@ -2263,44 +2288,69 @@ exports[`loaded state 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -271,44 +271,69 @@ exports[`render DocumentNodes 1`] = `
 
 .c24 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c24:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c24:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c24:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c22 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c22:checked + .c23 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c22:checked + .c23:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c22:enabled:checked + .c23 {
+  background: #00BFA6;
+}
+
+.c22:enabled:checked + .c23:hover {
+  background: #33CCB8;
+}
+
+.c22:enabled:checked + .c23:active {
+  background: #66D9CA;
 }
 
 .c22:disabled + .c23 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c22:disabled + .c23:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c22:disabled:checked + .c23 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c28 {

--- a/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -549,44 +549,69 @@ exports[`failed 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {
@@ -1703,44 +1728,69 @@ exports[`open source loaded 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
@@ -158,7 +158,7 @@ const StatusLight = styled(Box)`
   height: 8px;
   background-color: ${({ status, theme }) => {
     if (status === Status.Success) {
-      return theme.colors.success;
+      return theme.colors.success.main;
     }
     if (status === Status.Error) {
       return theme.colors.error.main;

--- a/web/packages/teleport/src/Discover/Shared/HintBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/HintBox.tsx
@@ -49,7 +49,7 @@ export const SuccessInfo = styled(Box)`
   background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
-  border: 2px solid ${props => props.theme.colors.success};
+  border: 2px solid ${props => props.theme.colors.success.main};
   display: flex;
   align-items: center;
 `;

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -231,7 +231,7 @@ const StatusLight = styled(Box)`
   height: 8px;
   background-color: ${({ status, theme }) => {
     if (status === Status.Success) {
-      return theme.colors.success;
+      return theme.colors.success.main;
     }
     if (status === Status.Error) {
       return theme.colors.error.main;

--- a/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -549,44 +549,69 @@ exports[`failed 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c31 {
@@ -1434,44 +1459,69 @@ exports[`loaded 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c31 {

--- a/web/packages/teleport/src/Login/__snapshots__/LoginSuccess.test.tsx.snap
+++ b/web/packages/teleport/src/Login/__snapshots__/LoginSuccess.test.tsx.snap
@@ -32,8 +32,13 @@ exports[`renders 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #00BFA5;
   margin-bottom: 16px;
+}
+
+.c3 color {
+  main: #00BFA6;
+  hover: #33CCB8;
+  active: #66D9CA;
 }
 
 .c0 {

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -559,44 +559,69 @@ exports[`failed 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {
@@ -1754,44 +1779,69 @@ exports[`loaded 1`] = `
 
 .c25 {
   width: 32px;
-  height: 12px;
-  border-radius: 12px;
-  background: #222C59;
+  height: 16px;
+  border-radius: 10px;
   cursor: inherit;
   flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  transition: background 0.15s ease-in-out;
+}
+
+.c25:hover {
+  background: rgba(255,255,255,0.13);
+}
+
+.c25:active {
+  background: rgba(255,255,255,0.18);
 }
 
 .c25:before {
   content: '';
   position: absolute;
   top: 50%;
-  transform: translate(0,-50%);
-  width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  background: #9F85FF;
+  width: 12px;
+  height: 12px;
+  transform: translate(2px,-50%);
+  border-radius: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px rgba(0,0,0,0.14),0px 1px 3px rgba(0,0,0,0.12);
+  transition: transform 0.05s ease-in;
 }
 
 .c23 {
   opacity: 0;
   position: absolute;
   cursor: inherit;
-}
-
-.c23:checked + .c24 {
-  background: rgba(255,255,255,0.13);
+  z-index: -1;
 }
 
 .c23:checked + .c24:before {
-  transform: translate(16px,-50%);
+  transform: translate(18px,-50%);
+}
+
+.c23:enabled:checked + .c24 {
+  background: #00BFA6;
+}
+
+.c23:enabled:checked + .c24:hover {
+  background: #33CCB8;
+}
+
+.c23:enabled:checked + .c24:active {
+  background: #66D9CA;
 }
 
 .c23:disabled + .c24 {
-  background: #222C59;
+  background: rgba(255,255,255,0.07);
 }
 
 .c23:disabled + .c24:before {
-  background: #455a64;
+  opacity: 0.36;
+  box-shadow: none;
+}
+
+.c23:disabled:checked + .c24 {
+  background: rgba(0,191,166,0.25);
 }
 
 .c5 {

--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -154,7 +154,7 @@ const ActionButton = styled.button`
     opacity: 1;
 
     .icon {
-      color: ${props => props.theme.colors.success};
+      color: ${props => props.theme.colors.success.main};
     }
   }
 
@@ -193,7 +193,7 @@ const StyledProgessBar = styled.div`
   }
 
   .grv-slider .bar-0 {
-    background-color: ${props => props.theme.colors.success};
+    background-color: ${props => props.theme.colors.success.main};
     box-shadow: none;
   }
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/ProgressBar.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/ProgressBar.tsx
@@ -67,7 +67,7 @@ function Phase({
   let bg = phaseSolidColor;
 
   if (status === 'success') {
-    bg = theme.colors.success;
+    bg = theme.colors.success.main;
   }
 
   if (status === 'error') {
@@ -87,7 +87,9 @@ function Phase({
       </StyledPhase>
       {!isLast && (
         <StyledLine
-          color={status === 'success' ? theme.colors.success : phaseSolidColor}
+          color={
+            status === 'success' ? theme.colors.success.main : phaseSolidColor
+          }
         />
       )}
     </>
@@ -153,7 +155,7 @@ function getPhaseSolidColor(theme: any): string {
 const Spinner = styled.div`
   opacity: 1;
   color: ${props => props.theme.colors.spotBackground[2]};
-  border: 3px solid ${props => props.theme.colors.success};
+  border: 3px solid ${props => props.theme.colors.success.main};
   border-radius: 50%;
   border-top: 3px solid ${props => props.theme.colors.spotBackground[0]};
   width: 24px;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
@@ -250,7 +250,7 @@ const StyledStatus = styled(Box)`
     }
 
     if (status === 'processing' || status === 'success') {
-      return { backgroundColor: theme.colors.success };
+      return { backgroundColor: theme.colors.success.main };
     }
 
     // 'error' status can be ignored as it's handled outside of StyledStatus.

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
@@ -32,7 +32,7 @@ const StyledStatus = styled<Props>(Box)`
   ${props => {
     const { $connected, theme } = props;
     const backgroundColor = $connected
-      ? theme.colors.success
+      ? theme.colors.success.main
       : theme.colors.grey[300];
     return {
       backgroundColor,

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIconStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIconStatusIndicator.tsx
@@ -36,7 +36,7 @@ const StyledStatus = styled<Props>(Box)`
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   ${props => {
     const { $connected, theme } = props;
-    const backgroundColor = $connected ? theme.colors.success : null;
+    const backgroundColor = $connected ? theme.colors.success.main : null;
     const border = $connected
       ? null
       : `1px solid ${theme.colors.text.slightlyMuted}`;


### PR DESCRIPTION
This PR updates the Toggle component to match the component in the new design system
See figma here https://www.figma.com/file/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?type=design&node-id=8543-43293&mode=design&t=Opu5Lh9Gvq29kPAe-0
e buddy: https://github.com/gravitational/teleport.e/pull/3141

The "real" change in this PR is adding the new tonal success colors (in the `xTheme` files), and updating the `Toggle` component. The rest are just updating the references to those colors.

old styles
![Screenshot 2024-01-10 at 3 31 16 PM](https://github.com/gravitational/teleport/assets/5201977/41e8c315-949a-4808-8e02-4d316d996c3d)
![Screenshot 2024-01-10 at 3 31 18 PM](https://github.com/gravitational/teleport/assets/5201977/52cc6a0e-7e1d-475a-85eb-10a16ebe4110)


new styles

![Screenshot 2024-01-10 at 3 24 57 PM](https://github.com/gravitational/teleport/assets/5201977/26b647a9-16f7-4922-a37d-8fcb014770df)
![Screenshot 2024-01-10 at 3 25 01 PM](https://github.com/gravitational/teleport/assets/5201977/f93b52a3-f119-4fdf-bd16-07f548f18f04)

closes https://github.com/gravitational/teleport/issues/22820