### PR TITLE
[v12] ci: Add URLs of PRs created in post-release to GitHub summary

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -107,5 +107,6 @@ jobs:
           gh pr create --fill --base=${{ steps.get-branch.outputs.branch }} \
              --label=automated --label=documentation --label=no-changelog \
              --reviewer=${{ github.event.release.author.login }}
+           echo "Docs PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Add the URLs of the PRs created by the post-release workflow to the
GitHub step summary that appears on the top-level workflow page to make
it simple to navigate to these PRs. The release manager needs to verify
and approve/merge these PRs and this can make it a little simpler to
find by navigating from the workflow run page at
https://github.com/gravitational/teleport/actions/workflows/post-release.yaml

Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
Backport: https://github.com/gravitational/teleport/pull/36504

---

Conflicts resolved:
* update-ami-ids.yaml does not exist on branch/v12 - that was never
  backported as that job only runs on the latest branch. So this just
  skips the changes to that file.