### PR TITLE
[v13] ci: Add URLs of PRs created in post-release to GitHub summary

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -107,5 +107,6 @@ jobs:
           gh pr create --fill --base=${{ steps.get-branch.outputs.branch }} \
              --label=automated --label=documentation --label=no-changelog \
              --reviewer=${{ github.event.release.author.login }}
+           echo "Docs PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -51,5 +51,6 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub"
           TELEPORT_VERSION=${{ inputs.version }} AMI_PR_REVIEWER=${{ github.event.release.author.login }} make -C assets/aws create-update-pr
+          echo "AMI PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Add the URLs of the PRs created by the post-release workflow to the
GitHub step summary that appears on the top-level workflow page to make
it simple to navigate to these PRs. The release manager needs to verify
and approve/merge these PRs and this can make it a little simpler to
find by navigating from the workflow run page at
https://github.com/gravitational/teleport/actions/workflows/post-release.yaml

Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
Backport: https://github.com/gravitational/teleport/pull/36504