### PR TITLE
Remove unused static token HTTP endpoints

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -157,9 +157,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// cluster configuration
 	srv.GET("/:version/configuration/name", srv.WithAuth(srv.getClusterName))
 	srv.POST("/:version/configuration/name", srv.WithAuth(srv.setClusterName))
-	srv.GET("/:version/configuration/static_tokens", srv.WithAuth(srv.getStaticTokens))
-	srv.DELETE("/:version/configuration/static_tokens", srv.WithAuth(srv.deleteStaticTokens))
-	srv.POST("/:version/configuration/static_tokens", srv.WithAuth(srv.setStaticTokens))
 
 	// SSO validation handlers
 	srv.POST("/:version/github/requests/validate", srv.WithAuth(srv.validateGithubAuthCallback))
@@ -912,48 +909,6 @@ func (s *APIServer) setClusterName(auth *ServerWithRoles, w http.ResponseWriter,
 	}
 
 	return message(fmt.Sprintf("cluster name set: %+v", cn)), nil
-}
-
-func (s *APIServer) getStaticTokens(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	st, err := auth.GetStaticTokens()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return rawMessage(services.MarshalStaticTokens(st, services.WithVersion(version), services.PreserveResourceID()))
-}
-
-func (s *APIServer) deleteStaticTokens(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteStaticTokens()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
-}
-
-type setStaticTokensReq struct {
-	StaticTokens json.RawMessage `json:"static_tokens"`
-}
-
-func (s *APIServer) setStaticTokens(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	var req setStaticTokensReq
-
-	err := httplib.ReadJSON(r, &req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	st, err := services.UnmarshalStaticTokens(req.StaticTokens)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	err = auth.SetStaticTokens(st)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return message(fmt.Sprintf("static tokens set: %+v", st)), nil
 }
 
 type upsertTunnelConnectionRawReq struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4156,30 +4156,6 @@ func (a *ServerWithRoles) UpsertClusterName(c types.ClusterName) error {
 	return a.authServer.UpsertClusterName(c)
 }
 
-// DeleteStaticTokens deletes static tokens
-func (a *ServerWithRoles) DeleteStaticTokens() error {
-	if err := a.action(apidefaults.Namespace, types.KindStaticTokens, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteStaticTokens()
-}
-
-// GetStaticTokens gets the list of static tokens used to provision nodes.
-func (a *ServerWithRoles) GetStaticTokens() (types.StaticTokens, error) {
-	if err := a.action(apidefaults.Namespace, types.KindStaticTokens, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a.authServer.GetStaticTokens()
-}
-
-// SetStaticTokens sets the list of static tokens used to provision nodes.
-func (a *ServerWithRoles) SetStaticTokens(s types.StaticTokens) error {
-	if err := a.action(apidefaults.Namespace, types.KindStaticTokens, types.VerbCreate, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.SetStaticTokens(s)
-}
-
 // GetAuthPreference gets cluster auth preference.
 func (a *ServerWithRoles) GetAuthPreference(ctx context.Context) (types.AuthPreference, error) {
 	if err := a.action(apidefaults.Namespace, types.KindClusterAuthPreference, types.VerbRead); err != nil {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -502,6 +502,21 @@ func (c *Client) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAut
 	return nil, "", trace.NotImplemented(notImplementedMessage)
 }
 
+// DeleteStaticTokens deletes static tokens
+func (c *Client) DeleteStaticTokens() error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
+// GetStaticTokens returns a list of static register tokens
+func (c *Client) GetStaticTokens() (types.StaticTokens, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+// SetStaticTokens sets a list of static register tokens
+func (c *Client) SetStaticTokens(st types.StaticTokens) error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
 // WebService implements features used by Web UI clients
 type WebService interface {
 	// GetWebSessionInfo checks if a web session is valid, returns session id in case if

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -954,42 +954,6 @@ func (c *HTTPClient) SetClusterName(cn types.ClusterName) error {
 	return nil
 }
 
-// DeleteStaticTokens deletes static tokens
-func (c *HTTPClient) DeleteStaticTokens() error {
-	_, err := c.Delete(context.TODO(), c.Endpoint("configuration", "static_tokens"))
-	return trace.Wrap(err)
-}
-
-// GetStaticTokens returns a list of static register tokens
-func (c *HTTPClient) GetStaticTokens() (types.StaticTokens, error) {
-	out, err := c.Get(context.TODO(), c.Endpoint("configuration", "static_tokens"), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	st, err := services.UnmarshalStaticTokens(out.Bytes())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return st, err
-}
-
-// SetStaticTokens sets a list of static register tokens
-func (c *HTTPClient) SetStaticTokens(st types.StaticTokens) error {
-	data, err := services.MarshalStaticTokens(st)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = c.PostJSON(context.TODO(), c.Endpoint("configuration", "static_tokens"), &setStaticTokensReq{StaticTokens: data})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
 func (c *HTTPClient) ValidateTrustedCluster(ctx context.Context, validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
 	validateRequestRaw, err := validateRequest.ToRaw()
 	if err != nil {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -3798,6 +3798,7 @@ func TestEvents(t *testing.T) {
 
 	suite := &suite.ServicesTestSuite{
 		ConfigS:       clt,
+		LocalConfigS:  testSrv.Auth(),
 		EventsS:       clt,
 		PresenceS:     clt,
 		CAS:           clt,

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -69,6 +69,7 @@ func setupServicesContext(ctx context.Context, t *testing.T) *servicesContext {
 		EventsS:       eventsService,
 		ChangesC:      make(chan interface{}),
 		ConfigS:       configService,
+		LocalConfigS:  configService,
 		RestrictionsS: NewRestrictionsService(tt.bk),
 		Clock:         clock,
 	}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -167,6 +167,11 @@ type ServicesTestSuite struct {
 	ProvisioningS services.Provisioner
 	WebS          services.Identity
 	ConfigS       services.ClusterConfiguration
+	// LocalConfigS is used for local config which can only be
+	// managed by the Auth service directly (static tokens).
+	// Used by some tests to differentiate between a server
+	// and client interface.
+	LocalConfigS  services.ClusterConfiguration
 	EventsS       types.Events
 	UsersS        services.UsersService
 	RestrictionsS services.Restrictions
@@ -1061,7 +1066,6 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 	require.NotEmpty(t, upserted.GetRevision())
 	require.NotEqual(t, updated.GetRevision(), upserted.GetRevision())
 	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
-
 }
 
 func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
@@ -1558,13 +1562,13 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = s.ConfigS.SetStaticTokens(staticTokens)
+				err = s.LocalConfigS.SetStaticTokens(staticTokens)
 				require.NoError(t, err)
 
-				out, err := s.ConfigS.GetStaticTokens()
+				out, err := s.LocalConfigS.GetStaticTokens()
 				require.NoError(t, err)
 
-				err = s.ConfigS.DeleteStaticTokens()
+				err = s.LocalConfigS.DeleteStaticTokens()
 				require.NoError(t, err)
 
 				return out


### PR DESCRIPTION
Since the introduction of dynamic provision tokens, these static token endpoints are unused. I suspect these were only kept around to maintain the `ClientI` interface. 

Adding/removing static tokens should not be possible, and it is something we directly prevent with `tctl tokens rm`.