### PR TITLE
Update AWS account ID used in `update-ami-ids` GHA workflow

### DIFF
--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-region:  us-west-2
-          role-to-assume: "arn:aws:iam::126027368216:role/tf-teleport-ami-gha-role"
+          aws-region: us-west-2
+          role-to-assume: "arn:aws:iam::146628656107:role/tf-teleport-ami-gha-role"
           role-session-name: "gha-update-ami-ids-${{ github.run_number }}"
 
       - name: Update AMI IDs and create PR


### PR DESCRIPTION
PR #36153 updated the AWS account ID used for pulling AMIs, but the GHA workflow was not updated to use this updated AWS account ID.

Depends on gravitational/cloud-terraform#3947.

Ref #34282.