### PR TITLE
List EC2 Instance Connect Endpoints: query multiple VPCs

### DIFF
--- a/lib/integrations/awsoidc/list_ec2ice_test.go
+++ b/lib/integrations/awsoidc/list_ec2ice_test.go
@@ -99,36 +99,39 @@ func TestListEC2ICE(t *testing.T) {
 
 		// First page must return pageSize number of Endpoints
 		resp, err := ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			VPCID:     "vpc-123",
+			VPCIDs:    []string{"vpc-123"},
 			Region:    "us-east-1",
 			NextToken: "",
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.NextToken)
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", resp.DashboardLink)
 		require.Len(t, resp.EC2ICEs, pageSize)
 		nextPageToken := resp.NextToken
 		require.Equal(t, "subnet-0", resp.EC2ICEs[0].SubnetID)
 
 		// Second page must return pageSize number of Endpoints
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			VPCID:     "vpc-abc",
+			VPCIDs:    []string{"vpc-abc"},
 			Region:    "us-east-1",
 			NextToken: nextPageToken,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.NextToken)
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", resp.DashboardLink)
 		require.Len(t, resp.EC2ICEs, pageSize)
 		nextPageToken = resp.NextToken
 		require.Equal(t, "subnet-100", resp.EC2ICEs[0].SubnetID)
 
 		// Third page must return only the remaining Endpoints and an empty nextToken
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			VPCID:     "vpc-abc",
+			VPCIDs:    []string{"vpc-abc"},
 			Region:    "us-east-1",
 			NextToken: nextPageToken,
 		})
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
+		require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", resp.DashboardLink)
 		require.Len(t, resp.EC2ICEs, 3)
 		require.Equal(t, "subnet-200", resp.EC2ICEs[0].SubnetID)
 	})
@@ -143,12 +146,13 @@ func TestListEC2ICE(t *testing.T) {
 		{
 			name: "valid for listing endpoints",
 			req: ListEC2ICERequest{
-				VPCID:     "vpc-abcd",
+				VPCIDs:    []string{"vpc-abcd"},
 				Region:    "us-east-1",
 				NextToken: "",
 			},
 			mockEndpoints: []ec2Types.Ec2InstanceConnectEndpoint{{
 				SubnetId:                  aws.String("subnet-123"),
+				VpcId:                     aws.String("vpc-abcd"),
 				InstanceConnectEndpointId: aws.String("ice-name"),
 				State:                     "create-complete",
 				StateMessage:              aws.String("success message"),
@@ -156,14 +160,16 @@ func TestListEC2ICE(t *testing.T) {
 			},
 			respCheck: func(t *testing.T, ldr *ListEC2ICEResponse) {
 				require.Len(t, ldr.EC2ICEs, 1, "expected 1 endpoint, got %d", len(ldr.EC2ICEs))
+				require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", ldr.DashboardLink)
 				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
 
 				endpoint := EC2InstanceConnectEndpoint{
 					Name:          "ice-name",
 					State:         "create-complete",
 					SubnetID:      "subnet-123",
+					VPCID:         "vpc-abcd",
 					StateMessage:  "success message",
-					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpc/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice-name",
+					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice-name",
 				}
 				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[0]))
 			},
@@ -172,7 +178,7 @@ func TestListEC2ICE(t *testing.T) {
 		{
 			name: "valid but ID needs URL encoding",
 			req: ListEC2ICERequest{
-				VPCID:     "vpc-abcd",
+				VPCIDs:    []string{"vpc-abcd"},
 				Region:    "us-east-1",
 				NextToken: "",
 			},
@@ -185,6 +191,7 @@ func TestListEC2ICE(t *testing.T) {
 			},
 			respCheck: func(t *testing.T, ldr *ListEC2ICEResponse) {
 				require.Len(t, ldr.EC2ICEs, 1, "expected 1 endpoint, got %d", len(ldr.EC2ICEs))
+				require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", ldr.DashboardLink)
 				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
 
 				endpoint := EC2InstanceConnectEndpoint{
@@ -192,9 +199,59 @@ func TestListEC2ICE(t *testing.T) {
 					State:         "create-complete",
 					SubnetID:      "subnet-123",
 					StateMessage:  "success message",
-					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpc/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice%2F123",
+					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice%2F123",
 				}
 				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[0]))
+			},
+			errCheck: noErrorFunc,
+		},
+		{
+			name: "valid for multiple VPCs",
+			req: ListEC2ICERequest{
+				VPCIDs:    []string{"vpc-01", "vpc-02"},
+				Region:    "us-east-1",
+				NextToken: "",
+			},
+			mockEndpoints: []ec2Types.Ec2InstanceConnectEndpoint{
+				{
+					SubnetId:                  aws.String("subnet-123"),
+					VpcId:                     aws.String("vpc-01"),
+					InstanceConnectEndpointId: aws.String("ice-name-1"),
+					State:                     "create-complete",
+					StateMessage:              aws.String("success message"),
+				},
+				{
+					SubnetId:                  aws.String("subnet-123"),
+					VpcId:                     aws.String("vpc-02"),
+					InstanceConnectEndpointId: aws.String("ice-name-2"),
+					State:                     "create-complete",
+					StateMessage:              aws.String("success message"),
+				},
+			},
+			respCheck: func(t *testing.T, ldr *ListEC2ICEResponse) {
+				require.Len(t, ldr.EC2ICEs, 2, "expected 1 endpoint, got %d", len(ldr.EC2ICEs))
+				require.Equal(t, "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#Endpoints:v=3;vpcEndpointType=EC2%20Instance%20Connect%20Endpoint", ldr.DashboardLink)
+				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
+
+				endpoint := EC2InstanceConnectEndpoint{
+					Name:          "ice-name-1",
+					State:         "create-complete",
+					SubnetID:      "subnet-123",
+					VPCID:         "vpc-01",
+					StateMessage:  "success message",
+					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice-name-1",
+				}
+				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[0]))
+
+				endpoint = EC2InstanceConnectEndpoint{
+					Name:          "ice-name-2",
+					State:         "create-complete",
+					SubnetID:      "subnet-123",
+					VPCID:         "vpc-02",
+					StateMessage:  "success message",
+					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpcconsole/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice-name-2",
+				}
+				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[1]))
 			},
 			errCheck: noErrorFunc,
 		},
@@ -208,7 +265,7 @@ func TestListEC2ICE(t *testing.T) {
 		{
 			name: "no region id",
 			req: ListEC2ICERequest{
-				VPCID: "vpc-123",
+				VPCIDs: []string{"vpc-123"},
 			},
 			errCheck: trace.IsBadParameter,
 		},

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -642,11 +642,16 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 		return nil, trace.Wrap(err)
 	}
 
+	vpcIds := req.VPCIDs
+	if len(vpcIds) == 0 {
+		vpcIds = []string{req.VPCID}
+	}
+
 	resp, err := awsoidc.ListEC2ICE(ctx,
 		listEC2ICEClient,
 		awsoidc.ListEC2ICERequest{
 			Region:    req.Region,
-			VPCID:     req.VPCID,
+			VPCIDs:    vpcIds,
 			NextToken: req.NextToken,
 		},
 	)
@@ -655,8 +660,9 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 	}
 
 	return ui.AWSOIDCListEC2ICEResponse{
-		NextToken: resp.NextToken,
-		EC2ICEs:   resp.EC2ICEs,
+		NextToken:     resp.NextToken,
+		DashboardLink: resp.DashboardLink,
+		EC2ICEs:       resp.EC2ICEs,
 	}, nil
 }
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -313,7 +313,10 @@ type AWSOIDCListEC2ICERequest struct {
 	// Region is the AWS Region.
 	Region string `json:"region"`
 	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
+	// Deprecated: use VPCIDs instead.
 	VPCID string `json:"vpcId"`
+	// VPCIDs is a list of VPCs to filter EC2 Instance Connect Endpoints.
+	VPCIDs []string `json:"vpcIds"`
 	// NextToken is the token to be used to fetch the next page.
 	// If empty, the first page is fetched.
 	NextToken string `json:"nextToken"`
@@ -323,6 +326,9 @@ type AWSOIDCListEC2ICERequest struct {
 type AWSOIDCListEC2ICEResponse struct {
 	// EC2ICEs contains the page of Endpoints
 	EC2ICEs []awsoidc.EC2InstanceConnectEndpoint `json:"ec2Ices"`
+
+	// DashboardLink is the URL for AWS Web Console that lists all the Endpoints for the queries VPCs.
+	DashboardLink string `json:"dashboardLink,omitempty"`
 
 	// NextToken is used for pagination.
 	// If non-empty, it can be used to request the next page.


### PR DESCRIPTION
Listing EC2 Instance Connect Endpoints now support multiple VPCs as filter.

The response will include a link to the VPC Endpoint Dashboard and for each EICE it will also include the corresponding VPC.

This is prep work for the EC2 w/ EICE Discovery flow.

Sending a single element is still supported to be compatible with the Single Instance flow.