### PR TITLE
Rename "Hardware Key" to "Passkey or Security Key"

### DIFF
--- a/web/packages/shared/components/FormPassword/FormPassword.tsx
+++ b/web/packages/shared/components/FormPassword/FormPassword.tsx
@@ -123,7 +123,7 @@ function FormPassword(props: Props) {
           />
           {mfaEnabled && (
             <Flex alignItems="flex-end" mb={4}>
-              <Box width="50%" data-testid="mfa-select">
+              <Box width="60%" data-testid="mfa-select">
                 <FieldSelect
                   label="Two-factor Type"
                   value={mfaType}
@@ -134,7 +134,7 @@ function FormPassword(props: Props) {
                   isDisabled={isProcessing}
                 />
               </Box>
-              <Box width="50%">
+              <Box width="40%">
                 {mfaType.value === 'otp' && (
                   <FieldInput
                     label="Authenticator Code"

--- a/web/packages/shared/components/FormPassword/__snapshots__/FormPassword.test.tsx.snap
+++ b/web/packages/shared/components/FormPassword/__snapshots__/FormPassword.test.tsx.snap
@@ -352,7 +352,7 @@ exports[`auth2faType "on" should render form with hardware key as first option i
                   <div
                     class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    Passkey or Hardware Key
+                    Passkey or Security Key
                   </div>
                   <input
                     aria-autocomplete="list"
@@ -799,7 +799,7 @@ exports[`auth2faType "optional" should render form with hardware key as first op
                   <div
                     class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    Passkey or Hardware Key
+                    Passkey or Security Key
                   </div>
                   <input
                     aria-autocomplete="list"

--- a/web/packages/shared/components/FormPassword/__snapshots__/FormPassword.test.tsx.snap
+++ b/web/packages/shared/components/FormPassword/__snapshots__/FormPassword.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`auth2faType "on" should render form with hardware key as first option i
 
 .c4 {
   box-sizing: border-box;
-  width: 50%;
+  width: 60%;
 }
 
 .c5 {
@@ -19,10 +19,15 @@ exports[`auth2faType "on" should render form with hardware key as first option i
 
 .c8 {
   box-sizing: border-box;
+  width: 40%;
+}
+
+.c9 {
+  box-sizing: border-box;
   margin-top: 32px;
 }
 
-.c10 {
+.c11 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -49,16 +54,16 @@ exports[`auth2faType "on" should render form with hardware key as first option i
   width: 100%;
 }
 
-.c10:hover,
-.c10:focus {
+.c11:hover,
+.c11:focus {
   background: #B29DFF;
 }
 
-.c10:active {
+.c11:active {
   background: #C5B6FF;
 }
 
-.c10:disabled {
+.c11:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
@@ -125,7 +130,7 @@ exports[`auth2faType "on" should render form with hardware key as first option i
   align-items: flex-end;
 }
 
-.c9 {
+.c10 {
   display: flex;
   gap: 32px;
 }
@@ -320,7 +325,7 @@ exports[`auth2faType "on" should render form with hardware key as first option i
       <div
         class="c4"
         data-testid="mfa-select"
-        width="50%"
+        width="60%"
       >
         <div
           class="c5"
@@ -347,7 +352,7 @@ exports[`auth2faType "on" should render form with hardware key as first option i
                   <div
                     class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    Hardware Key
+                    Passkey or Hardware Key
                   </div>
                   <input
                     aria-autocomplete="list"
@@ -388,8 +393,8 @@ exports[`auth2faType "on" should render form with hardware key as first option i
         </div>
       </div>
       <div
-        class="c4"
-        width="50%"
+        class="c8"
+        width="40%"
       />
     </div>
     <div
@@ -429,10 +434,10 @@ exports[`auth2faType "on" should render form with hardware key as first option i
       </label>
     </div>
     <div
-      class="c8 c9"
+      class="c9 c10"
     >
       <button
-        class="c10"
+        class="c11"
         kind="primary"
       >
         Update Password
@@ -450,7 +455,7 @@ exports[`auth2faType "optional" should render form with hardware key as first op
 
 .c4 {
   box-sizing: border-box;
-  width: 50%;
+  width: 60%;
 }
 
 .c5 {
@@ -461,10 +466,15 @@ exports[`auth2faType "optional" should render form with hardware key as first op
 
 .c8 {
   box-sizing: border-box;
+  width: 40%;
+}
+
+.c9 {
+  box-sizing: border-box;
   margin-top: 32px;
 }
 
-.c10 {
+.c11 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -491,16 +501,16 @@ exports[`auth2faType "optional" should render form with hardware key as first op
   width: 100%;
 }
 
-.c10:hover,
-.c10:focus {
+.c11:hover,
+.c11:focus {
   background: #B29DFF;
 }
 
-.c10:active {
+.c11:active {
   background: #C5B6FF;
 }
 
-.c10:disabled {
+.c11:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
@@ -567,7 +577,7 @@ exports[`auth2faType "optional" should render form with hardware key as first op
   align-items: flex-end;
 }
 
-.c9 {
+.c10 {
   display: flex;
   gap: 32px;
 }
@@ -762,7 +772,7 @@ exports[`auth2faType "optional" should render form with hardware key as first op
       <div
         class="c4"
         data-testid="mfa-select"
-        width="50%"
+        width="60%"
       >
         <div
           class="c5"
@@ -789,7 +799,7 @@ exports[`auth2faType "optional" should render form with hardware key as first op
                   <div
                     class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    Hardware Key
+                    Passkey or Hardware Key
                   </div>
                   <input
                     aria-autocomplete="list"
@@ -830,8 +840,8 @@ exports[`auth2faType "optional" should render form with hardware key as first op
         </div>
       </div>
       <div
-        class="c4"
-        width="50%"
+        class="c8"
+        width="40%"
       />
     </div>
     <div
@@ -871,10 +881,10 @@ exports[`auth2faType "optional" should render form with hardware key as first op
       </label>
     </div>
     <div
-      class="c8 c9"
+      class="c9 c10"
     >
       <button
-        class="c10"
+        class="c11"
         kind="primary"
       >
         Update Password

--- a/web/packages/shared/utils/createMfaOptions.ts
+++ b/web/packages/shared/utils/createMfaOptions.ts
@@ -29,7 +29,7 @@ export default function createMfaOptions(opts: Options) {
   const mfaEnabled = auth2faType === 'on' || auth2faType === 'optional';
 
   if (auth2faType === 'webauthn' || mfaEnabled) {
-    mfaOptions.push({ value: 'webauthn', label: 'Hardware Key' });
+    mfaOptions.push({ value: 'webauthn', label: 'Passkey or Hardware Key' });
   }
 
   if (auth2faType === 'otp' || mfaEnabled) {

--- a/web/packages/shared/utils/createMfaOptions.ts
+++ b/web/packages/shared/utils/createMfaOptions.ts
@@ -29,7 +29,7 @@ export default function createMfaOptions(opts: Options) {
   const mfaEnabled = auth2faType === 'on' || auth2faType === 'optional';
 
   if (auth2faType === 'webauthn' || mfaEnabled) {
-    mfaOptions.push({ value: 'webauthn', label: 'Passkey or Hardware Key' });
+    mfaOptions.push({ value: 'webauthn', label: 'Passkey or Security Key' });
   }
 
   if (auth2faType === 'otp' || mfaEnabled) {

--- a/web/packages/teleport/src/Account/ManageDevices/AddDevice/__snapshots__/AddDevice.story.test.tsx.snap
+++ b/web/packages/teleport/src/Account/ManageDevices/AddDevice/__snapshots__/AddDevice.story.test.tsx.snap
@@ -519,7 +519,7 @@ exports[`render dialog to add a new mfa device with webauthn as preferred type 1
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Hardware Key
+                        Passkey or Hardware Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -1218,7 +1218,7 @@ exports[`render failed state for dialog to add a new mfa device 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Hardware Key
+                        Passkey or Hardware Key
                       </div>
                       <input
                         aria-autocomplete="list"

--- a/web/packages/teleport/src/Account/ManageDevices/AddDevice/__snapshots__/AddDevice.story.test.tsx.snap
+++ b/web/packages/teleport/src/Account/ManageDevices/AddDevice/__snapshots__/AddDevice.story.test.tsx.snap
@@ -519,7 +519,7 @@ exports[`render dialog to add a new mfa device with webauthn as preferred type 1
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Passkey or Hardware Key
+                        Passkey or Security Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -1218,7 +1218,7 @@ exports[`render failed state for dialog to add a new mfa device 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Passkey or Hardware Key
+                        Passkey or Security Key
                       </div>
                       <input
                         aria-autocomplete="list"

--- a/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
+++ b/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
@@ -1022,7 +1022,7 @@ exports[`story.MfaDeviceOn 1`] = `
               <span
                 class="c18"
               >
-                Passkey or Hardware Key
+                Passkey or Security Key
               </span>
             </label>
             <label
@@ -2121,7 +2121,7 @@ exports[`story.MfaDeviceWebauthn 1`] = `
               <span
                 class="c18"
               >
-                Passkey or Hardware Key
+                Passkey or Security Key
               </span>
             </label>
           </div>

--- a/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
+++ b/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
@@ -1022,7 +1022,7 @@ exports[`story.MfaDeviceOn 1`] = `
               <span
                 class="c18"
               >
-                Hardware Key
+                Passkey or Hardware Key
               </span>
             </label>
             <label
@@ -2121,7 +2121,7 @@ exports[`story.MfaDeviceWebauthn 1`] = `
               <span
                 class="c18"
               >
-                Hardware Key
+                Passkey or Hardware Key
               </span>
             </label>
           </div>

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -292,7 +292,7 @@ const LocalForm = ({
             <Box mb={isRecoveryEnabled ? 2 : 3}>
               <Flex alignItems="flex-end">
                 <FieldSelect
-                  maxWidth="50%"
+                  maxWidth="60%"
                   width="100%"
                   data-testid="mfa-select"
                   label="Two-factor Type"
@@ -306,7 +306,7 @@ const LocalForm = ({
                 />
                 {mfaType.value === 'otp' && (
                   <FieldInput
-                    width="50%"
+                    width="40%"
                     label="Authenticator Code"
                     rule={requiredToken}
                     autoComplete="one-time-code"

--- a/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -756,7 +756,7 @@ exports[`auth2faType: optional rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Passkey or Hardware Key
+                            Passkey or Security Key
                           </div>
                           <input
                             aria-autocomplete="list"
@@ -1853,7 +1853,7 @@ exports[`auth2faType: webauthn rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Passkey or Hardware Key
+                            Passkey or Security Key
                           </div>
                           <input
                             aria-autocomplete="list"
@@ -2480,7 +2480,7 @@ exports[`cloud auth2faType: on rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Passkey or Hardware Key
+                            Passkey or Security Key
                           </div>
                           <input
                             aria-autocomplete="list"

--- a/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`auth2faType: optional rendering 1`] = `
 
 .c12 {
   box-sizing: border-box;
-  max-width: 50%;
+  max-width: 60%;
   margin-bottom: 0px;
   margin-right: 16px;
   width: 100%;
@@ -756,7 +756,7 @@ exports[`auth2faType: optional rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Hardware Key
+                            Passkey or Hardware Key
                           </div>
                           <input
                             aria-autocomplete="list"
@@ -850,7 +850,7 @@ exports[`auth2faType: otp rendering 1`] = `
 
 .c12 {
   box-sizing: border-box;
-  max-width: 50%;
+  max-width: 60%;
   margin-bottom: 0px;
   margin-right: 16px;
   width: 100%;
@@ -859,7 +859,7 @@ exports[`auth2faType: otp rendering 1`] = `
 .c15 {
   box-sizing: border-box;
   margin-bottom: 0px;
-  width: 50%;
+  width: 40%;
 }
 
 .c16 {
@@ -1339,7 +1339,7 @@ exports[`auth2faType: otp rendering 1`] = `
                 </div>
                 <div
                   class="c15"
-                  width="50%"
+                  width="40%"
                 >
                   <label
                     class="c8"
@@ -1411,7 +1411,7 @@ exports[`auth2faType: webauthn rendering 1`] = `
 
 .c12 {
   box-sizing: border-box;
-  max-width: 50%;
+  max-width: 60%;
   margin-bottom: 0px;
   margin-right: 16px;
   width: 100%;
@@ -1853,7 +1853,7 @@ exports[`auth2faType: webauthn rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Hardware Key
+                            Passkey or Hardware Key
                           </div>
                           <input
                             aria-autocomplete="list"
@@ -1962,7 +1962,7 @@ exports[`cloud auth2faType: on rendering 1`] = `
 
 .c17 {
   box-sizing: border-box;
-  max-width: 50%;
+  max-width: 60%;
   margin-bottom: 0px;
   margin-right: 16px;
   width: 100%;
@@ -2480,7 +2480,7 @@ exports[`cloud auth2faType: on rendering 1`] = `
                           <div
                             class="react-select__single-value css-1uccc91-singleValue"
                           >
-                            Hardware Key
+                            Passkey or Hardware Key
                           </div>
                           <input
                             aria-autocomplete="list"

--- a/web/packages/teleport/src/components/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleport/src/components/ReAuthenticate/ReAuthenticate.tsx
@@ -94,7 +94,7 @@ export function ReAuthenticate({
             <DialogContent>
               <Flex mt={2} alignItems="flex-end">
                 <FieldSelect
-                  width="50%"
+                  width="60%"
                   label="Two-factor Type"
                   value={mfaOption}
                   options={mfaOptions}
@@ -108,7 +108,7 @@ export function ReAuthenticate({
                   isDisabled={attempt.status === 'processing'}
                   elevated={true}
                 />
-                <Box width="50%">
+                <Box width="40%">
                   {mfaOption.value === 'otp' && (
                     <FieldInput
                       label="Authenticator Code"

--- a/web/packages/teleport/src/components/ReAuthenticate/__snapshots__/ReAuthenticate.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/ReAuthenticate/__snapshots__/ReAuthenticate.story.test.tsx.snap
@@ -471,7 +471,7 @@ exports[`render failed state for re-authentication dialog 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Passkey or Hardware Key
+                        Passkey or Security Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -980,7 +980,7 @@ exports[`render re-authentication dialog 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Passkey or Hardware Key
+                        Passkey or Security Key
                       </div>
                       <input
                         aria-autocomplete="list"

--- a/web/packages/teleport/src/components/ReAuthenticate/__snapshots__/ReAuthenticate.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/ReAuthenticate/__snapshots__/ReAuthenticate.story.test.tsx.snap
@@ -45,12 +45,12 @@ exports[`render failed state for re-authentication dialog 1`] = `
   box-sizing: border-box;
   margin-bottom: 0px;
   margin-right: 16px;
-  width: 50%;
+  width: 60%;
 }
 
 .c16 {
   box-sizing: border-box;
-  width: 50%;
+  width: 40%;
 }
 
 .c17 {
@@ -447,7 +447,7 @@ exports[`render failed state for re-authentication dialog 1`] = `
             <div
               class="c13"
               data-testid="mfa-select"
-              width="50%"
+              width="60%"
             >
               <label
                 class="c14"
@@ -471,7 +471,7 @@ exports[`render failed state for re-authentication dialog 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Hardware Key
+                        Passkey or Hardware Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -512,7 +512,7 @@ exports[`render failed state for re-authentication dialog 1`] = `
             </div>
             <div
               class="c16"
-              width="50%"
+              width="40%"
             />
           </div>
         </div>
@@ -561,12 +561,12 @@ exports[`render re-authentication dialog 1`] = `
   box-sizing: border-box;
   margin-bottom: 0px;
   margin-right: 16px;
-  width: 50%;
+  width: 60%;
 }
 
 .c15 {
   box-sizing: border-box;
-  width: 50%;
+  width: 40%;
 }
 
 .c16 {
@@ -956,7 +956,7 @@ exports[`render re-authentication dialog 1`] = `
             <div
               class="c12"
               data-testid="mfa-select"
-              width="50%"
+              width="60%"
             >
               <label
                 class="c13"
@@ -980,7 +980,7 @@ exports[`render re-authentication dialog 1`] = `
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        Hardware Key
+                        Passkey or Hardware Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -1021,7 +1021,7 @@ exports[`render re-authentication dialog 1`] = `
             </div>
             <div
               class="c15"
-              width="50%"
+              width="40%"
             />
           </div>
         </div>

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
@@ -103,7 +103,7 @@ export const FormLocal = ({
           {secondFactor !== 'off' && (
             <Flex alignItems="flex-end" mb={4}>
               <FieldSelect
-                maxWidth="50%"
+                maxWidth="60%"
                 width="100%"
                 data-testid="mfa-select"
                 label="Two-factor Type"
@@ -117,7 +117,7 @@ export const FormLocal = ({
               />
               {mfaType.value === 'otp' && (
                 <FieldInput
-                  width="50%"
+                  width="40%"
                   label="Authenticator Code"
                   rule={requiredToken}
                   autoComplete="one-time-code"


### PR DESCRIPTION
Contributes to #36234 

This change enhances the UX by decreasing confusion over what "hardware key" means (it actually means "either a hardware key or other allowed passkey type").

Width distribution changes are necessary to accomodate a bit longer text in the UI.

![Screenshot 2024-01-11 at 20 01 40](https://github.com/gravitational/teleport/assets/9391503/498cc3c8-9737-4374-9b5c-33b1507e2d96)
![Screenshot 2024-01-11 at 20 01 47](https://github.com/gravitational/teleport/assets/9391503/d1b291fd-ca53-46fe-a0f9-b360706e383b)

cc @benarent