### PR TITLE
AWSOIDC Deploy EICE: allow multiple endpoints

### DIFF
--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -20,6 +20,7 @@ package awsoidc
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -37,12 +38,8 @@ type CreateEC2ICERequest struct {
 	// Used to tag resources created in AWS.
 	IntegrationName string
 
-	// SubnetID is the Subnet where the Endpoint will be created.
-	SubnetID string
-
-	// SecurityGroupIDs is a list of SecurityGroups to assign to the Endpoint.
-	// If not specified, the Endpoint will receive the default SG for the Subnet's VPC.
-	SecurityGroupIDs []string
+	// Endpoints is a list of EC2 Instance Connect Endpoints to be createed.
+	Endpoints []CreateEC2ICERequestEndpoint
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
 	// Defaults to:
@@ -50,6 +47,17 @@ type CreateEC2ICERequest struct {
 	// - teleport.dev/origin: aws-oidc-integration
 	// - teleport.dev/integration: <integrationName>
 	ResourceCreationTags AWSTags
+}
+
+// CreateEC2ICERequestEndpoint contains the information for a single Endpoint to be created.
+
+type CreateEC2ICERequestEndpoint struct {
+	// SubnetID is the Subnet where the Endpoint will be created.
+	SubnetID string
+
+	// SecurityGroupIDs is a list of SecurityGroups to assign to the Endpoint.
+	// If not specified, the Endpoint will receive the default SG for the Subnet's VPC.
+	SecurityGroupIDs []string
 }
 
 // CheckAndSetDefaults checks if the required fields are present.
@@ -62,8 +70,14 @@ func (req *CreateEC2ICERequest) CheckAndSetDefaults() error {
 		return trace.BadParameter("integration is required")
 	}
 
-	if req.SubnetID == "" {
-		return trace.BadParameter("subnet id is required")
+	if len(req.Endpoints) == 0 {
+		return trace.BadParameter("endpoints is required")
+	}
+
+	for i, endpoint := range req.Endpoints {
+		if endpoint.SubnetID == "" {
+			return trace.BadParameter("missing Subnet in endpoint (index %d)", i)
+		}
 	}
 
 	if len(req.ResourceCreationTags) == 0 {
@@ -77,6 +91,9 @@ func (req *CreateEC2ICERequest) CheckAndSetDefaults() error {
 type CreateEC2ICEResponse struct {
 	// Name is the Endpoint ID.
 	Name string
+
+	// CreatedEndpoints contains the name of created endpoints and their Subnet.
+	CreatedEndpoints map[string]string
 }
 
 // CreateEC2ICE describes the required methods to List EC2 Instances using a 3rd Party API.
@@ -113,26 +130,35 @@ func CreateEC2ICE(ctx context.Context, clt CreateEC2ICEClient, req CreateEC2ICER
 		return nil, trace.Wrap(err)
 	}
 
-	createEC2ICEInput := &ec2.CreateInstanceConnectEndpointInput{
-		SubnetId:         &req.SubnetID,
-		SecurityGroupIds: req.SecurityGroupIDs,
-		TagSpecifications: []ec2types.TagSpecification{{
-			ResourceType: ec2types.ResourceTypeInstanceConnectEndpoint,
-			Tags:         req.ResourceCreationTags.ToEC2Tags(),
-		}},
-	}
+	createdEndpoints := make(map[string]string, len(req.Endpoints))
+	endpointNames := make([]string, 0, len(req.Endpoints))
 
-	ec2ICEndpoint, err := clt.CreateInstanceConnectEndpoint(ctx, createEC2ICEInput)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	for _, endpoint := range req.Endpoints {
+		createEC2ICEInput := &ec2.CreateInstanceConnectEndpointInput{
+			SubnetId:         &endpoint.SubnetID,
+			SecurityGroupIds: endpoint.SecurityGroupIDs,
+			TagSpecifications: []ec2types.TagSpecification{{
+				ResourceType: ec2types.ResourceTypeInstanceConnectEndpoint,
+				Tags:         req.ResourceCreationTags.ToEC2Tags(),
+			}},
+		}
 
-	endpointName := "unknown"
-	if ec2ICEndpoint.InstanceConnectEndpoint != nil {
-		endpointName = aws.ToString(ec2ICEndpoint.InstanceConnectEndpoint.InstanceConnectEndpointId)
+		ec2ICEndpoint, err := clt.CreateInstanceConnectEndpoint(ctx, createEC2ICEInput)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		endpointName := "unknown"
+		if ec2ICEndpoint.InstanceConnectEndpoint != nil {
+			endpointName = aws.ToString(ec2ICEndpoint.InstanceConnectEndpoint.InstanceConnectEndpointId)
+		}
+		endpointNames = append(endpointNames, endpointName)
+
+		createdEndpoints[endpointName] = endpoint.SubnetID
 	}
 
 	return &CreateEC2ICEResponse{
-		Name: endpointName,
+		Name:             strings.Join(endpointNames, ","),
+		CreatedEndpoints: createdEndpoints,
 	}, nil
 }

--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -39,7 +39,7 @@ type CreateEC2ICERequest struct {
 	IntegrationName string
 
 	// Endpoints is a list of EC2 Instance Connect Endpoints to be createed.
-	Endpoints []CreateEC2ICERequestEndpoint
+	Endpoints []EC2ICEEndpoint
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
 	// Defaults to:
@@ -49,9 +49,12 @@ type CreateEC2ICERequest struct {
 	ResourceCreationTags AWSTags
 }
 
-// CreateEC2ICERequestEndpoint contains the information for a single Endpoint to be created.
+// EC2ICEEndpoint contains the information for a single Endpoint to be created.
 
-type CreateEC2ICERequestEndpoint struct {
+type EC2ICEEndpoint struct {
+	// Name is the endpoint name.
+	Name string
+
 	// SubnetID is the Subnet where the Endpoint will be created.
 	SubnetID string
 
@@ -93,7 +96,7 @@ type CreateEC2ICEResponse struct {
 	Name string
 
 	// CreatedEndpoints contains the name of created endpoints and their Subnet.
-	CreatedEndpoints map[string]string
+	CreatedEndpoints []EC2ICEEndpoint
 }
 
 // CreateEC2ICE describes the required methods to List EC2 Instances using a 3rd Party API.
@@ -130,7 +133,7 @@ func CreateEC2ICE(ctx context.Context, clt CreateEC2ICEClient, req CreateEC2ICER
 		return nil, trace.Wrap(err)
 	}
 
-	createdEndpoints := make(map[string]string, len(req.Endpoints))
+	createdEndpoints := make([]EC2ICEEndpoint, 0, len(req.Endpoints))
 	endpointNames := make([]string, 0, len(req.Endpoints))
 
 	for _, endpoint := range req.Endpoints {
@@ -148,13 +151,19 @@ func CreateEC2ICE(ctx context.Context, clt CreateEC2ICEClient, req CreateEC2ICER
 			return nil, trace.Wrap(err)
 		}
 
+		// Sentinel value that indicates that the API returned a nil ec2ICEndpoint.InstanceConnectEndpoint.
+		// Very unlikely to happen.
 		endpointName := "unknown"
 		if ec2ICEndpoint.InstanceConnectEndpoint != nil {
 			endpointName = aws.ToString(ec2ICEndpoint.InstanceConnectEndpoint.InstanceConnectEndpointId)
 		}
 		endpointNames = append(endpointNames, endpointName)
 
-		createdEndpoints[endpointName] = endpoint.SubnetID
+		createdEndpoints = append(createdEndpoints, EC2ICEEndpoint{
+			Name:             endpointName,
+			SubnetID:         endpoint.SubnetID,
+			SecurityGroupIDs: endpoint.SecurityGroupIDs,
+		})
 	}
 
 	return &CreateEC2ICEResponse{

--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -50,7 +50,6 @@ type CreateEC2ICERequest struct {
 }
 
 // EC2ICEEndpoint contains the information for a single Endpoint to be created.
-
 type EC2ICEEndpoint struct {
 	// Name is the endpoint name.
 	Name string

--- a/lib/integrations/awsoidc/create_ec2ice_test.go
+++ b/lib/integrations/awsoidc/create_ec2ice_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/google/go-cmp/cmp"
@@ -31,8 +32,8 @@ import (
 )
 
 type mockCreateEC2ICEClient struct {
-	name string
-	err  error
+	subnetToNameMap map[string]string
+	err             error
 }
 
 func (m mockCreateEC2ICEClient) CreateInstanceConnectEndpoint(ctx context.Context, params *ec2.CreateInstanceConnectEndpointInput, optFns ...func(*ec2.Options)) (*ec2.CreateInstanceConnectEndpointOutput, error) {
@@ -40,9 +41,14 @@ func (m mockCreateEC2ICEClient) CreateInstanceConnectEndpoint(ctx context.Contex
 		return nil, m.err
 	}
 
+	name, ok := m.subnetToNameMap[aws.ToString(params.SubnetId)]
+	if !ok {
+		return nil, trace.NotFound("subnet not configured")
+	}
+
 	return &ec2.CreateInstanceConnectEndpointOutput{
 		InstanceConnectEndpoint: &ec2Types.Ec2InstanceConnectEndpoint{
-			InstanceConnectEndpointId: &m.name,
+			InstanceConnectEndpointId: &name,
 		},
 	}, nil
 }
@@ -50,15 +56,42 @@ func (m mockCreateEC2ICEClient) CreateInstanceConnectEndpoint(ctx context.Contex
 func TestCreateEC2ICE_success(t *testing.T) {
 	ctx := context.Background()
 	mockCreateClient := &mockCreateEC2ICEClient{
-		name: "eice-123",
+		subnetToNameMap: map[string]string{
+			"subnet-id123": "eice-123",
+		},
 	}
 	resp, err := CreateEC2ICE(ctx, mockCreateClient, CreateEC2ICERequest{
 		Cluster:         "c1",
 		IntegrationName: "i1",
-		SubnetID:        "subnet-id123",
+		Endpoints: []CreateEC2ICERequestEndpoint{{
+			SubnetID: "subnet-id123",
+		}},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "eice-123", resp.Name)
+}
+
+func TestCreateEC2ICE_success_multiple(t *testing.T) {
+	ctx := context.Background()
+	mockCreateClient := &mockCreateEC2ICEClient{
+		subnetToNameMap: map[string]string{
+			"subnet-id123": "eice-123",
+			"subnet-id456": "eice-456",
+		},
+	}
+	resp, err := CreateEC2ICE(ctx, mockCreateClient, CreateEC2ICERequest{
+		Cluster:         "c1",
+		IntegrationName: "i1",
+		Endpoints: []CreateEC2ICERequestEndpoint{
+			{SubnetID: "subnet-id123"},
+			{SubnetID: "subnet-id456"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "eice-123,eice-456", resp.Name)
+	require.Len(t, resp.CreatedEndpoints, 2)
+	require.Equal(t, "subnet-id123", resp.CreatedEndpoints["eice-123"])
+	require.Equal(t, "subnet-id456", resp.CreatedEndpoints["eice-456"])
 }
 
 func TestCreateEC2ICE_error_quota_reached(t *testing.T) {
@@ -69,7 +102,9 @@ func TestCreateEC2ICE_error_quota_reached(t *testing.T) {
 	_, err := CreateEC2ICE(ctx, mockCreateClient, CreateEC2ICERequest{
 		Cluster:         "c1",
 		IntegrationName: "i1",
-		SubnetID:        "subnet-id123",
+		Endpoints: []CreateEC2ICERequestEndpoint{{
+			SubnetID: "subnet-id123",
+		}},
 	})
 	require.ErrorContains(t, err, "api error ResourceLimitExceeded: You've reached the quota for the maximum number of Instance Connect Endpoints for this subnet. Delete unused Instance Connect Endpoints, or request a quota increase.")
 }
@@ -81,10 +116,12 @@ func TestCreateEC2ICERequest(t *testing.T) {
 
 	baseReqFn := func() CreateEC2ICERequest {
 		return CreateEC2ICERequest{
-			Cluster:          "teleport-cluster",
-			IntegrationName:  "teleportdev",
-			SubnetID:         "subnet-123",
-			SecurityGroupIDs: []string{"sg-1", "sg-2"},
+			Cluster:         "teleport-cluster",
+			IntegrationName: "teleportdev",
+			Endpoints: []CreateEC2ICERequestEndpoint{{
+				SubnetID:         "subnet-123",
+				SecurityGroupIDs: []string{"sg-1", "sg-2"},
+			}},
 		}
 	}
 
@@ -123,7 +160,16 @@ func TestCreateEC2ICERequest(t *testing.T) {
 			name: "missing subnet id",
 			req: func() CreateEC2ICERequest {
 				r := baseReqFn()
-				r.SubnetID = ""
+				r.Endpoints[0].SubnetID = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing endpoints list",
+			req: func() CreateEC2ICERequest {
+				r := baseReqFn()
+				r.Endpoints = nil
 				return r
 			},
 			errCheck: isBadParamErrFn,
@@ -133,10 +179,12 @@ func TestCreateEC2ICERequest(t *testing.T) {
 			req:      baseReqFn,
 			errCheck: require.NoError,
 			reqWithDefaults: CreateEC2ICERequest{
-				Cluster:          "teleport-cluster",
-				IntegrationName:  "teleportdev",
-				SubnetID:         "subnet-123",
-				SecurityGroupIDs: []string{"sg-1", "sg-2"},
+				Cluster:         "teleport-cluster",
+				IntegrationName: "teleportdev",
+				Endpoints: []CreateEC2ICERequestEndpoint{{
+					SubnetID:         "subnet-123",
+					SecurityGroupIDs: []string{"sg-1", "sg-2"},
+				}},
 				ResourceCreationTags: AWSTags{
 					"teleport.dev/origin":      "integration_awsoidc",
 					"teleport.dev/cluster":     "teleport-cluster",

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -685,10 +685,10 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.Wrap(err)
 	}
 
-	endpoints := make([]awsoidc.CreateEC2ICERequestEndpoint, 0, len(req.Endpoints))
+	endpoints := make([]awsoidc.EC2ICEEndpoint, 0, len(req.Endpoints))
 
 	for _, endpoint := range req.Endpoints {
-		endpoints = append(endpoints, awsoidc.CreateEC2ICERequestEndpoint{
+		endpoints = append(endpoints, awsoidc.EC2ICEEndpoint{
 			SubnetID:         endpoint.SubnetID,
 			SecurityGroupIDs: endpoint.SecurityGroupIDs,
 		})
@@ -696,7 +696,7 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 
 	// Backwards compatible: get the endpoint from the deprecated fields.
 	if len(endpoints) == 0 {
-		endpoints = append(endpoints, awsoidc.CreateEC2ICERequestEndpoint{
+		endpoints = append(endpoints, awsoidc.EC2ICEEndpoint{
 			SubnetID:         req.SubnetID,
 			SecurityGroupIDs: req.SecurityGroupIDs,
 		})
@@ -715,10 +715,10 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 	}
 
 	respEndpoints := make([]ui.AWSOIDCDeployEC2ICEResponseEndpoint, 0, len(resp.CreatedEndpoints))
-	for name, subnet := range resp.CreatedEndpoints {
+	for _, endpoint := range resp.CreatedEndpoints {
 		respEndpoints = append(respEndpoints, ui.AWSOIDCDeployEC2ICEResponseEndpoint{
-			Name:     name,
-			SubnetID: subnet,
+			Name:     endpoint.Name,
+			SubnetID: endpoint.SubnetID,
 		})
 	}
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -339,6 +339,20 @@ type AWSOIDCListEC2ICEResponse struct {
 type AWSOIDCDeployEC2ICERequest struct {
 	// Region is the AWS Region.
 	Region string `json:"region"`
+	// Endpoints is a list of endpoinst to create.
+	Endpoints []AWSOIDCDeployEC2ICERequestEndpoint `json:"endpoints"`
+
+	// SubnetID is the subnet id for the EC2 Instance Connect Endpoint.
+	// Deprecated: use Endpoints instead.
+	SubnetID string `json:"subnetId"`
+	// SecurityGroupIDs is the list of SecurityGroups to apply to the Endpoint.
+	// If not specified, the Endpoint will receive the default SG for the Subnet's VPC.
+	// Deprecated: use Endpoints instead.
+	SecurityGroupIDs []string `json:"securityGroupIds"`
+}
+
+// AWSOIDCDeployEC2ICERequestEndpoint is a single Endpoint that should be created.
+type AWSOIDCDeployEC2ICERequestEndpoint struct {
 	// SubnetID is the subnet id for the EC2 Instance Connect Endpoint.
 	SubnetID string `json:"subnetId"`
 	// SecurityGroupIDs is the list of SecurityGroups to apply to the Endpoint.
@@ -349,5 +363,19 @@ type AWSOIDCDeployEC2ICERequest struct {
 // AWSOIDCDeployEC2ICEResponse is the response after creating an AWS EC2 Instance Connect Endpoint.
 type AWSOIDCDeployEC2ICEResponse struct {
 	// Name is the name of the endpoint that was created.
+	// If multiple endpoints were created, this will contain all of them joined by a `,`.
+	// Eg, eice-1,eice-2
+	// Deprecated: use Endpoints instead.
 	Name string `json:"name"`
+
+	// Endpoints is a list of created endpoints
+	Endpoints []AWSOIDCDeployEC2ICEResponseEndpoint `json:"endpoints"`
+}
+
+// AWSOIDCDeployEC2ICEResponseEndpoint describes a single endpoint that was created.
+type AWSOIDCDeployEC2ICEResponseEndpoint struct {
+	// Name is the EC2 Instance Connect Endpoint name.
+	Name string `json:"name"`
+	// SubnetID is the subnet where this endpoint was created.
+	SubnetID string `json:"subnetId"`
 }


### PR DESCRIPTION
Deploying EC2 Instance Connect Endpoints now support multiple receiving multiple endpoints.
Each endpoint contains a single Subnet and multiple (0+) SecurityGroups.

Previously only one Endpoint could be created.

The response will include all the created endpoints.

This is prep work for the EC2 w/ EICE Discovery flow.

Sending a single element is still supported to be compatible with the Single Instance flow.