### PR TITLE
Mention Connect in OTP section of per-session MFA docs

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -220,7 +220,7 @@ $ tsh ssh jerry@prod3.example.com
 If you are using `tsh` in a constrained environment, you can tell it to use
 OTP by doing `tsh --mfa-mode=otp ssh prod3.example.com`.
 
-OTP can only be used with per-session MFA when using the `tsh` client to
+OTP can only be used with per-session MFA when using `tsh` or Teleport Connect to
 establish connections. A hardware MFA key is required for using per-session
 MFA with Teleport's Web UI.
 </Admonition>


### PR DESCRIPTION
Connect now supports per-session MFA with Kube access (#35361). It also supports OTP as the MFA method, so I figured it's worth mentioning it there.