### PR TITLE
[v14] Fix accesslist `tctl`

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -450,6 +450,9 @@ func (a *Audit) UnmarshalJSON(data []byte) error {
 		return trace.Wrap(err)
 	}
 
+	if audit.NextAuditDate == "" {
+		return nil
+	}
 	var err error
 	a.NextAuditDate, err = time.Parse(time.RFC3339Nano, audit.NextAuditDate)
 	if err != nil {

--- a/docs/pages/access-controls/access-lists/reference.mdx
+++ b/docs/pages/access-controls/access-lists/reference.mdx
@@ -72,11 +72,24 @@ spec:
   # audit defines how frequently an Access List and its membership must be audited, along
   # with the next audit date.
   audit:
-    # Audit frequency defaults to 6 months. Format to golang's time.ParseDuration function:
-    # https://pkg.go.dev/time#ParseDuration
-    frequency: 4380h
+    recurrence:
+      # Frequency is the frequency between access list reviews.
+      # Defaults to 6months.
+      # Possible values are: 1month, 3months, 6months, 1year
+      frequency: 6months
+      # DayOfMonth is the day of month subsequent reviews will be scheduled on.
+      # Defaults to 1.
+      # Possible values are: 1, 15, last
+      day_of_month: "1"
     # The next time this Access List must be audited by.
-    next_audit_date: "2024-01-01T00:00:00Z"
+    # If not set, the next audit date will be picked up automatically.
+    notifications:
+      # When the access-request plugins will start to notify before the audit
+      # deadline.  Format to golang's time.ParseDuration function:
+      # https://pkg.go.dev/time#ParseDuration
+      # Defaults to two weeks.
+      start: 336h # two weeks
+    next_audit_date: "2025-01-01T00:00:00Z"
   description: "A description of the Access List and its purpose"
   # owners are a list of Teleport users who own the Access List. Provided the owners
   # meet the ownership requirements, these users can control membership requirements

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -42,6 +42,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/installers"
@@ -2270,6 +2271,16 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			return nil, trace.Wrap(err)
 		}
 		return &serverInfoCollection{serverInfos: serverInfos}, nil
+	case types.KindAccessList:
+		if rc.ref.Name != "" {
+			resource, err := client.AccessListClient().GetAccessList(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &accessListCollection{accessLists: []*accesslist.AccessList{resource}}, nil
+		}
+		accessLists, err := client.AccessListClient().GetAccessLists(ctx)
+		return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
Backport #36531 to branch/v14

changelog: fix `tctl get access_list` and support creating Access Lists without a next audit date.
