### PR TITLE
switch to uuid-like revisions for firestore

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -51,6 +52,13 @@ func init() {
 		return New(ctx, p, Options{})
 	})
 }
+
+const (
+	// maxTxnAttempts is the maximum amount of internal retries to be used by the
+	// firestore package during RunTransaction. As of the time of writing the default
+	// value used by the library is 5.
+	maxTxnAttempts = 16
+)
 
 // Config structure represents Firestore configuration as appears in `storage` section of Teleport YAML
 type Config struct {
@@ -118,12 +126,13 @@ type Backend struct {
 }
 
 type record struct {
-	Key       []byte `firestore:"key,omitempty"`
-	Timestamp int64  `firestore:"timestamp,omitempty"`
-	Expires   int64  `firestore:"expires,omitempty"`
-	ID        int64  `firestore:"id,omitempty"`
-	Value     []byte `firestore:"value,omitempty"`
-	Revision  string `firestore:"-"`
+	Key        []byte `firestore:"key,omitempty"`
+	Timestamp  int64  `firestore:"timestamp,omitempty"`
+	Expires    int64  `firestore:"expires,omitempty"`
+	ID         int64  `firestore:"id,omitempty"`
+	Value      []byte `firestore:"value,omitempty"`
+	RevisionV2 string `firestore:"revision,omitempty"`
+	RevisionV1 string `firestore:"-"`
 }
 
 func (r *record) updates() []firestore.Update {
@@ -133,6 +142,7 @@ func (r *record) updates() []firestore.Update {
 		{Path: expiresDocProperty, Value: r.Expires},
 		{Path: idDocProperty, Value: r.ID},
 		{Path: valueDocProperty, Value: r.Value},
+		{Path: revisionDocProperty, Value: r.RevisionV2},
 	}
 }
 
@@ -158,8 +168,14 @@ func newRecord(from backend.Item, clock clockwork.Clock) record {
 		Value:     from.Value,
 		Timestamp: clock.Now().UTC().Unix(),
 		ID:        id(clock.Now()),
-		Revision:  from.Revision,
 	}
+
+	if isRevisionV2(from.Revision) {
+		r.RevisionV2 = from.Revision
+	} else {
+		r.RevisionV1 = from.Revision
+	}
+
 	if !from.Expires.IsZero() {
 		r.Expires = from.Expires.UTC().Unix()
 	}
@@ -184,7 +200,9 @@ func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 			ID:        rl.ID,
 		}
 	}
-	r.Revision = toBackendRevision(doc.UpdateTime)
+	if r.RevisionV2 == "" {
+		r.RevisionV1 = toRevisionV1(doc.UpdateTime)
+	}
 	return &r, nil
 }
 
@@ -199,11 +217,17 @@ func (r *record) isExpired(now time.Time) bool {
 
 func (r *record) backendItem() backend.Item {
 	bi := backend.Item{
-		Key:      r.Key,
-		Value:    r.Value,
-		ID:       r.ID,
-		Revision: r.Revision,
+		Key:   r.Key,
+		Value: r.Value,
+		ID:    r.ID,
 	}
+
+	if r.RevisionV2 != "" {
+		bi.Revision = r.RevisionV2
+	} else {
+		bi.Revision = r.RevisionV1
+	}
+
 	if r.Expires != 0 {
 		bi.Expires = time.Unix(r.Expires, 0).UTC()
 	}
@@ -225,6 +249,8 @@ const (
 	idDocProperty = "id"
 	// valueDocProperty references the value of the record
 	valueDocProperty = "value"
+	// revisionDocProperty references the record's revision
+	revisionDocProperty = "revision"
 	// timeInBetweenIndexCreationStatusChecks
 	timeInBetweenIndexCreationStatusChecks = time.Second * 10
 )
@@ -369,40 +395,40 @@ func (b *Backend) GetName() string {
 
 // Create creates item if it does not exist
 func (b *Backend) Create(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	item.Revision = createRevisionV2()
 	r := newRecord(item, b.clock)
-	res, err := b.svc.Collection(b.CollectionName).
+	_, err := b.svc.Collection(b.CollectionName).
 		Doc(b.keyToDocumentID(item.Key)).
 		Create(ctx, r)
 	if err != nil {
 		return nil, ConvertGRPCError(err)
 	}
-	item.Revision = toBackendRevision(res.UpdateTime)
 	return backend.NewLease(item), nil
 }
 
 // Put puts value into backend (creates if it does not exist, updates it otherwise)
 func (b *Backend) Put(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	item.Revision = createRevisionV2()
 	r := newRecord(item, b.clock)
-	res, err := b.svc.Collection(b.CollectionName).
+	_, err := b.svc.Collection(b.CollectionName).
 		Doc(b.keyToDocumentID(item.Key)).
 		Set(ctx, r)
 	if err != nil {
 		return nil, ConvertGRPCError(err)
 	}
-	item.Revision = toBackendRevision(res.UpdateTime)
 	return backend.NewLease(item), nil
 }
 
 // Update updates value in the backend
 func (b *Backend) Update(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	item.Revision = createRevisionV2()
 	r := newRecord(item, b.clock)
-	res, err := b.svc.Collection(b.CollectionName).
+	_, err := b.svc.Collection(b.CollectionName).
 		Doc(b.keyToDocumentID(item.Key)).
 		Update(ctx, r.updates())
 	if err != nil {
 		return nil, ConvertGRPCError(err)
 	}
-	item.Revision = toBackendRevision(res.UpdateTime)
 	return backend.NewLease(item), nil
 }
 
@@ -549,41 +575,48 @@ func (b *Backend) CompareAndSwap(ctx context.Context, expected backend.Item, rep
 		return nil, trace.BadParameter("expected and replaceWith keys should match")
 	}
 
-	// The operations performed are get, compare values, and conditional update instead of using
-	// a transaction because the firestore api does not return the commit time from RunTransaction.
-	// See https://github.com/googleapis/google-cloud-go/issues/6841.
-	for i := 0; i < 3; i++ {
-		docSnap, err := b.svc.Collection(b.CollectionName).
-			Doc(b.keyToDocumentID(expected.Key)).
-			Get(ctx)
+	replaceWith.Revision = createRevisionV2()
+	replaceRec := newRecord(replaceWith, b.clock)
+
+	docRef := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(replaceWith.Key))
+
+	err := b.svc.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		docSnap, err := tx.Get(docRef)
 		if err != nil {
-			err = ConvertGRPCError(err)
-			if trace.IsNotFound(err) {
-				return nil, trace.CompareFailed(err.Error())
+			if status.Code(err) == codes.NotFound {
+				return trace.CompareFailed("key %q was concurrently deleted", replaceWith.Key)
 			}
-			return nil, trace.Wrap(err)
+			return trace.Wrap(ConvertGRPCError(err))
 		}
 
-		r, err := newRecordFromDoc(docSnap)
+		currentRec, err := newRecordFromDoc(docSnap)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
-		if !bytes.Equal(r.Value, expected.Value) {
-			return nil, trace.CompareFailed("expected item value %v does not match actual item value %v", string(expected.Value), r.Value)
+		if !bytes.Equal(currentRec.Value, expected.Value) {
+			return trace.CompareFailed("expected item value %v does not match actual item value %v", string(expected.Value), currentRec.Value)
 		}
 
-		replaceWith.Revision = expected.Revision
-		lease, err := b.ConditionalUpdate(ctx, replaceWith)
-		switch {
-		case err == nil:
-			return lease, err
-		case !trace.IsCompareFailed(err):
-			return nil, trace.Wrap(err)
+		if err := tx.Set(docRef, replaceRec); err != nil {
+			return trace.Wrap(ConvertGRPCError(err))
 		}
+
+		return nil
+	}, firestore.MaxAttempts(maxTxnAttempts))
+
+	if err != nil {
+		if status.Code(err) == codes.Aborted {
+			// RunTransaction does not officially document what error is returned if MaxAttempts is exceeded,
+			// but as currently implemented it should simply bubble up the Aborted error from the most recent
+			// failed commit attempt.
+			return nil, trace.CompareFailed("too many attempts during CompareAndSwap for key %q", replaceWith.Key)
+		}
+
+		return nil, trace.Wrap(ConvertGRPCError(err))
 	}
 
-	return nil, trace.CompareFailed("too many attempts during CompareAndSwap for key %q", replaceWith.Key)
+	return backend.NewLease(replaceWith), nil
 }
 
 // Delete deletes item by key
@@ -606,7 +639,53 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 
 // ConditionalDelete deletes item by key if the revision matches
 func (b *Backend) ConditionalDelete(ctx context.Context, key []byte, rev string) error {
-	revision, err := fromBackendRevision(rev)
+	if !isRevisionV2(rev) {
+		return b.legacyConditionalDelete(ctx, key, rev)
+	}
+
+	docRef := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(key))
+
+	err := b.svc.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		docSnap, err := tx.Get(docRef)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return trace.Wrap(backend.ErrIncorrectRevision)
+			}
+			return trace.Wrap(ConvertGRPCError(err))
+		}
+
+		rec, err := newRecordFromDoc(docSnap)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if rec.RevisionV2 != rev {
+			return trace.Wrap(backend.ErrIncorrectRevision)
+		}
+
+		if err := tx.Delete(docRef); err != nil {
+			return trace.Wrap(ConvertGRPCError(err))
+		}
+
+		return nil
+	}, firestore.MaxAttempts(maxTxnAttempts))
+
+	if err != nil {
+		if status.Code(err) == codes.Aborted {
+			// RunTransaction does not officially document what error is returned if MaxAttempts is exceeded,
+			// but as currently implemented it should simply bubble up the Aborted error from the most recent
+			// failed commit attempt.
+			return trace.CompareFailed("too many attempts during ConditionalDelete for key %q", key)
+		}
+
+		return trace.Wrap(ConvertGRPCError(err))
+	}
+
+	return nil
+}
+
+func (b *Backend) legacyConditionalDelete(ctx context.Context, key []byte, rev string) error {
+	revision, err := fromRevisionV1(rev)
 	if err != nil {
 		return trace.Wrap(backend.ErrIncorrectRevision)
 	}
@@ -624,7 +703,56 @@ func (b *Backend) ConditionalDelete(ctx context.Context, key []byte, rev string)
 }
 
 func (b *Backend) ConditionalUpdate(ctx context.Context, item backend.Item) (*backend.Lease, error) {
-	revision, err := fromBackendRevision(item.Revision)
+	if !isRevisionV2(item.Revision) {
+		return b.legacyConditionalUpdate(ctx, item)
+	}
+
+	expectedRevision := item.Revision
+	item.Revision = createRevisionV2()
+	newRec := newRecord(item, b.clock)
+	docRef := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(item.Key))
+
+	err := b.svc.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		docSnap, err := tx.Get(docRef)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return trace.Wrap(backend.ErrIncorrectRevision)
+			}
+			return trace.Wrap(ConvertGRPCError(err))
+		}
+
+		existingRec, err := newRecordFromDoc(docSnap)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if existingRec.RevisionV2 != expectedRevision {
+			return trace.Wrap(backend.ErrIncorrectRevision)
+		}
+
+		if err := tx.Set(docRef, newRec); err != nil {
+			return trace.Wrap(ConvertGRPCError(err))
+		}
+
+		return nil
+	}, firestore.MaxAttempts(maxTxnAttempts))
+
+	if err != nil {
+		if status.Code(err) == codes.Aborted {
+			// RunTransaction does not officially document what error is returned if MaxAttempts is exceeded,
+			// but as currently implemented it should simply bubble up the Aborted error from the most recent
+			// failed commit attempt.
+			return nil, trace.CompareFailed("too many attempts during ConditionalUpdate for key %q", item.Key)
+		}
+
+		return nil, trace.Wrap(ConvertGRPCError(err))
+	}
+
+	return backend.NewLease(item), nil
+}
+
+func (b *Backend) legacyConditionalUpdate(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	revision, err := fromRevisionV1(item.Revision)
 	if err != nil {
 		return nil, trace.Wrap(backend.ErrIncorrectRevision)
 	}
@@ -641,7 +769,7 @@ func (b *Backend) ConditionalUpdate(ctx context.Context, item backend.Item) (*ba
 		return nil, trace.Wrap(backend.ErrIncorrectRevision)
 	}
 
-	item.Revision = toBackendRevision(res.UpdateTime)
+	item.Revision = toRevisionV1(res.UpdateTime)
 	return backend.NewLease(item), nil
 }
 
@@ -682,6 +810,7 @@ func (b *Backend) KeepAlive(ctx context.Context, lease backend.Lease, expires ti
 		{Path: expiresDocProperty, Value: expires.UTC().Unix()},
 		{Path: timestampDocProperty, Value: b.clock.Now().UTC().Unix()},
 		{Path: idDocProperty, Value: id(b.clock.Now())},
+		{Path: revisionDocProperty, Value: createRevisionV2()},
 	}
 	_, err = docSnap.Ref.Update(ctx, updates)
 	if err != nil {
@@ -1027,11 +1156,23 @@ func id(now time.Time) int64 {
 	return now.UTC().UnixNano()
 }
 
-func toBackendRevision(rev time.Time) string {
+// revisionV2Prefix uniquely identifies version 2 firestore revision values. Older firestore documents
+// use the update time as their revision. Newer documents use a random string value as their revision.
+const revisionV2Prefix = "f2:"
+
+func createRevisionV2() string {
+	return revisionV2Prefix + backend.CreateRevision()
+}
+
+func isRevisionV2(r string) bool {
+	return strings.HasPrefix(r, revisionV2Prefix)
+}
+
+func toRevisionV1(rev time.Time) string {
 	return strconv.FormatInt(rev.UnixNano(), 10)
 }
 
-func fromBackendRevision(rev string) (time.Time, error) {
+func fromRevisionV1(rev string) (time.Time, error) {
 	n, err := strconv.ParseInt(rev, 10, 64)
 	if err != nil {
 		return time.Time{}, trace.BadParameter("invalid revision: %s", err)

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -193,8 +193,8 @@ func (r *record) isExpired(now time.Time) bool {
 	if r.Expires == 0 {
 		return false
 	}
-	expiryDateUTC := time.Unix(r.Expires, 0).UTC()
-	return now.UTC().After(expiryDateUTC)
+
+	return now.UTC().Unix() > r.Expires
 }
 
 func (r *record) backendItem() backend.Item {


### PR DESCRIPTION
This PR switches the firestore backend to use uuid-like revisions instead of firestore's builtin `UpdateTime`.  This switch is a prerequisite for implementing the `AtomicWrite` API for firestore.  Because firestore doesn't support non-interactive preconditions for values other than `UpdateTime`, this switch necessitates migrating the conditional APIs to use Firestore's transaction API.

The switch to the new revision style is done lazily rather than via migration.  All APIs continue to support the old revision, but all future writes add the new revision.  This change is safe for concurrent operation with older backend impls because adding the new revision field does not prevent continuing use of `UpdateTime`.

In order to verify the backwards compatibility of this feature, I created a fork of this branch that randomly applied revision v2 on only 50% of writes and ran through the test plan multiple times.  All tests passed seamlessly using a mix of revision styles.