### PR TITLE
Improve Linux installation instructions

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -33,7 +33,7 @@ Opsgenie.
   ```
 
   You can download these tools by following the appropriate [Installation 
-  instructions](../../installation.mdx#installation-instructions) for your environment and Teleport edition.
+  instructions](../../installation.mdx#linux) for your environment and Teleport edition.
 
 - An Opsgenie account with the ability to create API keys with the 'read' and
   'create and update' access rights.

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -32,7 +32,7 @@ government agencies.
 Teleport Enterprise customers can download the custom FIPS package from their
 [Teleport account](https://teleport.sh). Look for `Linux 64-bit (FedRAMP/FIPS)`.
 
-You also can follow the [Installation instructions](../../installation.mdx#installation-instructions) for 
+You also can follow the [Installation instructions](../../installation.mdx#linux) for 
 Teleport Enterprise edition to download and install the appropriate FIPS-compliant binaries for 
 your operating environment and package manager or from compressed archive (tarball).
 

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -38,7 +38,7 @@ To complete the steps in this guide, verify your environment meets the following
   ```
 
   You can download these tools by following the appropriate [Installation
-  instructions](../installation.mdx#installation-instructions) for the Teleport
+  instructions](../installation.mdx#linux) for the Teleport
   edition you use.
 
 - A Linux server to run the Teleport Windows Desktop Service.

--- a/docs/pages/desktop-access/active-directory.mdx
+++ b/docs/pages/desktop-access/active-directory.mdx
@@ -28,7 +28,7 @@ Azure Active Directory.
   ```
 
   You can download these tools by following the appropriate [Installation 
-  instructions](../installation.mdx#installation-instructions) for your environment 
+  instructions](../installation.mdx#linux) for your environment 
   and Teleport edition.
 
 - A server or virtual machine running the Windows Server operating system on which you can

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -127,7 +127,7 @@ Windows Desktop Service by running the following command:
    ```
 
    If Teleport isn't installed on the Linux server, follow the appropriate [Installation
-instructions](../installation.mdx#installation-instructions) for your environment.
+instructions](../installation.mdx#linux) for your environment.
 
 1. Configure the `/etc/teleport.yaml` file on the Linux server with settings similar to the
 following for the Windows Desktop Service:

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -16,4 +16,4 @@
   ```
 
   You can download these tools by following the appropriate [Installation 
-  instructions](../installation.mdx#installation-instructions) for your environment and Teleport edition.
+  instructions](../installation.mdx#linux) for your environment and Teleport edition.

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -3,6 +3,7 @@ title: Installing Teleport
 description: How to install Teleport and Teleport's client tools on your platform, including binaries and instructions for Docker and Helm.
 h1: Installation
 videoBanner: fjk29wqXm1A
+tocDepth: 3
 ---
 
 This guide shows you how to install Teleport binaries on your platform,
@@ -63,16 +64,19 @@ agents by:
   you can select a resource to enroll in your Teleport cluster and retrieve an
   installation script to run on Linux hosts.
 - Using the example Terraform module for deploying agents in [Deploy Agents with
-  Terraform](docs/pages/agents/deploy-agents-terraform.mdx). Read [Upgrade
-  Teleport Cloud Agents on Linux ](./upgrading/cloud-linux.mdx) to set up
-  automatic agent upgrades.
+  Terraform](docs/pages/agents/deploy-agents-terraform.mdx).
 - Reading the instructions in this section to install Teleport agent binaries
   manually.
 
+We recommend that Teleport Team and Teleport Enterprise Cloud users enable
+automatic upgrades for agents. Read [Upgrade Teleport Cloud Agents on Linux
+](./upgrading/cloud-linux.mdx) to set up automatic agent upgrades on Linux
+servers.
+
 If you are running a self-hosted Teleport Enterprise cluster, read our guidance
 in [Deploying a High-Availability Teleport
-Cluster](./deploy-a-cluster/introduction.mdx), provides full requirements and
-Terraform modules for deploying Teleport Enterprise.
+Cluster](./deploy-a-cluster/introduction.mdx), which provides full requirements
+and Terraform modules for deploying Teleport Enterprise on your infrastructure.
 
 The instructions in this section are intended for:
 - Linux desktop users.
@@ -102,111 +106,124 @@ Valid editions are:
 | `oss`        | Teleport Community Edition        |
 | `team`       | Teleport Team                     |
 
-If running Teleport Enterprise Cloud, Teleport agents must be running version
-(=cloud.version=) or one major version below.
+### Package repositories
 
-### Using Teleport packages and archives
+Teleport maintains DEB and RPM package repositories for different operating
+systems, platforms, and Teleport versions. A server that installs Teleport from
+a DEB or RPM package must have systemd installed.
+
+#### Package manager examples
 
 Read the instructions in this section for how to install Teleport on a Linux
-server with your package manager of choice. Note that the [one-line installation
-script](#one-line-installation-script) runs these commands for you after
-determining which package manager to use.
+server with your package manager of choice. For more information about how our
+package repositories work, read [Package repositories and TAR
+archives](#package-repositories-and-tar-archives).
 
-#### apt
+Assign the following environment variables in the terminal where you will run
+Teleport installation commands:
 
-Run the following commands to install Teleport binaries on Linux systems that
-use the `apt` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
-Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
+<Tabs>
+<TabItem label="Teleport Community Edition">
 
 ```code
-$ TELEPORT_PKG=teleport
+$ export TELEPORT_PKG=teleport
+$ export TELEPORT_VERSION=v(=teleport.major_version=)
+```
+
+</TabItem>
+<TabItem label="Teleport Cloud">
+
+Install the automatic agent updater along with the `teleport` binary:
+
+```code
+$ export TELEPORT_PKG="teleport-ent teleport-ent-updater"
+$ export TELEPORT_VERSION="cloud"
+```
+
+</TabItem>
+<TabItem label="Teleport Enterprise (Self-Hosted)">
+
+```code
+$ export TELEPORT_PKG=teleport-ent
+$ export TELEPORT_VERSION=v(=teleport.major_version=)
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ export TELEPORT_PKG=teleport-ent-fips
+```
+
+</TabItem>
+</Tabs>
+
+Follow the instructions for your package manager:
+
+<Tabs>
+<TabItem label="apt">
+
+```code
 # Download the Teleport PGP public key
 $ sudo curl https://apt.releases.teleport.dev/gpg \
 -o /usr/share/keyrings/teleport-archive-keyring.asc
 # Source variables about OS version
 $ source /etc/os-release
-# Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
-# file for each major release of Teleport.
+# Add the Teleport APT repository. You'll need to update this file for each
+# major release of Teleport.
 $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
+stable/${TELEPORT_VERSION?}" \
 | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
 $ sudo apt-get update
 $ sudo apt-get install ${TELEPORT_PKG?}
 ```
 
-For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+</TabItem>
+
+<TabItem label="yum">
 
 ```code
-$ sudo apt-get install teleport-ent-fips
-```
-
-#### yum
-
-Run the following commands to install Teleport binaries on Linux systems that
-use the `yum` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
-Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
-
-```code
-$ TELEPORT_PKG=teleport
 # Source variables about the OS version
 $ source /etc/os-release
-# Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-# file for each major release of Teleport.
+# Add the Teleport YUM repository. You'll need to update this file for each
+# major release of Teleport.
 # First, get the major version from $VERSION_ID so this fetches the correct
 # package version.
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 $ sudo yum install -y yum-utils
-$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
 $ sudo yum install ${TELEPORT_PKG?}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
 ```
 
-For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+</TabItem>
+
+<TabItem label="zypper">
 
 ```code
-$ sudo yum install teleport-ent-fips
-```
-
-#### zypper
-
-Run the following commands to install Teleport binaries on Linux systems that
-use the `zypper` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
-Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
-
-```code
-$ TELEPORT_PKG=teleport
 # Source variables about OS version
 $ source /etc/os-release
-# Add the Teleport Zypper repository for v(=teleport.major_version=). You'll need to update this
-# file for each major release of Teleport.
+# Add the Teleport Zypper repository. You'll need to update this file for each
+# major release of Teleport.
 # First, get the OS major version from $VERSION_ID so this fetches the correct
 # package version.
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
 # Use zypper to add the teleport RPM repo
-$ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
+$ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport-zypper.repo")
 $ sudo yum install ${TELEPORT_PKG?}
 #
 # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
 ```
 
-For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+</TabItem>
+
+<TabItem label="dnf">
 
 ```code
-$ sudo yum install teleport-ent-fips
-```
-
-#### dnf
-
-Run the following commands to install Teleport binaries on Linux systems that
-use the `dnf` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
-Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
-
-```code
-$ TELEPORT_PKG=teleport
 # Source variables about OS version
 $ source /etc/os-release
 # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
@@ -214,8 +231,10 @@ $ source /etc/os-release
 # First, get the major version from $VERSION_ID so this fetches the correct
 # package version.
 $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+# Install dnf config-manager
+$ sudo yum install -y yum-utils
 # Use the dnf config manager plugin to add the teleport RPM repo
-$ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+$ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
 
 # Install teleport
 $ sudo dnf install ${TELEPORT_PKG}
@@ -224,13 +243,131 @@ $ sudo dnf install ${TELEPORT_PKG}
 # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
 ```
 
-For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+</TabItem>
+</Tabs>
 
-```code
-$ sudo dnf install teleport-ent-fips
+#### RPM repositories
+
+A Teleport RPM repository URL has the following format:
+
+```sh
+https://yum.releases.teleport.dev/OPERATION_SYSTEM/OS_VERSION/Teleport/SYSTEM_ARCHITECTURE/stable/TELEPORT_VERSION
 ```
 
-#### tar
+For example, this URL points to an RPM repository for RHEL v7 intended for
+devices with a 64-bit ARM architecture, targeting Teleport major version
+(=teleport.major_version=):
+
+```sh
+https://yum.releases.teleport.dev/rhel/7/Teleport/aarch64/stable/v(=teleport.major_version=)
+```
+
+The parameters are designed to be queried from your system:
+
+| Parameter           | Source                                                            |
+|---------------------|-------------------------------------------------------------------|
+| `OPERATING_SYSTEM` | The `ID` variable in `/etc/os-release`.                            |
+| `OS_VERSION` | The `VERSION_ID` variable in `/etc/os-release`.                    |
+| `SYSTEM_ARCHITECTURE` | The `%{_arch}` RPM macro.                                          |
+| `TELEPORT_VERSION` | `cloud` for Teleport Enterprise Cloud and Teleport Team. A major version number, e.g., `v(=teleport.major_version=)`, for self-hosted deployments. See [Upgrading Compatibility Overview](./upgrading/overview.mdx/). |
+
+RPM repositories don't expose packages for all distribution variants. When
+installing Teleport using RPM repositories, you may need to replace the `ID`
+variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
+closest supported distribution.
+
+Currently supported distributions (and `ID` values) are:
+
+| Distribution | Version              | `ID` value in `/etc/os-release` |
+|--------------|----------------------|---------------------------------|
+| RHEL         | >= 7                 | `rhel`                          |
+| CentOS       | >= 7                 | `centos`                        |
+| Amazon Linux | 2 and 2023           | `amzn`                          |
+| SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
+
+Note that [Enhanced Session
+Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
+kernel version 5.8+. This means that it requires more recent OS versions than
+other Teleport features:
+
+| Distribution | Version                  |
+|--------------|--------------------------|
+| CentOS/RHEL  | 9+                       |
+| Amazon Linux | 2 (post 11/2021), 2023   |
+| SLES         | 12 SP5, 15 SP5           |
+
+#### DEB repositories
+
+To target a Teleport DEB repository, add a `sources.list` entry with the
+following format:
+
+```sh
+deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/OPERATING_SYSTEM VERSION_CODENAME stable/TELEPORT_VERSION
+```
+
+For example, the following targets the DEB repository for Ubuntu Jammy to
+install Teleport v(=teleport.major_version=):
+
+```
+deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/ubuntu jammy stable/v(=teleport.major_version=)
+```
+
+The parameters are designed to be queried from your system:
+
+| Parameter           | Source                                                            |
+|---------------------|-------------------------------------------------------------------|
+| `OPERATING_SYSTEM` | The `ID` variable in `/etc/os-release`.                            |
+| `VERSION_CODENAME` | The `VERSION_CODENAME` variable in `/etc/os-release`.              |
+| `TELEPORT_VERSION` | `cloud` for Teleport Enterprise Cloud and Teleport Team. A major version number, e.g., `v(=teleport.major_version=)`, for self-hosted deployments. See [Upgrading Compatibility Overview](./upgrading/overview.mdx/). |
+
+DEB repositories don't expose packages for all distribution variants. When
+installing Teleport using DEB repositories, you may need to replace the `ID`
+variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
+closest supported distribution.
+
+Currently supported distributions (and `ID` values) are:
+
+| Distribution | Version    | `ID` value in `/etc/os-release` |
+|--------------|------------|---------------------------------|
+| Debian       | >= 9       | `debian`                        |
+| Ubuntu       | >= 16.04   | `ubuntu`                        |
+
+Note that [Enhanced Session
+Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
+kernel version 5.8+. This means that it requires more recent OS versions than
+other Teleport features:
+
+| Distribution | Version                  |
+|--------------|--------------------------|
+| Debian       | 11, or 10 with backports |
+| Ubuntu       | 20.042+                  |
+
+#### Specifying a Teleport edition
+
+To download Teleport binaries for a particular edition from the Teleport DEB and
+RPM repositories, specify the edition when you enter the name of the package to
+install. For example, the following command installs Teleport Enterprise
+binaries on Ubuntu/Debian systems:
+
+```code
+$ sudo apt-get install teleport-ent
+```
+
+The following package names are available:
+
+| Name                | Edition(s)                                                                  |
+|---------------------|-----------------------------------------------------------------------------|
+| `teleport`          | Teleport Community Edition                                                  |
+| `teleport-ent`      | Teleport Team, Teleport Enterprise Cloud, Teleport Enterprise (Self-Hosted) |
+| `teleport-ent-fips` | Teleport Enterprise (Self-Hosted)                                           |
+
+### TAR archives
+
+Teleport maintains TAR archives for Linux-compatible binaries at
+`https://cdn.teleport.dev`. This section explains the Teleport TAR archives and
+how to use them.
+
+#### Example commands
 
 Run the following commands to install Teleport binaries on Linux systems that do
 not have a package manager available. Replace `TELEPORT_PKG` with `teleport-ent`
@@ -266,113 +403,12 @@ $ cd teleport-ent
 $ sudo ./install
 ```
 
-### Package repositories and TAR archives
+For more information about our TAR archives, read [Package repositories and TAR
+archives](#tar-archives).
 
-Teleport maintains DEB and RPM package repositories for different operating
-systems, platforms, and Teleport versions. A server that installs Teleport from
-a DEB or RPM package must have systemd installed.
+#### Selecting an archive to download
 
-#### RPM repositories
-
-A Teleport RPM repository URL has the following format:
-
-```sh
-https://yum.releases.teleport.dev/OPERATION_SYSTEM/OS_VERSION/Teleport/ARCHITECTURE/stable/TELEPORT_VERSION
-```
-
-For example, this URL points to an RPM repository for RHEL v7 intended for
-devices with a 64-bit ARM architecture, targeting Teleport major version
-(=teleport.major_version=):
-
-```sh
-https://yum.releases.teleport.dev/rhel/7/Teleport/aarch64/stable/v(=teleport.major_version=)
-```
-
-The parameters are designed to be queried from your system:
-
-| Parameter           | Source                                                            |
-|---------------------|-------------------------------------------------------------------|
-| Operating system    | The `ID` variable in `/etc/os-release`                            |
-| OS version          | The `VERSION_ID` variable in `/etc/os-release`                    |
-| System architecture | The `%{_arch}` RPM macro                                          |
-| Teleport version    | See [Upgrading Compatibility Overview](./upgrading/overview.mdx/) |
-
-RPM repositories don't expose packages for all distribution variants. When
-installing Teleport using these package managers, you may need to replace the
-`ID` variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
-closest supported distribution.
-
-Currently supported distributions (and `ID` values) are:
-
-| Distribution | Version              | `ID` value in `/etc/os-release` |
-|--------------|----------------------|---------------------------------|
-| RHEL         | >= 7                 | `rhel`                          |
-| CentOS       | >= 7                 | `centos`                        |
-| Amazon Linux | 2 and 2023           | `amzn`                          |
-| SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
-
-Note that [Enhanced Session
-Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
-kernel version 5.8+. This means that the OS versions it requires are more recent
-than do other Teleport features:
-
-| Distribution | Version                  |
-|--------------|--------------------------|
-| CentOS/RHEL  | 9+                       |
-| Amazon Linux | 2 (post 11/2021), 2023   |
-| SLES         | 12 SP5, 15 SP5           |
-
-#### DEB repositories
-
-To target a Teleport DEB repository, add a `sources.list` entry with the
-following format:
-
-```sh
-deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/OPERATING_SYSTEM VERSION_CODENAME stable/TELEPORT_VERSION
-```
-
-For example, the following targets the DEB repository for Ubuntu Jammy to
-install Teleport v(=teleport.major_version=):
-
-```
-deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/ubuntu jammy stable/v(=teleport.major_version=)
-```
-
-
-The parameters are designed to be queried from your system:
-
-| Parameter           | Source                                                            |
-|---------------------|-------------------------------------------------------------------|
-| Operating system    | The `ID` variable in `/etc/os-release`                            |
-| OS version codename | The `VERSION_CODENAME` variable in `/etc/os-release`              |
-| Teleport version    | See [Upgrading Compatibility Overview](./upgrading/overview.mdx/) |
-
-DEB repositories don't expose packages for all distribution variants. When
-installing Teleport using these package managers, you may need to replace the
-`ID` variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
-closest supported distribution.
-
-Currently supported distributions (and `ID` values) are:
-
-| Distribution | Version    | `ID` value in `/etc/os-release` |
-|--------------|------------|---------------------------------|
-| Debian       | >= 9       | `debian`                        |
-| Ubuntu       | >= 16.04   | `ubuntu`                        |
-
-Note that [Enhanced Session
-Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
-kernel version 5.8+. This means that the OS versions it requires are more recent
-than do other Teleport features:
-
-| Distribution | Version                  |
-|--------------|--------------------------|
-| Debian       | 11, or 10 with backports |
-| Ubuntu       | 20.042+                  |
-
-#### TAR archives
-
-You can also download a TAR archive containing Teleport binaries. You can find
-archives at a URL with the following format:
+You can find TAR archives at a URL with the following format:
 
 ```sh
 https://cdn.teleport.dev/TELEPORT_EDITION-TELEPORT_VERSION-linux-ARCHITECTURE-bin.tar.gz
@@ -404,26 +440,7 @@ to the following:
 https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-SYSTEM_ARCH-fips-bin.tar.gz
 ```
 
-### Specifying a Teleport edition
-
-To download Teleport binaries for a particular edition from the Teleport DEB and
-RPM repositories, specify the edition when you enter the name of the package to
-install. For example, the following command installs Teleport Enterprise
-binaries on Ubuntu/Debian systems:
-
-```code
-$ sudo apt-get install teleport-ent
-```
-
-The following package names are available:
-
-| Name                | Edition(s)                                                                  |
-|---------------------|-----------------------------------------------------------------------------|
-| `teleport`          | Teleport Community Edition                                                  |
-| `teleport-ent`      | Teleport Team, Teleport Enterprise Cloud, Teleport Enterprise (Self-Hosted) |
-| `teleport-ent-fips` | Teleport Enterprise (Self-Hosted)                                           |
-
-### Download binaries from your browser
+### From your browser
 
 For Teleport Community Edition, check the
 [Downloads](https://goteleport.com/download/) page for the most up-to-date

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -48,55 +48,391 @@ supports most features on Windows 10 and later.*
 
 ## Linux
 
-All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
+You can install Teleport binaries on Linux using RPM and DEB packages as well as
+TAR archives. All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
+This section shows you how to install Teleport binaries on a single Linux
+server.
 
-### Feature support
+### Recommended installation steps
 
-Some Teleport features have additional requirements:
+If you are starting out with Teleport, we recommend beginning with a [Teleport
+Team](https://goteleport.com/signup/) account. From there, the only Teleport
+components you need to deploy yourself are Teleport agents. You can deploy
+agents by:
+- Following the instructions in the Teleport Web UI at `/web/discover`, where
+  you can select a resource to enroll in your Teleport cluster and retrieve an
+  installation script to run on Linux hosts.
+- Using the example Terraform module for deploying agents in [Deploy Agents with
+  Terraform](docs/pages/agents/deploy-agents-terraform.mdx). Read [Upgrade
+  Teleport Cloud Agents on Linux ](./upgrading/cloud-linux.mdx) to set up
+  automatic agent upgrades.
+- Reading the instructions in this section to install Teleport agent binaries
+  manually.
 
-| Feature                                                                        | Requirement   | Debian                   | Ubuntu   | CentOS/RHEL | Amazon Linux           | SLES           |
-|--------------------------------------------------------------------------------|---------------|--------------------------|----------|-------------|------------------------|----------------|
-| [Enhanced Session Recording](./server-access/guides/bpf-session-recording.mdx) | Kernel  v5.8+ | 11, or 10 with backports | 20.04.2+ | 9+          | 2 (post 11/2021), 2023 | 12 SP5, 15 SP5 |
-| Automatic Updates                                                              | systemd-based | 9+                       | 16.04+   | 7+          | 2, 2023                | 12 SP5, 15 SP5 |
-| Installation through apt/yum/zypper repos                                      | systemd-based | 9+                       | 16.04+   | 7+          | 2, 2023                | 12 SP5, 15 SP5 |
+If you are running a self-hosted Teleport Enterprise cluster, read our guidance
+in [Deploying a High-Availability Teleport
+Cluster](./deploy-a-cluster/introduction.mdx), provides full requirements and
+Terraform modules for deploying Teleport Enterprise.
 
-<Admonition type="note">
-`apt`, `yum`, and `zypper` repos don't expose packages for all distribution variants.
-When following installation instructions, you might need to replace `ID` with
-`ID_LIKE` to install packages of the closest supported distribution.
+The instructions in this section are intended for:
+- Linux desktop users.
+- Operators who want to incorporate Teleport installation commands into custom
+  scripts when the approaches listed above are not suitable.
 
-Currently supported distributions (and `ID`) are:
-- RHEL >= 7 (`rhel`)
-- CentOS >= 7 (`centos`)
-- Debian >= 9 (`debian`)
-- Ubuntu >= 16.04 (`ubuntu`)
-- Amazon Linux 2 and 2023 (`amzn`)
-- SLES >= 12 SP5, >= 15 SP5 (`sles`)
+### One-line installation script
 
-</Admonition>
+You can run a one-line command to install Teleport binaries on a Linux server:
+
+```code
+$ EDITION="oss"
+$ VERSION="(=teleport.version=)"
+$ curl https://goteleport.com/static/install.sh | bash -s ${VERSION?} ${EDITION?} 
+```
+
+The command takes the Teleport version and edition to install, then uses
+information about the operating system where it runs to choose a package manager
+and install Teleport.
+
+Valid editions are:
+
+| Value        | Edition                           |
+|--------------|-----------------------------------|
+| `cloud`      | Teleport Enterprise Cloud         |
+| `enterprise` | Teleport Enterprise (Self-Hosted) |
+| `oss`        | Teleport Community Edition        |
+| `team`       | Teleport Team                     |
+
+If running Teleport Enterprise Cloud, Teleport agents must be running version
+(=cloud.version=) or one major version below.
+
+### Using Teleport packages and archives
+
+Read the instructions in this section for how to install Teleport on a Linux
+server with your package manager of choice. Note that the [one-line installation
+script](#one-line-installation-script) runs these commands for you after
+determining which package manager to use.
+
+#### apt
+
+Run the following commands to install Teleport binaries on Linux systems that
+use the `apt` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
+Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
+
+```code
+$ TELEPORT_PKG=teleport
+# Download the Teleport PGP public key
+$ sudo curl https://apt.releases.teleport.dev/gpg \
+-o /usr/share/keyrings/teleport-archive-keyring.asc
+# Source variables about OS version
+$ source /etc/os-release
+# Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
+# file for each major release of Teleport.
+$ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+| sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+
+$ sudo apt-get update
+$ sudo apt-get install ${TELEPORT_PKG?}
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ sudo apt-get install teleport-ent-fips
+```
+
+#### yum
+
+Run the following commands to install Teleport binaries on Linux systems that
+use the `yum` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
+Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
+
+```code
+$ TELEPORT_PKG=teleport
+# Source variables about the OS version
+$ source /etc/os-release
+# Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+# file for each major release of Teleport.
+# First, get the major version from $VERSION_ID so this fetches the correct
+# package version.
+$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+$ sudo yum install -y yum-utils
+$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+$ sudo yum install ${TELEPORT_PKG?}
+#
+# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ sudo yum install teleport-ent-fips
+```
+
+#### zypper
+
+Run the following commands to install Teleport binaries on Linux systems that
+use the `zypper` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
+Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
+
+```code
+$ TELEPORT_PKG=teleport
+# Source variables about OS version
+$ source /etc/os-release
+# Add the Teleport Zypper repository for v(=teleport.major_version=). You'll need to update this
+# file for each major release of Teleport.
+# First, get the OS major version from $VERSION_ID so this fetches the correct
+# package version.
+$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+# Use zypper to add the teleport RPM repo
+$ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
+$ sudo yum install ${TELEPORT_PKG?}
+#
+# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ sudo yum install teleport-ent-fips
+```
+
+#### dnf
+
+Run the following commands to install Teleport binaries on Linux systems that
+use the `dnf` package manager. Replace `TELEPORT_PKG` with `teleport-ent` for
+Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise (Self-Hosted):
+
+```code
+$ TELEPORT_PKG=teleport
+# Source variables about OS version
+$ source /etc/os-release
+# Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+# file for each major release of Teleport.
+# First, get the major version from $VERSION_ID so this fetches the correct
+# package version.
+$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+# Use the dnf config manager plugin to add the teleport RPM repo
+$ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+
+# Install teleport
+$ sudo dnf install ${TELEPORT_PKG}
+
+# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+```
+
+For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+```code
+$ sudo dnf install teleport-ent-fips
+```
+
+#### tar
+
+Run the following commands to install Teleport binaries on Linux systems that do
+not have a package manager available. Replace `TELEPORT_PKG` with `teleport-ent`
+for Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise
+(Self-Hosted). Update `SYSTEM_ARCH` with the appropriate value (`amd64`,
+`arm64`, or `arm`):
+
+```code
+$ TELEPORT_PKG=teleport
+$ SYSTEM_ARCH=arm64
+$ curl https://get.gravitational.com/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://cdn.teleport.dev/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+$ shasum -a 256 ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+# Verify that the checksums match
+$ tar -xvf ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+$ cd ${TELEPORT_PKG?}
+$ sudo ./install
+```
+
+For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
+will be slightly different:
+
+```code
+$ SYSTEM_ARCH=arm64
+$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+# Verify that the checksums match
+$ tar -xvf teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+$ cd teleport-ent
+$ sudo ./install
+```
+
+### Package repositories and TAR archives
+
+Teleport maintains DEB and RPM package repositories for different operating
+systems, platforms, and Teleport versions. A server that installs Teleport from
+a DEB or RPM package must have systemd installed.
+
+#### RPM repositories
+
+A Teleport RPM repository URL has the following format:
+
+```sh
+https://yum.releases.teleport.dev/OPERATION_SYSTEM/OS_VERSION/Teleport/ARCHITECTURE/stable/TELEPORT_VERSION
+```
+
+For example, this URL points to an RPM repository for RHEL v7 intended for
+devices with a 64-bit ARM architecture, targeting Teleport major version
+(=teleport.major_version=):
+
+```sh
+https://yum.releases.teleport.dev/rhel/7/Teleport/aarch64/stable/v(=teleport.major_version=)
+```
+
+The parameters are designed to be queried from your system:
+
+| Parameter           | Source                                                            |
+|---------------------|-------------------------------------------------------------------|
+| Operating system    | The `ID` variable in `/etc/os-release`                            |
+| OS version          | The `VERSION_ID` variable in `/etc/os-release`                    |
+| System architecture | The `%{_arch}` RPM macro                                          |
+| Teleport version    | See [Upgrading Compatibility Overview](./upgrading/overview.mdx/) |
+
+RPM repositories don't expose packages for all distribution variants. When
+installing Teleport using these package managers, you may need to replace the
+`ID` variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
+closest supported distribution.
+
+Currently supported distributions (and `ID` values) are:
+
+| Distribution | Version              | `ID` value in `/etc/os-release` |
+|--------------|----------------------|---------------------------------|
+| RHEL         | >= 7                 | `rhel`                          |
+| CentOS       | >= 7                 | `centos`                        |
+| Amazon Linux | 2 and 2023           | `amzn`                          |
+| SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
+
+Note that [Enhanced Session
+Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
+kernel version 5.8+. This means that the OS versions it requires are more recent
+than do other Teleport features:
+
+| Distribution | Version                  |
+|--------------|--------------------------|
+| CentOS/RHEL  | 9+                       |
+| Amazon Linux | 2 (post 11/2021), 2023   |
+| SLES         | 12 SP5, 15 SP5           |
+
+#### DEB repositories
+
+To target a Teleport DEB repository, add a `sources.list` entry with the
+following format:
+
+```sh
+deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/OPERATING_SYSTEM VERSION_CODENAME stable/TELEPORT_VERSION
+```
+
+For example, the following targets the DEB repository for Ubuntu Jammy to
+install Teleport v(=teleport.major_version=):
+
+```
+deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/ubuntu jammy stable/v(=teleport.major_version=)
+```
 
 
-### Installation instructions
+The parameters are designed to be queried from your system:
 
-(!docs/pages/includes/permission-warning.mdx!)
+| Parameter           | Source                                                            |
+|---------------------|-------------------------------------------------------------------|
+| Operating system    | The `ID` variable in `/etc/os-release`                            |
+| OS version codename | The `VERSION_CODENAME` variable in `/etc/os-release`              |
+| Teleport version    | See [Upgrading Compatibility Overview](./upgrading/overview.mdx/) |
 
-(!docs/pages/includes/install-linux.mdx!)
+DEB repositories don't expose packages for all distribution variants. When
+installing Teleport using these package managers, you may need to replace the
+`ID` variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
+closest supported distribution.
 
-<Tabs>
-<TabItem scope="oss" label="Teleport Community Edition">
+Currently supported distributions (and `ID` values) are:
 
-Check the [Downloads](https://goteleport.com/download/) page for the most
-up-to-date information.
+| Distribution | Version    | `ID` value in `/etc/os-release` |
+|--------------|------------|---------------------------------|
+| Debian       | >= 9       | `debian`                        |
+| Ubuntu       | >= 16.04   | `ubuntu`                        |
 
-</TabItem>
-<TabItem scope="cloud" label="Teleport Enterprise Cloud">
+Note that [Enhanced Session
+Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
+kernel version 5.8+. This means that the OS versions it requires are more recent
+than do other Teleport features:
 
-Check the [Cloud Downloads](./choose-an-edition/teleport-cloud/downloads.mdx) page for the most up-to-date
-information on obtaining Teleport binaries compatible with Teleport Cloud.
+| Distribution | Version                  |
+|--------------|--------------------------|
+| Debian       | 11, or 10 with backports |
+| Ubuntu       | 20.042+                  |
 
-</TabItem>
+#### TAR archives
 
-</Tabs>
+You can also download a TAR archive containing Teleport binaries. You can find
+archives at a URL with the following format:
+
+```sh
+https://cdn.teleport.dev/TELEPORT_EDITION-TELEPORT_VERSION-linux-ARCHITECTURE-bin.tar.gz
+```
+
+For example, you can find a TAR archive containing binaries for Teleport
+v(=teleport.version=) targeting x86-64 systems with this URL:
+
+```sh
+https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+```
+
+The available architecture values are:
+
+- `amd64`
+- `arm64`
+- `arm`
+- `386`
+
+Unlike the DEB and RPM repositories, the TAR archive URLs require you to specify
+a Teleport edition. For Teleport Team, Teleport Enterprise Cloud, and Teleport
+Enterprise (Self-Hosted), use`teleport-ent`. For Teleport Community Edition, use
+`teleport`.
+
+If downloading FIPS-compatible Teleport Enterprise binaries, use a URL similar
+to the following:
+
+```sh
+https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-SYSTEM_ARCH-fips-bin.tar.gz
+```
+
+### Specifying a Teleport edition
+
+To download Teleport binaries for a particular edition from the Teleport DEB and
+RPM repositories, specify the edition when you enter the name of the package to
+install. For example, the following command installs Teleport Enterprise
+binaries on Ubuntu/Debian systems:
+
+```code
+$ sudo apt-get install teleport-ent
+```
+
+The following package names are available:
+
+| Name                | Edition(s)                                                                  |
+|---------------------|-----------------------------------------------------------------------------|
+| `teleport`          | Teleport Community Edition                                                  |
+| `teleport-ent`      | Teleport Team, Teleport Enterprise Cloud, Teleport Enterprise (Self-Hosted) |
+| `teleport-ent-fips` | Teleport Enterprise (Self-Hosted)                                           |
+
+### Download binaries from your browser
+
+For Teleport Community Edition, check the
+[Downloads](https://goteleport.com/download/) page for the most up-to-date
+information.
+
+For Teleport Team and Teleport Enterprise Cloud, check the [Cloud
+Downloads](./choose-an-edition/teleport-cloud/downloads.mdx) page for the most
+up-to-date information on obtaining Teleport binaries compatible with Teleport
+Cloud.
 
 ## Docker
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -68,7 +68,7 @@ agents by:
   you can select a resource to enroll in your Teleport cluster and retrieve an
   installation script to run on Linux hosts.
 - Using the example Terraform module for deploying agents in [Deploy Agents with
-  Terraform](docs/pages/agents/deploy-agents-terraform.mdx).
+  Terraform](agents/deploy-agents-terraform.mdx).
 - Running the [one-line installation script](#one-line-installation-script) on
   each Linux server where you want to install a Teleport agent.
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -61,7 +61,7 @@ archives containing Teleport binaries. All installations include `teleport`,
 ### Recommended installation steps
 
 If you are starting out with Teleport, we recommend beginning with a [Teleport
-Team](https://goteleport.com/signup/) account. From there, the only Teleport
+Cloud](https://goteleport.com/signup/) account. From there, the only Teleport
 components you need to deploy yourself are Teleport agents. You can deploy
 agents by:
 - Following the instructions in the Teleport Web UI at `/web/discover`, where
@@ -299,46 +299,38 @@ repositories.
    </TabItem>
    </Tabs>
 
-### TAR archives
+### TAR archives (self-hosted only)
 
 For self-hosted deployments, Teleport maintains TAR archives for
 Linux-compatible binaries at `https://cdn.teleport.dev`. This section explains
 the Teleport TAR archives and how to use them.
-
-<Notice type="warning">
 
 It is not possible to install the automatic agent updater using TAR archives.
 Teleport Cloud customers must use the [one-line installation
 script](#one-line-installation-script) or manually install Teleport from a
 [package repository](#package-repositories) in order to install the updater.
 
-</Notice>
+1. In your terminal, assign environment variables that you will use to download
+   your intended archive.
 
-1. Assign environment variables that you will use to download your intended
-   archive:
+   For Teleport Community Edition, the Teleport package is called `teleport`:
 
-   <Tabs>
-   <TabItem label="Teleport Community Edition">
-   
    ```code
-   $ export TELEPORT_PKG=teleport
-   $ export TELEPORT_VERSION=(=teleport.version=)
+   $ TELEPORT_PKG=teleport
    ```
 
-   </TabItem>
-   <TabItem label="Teleport Enterprise">
+   For self-hosted Teleport Enterprise deployments, the package is called
+   `teleport-ent`:
 
    ```code
-   $ export TELEPORT_PKG=teleport-ent
-   $ export TELEPORT_VERSION=(=teleport.version=)
+   $ TELEPORT_PKG=teleport-ent
    ```
 
-   </TabItem>
-   </Tabs>
-
-1. Specify your system architecture by assigning an environment variable:
+1. Specify your system Teleport version and system architecture by assigning an
+   environment variable:
 
    ```code
+   $ TELEPORT_VERSION=(=teleport.version=)
    $ SYSTEM_ARCH=""
    ```
 
@@ -383,7 +375,7 @@ For Teleport Community Edition, check the
 [Downloads](https://goteleport.com/download/) page for the most up-to-date
 information.
 
-For Teleport Team and Teleport Enterprise Cloud, check the [Cloud
+For Teleport Enterprise Cloud, check the [Cloud
 Downloads](./choose-an-edition/teleport-cloud/downloads.mdx) page for the most
 up-to-date information on obtaining Teleport binaries compatible with Teleport
 Cloud.

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -49,10 +49,14 @@ supports most features on Windows 10 and later.*
 
 ## Linux
 
-You can install Teleport binaries on Linux using RPM and DEB packages as well as
-TAR archives. All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
 This section shows you how to install Teleport binaries on a single Linux
 server.
+
+Teleport maintains DEB and RPM package repositories for different operating
+systems, platforms, and Teleport versions. A server that installs Teleport from
+a DEB or RPM package must have systemd installed. You can also download TAR
+archives containing Teleport binaries. All installations include `teleport`,
+`tsh`, `tctl`, and `tbot`.
 
 ### Recommended installation steps
 
@@ -65,380 +69,313 @@ agents by:
   installation script to run on Linux hosts.
 - Using the example Terraform module for deploying agents in [Deploy Agents with
   Terraform](docs/pages/agents/deploy-agents-terraform.mdx).
-- Reading the instructions in this section to install Teleport agent binaries
-  manually.
-
-We recommend that Teleport Team and Teleport Enterprise Cloud users enable
-automatic upgrades for agents. Read [Upgrade Teleport Cloud Agents on Linux
-](./upgrading/cloud-linux.mdx) to set up automatic agent upgrades on Linux
-servers.
+- Running the [one-line installation script](#one-line-installation-script) on
+  each Linux server where you want to install a Teleport agent.
 
 If you are running a self-hosted Teleport Enterprise cluster, read our guidance
 in [Deploying a High-Availability Teleport
 Cluster](./deploy-a-cluster/introduction.mdx), which provides full requirements
 and Terraform modules for deploying Teleport Enterprise on your infrastructure.
 
-The instructions in this section are intended for:
-- Linux desktop users.
-- Operators who want to incorporate Teleport installation commands into custom
-  scripts when the approaches listed above are not suitable.
-
 ### One-line installation script
 
-You can run a one-line command to install Teleport binaries on a Linux server:
-
-```code
-$ EDITION="oss"
-$ VERSION="(=teleport.version=)"
-$ curl https://goteleport.com/static/install.sh | bash -s ${VERSION?} ${EDITION?} 
-```
-
+You can run a one-line command to install Teleport binaries on a Linux server.
 The command takes the Teleport version and edition to install, then uses
 information about the operating system where it runs to choose a package manager
 and install Teleport.
 
-Valid editions are:
-
-| Value        | Edition                           |
-|--------------|-----------------------------------|
-| `cloud`      | Teleport Enterprise Cloud         |
-| `enterprise` | Teleport Enterprise (Self-Hosted) |
-| `oss`        | Teleport Community Edition        |
-| `team`       | Teleport Team                     |
-
-### Package repositories
-
-Teleport maintains DEB and RPM package repositories for different operating
-systems, platforms, and Teleport versions. A server that installs Teleport from
-a DEB or RPM package must have systemd installed.
-
-#### Package manager examples
-
-Read the instructions in this section for how to install Teleport on a Linux
-server with your package manager of choice. For more information about how our
-package repositories work, read [Package repositories and TAR
-archives](#package-repositories-and-tar-archives).
-
-Assign the following environment variables in the terminal where you will run
-Teleport installation commands:
+First, assign environment variables based on your edition:
 
 <Tabs>
 <TabItem label="Teleport Community Edition">
 
 ```code
-$ export TELEPORT_PKG=teleport
-$ export TELEPORT_VERSION=v(=teleport.major_version=)
+$ TELEPORT_EDITION="oss"
+$ TELEPORT_VERSION="(=teleport.version=)"
 ```
 
 </TabItem>
 <TabItem label="Teleport Cloud">
 
-Install the automatic agent updater along with the `teleport` binary:
+The following commands show you how to determine the Teleport version to install
+by querying your Teleport Cloud account. This way, the Teleport installation has
+the same major version as the service that manages automatic updates:
 
 ```code
-$ export TELEPORT_PKG="teleport-ent teleport-ent-updater"
-$ export TELEPORT_VERSION="cloud"
+$ TELEPORT_EDITION="cloud"
+$ TELEPORT_DOMAIN=<Var name="example.teleport.sh" />
+$ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')
 ```
 
 </TabItem>
-<TabItem label="Teleport Enterprise (Self-Hosted)">
+<TabItem label="Teleport Enterprise">
 
 ```code
-$ export TELEPORT_PKG=teleport-ent
-$ export TELEPORT_VERSION=v(=teleport.major_version=)
-```
-
-For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
-
-```code
-$ export TELEPORT_PKG=teleport-ent-fips
+$ TELEPORT_EDITION="enterprise"
+$ TELEPORT_VERSION="(=teleport.version=)"
 ```
 
 </TabItem>
 </Tabs>
 
-Follow the instructions for your package manager:
-
-<Tabs>
-<TabItem label="apt">
+Download and run the installation script on the server where you want to install
+Teleport:
 
 ```code
-# Download the Teleport PGP public key
-$ sudo curl https://apt.releases.teleport.dev/gpg \
--o /usr/share/keyrings/teleport-archive-keyring.asc
-# Source variables about OS version
-$ source /etc/os-release
-# Add the Teleport APT repository. You'll need to update this file for each
-# major release of Teleport.
-$ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
-stable/${TELEPORT_VERSION?}" \
-| sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-
-$ sudo apt-get update
-$ sudo apt-get install ${TELEPORT_PKG?}
+$ curl https://goteleport.com/static/install.sh | bash -s ${TELEPORT_VERSION?} ${TELEPORT_EDITION?} 
 ```
 
-</TabItem>
+### Package repositories
 
-<TabItem label="yum">
+The [one-line installation script](#one-line-installation-script) automatically
+detects a package manager on the local system and uses it to install Teleport
+from an upstream repository.
 
-```code
-# Source variables about the OS version
-$ source /etc/os-release
-# Add the Teleport YUM repository. You'll need to update this file for each
-# major release of Teleport.
-# First, get the major version from $VERSION_ID so this fetches the correct
-# package version.
-$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-$ sudo yum install -y yum-utils
-$ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
-$ sudo yum install ${TELEPORT_PKG?}
-#
-# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-```
+If your system does not support the one-line installation script, read the
+instructions in this section for instructions on working with Teleport package
+repositories.
 
-</TabItem>
+1. Assign the following environment variables in the terminal where you will run
+   Teleport installation commands, indicating the package and version to
+   install:
 
-<TabItem label="zypper">
+   <Tabs>
+   <TabItem label="Teleport Community Edition">
+   
+   ```code
+   $ export TELEPORT_PKG=teleport
+   $ export TELEPORT_VERSION=v(=teleport.major_version=)
+   ```
+   
+   </TabItem>
+   <TabItem label="Teleport Cloud">
+   
+   Teleport Cloud installations must include the automatic agent updater. The
+   following commands show you how to determine the Teleport version to install
+   by querying your Teleport Cloud account. This way, the Teleport installation
+   has the same major version as the service that conducts automatic updates:
+   
+   ```code
+   $ export TELEPORT_PKG="teleport-ent teleport-ent-updater"
+   $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')
+   ```
 
-```code
-# Source variables about OS version
-$ source /etc/os-release
-# Add the Teleport Zypper repository. You'll need to update this file for each
-# major release of Teleport.
-# First, get the OS major version from $VERSION_ID so this fetches the correct
-# package version.
-$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-# Use zypper to add the teleport RPM repo
-$ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport-zypper.repo")
-$ sudo yum install ${TELEPORT_PKG?}
-#
-# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-```
+   </TabItem>
+   <TabItem label="Teleport Enterprise (Self-Hosted)">
+   
+   ```code
+   $ export TELEPORT_PKG=teleport-ent
+   $ export TELEPORT_VERSION=v(=teleport.major_version=)
+   ```
+   
+   For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+   
+   ```code
+   $ export TELEPORT_PKG=teleport-ent-fips
+   ```
+   
+   </TabItem>
+   </Tabs>
 
-</TabItem>
+1. Teleport maintains DEB and RPM package repositories for different Linux
+   distributions based on variables defined in `/etc/os-release` on Linux
+   systems. Source this file to define the variables:
 
-<TabItem label="dnf">
+   ```code
+   $ source /etc/os-release
+   ```
 
-```code
-# Source variables about OS version
-$ source /etc/os-release
-# Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-# file for each major release of Teleport.
-# First, get the major version from $VERSION_ID so this fetches the correct
-# package version.
-$ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-# Install dnf config-manager
-$ sudo yum install -y yum-utils
-# Use the dnf config manager plugin to add the teleport RPM repo
-$ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
+   <Details title="Supported distribution IDs">
 
-# Install teleport
-$ sudo dnf install ${TELEPORT_PKG}
+   The Teleport DEB and RPM repositories don't expose packages for all
+   distribution variants. When installing Teleport using RPM repositories, you
+   may need to replace the `ID` variable set in `/etc/os-release` with `ID_LIKE`
+   to install packages of the closest supported distribution.
+   
+   Currently supported distributions (and `ID` values) are:
+   
+   | Distribution | Version              | `ID` value in `/etc/os-release` |
+   |--------------|----------------------|---------------------------------|
+   | Amazon Linux | 2 and 2023           | `amzn`                          |
+   | CentOS       | >= 7                 | `centos`                        |
+   | Debian       | >= 9                 | `debian`                        |
+   | RHEL         | >= 7                 | `rhel`                          |
+   | SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
+   | Ubuntu       | >= 16.04             | `ubuntu`                        |
+   
+   Note that [Enhanced Session
+   Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
+   kernel version 5.8+. This means that it requires more recent OS versions than
+   other Teleport features:
+   
+   | Distribution | Version                  |
+   |--------------|--------------------------|
+   | Amazon Linux | 2 (post 11/2021), 2023   |
+   | CentOS/RHEL  | 9+                       |
+   | Debian       | 11, or 10 with backports |
+   | Ubuntu       | 20.042+                  |
 
-# Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-# echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-```
+   </Details>
 
-</TabItem>
-</Tabs>
+1. Follow the instructions for your package manager:
 
-#### RPM repositories
-
-A Teleport RPM repository URL has the following format:
-
-```sh
-https://yum.releases.teleport.dev/OPERATION_SYSTEM/OS_VERSION/Teleport/SYSTEM_ARCHITECTURE/stable/TELEPORT_VERSION
-```
-
-For example, this URL points to an RPM repository for RHEL v7 intended for
-devices with a 64-bit ARM architecture, targeting Teleport major version
-(=teleport.major_version=):
-
-```sh
-https://yum.releases.teleport.dev/rhel/7/Teleport/aarch64/stable/v(=teleport.major_version=)
-```
-
-The parameters are designed to be queried from your system:
-
-| Parameter           | Source                                                            |
-|---------------------|-------------------------------------------------------------------|
-| `OPERATING_SYSTEM` | The `ID` variable in `/etc/os-release`.                            |
-| `OS_VERSION` | The `VERSION_ID` variable in `/etc/os-release`.                    |
-| `SYSTEM_ARCHITECTURE` | The `%{_arch}` RPM macro.                                          |
-| `TELEPORT_VERSION` | `cloud` for Teleport Enterprise Cloud and Teleport Team. A major version number, e.g., `v(=teleport.major_version=)`, for self-hosted deployments. See [Upgrading Compatibility Overview](./upgrading/overview.mdx/). |
-
-RPM repositories don't expose packages for all distribution variants. When
-installing Teleport using RPM repositories, you may need to replace the `ID`
-variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
-closest supported distribution.
-
-Currently supported distributions (and `ID` values) are:
-
-| Distribution | Version              | `ID` value in `/etc/os-release` |
-|--------------|----------------------|---------------------------------|
-| RHEL         | >= 7                 | `rhel`                          |
-| CentOS       | >= 7                 | `centos`                        |
-| Amazon Linux | 2 and 2023           | `amzn`                          |
-| SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
-
-Note that [Enhanced Session
-Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
-kernel version 5.8+. This means that it requires more recent OS versions than
-other Teleport features:
-
-| Distribution | Version                  |
-|--------------|--------------------------|
-| CentOS/RHEL  | 9+                       |
-| Amazon Linux | 2 (post 11/2021), 2023   |
-| SLES         | 12 SP5, 15 SP5           |
-
-#### DEB repositories
-
-To target a Teleport DEB repository, add a `sources.list` entry with the
-following format:
-
-```sh
-deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/OPERATING_SYSTEM VERSION_CODENAME stable/TELEPORT_VERSION
-```
-
-For example, the following targets the DEB repository for Ubuntu Jammy to
-install Teleport v(=teleport.major_version=):
-
-```
-deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://apt.releases.teleport.dev/ubuntu jammy stable/v(=teleport.major_version=)
-```
-
-The parameters are designed to be queried from your system:
-
-| Parameter           | Source                                                            |
-|---------------------|-------------------------------------------------------------------|
-| `OPERATING_SYSTEM` | The `ID` variable in `/etc/os-release`.                            |
-| `VERSION_CODENAME` | The `VERSION_CODENAME` variable in `/etc/os-release`.              |
-| `TELEPORT_VERSION` | `cloud` for Teleport Enterprise Cloud and Teleport Team. A major version number, e.g., `v(=teleport.major_version=)`, for self-hosted deployments. See [Upgrading Compatibility Overview](./upgrading/overview.mdx/). |
-
-DEB repositories don't expose packages for all distribution variants. When
-installing Teleport using DEB repositories, you may need to replace the `ID`
-variable set in `/etc/os-release` with `ID_LIKE` to install packages of the
-closest supported distribution.
-
-Currently supported distributions (and `ID` values) are:
-
-| Distribution | Version    | `ID` value in `/etc/os-release` |
-|--------------|------------|---------------------------------|
-| Debian       | >= 9       | `debian`                        |
-| Ubuntu       | >= 16.04   | `ubuntu`                        |
-
-Note that [Enhanced Session
-Recording](./server-access/guides/bpf-session-recording.mdx) requires Linux
-kernel version 5.8+. This means that it requires more recent OS versions than
-other Teleport features:
-
-| Distribution | Version                  |
-|--------------|--------------------------|
-| Debian       | 11, or 10 with backports |
-| Ubuntu       | 20.042+                  |
-
-#### Specifying a Teleport edition
-
-To download Teleport binaries for a particular edition from the Teleport DEB and
-RPM repositories, specify the edition when you enter the name of the package to
-install. For example, the following command installs Teleport Enterprise
-binaries on Ubuntu/Debian systems:
-
-```code
-$ sudo apt-get install teleport-ent
-```
-
-The following package names are available:
-
-| Name                | Edition(s)                                                                  |
-|---------------------|-----------------------------------------------------------------------------|
-| `teleport`          | Teleport Community Edition                                                  |
-| `teleport-ent`      | Teleport Team, Teleport Enterprise Cloud, Teleport Enterprise (Self-Hosted) |
-| `teleport-ent-fips` | Teleport Enterprise (Self-Hosted)                                           |
+   <Tabs>
+   <TabItem label="apt">
+   
+   ```code
+   # Download the Teleport PGP public key
+   $ sudo curl https://apt.releases.teleport.dev/gpg \
+   -o /usr/share/keyrings/teleport-archive-keyring.asc
+   # Add the Teleport APT repository. You'll need to update this file for each
+   # major release of Teleport.
+   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
+   stable/${TELEPORT_VERSION?}" \
+   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+   
+   $ sudo apt-get update
+   $ sudo apt-get install ${TELEPORT_PKG?}
+   ```
+   
+   </TabItem>
+   
+   <TabItem label="yum">
+   
+   ```code
+   # Add the Teleport YUM repository. You'll need to update this file for each
+   # major release of Teleport.
+   # First, get the major version from $VERSION_ID so this fetches the correct
+   # package version.
+   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+   $ sudo yum install -y yum-utils
+   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
+   $ sudo yum install ${TELEPORT_PKG?}
+   #
+   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+   ```
+   
+   </TabItem>
+   
+   <TabItem label="zypper">
+   
+   ```code
+   # Add the Teleport Zypper repository. You'll need to update this file for each
+   # major release of Teleport.
+   # First, get the OS major version from $VERSION_ID so this fetches the correct
+   # package version.
+   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+   # Use zypper to add the teleport RPM repo
+   $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport-zypper.repo")
+   $ sudo yum install ${TELEPORT_PKG?}
+   #
+   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+   ```
+   
+   </TabItem>
+   
+   <TabItem label="dnf">
+   
+   ```code
+   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+   # file for each major release of Teleport.
+   # First, get the major version from $VERSION_ID so this fetches the correct
+   # package version.
+   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
+   # Install dnf config-manager
+   $ sudo yum install -y yum-utils
+   # Use the dnf config manager plugin to add the teleport RPM repo
+   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/${TELEPORT_VERSION?}/teleport.repo")"
+   
+   # Install teleport
+   $ sudo dnf install ${TELEPORT_PKG}
+   
+   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+   ```
+   
+   </TabItem>
+   </Tabs>
 
 ### TAR archives
 
-Teleport maintains TAR archives for Linux-compatible binaries at
-`https://cdn.teleport.dev`. This section explains the Teleport TAR archives and
-how to use them.
+For self-hosted deployments, Teleport maintains TAR archives for
+Linux-compatible binaries at `https://cdn.teleport.dev`. This section explains
+the Teleport TAR archives and how to use them.
 
-#### Example commands
+<Notice type="warning">
 
-Run the following commands to install Teleport binaries on Linux systems that do
-not have a package manager available. Replace `TELEPORT_PKG` with `teleport-ent`
-for Teleport Enterprise Cloud, Teleport Team, and Teleport Enterprise
-(Self-Hosted). Update `SYSTEM_ARCH` with the appropriate value (`amd64`,
-`arm64`, or `arm`):
+It is not possible to install the automatic agent updater using TAR archives.
+Teleport Cloud customers must use the [one-line installation
+script](#one-line-installation-script) or manually install Teleport from a
+[package repository](#package-repositories) in order to install the updater.
 
-```code
-$ TELEPORT_PKG=teleport
-$ SYSTEM_ARCH=arm64
-$ curl https://get.gravitational.com/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz.sha256
-# <checksum> <filename>
-$ curl -O https://cdn.teleport.dev/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
-$ shasum -a 256 ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
-# Verify that the checksums match
-$ tar -xvf ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
-$ cd ${TELEPORT_PKG?}
-$ sudo ./install
-```
+</Notice>
 
-For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
-will be slightly different:
+1. Assign environment variables that you will use to download your intended
+   archive:
 
-```code
-$ SYSTEM_ARCH=arm64
-$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz.sha256
-# <checksum> <filename>
-$ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
-$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
-# Verify that the checksums match
-$ tar -xvf teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
-$ cd teleport-ent
-$ sudo ./install
-```
+   <Tabs>
+   <TabItem label="Teleport Community Edition">
+   
+   ```code
+   $ export TELEPORT_PKG=teleport
+   $ export TELEPORT_VERSION=(=teleport.version=)
+   ```
 
-For more information about our TAR archives, read [Package repositories and TAR
-archives](#tar-archives).
+   </TabItem>
+   <TabItem label="Teleport Enterprise">
 
-#### Selecting an archive to download
+   ```code
+   $ export TELEPORT_PKG=teleport-ent
+   $ export TELEPORT_VERSION=(=teleport.version=)
+   ```
 
-You can find TAR archives at a URL with the following format:
+   </TabItem>
+   </Tabs>
 
-```sh
-https://cdn.teleport.dev/TELEPORT_EDITION-TELEPORT_VERSION-linux-ARCHITECTURE-bin.tar.gz
-```
+1. Specify your system architecture by assigning an environment variable:
 
-For example, you can find a TAR archive containing binaries for Teleport
-v(=teleport.version=) targeting x86-64 systems with this URL:
+   ```code
+   $ SYSTEM_ARCH=""
+   ```
 
-```sh
-https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-```
+   The following architecture values are available:   
 
-The available architecture values are:
+   - `amd64`
+   - `arm64`
+   - `arm`
+   - `386`
 
-- `amd64`
-- `arm64`
-- `arm`
-- `386`
+1. Run the following commands to download the Teleport archive, unpack it, and
+   install binaries:
 
-Unlike the DEB and RPM repositories, the TAR archive URLs require you to specify
-a Teleport edition. For Teleport Team, Teleport Enterprise Cloud, and Teleport
-Enterprise (Self-Hosted), use`teleport-ent`. For Teleport Community Edition, use
-`teleport`.
+   ```code
+   $ curl https://get.gravitational.com/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz.sha256
+   # <checksum> <filename>
+   $ curl -O https://cdn.teleport.dev/${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+   $ shasum -a 256 ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+   # Verify that the checksums match
+   $ tar -xvf ${TELEPORT_PKG?}-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-bin.tar.gz
+   $ cd ${TELEPORT_PKG?}
+   $ sudo ./install
+   ```
 
-If downloading FIPS-compatible Teleport Enterprise binaries, use a URL similar
-to the following:
+   For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
+   are slightly different:
 
-```sh
-https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-SYSTEM_ARCH-fips-bin.tar.gz
-```
+   ```code
+   $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz.sha256
+   # <checksum> <filename>
+   $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+   $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+   # Verify that the checksums match
+   $ tar -xvf teleport-ent-v(=teleport.version=)-linux-${SYSTEM_ARCH?}-fips-bin.tar.gz
+   $ cd teleport-ent
+   $ sudo ./install
+   ```
 
 ### From your browser
 

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -36,7 +36,7 @@ For information about other ways to enroll and discover Kubernetes clusters, see
   ```
 
   You can download these tools by following the appropriate [Installation 
-  instructions](../installation.mdx#installation-instructions) for your environment.
+  instructions](../installation.mdx#linux) for your environment.
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 


### PR DESCRIPTION
Closes #32387
Closes #38144

In the Installation page, the instructions for installing Teleport on Linux reuses the partial we use for how-to guides, `install-linux.mdx`. This is inappropriate for an installation reference, since the partial is not intended for users interested in a specific package manager. This change provides a comprehensive description of our package repositories for Teleport installations on Linux.

Since the Installation page is a common entrypoint for users looking to get started with Teleport, this change also adds a section to the Linux installation instructions with recommended pages to follow for setting up Teleport.

Also, since we have a script available form the corporate Teleport site that automatically chooses a package manager and configures it to target a Teleport package repo, this change adds instructions to use this.

I have organized the Linux installation section to place H3 sections from less work/configuration to more work/configuration, from the one-line installation script to package manager-specific instructions and, finally, general information about our package repositories.