### PR TITLE
[v14] Update cloud installation docs

### DIFF
--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -15,6 +15,7 @@
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
   $ sudo apt-get update
+  $ sudo apt-get install teleport-ent=(=cloud.version=)
   $ sudo apt-get install teleport-ent-updater
   ```
 
@@ -30,6 +31,7 @@
   $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   $ sudo yum install -y yum-utils
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
+  $ sudo yum install teleport-ent-(=cloud.version=)
   $ sudo yum install teleport-ent-updater
   #
   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
@@ -50,6 +52,7 @@
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
   
   # Install teleport
+  $ sudo dnf install teleport-ent-(=cloud.version=)
   $ sudo dnf install teleport-ent-updater
   
   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
@@ -70,6 +73,7 @@
   $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
   
   # Install teleport
+  $ sudo zypper install teleport-ent=(=cloud.version=)
   $ sudo zypper install teleport-ent-updater
   ```
 

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -84,7 +84,7 @@ This section assumes that the name of your `teleport-kube-agent` release is
    ```code
    $  helm -n <Var name="teleport" /> upgrade <Var name="teleport-agent" /> teleport/teleport-kube-agent  \
    --values=values.yaml \
-   --version=<Var name="(=teleport.version=)" />
+   --version=<Var name="(=cloud.version=)" />
    ```
 
 1. Validate the updater is running properly by checking if its pod is ready:
@@ -134,6 +134,6 @@ Run the following commands to upgrade Teleport agents running on Kubernetes.
    ```code
    $ helm -n <Var name="teleport" /> upgrade <Var name="teleport-agent" /> teleport/teleport-kube-agent \
    --values=values.yaml \
-   --version=<Var name="(=teleport.version=)" />
+   --version=<Var name="(=cloud.version=)" />
    ```
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/36600 to branch/v14.