### PR TITLE
Reuse MFA for Admin Action - Add User

### DIFF
--- a/api/client/mfa_test.go
+++ b/api/client/mfa_test.go
@@ -70,7 +70,7 @@ func TestPerformMFACeremony(t *testing.T) {
 	clt, err := New(ctx, cfg)
 	require.NoError(t, err)
 
-	resp, err := clt.performAdminActionMFACeremony(ctx)
+	resp, err := clt.performAdminActionMFACeremony(ctx, "AdminAction")
 	require.NoError(t, err)
 	require.Equal(t, mfaTestResp.Response, resp.Response)
 }

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -31,7 +31,7 @@ import (
 // to the rpc call when an MFA response is provided through the context. Additionally,
 // when the call returns an error that indicates that MFA is required, this interceptor
 // will prompt for MFA using the given mfaCeremony and retry.
-func WithMFAUnaryInterceptor(mfaCeremony func(ctx context.Context, opts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)) grpc.UnaryClientInterceptor {
+func WithMFAUnaryInterceptor(mfaCeremony func(ctx context.Context, adminActionName string) (*proto.MFAAuthenticateResponse, error)) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		// Check for MFA response passed through the context.
 		if mfaResp, err := mfa.MFAResponseFromContext(ctx); err == nil {
@@ -52,7 +52,7 @@ func WithMFAUnaryInterceptor(mfaCeremony func(ctx context.Context, opts ...mfa.P
 
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"
-		mfaResp, ceremonyErr := mfaCeremony(ctx, mfa.WithPromptReasonAdminAction(readableMethodName))
+		mfaResp, ceremonyErr := mfaCeremony(ctx, readableMethodName)
 		if ceremonyErr != nil {
 			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
 		}

--- a/api/utils/grpc/interceptors/mfa_test.go
+++ b/api/utils/grpc/interceptors/mfa_test.go
@@ -97,7 +97,7 @@ func TestRetryWithMFA(t *testing.T) {
 		assert.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired, "Ping error mismatch")
 	})
 
-	okMFACeremony := func(ctx context.Context, opts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	okMFACeremony := func(ctx context.Context, adminActionName string) (*proto.MFAAuthenticateResponse, error) {
 		return &proto.MFAAuthenticateResponse{
 			Response: &proto.MFAAuthenticateResponse_TOTP{
 				TOTP: &proto.TOTPResponse{
@@ -108,7 +108,7 @@ func TestRetryWithMFA(t *testing.T) {
 	}
 
 	mfaCeremonyErr := trace.BadParameter("client does not support mfa")
-	nokMFACeremony := func(ctx context.Context, opts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	nokMFACeremony := func(ctx context.Context, adminActionName string) (*proto.MFAAuthenticateResponse, error) {
 		return nil, mfaCeremonyErr
 	}
 
@@ -160,7 +160,7 @@ func TestRetryWithMFA(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			mfaResp, _ := okMFACeremony(ctx)
+			mfaResp, _ := okMFACeremony(ctx, "AdminAction")
 			ctx := mfa.ContextWithMFAResponse(ctx, mfaResp)
 
 			client := proto.NewAuthServiceClient(conn)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -40,6 +40,7 @@ import (
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	accessgraphv1 "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
@@ -981,4 +982,7 @@ type ClientI interface {
 	// which is what we want when handling things like ambiguous host errors and resource-based access requests,
 	// but may result in confusing behavior if it is used outside of those contexts.
 	GetSSHTargets(ctx context.Context, req *proto.GetSSHTargetsRequest) (*proto.GetSSHTargetsResponse, error)
+
+	// PromptMFA prompts the user for MFA.
+	PromptMFA(ctx context.Context, chal *proto.MFAAuthenticateChallenge, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
 }

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -35,9 +35,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
-	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -310,8 +310,10 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 				},
 			},
 		},
-		AllowReuse: true,
-		Scope:      webauthnpb.ChallengeScope_CHALLENGE_SCOPE_ADMIN_ACTION,
+		ChallengeExtensions: &mfav1.ChallengeExtensions{
+			Scope:      mfav1.ChallengeScope_CHALLENGE_SCOPE_ADMIN_ACTION,
+			AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+		},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -21,6 +21,7 @@ import { useAttempt } from 'shared/hooks';
 
 import { User } from 'teleport/services/user';
 import useTeleport from 'teleport/useTeleport';
+import auth, { MFAChallengeScope } from 'teleport/services/auth/auth';
 
 export default function useUsers({
   InviteCollaborators,
@@ -82,11 +83,26 @@ export default function useUsers({
     });
   }
 
-  function onCreate(u: User) {
+  async function onCreate(u: User) {
+    const webauthnResponse = await auth.getWebauthnResponse(
+      MFAChallengeScope.ADMIN_ACTION,
+      true,
+      {
+        admin_action: {
+          name: 'CreateUser',
+        },
+      }
+    );
     return ctx.userService
-      .createUser(u)
+      .createUser(u, webauthnResponse)
       .then(result => setUsers([result, ...users]))
-      .then(() => ctx.userService.createResetPasswordToken(u.name, 'invite'));
+      .then(() =>
+        ctx.userService.createResetPasswordToken(
+          u.name,
+          'invite',
+          webauthnResponse
+        )
+      );
   }
 
   function onInviteCollaboratorsClose(newUsers?: User[]) {

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -31,12 +31,16 @@ const api = {
     return api.fetchJsonWithMfaAuthnRetry(url, { signal: abortSignal });
   },
 
-  post(url, data?, abortSignal?) {
-    return api.fetchJsonWithMfaAuthnRetry(url, {
-      body: JSON.stringify(data),
-      method: 'POST',
-      signal: abortSignal,
-    });
+  post(url, data?, abortSignal?, webauthnResponse?: WebauthnAssertionResponse) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        body: JSON.stringify(data),
+        method: 'POST',
+        signal: abortSignal,
+      },
+      webauthnResponse
+    );
   },
 
   postFormData(url, formData) {


### PR DESCRIPTION
Use reusable scoped webauthn credentials for creating users. This prevents the additional MFA prompt added from MFA for admin actions work.

Based off https://github.com/gravitational/teleport/pull/36830, https://github.com/gravitational/teleport/pull/36784