### PR TITLE
Remove custom styling for toggles in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -1030,16 +1030,7 @@ function ContentAndAdvancedSearch(
     <Flex gap={2} justifyContent="space-between" alignItems="flex-start">
       {props.children}
       {props.advancedSearch && (
-        <AdvancedSearchToggle
-          {...props.advancedSearch}
-          css={`
-            //TODO(gzdunek): Remove when we get a toggle that can be displayed
-            // on a white background
-            label > div {
-              border: 1px solid ${props => props.theme.colors.spotBackground[1]};
-            }
-          `}
-        />
+        <AdvancedSearchToggle {...props.advancedSearch} />
       )}
     </Flex>
   );

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
@@ -85,7 +85,7 @@ export function ShareFeedbackFormFields({
         onChange={e => updateFormField('feedback', e.target.value)}
         placeholder="Type your suggestions here"
       />
-      <ToggleWithCustomStyling
+      <Toggle
         disabled={disabled}
         isToggled={formValues.newsletterEnabled}
         onToggle={() => {
@@ -95,8 +95,8 @@ export function ShareFeedbackFormFields({
         <Text ml={2} color="text.main">
           Sign me up for the newsletter
         </Text>
-      </ToggleWithCustomStyling>
-      <ToggleWithCustomStyling
+      </Toggle>
+      <Toggle
         disabled={disabled}
         isToggled={formValues.salesContactEnabled}
         onToggle={() => {
@@ -115,15 +115,7 @@ export function ShareFeedbackFormFields({
         >
           I would like a demo of Teleport&nbsp;Enterprise features
         </Text>
-      </ToggleWithCustomStyling>
+      </Toggle>
     </>
   );
 }
-
-// Custom styling for the toggle to make it readable on a light background.
-// TODO(gzdunek): remove when design team finish work on this form control.
-const ToggleWithCustomStyling = styled(Toggle)`
-  > div:first-of-type {
-    border: 1px solid ${props => props.theme.colors.spotBackground[1]};
-  }
-`;

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
@@ -17,7 +17,6 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredField } from 'shared/components/Validation/rules';
 import { FieldTextArea } from 'shared/components/FieldTextArea';
@@ -25,18 +24,15 @@ import { Text, Toggle } from 'design';
 
 import { ShareFeedbackFormValues } from './types';
 
-interface ShareFeedbackFormProps {
-  disabled: boolean;
-  formValues: ShareFeedbackFormValues;
-
-  setFormValues(values: ShareFeedbackFormValues): void;
-}
-
 export function ShareFeedbackFormFields({
   formValues,
   setFormValues,
   disabled,
-}: ShareFeedbackFormProps) {
+}: {
+  disabled: boolean;
+  formValues: ShareFeedbackFormValues;
+  setFormValues(values: ShareFeedbackFormValues): void;
+}) {
   function updateFormField<T extends keyof ShareFeedbackFormValues>(
     field: T,
     value: ShareFeedbackFormValues[T]


### PR DESCRIPTION
Since we have [new toggles](https://github.com/gravitational/teleport/pull/36535) that can be displayed on a white background, we can remove the custom styling.

### Before:
<img width="375" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/38195a97-7cda-45a6-a1ce-25c44b0c3ae8">

### After:
<img width="375" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/e8870f17-c900-4d3c-9b19-5019751fb566">
