### PR TITLE
Allow requesting resources with empty `resourceName`

### DIFF
--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -123,3 +123,17 @@ test('addOrRemoveResource() removes resource if it already exists on pending req
   const pendingAccessRequest = service.getPendingAccessRequest();
   expect(pendingAccessRequest['node']).not.toHaveProperty('123');
 });
+
+test('addOrRemoveResource() uses resourceId when resourceName is empty', () => {
+  let service = createService(
+    getMockPendingAccessRequest(),
+    getMockAssumed({})
+  );
+  const resourceId = '567';
+  const resourceName = '';
+
+  service.addOrRemoveResource('app', resourceId, resourceName);
+  const pendingAccessRequest = service.getPendingAccessRequest();
+
+  expect(pendingAccessRequest['app'][resourceId]).toBe(resourceId);
+});

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -68,13 +68,17 @@ export class AccessRequestsService {
     );
   }
 
-  addOrRemoveResource(kind: ResourceKind, name: string, resourceName: string) {
+  addOrRemoveResource(
+    kind: ResourceKind,
+    resourceId: string,
+    resourceName: string
+  ) {
     this.setState(draftState => {
       const kindIds = draftState.pending[kind];
-      if (kindIds[name]) {
-        delete kindIds[name];
+      if (kindIds[resourceId]) {
+        delete kindIds[resourceId];
       } else {
-        kindIds[name] = resourceName ?? name;
+        kindIds[resourceId] = resourceName || resourceId;
       }
     });
   }


### PR DESCRIPTION
When an app is added to the request, it uses `friendlyName` as `resourceName`.
```ts
addOrRemoveResource('app', agent.name, agent.friendlyName)
```
This field is empty ("") for non-Okta apps. The code in `accessRequestsService` incorrectly assumed that `resourceName` field can't be an empty string by using [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing). 

This aligns Connect's [implementation with Web UI](https://github.com/gravitational/teleport.e/blob/b318add53d695f3d169c0f18f329fc721fc289d9/web/teleport/src/Workflow/NewRequest/useNewRequest.ts#L357-L359).