### PR TITLE
Fix routing to public addresses

### DIFF
--- a/api/utils/route_test.go
+++ b/api/utils/route_test.go
@@ -110,7 +110,7 @@ type mockRouteableServer struct {
 	hostname   string
 	addr       string
 	useTunnel  bool
-	publicAddr string
+	publicAddr []string
 }
 
 func (m mockRouteableServer) GetName() string {
@@ -129,7 +129,7 @@ func (m mockRouteableServer) GetUseTunnel() bool {
 	return m.useTunnel
 }
 
-func (m mockRouteableServer) GetPublicAddr() string {
+func (m mockRouteableServer) GetPublicAddrs() []string {
 	return m.publicAddr
 }
 
@@ -140,7 +140,7 @@ func TestRouteToServer(t *testing.T) {
 	matchAddrServer := mockRouteableServer{
 		name:       "test",
 		addr:       "example.com:1111",
-		publicAddr: "public.example.com:1111",
+		publicAddr: []string{"node:1234", "public.example.com:1111"},
 	}
 
 	tests := []struct {
@@ -156,7 +156,7 @@ func TestRouteToServer(t *testing.T) {
 				name:       "test",
 				addr:       "localhost",
 				hostname:   "example.com",
-				publicAddr: "example.com",
+				publicAddr: []string{"example.com"},
 			},
 			assert: require.False,
 		},
@@ -167,7 +167,7 @@ func TestRouteToServer(t *testing.T) {
 				name:       testUUID,
 				addr:       "localhost",
 				hostname:   "example.com",
-				publicAddr: "example.com",
+				publicAddr: []string{"example.com"},
 			},
 			assert: require.True,
 		},
@@ -178,7 +178,7 @@ func TestRouteToServer(t *testing.T) {
 				name:       testUUID,
 				addr:       "addr.example.com",
 				hostname:   "example.com",
-				publicAddr: "public.example.com",
+				publicAddr: []string{"public.example.com"},
 				useTunnel:  true,
 			},
 			assert: require.True,
@@ -190,7 +190,7 @@ func TestRouteToServer(t *testing.T) {
 				name:       testUUID,
 				addr:       "example.com",
 				hostname:   "fake.example.com",
-				publicAddr: "example.com",
+				publicAddr: []string{"example.com"},
 				useTunnel:  true,
 			},
 			assert: require.False,
@@ -214,7 +214,13 @@ func TestRouteToServer(t *testing.T) {
 			assert:  require.False,
 		},
 		{
-			name:    "match public addr",
+			name:    "match first public addr",
+			matcher: NewSSHRouteMatcher("node", "1234", true),
+			server:  matchAddrServer,
+			assert:  require.True,
+		},
+		{
+			name:    "match second public addr",
 			matcher: NewSSHRouteMatcher("public.example.com", "1111", true),
 			server:  matchAddrServer,
 			assert:  require.True,

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1722,8 +1722,8 @@ type Node interface {
 	GetTeleportVersion() string
 	// GetAddr return server address
 	GetAddr() string
-	// GetPublicAddr returns a public address where this server can be reached.
-	GetPublicAddr() string
+	// GetPublicAddrs returns all public addresses where this server can be reached.
+	GetPublicAddrs() []string
 	// GetHostname returns server hostname
 	GetHostname() string
 	// GetNamespace returns server namespace
@@ -1734,7 +1734,7 @@ type Node interface {
 	GetRotation() types.Rotation
 	// GetUseTunnel gets if a reverse tunnel should be used to connect to this node.
 	GetUseTunnel() bool
-	// GetProxyID returns a list of proxy ids this server is connected to.
+	// GetProxyIDs returns a list of proxy ids this server is connected to.
 	GetProxyIDs() []string
 }
 


### PR DESCRIPTION
#36584 allowed routing to work for public addresses, however it used GetPublicAddr to retrieve the public address. types.Server can have multiple public addresses though which means routing was only ever considering the first public address defined. This updates the routing logic to use GetPublicAddrs so they are all considered.


Changelog: Fixed routing to nodes by their public addresses