### PR TITLE
Extend expiry functionality of FnCache

### DIFF
--- a/lib/utils/fncache.go
+++ b/lib/utils/fncache.go
@@ -32,20 +32,21 @@ import (
 // NOTE: when making changes to this file, run tests with `TEST_FNCACHE_FUZZY=yes` to enable
 // additional fuzzy tests which aren't run during normal CI.
 
-var (
-	// ErrFnCacheClosed is returned from Get when the FnCache context is closed
-	ErrFnCacheClosed = errors.New("fncache permanently closed")
-)
+// ErrFnCacheClosed is returned from Get when the FnCache context is closed
+var ErrFnCacheClosed = errors.New("fncache permanently closed")
 
 // FnCache is a helper for temporarily storing the results of regularly called functions. This helper is
 // used to limit the amount of backend reads that occur while the primary cache is unhealthy.  Most resources
-// do not require this treatment, but certain resources (cas, nodes, etc) can be loaded on a per-request
-// basis and can cause significant numbers of backend reads if the cache is unhealthy or taking a while to init.
+// do not require this treatment, however, certain resources (cas, nodes, etc.) can be loaded on a per-request
+// basis and can cause a significant number of backend reads if the cache is unhealthy or taking a while to initialize.
 type FnCache struct {
 	cfg         FnCacheConfig
-	mu          sync.Mutex
+	closed      bool
+	cancel      context.CancelFunc
 	nextCleanup time.Time
-	entries     map[any]*fnCacheEntry
+
+	mu      sync.Mutex
+	entries map[any]*fnCacheEntry
 }
 
 // cleanupMultiplier is an arbitrary multiplier used to derive the default interval
@@ -56,13 +57,14 @@ type FnCache struct {
 // custom CleanupInterval should be provided.
 const cleanupMultiplier time.Duration = 16
 
+// FnCacheConfig contains dependencies for a FnCache.
 type FnCacheConfig struct {
 	// TTL is the time to live for cache entries.
 	TTL time.Duration
 	// Clock is the clock used to determine the current time.
 	Clock clockwork.Clock
 	// Context is the context used to cancel the cache. All loadfns
-	// will be provided this context.
+	// will be provided with this context.
 	Context context.Context
 	// ReloadOnErr causes entries to be reloaded immediately if
 	// the currently loaded value is an error. Note that all concurrent
@@ -74,8 +76,13 @@ type FnCacheConfig struct {
 	// caches where keys are unlikely to become orphaned. Shorter cleanup
 	// intervals should be used when keys regularly become orphaned.
 	CleanupInterval time.Duration
+	// OnExpiry is an optional callback that will be executed any time
+	// an item is expired and removed from the cache.
+	OnExpiry func(ctx context.Context, key any, value any)
 }
 
+// CheckAndSetDefaults validates the FnCacheConfig is populated
+// with required fields and sets any omitted fields to default values.
 func (c *FnCacheConfig) CheckAndSetDefaults() error {
 	if c.TTL <= 0 {
 		return trace.BadParameter("missing TTL parameter")
@@ -96,29 +103,92 @@ func (c *FnCacheConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
+// NewFnCache creates a [FnCache] from the provided [FnCacheConfig].
 func NewFnCache(cfg FnCacheConfig) (*FnCache, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &FnCache{
+	cache := &FnCache{
 		cfg:     cfg,
 		entries: make(map[any]*fnCacheEntry),
-	}, nil
+	}
+
+	cache.cfg.Context, cache.cancel = context.WithCancel(cfg.Context)
+
+	return cache, nil
+
 }
 
 type fnCacheEntry struct {
 	v      any
 	e      error
 	t      time.Time
+	ttl    time.Duration
 	loaded chan struct{}
+}
+
+// Shutdown expires all items in the cache. If the OnExpires
+// callback was set in the FnCacheConfig it will be called once
+// per item in the cache.
+func (c *FnCache) Shutdown(ctx context.Context) {
+	c.mu.Lock()
+	c.cancel()
+	c.closed = true
+	entries := c.entries
+	c.entries = make(map[any]*fnCacheEntry)
+	c.mu.Unlock()
+
+	// non-blocking eviction
+	for key, entry := range entries {
+		select {
+		case <-entry.loaded:
+			if c.cfg.OnExpiry != nil && entry.e == nil {
+				c.cfg.OnExpiry(ctx, key, entry.v)
+			}
+
+			delete(entries, key)
+		case <-ctx.Done():
+			return
+		default:
+			// entry is still being loaded
+		}
+	}
+
+	// blocking eviction
+	for key, entry := range entries {
+		select {
+		case <-entry.loaded:
+			if c.cfg.OnExpiry != nil && entry.e == nil {
+				c.cfg.OnExpiry(ctx, key, entry.v)
+			}
+
+			delete(entries, key)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// RemoveExpired purges any items from the cache which have exceeded their TTL.
+func (c *FnCache) RemoveExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.cfg.Clock.Now()
+	c.removeExpiredLocked(now)
+	c.nextCleanup = now.Add(c.cfg.CleanupInterval)
 }
 
 func (c *FnCache) removeExpiredLocked(now time.Time) {
 	for key, entry := range c.entries {
 		select {
 		case <-entry.loaded:
-			if now.After(entry.t.Add(c.cfg.TTL)) {
+			if now.After(entry.t.Add(entry.ttl)) {
+				if c.cfg.OnExpiry != nil && entry.e == nil {
+					c.cfg.OnExpiry(c.cfg.Context, key, entry.v)
+				}
+
 				delete(c.entries, key)
 			}
 		default:
@@ -127,13 +197,19 @@ func (c *FnCache) removeExpiredLocked(now time.Time) {
 	}
 }
 
-// FnCacheGet loads the result associated with the supplied key.  If no result is currently stored, or the stored result
-// was acquired >ttl ago, then loadfn is used to reload it.  Subsequent calls while the value is being loaded/reloaded
-// block until the first call updates the entry.  Note that the supplied context can cancel the call to Get, but will
-// not cancel loading.  The supplied loadfn should not be canceled just because the specific request happens to have
+// FnCacheGet loads the result associated with the supplied key. If no result is currently stored, or the stored result
+// was acquired >TTL ago, then loadfn is used to reload it. Subsequent calls while the value is being loaded/reloaded
+// block until the first call updates the entry. Note that the supplied context can cancel the call to Get, but will
+// not cancel loading. The supplied loadfn should not be canceled just because the specific request happens to have
 // been canceled.
 func FnCacheGet[T any](ctx context.Context, cache *FnCache, key any, loadfn func(ctx context.Context) (T, error)) (T, error) {
-	t, err := cache.get(ctx, key, func(ctx context.Context) (any, error) {
+	return FnCacheGetWithTTL(ctx, cache, key, cache.cfg.TTL, loadfn)
+}
+
+// FnCacheGetWithTTL is identical to FnCacheGet except that it allows individual keys to specify
+// a TTL that is used instead of the configured TTL for the FnCache.
+func FnCacheGetWithTTL[T any](ctx context.Context, cache *FnCache, key any, ttl time.Duration, loadfn func(ctx context.Context) (T, error)) (T, error) {
+	t, err := cache.get(ctx, key, ttl, func(ctx context.Context) (any, error) {
 		return loadfn(ctx)
 	})
 
@@ -148,12 +224,12 @@ func FnCacheGet[T any](ctx context.Context, cache *FnCache, key any, loadfn func
 	return ret, err
 }
 
-// get loads the result associated with the supplied key.  If no result is currently stored, or the stored result
-// was acquired >ttl ago, then loadfn is used to reload it.  Subsequent calls while the value is being loaded/reloaded
-// block until the first call updates the entry.  Note that the supplied context can cancel the call to Get, but will
-// not cancel loading.  The supplied loadfn should not be canceled just because the specific request happens to have
+// get loads the result associated with the supplied key. If no result is currently stored, or the stored result
+// was acquired >ttl ago, then loadfn is used to reload it. Subsequent calls while the value is being loaded/reloaded
+// block until the first call updates the entry. Note that the supplied context can cancel the call to Get, but will
+// not cancel loading. The supplied loadfn should not be canceled just because the specific request happens to have
 // been canceled.
-func (c *FnCache) get(ctx context.Context, key any, loadfn func(ctx context.Context) (any, error)) (any, error) {
+func (c *FnCache) get(ctx context.Context, key any, ttl time.Duration, loadfn func(ctx context.Context) (any, error)) (any, error) {
 	select {
 	case <-c.cfg.Context.Done():
 		return nil, ErrFnCacheClosed
@@ -162,9 +238,14 @@ func (c *FnCache) get(ctx context.Context, key any, loadfn func(ctx context.Cont
 
 	c.mu.Lock()
 
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrFnCacheClosed
+	}
+
 	now := c.cfg.Clock.Now()
 
-	// check if we need to perform periodic cleanup
+	// Check if we need to perform periodic cleanup.
 	if now.After(c.nextCleanup) {
 		c.removeExpiredLocked(now)
 		c.nextCleanup = now.Add(c.cfg.CleanupInterval)
@@ -177,7 +258,7 @@ func (c *FnCache) get(ctx context.Context, key any, loadfn func(ctx context.Cont
 	if entry != nil {
 		select {
 		case <-entry.loaded:
-			needsReload = now.After(entry.t.Add(c.cfg.TTL))
+			needsReload = now.After(entry.t.Add(entry.ttl))
 			if c.cfg.ReloadOnErr && entry.e != nil {
 				needsReload = true
 			}
@@ -188,14 +269,15 @@ func (c *FnCache) get(ctx context.Context, key any, loadfn func(ctx context.Cont
 	}
 
 	if needsReload {
-		// insert a new entry with a new loaded channel.  this channel will
+		// Insert a new entry with a new loaded channel. This channel will
 		// block subsequent reads, and serve as a memory barrier for the results.
 		entry = &fnCacheEntry{
 			loaded: make(chan struct{}),
+			ttl:    ttl,
 		}
 		c.entries[key] = entry
 		go func() {
-			// link the config context with the span from ctx, if one exists,
+			// Link the config context with the span from ctx, if one exists,
 			// so that the loadfn can be traced appropriately.
 			loadCtx := oteltrace.ContextWithSpan(c.cfg.Context, oteltrace.SpanFromContext(ctx))
 			entry.v, entry.e = loadfn(loadCtx)
@@ -206,7 +288,7 @@ func (c *FnCache) get(ctx context.Context, key any, loadfn func(ctx context.Cont
 
 	c.mu.Unlock()
 
-	// wait for result to be loaded (this is also a memory barrier)
+	// Wait for the result to be loaded (this is also a memory barrier).
 	select {
 	case <-entry.loaded:
 		return entry.v, entry.e

--- a/lib/utils/fncache_test.go
+++ b/lib/utils/fncache_test.go
@@ -76,7 +76,7 @@ func TestFnCacheGet(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	value, err := cache.get(context.Background(), "test", func(ctx context.Context) (any, error) {
+	value, err := FnCacheGet(context.Background(), cache, "test", func(ctx context.Context) (any, error) {
 		return 123, nil
 	})
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestFnCacheConcurrentReads(t *testing.T) {
 
 	for i := 0; i < workers; i++ {
 		go func(n int) {
-			val, err := cache.get(ctx, "key", func(context.Context) (any, error) {
+			val, err := FnCacheGet(ctx, cache, "key", func(context.Context) (any, error) {
 				// return a unique value for each worker so that we can verify whether
 				// the values we get come from the same loadfn or not.
 				return fmt.Sprintf("val-%d", n), nil
@@ -143,7 +143,7 @@ func TestFnCacheExpiry(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 
-	cache, err := NewFnCache(FnCacheConfig{TTL: time.Millisecond, Clock: clock})
+	cache, err := NewFnCache(FnCacheConfig{TTL: time.Hour, Clock: clock, CleanupInterval: time.Second})
 	require.NoError(t, err)
 
 	// get is helper for checking if we hit/miss
@@ -157,6 +157,16 @@ func TestFnCacheExpiry(t *testing.T) {
 		return
 	}
 
+	ttlGet := func() (load bool) {
+		val, err := FnCacheGetWithTTL(ctx, cache, "key2", 20*time.Minute, func(context.Context) (string, error) {
+			load = true
+			return "val2", nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "val2", val)
+		return
+	}
+
 	// first get runs the loadfn
 	require.True(t, get())
 
@@ -165,13 +175,30 @@ func TestFnCacheExpiry(t *testing.T) {
 		require.False(t, get())
 	}
 
-	clock.Advance(time.Millisecond * 2)
+	clock.Advance(61 * time.Minute)
 
 	// value has ttl'd out, loadfn is run again
 	require.True(t, get())
+	require.True(t, ttlGet())
+
+	clock.Advance(time.Minute)
 
 	// and now we're back to hitting a cached value
 	require.False(t, get())
+	require.False(t, ttlGet())
+
+	clock.Advance(21 * time.Minute)
+
+	// the item with the custom ttl should be loaded while the
+	// other item should still be cached
+	require.False(t, get())
+	require.True(t, ttlGet())
+
+	clock.Advance(10 * time.Minute)
+
+	// we're still hitting a cached value
+	require.False(t, get())
+	require.False(t, ttlGet())
 }
 
 // TestFnCacheFuzzy runs basic FnCache test cases that rely on fuzzy logic and timing to detect
@@ -334,20 +361,21 @@ func TestFnCacheContext(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = cache.get(context.Background(), "key", func(context.Context) (any, error) {
+	_, err = FnCacheGet(context.Background(), cache, "key", func(context.Context) (any, error) {
 		return "val", nil
 	})
 	require.NoError(t, err)
 
 	cancel()
 
-	_, err = cache.get(context.Background(), "key", func(context.Context) (any, error) {
+	_, err = FnCacheGet(context.Background(), cache, "key", func(context.Context) (any, error) {
 		return "val", nil
 	})
 	require.ErrorIs(t, err, ErrFnCacheClosed)
 }
 
 func TestFnCacheReloadOnErr(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -397,4 +425,112 @@ func TestFnCacheReloadOnErr(t *testing.T) {
 	}
 	require.Equal(t, int64(1), happy.Load())
 	require.Greater(t, int64(200), sad.Load())
+}
+
+func TestFnCacheEviction(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clock := clockwork.NewFakeClock()
+
+	type item struct {
+		k any
+		v any
+	}
+	expiredC := make(chan item, 5)
+	cache, err := NewFnCache(FnCacheConfig{
+		TTL:     time.Hour,
+		Context: ctx,
+		Clock:   clock,
+		OnExpiry: func(ctx context.Context, key, expired any) {
+			expiredC <- item{k: key, v: expired}
+		},
+	})
+	require.NoError(t, err)
+
+	// Populate the cache with items that have varying TTL.
+	out, err := FnCacheGet(ctx, cache, "test", func(ctx context.Context) (int, error) {
+		return 100, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 100, out)
+
+	out2, err := FnCacheGetWithTTL(ctx, cache, 100, 24*time.Hour, func(ctx context.Context) (string, error) {
+		return "test", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "test", out2)
+
+	// Assert that eviction does not occur prematurely.
+	for i := 0; i < 6; i++ {
+		clock.Advance(10 * time.Minute)
+		cache.RemoveExpired()
+
+		select {
+		case item := <-expiredC:
+			t.Fatalf("item %v was prematurely expired from the cache", item.k)
+		default:
+		}
+	}
+
+	// Assert that eviction occurs for the expected resource.
+	clock.Advance(10 * time.Minute)
+	cache.RemoveExpired()
+	select {
+	case expired := <-expiredC:
+		key, ok := expired.k.(string)
+		require.True(t, ok)
+		require.Equal(t, "test", key)
+		val, ok := expired.v.(int)
+		require.True(t, ok)
+		require.Equal(t, 100, val)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for item to be expired from the cache")
+	}
+
+	// Assert that eviction never occurs for the other resource.
+	select {
+	case item := <-expiredC:
+		t.Fatalf("item %v was prematurely expired from the cache", item.k)
+	default:
+	}
+
+	// Add a value with the default TTL again.
+	out, err = FnCacheGet(ctx, cache, "test", func(ctx context.Context) (int, error) {
+		return 100, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 100, out)
+
+	// Shutdown the cache and validate all items are expired.
+	cache.Shutdown(context.Background())
+	timeout := time.After(10 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case expired := <-expiredC:
+			switch k := expired.k.(type) {
+			case string:
+				require.Equal(t, "test", k)
+				val, ok := expired.v.(int)
+				require.True(t, ok)
+				require.Equal(t, 100, val)
+			case int:
+				require.Equal(t, 100, k)
+				val, ok := expired.v.(string)
+				require.True(t, ok)
+				require.Equal(t, "test", val)
+			}
+
+		case <-timeout:
+			t.Fatalf("timed out waiting for item to be expired from the cache")
+		}
+	}
+
+	// Assert that once the cache is shutdown that it does not accept any new values.
+	_, err = FnCacheGet(ctx, cache, "test", func(ctx context.Context) (int, error) {
+		return 100, nil
+	})
+	require.ErrorIs(t, err, ErrFnCacheClosed)
 }


### PR DESCRIPTION
The FnCacheConfig now provides an optional OnExpires callback which will be called when any item in the cache is removed due to expiry. Eviction of expired entries used to only happen on retrieval attempts, but this can now be triggered on demand using (FnCache) RemoveExpired. A new Shutdown method was also added to allow all items in the cache to be removed. If OnExpires is set then it will be called for every item in the cache during Shutdown.