### PR TITLE
Prevent ConnectionMonitor leaks

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -722,7 +722,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 		return nil, trace.Wrap(err)
 	}
 
-	ctx = authz.ContextWithUser(s.closeContext, user)
+	ctx = authz.ContextWithUser(ctx, user)
 	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
 	authCtx, _, err := s.authorizeContext(ctx)
 
@@ -750,12 +750,15 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	// differently than HTTP requests from web apps.
 	if app.IsTCP() {
 		identity := authCtx.Identity.GetIdentity()
-		return nil, s.handleTCPApp(ctx, tlsConn, &identity, app)
+		defer cancel(nil)
+		return nil, trace.Wrap(s.handleTCPApp(ctx, tlsConn, &identity, app))
 	}
 
-	return func() {
+	cleanup := func() {
+		cancel(nil)
 		s.deleteConnAuth(tlsConn)
-	}, s.handleHTTPApp(ctx, tlsConn)
+	}
+	return cleanup, trace.Wrap(s.handleHTTPApp(ctx, tlsConn))
 }
 
 // handleTCPApp handles connection for a TCP application.

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -407,7 +407,6 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 			lockWatchDoneC = nil
 
 		case <-w.Context.Done():
-			w.Entry.Debugf("Releasing associated resources - context has been closed.")
 			return
 		}
 	}


### PR DESCRIPTION
The context used to create the connection monitor for app sessions was never canceled which left the connection monitor running until the certificate expired, the user was locked, or the idle timeout was enforced. By using the correct context and canceling appropriately the monitor is terminated as soon as the app session has concluded.

Partially addresses https://github.com/gravitational/teleport/issues/36541.

changelog: Prevent a goroutine leak caused by app sessions not cleaning up resources properly