### PR TITLE
Add UI for enrolling AWS EKS clusters in Discover

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
@@ -17,13 +17,13 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { Flex, Box } from 'design';
 import Table from 'design/DataTable';
 import { FetchStatus } from 'design/DataTable/types';
 
 import {
   DisableableCell as Cell,
+  StatusCell,
+  ItemStatus,
   RadioCell,
   Labels,
   labelMatcher,
@@ -100,7 +100,11 @@ export const DatabaseList = ({
           key: 'status',
           headerText: 'Status',
           render: item => (
-            <StatusCell item={item} wantAutoDiscover={wantAutoDiscover} />
+            <StatusCell
+              status={getStatus(item)}
+              statusText={item.status}
+              {...disabledStates(item, wantAutoDiscover)}
+            />
           ),
         },
       ]}
@@ -113,62 +117,16 @@ export const DatabaseList = ({
   );
 };
 
-const StatusCell = ({
-  item,
-  wantAutoDiscover,
-}: {
-  item: CheckedAwsRdsDatabase;
-  wantAutoDiscover: boolean;
-}) => {
-  const status = getStatus(item);
-
-  return (
-    <Cell {...disabledStates(item, wantAutoDiscover)}>
-      <Flex alignItems="center">
-        <StatusLight status={status} />
-        {item.status}
-      </Flex>
-    </Cell>
-  );
-};
-
-enum Status {
-  Success,
-  Warning,
-  Error,
-}
-
 function getStatus(item: CheckedAwsRdsDatabase) {
   switch (item.status) {
     case 'available':
-      return Status.Success;
+      return ItemStatus.Success;
 
     case 'failed':
     case 'deleting':
-      return Status.Error;
+      return ItemStatus.Error;
   }
 }
-
-// TODO(lisa): copy from IntegrationList.tsx
-// move to common file for both files.
-const StatusLight = styled(Box)`
-  border-radius: 50%;
-  margin-right: 6px;
-  width: 8px;
-  height: 8px;
-  background-color: ${({ status, theme }) => {
-    if (status === Status.Success) {
-      return theme.colors.success.main;
-    }
-    if (status === Status.Error) {
-      return theme.colors.error.main;
-    }
-    if (status === Status.Warning) {
-      return theme.colors.warning;
-    }
-    return theme.colors.grey[300]; // Unknown
-  }};
-`;
 
 function disabledStates(
   item: CheckedAwsRdsDatabase,

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -1,0 +1,147 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import Dialog, { DialogContent } from 'design/DialogConfirmation';
+import { AnimatedProgressBar, Box, ButtonPrimary, Text } from 'design';
+import React from 'react';
+
+import * as Icons from 'design/Icon';
+
+import { Kube } from 'teleport/services/kube';
+import { JoinToken } from 'teleport/services/joinToken';
+import { usePingTeleport } from 'teleport/Discover/Shared/PingTeleportContext';
+import { Mark, TextIcon, useShowHint } from 'teleport/Discover/Shared';
+import { HintBox } from 'teleport/Discover/Shared/HintBox';
+
+type AgentWaitingDialogProps = {
+  joinToken: JoinToken;
+  status: string;
+  clusterName: string;
+  setWaitingResult(cluster: Kube): void;
+  close(): void;
+};
+
+export function AgentWaitingDialog({
+  joinToken,
+  status,
+  clusterName,
+  setWaitingResult,
+  close,
+}: AgentWaitingDialogProps) {
+  const { result, active } = usePingTeleport<Kube>(joinToken);
+  setWaitingResult(result);
+  const showHint = useShowHint(active);
+
+  function hintMessage() {
+    if (showHint && !result) {
+      return (
+        <Box mb={3}>
+          <HintBox header="We're still looking for your server">
+            <Text mb={3}>
+              There are a few of possible reasons for why we haven't been able
+              to detect your Kubernetes cluster.
+            </Text>
+
+            <Text mb={1}>- The cluster doesn't have active nodes.</Text>
+
+            <Text mb={1}>
+              - The manual command was not run on the server you were trying to
+              add.
+            </Text>
+
+            <Text mb={3}>
+              - The Teleport Service could not join this Teleport cluster. Check
+              the logs for errors by running
+              <br />
+              <Mark>kubectl logs -l app=teleport-agent -n teleport-agent</Mark>
+            </Text>
+
+            <Text>
+              We'll continue to look for your Kubernetes cluster whilst you
+              diagnose the issue.
+            </Text>
+          </HintBox>
+        </Box>
+      );
+    }
+  }
+
+  function content() {
+    if (status === 'awaitingAgent') {
+      return (
+        <>
+          <Text bold caps mb={4}>
+            EKS Cluster Enrollment
+          </Text>
+          <AnimatedProgressBar mb={3} />
+          <TextIcon
+            mb={3}
+            css={`
+              white-space: pre;
+            `}
+          >
+            <Icons.Check size="medium" />
+            <Text>1. Installing Teleport agent</Text>
+          </TextIcon>
+          <TextIcon
+            mb={3}
+            css={`
+              white-space: pre;
+            `}
+          >
+            <Icons.Clock size="medium" />
+            <Text>
+              2. Waiting for the Teleport agent to come online (1-5 minutes)...
+            </Text>
+          </TextIcon>
+          {hintMessage()}
+          <ButtonPrimary width="100%" onClick={close}>
+            Cancel
+          </ButtonPrimary>
+        </>
+      );
+    } else {
+      return (
+        <>
+          <Text bold caps mb={4}>
+            EKS Cluster Enrollment
+          </Text>
+          <Text mb={3} style={{ display: 'flex' }}>
+            <Icons.Check size="small" ml={1} mr={2} color="success" />
+            Cluster "{clusterName}" was successfully enrolled.
+          </Text>
+          <ButtonPrimary width="100%" onClick={close}>
+            Close
+          </ButtonPrimary>
+        </>
+      );
+    }
+  }
+
+  return (
+    <Dialog open={true}>
+      <DialogContent
+        width="460px"
+        alignItems="center"
+        mb={0}
+        textAlign="center"
+      >
+        {content()}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -110,10 +110,10 @@ export function AgentWaitingDialog({
           <Text bold caps mb={4}>
             EKS Cluster Enrollment
           </Text>
-          <Text mb={3} style={{ display: 'flex' }}>
-            <Icons.Check size="small" ml={1} mr={2} color="success" />
+          <Flex mb={3}>
+            <Icons.Check size="small" ml={1} mr={2} color="success.main" />
             Cluster "{clusterName}" was successfully enrolled.
-          </Text>
+          </Flex>
           <ButtonPrimary width="100%" onClick={close}>
             Close
           </ButtonPrimary>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -31,7 +31,7 @@ type AgentWaitingDialogProps = {
   joinToken: JoinToken;
   status: string;
   clusterName: string;
-  setWaitingResult(cluster: Kube): void;
+  updateWaitingResult(cluster: Kube): void;
   close(): void;
 };
 
@@ -39,11 +39,11 @@ export function AgentWaitingDialog({
   joinToken,
   status,
   clusterName,
-  setWaitingResult,
+  updateWaitingResult,
   close,
 }: AgentWaitingDialogProps) {
   const { result, active } = usePingTeleport<Kube>(joinToken);
-  setWaitingResult(result);
+  updateWaitingResult(result);
   const showHint = useShowHint(active);
 
   function hintMessage() {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -45,7 +45,10 @@ export function AgentWaitingDialog({
   next,
 }: AgentWaitingDialogProps) {
   const { result, active } = usePingTeleport<Kube>(joinToken);
-  updateWaitingResult(result);
+  if (result) {
+    updateWaitingResult(result);
+  }
+
   const showHint = useShowHint(active);
 
   function hintMessage() {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
-import { AnimatedProgressBar, Box, ButtonPrimary, Text } from 'design';
+import { AnimatedProgressBar, Box, ButtonPrimary, Text, Flex } from 'design';
 import React from 'react';
 
 import * as Icons from 'design/Icon';

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -89,7 +89,7 @@ export function AgentWaitingDialog({
           </Text>
           <AnimatedProgressBar mb={3} />
           <TextIcon mb={3}>
-            <Icons.Check size="medium" />
+            <Icons.Check size="medium" color="success.main" />
             <Text>1. Installing Teleport agent</Text>
           </TextIcon>
           <TextIcon mb={3}>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -17,7 +17,7 @@
  */
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
 import { AnimatedProgressBar, Box, ButtonPrimary, Text, Flex } from 'design';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import * as Icons from 'design/Icon';
 
@@ -53,9 +53,11 @@ export function AgentWaitingDialog({
     id: '',
     suggestedLabels: [],
   });
-  if (result) {
-    updateWaitingResult(result);
-  }
+  useEffect(() => {
+    if (result) {
+      updateWaitingResult(result);
+    }
+  }, [result]);
 
   const showHint = useShowHint(active);
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -51,7 +51,7 @@ export function AgentWaitingDialog({
   function hintMessage() {
     if (showHint && !result) {
       return (
-        <Box mb={3}>
+        <Box textAlign={'left'} mb={3}>
           <HintBox header="We're still looking for your server">
             <Text mb={3}>
               There are a few of possible reasons for why we haven't been able

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -32,7 +32,8 @@ type AgentWaitingDialogProps = {
   status: string;
   clusterName: string;
   updateWaitingResult(cluster: Kube): void;
-  close(): void;
+  cancel(): void;
+  next(): void;
 };
 
 export function AgentWaitingDialog({
@@ -40,7 +41,8 @@ export function AgentWaitingDialog({
   status,
   clusterName,
   updateWaitingResult,
-  close,
+  cancel,
+  next,
 }: AgentWaitingDialogProps) {
   const { result, active } = usePingTeleport<Kube>(joinToken);
   updateWaitingResult(result);
@@ -99,7 +101,7 @@ export function AgentWaitingDialog({
             </Text>
           </TextIcon>
           {hintMessage()}
-          <ButtonPrimary width="100%" onClick={close}>
+          <ButtonPrimary width="100%" onClick={cancel}>
             Cancel
           </ButtonPrimary>
         </>
@@ -114,8 +116,8 @@ export function AgentWaitingDialog({
             <Icons.Check size="small" ml={1} mr={2} color="success.main" />
             Cluster "{clusterName}" was successfully enrolled.
           </Flex>
-          <ButtonPrimary width="100%" onClick={close}>
-            Close
+          <ButtonPrimary width="100%" onClick={next}>
+            Next
           </ButtonPrimary>
         </>
       );

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -88,21 +88,11 @@ export function AgentWaitingDialog({
             EKS Cluster Enrollment
           </Text>
           <AnimatedProgressBar mb={3} />
-          <TextIcon
-            mb={3}
-            css={`
-              white-space: pre;
-            `}
-          >
+          <TextIcon mb={3}>
             <Icons.Check size="medium" />
             <Text>1. Installing Teleport agent</Text>
           </TextIcon>
-          <TextIcon
-            mb={3}
-            css={`
-              white-space: pre;
-            `}
-          >
+          <TextIcon mb={3}>
             <Icons.Clock size="medium" />
             <Text>
               2. Waiting for the Teleport agent to come online (1-5 minutes)...

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -22,13 +22,12 @@ import React from 'react';
 import * as Icons from 'design/Icon';
 
 import { Kube } from 'teleport/services/kube';
-import { JoinToken } from 'teleport/services/joinToken';
 import { usePingTeleport } from 'teleport/Discover/Shared/PingTeleportContext';
 import { Mark, TextIcon, useShowHint } from 'teleport/Discover/Shared';
 import { HintBox } from 'teleport/Discover/Shared/HintBox';
 
 type AgentWaitingDialogProps = {
-  joinToken: JoinToken;
+  joinResourceId: string;
   status: string;
   clusterName: string;
   updateWaitingResult(cluster: Kube): void;
@@ -37,14 +36,23 @@ type AgentWaitingDialogProps = {
 };
 
 export function AgentWaitingDialog({
-  joinToken,
+  joinResourceId,
   status,
   clusterName,
   updateWaitingResult,
   cancel,
   next,
 }: AgentWaitingDialogProps) {
-  const { result, active } = usePingTeleport<Kube>(joinToken);
+  const { result, active } = usePingTeleport<Kube>({
+    internalResourceId: joinResourceId,
+
+    // These are not used by usePingTeleport
+    // todo(anton): Refactor usePingTeleport to not require full join token.
+    expiry: undefined,
+    expiryText: '',
+    id: '',
+    suggestedLabels: [],
+  });
   if (result) {
     updateWaitingResult(result);
   }

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -59,13 +59,7 @@ export const AgentWaitingDialogStory = () => (
         resourceKind={ResourceKind.Kubernetes}
       >
         <AgentWaitingDialog
-          joinToken={{
-            id: 'token-id',
-            expiry: null,
-            expiryText: '',
-            internalResourceId: 'resource-id',
-            suggestedLabels: [],
-          }}
+          joinResourceId="resource-id"
           status={'awaitingAgent'}
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}
@@ -95,13 +89,7 @@ export const AgentWaitingDialogSuccess = () => (
         resourceKind={ResourceKind.Kubernetes}
       >
         <AgentWaitingDialog
-          joinToken={{
-            id: 'token-id',
-            expiry: null,
-            expiryText: '',
-            internalResourceId: 'resource-id',
-            suggestedLabels: [],
-          }}
+          joinResourceId="resource-id"
           status={'success'}
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -67,7 +67,7 @@ export const AgentWaitingDialogStory = () => (
           }}
           status={'awaitingAgent'}
           clusterName={'EKS1'}
-          setWaitingResult={() => {}}
+          updateWaitingResult={() => {}}
           close={() => {}}
         />
       </PingTeleportProvider>
@@ -102,7 +102,7 @@ export const AgentWaitingDialogSuccess = () => (
           }}
           status={'success'}
           clusterName={'EKS1'}
-          setWaitingResult={() => {}}
+          updateWaitingResult={() => {}}
           close={() => {}}
         />
       </PingTeleportProvider>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -72,7 +72,6 @@ export const AgentWaitingDialogStory = () => (
     </ContextProvider>
   </MemoryRouter>
 );
-// cfg.api.kubernetesPath
 AgentWaitingDialogStory.storyName = 'AgentWaitingDialog';
 AgentWaitingDialogStory.parameters = {
   msw: {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -45,6 +45,7 @@ export const EnrollmentDialogStory = () => (
       status={'enrolling'}
       error={''}
       close={() => {}}
+      retry={() => {}}
     />
   </MemoryRouter>
 );
@@ -69,6 +70,7 @@ export const AgentWaitingDialogStory = () => (
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}
           cancel={() => {}}
+          next={() => {}}
         />
       </PingTeleportProvider>
     </ContextProvider>
@@ -104,6 +106,7 @@ export const AgentWaitingDialogSuccess = () => (
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}
           cancel={() => {}}
+          next={() => {}}
         />
       </PingTeleportProvider>
     </ContextProvider>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -27,10 +27,11 @@ import { ResourceKind } from 'teleport/Discover/Shared';
 import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportContext';
 import { ContextProvider } from 'teleport';
 
+import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
+
 import { ManualHelmDialog } from './ManualHelmDialog';
 import { AgentWaitingDialog } from './AgentWaitingDialog';
 import { EnrollmentDialog } from './EnrollmentDialog';
-import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
 
 export default {
   title: 'Teleport/Discover/Kube/EnrollEksClusters/Dialogs',

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -68,7 +68,7 @@ export const AgentWaitingDialogStory = () => (
           status={'awaitingAgent'}
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}
-          close={() => {}}
+          cancel={() => {}}
         />
       </PingTeleportProvider>
     </ContextProvider>
@@ -103,7 +103,7 @@ export const AgentWaitingDialogSuccess = () => (
           status={'success'}
           clusterName={'EKS1'}
           updateWaitingResult={() => {}}
-          close={() => {}}
+          cancel={() => {}}
         />
       </PingTeleportProvider>
     </ContextProvider>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -30,6 +30,7 @@ import { ContextProvider } from 'teleport';
 import { ManualHelmDialog } from './ManualHelmDialog';
 import { AgentWaitingDialog } from './AgentWaitingDialog';
 import { EnrollmentDialog } from './EnrollmentDialog';
+import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
 
 export default {
   title: 'Teleport/Discover/Kube/EnrollEksClusters/Dialogs',
@@ -117,20 +118,24 @@ AgentWaitingDialogSuccess.parameters = {
   },
 };
 
-const helmCommand = `cat << EOF > prod-cluster-values.yaml
-roles: kube,app,discovery
-authToken: token-id
-proxyAddr: some-long-cluster-public-url-name.cloud.teleport.gravitational.io:1234
-kubeClusterName: EKS1
-labels:
-    teleport.internal/resource-id: resource-id
-    teleport.dev/cloud: AWS
-    region: us-east-1
-    account-id: 1234567789012
-EOF
- 
-helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml \\
---version 14.3.2  --create-namespace --namespace teleport-agent`;
+const helmCommand = generateCmd({
+  namespace: 'teleport-agent',
+  clusterName: 'EKS1',
+  proxyAddr: 'teleport-proxy.example.com:1234',
+  tokenId: 'token-id',
+  clusterVersion: '14.3.2',
+  resourceId: 'resource-id',
+  isEnterprise: false,
+  isCloud: false,
+  automaticUpgradesEnabled: false,
+  automaticUpgradesTargetVersion: '',
+  joinLabels: [
+    { name: 'teleport.dev/cloud', value: 'AWS' },
+    { name: 'region', value: 'us-east-1' },
+    { name: 'account-id', value: '1234567789012' },
+  ],
+});
+
 export const ManualHelmDialogStory = () => (
   <MemoryRouter initialEntries={[{ state: { discover: {} } }]}>
     <ManualHelmDialog

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -1,0 +1,144 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { rest } from 'msw';
+import { mswLoader } from 'msw-storybook-addon';
+
+import cfg from 'teleport/config';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportContext';
+import { ContextProvider } from 'teleport';
+
+import { ManualHelmDialog } from './ManualHelmDialog';
+import { AgentWaitingDialog } from './AgentWaitingDialog';
+import { EnrollmentDialog } from './EnrollmentDialog';
+
+export default {
+  title: 'Teleport/Discover/Kube/EnrollEksClusters/Dialogs',
+  loaders: [mswLoader],
+};
+
+export const EnrollmentDialogStory = () => (
+  <MemoryRouter initialEntries={[{ state: { discover: {} } }]}>
+    <EnrollmentDialog
+      clusterName={'EKS1'}
+      status={'enrolling'}
+      error={''}
+      close={() => {}}
+    />
+  </MemoryRouter>
+);
+EnrollmentDialogStory.storyName = 'EnrollmentDialog';
+
+export const AgentWaitingDialogStory = () => (
+  <MemoryRouter initialEntries={[{ state: { discover: {} } }]}>
+    <ContextProvider ctx={createTeleportContext()}>
+      <PingTeleportProvider
+        interval={100000}
+        resourceKind={ResourceKind.Kubernetes}
+      >
+        <AgentWaitingDialog
+          joinToken={{
+            id: 'token-id',
+            expiry: null,
+            expiryText: '',
+            internalResourceId: 'resource-id',
+            suggestedLabels: [],
+          }}
+          status={'awaitingAgent'}
+          clusterName={'EKS1'}
+          setWaitingResult={() => {}}
+          close={() => {}}
+        />
+      </PingTeleportProvider>
+    </ContextProvider>
+  </MemoryRouter>
+);
+// cfg.api.kubernetesPath
+AgentWaitingDialogStory.storyName = 'AgentWaitingDialog';
+AgentWaitingDialogStory.parameters = {
+  msw: {
+    handlers: [
+      rest.get(cfg.api.kubernetesPath, (req, res, ctx) => {
+        return res(ctx.delay('infinite'));
+      }),
+    ],
+  },
+};
+
+export const AgentWaitingDialogSuccess = () => (
+  <MemoryRouter initialEntries={[{ state: { discover: {} } }]}>
+    <ContextProvider ctx={createTeleportContext()}>
+      <PingTeleportProvider
+        interval={100000}
+        resourceKind={ResourceKind.Kubernetes}
+      >
+        <AgentWaitingDialog
+          joinToken={{
+            id: 'token-id',
+            expiry: null,
+            expiryText: '',
+            internalResourceId: 'resource-id',
+            suggestedLabels: [],
+          }}
+          status={'success'}
+          clusterName={'EKS1'}
+          setWaitingResult={() => {}}
+          close={() => {}}
+        />
+      </PingTeleportProvider>
+    </ContextProvider>
+  </MemoryRouter>
+);
+AgentWaitingDialogSuccess.parameters = {
+  msw: {
+    handlers: [
+      rest.get(cfg.api.kubernetesPath, (req, res, ctx) => {
+        return res(ctx.delay('infinite'));
+      }),
+    ],
+  },
+};
+
+const helmCommand = `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: some-long-cluster-public-url-name.cloud.teleport.gravitational.io:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+    teleport.dev/cloud: AWS
+    region: us-east-1
+    account-id: 1234567789012
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml \\
+--version 14.3.2  --create-namespace --namespace teleport-agent`;
+export const ManualHelmDialogStory = () => (
+  <MemoryRouter initialEntries={[{ state: { discover: {} } }]}>
+    <ManualHelmDialog
+      command={helmCommand}
+      confirmedCommands={() => {}}
+      cancel={() => {}}
+    />
+  </MemoryRouter>
+);
+ManualHelmDialogStory.storyName = 'ManualHelmDialog';

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
@@ -1,0 +1,156 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Flex, Box } from 'design';
+import Table from 'design/DataTable';
+import { FetchStatus } from 'design/DataTable/types';
+
+import {
+  DisableableCell as Cell,
+  RadioCell,
+  Labels,
+  labelMatcher,
+} from 'teleport/Discover/Shared';
+
+import { CheckedEksCluster } from './EnrollEksCluster';
+
+type Props = {
+  items: CheckedEksCluster[];
+  fetchStatus: FetchStatus;
+  fetchNextPage(): void;
+
+  onSelectCluster(item: CheckedEksCluster): void;
+  selectedCluster?: CheckedEksCluster;
+};
+
+const disabledText = `This EKS cluster is already enrolled`;
+
+export const ClustersList = ({
+  items = [],
+  fetchStatus = '',
+  fetchNextPage,
+  onSelectCluster,
+  selectedCluster,
+}: Props) => {
+  return (
+    <Table
+      data={items}
+      columns={[
+        {
+          altKey: 'radio-select',
+          headerText: 'Select',
+          render: item => {
+            const isChecked = item.name === selectedCluster?.name;
+            return (
+              <RadioCell<CheckedEksCluster>
+                disabledText={disabledText}
+                item={item}
+                key={`${item.name}${item.region}`}
+                isChecked={isChecked}
+                onChange={onSelectCluster}
+                disabled={item.kubeServerExists}
+                value={item.name}
+              />
+            );
+          },
+        },
+        {
+          key: 'name',
+          headerText: 'Name',
+          render: ({ name, kubeServerExists }) => (
+            <Cell disabledText={disabledText} disabled={kubeServerExists}>
+              {name}
+            </Cell>
+          ),
+        },
+        {
+          key: 'labels',
+          headerText: 'Labels',
+          render: ({ labels, kubeServerExists }) => (
+            <Cell disabledText={disabledText} disabled={kubeServerExists}>
+              <Labels labels={labels} />
+            </Cell>
+          ),
+        },
+        {
+          key: 'status',
+          headerText: 'Status',
+          render: item => <StatusCell item={item} />,
+        },
+      ]}
+      emptyText="No Results"
+      customSearchMatchers={[labelMatcher]}
+      pagination={{ pageSize: 10 }}
+      fetching={{ onFetchMore: fetchNextPage, fetchStatus }}
+      isSearchable
+    />
+  );
+};
+
+const StatusCell = ({ item }: { item: CheckedEksCluster }) => {
+  const status = getStatus(item);
+
+  return (
+    <Cell disabledText={disabledText} disabled={item.kubeServerExists}>
+      <Flex alignItems="center">
+        <StatusLight status={status} />
+        {item.status}
+      </Flex>
+    </Cell>
+  );
+};
+
+enum Status {
+  Success,
+  Warning,
+  Error,
+}
+
+function getStatus(item: CheckedEksCluster) {
+  switch (item.status.toLowerCase()) {
+    case 'active':
+      return Status.Success;
+
+    case 'failed':
+    case 'deleting':
+      return Status.Error;
+  }
+}
+
+// TODO(lisa): copy from IntegrationList.tsx
+// move to common file for both files.
+const StatusLight = styled(Box)`
+  border-radius: 50%;
+  margin-right: 6px;
+  width: 8px;
+  height: 8px;
+  background-color: ${({ status, theme }) => {
+    if (status === Status.Success) {
+      return theme.colors.success;
+    }
+    if (status === Status.Error) {
+      return theme.colors.error.main;
+    }
+    if (status === Status.Warning) {
+      return theme.colors.warning;
+    }
+    return theme.colors.grey[300]; // Unknown
+  }};
+`;

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -242,7 +242,6 @@ const Component = () => {
     eventState: null,
   };
 
-  cfg.proxyCluster = 'localhost';
   return (
     <MemoryRouter
       initialEntries={[

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -49,7 +49,7 @@ const { worker } = window.msw;
 const integrationName = 'test-oidc';
 
 initialize();
-const defaultIsCloud = false;
+const defaultIsCloud = cfg.isCloud;
 
 export default {
   title: 'Teleport/Discover/Kube/EnrollEksClusters',

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -39,6 +39,7 @@ import { createTeleportContext, getUserContext } from 'teleport/mocks/contexts';
 import { clearCachedJoinTokenResult } from 'teleport/Discover/Shared/useJoinTokenSuspender';
 import { ResourceKind } from 'teleport/Discover/Shared';
 import { INTERNAL_RESOURCE_ID_LABEL_KEY } from 'teleport/services/joinToken';
+import { DiscoverEventResource } from 'teleport/services/userEvent/types';
 import { Kube } from 'teleport/services/kube';
 import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportContext';
 
@@ -220,7 +221,11 @@ const Component = () => {
     agentMeta: {
       resourceName: 'db-name',
       agentMatcherLabels: [],
-      kube: {} as any,
+      kube: {
+        kind: 'kube_cluster',
+        name: '',
+        labels: [],
+      },
       awsIntegration: {
         kind: IntegrationKind.AwsOidc,
         name: integrationName,
@@ -237,7 +242,11 @@ const Component = () => {
     onSelectResource: () => null,
     resourceSpec: {
       name: 'Eks',
-    } as any,
+      kind: ResourceKind.Kubernetes,
+      icon: 'Eks',
+      keywords: '',
+      event: DiscoverEventResource.KubernetesEks,
+    },
     exitFlow: () => null,
     viewConfig: null,
     indexedViews: [],

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -1,0 +1,318 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useEffect } from 'react';
+
+import { MemoryRouter } from 'react-router';
+
+import { Info } from 'design/Alert';
+
+import { rest } from 'msw';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import {
+  AwsEksCluster,
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+import {
+  DiscoverContextState,
+  DiscoverProvider,
+} from 'teleport/Discover/useDiscover';
+import { createTeleportContext, getUserContext } from 'teleport/mocks/contexts';
+import { clearCachedJoinTokenResult } from 'teleport/Discover/Shared/useJoinTokenSuspender';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import { INTERNAL_RESOURCE_ID_LABEL_KEY } from 'teleport/services/joinToken';
+import { Kube } from 'teleport/services/kube';
+import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportContext';
+
+import { EnrollEksCluster } from './EnrollEksCluster';
+
+const { worker } = window.msw;
+
+const integrationName = 'test-oidc';
+
+initialize();
+const defaultIsCloud = false;
+
+export default {
+  title: 'Teleport/Discover/Kube/EnrollEksClusters',
+  loaders: [mswLoader],
+  decorators: [
+    Story => {
+      worker.resetHandlers();
+      clearCachedJoinTokenResult([ResourceKind.Kubernetes]);
+
+      useEffect(() => {
+        // Clean up
+        return () => {
+          cfg.isCloud = defaultIsCloud;
+        };
+      }, []);
+      return <Story />;
+    },
+  ],
+};
+
+const tokenHandler = rest.post(cfg.api.joinTokenPath, (req, res, ctx) => {
+  return res(
+    ctx.json({
+      id: 'token-id',
+      suggestedLabels: [
+        { name: INTERNAL_RESOURCE_ID_LABEL_KEY, value: 'resource-id' },
+      ],
+    })
+  );
+});
+
+const successEnrollmentHandler = rest.post(
+  cfg.getEnrollEksClusterUrl(integrationName),
+  (req, res, ctx) => {
+    return res(
+      ctx.delay(1000),
+      ctx.status(200),
+      ctx.json({
+        results: [{ clusterName: 'EKS1' }, { clusterName: 'EKS3' }],
+      })
+    );
+  }
+);
+
+export const ClustersList = () => <Component />;
+
+ClustersList.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      successEnrollmentHandler,
+      rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) => {
+        {
+          return res(ctx.json({ clusters: eksClusters }));
+        }
+      }),
+      rest.get(
+        cfg.getKubernetesUrl(getUserContext().cluster.clusterId, {}),
+        (req, res, ctx) => {
+          return res(ctx.json({ items: kubeServers }));
+        }
+      ),
+    ],
+  },
+};
+
+export const ClustersListInCloud = () => {
+  cfg.isCloud = true;
+  cfg.automaticUpgrades = true;
+  cfg.automaticUpgradesTargetVersion = 'v14.3.2';
+  return <Component />;
+};
+
+ClustersListInCloud.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      successEnrollmentHandler,
+      rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) => {
+        {
+          return res(ctx.json({ clusters: eksClusters }));
+        }
+      }),
+      rest.get(
+        cfg.getKubernetesUrl(getUserContext().cluster.clusterId, {}),
+        (req, res, ctx) => {
+          return res(ctx.json({ items: kubeServers }));
+        }
+      ),
+    ],
+  },
+};
+
+export const WithAwsPermissionsError = () => <Component />;
+
+WithAwsPermissionsError.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) =>
+        res(
+          ctx.status(403),
+          ctx.json({ message: 'StatusCode: 403, RequestID: operation error' })
+        )
+      ),
+    ],
+  },
+};
+
+export const WithEnrollmentError = () => <Component />;
+
+WithEnrollmentError.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) => {
+        {
+          return res(ctx.json({ clusters: eksClusters }));
+        }
+      }),
+      rest.get(
+        cfg.getKubernetesUrl(getUserContext().cluster.clusterId, {}),
+        (req, res, ctx) => {
+          return res(ctx.json({ items: kubeServers }));
+        }
+      ),
+      rest.post(
+        cfg.getEnrollEksClusterUrl(integrationName),
+        (req, res, ctx) => {
+          return res(
+            ctx.delay(1000),
+            ctx.status(200),
+            ctx.json({
+              results: [
+                { clusterName: 'EKS1', error: 'something bad happened' },
+                { clusterName: 'EKS3', error: 'something bad happened' },
+              ],
+            })
+          );
+        }
+      ),
+    ],
+  },
+};
+
+export const WithOtherError = () => <Component />;
+
+WithOtherError.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) =>
+        res(ctx.status(503))
+      ),
+    ],
+  },
+};
+
+const Component = () => {
+  const ctx = createTeleportContext();
+  const discoverCtx: DiscoverContextState = {
+    agentMeta: {
+      resourceName: 'db-name',
+      agentMatcherLabels: [],
+      kube: {} as any,
+      awsIntegration: {
+        kind: IntegrationKind.AwsOidc,
+        name: integrationName,
+        resourceType: 'integration',
+        spec: {
+          roleArn: 'arn:aws:iam::123456789012:role/test-role-arn',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      },
+    },
+    currentStep: 0,
+    nextStep: () => null,
+    prevStep: () => null,
+    onSelectResource: () => null,
+    resourceSpec: {
+      name: 'Eks',
+    } as any,
+    exitFlow: () => null,
+    viewConfig: null,
+    indexedViews: [],
+    setResourceSpec: () => null,
+    updateAgentMeta: () => null,
+    emitErrorEvent: () => null,
+    emitEvent: () => null,
+    eventState: null,
+  };
+
+  cfg.proxyCluster = 'localhost';
+  return (
+    <MemoryRouter
+      initialEntries={[
+        { pathname: cfg.routes.discover, state: { entity: 'eks' } },
+      ]}
+    >
+      <ContextProvider ctx={ctx}>
+        <PingTeleportProvider
+          interval={1000}
+          resourceKind={ResourceKind.Kubernetes}
+        >
+          <DiscoverProvider mockCtx={discoverCtx}>
+            <Info>Devs: Select any region to see story state</Info>
+            <EnrollEksCluster
+              nextStep={discoverCtx.nextStep}
+              updateAgentMeta={discoverCtx.updateAgentMeta}
+            />
+          </DiscoverProvider>
+        </PingTeleportProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};
+
+const kubeServers: Kube[] = [
+  {
+    kind: 'kube_cluster',
+    name: 'EKS2',
+    labels: [
+      { name: 'region', value: 'us-east-1' },
+      { name: 'account-id', value: '123456789012' },
+    ],
+  },
+];
+
+const eksClusters: AwsEksCluster[] = [
+  {
+    name: 'EKS1',
+    region: 'us-east-1',
+    accountId: '123456789012',
+    status: 'active',
+    labels: [{ name: 'env', value: 'staging' }],
+    joinLabels: [
+      { name: 'teleport.dev/cloud', value: 'AWS' },
+      { name: 'region', value: 'us-east-1' },
+      { name: 'account-id', value: '1234567789012' },
+    ],
+  },
+  {
+    name: 'EKS2',
+    region: 'us-east-1',
+    accountId: '123456789012',
+    status: 'active',
+    labels: [{ name: 'env', value: 'dev' }],
+    joinLabels: [
+      { name: 'teleport.dev/cloud', value: 'AWS' },
+      { name: 'region', value: 'us-east1' },
+      { name: 'account-id', value: '1234567789012' },
+    ],
+  },
+  {
+    name: 'EKS3',
+    region: 'us-east-1',
+    accountId: '123456789012',
+    status: 'active',
+    labels: [{ name: 'env', value: 'prod' }],
+    joinLabels: [
+      { name: 'teleport.dev/cloud', value: 'AWS' },
+      { name: 'region', value: 'us-east-1' },
+      { name: 'account-id', value: '1234567789012' },
+    ],
+  },
+];

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -50,6 +50,9 @@ const integrationName = 'test-oidc';
 
 initialize();
 const defaultIsCloud = cfg.isCloud;
+const defaultAutomaticUpgrades = cfg.automaticUpgrades;
+const defaultAutomaticUpgradesTargetVersion =
+  cfg.automaticUpgradesTargetVersion;
 
 export default {
   title: 'Teleport/Discover/Kube/EnrollEksClusters',
@@ -63,6 +66,9 @@ export default {
         // Clean up
         return () => {
           cfg.isCloud = defaultIsCloud;
+          cfg.automaticUpgrades = defaultAutomaticUpgrades;
+          cfg.automaticUpgradesTargetVersion =
+            defaultAutomaticUpgradesTargetVersion;
         };
       }, []);
       return <Story />;

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -96,6 +96,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
   const [isAgentWaitingDialogShown, setIsAgentWaitingDialogShown] =
     useState(false);
   const [isManualHelmDialogShown, setIsManualHelmDialogShown] = useState(false);
+  const [waitingResourceId, setWaitingResourceId] = useState('');
   const ctx = useTeleport();
 
   const { joinToken } = useJoinTokenSuspender([
@@ -239,6 +240,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       } else {
         setEnrollmentState({ status: 'awaitingAgent' });
         setIsAgentWaitingDialogShown(true);
+        setWaitingResourceId(result.resourceId);
       }
     } catch (err) {
       setEnrollmentState({
@@ -384,7 +386,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       )}
       {isAgentWaitingDialogShown && (
         <AgentWaitingDialog
-          joinToken={joinToken}
+          joinResourceId={waitingResourceId || joinToken.internalResourceId}
           status={enrollmentState.status}
           clusterName={selectedCluster.name}
           updateWaitingResult={(result: Kube) => {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -40,7 +40,7 @@ import { AgentStepProps } from 'teleport/Discover/types';
 import useTeleport from 'teleport/useTeleport';
 
 import { useJoinTokenSuspender } from 'teleport/Discover/Shared/useJoinTokenSuspender';
-import { GenerateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
+import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
 import { Kube } from 'teleport/services/kube';
 
 import { ActionButtons, Header, ResourceKind } from '../../Shared';
@@ -270,7 +270,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
 
   let command = '';
   if (selectedCluster) {
-    command = GenerateCmd({
+    command = generateCmd({
       namespace: 'teleport-agent',
       clusterName: selectedCluster.name,
       proxyAddr: ctx.storeUser.state.cluster.publicURL,

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -229,11 +229,13 @@ export function EnrollEksCluster(props: AgentStepProps) {
           status: 'error',
           error: `Cluster "${selectedCluster.name}" enrollment result is unknown.`,
         });
+        emitErrorEvent('unknown error during EKS enrollment.');
       } else if (result.error) {
         setEnrollmentState({
           status: 'error',
           error: `Cluster enrollment error: ${result.error}`,
         });
+        emitErrorEvent(`failed to enroll EKS cluster: ${result.error}`);
       } else {
         setEnrollmentState({ status: 'awaitingAgent' });
         setIsAgentWaitingDialogShown(true);
@@ -243,6 +245,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
         status: 'error',
         error: `Cluster enrollment error: ${getErrMessage(err)}.`,
       });
+      emitErrorEvent(`failed to enroll EKS cluster: ${getErrMessage(err)}`);
     }
   }
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -181,7 +181,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       const errMsg = getErrMessage(err);
       setFetchClustersAttempt({ status: 'failed', statusText: errMsg });
       setTableData(data); // fallback to previous data
-      emitErrorEvent(`database fetch error: ${errMsg}`);
+      emitErrorEvent(`EKS clusters fetch error: ${errMsg}`);
     }
   }
 
@@ -291,7 +291,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
         <Danger mt={3}>{fetchClustersAttempt.statusText}</Danger>
       )}
       <Text mt={4}>
-        Select the AWS Region you would like to see databases for:
+        Select the AWS Region you would like to see EKS clusters for:
       </Text>
       <AwsRegionSelector
         onFetch={fetchClustersWithNewRegion}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -151,7 +151,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       const existingKubeServers = await fetchKubeServers(query, 0);
       const checkedEksClusters: CheckedEksCluster[] = fetchedEKSClusters.map(
         cluster => {
-          let serverExists = existingKubeServers.agents.some(k => {
+          const serverExists = existingKubeServers.agents.some(k => {
             const regionLabel = k.labels?.find(l => l.name === 'region')?.value;
             const accountLabel = k.labels?.find(
               l => l.name === 'account-id'

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -1,0 +1,421 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+import { Box, ButtonSecondary, ButtonText, Text, Toggle } from 'design';
+import styled from 'styled-components';
+import { FetchStatus } from 'design/DataTable/types';
+import { Danger } from 'design/Alert';
+
+import useAttempt from 'shared/hooks/useAttemptNext';
+import { ToolTipInfo } from 'shared/components/ToolTip';
+import { getErrMessage } from 'shared/utils/errorType';
+
+import { EksMeta, useDiscover } from 'teleport/Discover/useDiscover';
+import {
+  Regions,
+  integrationService,
+  AwsEksCluster,
+} from 'teleport/services/integrations';
+
+import { AwsRegionSelector } from 'teleport/Discover/Shared/AwsRegionSelector';
+import { ConfigureIamPerms } from 'teleport/Discover/Shared/Aws/ConfigureIamPerms';
+import { isIamPermError } from 'teleport/Discover/Shared/Aws/error';
+import { AgentStepProps } from 'teleport/Discover/types';
+import useTeleport from 'teleport/useTeleport';
+
+import { useJoinTokenSuspender } from 'teleport/Discover/Shared/useJoinTokenSuspender';
+import { GenerateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
+import { Kube } from 'teleport/services/kube';
+
+import { ActionButtons, Header, ResourceKind } from '../../Shared';
+
+import { ClustersList } from './EksClustersList';
+import { ManualHelmDialog } from './ManualHelmDialog';
+import { EnrollmentDialog } from './EnrollmentDialog';
+import { AgentWaitingDialog } from './AgentWaitingDialog';
+
+type TableData = {
+  items: CheckedEksCluster[];
+  fetchStatus: FetchStatus;
+  startKey?: string;
+  currRegion?: Regions;
+};
+
+const emptyTableData: TableData = {
+  items: [],
+  fetchStatus: 'disabled',
+  startKey: '',
+};
+
+// CheckedEksCluster is a type to describe that a
+// Kube cluster has been checked with the backend
+// whether or not a kube server already exists for it.
+export type CheckedEksCluster = AwsEksCluster & {
+  kubeServerExists?: boolean;
+};
+
+type EKSClusterEnrollmentState = {
+  status: 'notStarted' | 'enrolling' | 'awaitingAgent' | 'success' | 'error';
+  error?: string;
+};
+
+export function EnrollEksCluster(props: AgentStepProps) {
+  const { agentMeta, emitErrorEvent } = useDiscover();
+  const { attempt: fetchClustersAttempt, setAttempt: setFetchClustersAttempt } =
+    useAttempt('');
+
+  const [tableData, setTableData] = useState<TableData>({
+    items: [],
+    startKey: '',
+    fetchStatus: 'disabled',
+  });
+  const [selectedCluster, setSelectedCluster] = useState<CheckedEksCluster>();
+  const [selectedRegion, setSelectedRegion] = useState<Regions>();
+  const [confirmedCluster, setConfirmedCluster] = useState<Kube>();
+  const [enrollmentState, setEnrollmentState] =
+    useState<EKSClusterEnrollmentState>({
+      status: 'notStarted',
+    });
+  const [isAppDiscoveryEnabled, setAppDiscoveryEnabled] =
+    useState<boolean>(true);
+  const [isAgentWaitingDialogShown, setIsAgentWaitingDialogShown] =
+    useState<boolean>(false);
+  const [isManualHelmDialogShown, setIsManualHelmDialogShown] =
+    useState<boolean>(false);
+  const ctx = useTeleport();
+
+  const { joinToken } = useJoinTokenSuspender([
+    ResourceKind.Kubernetes,
+    ResourceKind.Application,
+    ResourceKind.Discovery,
+  ]);
+
+  function fetchClustersWithNewRegion(region: Regions) {
+    setSelectedRegion(region);
+    // Clear table when fetching with new region.
+    fetchClusters({ ...emptyTableData, currRegion: region });
+  }
+
+  function fetchNextPage() {
+    fetchClusters({ ...tableData });
+  }
+
+  function refreshClustersList() {
+    setSelectedCluster(null);
+    // When refreshing, start the table back at page 1.
+    fetchClusters({ ...tableData, startKey: '', items: [] });
+  }
+
+  async function fetchClusters(data: TableData) {
+    const integrationName = (agentMeta as EksMeta).awsIntegration.name;
+
+    setTableData({ ...data, fetchStatus: 'loading' });
+    setFetchClustersAttempt({ status: 'processing' });
+
+    try {
+      const { clusters: fetchedEKSClusters, nextToken } =
+        await integrationService.fetchEksClusters(integrationName, {
+          region: data.currRegion,
+          nextToken: data.startKey,
+        });
+
+      // Abort if there were no EKS clusters for the selected region.
+      if (fetchedEKSClusters.length <= 0) {
+        setFetchClustersAttempt({ status: 'success' });
+        setTableData({ ...data, fetchStatus: 'disabled' });
+        return;
+      }
+
+      // Check if fetched EKS clusters have a Kube
+      // server for it, to prevent user from enrolling
+      // the same cluster.
+      const query = fetchedEKSClusters
+        .map(cluster => `name == "${cluster.name}"`)
+        .join(' || ');
+      const existingKubeServers = await fetchKubeServers(query, 0);
+      const checkedEksClusters: CheckedEksCluster[] = fetchedEKSClusters.map(
+        cluster => {
+          let serverExists = existingKubeServers.agents.some(k => {
+            const regionLabel = k.labels?.find(l => l.name === 'region')?.value;
+            const accountLabel = k.labels?.find(
+              l => l.name === 'account-id'
+            )?.value;
+
+            return (
+              cluster.name === k.name &&
+              cluster.region === regionLabel &&
+              cluster.accountId === accountLabel
+            );
+          });
+
+          return {
+            ...cluster,
+            kubeServerExists: serverExists,
+          };
+        }
+      );
+
+      setFetchClustersAttempt({ status: 'success' });
+      setTableData({
+        currRegion: data.currRegion,
+        startKey: nextToken,
+        fetchStatus: nextToken ? '' : 'disabled',
+        // concat each page fetch.
+        items: [...data.items, ...checkedEksClusters],
+      });
+    } catch (err) {
+      const errMsg = getErrMessage(err);
+      setFetchClustersAttempt({ status: 'failed', statusText: errMsg });
+      setTableData(data); // fallback to previous data
+      emitErrorEvent(`database fetch error: ${errMsg}`);
+    }
+  }
+
+  function clear() {
+    if (fetchClustersAttempt.status === 'failed') {
+      setFetchClustersAttempt({ status: '' });
+    }
+    if (tableData.items.length > 0) {
+      setTableData(emptyTableData);
+    }
+    if (selectedCluster) {
+      setSelectedCluster(null);
+    }
+    setEnrollmentState({ status: 'notStarted' });
+  }
+
+  function fetchKubeServers(query: string, limit: number) {
+    return ctx.kubeService.fetchKubernetes(ctx.storeUser.getClusterId(), {
+      query,
+      limit,
+    });
+  }
+
+  async function handleOnEnroll() {
+    const integrationName = (agentMeta as EksMeta).awsIntegration.name;
+    setEnrollmentState({ status: 'enrolling' });
+
+    try {
+      const response = await integrationService.enrollEksClusters(
+        integrationName,
+        {
+          region: selectedRegion,
+          enableAppDiscovery: isAppDiscoveryEnabled,
+          joinToken: joinToken.id,
+          resourceId: joinToken.internalResourceId,
+          clusterNames: [selectedCluster.name],
+        }
+      );
+
+      const result = response.results?.find(
+        c => c.clusterName === selectedCluster.name
+      );
+      if (!result) {
+        setEnrollmentState({
+          status: 'error',
+          error: `Cluster "${selectedCluster.name}" enrollment result is unknown.`,
+        });
+      } else if (result.error) {
+        setEnrollmentState({
+          status: 'error',
+          error: `Cluster enrollment error: ${result.error}`,
+        });
+      } else {
+        setEnrollmentState({ status: 'awaitingAgent' });
+        setIsAgentWaitingDialogShown(true);
+      }
+    } catch (err) {
+      setEnrollmentState({
+        status: 'error',
+        error: `Cluster enrollment error: ${getErrMessage(err)}.`,
+      });
+    }
+  }
+
+  async function handleOnProceed() {
+    props.updateAgentMeta({
+      kube: confirmedCluster,
+      resourceName: confirmedCluster.name,
+    } as EksMeta);
+
+    props.nextStep();
+  }
+
+  const hasIamPermError = isIamPermError(fetchClustersAttempt);
+
+  const closeEnrollmentDialog = () => {
+    setEnrollmentState({ status: 'notStarted' });
+  };
+
+  const enrollmentNotAllowed =
+    fetchClustersAttempt.status === 'processing' ||
+    !selectedCluster ||
+    enrollmentState.status !== 'notStarted';
+
+  let command = '';
+  if (selectedCluster) {
+    command = GenerateCmd({
+      namespace: 'teleport-agent',
+      clusterName: selectedCluster.name,
+      proxyAddr: ctx.storeUser.state.cluster.publicURL,
+      tokenId: joinToken.id,
+      clusterVersion: ctx.storeUser.state.cluster.authVersion,
+      resourceId: joinToken.internalResourceId,
+      isEnterprise: ctx.isEnterprise,
+      isCloud: ctx.isCloud,
+      automaticUpgradesEnabled: ctx.automaticUpgradesEnabled,
+      automaticUpgradesTargetVersion: ctx.automaticUpgradesTargetVersion,
+      joinLabels: [...selectedCluster.labels, ...selectedCluster.joinLabels],
+      disableAppDiscovery: !isAppDiscoveryEnabled,
+    });
+  }
+
+  return (
+    <Box maxWidth="1000px">
+      <Header>Enroll an EKS Cluster</Header>
+      {fetchClustersAttempt.status === 'failed' && !hasIamPermError && (
+        <Danger mt={3}>{fetchClustersAttempt.statusText}</Danger>
+      )}
+      <Text mt={4}>
+        Select the AWS Region you would like to see databases for:
+      </Text>
+      <AwsRegionSelector
+        onFetch={fetchClustersWithNewRegion}
+        onRefresh={refreshClustersList}
+        clear={clear}
+        disableSelector={fetchClustersAttempt.status === 'processing'}
+      />
+      {!hasIamPermError && tableData.currRegion && (
+        <>
+          <Box mb={2}>
+            <Toggle
+              isToggled={isAppDiscoveryEnabled}
+              onToggle={() => setAppDiscoveryEnabled(!isAppDiscoveryEnabled)}
+            >
+              <Box ml={2} mr={1}>
+                Enable Kubernetes App Discovery
+              </Box>
+              <ToolTipInfo>
+                Teleport's Kubernetes App Discovery will automatically identify
+                and enroll to Teleport HTTP applications running inside a
+                Kubernetes cluster.
+              </ToolTipInfo>
+            </Toggle>
+          </Box>
+          <ClustersList
+            items={tableData.items}
+            fetchStatus={tableData.fetchStatus}
+            selectedCluster={selectedCluster}
+            onSelectCluster={setSelectedCluster}
+            fetchNextPage={fetchNextPage}
+          />
+          <StyledBox mb={5} mt={5}>
+            <Text mb={2}>Automatically enroll selected EKS cluster</Text>
+            <ButtonSecondary
+              width="215px"
+              type="submit"
+              onClick={handleOnEnroll}
+              disabled={enrollmentNotAllowed}
+              mt={2}
+              mb={2}
+            >
+              Enroll EKS Cluster
+            </ButtonSecondary>
+            <Box>
+              <ButtonText
+                disabled={enrollmentNotAllowed}
+                onClick={() => {
+                  setIsManualHelmDialogShown(b => !b);
+                }}
+                pl={0}
+              >
+                Or click here to see instructions for manual enrollment
+              </ButtonText>
+            </Box>
+          </StyledBox>
+        </>
+      )}
+      {hasIamPermError && (
+        <Box mb={5}>
+          <ConfigureIamPerms
+            kind="eks"
+            region={tableData.currRegion}
+            integrationRoleArn={agentMeta.awsIntegration.spec.roleArn}
+          />
+        </Box>
+      )}
+      {(enrollmentState.status === 'enrolling' ||
+        enrollmentState.status === 'error') && (
+        <EnrollmentDialog
+          clusterName={selectedCluster.name}
+          close={closeEnrollmentDialog}
+          error={enrollmentState.error}
+          status={enrollmentState.status}
+        />
+      )}
+      {isManualHelmDialogShown && (
+        <ManualHelmDialog
+          command={command}
+          cancel={() => setIsManualHelmDialogShown(false)}
+          confirmedCommands={() => {
+            setEnrollmentState({ status: 'awaitingAgent' });
+            setIsManualHelmDialogShown(false);
+            setIsAgentWaitingDialogShown(true);
+          }}
+        />
+      )}
+      {isAgentWaitingDialogShown && (
+        <AgentWaitingDialog
+          joinToken={joinToken}
+          status={enrollmentState.status}
+          clusterName={selectedCluster.name}
+          setWaitingResult={(result: Kube) => {
+            if (result) {
+              setConfirmedCluster(result);
+              setEnrollmentState({ status: 'success' });
+            }
+          }}
+          close={() => {
+            if (enrollmentState.status != 'success') {
+              setEnrollmentState({ status: 'notStarted' });
+            }
+            setIsAgentWaitingDialogShown(false);
+          }}
+        />
+      )}
+
+      <ActionButtons
+        onProceed={handleOnProceed}
+        disableProceed={
+          fetchClustersAttempt.status === 'processing' ||
+          !selectedCluster ||
+          hasIamPermError ||
+          !confirmedCluster
+        }
+      />
+    </Box>
+  );
+}
+
+const StyledBox = styled(Box)`
+  max-width: 1000px;
+  background-color: ${props => props.theme.colors.spotBackground[0]};
+  padding: ${props => `${props.theme.space[3]}px`};
+  border-radius: ${props => `${props.theme.space[2]}px`};
+`;

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -205,7 +205,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
     });
   }
 
-  async function handleOnEnroll() {
+  async function enroll() {
     const integrationName = (agentMeta as EksMeta).awsIntegration.name;
     setEnrollmentState({ status: 'enrolling' });
 
@@ -331,7 +331,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
             <ButtonSecondary
               width="215px"
               type="submit"
-              onClick={handleOnEnroll}
+              onClick={enroll}
               disabled={enrollmentNotAllowed}
               mt={2}
               mb={2}
@@ -366,7 +366,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
         <EnrollmentDialog
           clusterName={selectedCluster.name}
           close={closeEnrollmentDialog}
-          retry={handleOnEnroll}
+          retry={enroll}
           error={enrollmentState.error}
           status={enrollmentState.status}
         />

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -219,7 +219,9 @@ export function EnrollEksCluster(props: AgentStepProps) {
           status: 'error',
           error: `Cluster "${selectedCluster.name}" enrollment result is unknown.`,
         });
-        emitErrorEvent('unknown error during EKS enrollment.');
+        emitErrorEvent(
+          'unknown error: no results came back from enrolling the EKS cluster.'
+        );
       } else if (result.error) {
         setEnrollmentState({
           status: 'error',

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -43,7 +43,7 @@ import { useJoinTokenSuspender } from 'teleport/Discover/Shared/useJoinTokenSusp
 import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
 import { Kube } from 'teleport/services/kube';
 
-import { ActionButtons, Header, ResourceKind } from '../../Shared';
+import { Header, ResourceKind } from '../../Shared';
 
 import { ClustersList } from './EksClustersList';
 import { ManualHelmDialog } from './ManualHelmDialog';
@@ -389,24 +389,15 @@ export function EnrollEksCluster(props: AgentStepProps) {
               setEnrollmentState({ status: 'success' });
             }
           }}
-          close={() => {
+          cancel={() => {
             if (enrollmentState.status != 'success') {
               setEnrollmentState({ status: 'notStarted' });
             }
             setIsAgentWaitingDialogShown(false);
           }}
+          next={handleOnProceed}
         />
       )}
-
-      <ActionButtons
-        onProceed={handleOnProceed}
-        disableProceed={
-          fetchClustersAttempt.status === 'processing' ||
-          !selectedCluster ||
-          hasIamPermError ||
-          !confirmedCluster
-        }
-      />
     </Box>
   );
 }

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -383,7 +383,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
           joinToken={joinToken}
           status={enrollmentState.status}
           clusterName={selectedCluster.name}
-          setWaitingResult={(result: Kube) => {
+          updateWaitingResult={(result: Kube) => {
             if (result) {
               setConfirmedCluster(result);
               setEnrollmentState({ status: 'success' });

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -92,12 +92,10 @@ export function EnrollEksCluster(props: AgentStepProps) {
     useState<EKSClusterEnrollmentState>({
       status: 'notStarted',
     });
-  const [isAppDiscoveryEnabled, setAppDiscoveryEnabled] =
-    useState<boolean>(true);
+  const [isAppDiscoveryEnabled, setAppDiscoveryEnabled] = useState(true);
   const [isAgentWaitingDialogShown, setIsAgentWaitingDialogShown] =
-    useState<boolean>(false);
-  const [isManualHelmDialogShown, setIsManualHelmDialogShown] =
-    useState<boolean>(false);
+    useState(false);
+  const [isManualHelmDialogShown, setIsManualHelmDialogShown] = useState(false);
   const ctx = useTeleport();
 
   const { joinToken } = useJoinTokenSuspender([

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -144,24 +144,13 @@ export function EnrollEksCluster(props: AgentStepProps) {
       // Check if fetched EKS clusters have a Kube
       // server for it, to prevent user from enrolling
       // the same cluster.
-      const query = fetchedEKSClusters
-        .map(cluster => `name == "${cluster.name}"`)
-        .join(' || ');
+      const query = `labels["region"] == "${fetchedEKSClusters[0].region}"`;
       const existingKubeServers = await fetchKubeServers(query, 0);
       const checkedEksClusters: CheckedEksCluster[] = fetchedEKSClusters.map(
         cluster => {
-          const serverExists = existingKubeServers.agents.some(k => {
-            const regionLabel = k.labels?.find(l => l.name === 'region')?.value;
-            const accountLabel = k.labels?.find(
-              l => l.name === 'account-id'
-            )?.value;
-
-            return (
-              cluster.name === k.name &&
-              cluster.region === regionLabel &&
-              cluster.accountId === accountLabel
-            );
-          });
+          const serverExists = existingKubeServers.agents.some(k =>
+            k.name.startsWith(`${cluster.name}-${cluster.region}`)
+          );
 
           return {
             ...cluster,

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -388,10 +388,8 @@ export function EnrollEksCluster(props: AgentStepProps) {
           status={enrollmentState.status}
           clusterName={selectedCluster.name}
           updateWaitingResult={(result: Kube) => {
-            if (result) {
-              setConfirmedCluster(result);
-              setEnrollmentState({ status: 'success' });
-            }
+            setConfirmedCluster(result);
+            setEnrollmentState({ status: 'success' });
           }}
           cancel={() => {
             if (enrollmentState.status != 'success') {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -363,6 +363,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
         <EnrollmentDialog
           clusterName={selectedCluster.name}
           close={closeEnrollmentDialog}
+          retry={handleOnEnroll}
           error={enrollmentState.error}
           status={enrollmentState.status}
         />

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -16,7 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { AnimatedProgressBar, ButtonPrimary, Text, Flex } from 'design';
+import {
+  AnimatedProgressBar,
+  ButtonPrimary,
+  Text,
+  Flex,
+  ButtonSecondary,
+} from 'design';
 
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';
@@ -28,12 +34,14 @@ type EnrollmentDialogProps = {
   status: string;
   error: string;
   close(): void;
+  retry(): void;
 };
 
 export function EnrollmentDialog({
   status,
   error,
   close,
+  retry,
 }: EnrollmentDialogProps) {
   function dialogContent() {
     switch (status) {
@@ -61,9 +69,14 @@ export function EnrollmentDialog({
               <Icons.Warning size="large" ml={1} mr={2} color="error.main" />
               <Text>{error}</Text>
             </Flex>
-            <ButtonPrimary width="100%" onClick={close}>
-              Close
-            </ButtonPrimary>
+            <Flex>
+              <ButtonPrimary mr={3} width="50%" onClick={retry}>
+                Retry
+              </ButtonPrimary>
+              <ButtonSecondary width="50%" onClick={close}>
+                Close
+              </ButtonSecondary>
+            </Flex>
           </>
         );
     }

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -57,10 +57,10 @@ export function EnrollmentDialog({
       case 'error':
         return (
           <>
-            <Text mb={5} alignItems="center">
+            <Flex mb={5} alignItems="center">
               <Icons.Warning size="large" ml={1} mr={2} color="error.main" />
               <Text>{error}</Text>
-            </Text>
+            </Flex>
             <ButtonPrimary width="100%" onClick={close}>
               Close
             </ButtonPrimary>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -41,12 +41,7 @@ export function EnrollmentDialog({
         return (
           <>
             <AnimatedProgressBar mb={3} />
-            <TextIcon
-              mb={3}
-              css={`
-                white-space: pre;
-              `}
-            >
+            <TextIcon mb={3}>
               <Icons.Clock size="medium" />
               <Text>1. Installing Teleport agent...</Text>
             </TextIcon>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { AnimatedProgressBar, ButtonPrimary, Text } from 'design';
+import { AnimatedProgressBar, ButtonPrimary, Text, Flex } from 'design';
 
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -69,8 +69,8 @@ export function EnrollmentDialog({
               <Icons.Warning size="large" ml={1} mr={2} color="error.main" />
               <Text>{error}</Text>
             </Flex>
-            <Flex>
-              <ButtonPrimary gap={4} width="50%" onClick={retry}>
+            <Flex gap={4}>
+              <ButtonPrimary width="50%" onClick={retry}>
                 Retry
               </ButtonPrimary>
               <ButtonSecondary width="50%" onClick={close}>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -70,7 +70,7 @@ export function EnrollmentDialog({
               <Text>{error}</Text>
             </Flex>
             <Flex>
-              <ButtonPrimary mr={3} width="50%" onClick={retry}>
+              <ButtonPrimary gap={4} width="50%" onClick={retry}>
                 Retry
               </ButtonPrimary>
               <ButtonSecondary width="50%" onClick={close}>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -1,0 +1,92 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { AnimatedProgressBar, ButtonPrimary, Text } from 'design';
+
+import * as Icons from 'design/Icon';
+import Dialog, { DialogContent } from 'design/DialogConfirmation';
+
+import { TextIcon } from 'teleport/Discover/Shared';
+
+type EnrollmentDialogProps = {
+  clusterName: string;
+  status: string;
+  error: string;
+  close(): void;
+};
+
+export function EnrollmentDialog({
+  status,
+  error,
+  close,
+}: EnrollmentDialogProps) {
+  function dialogContent() {
+    switch (status) {
+      case 'enrolling':
+        return (
+          <>
+            <AnimatedProgressBar mb={3} />
+            <TextIcon
+              mb={3}
+              css={`
+                white-space: pre;
+              `}
+            >
+              <Icons.Clock size="medium" />
+              <Text>1. Installing Teleport agent...</Text>
+            </TextIcon>
+            <Text mb={3}>
+              2. Waiting for the Teleport agent to come online (1-5 minutes)
+            </Text>
+            <ButtonPrimary width="100%" disabled>
+              Cancel
+            </ButtonPrimary>
+          </>
+        );
+
+      case 'error':
+        return (
+          <>
+            <Text mb={5} alignItems="center">
+              <Icons.Warning size="large" ml={1} mr={2} color="error.main" />
+              <Text>{error}</Text>
+            </Text>
+            <ButtonPrimary width="100%" onClick={close}>
+              Close
+            </ButtonPrimary>
+          </>
+        );
+    }
+  }
+
+  return (
+    <Dialog open={true}>
+      <DialogContent
+        width="460px"
+        alignItems="center"
+        mb={0}
+        textAlign="center"
+      >
+        <Text bold caps mb={4}>
+          EKS Cluster Enrollment
+        </Text>
+        {dialogContent()}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
@@ -1,0 +1,91 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Dialog, { DialogContent, DialogFooter } from 'design/DialogConfirmation';
+import { Box, ButtonPrimary, ButtonSecondary, Text } from 'design';
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
+import { CommandBox } from 'teleport/Discover/Shared/CommandBox';
+
+type ManualHelmDialogProps = {
+  command: string;
+  confirmedCommands(): void;
+  cancel(): void;
+};
+
+export function ManualHelmDialog({
+  command,
+  cancel,
+  confirmedCommands,
+}: ManualHelmDialogProps) {
+  return (
+    <Dialog disableEscapeKeyDown={false} onClose={cancel} open={true}>
+      <DialogContent width="850px" mb={0}>
+        <Text bold caps mb={4}>
+          Manual EKS Cluster Enrollment
+        </Text>
+        <StyledBox mb={5}>
+          <Text bold>Step 1</Text>
+          <Text typography="subtitle1" mb={3}>
+            Add teleport-agent chart to your charts repository
+          </Text>
+          <TextSelectCopyMulti
+            lines={[
+              {
+                text: 'helm repo add teleport https://charts.releases.teleport.dev && helm repo update',
+              },
+            ]}
+          />
+        </StyledBox>
+        <CommandBox
+          header={
+            <>
+              <Text bold>Step 2</Text>
+              <Text typography="subtitle1" mb={3}>
+                Run the command below on the server your target EKS cluster. It
+                may take up to a minute for the Teleport Service to join after
+                running the command.
+              </Text>
+            </>
+          }
+        >
+          <TextSelectCopyMulti lines={[{ text: command }]} />
+        </CommandBox>
+      </DialogContent>
+      <DialogFooter alignItems="center">
+        <ButtonPrimary width="45%" onClick={confirmedCommands} mr={'10%'}>
+          I ran these commands
+        </ButtonPrimary>
+        <ButtonSecondary width="45%" onClick={cancel}>
+          Cancel
+        </ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}
+
+const StyledBox = styled(Box)`
+  max-width: 1000px;
+  background-color: ${props => props.theme.colors.spotBackground[0]};
+  padding: ${props => `${props.theme.space[3]}px`};
+  border-radius: ${props => `${props.theme.space[2]}px`};
+`;

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
@@ -61,7 +61,7 @@ export function ManualHelmDialog({
             <>
               <Text bold>Step 2</Text>
               <Text typography="subtitle1" mb={3}>
-                Run the command below on the server your target EKS cluster. It
+                Run the command below on the server your target EKS cluster is at. It
                 may take up to a minute for the Teleport Service to join after
                 running the command.
               </Text>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
@@ -38,7 +38,7 @@ export function ManualHelmDialog({
   confirmedCommands,
 }: ManualHelmDialogProps) {
   return (
-    <Dialog disableEscapeKeyDown={false} onClose={cancel} open={true}>
+    <Dialog onClose={cancel} open={true}>
       <DialogContent width="850px" mb={0}>
         <Text bold caps mb={4}>
           Manual EKS Cluster Enrollment

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/ManualHelmDialog.tsx
@@ -17,7 +17,7 @@
  */
 
 import Dialog, { DialogContent, DialogFooter } from 'design/DialogConfirmation';
-import { Box, ButtonPrimary, ButtonSecondary, Text } from 'design';
+import { Box, Flex, ButtonPrimary, ButtonSecondary, Text } from 'design';
 
 import React from 'react';
 
@@ -61,9 +61,9 @@ export function ManualHelmDialog({
             <>
               <Text bold>Step 2</Text>
               <Text typography="subtitle1" mb={3}>
-                Run the command below on the server your target EKS cluster is at. It
-                may take up to a minute for the Teleport Service to join after
-                running the command.
+                Run the command below on the server your target EKS cluster is
+                at. It may take up to a minute for the Teleport Service to join
+                after running the command.
               </Text>
             </>
           }
@@ -71,11 +71,11 @@ export function ManualHelmDialog({
           <TextSelectCopyMulti lines={[{ text: command }]} />
         </CommandBox>
       </DialogContent>
-      <DialogFooter alignItems="center">
-        <ButtonPrimary width="45%" onClick={confirmedCommands} mr={'10%'}>
+      <DialogFooter alignItems="center" as={Flex} gap={4}>
+        <ButtonPrimary width="50%" onClick={confirmedCommands}>
           I ran these commands
         </ButtonPrimary>
-        <ButtonSecondary width="45%" onClick={cancel}>
+        <ButtonSecondary width="50%" onClick={cancel}>
           Cancel
         </ButtonSecondary>
       </DialogFooter>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { EnrollEksCluster } from './EnrollEksCluster';

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { generateCmd, generateCmdProps } from './HelmChart';
+
+describe('generateCmd', () => {
+  const baseParams: generateCmdProps = {
+    namespace: 'teleport-agent',
+    clusterName: 'EKS1',
+    proxyAddr: 'proxyaddr.example.com:1234',
+    tokenId: 'token-id',
+    clusterVersion: '12.3.4',
+    resourceId: 'resource-id',
+    isEnterprise: false,
+    isCloud: false,
+    automaticUpgradesEnabled: false,
+    automaticUpgradesTargetVersion: '',
+  };
+  const testCases: {
+    name: string;
+    params: generateCmdProps;
+    expected: string;
+  }[] = [
+    {
+      name: 'simplest case',
+      params: { ...baseParams },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 12.3.4 \\
+--create-namespace --namespace teleport-agent`,
+    },
+    {
+      name: 'disabled app discovery',
+      params: { ...baseParams, disableAppDiscovery: true },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 12.3.4 \\
+--create-namespace --namespace teleport-agent`,
+    },
+    {
+      name: 'join labels present',
+      params: {
+        ...baseParams,
+        joinLabels: [
+          { name: 'label1', value: 'value1' },
+          { name: 'label2', value: 'value2' },
+        ],
+      },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+    label1: value1
+    label2: value2
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 12.3.4 \\
+--create-namespace --namespace teleport-agent`,
+    },
+    {
+      name: 'enterprise',
+      params: {
+        ...baseParams,
+        isEnterprise: true,
+      },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+enterprise: true
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 12.3.4 \\
+--create-namespace --namespace teleport-agent`,
+    },
+    {
+      name: 'cloud automatic upgrades',
+      params: {
+        ...baseParams,
+        isCloud: true,
+        automaticUpgradesEnabled: true,
+        automaticUpgradesTargetVersion: '14.5.6',
+      },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+updater:
+    enabled: true
+    releaseChannel: "stable/cloud"
+highAvailability:
+    replicaCount: 2
+    podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 14.5.6 \\
+--create-namespace --namespace teleport-agent`,
+    },
+    {
+      name: 'enterprise, with join labels, with cloud automatic upgrades',
+      params: {
+        ...baseParams,
+        isEnterprise: true,
+        isCloud: true,
+        joinLabels: [
+          { name: 'label1', value: 'value1' },
+          { name: 'label2', value: 'value2' },
+        ],
+        automaticUpgradesEnabled: true,
+        automaticUpgradesTargetVersion: '14.5.6',
+      },
+      expected: `cat << EOF > prod-cluster-values.yaml
+roles: kube,app,discovery
+authToken: token-id
+proxyAddr: proxyaddr.example.com:1234
+kubeClusterName: EKS1
+labels:
+    teleport.internal/resource-id: resource-id
+    label1: value1
+    label2: value2
+enterprise: true
+updater:
+    enabled: true
+    releaseChannel: "stable/cloud"
+highAvailability:
+    replicaCount: 2
+    podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+EOF
+ 
+helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version 14.5.6 \\
+--create-namespace --namespace teleport-agent`,
+    },
+  ];
+
+  test.each(testCases)('$name', testCase => {
+    expect(generateCmd(testCase.params)).toEqual(testCase.expected);
+  });
+});

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.test.tsx
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { generateCmd, generateCmdProps } from './HelmChart';
+import { generateCmd, GenerateCmdProps } from './HelmChart';
 
 describe('generateCmd', () => {
-  const baseParams: generateCmdProps = {
+  const baseParams: GenerateCmdProps = {
     namespace: 'teleport-agent',
     clusterName: 'EKS1',
     proxyAddr: 'proxyaddr.example.com:1234',
@@ -33,7 +33,7 @@ describe('generateCmd', () => {
   };
   const testCases: {
     name: string;
-    params: generateCmdProps;
+    params: GenerateCmdProps;
     expected: string;
   }[] = [
     {

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -319,7 +319,7 @@ const StepTwo = ({
   );
 };
 
-export function generateCmd(data: {
+export type generateCmdProps = {
   namespace: string;
   clusterName: string;
   proxyAddr: string;
@@ -332,7 +332,9 @@ export function generateCmd(data: {
   automaticUpgradesTargetVersion: string;
   joinLabels?: ResourceLabel[];
   disableAppDiscovery?: boolean;
-}) {
+};
+
+export function generateCmd(data: generateCmdProps) {
   let extraYAMLConfig = '';
   let deployVersion = data.clusterVersion;
   let roles: JoinRole[] = ['Kube', 'App', 'Discovery'];

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -319,7 +319,7 @@ const StepTwo = ({
   );
 };
 
-export function GenerateCmd(data: {
+export function generateCmd(data: {
   namespace: string;
   clusterName: string;
   proxyAddr: string;
@@ -470,7 +470,7 @@ const InstallHelmChart = ({
     nextStep();
   }
 
-  const command = GenerateCmd({
+  const command = generateCmd({
     namespace,
     clusterName,
     proxyAddr: host,

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -319,7 +319,7 @@ const StepTwo = ({
   );
 };
 
-export type generateCmdProps = {
+export type GenerateCmdProps = {
   namespace: string;
   clusterName: string;
   proxyAddr: string;
@@ -334,7 +334,7 @@ export type generateCmdProps = {
   disableAppDiscovery?: boolean;
 };
 
-export function generateCmd(data: generateCmdProps) {
+export function generateCmd(data: GenerateCmdProps) {
   let extraYAMLConfig = '';
   let deployVersion = data.clusterVersion;
   let roles: JoinRole[] = ['Kube', 'App', 'Discovery'];

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -370,6 +370,7 @@ export function generateCmd(data: {
 
   const yamlRoles = roles.join(',').toLowerCase();
 
+  // whitespace in the beginning if a string is intentional, to correctly align in yaml.
   const joinLabelsText = data.joinLabels
     ? data.joinLabels.map(l => `    ${l.name}: ${l.value}`).join('\n')
     : '';

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -372,7 +372,7 @@ export function generateCmd(data: {
 
   // whitespace in the beginning if a string is intentional, to correctly align in yaml.
   const joinLabelsText = data.joinLabels
-    ? data.joinLabels.map(l => `    ${l.name}: ${l.value}`).join('\n')
+    ? '\n' + data.joinLabels.map(l => `    ${l.name}: ${l.value}`).join('\n')
     : '';
 
   return `cat << EOF > prod-cluster-values.yaml
@@ -381,8 +381,7 @@ authToken: ${data.tokenId}
 proxyAddr: ${data.proxyAddr}
 kubeClusterName: ${data.clusterName}
 labels:
-    teleport.internal/resource-id: ${data.resourceId}
-${joinLabelsText}
+    teleport.internal/resource-id: ${data.resourceId}${joinLabelsText}
 ${extraYAMLConfig}EOF
  
 helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --version ${deployVersion} \\

--- a/web/packages/teleport/src/Discover/Kubernetes/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/index.tsx
@@ -34,6 +34,17 @@ export const KubernetesResource: ResourceViewConfig = {
   wrapper: (component: React.ReactNode) => (
     <KubeWrapper>{component}</KubeWrapper>
   ),
+  shouldPrompt(currentStep, resourceSpec) {
+    if (resourceSpec?.kubeMeta?.location === KubeLocation.Aws) {
+      // Allow user to bypass prompting on this step (Connect AWS Account)
+      // on exit because users might need to change route to setup an
+      // integration.
+      if (currentStep === 0) {
+        return false;
+      }
+    }
+    return true;
+  },
   views(resource: ResourceSpec) {
     let configuredResourceViews = [
       {

--- a/web/packages/teleport/src/Discover/Kubernetes/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/index.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { AwsAccount, Finished, ResourceKind } from 'teleport/Discover/Shared';
 import { ResourceViewConfig } from 'teleport/Discover/flow';
 import { DiscoverEvent } from 'teleport/services/userEvent';
-import { ResourceSpec } from 'teleport/Discover/SelectResource';
+import { KubeLocation, ResourceSpec } from 'teleport/Discover/SelectResource';
 import { EnrollEksCluster } from 'teleport/Discover/Kubernetes/EnrollEKSCluster';
 
 import { KubeWrapper } from './KubeWrapper';
@@ -35,8 +35,15 @@ export const KubernetesResource: ResourceViewConfig = {
     <KubeWrapper>{component}</KubeWrapper>
   ),
   views(resource: ResourceSpec) {
-    if (resource.name === 'EKS') {
-      return [
+    let configuredResourceViews = [
+      {
+        title: 'Configure Resource',
+        component: HelmChart,
+        eventName: DiscoverEvent.DeployService,
+      },
+    ];
+    if (resource?.kubeMeta.location === KubeLocation.Aws) {
+      configuredResourceViews = [
         {
           title: 'Connect AWS Account',
           component: AwsAccount,
@@ -47,32 +54,11 @@ export const KubernetesResource: ResourceViewConfig = {
           component: EnrollEksCluster,
           eventName: DiscoverEvent.KubeEKSEnrollEvent,
         },
-        {
-          title: 'Set Up Access',
-          component: SetupAccess,
-          eventName: DiscoverEvent.PrincipalsConfigure,
-        },
-        {
-          title: 'Test Connection',
-          component: TestConnection,
-          eventName: DiscoverEvent.TestConnection,
-          manuallyEmitSuccessEvent: true,
-        },
-        {
-          title: 'Finished',
-          component: Finished,
-          hide: true,
-          eventName: DiscoverEvent.Completed,
-        },
       ];
     }
 
     return [
-      {
-        title: 'Configure Resource',
-        component: HelmChart,
-        eventName: DiscoverEvent.DeployService,
-      },
+      ...configuredResourceViews,
       {
         title: 'Set Up Access',
         component: SetupAccess,

--- a/web/packages/teleport/src/Discover/Kubernetes/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/index.tsx
@@ -42,7 +42,7 @@ export const KubernetesResource: ResourceViewConfig = {
         eventName: DiscoverEvent.DeployService,
       },
     ];
-    if (resource?.kubeMeta.location === KubeLocation.Aws) {
+    if (resource?.kubeMeta?.location === KubeLocation.Aws) {
       configuredResourceViews = [
         {
           title: 'Connect AWS Account',

--- a/web/packages/teleport/src/Discover/Kubernetes/index.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/index.tsx
@@ -18,9 +18,11 @@
 
 import React from 'react';
 
-import { Finished, ResourceKind } from 'teleport/Discover/Shared';
+import { AwsAccount, Finished, ResourceKind } from 'teleport/Discover/Shared';
 import { ResourceViewConfig } from 'teleport/Discover/flow';
 import { DiscoverEvent } from 'teleport/services/userEvent';
+import { ResourceSpec } from 'teleport/Discover/SelectResource';
+import { EnrollEksCluster } from 'teleport/Discover/Kubernetes/EnrollEKSCluster';
 
 import { KubeWrapper } from './KubeWrapper';
 import { SetupAccess } from './SetupAccess';
@@ -32,28 +34,62 @@ export const KubernetesResource: ResourceViewConfig = {
   wrapper: (component: React.ReactNode) => (
     <KubeWrapper>{component}</KubeWrapper>
   ),
-  views: [
-    {
-      title: 'Configure Resource',
-      component: HelmChart,
-      eventName: DiscoverEvent.DeployService,
-    },
-    {
-      title: 'Set Up Access',
-      component: SetupAccess,
-      eventName: DiscoverEvent.PrincipalsConfigure,
-    },
-    {
-      title: 'Test Connection',
-      component: TestConnection,
-      eventName: DiscoverEvent.TestConnection,
-      manuallyEmitSuccessEvent: true,
-    },
-    {
-      title: 'Finished',
-      component: Finished,
-      hide: true,
-      eventName: DiscoverEvent.Completed,
-    },
-  ],
+  views(resource: ResourceSpec) {
+    if (resource.name === 'EKS') {
+      return [
+        {
+          title: 'Connect AWS Account',
+          component: AwsAccount,
+          eventName: DiscoverEvent.IntegrationAWSOIDCConnectEvent,
+        },
+        {
+          title: 'Enroll EKS Clusters',
+          component: EnrollEksCluster,
+          eventName: DiscoverEvent.KubeEKSEnrollEvent,
+        },
+        {
+          title: 'Set Up Access',
+          component: SetupAccess,
+          eventName: DiscoverEvent.PrincipalsConfigure,
+        },
+        {
+          title: 'Test Connection',
+          component: TestConnection,
+          eventName: DiscoverEvent.TestConnection,
+          manuallyEmitSuccessEvent: true,
+        },
+        {
+          title: 'Finished',
+          component: Finished,
+          hide: true,
+          eventName: DiscoverEvent.Completed,
+        },
+      ];
+    }
+
+    return [
+      {
+        title: 'Configure Resource',
+        component: HelmChart,
+        eventName: DiscoverEvent.DeployService,
+      },
+      {
+        title: 'Set Up Access',
+        component: SetupAccess,
+        eventName: DiscoverEvent.PrincipalsConfigure,
+      },
+      {
+        title: 'Test Connection',
+        component: TestConnection,
+        eventName: DiscoverEvent.TestConnection,
+        manuallyEmitSuccessEvent: true,
+      },
+      {
+        title: 'Finished',
+        component: Finished,
+        hide: true,
+        eventName: DiscoverEvent.Completed,
+      },
+    ];
+  },
 };

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -1254,6 +1254,47 @@ exports[`render with all access 1`] = `
           class="c14"
         >
           <div
+            class="c15"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Amazon Web Services (AWS)
+          </div>
+          <div
+            class="c16"
+          >
+            EKS
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c7"
+      data-testid="3"
+    >
+      <div
+        class="c8"
+      >
+        Guided
+      </div>
+      <div
+        class="c9 c10"
+      >
+        <div
+          class="c11 c12"
+          width="24px"
+        >
+          <img
+            class="c13"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c14"
+        >
+          <div
             class="c16"
           >
             Kubernetes
@@ -3383,6 +3424,48 @@ exports[`render with no access 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="c7"
+      data-testid="3"
+    >
+      <div
+        class="c8 c9"
+        data-testid="tooltip"
+      >
+        Lacking Permissions
+      </div>
+      <div
+        class="c10 c11"
+      >
+        <div
+          class="c12 c13"
+          width="24px"
+        >
+          <img
+            class="c14"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c15"
+        >
+          <div
+            class="c16"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Amazon Web Services (AWS)
+          </div>
+          <div
+            class="c17"
+          >
+            EKS
+          </div>
+        </div>
+      </div>
+    </div>
     <a
       class="c18 c7"
       data-testid="1"
@@ -4973,6 +5056,47 @@ exports[`render with partial access 1`] = `
             class="c16"
           >
             EC2 Instance
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c7"
+      data-testid="3"
+    >
+      <div
+        class="c8"
+      >
+        Guided
+      </div>
+      <div
+        class="c9 c10"
+      >
+        <div
+          class="c11 c12"
+          width="24px"
+        >
+          <img
+            class="c13"
+            height="24px"
+            src="file_stub"
+            width="23.9px"
+          />
+        </div>
+        <div
+          class="c14"
+        >
+          <div
+            class="c15"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Amazon Web Services (AWS)
+          </div>
+          <div
+            class="c16"
+          >
+            EKS
           </div>
         </div>
       </div>

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -1295,6 +1295,13 @@ exports[`render with all access 1`] = `
           class="c14"
         >
           <div
+            class="c15"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Self-Hosted
+          </div>
+          <div
             class="c16"
           >
             Kubernetes
@@ -3678,6 +3685,13 @@ exports[`render with no access 1`] = `
           class="c15"
         >
           <div
+            class="c16"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Self-Hosted
+          </div>
+          <div
             class="c17"
           >
             Kubernetes
@@ -5127,6 +5141,13 @@ exports[`render with partial access 1`] = `
         <div
           class="c14"
         >
+          <div
+            class="c15"
+            color="text.slightlyMuted"
+            font-size="12px"
+          >
+            Self-Hosted
+          </div>
           <div
             class="c16"
           >

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -37,6 +37,7 @@ import {
 import { SAML_APPLICATIONS } from './resourcesE';
 
 const baseServerKeywords = 'server node';
+const awsKeywords = 'aws amazon ';
 export const SERVERS: ResourceSpec[] = [
   {
     name: 'Ubuntu 14.04+',
@@ -139,7 +140,7 @@ export const KUBERNETES: ResourceSpec[] = [
   {
     name: 'EKS',
     kind: ResourceKind.Kubernetes,
-    keywords: 'kubernetes cluster kubes eks',
+    keywords: awsKeywords + 'kubernetes cluster kubes eks',
     icon: 'Aws',
     event: DiscoverEventResource.Kubernetes,
   },

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -29,9 +29,10 @@ import {
   DATABASES_UNGUIDED_DOC,
 } from './databases';
 import {
-  ResourceSpec,
-  DatabaseLocation,
   DatabaseEngine,
+  DatabaseLocation,
+  KubeLocation,
+  ResourceSpec,
   ServerLocation,
 } from './types';
 import { SAML_APPLICATIONS } from './resourcesE';
@@ -143,6 +144,7 @@ export const KUBERNETES: ResourceSpec[] = [
     keywords: awsKeywords + 'kubernetes cluster kubes eks',
     icon: 'Aws',
     event: DiscoverEventResource.Kubernetes,
+    kubeMeta: { location: KubeLocation.Aws },
   },
 ];
 
@@ -189,7 +191,9 @@ export function getResourcePretitle(r: ResourceSpec) {
     case ResourceKind.Desktop:
       return 'Windows Desktop';
     case ResourceKind.Kubernetes:
-      return r.name === 'EKS' ? 'Amazon Web Services (AWS)' : '';
+      return r.kubeMeta?.location === KubeLocation.Aws
+        ? 'Amazon Web Services (AWS)'
+        : '';
     case ResourceKind.Server:
       if (r.nodeMeta?.location === ServerLocation.Aws) {
         return 'Amazon Web Services (AWS)';

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -20,6 +20,7 @@ import { Platform } from 'design/platform';
 
 import { DiscoverEventResource } from 'teleport/services/userEvent';
 import cfg from 'teleport/config';
+import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 
@@ -137,6 +138,7 @@ export const KUBERNETES: ResourceSpec[] = [
     keywords: 'kubernetes cluster kubes',
     icon: 'Kube',
     event: DiscoverEventResource.Kubernetes,
+    kubeMeta: { location: KubeLocation.SelfHosted },
   },
   {
     name: 'EKS',
@@ -191,9 +193,17 @@ export function getResourcePretitle(r: ResourceSpec) {
     case ResourceKind.Desktop:
       return 'Windows Desktop';
     case ResourceKind.Kubernetes:
-      return r.kubeMeta?.location === KubeLocation.Aws
-        ? 'Amazon Web Services (AWS)'
-        : '';
+      if (r.kubeMeta) {
+        switch (r.kubeMeta.location) {
+          case KubeLocation.Aws:
+            return 'Amazon Web Services (AWS)';
+          case KubeLocation.SelfHosted:
+            return 'Self-Hosted';
+          default:
+            assertUnreachable(r.kubeMeta.location);
+        }
+      }
+      break;
     case ResourceKind.Server:
       if (r.nodeMeta?.location === ServerLocation.Aws) {
         return 'Amazon Web Services (AWS)';

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -136,6 +136,13 @@ export const KUBERNETES: ResourceSpec[] = [
     icon: 'Kube',
     event: DiscoverEventResource.Kubernetes,
   },
+  {
+    name: 'EKS',
+    kind: ResourceKind.Kubernetes,
+    keywords: 'kubernetes cluster kubes eks',
+    icon: 'Aws',
+    event: DiscoverEventResource.Kubernetes,
+  },
 ];
 
 const BASE_RESOURCES: ResourceSpec[] = [
@@ -180,6 +187,8 @@ export function getResourcePretitle(r: ResourceSpec) {
       break;
     case ResourceKind.Desktop:
       return 'Windows Desktop';
+    case ResourceKind.Kubernetes:
+      return r.name === 'EKS' ? 'Amazon Web Services (AWS)' : '';
     case ResourceKind.Server:
       if (r.nodeMeta?.location === ServerLocation.Aws) {
         return 'Amazon Web Services (AWS)';

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -144,7 +144,7 @@ export const KUBERNETES: ResourceSpec[] = [
   {
     name: 'EKS',
     kind: ResourceKind.Kubernetes,
-    keywords: awsKeywords + 'kubernetes cluster kubes eks',
+    keywords: awsKeywords + 'kubernetes cluster kubes eks elastic service',
     icon: 'Aws',
     event: DiscoverEventResource.KubernetesEks,
     kubeMeta: { location: KubeLocation.Aws },

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -146,7 +146,7 @@ export const KUBERNETES: ResourceSpec[] = [
     kind: ResourceKind.Kubernetes,
     keywords: awsKeywords + 'kubernetes cluster kubes eks',
     icon: 'Aws',
-    event: DiscoverEventResource.Kubernetes,
+    event: DiscoverEventResource.KubernetesEks,
     kubeMeta: { location: KubeLocation.Aws },
   },
 ];

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -18,9 +18,10 @@
 
 import { Platform } from 'design/platform';
 
+import { assertUnreachable } from 'shared/utils/assertUnreachable';
+
 import { DiscoverEventResource } from 'teleport/services/userEvent';
 import cfg from 'teleport/config';
-import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -61,6 +61,7 @@ export enum ServerLocation {
 }
 
 export enum KubeLocation {
+  SelfHosted,
   Aws,
 }
 

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -60,9 +60,14 @@ export enum ServerLocation {
   Aws,
 }
 
+export enum KubeLocation {
+  Aws,
+}
+
 export interface ResourceSpec {
   dbMeta?: { location: DatabaseLocation; engine: DatabaseEngine };
   nodeMeta?: { location: ServerLocation };
+  kubeMeta?: { location: KubeLocation };
   name: string;
   popular?: boolean;
   kind: ResourceKind;

--- a/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
@@ -36,7 +36,7 @@ export const StatusCell = ({
 }) => {
   return (
     <Cell disabled={disabled} disabledText={disabledText}>
-      <Flex alignItems="center">
+      <Flex alignItems="baseline">
         <StatusLight status={status} />
         {statusText}
       </Flex>

--- a/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { DisableableCell } from './DisableableCell';
-export { Labels, labelMatcher } from './Labels';
-export { RadioCell } from './RadioCell';
-export { StatusCell } from './StatusCell';
+import { Flex } from 'design';
+import React from 'react';
+
+import { DisableableCell as Cell } from 'teleport/Discover/Shared';
+
+import { StatusLight, ItemStatus } from '../StatusLight';
+
+export const StatusCell = ({
+  status,
+  statusText,
+  disabled,
+  disabledText,
+}: {
+  status: ItemStatus;
+  statusText: string;
+  disabled: boolean;
+  disabledText: string;
+}) => {
+  return (
+    <Cell disabled={disabled} disabledText={disabledText}>
+      <Flex alignItems="center">
+        <StatusLight status={status} />
+        {statusText}
+      </Flex>
+    </Cell>
+  );
+};

--- a/web/packages/teleport/src/Discover/Shared/StatusLight.tsx
+++ b/web/packages/teleport/src/Discover/Shared/StatusLight.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { DisableableCell } from './DisableableCell';
-export { Labels, labelMatcher } from './Labels';
-export { RadioCell } from './RadioCell';
-export { StatusCell } from './StatusCell';
+import { Box } from 'design';
+import styled from 'styled-components';
+
+export enum ItemStatus {
+  Success,
+  Warning,
+  Error,
+}
+
+export const StatusLight = styled(Box)`
+  border-radius: 50%;
+  margin-right: 6px;
+  width: 8px;
+  height: 8px;
+  background-color: ${({ status, theme }) => {
+    if (status === ItemStatus.Success) {
+      return theme.colors.success.main;
+    }
+    if (status === ItemStatus.Error) {
+      return theme.colors.error.main;
+    }
+    if (status === ItemStatus.Warning) {
+      return theme.colors.warning;
+    }
+    return theme.colors.grey[300]; // Unknown
+  }};
+`;

--- a/web/packages/teleport/src/Discover/Shared/StatusLight.tsx
+++ b/web/packages/teleport/src/Discover/Shared/StatusLight.tsx
@@ -27,7 +27,7 @@ export enum ItemStatus {
 
 export const StatusLight = styled(Box)`
   border-radius: 50%;
-  margin-right: 6px;
+  margin-right: ${props => props.theme.space[2]}px;
   width: 8px;
   height: 8px;
   background-color: ${({ status, theme }) => {

--- a/web/packages/teleport/src/Discover/Shared/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/index.ts
@@ -35,7 +35,14 @@ export { StepBox } from './StepBox';
 export { SecurityGroupPicker } from './SecurityGroupPicker';
 export type { ViewRulesSelection } from './SecurityGroupPicker';
 export { AwsAccount } from './AwsAccount';
-export { DisableableCell, Labels, labelMatcher, RadioCell } from './Aws';
+export { StatusLight, ItemStatus } from './StatusLight';
+export {
+  DisableableCell,
+  Labels,
+  labelMatcher,
+  RadioCell,
+  StatusCell,
+} from './Aws';
 export { StyledBox } from './StyledBox';
 
 export type { DiscoverLabel } from './LabelsCreater';

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -523,6 +523,12 @@ export type KubeMeta = BaseMeta & {
   kube: Kube;
 };
 
-export type AgentMeta = DbMeta | NodeMeta | KubeMeta;
+// KubeMeta describes the fields for a kube resource
+// that needs to be preserved throughout the flow.
+export type EksMeta = BaseMeta & {
+  kube: Kube;
+};
+
+export type AgentMeta = DbMeta | NodeMeta | KubeMeta | EksMeta;
 
 export type State = ReturnType<typeof useDiscover>;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -289,6 +289,11 @@ const cfg = {
     awsSecurityGroupsListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/securitygroups',
 
+    eksClustersListPath:
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/eksclusters',
+    eksEnrollClustersPath:
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/enrolleksclusters',
+
     ec2InstancesListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/ec2',
     ec2InstanceConnectEndpointsListPath:
@@ -922,6 +927,24 @@ const cfg = {
 
   getAccessGraphFeaturesUrl() {
     return cfg.api.accessGraphFeatures;
+  },
+
+  getEnrollEksClusterUrl(integrationName: string): string {
+    const clusterId = cfg.proxyCluster;
+
+    return generatePath(cfg.api.eksEnrollClustersPath, {
+      clusterId,
+      name: integrationName,
+    });
+  },
+
+  getListEKSClustersUrl(integrationName: string): string {
+    const clusterId = cfg.proxyCluster;
+
+    return generatePath(cfg.api.eksClustersListPath, {
+      clusterId,
+      name: integrationName,
+    });
   },
 
   getListEc2InstancesUrl(integrationName: string) {

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -42,6 +42,10 @@ import {
   DeployEc2InstanceConnectEndpointRequest,
   DeployEc2InstanceConnectEndpointResponse,
   SecurityGroup,
+  ListEksClustersResponse,
+  EnrollEksClustersResponse,
+  EnrollEksClustersRequest,
+  ListEksClustersRequest,
   AwsOidcDeployDatabaseServicesRequest,
 } from './types';
 
@@ -155,6 +159,28 @@ export const integrationService = {
     return api
       .post(cfg.getAwsRdsDbsDeployServicesUrl(integrationName), req)
       .then(resp => resp.clusterDashboardUrl);
+  },
+
+  enrollEksClusters(
+    integrationName: string,
+    req: EnrollEksClustersRequest
+  ): Promise<EnrollEksClustersResponse> {
+    return api.post(cfg.getEnrollEksClusterUrl(integrationName), req);
+  },
+
+  fetchEksClusters(
+    integrationName: string,
+    req: ListEksClustersRequest
+  ): Promise<ListEksClustersResponse> {
+    return api
+      .post(cfg.getListEKSClustersUrl(integrationName), req)
+      .then(json => {
+        const eksClusters = json?.clusters ?? [];
+        return {
+          clusters: eksClusters,
+          nextToken: json?.nextToken,
+        };
+      });
   },
 
   // Returns a list of EC2 Instances using the ListEC2ICE action of the AWS OIDC Integration.

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -293,6 +293,46 @@ export type AwsOidcDeployDatabaseServicesRequest = {
   deployments: DeployDatabaseServiceDeployment[];
 };
 
+export type AwsEksCluster = {
+  name: string;
+  region: string;
+  accountId: string;
+  status:
+    | 'active'
+    | 'pending'
+    | 'creating'
+    | 'failed'
+    | 'updating'
+    | 'deleting';
+  // labels contains this cluster's tags.
+  labels: Label[];
+  // joinLabels contains labels that should be injected into teleport kube agent, if EKS cluster is being enrolled.
+  joinLabels: Label[];
+};
+
+export type EnrollEksClustersRequest = {
+  region: string;
+  enableAppDiscovery: boolean;
+  joinToken: string;
+  resourceId: string;
+  clusterNames: string[];
+};
+
+export type EnrollEksClustersResponse = {
+  results: { clusterName: string; error: { message: string } }[];
+};
+
+export type ListEksClustersRequest = {
+  region: Regions;
+  nextToken?: string;
+};
+
+export type ListEksClustersResponse = {
+  // clusters is the list of EKS clusters.
+  clusters: AwsEksCluster[];
+  nextToken?: string;
+};
+
 export type ListEc2InstancesRequest = {
   region: Regions;
   nextToken?: string;

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -304,7 +304,9 @@ export type AwsEksCluster = {
     | 'failed'
     | 'updating'
     | 'deleting';
-  // labels contains this cluster's tags.
+  /**
+   * labels contains this cluster's tags.
+   */
   labels: Label[];
   // joinLabels contains labels that should be injected into teleport kube agent, if EKS cluster is being enrolled.
   joinLabels: Label[];

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -323,7 +323,11 @@ export type EnrollEksClustersRequest = {
 };
 
 export type EnrollEksClustersResponse = {
-  results: { clusterName: string; error: { message: string } }[];
+  results: {
+    clusterName: string;
+    resourceId: string;
+    error: { message: string };
+  }[];
 };
 
 export type ListEksClustersRequest = {

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -308,7 +308,9 @@ export type AwsEksCluster = {
    * labels contains this cluster's tags.
    */
   labels: Label[];
-  // joinLabels contains labels that should be injected into teleport kube agent, if EKS cluster is being enrolled.
+  /**
+   * joinLabels contains labels that should be injected into teleport kube agent, if EKS cluster is being enrolled.
+   */
   joinLabels: Label[];
 };
 
@@ -330,7 +332,9 @@ export type ListEksClustersRequest = {
 };
 
 export type ListEksClustersResponse = {
-  // clusters is the list of EKS clusters.
+  /**
+   * clusters is the list of EKS clusters.
+   */
   clusters: AwsEksCluster[];
   nextToken?: string;
 };

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -295,7 +295,7 @@ export type AwsOidcDeployDatabaseServicesRequest = {
 
 export type AwsEksCluster = {
   name: string;
-  region: string;
+  region: Regions;
   accountId: string;
   status:
     | 'active'

--- a/web/packages/teleport/src/services/userEvent/types.ts
+++ b/web/packages/teleport/src/services/userEvent/types.ts
@@ -91,6 +91,7 @@ export enum DiscoverEvent {
   EC2InstanceSelection = 'tp.ui.discover.selectedEC2Instance',
   EC2DeployEICE = 'tp.ui.discover.deployEICE',
   CreateNode = 'tp.ui.discover.createNode',
+  KubeEKSEnrollEvent = 'tp.ui.discover.kube.enroll.eks',
   PrincipalsConfigure = 'tp.ui.discover.principals.configure',
   TestConnection = 'tp.ui.discover.testConnection',
   Completed = 'tp.ui.discover.completed',

--- a/web/packages/teleport/src/services/userEvent/types.ts
+++ b/web/packages/teleport/src/services/userEvent/types.ts
@@ -101,6 +101,7 @@ export enum DiscoverEvent {
 export enum DiscoverEventResource {
   Server = 'DISCOVER_RESOURCE_SERVER',
   Kubernetes = 'DISCOVER_RESOURCE_KUBERNETES',
+  KubernetesEks = 'DISCOVER_RESOURCE_KUBERNETES_EKS',
   DatabasePostgresSelfHosted = 'DISCOVER_RESOURCE_DATABASE_POSTGRES_SELF_HOSTED',
   DatabaseMysqlSelfHosted = 'DISCOVER_RESOURCE_DATABASE_MYSQL_SELF_HOSTED',
   DatabaseMongodbSelfHosted = 'DISCOVER_RESOURCE_DATABASE_MONGODB_SELF_HOSTED',


### PR DESCRIPTION
This PR Adds UI for enrolling AWS EKS clusters in Discover.

Demo of the UI in action: https://www.loom.com/share/2dda8fd5fe45456cbbf8199821c8c845

Backend counterpart: https://github.com/gravitational/teleport/pull/36594

Changelog: Add guided AWS EKS clusters enrolment to the Discover UI.