### PR TITLE
Explicitly close FIDO2 devices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -492,7 +492,7 @@ replace (
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.1
 	github.com/gravitational/teleport/api => ./api
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
-	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-0.20230728202351-0b44d4f35e28
+	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-0.20240115202727-b267d1ed4947
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3
 	// replace module github.com/moby/spdystream until https://github.com/moby/spdystream/pull/91 merges and deps are updated
 	// otherwise tests fail with a data race detection.

--- a/go.sum
+++ b/go.sum
@@ -765,8 +765,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gravitational/go-cassandra-native-protocol v0.0.0-20221005103706-b9e66c056e90 h1:fPNJE2kaWC0Oy2YKxk1tbnqhKl3aTeXVAfjXzphJmI8=
 github.com/gravitational/go-cassandra-native-protocol v0.0.0-20221005103706-b9e66c056e90/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
-github.com/gravitational/go-libfido2 v1.5.3-0.20230728202351-0b44d4f35e28 h1:SMIYLghy2DvLsIYeyfux5mkliM8CbljqsRfDZk8vNYE=
-github.com/gravitational/go-libfido2 v1.5.3-0.20230728202351-0b44d4f35e28/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
+github.com/gravitational/go-libfido2 v1.5.3-0.20240115202727-b267d1ed4947 h1:0clh0rAkUeDYNvJGgUWIRR5zSVdVBeSI05jQYFqqsMM=
+github.com/gravitational/go-libfido2 v1.5.3-0.20240115202727-b267d1ed4947/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3 h1:3JGTacvAeV5tIC4/9XsdLC2K5K7FWaXxIwpW4t+dGH0=
 github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3/go.mod h1:LbRWqr72fXehxAGLXO8nDNQAi4gthRz4j7f8L2LS0XM=
 github.com/gravitational/go-mysql v1.5.0-teleport.1 h1:EyFryeiTYyP6KslLVp0Q5QTKwtUG5RioVrTIoP4pOuI=

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -736,7 +736,7 @@ func withInteractiveError(filter deviceFilterFunc, cb pinAwareCallbackFunc) pinA
 				filterErr = ErrUsingNonRegisteredDevice
 			}
 		default:
-			log.Warnf("FIDO2: Device %v: unexpected wait error: %q", info.path, waitErr)
+			log.Warnf("FIDO2: Device %v: unexpected wait error: %v", info.path, waitErr)
 		}
 
 		return false, trace.Wrap(filterErr)
@@ -924,11 +924,11 @@ func selectDevice(
 
 	select {
 	case <-done:
-		log.Debugf("FIDO2: device %v: selected with err=%v", dev.info.path, err)
+		log.Debugf("FIDO2: Device %v: selected with err=%v", dev.info.path, err)
 	case <-ctx.Done():
-		log.Debugf("FIDO2: device %v: requesting cancel", dev.info.path)
+		log.Debugf("FIDO2: Device %v: requesting cancel", dev.info.path)
 		if err := dev.Cancel(); err != nil {
-			log.Debugf("FIDO2: device %v: cancel errored: %v", dev.info.path, err)
+			log.Debugf("FIDO2: Device %v: cancel errored: %v", dev.info.path, err)
 		}
 
 		// Give the device a grace period to cancel/cleanup, but do not wait

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -886,7 +886,7 @@ func findDevices(knownPaths map[string]struct{}) ([]*deviceWithInfo, error) {
 			case err != nil:
 				// Unexpected error, retry anyway.
 				// Note that U2F devices fail in a variety of different ways.
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(fido2RetryInterval)
 				continue
 			}
 			break // err == nil

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -577,7 +577,12 @@ func runOnFIDO2Devices(
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	closeDev := true
 	defer func() {
+		if !closeDev {
+			return
+		}
 		err := dev.Close()
 		log.Debugf("FIDO2: Close device %v: %v", dev.info.path, err)
 	}()
@@ -606,11 +611,15 @@ func runOnFIDO2Devices(
 		return trace.Wrap(err)
 	}
 
+	// Relinquish device ownership to the selectDevice call below.
+	// This is important because closing the device while the callback runs will
+	// cause a panic/segfault.
+	closeDev = false
+
 	// Run the callback again with the informed PIN.
 	// selectDevice is used since it correctly deals with cancellation.
 	cb = withoutPINHandler(withRetries(deviceCallback))
-	_, err = selectDevice(ctx, pin, dev, cb)
-	if err != nil {
+	if _, err = selectDevice(ctx, pin, dev, cb, true /* takeOwnership */); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -846,7 +855,7 @@ func findAndSelectDevice(ctx context.Context, filter deviceFilterFunc, deviceCal
 				dev := dev
 				selectGoroutines++
 				go func() {
-					requiresPIN, err := selectDevice(innerCtx, "" /* pin */, dev, cb)
+					requiresPIN, err := selectDevice(innerCtx, "" /* pin */, dev, cb, false /* takeOwnership */)
 					selectC <- selectResp{
 						dev:         dev,
 						requiresPIN: requiresPIN,
@@ -941,6 +950,7 @@ func findDevices(knownPaths map[string]struct{}) ([]*deviceWithInfo, error) {
 func selectDevice(
 	ctx context.Context,
 	pin string, dev *deviceWithInfo, cb pinAwareCallbackFunc,
+	takeOwnership bool,
 ) (requiresPIN bool, err error) {
 	// Spin a goroutine to run the callback so we can deal with context
 	// cancellation.
@@ -948,6 +958,11 @@ func selectDevice(
 	go func() {
 		requiresPIN, err = cb(dev, dev.info, pin)
 		close(done)
+
+		if takeOwnership {
+			closeErr := dev.Close()
+			log.Debugf("FIDO2: Close device %v: %v", dev.info.path, closeErr)
+		}
 	}()
 
 	select {

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -66,6 +66,9 @@ type FIDODevice interface {
 	// Close mirrors libfido2.Device.Close.
 	Close() error
 
+	// SetTimeout mirrors libfido2.Device.SetTimeout.
+	SetTimeout(time.Duration) error
+
 	// MakeCredential mirrors libfido2.Device.MakeCredential.
 	MakeCredential(
 		clientDataHash []byte,
@@ -907,6 +910,10 @@ func findDevices(knownPaths map[string]struct{}) ([]*deviceWithInfo, error) {
 		if err != nil {
 			return nil, trace.Wrap(err, "device %v: open", path)
 		}
+
+		// Set a timeout for assertions, credential creation, etc.
+		// Timed out methods fail with FIDO_ERR_RX.
+		dev.SetTimeout(fido2DeviceTimeout)
 
 		var info *libfido2.DeviceInfo
 		var u2f bool

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -35,6 +35,9 @@ var (
 	// FIDO2PollInterval is the poll interval used to check for new FIDO2 devices.
 	FIDO2PollInterval  = 5 * time.Second        // Poll less frequently than 2 Hz / 0.5 second.
 	fido2RetryInterval = 600 * time.Millisecond // Poll less frequently than 2 Hz / 0.5 second.
+
+	// Timeout for FIDO2 device communication.
+	fido2DeviceTimeout = 30 * time.Second
 )
 
 // FIDO2Login implements Login for CTAP1 and CTAP2 devices.

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -31,8 +31,11 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 )
 
-// FIDO2PollInterval is the poll interval used to check for new FIDO2 devices.
-var FIDO2PollInterval = 200 * time.Millisecond
+var (
+	// FIDO2PollInterval is the poll interval used to check for new FIDO2 devices.
+	FIDO2PollInterval  = 5 * time.Second        // Poll less frequently than 2 Hz / 0.5 second.
+	fido2RetryInterval = 600 * time.Millisecond // Poll less frequently than 2 Hz / 0.5 second.
+)
 
 // FIDO2Login implements Login for CTAP1 and CTAP2 devices.
 // It must be called with a context with timeout, otherwise it can run

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -189,7 +189,7 @@ func TestIsFIDO2Available(t *testing.T) {
 
 func TestFIDO2Login(t *testing.T) {
 	resetFIDO2AfterTests(t)
-	wancli.FIDO2PollInterval = 1 * time.Millisecond // run fast on tests
+	wancli.FIDO2PollInterval = 1 * time.Millisecond // Run fast on tests
 
 	const rpID = "example.com"
 	const appID = "https://example.com"
@@ -832,6 +832,7 @@ func (cp *countingPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
 
 func TestFIDO2Login_PromptTouch(t *testing.T) {
 	resetFIDO2AfterTests(t)
+	wancli.FIDO2PollInterval = 1 * time.Millisecond // Run fast on tests.
 
 	const rpID = "example.com"
 	const origin = "https://example.com"
@@ -1405,6 +1406,7 @@ func TestFIDO2_LoginRegister_interactionErrors(t *testing.T) {
 
 func TestFIDO2Register(t *testing.T) {
 	resetFIDO2AfterTests(t)
+	wancli.FIDO2PollInterval = 1 * time.Millisecond // Run fast on tests.
 
 	const rpID = "example.com"
 	const origin = "https://example.com"

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -2066,6 +2066,10 @@ func (f *fakeFIDO2Device) Close() error {
 	return nil
 }
 
+func (f *fakeFIDO2Device) SetTimeout(time.Duration) error {
+	return nil
+}
+
 func (f *fakeFIDO2Device) PromptPIN() (string, error) {
 	return f.pin, nil
 }

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -2060,6 +2060,10 @@ func newFIDO2Device(path, pin string, info *libfido2.DeviceInfo, creds ...*libfi
 	}, nil
 }
 
+func (f *fakeFIDO2Device) Close() error {
+	return nil
+}
+
 func (f *fakeFIDO2Device) PromptPIN() (string, error) {
 	return f.pin, nil
 }


### PR DESCRIPTION
Keep FIDO2 devices open for the duration of the interactions and explicitly close them at the end.

Requires https://github.com/gravitational/go-libfido2/pull/15.

#36640

Changelog: Improve speed and reliability of FIDO2 devices