### PR TITLE
[v13] Set cloud version to 13

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1880,8 +1880,8 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "14.3.0",
-      "major_version": "14",
+      "version": "13.4.14",
+      "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",
         "monthly_downtime": "44 minutes"


### PR DESCRIPTION
Teleport Cloud is no longer pinned to a single universal version for auto upgrades. The v13 docs should recommend using a v13 version of Teleport with Teleport Cloud.