### PR TITLE
Add `server_info` to editor role

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -171,6 +171,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindSecurityReport, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAuditQuery, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAccessGraph, RW()),
+					types.NewRule(types.KindServerInfo, RW()),
 				},
 			},
 		},


### PR DESCRIPTION
This change adds permissions to edit the `server_info` resource to the built-in editor role.

Changelog: Added `server_info` to editor role