### PR TITLE
[docs] select db roles support for auto-provisioned db

### DIFF
--- a/docs/pages/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/database-access/auto-user-provisioning/mongodb.mdx
@@ -116,7 +116,7 @@ Users created within the database will:
 
 ## Step 3/3. Connect to the database
 
-(!docs/pages/includes/database-access/auto-user-provisioning/connect.mdx gui="MongoDB Compass"!)
+(!docs/pages/includes/database-access/auto-user-provisioning/connect.mdx gui="MongoDB Compass" selectRoles="myCustomRole@db2"!)
 
 ## Next steps
 - Learn more about MongoDB [built-in roles](https://www.mongodb.com/docs/manual/reference/built-in-roles/) and [User-Defined Roles](https://www.mongodb.com/docs/manual/core/security-user-defined-roles/).

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -297,6 +297,7 @@ $ tsh db login --db-user=postgres --db-name=postgres example
 | - | - |
 | `--db-user` | The database user to log in as. |
 | `--db-name` | The database name to log in to. |
+| `--db-roles` | Comma-separated list of database roles to use for auto-provisioned user. If not provided, all database roles will be assigned. |
 
 (!docs/pages/includes/db-user-name-flags.mdx!)
 
@@ -320,6 +321,8 @@ $ tsh db connect
 $ tsh db connect example
 # Provide database user and name to connect to.
 $ tsh db connect --db-user=alice --db-name=db example
+# Select a subset of allowed database roles.
+$ tsh db connect --db-user=alice --db-name=db --db-roles reader example
 ```
 
 <Admonition type="note" title="Note">
@@ -331,6 +334,7 @@ $ tsh db connect --db-user=alice --db-name=db example
 | - | - |
 | `--db-user` | The database user to log in as. |
 | `--db-name` | The database name to log in to. |
+| `--db-roles` | Comma-separated list of database roles to use for auto-provisioned user. If not provided, all database roles will be assigned. |
 
 (!docs/pages/includes/db-user-name-flags.mdx!)
 

--- a/docs/pages/includes/database-access/auto-user-provisioning/connect.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/connect.mdx
@@ -1,3 +1,5 @@
+{{ selectRoles="reader" }}
+
 Now, log into your Teleport cluster and connect to the database:
 
 ```code
@@ -13,4 +15,18 @@ If using a GUI database client like {{gui}}, make sure to use your Teleport
 username as the database username. `tsh db connect` will default to your
 Teleport username automatically when connecting to a database with user
 provisioning enabled.
+
+When connecting to a leaf cluster database with user provisioning enabled, the
+Database Service expects the database username to be
+`remote-<your-teleport-username>-<root-cluster-name>`.
 </Admonition>
+
+
+To view the list of database roles that are allowed for each database, you can
+use the command `tsh db ls -v`. By default, all database roles will be assigned
+to your auto-provisioned database user. You can optionally select a subset of
+the database roles with `--db-roles`:
+
+```code
+$ tsh db connect --db-name <database> --db-roles {{ selectRoles }} example
+```


### PR DESCRIPTION
Related issue:
- https://github.com/gravitational/teleport/pull/35582
- https://github.com/gravitational/teleport/pull/35867

In addition to the "select db role" support, also made a small update on:
- https://github.com/gravitational/teleport/issues/35901
(This still needs more code changes to fix properly. But I decided to take this opportunity to fix the docs first since the docs update does not depend on the upcoming fix. It's good to clarify on the docs.)