### PR TITLE
Stop populating the http reverse proxy ErrorLog

### DIFF
--- a/lib/httplib/reverseproxy/reverse_proxy.go
+++ b/lib/httplib/reverseproxy/reverse_proxy.go
@@ -19,8 +19,6 @@
 package reverseproxy
 
 import (
-	"io"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -63,7 +61,7 @@ type Forwarder struct {
 	passHostHeader bool
 	headerRewriter Rewriter
 	*httputil.ReverseProxy
-	log       utils.FieldLoggerWithWriter
+	log       logrus.FieldLogger
 	transport http.RoundTripper
 }
 
@@ -121,22 +119,9 @@ func WithFlushInterval(interval time.Duration) Option {
 
 // WithLogger sets the logger for the forwarder. It uses the logger.Writer()
 // method to get the io.Writer to use for the stdlib logger.
-func WithLogger(logger utils.FieldLoggerWithWriter) Option {
+func WithLogger(logger logrus.FieldLogger) Option {
 	return func(rp *Forwarder) {
 		rp.log = logger
-		// TODO: this is a hack to get the stdlib logger to work with the
-		// logrus logger.
-		if rp.ReverseProxy.ErrorLog == nil {
-			rp.ReverseProxy.ErrorLog = log.New(logger.WriterLevel(logrus.DebugLevel), "", log.LstdFlags)
-		}
-	}
-}
-
-// WithLogWriter sets the writer for the stdlib logger to use a different
-// io.Writer than the default one created when using WithLogger.
-func WithLogWriter(w *io.PipeWriter) Option {
-	return func(rp *Forwarder) {
-		rp.ReverseProxy.ErrorLog = log.New(w, "", log.LstdFlags)
 	}
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -150,7 +150,7 @@ type ForwarderConfig struct {
 	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
 	PROXYSigner multiplexer.PROXYHeaderSigner
 	// log is the logger function
-	log utils.FieldLoggerWithWriter
+	log logrus.FieldLogger
 	// TracerProvider is used to create tracers capable
 	// of starting spans.
 	TracerProvider oteltrace.TracerProvider
@@ -328,7 +328,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 // however some requests like exec sessions it intercepts and records.
 type Forwarder struct {
 	mu     sync.Mutex
-	log    utils.FieldLoggerWithWriter
+	log    logrus.FieldLogger
 	router http.Handler
 	cfg    ForwarderConfig
 	// activeRequests is a map used to serialize active CSR requests to the auth server

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -54,7 +54,7 @@ type signerHandler struct {
 // SignerHandlerConfig is the awsSignerHandler configuration.
 type SignerHandlerConfig struct {
 	// Log is a logger for the handler.
-	Log utils.FieldLoggerWithWriter
+	Log logrus.FieldLogger
 	// RoundTripper is an http.RoundTripper instance used for requests.
 	RoundTripper http.RoundTripper
 	// SigningService is used to sign requests before forwarding them.
@@ -99,7 +99,7 @@ func NewAWSSignerHandler(ctx context.Context, config SignerHandlerConfig) (http.
 	handler.fwd, err = reverseproxy.New(
 		reverseproxy.WithRoundTripper(config.RoundTripper),
 		reverseproxy.WithLogger(config.Log),
-		reverseproxy.WithErrorHandler(reverseproxy.ErrorHandlerFunc(handler.formatForwardResponseError)),
+		reverseproxy.WithErrorHandler(handler.formatForwardResponseError),
 	)
 
 	return handler, trace.Wrap(err)

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -49,7 +49,7 @@ type HandlerConfig struct {
 	// RoundTripper is the underlying transport given to an oxy Forwarder.
 	RoundTripper http.RoundTripper
 	// Log is the Logger.
-	Log utils.FieldLoggerWithWriter
+	Log logrus.FieldLogger
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
 

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -68,7 +68,7 @@ type HandlerConfig struct {
 	// RoundTripper is the underlying transport given to an oxy Forwarder.
 	RoundTripper http.RoundTripper
 	// Log is the Logger.
-	Log utils.FieldLoggerWithWriter
+	Log logrus.FieldLogger
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
 	// cloudClientGCP holds a reference to GCP IAM client. Normally set in CheckAndSetDefaults, it is overridden in tests.

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -202,14 +202,6 @@ type Logger interface {
 	SetLevel(level logrus.Level)
 }
 
-// FieldLoggerWithWriter describes a logger that can expose a writer
-// to be used by stdlib loggers.
-type FieldLoggerWithWriter interface {
-	logrus.FieldLogger
-	Writer() *io.PipeWriter
-	WriterLevel(logrus.Level) *io.PipeWriter
-}
-
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging
 // information, sends it to the logger, strips it off and prints a clean message to stderr
 func FatalError(err error) {


### PR DESCRIPTION
When creating a reverse proxy the ErrorLog was being created with the writer returned from logrus.WriterLevel. This writer uses an io.Pipe and a goroutine to get any log messages written from a standard log.Logger to our custom formatted logrus.Entry. The ErrorLog only ever omits output in a few very rare (hopefully) error cases, which means we were creating an extra goroutine per reverse proxy which in most cases would never be used to produce any added output. Additionally, now that we are starting to support log/slog, any output from a log.Logger will now be formatted via our registered default slog handler. Meaning that we can still get the benefits of producing output from the ErrorLog in the desired format without the penalty incurred by using logrus.WriterLevel.

Partially addresses #36541.