### PR TITLE
fix missing `tctl create` feedback messages

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -839,7 +839,11 @@ func (rc *ResourceCommand) createToken(ctx context.Context, client auth.ClientI,
 	}
 
 	err = client.UpsertToken(ctx, token)
-	return trace.Wrap(err)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("provision_token %q has been created\n", token.GetName())
+	return nil
 }
 
 func (rc *ResourceCommand) createInstaller(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
@@ -849,7 +853,11 @@ func (rc *ResourceCommand) createInstaller(ctx context.Context, client auth.Clie
 	}
 
 	err = client.SetInstaller(ctx, inst)
-	return trace.Wrap(err)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("installer %q has been set\n", inst.GetName())
+	return nil
 }
 
 func (rc *ResourceCommand) createUIConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
@@ -857,8 +865,13 @@ func (rc *ResourceCommand) createUIConfig(ctx context.Context, client auth.Clien
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	err = client.SetUIConfig(ctx, uic)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("ui_config %q has been set\n", uic.GetName())
+	return nil
 
-	return trace.Wrap(client.SetUIConfig(ctx, uic))
 }
 
 func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
@@ -882,7 +895,11 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, 
 	}
 
 	_, err = client.UpsertNode(ctx, server)
-	return trace.Wrap(err)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("node %q has been %s\n", name, UpsertVerb(exists, rc.IsForced()))
+	return nil
 }
 
 func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
@@ -980,16 +997,25 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client auth.Clie
 	}
 
 	loginRuleClient := client.LoginRuleClient()
-	if rc.IsForced() {
+	switch rc.IsForced() {
+	case true:
 		_, err := loginRuleClient.UpsertLoginRule(ctx, &loginrulepb.UpsertLoginRuleRequest{
 			LoginRule: rule,
 		})
-		return trail.FromGRPC(err)
+		if err != nil {
+			return trail.FromGRPC(err)
+		}
+	case false:
+		_, err = loginRuleClient.CreateLoginRule(ctx, &loginrulepb.CreateLoginRuleRequest{
+			LoginRule: rule,
+		})
+		if err != nil {
+			return trail.FromGRPC(err)
+		}
 	}
-	_, err = loginRuleClient.CreateLoginRule(ctx, &loginrulepb.CreateLoginRuleRequest{
-		LoginRule: rule,
-	})
-	return trail.FromGRPC(err)
+	verb := UpsertVerb(false /* we don't know if it existed before */, rc.IsForced() /* force update*/)
+	fmt.Printf("login_rule %q has been %s\n", rule.GetMetadata().GetName(), verb)
+	return nil
 }
 
 func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -997,15 +997,14 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client auth.Clie
 	}
 
 	loginRuleClient := client.LoginRuleClient()
-	switch rc.IsForced() {
-	case true:
+	if rc.IsForced() {
 		_, err := loginRuleClient.UpsertLoginRule(ctx, &loginrulepb.UpsertLoginRuleRequest{
 			LoginRule: rule,
 		})
 		if err != nil {
 			return trail.FromGRPC(err)
 		}
-	case false:
+	} else {
 		_, err = loginRuleClient.CreateLoginRule(ctx, &loginrulepb.CreateLoginRuleRequest{
 			LoginRule: rule,
 		})
@@ -1013,7 +1012,7 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client auth.Clie
 			return trail.FromGRPC(err)
 		}
 	}
-	verb := UpsertVerb(false /* we don't know if it existed before */, rc.IsForced() /* force update*/)
+	verb := UpsertVerb(false /* we don't know if it existed before */, rc.IsForced() /* force update */)
 	fmt.Printf("login_rule %q has been %s\n", rule.GetMetadata().GetName(), verb)
 	return nil
 }


### PR DESCRIPTION
changelog: add missing create/update messages for some `tctl create` commands

This PR only does backward compatible changes in `tctl create`: adding messages without changing the calls made to the backend. Because of this, some messages might be inaccurate, but at least there's some message.

However there are A LOT of inconsistencies in tctl (some potentially dangerous) that would require a breaking change, or at least additional API calls:
- for some resources we don't check if `-f` before force-updating (e.g. tokens).
- for some resources we don't check if the resource already exists, so we cannot accurately say if the resource was created or updated if `-f` is set (e.g. login rules) in the output.
- for most resource checking if `exists`, we have a race condition if the resource is created between the existence check and the creation (e.g. users).
- this race condition combined with the upsert method can lead to overwriting resources even if `-f` is not set (e.g. locks).

I think the only sane implementation that still accurately displays "created/updated" is the `kubernetes_cluster`, so congrats @tigrato  :sweat_smile: 

We might want to leverage generics or a standard interface for resource creation/update instead of doing X different implementations.

Fixes https://github.com/gravitational/teleport/issues/24733