### PR TITLE
fix updating and upserting users with broken roles or password/mfa

### DIFF
--- a/lib/auth/users/usersv1/okta_test.go
+++ b/lib/auth/users/usersv1/okta_test.go
@@ -328,7 +328,10 @@ func TestOktaCRUD(t *testing.T) {
 
 			// When I modify the local copy of the user record and try - as a
 			// non-okta service - to update the backend record...
-			user.AddRole(teleport.PresetAccessRoleName)
+			traits := map[string][]string{
+				"foo": {"bar"},
+			}
+			user.SetTraits(traits)
 			_, err = env.UpsertUser(adminCtx,
 				&userspb.UpsertUserRequest{User: user.(*types.UserV2)})
 

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -385,6 +385,12 @@ func TestUpdateUser(t *testing.T) {
 	createEvent, ok = event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
 	assert.Equal(t, "alice", createEvent.UserMetadata.User)
+
+	// Attempt to update an existing user and set invalid roles
+	updated.User.AddRole("does-not-exist")
+	_, err = env.UpdateUser(ctx, &userspb.UpdateUserRequest{User: updated.User})
+	assert.True(t, trace.IsNotFound(err), "expected a not found error, got %T", err)
+	require.Error(t, err, "user allowed to be updated with a role that does not exist")
 }
 
 func TestUpsertUser(t *testing.T) {
@@ -427,6 +433,12 @@ func TestUpsertUser(t *testing.T) {
 	createEvent, ok = event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
 	assert.Equal(t, "alice", createEvent.UserMetadata.User)
+
+	// Attempt to upsert a  user and set invalid roles
+	updated.User.AddRole("does-not-exist")
+	_, err = env.UpsertUser(ctx, &userspb.UpsertUserRequest{User: updated.User})
+	assert.True(t, trace.IsNotFound(err), "expected a not found error, got %T", err)
+	require.Error(t, err, "user allowed to be upserted with a role that does not exist")
 }
 
 func TestListUsers(t *testing.T) {


### PR DESCRIPTION
changelog: fixes a bug that allowed users to be updated/upserted with non-existing roles

Teleport is supposed to block you from having a user with a missing role (as it poses security issues, and blocks the user from logging in). But after each refactoring we keep allowing it again.