### PR TITLE
[v14] Add `server_info` to editor role

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -167,6 +167,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindSecurityReport, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAuditQuery, append(RW(), types.VerbUse)),
 					types.NewRule(types.KindAccessGraph, RW()),
+					types.NewRule(types.KindServerInfo, RW()),
 				},
 			},
 		},


### PR DESCRIPTION
Backport #36642 to branch/v14

changelog: Added `server_info` to editor role
