### PR TITLE
[v14] Prevent ConnectionMonitor leaks

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -720,7 +720,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 		return nil, trace.Wrap(err)
 	}
 
-	ctx = authz.ContextWithUser(s.closeContext, user)
+	ctx = authz.ContextWithUser(ctx, user)
 	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
 	authCtx, _, err := s.authorizeContext(ctx)
 
@@ -748,12 +748,15 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	// differently than HTTP requests from web apps.
 	if app.IsTCP() {
 		identity := authCtx.Identity.GetIdentity()
-		return nil, s.handleTCPApp(ctx, tlsConn, &identity, app)
+		defer cancel(nil)
+		return nil, trace.Wrap(s.handleTCPApp(ctx, tlsConn, &identity, app))
 	}
 
-	return func() {
+	cleanup := func() {
+		cancel(nil)
 		s.deleteConnAuth(tlsConn)
-	}, s.handleHTTPApp(ctx, tlsConn)
+	}
+	return cleanup, trace.Wrap(s.handleHTTPApp(ctx, tlsConn))
 }
 
 // handleTCPApp handles connection for a TCP application.

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -405,7 +405,6 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 			lockWatchDoneC = nil
 
 		case <-w.Context.Done():
-			w.Entry.Debugf("Releasing associated resources - context has been closed.")
 			return
 		}
 	}


### PR DESCRIPTION
Backport #36621 to branch/v14

changelog: Prevent a goroutine leak caused by app sessions not cleaning up resources properly
