### PR TITLE
[v13] Prevent ConnectionMonitor leaks

### DIFF
--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -394,7 +394,6 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 			lockWatchDoneC = nil
 
 		case <-w.Context.Done():
-			w.Entry.Debugf("Releasing associated resources - context has been closed.")
 			return
 		}
 	}


### PR DESCRIPTION
Backport #36621 to branch/v13

changelog: Prevent a goroutine leak caused by app sessions not cleaning up resources properly
