### PR TITLE
Restore icons in navigation

### DIFF
--- a/web/packages/teleport/src/Navigation/NavigationItem.test.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationItem.test.tsx
@@ -17,9 +17,10 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
 
 import { render, screen } from 'design/utils/testing';
+
+import { Server } from 'design/Icon';
 
 import { generatePath, Router } from 'react-router';
 
@@ -53,7 +54,7 @@ class MockUserFeature implements TeleportFeature {
 
   navigationItem = {
     title: NavTitle.Users,
-    icon: styled.div,
+    icon: Server,
     exact: true,
     getLink(clusterId: string) {
       return generatePath('/web/cluster/:clusterId/feature', { clusterId });
@@ -77,7 +78,7 @@ class MockAccessListFeature implements TeleportFeature {
 
   navigationItem = {
     title: NavTitle.AccessLists,
-    icon: styled.div,
+    icon: Server,
     exact: true,
     getLink(clusterId: string) {
       return generatePath('/web/cluster/:clusterId/feature', { clusterId });

--- a/web/packages/teleport/src/Navigation/utils.tsx
+++ b/web/packages/teleport/src/Navigation/utils.tsx
@@ -29,9 +29,9 @@ import type { TeleportFeature } from 'teleport/types';
 export function getIcon(feature: TeleportFeature, size: NavigationItemSize) {
   switch (size) {
     case NavigationItemSize.Large:
-      return <Icon>{feature.navigationItem.icon}</Icon>;
+      return <Icon>{<feature.navigationItem.icon />}</Icon>;
 
     case NavigationItemSize.Small:
-      return <SmallIcon>{feature.navigationItem.icon}</SmallIcon>;
+      return <SmallIcon>{<feature.navigationItem.icon />}</SmallIcon>;
   }
 }


### PR DESCRIPTION
During the topbar upgrade, the icons were accidentally not rendered in the access management navigation menu
<img width="517" alt="Screenshot 2024-01-13 at 1 46 40 PM" src="https://github.com/gravitational/teleport/assets/5201977/96809ded-ac23-41f6-9888-7253daf74381">

This PR returns them
<img width="278" alt="Screenshot 2024-01-13 at 1 46 50 PM" src="https://github.com/gravitational/teleport/assets/5201977/93df2b62-a723-44e3-82a9-94236e0f726b">
