### PR TITLE
Remove unused Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,6 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
 ]
 
 [[package]]
@@ -399,16 +398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,15 +426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -524,12 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-
-[[package]]
 name = "delog"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +534,6 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -722,15 +695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,16 +715,6 @@ name = "flagset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1191,10 +1145,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 name = "ironrdp"
 version = "0.1.0"
 dependencies = [
- "byteorder",
- "bytes",
  "console_error_panic_hook",
- "console_log",
  "getrandom",
  "ironrdp-graphics",
  "ironrdp-pdu",
@@ -1206,7 +1157,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-web",
  "wasm-bindgen",
- "wasm-logger",
  "web-sys",
 ]
 
@@ -1513,7 +1463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -1644,15 +1593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs",
 ]
 
 [[package]]
@@ -1922,19 +1862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
-name = "png"
-version = "0.17.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,12 +1966,8 @@ dependencies = [
  "ironrdp-tokio",
  "iso7816",
  "iso7816-tlv",
- "libc",
  "log",
- "num-derive",
- "num-traits",
  "parking_lot 0.12.1",
- "png",
  "rand",
  "rand_chacha",
  "rsa",
@@ -2055,7 +1978,6 @@ dependencies = [
  "tokio-boring",
  "utf16string",
  "uuid",
- "x509-parser",
 ]
 
 [[package]]
@@ -2467,12 +2389,6 @@ dependencies = [
  "digest",
  "rand_core",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -3153,17 +3069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
-name = "wasm-logger"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,23 +3322,6 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror",
- "time",
 ]
 
 [[package]]

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -25,12 +25,8 @@ ironrdp-tls.workspace = true
 ironrdp-tokio.workspace = true
 iso7816 = "0.1.2"
 iso7816-tlv = "0.4.3"
-libc = "0.2.151"
 log = "0.4.20"
-num-derive = "0.4.1"
-num-traits = "0.2.17"
 parking_lot = "0.12.1"
-png = "0.17.10"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_chacha = "0.3.1"
 rsa = "0.9.6"
@@ -40,7 +36,6 @@ tokio = { version = "1.35", features = ["full"] }
 tokio-boring = { version = "4.3.0", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.6.1", features = ["v4"] }
-x509-parser = "0.15"
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -11,10 +11,7 @@ publish.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-byteorder = "1.5.0"
-bytes = "1.4.0"
 console_error_panic_hook = "0.1.7"
-console_log = "1.0.0"
 getrandom = { version = "0.2", features = ["js"] }
 ironrdp-session.workspace = true
 ironrdp-pdu.workspace = true
@@ -26,5 +23,4 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["time"] }
 tracing-web = "0.1.2"
 wasm-bindgen = "0.2.84"
-wasm-logger = "0.2.0"
 web-sys = { version = "0.3.61", features = ["ImageData"] }

--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -61,7 +61,7 @@ pub fn init_wasm_log(log_level: &str) {
             .with(level_filter)
             .init();
 
-        debug!("IronRDP wasm log is ready");
+        debug!("WASM log is ready");
         // TODO(isaiah): is it possible to set up logging for IronRDP trace logs like so: https://github.com/Devolutions/IronRDP/blob/c71ada5783fee13eea512d5d3d8ac79606716dc5/crates/ironrdp-client/src/main.rs#L47-L78
     }
 }


### PR DESCRIPTION
Some of these were never used, others are no longer used since we dropped rdp-rs.