### PR TITLE
Bring back the new account settings UI

### DIFF
--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -51,7 +51,7 @@ import type { FeatureFlags, TeleportFeature } from './types';
 const Audit = lazy(() => import('./Audit'));
 const Sessions = lazy(() => import('./Sessions'));
 const UnifiedResources = lazy(() => import('./UnifiedResources'));
-const Account = lazy(() => import('./Account'));
+const Account = lazy(() => import('./Account/AccountNew'));
 const Support = lazy(() => import('./Support'));
 const Clusters = lazy(() => import('./Clusters'));
 const Nodes = lazy(() => import('./Nodes'));


### PR DESCRIPTION
This UI was accidentally brought back to the old version in https://github.com/gravitational/teleport/pull/36532.