### PR TITLE
Set up tsh daemon client in main process of Electron app

### DIFF
--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -40,30 +40,49 @@ const (
 	// rendererCertFileName is the file name of the cert created by the renderer process of the
 	// Electron app.
 	rendererCertFileName = "renderer.crt"
+	// mainProcessCertFileName is the file name of the cert created by the main process of the
+	// Electron app.
+	mainProcessCertFileName = "main-process.crt"
 )
 
-// createServerCredentials creates mTLS credentials for a gRPC server. The client cert file is read
-// only on an incoming connection, not upfront. The way Connect startup is set up guarantees that by
-// the time the client reaches out to us, its public key is saved to the file under clientCertPath.
-func createServerCredentials(serverKeyPair tls.Certificate, clientCertPath string) (grpc.ServerOption, error) {
+// createServerCredentials creates mTLS credentials for a gRPC server. This mTLS setup hinges on
+// server and client processes being able to read and write files to a directory that only the
+// current user is able to write to. It's meant a simple replacement for using Unix sockets in
+// environments like Windows where we can't use them.
+//
+// In this mTLS setup, there is no single CA which creates certs for clients. Instead, each client
+// generates a self-signed cert that it's going to use to initiate a connection. The cert is then
+// saved under a predetermined path. The path is passed out of bound during tsh daemon startup.
+//
+// createServerCredentials then reads each cert and adds it to ClientCAs. Those certs will be then
+// used by clients to initiate connections.
+//
+// The startup of Connect is orchestrated in a way where those client public keys are expected to be saved
+// to disk before a client attempts to connect to the server.
+func createServerCredentials(serverKeyPair tls.Certificate, clientCertPaths []string) (grpc.ServerOption, error) {
 	config := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{serverKeyPair},
 	}
 
 	config.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-		clientCert, err := os.ReadFile(clientCertPath)
-		if err != nil {
-			log.WithError(err).Error("Failed to read the client cert file")
-			// Fall back to the default config.
-			return nil, nil
-		}
-
 		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(clientCert) {
-			log.Error("Failed to add the client cert to the pool")
-			// Fall back to the default config.
-			return nil, nil
+
+		for _, clientCertPath := range clientCertPaths {
+			log := log.WithField("cert_path", clientCertPath)
+
+			clientCert, err := os.ReadFile(clientCertPath)
+			if err != nil {
+				log.WithError(err).Error("Failed to read the client cert file")
+				// Fall back to the default config.
+				return nil, nil
+			}
+
+			if !certPool.AppendCertsFromPEM(clientCert) {
+				log.Error("Failed to add the client cert to the pool")
+				// Fall back to the default config.
+				return nil, nil
+			}
 		}
 
 		configClone := config.Clone()

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -212,9 +212,14 @@ func dialTCP(t *testing.T, addr utils.NetAddr, certsDir string, createClientTLSC
 func createValidClientTLSConfig(t *testing.T, certsDir string) *tls.Config {
 	// Hardcoded filenames under which Connect expects certs. In this test suite, we're trying to
 	// reach the tsh gRPC server, so we need to use the renderer cert as the client cert.
+	// The main process cert is created as well as the gRPC server is configured to expect both.
 	clientCertPath := filepath.Join(certsDir, rendererCertFileName)
+	mainProcessCertPath := filepath.Join(certsDir, mainProcessCertFileName)
 	serverCertPath := filepath.Join(certsDir, tshdCertFileName)
+
 	clientCert, err := generateAndSaveCert(clientCertPath, x509.ExtKeyUsageClientAuth)
+	require.NoError(t, err)
+	_, err = generateAndSaveCert(mainProcessCertPath, x509.ExtKeyUsageClientAuth)
 	require.NoError(t, err)
 
 	tlsConfig, err := createClientTLSConfig(clientCert, serverCertPath)

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -120,7 +120,7 @@ export default class MainProcess {
 
   static create(opts: Options) {
     const instance = new MainProcess(opts);
-    instance._init();
+    instance.init();
     return instance;
   }
 
@@ -136,21 +136,21 @@ export default class MainProcess {
     ]);
   }
 
-  private _init() {
+  private init() {
     this.updateAboutPanelIfNeeded();
-    this._setAppMenu();
+    this.setAppMenu();
     try {
-      this._initTshd();
-      this._initSharedProcess();
-      this._initResolvingChildProcessAddresses();
-      this._initIpc();
+      this.initTshd();
+      this.initSharedProcess();
+      this.initResolvingChildProcessAddresses();
+      this.initIpc();
     } catch (err) {
       this.logger.error('Failed to start main process: ', err.message);
       app.exit(1);
     }
   }
 
-  private _initTshd() {
+  private initTshd() {
     const { binaryPath, flags, homeDir } = this.settings.tshd;
     this.logger.info(`Starting tsh daemon from ${binaryPath}`);
 
@@ -174,7 +174,7 @@ export default class MainProcess {
     }).pipeProcessOutputIntoLogger(this.tshdProcess);
   }
 
-  private _initSharedProcess() {
+  private initSharedProcess() {
     this.sharedProcess = fork(
       path.join(__dirname, 'sharedProcess.js'),
       [`--runtimeSettingsJson=${JSON.stringify(this.settings)}`],
@@ -194,7 +194,7 @@ export default class MainProcess {
     }).pipeProcessOutputIntoLogger(this.sharedProcess);
   }
 
-  private _initResolvingChildProcessAddresses(): void {
+  private initResolvingChildProcessAddresses(): void {
     this.resolvedChildProcessAddresses = Promise.all([
       resolveNetworkAddress(
         this.settings.tshd.requestedNetworkAddress,
@@ -207,7 +207,7 @@ export default class MainProcess {
     ]).then(([tsh, shared]) => ({ tsh, shared }));
   }
 
-  private _initIpc() {
+  private initIpc() {
     ipcMain.on(MainProcessIpc.GetRuntimeSettings, event => {
       event.returnValue = this.settings;
     });
@@ -421,7 +421,7 @@ export default class MainProcess {
     subscribeToFileStorageEvents(this.appStateFileStorage);
   }
 
-  private _setAppMenu() {
+  private setAppMenu() {
     const isMac = this.settings.platform === 'darwin';
     const commonHelpTemplate: MenuItemConstructorOptions[] = [
       { label: 'Open Documentation', click: openDocsUrl },

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -118,6 +118,10 @@ async function createGrpcCredentials(
     generateAndSaveGrpcCert(certsDir, GrpcCertName.Renderer),
     readGrpcCert(certsDir, GrpcCertName.Tshd),
     readGrpcCert(certsDir, GrpcCertName.Shared),
+    // tsh daemon expects both certs to be created before accepting connections. So even though the
+    // renderer process does not use the cert of the main process, it must still wait for the cert
+    // to be saved to disk.
+    readGrpcCert(certsDir, GrpcCertName.MainProcess),
   ]);
 
   return {

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -19,7 +19,7 @@
 import { contextBridge } from 'electron';
 import { ChannelCredentials, ServerCredentials } from '@grpc/grpc-js';
 
-import createTshClient from 'teleterm/services/tshd/createClient';
+import { createTshdClient } from 'teleterm/services/tshd/createClient';
 import createMainProcessClient from 'teleterm/mainProcess/mainProcessClient';
 import { createFileLoggerService } from 'teleterm/services/logger';
 import Logger from 'teleterm/logger';
@@ -60,7 +60,7 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     mainProcessClient.getResolvedChildProcessAddresses(),
     createGrpcCredentials(runtimeSettings),
   ]);
-  const tshClient = createTshClient(addresses.tsh, credentials.tshd);
+  const tshClient = createTshdClient(addresses.tsh, credentials.tshd);
   const ptyServiceClient = createPtyService(
     addresses.shared,
     credentials.shared,

--- a/web/packages/teleterm/src/services/grpcCredentials/types.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/types.ts
@@ -19,9 +19,10 @@
 // Each process creates its own key pair. The public key is saved to disk under the specified
 // filename, the private key stays in the memory.
 //
-// `Renderer` and `Tshd` file names are also used on the tshd side.
+// `Renderer`, `Tshd`, and `MainProcess` file names are also used on the tshd side.
 export enum GrpcCertName {
   Renderer = 'renderer.crt',
   Tshd = 'tshd.crt',
   Shared = 'shared.crt',
+  MainProcess = 'main-process.crt',
 }

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -43,10 +43,10 @@ import {
   UpdateHeadlessAuthenticationStateParams,
 } from './types';
 
-export default function createClient(
+export function createTshdClient(
   addr: string,
   credentials: grpc.ChannelCredentials
-) {
+): types.TshdClient {
   const logger = new Logger('tshd');
   const tshd = middleware(new TerminalServiceClient(addr, credentials), [
     withLogging(logger),

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -20,7 +20,7 @@ import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 
 import * as types from '../types';
 
-export class MockTshClient implements types.TshClient {
+export class MockTshClient implements types.TshdClient {
   listRootClusters: () => Promise<types.Cluster[]>;
   listLeafClusters = () => Promise.resolve([]);
   getKubes: (
@@ -106,4 +106,6 @@ export class MockTshClient implements types.TshClient {
   updateUserPreferences = async () => ({});
   getSuggestedAccessLists = async () => [];
   promoteAccessRequest = async () => undefined;
+
+  updateTshdEventsServerAddress: (address: string) => Promise<void>;
 }

--- a/web/packages/teleterm/src/services/tshd/types.test.ts
+++ b/web/packages/teleterm/src/services/tshd/types.test.ts
@@ -18,12 +18,12 @@
 
 import { createInsecureClientCredentials } from 'teleterm/services/grpcCredentials';
 
-import createClient from './createClient';
+import { createTshdClient } from './createClient';
 
 // This test detects situations where one of the generated JS protobufs has missing dependencies.
 // Dependencies must be provided as `--path` values to `buf generate` in build.assets/genproto.sh.
 test('generated protos import necessary dependencies', () => {
   expect(() => {
-    createClient('localhost:0', createInsecureClientCredentials());
+    createTshdClient('localhost:0', createInsecureClientCredentials());
   }).not.toThrow();
 });

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -223,7 +223,7 @@ export type WebauthnLoginCredentialPrompt = {
 export type LoginPasswordlessRequest =
   Partial<apiService.LoginPasswordlessRequest.AsObject>;
 
-export type TshClient = {
+export type TshdClient = {
   listRootClusters: () => Promise<Cluster[]>;
   listLeafClusters: (clusterUri: uri.RootClusterUri) => Promise<Cluster[]>;
   getKubes: (params: GetResourcesParams) => Promise<GetKubesResponse>;
@@ -339,6 +339,8 @@ export type TshClient = {
     params: PromoteAccessRequestParams,
     abortSignal?: TshAbortSignal
   ) => Promise<AccessRequest>;
+
+  updateTshdEventsServerAddress: (address: string) => Promise<void>;
 };
 
 export type TshAbortController = {

--- a/web/packages/teleterm/src/types.ts
+++ b/web/packages/teleterm/src/types.ts
@@ -18,7 +18,7 @@
 
 import { ITshdEventsServiceServer } from 'gen-proto-js/teleport/lib/teleterm/v1/tshd_events_service_grpc_pb';
 
-import { TshClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd/types';
 import { PtyServiceClient } from 'teleterm/services/pty';
 import { RuntimeSettings, MainProcessClient } from 'teleterm/mainProcess/types';
 import { FileStorage } from 'teleterm/services/fileStorage';
@@ -103,7 +103,7 @@ export type TshdEventContextBridgeService = {
 
 export type ElectronGlobals = {
   readonly mainProcessClient: MainProcessClient;
-  readonly tshClient: TshClient;
+  readonly tshClient: TshdClient;
   readonly ptyServiceClient: PtyServiceClient;
   readonly setupTshdEventContextBridgeService: (
     listener: TshdEventContextBridgeService

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -38,7 +38,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ResourcesService } from 'teleterm/ui/services/resources';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { ConfigService } from 'teleterm/services/config';
-import { TshClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd/types';
 import { IAppContext } from 'teleterm/ui/types';
 import { DeepLinksService } from 'teleterm/ui/services/deepLinks';
 import { parseDeepLink } from 'teleterm/deepLinks';
@@ -60,7 +60,7 @@ export default class AppContext implements IAppContext {
   connectionTracker: ConnectionTrackerService;
   fileTransferService: FileTransferService;
   resourcesService: ResourcesService;
-  tshd: TshClient;
+  tshd: TshdClient;
   /**
    * setupTshdEventContextBridgeService adds a context-bridge-compatible version of a gRPC service
    * that's going to be called every time a client makes a particular RPC to the tshd events

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -57,9 +57,9 @@ const NotificationsServiceMock = NotificationsService as jest.MockedClass<
 >;
 const UsageServiceMock = UsageService as jest.MockedClass<typeof UsageService>;
 
-function createService(client: Partial<tsh.TshClient>): ClustersService {
+function createService(client: Partial<tsh.TshdClient>): ClustersService {
   return new ClustersService(
-    client as tsh.TshClient,
+    client as tsh.TshdClient,
     {
       removeKubeConfig: jest.fn().mockResolvedValueOnce(undefined),
     } as unknown as MainProcessClient,
@@ -68,7 +68,7 @@ function createService(client: Partial<tsh.TshClient>): ClustersService {
   );
 }
 
-function getClientMocks(): Partial<tsh.TshClient> {
+function getClientMocks(): Partial<tsh.TshdClient> {
   return {
     loginLocal: jest.fn().mockResolvedValueOnce(undefined),
     logout: jest.fn().mockResolvedValueOnce(undefined),

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -55,7 +55,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   state: types.ClustersServiceState = createClusterServiceState();
 
   constructor(
-    public client: tsh.TshClient,
+    public client: tsh.TshdClient,
     private mainProcessClient: MainProcessClient,
     private notificationsService: NotificationsService,
     private usageService: UsageService

--- a/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
@@ -22,7 +22,7 @@ import {
   CreateConnectMyComputerRoleResponse,
   Server,
   TshAbortSignal,
-  TshClient,
+  TshdClient,
 } from 'teleterm/services/tshd/types';
 
 import type * as uri from 'teleterm/ui/uri';
@@ -30,7 +30,7 @@ import type * as uri from 'teleterm/ui/uri';
 export class ConnectMyComputerService {
   constructor(
     private mainProcessClient: MainProcessClient,
-    private tshClient: TshClient
+    private tshClient: TshdClient
   ) {}
 
   async downloadAgent(): Promise<void> {

--- a/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
+++ b/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
@@ -21,13 +21,13 @@ import { FileTransferListeners } from 'shared/components/FileTransfer';
 import {
   FileTransferDirection,
   FileTransferRequest,
-  TshClient,
+  TshdClient,
 } from 'teleterm/services/tshd/types';
 import { UsageService } from 'teleterm/ui/services/usage';
 
 export class FileTransferService {
   constructor(
-    private tshClient: TshClient,
+    private tshClient: TshdClient,
     private usageService: UsageService
   ) {}
 

--- a/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
+++ b/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
@@ -27,7 +27,7 @@ export class HeadlessAuthenticationService {
   constructor(
     private mainProcessClient: MainProcessClient,
     private modalsService: ModalsService,
-    private tshClient: types.TshClient,
+    private tshClient: types.TshdClient,
     private configService: ConfigService
   ) {}
 

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -36,7 +36,7 @@ describe('getServerByHostname', () => {
   const getServerByHostnameTests: Array<
     {
       name: string;
-      getServersMockedValue: Awaited<ReturnType<tsh.TshClient['getServers']>>;
+      getServersMockedValue: Awaited<ReturnType<tsh.TshdClient['getServers']>>;
     } & (
       | { expectedServer: tsh.Server; expectedErr?: never }
       | { expectedErr: any; expectedServer?: never }
@@ -73,10 +73,10 @@ describe('getServerByHostname', () => {
   test.each(getServerByHostnameTests)(
     '$name',
     async ({ getServersMockedValue, expectedServer, expectedErr }) => {
-      const tshClient: Partial<tsh.TshClient> = {
+      const tshClient: Partial<tsh.TshdClient> = {
         getServers: jest.fn().mockResolvedValueOnce(getServersMockedValue),
       };
-      const service = new ResourcesService(tshClient as tsh.TshClient);
+      const service = new ResourcesService(tshClient as tsh.TshdClient);
 
       const promise = service.getServerByHostname('/clusters/bar', 'foo');
 
@@ -105,7 +105,7 @@ describe('searchResources', () => {
     const kube = makeKube();
     const app = makeApp();
 
-    const tshClient: Partial<tsh.TshClient> = {
+    const tshClient: Partial<tsh.TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce({
         agentsList: [server],
         totalCount: 1,
@@ -127,7 +127,7 @@ describe('searchResources', () => {
         startKey: '',
       }),
     };
-    const service = new ResourcesService(tshClient as tsh.TshClient);
+    const service = new ResourcesService(tshClient as tsh.TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -159,14 +159,14 @@ describe('searchResources', () => {
 
   it('returns a single item if a filter is supplied', async () => {
     const server = makeServer();
-    const tshClient: Partial<tsh.TshClient> = {
+    const tshClient: Partial<tsh.TshdClient> = {
       getServers: jest.fn().mockResolvedValueOnce({
         agentsList: [server],
         totalCount: 1,
         startKey: '',
       }),
     };
-    const service = new ResourcesService(tshClient as tsh.TshClient);
+    const service = new ResourcesService(tshClient as tsh.TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',
@@ -185,13 +185,13 @@ describe('searchResources', () => {
 
   it('returns a custom error pointing at resource kind and cluster when an underlying promise gets rejected', async () => {
     const expectedCause = new Error('oops');
-    const tshClient: Partial<tsh.TshClient> = {
+    const tshClient: Partial<tsh.TshdClient> = {
       getServers: jest.fn().mockRejectedValueOnce(expectedCause),
       getDatabases: jest.fn().mockRejectedValueOnce(expectedCause),
       getKubes: jest.fn().mockRejectedValueOnce(expectedCause),
       getApps: jest.fn().mockRejectedValueOnce(expectedCause),
     };
-    const service = new ResourcesService(tshClient as tsh.TshClient);
+    const service = new ResourcesService(tshClient as tsh.TshdClient);
 
     const searchResults = await service.searchResources({
       clusterUri: '/clusters/foo',

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -25,7 +25,7 @@ import type * as uri from 'teleterm/ui/uri';
 import type { ResourceTypeFilter } from 'teleterm/ui/Search/searchResult';
 
 export class ResourcesService {
-  constructor(private tshClient: types.TshClient) {}
+  constructor(private tshClient: types.TshdClient) {}
 
   fetchServers(params: types.GetResourcesParams) {
     return this.tshClient.getServers(params);

--- a/web/packages/teleterm/src/ui/services/usage/usageService.ts
+++ b/web/packages/teleterm/src/ui/services/usage/usageService.ts
@@ -20,7 +20,7 @@ import { ClusterOrResourceUri, ClusterUri, routing } from 'teleterm/ui/uri';
 import {
   Cluster,
   ReportUsageEventRequest,
-  TshClient,
+  TshdClient,
 } from 'teleterm/services/tshd/types';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { ConfigService } from 'teleterm/services/config';
@@ -38,7 +38,7 @@ export class UsageService {
   private logger = new Logger('UsageService');
 
   constructor(
-    private tshClient: TshClient,
+    private tshClient: TshdClient,
     private configService: ConfigService,
     private notificationsService: NotificationsService,
     // `findCluster` function - it is a workaround that allows to use `UsageEventService` in `ClustersService`.

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -37,7 +37,7 @@ import { UsageService } from 'teleterm/ui/services/usage';
 import { ConfigService } from 'teleterm/services/config';
 import { ConnectMyComputerService } from 'teleterm/ui/services/connectMyComputer';
 import { HeadlessAuthenticationService } from 'teleterm/ui/services/headlessAuthn/headlessAuthnService';
-import { TshClient } from 'teleterm/services/tshd/types';
+import { TshdClient } from 'teleterm/services/tshd/types';
 
 export interface IAppContext {
   clustersService: ClustersService;
@@ -61,7 +61,7 @@ export interface IAppContext {
   configService: ConfigService;
   connectMyComputerService: ConnectMyComputerService;
   headlessAuthenticationService: HeadlessAuthenticationService;
-  tshd: TshClient;
+  tshd: TshdClient;
 
   pullInitialState(): Promise<void>;
 }


### PR DESCRIPTION
In order to [allow opening links to cluster apps](https://github.com/gravitational/teleport/issues/35554), the main process in Connect must know which clusters have been added in the app. It can get this info from the gRPC service running in the tsh daemon.

This PR sets up a gRPC client for that service. Up until now, all communication between tsh daemon and the Electron app originated from the renderer process which handles the browser window, not the main process.

main.ts includes an example of how the tshd client can be used.