### PR TITLE
[v15] Update FIPS algorithms inline with upstream `x/crypto/ssh` proposed changes

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
@@ -740,45 +741,69 @@ const (
 )
 
 var (
-	// FIPSCipherSuites is a list of supported FIPS compliant TLS cipher suites.
+	// FIPSCipherSuites is a list of supported FIPS compliant TLS cipher suites (for TLS 1.2 only).
+	// Order will dictate the selected cipher, as per RFC 5246 § 7.4.1.2.
+	// See https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.2 for more information.
+	// This aligns to `crypto/tls`'s `CipherSuites` `supportedOnlyTLS12` list, but
+	// just constrained to only FIPS-approved ciphers supported by `crypto/tls`
+	// and ordered based on `cipherSuitesPreferenceOrder`.
 	FIPSCipherSuites = []uint16{
-		//
-		// These two ciper suites:
-		//
-		// tls.TLS_RSA_WITH_AES_128_GCM_SHA256
-		// tls.TLS_RSA_WITH_AES_256_GCM_SHA384
-		//
-		// although supported by FIPS, are blacklisted in http2 spec:
-		//
-		// https://tools.ietf.org/html/rfc7540#appendix-A
-		//
-		// therefore we do not include them in this list.
-		//
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	}
 
 	// FIPSCiphers is a list of supported FIPS compliant SSH ciphers.
+	// Order will dictate the selected cipher, as per RFC 4253 § 7.1.
+	// See `encryption_algorithms` section of https://datatracker.ietf.org/doc/html/rfc4253#section-7.1.
+	// This aligns to `x/crypto/ssh`'s `preferredCiphers`, but just constrained to
+	// only FIPS-approved ciphers.
+	// Can also be compared to OpenSSH's `KEX_SERVER_ENCRYPT` / `KEX_CLIENT_ENCRYPT`.
 	FIPSCiphers = []string{
+		"aes128-gcm@openssh.com",
+		"aes256-gcm@openssh.com",
 		"aes128-ctr",
 		"aes192-ctr",
 		"aes256-ctr",
-		"aes128-gcm@openssh.com",
 	}
 
 	// FIPSKEXAlgorithms is a list of supported FIPS compliant SSH kex algorithms.
+	// Order will dictate the selected algorithm, as per RFC 4253 § 7.1.
+	// See `kex_algorithms` section of https://datatracker.ietf.org/doc/html/rfc4253#section-7.1.
+	// This aligns to `x/crypto/ssh`'s `preferredKeyAlgos`, but just constrained to
+	// only FIPS-approved algorithms.
+	// Can also be compared to OpenSSH's `KEX_SERVER_KEX` / `KEX_CLIENT_KEX`.
 	FIPSKEXAlgorithms = []string{
 		"ecdh-sha2-nistp256",
 		"ecdh-sha2-nistp384",
-		"echd-sha2-nistp521",
 	}
 
 	// FIPSMACAlgorithms is a list of supported FIPS compliant SSH mac algorithms.
+	// Order will dictate the selected algorithm, as per RFC 4253 § 7.1.
+	// See `mac_algorithms` section of https://datatracker.ietf.org/doc/html/rfc4253#section-7.1.
+	// This aligns to `x/crypto/ssh`'s `preferredMACs`, but just constrained to
+	// only FIPS-approved algorithms.
+	// Can also be compared to OpenSSH's `KEX_SERVER_MAC` / `KEX_CLIENT_MAC`.
 	FIPSMACAlgorithms = []string{
 		"hmac-sha2-256-etm@openssh.com",
+		"hmac-sha2-512-etm@openssh.com",
 		"hmac-sha2-256",
+		"hmac-sha2-512",
+	}
+
+	// FIPSPubKeyAuthAlgorithms is a list of supported FIPS compliant SSH public
+	// key authentication algorithms.
+	// Order will dictate the selected algorithm, as per RFC 4253 § 7.1.
+	// See `server_host_key_algorithms` section of https://datatracker.ietf.org/doc/html/rfc4253#section-7.1.
+	// This aligns to `x/crypto/ssh`'s `preferredPubKeyAuthAlgos`, but just
+	// constrained to only FIPS-approved algorithms.
+	// Can also be compared to OpenSSH's `KEX_DEFAULT_PK_ALG`.
+	FIPSPubKeyAuthAlgorithms = []string{
+		ssh.KeyAlgoECDSA256,
+		ssh.KeyAlgoECDSA384,
+		ssh.KeyAlgoRSASHA256,
+		ssh.KeyAlgoRSASHA512,
 	}
 )
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -243,6 +243,10 @@ func NewServer(
 	s.cfg.PasswordCallback = ah.Password
 	s.cfg.NoClientAuth = ah.NoClient
 
+	if s.fips {
+		s.cfg.PublicKeyAuthAlgorithms = defaults.FIPSPubKeyAuthAlgorithms
+	}
+
 	// Teleport servers need to identify as such to allow passing of the client
 	// IP from the client to the proxy to the destination node.
 	s.cfg.ServerVersion = SSHVersionPrefix


### PR DESCRIPTION
Backport #36685 to branch/v15

changelog: Update FIPS algorithms to match proposed `x/crypto/ssh` changes
