### PR TITLE
Add an option to disable SSH connection resumption in Connect

### DIFF
--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -64,7 +64,10 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
   const ptyServiceClient = createPtyService(
     addresses.shared,
     credentials.shared,
-    runtimeSettings
+    runtimeSettings,
+    {
+      noResume: mainProcessClient.configService.get('ssh.noResume').value,
+    }
   );
   const {
     setupTshdEventContextBridgeService,

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -118,6 +118,10 @@ export const createAppConfigSchema = (platform: Platform) => {
       .describe(
         'Skips the confirmation prompt for headless login approval and instead prompts for WebAuthn immediately.'
       ),
+    'ssh.noResume': z
+      .boolean()
+      .default(false)
+      .describe('Disables SSH connection resumption.'),
   });
 };
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.test.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.test.ts
@@ -18,7 +18,11 @@
 
 import { makeRuntimeSettings } from 'teleterm/mainProcess/fixtures/mocks';
 
-import { ShellCommand, GatewayCliClientCommand } from '../types';
+import {
+  ShellCommand,
+  TshLoginCommand,
+  GatewayCliClientCommand,
+} from '../types';
 
 import { getPtyProcessOptions } from './buildPtyOptions';
 
@@ -43,6 +47,7 @@ describe('getPtyProcessOptions', () => {
 
       const { env } = getPtyProcessOptions(
         makeRuntimeSettings(),
+        { noResume: false },
         cmd,
         processEnv
       );
@@ -71,6 +76,7 @@ describe('getPtyProcessOptions', () => {
 
       const { env } = getPtyProcessOptions(
         makeRuntimeSettings(),
+        { noResume: false },
         cmd,
         processEnv
       );
@@ -78,6 +84,31 @@ describe('getPtyProcessOptions', () => {
       expect(env.processExclusive).toBe('process');
       expect(env.cmdExclusive).toBe('cmd');
       expect(env.shared).toBe('fromCmd');
+    });
+
+    it('disables SSH connection resumption on tsh ssh invocations if the option is set', () => {
+      const processEnv = {
+        processExclusive: 'process',
+        shared: 'fromProcess',
+      };
+      const cmd: TshLoginCommand = {
+        kind: 'pty.tsh-login',
+        clusterName: 'bar',
+        proxyHost: 'baz',
+        login: 'bob',
+        serverId: '01234567-89ab-cdef-0123-456789abcdef',
+        rootClusterId: 'baz',
+        leafClusterId: undefined,
+      };
+
+      const { args } = getPtyProcessOptions(
+        makeRuntimeSettings(),
+        { noResume: true },
+        cmd,
+        processEnv
+      );
+
+      expect(args).toContain('--no-resume');
     });
   });
 });

--- a/web/packages/teleterm/src/services/pty/ptyService.ts
+++ b/web/packages/teleterm/src/services/pty/ptyService.ts
@@ -23,12 +23,13 @@ import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { buildPtyOptions } from './ptyHost/buildPtyOptions';
 import { createPtyHostClient } from './ptyHost/ptyHostClient';
 import { createPtyProcess } from './ptyHost/ptyProcess';
-import { PtyServiceClient } from './types';
+import { PtyServiceClient, SshOptions } from './types';
 
 export function createPtyService(
   address: string,
   credentials: ChannelCredentials,
-  runtimeSettings: RuntimeSettings
+  runtimeSettings: RuntimeSettings,
+  sshOptions: SshOptions
 ): PtyServiceClient {
   const ptyHostClient = createPtyHostClient(address, credentials);
 
@@ -36,6 +37,7 @@ export function createPtyService(
     createPtyProcess: async command => {
       const { processOptions, creationStatus } = await buildPtyOptions(
         runtimeSettings,
+        sshOptions,
         command
       );
       const ptyId = await ptyHostClient.createPtyProcess(processOptions);

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -99,3 +99,11 @@ export type PtyCommand =
   | TshLoginCommand
   | TshKubeLoginCommand
   | GatewayCliClientCommand;
+
+export type SshOptions = {
+  /**
+   * Disables SSH connection resumption when running `tsh ssh`
+   * (by adding the `--no-resume` option).
+   */
+  noResume: boolean;
+};


### PR DESCRIPTION
This PR adds a `ssh.noResume` option in the Connect config file to disable SSH connection resumption (by passing `--no-resume` to `tsh ssh`).