### PR TITLE
Symlink `cmake` to `cmake3` in CentOS 7 docker image

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -53,6 +53,7 @@ RUN yum install --nogpgcheck -y \
 
 # Needed for boring-rs
 ENV CMAKE=cmake3
+RUN ln -s /usr/bin/cmake3 /usr/local/bin/cmake
 
 ## GIT2 ###################################################################
 


### PR DESCRIPTION
Various build scripts look for `cmake`, but `cmake` and `cmake3` are different on CentOS 7, and we only install `cmake3`. Add a symlink pointing `cmake` to `cmake3`.