### PR TITLE
Swap to fork of `boring-rs` for build fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "boring"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
+source = "git+https://github.com/gravitational/boring?rev=605253d99d5e363e178bcf97e1d4622e33844cd5#605253d99d5e363e178bcf97e1d4622e33844cd5"
 dependencies = [
  "bitflags 2.4.2",
  "boring-sys",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
+source = "git+https://github.com/gravitational/boring?rev=605253d99d5e363e178bcf97e1d4622e33844cd5#605253d99d5e363e178bcf97e1d4622e33844cd5"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
+source = "git+https://github.com/gravitational/boring?rev=605253d99d5e363e178bcf97e1d4622e33844cd5#605253d99d5e363e178bcf97e1d4622e33844cd5"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,8 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fabc62c27039b971303b808e3d2683863cc4bbcffbf1615f18d6190b20eaa6"
+version = "4.3.0"
+source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
 dependencies = [
  "bitflags 2.4.2",
  "boring-sys",
@@ -295,9 +294,8 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007c69b35cbe5c5963eecfc50f224d60199c95b2bfbeb957eedba5988e57f91c"
+version = "4.3.0"
+source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2821,9 +2819,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfddfd874d2d82e6fd1df7c8abbf064904853d48ebceac4b1a32e7986df1cc16"
+version = "4.3.0"
+source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "boring"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
+source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
 dependencies = [
  "bitflags 2.4.2",
  "boring-sys",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
+source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "4.4.0"
-source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
+source = "git+https://github.com/gravitational/boring?rev=83055ff0dcf6f88f58a642902b53d2592d74382e#83055ff0dcf6f88f58a642902b53d2592d74382e"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,8 +282,8 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "4.3.0"
-source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
+version = "4.4.0"
+source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
 dependencies = [
  "bitflags 2.4.2",
  "boring-sys",
@@ -294,8 +294,8 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "4.3.0"
-source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
+version = "4.4.0"
+source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2819,8 +2819,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "4.3.0"
-source = "git+https://github.com/gravitational/boring?rev=6559c29fd25cf4823f71b2cadf21dbaa77ec92f7#6559c29fd25cf4823f71b2cadf21dbaa77ec92f7"
+version = "4.4.0"
+source = "git+https://github.com/gravitational/boring?rev=048c8ec0de01ab2a54a34201d787ba274d908b92#048c8ec0de01ab2a54a34201d787ba274d908b92"
 dependencies = [
  "boring",
  "boring-sys",

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -71,37 +71,6 @@ RUN git clone --depth=1 https://github.com/git/git.git -b v2.42.0 && \
     make -j"$(nproc)" all && \
     DESTDIR=/opt/git make install"
 
-## NINJA-BUILD ###################################################################
-
-## ninja-build is required for building boringssl. The version included in CentOS 7 AMR64
-## is too old, so we need to build it from source.
-FROM --platform=$BUILDPLATFORM base AS ninja-build
-
-# Install additional required dependencies.
-RUN  yum install -y expat-devel \
-     gettext \
-     libcurl-devel \
-     openssl-devel \
-     pcre-devel \
-     xmlto \
-     zlib-devel \
-     && yum clean all
-
-# mno-outline-atomics flag is needed to make the build works on ARM64 docker.
-RUN git clone --depth=1 https://github.com/Kitware/CMake.git -b v3.28.1 && \
-    cd CMake && \
-    [ "$(git rev-parse HEAD)" = '1eed682d7cca9bb2c2b0709a6c3202a3b08613b2' ] && \
-    scl enable ${DEVTOOLSET} "if [ "${BUILDARCH}" = "arm64" ]; then export CFLAGS=-mno-outline-atomics; fi &&  ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install"
-
-ENV PATH="/opt/cmake/bin:$PATH"
-
-RUN git clone --depth=1 https://github.com/ninja-build/ninja.git -b v1.11.1 && \
-        cd ninja && \
-        [ "$(git rev-parse HEAD)" = 'a524bf3f6bacd1b4ad85d719eed2737d8562f27a' ] && \
-        scl enable ${DEVTOOLSET} "cmake -Bbuild-cmake && \
-    cmake --build build-cmake -j"$(nproc)" && \
-    cmake --build build-cmake --target  install"
-
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
@@ -337,7 +306,7 @@ COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 # Copy the pre-built CentOS 7 assets with clang. Needed to build BoringSSL and BPF tools.
 COPY --from=teleport-buildbox-centos7-assets /opt/llvm /opt/llvm
 # Bring in our custom ninja build, needed for BorinSSL.
-COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
+COPY --from=teleport-buildbox-centos7-assets /usr/local/bin/ninja /usr/local/bin/ninja
 
 # Libclang is needed by boring-rs to generate bindings. libclang is kept in /opt/llvm/lib
 # and without this environment variable, boring-rs will not be able to find it.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -293,11 +293,14 @@ RUN cd /usr/local/lib64 && \
 COPY pkgconfig/centos7/ /
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 
+# Install libpcsclite.
 COPY --from=libpcsclite /usr/local/include/ /usr/local/include/
 COPY --from=libpcsclite /usr/local/lib/pkgconfig/ /usr/local/lib64/pkgconfig/
 COPY --from=libpcsclite \
     /usr/local/lib/libpcsclite.a \
     /usr/local/lib/
+# Set LIBRARY_PATH so that libpcsclite can be found by the linker.
+ENV LIBRARY_PATH=/usr/local/lib:${LIBRARY_PATH}
 
 # Copy libbpf into the final image.
 ARG LIBBPF_VERSION

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -315,5 +315,11 @@ COPY --from=teleport-buildbox-centos7-assets /usr/local/bin/ninja /usr/local/bin
 # and without this environment variable, boring-rs will not be able to find it.
 ENV LIBCLANG_PATH=/opt/llvm/lib/
 
+# C++14 compatible headers are required to build boring-rs.
+# Teleport's boring fork includes a patch that reads this variable
+# and injects it into the environment as CPLUS_INCLUDE_PATH before
+# boring is built.
+ENV BORING_BSSL_FIPS_CPLUS_INCLUDE_PATH=/opt/llvm/include/c++/v1/
+
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -35,10 +35,44 @@ RUN yum install --nogpgcheck -y \
         ${DEVTOOLSET}-make && \
     yum clean all
 
+## NINJA-BUILD ###################################################################
+
+## ninja-build is required for building boringssl. The version included in CentOS 7 AMR64
+## is too old, so we need to build it from source.
+FROM --platform=$BUILDPLATFORM centos-devtoolset AS ninja-build
+
+# Install additional required dependencies.
+RUN  yum install -y expat-devel \
+     gettext \
+     libcurl-devel \
+     openssl-devel \
+     pcre-devel \
+     xmlto \
+     zlib-devel \
+     && yum clean all
+
+# mno-outline-atomics flag is needed to make the build works on ARM64 docker.
+RUN git clone --depth=1 https://github.com/Kitware/CMake.git -b v3.28.1 && \
+    cd CMake && \
+    [ "$(git rev-parse HEAD)" = '1eed682d7cca9bb2c2b0709a6c3202a3b08613b2' ] && \
+    scl enable ${DEVTOOLSET} "if [ "${BUILDARCH}" = "arm64" ]; then export CFLAGS=-mno-outline-atomics; fi &&  ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install"
+
+ENV PATH="/opt/cmake/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/ninja-build/ninja.git -b v1.11.1 && \
+        cd ninja && \
+        [ "$(git rev-parse HEAD)" = 'a524bf3f6bacd1b4ad85d719eed2737d8562f27a' ] && \
+        scl enable ${DEVTOOLSET} "cmake -Bbuild-cmake && \
+    cmake --build build-cmake -j"$(nproc)" && \
+    cmake --build build-cmake --target  install"
+
 # Use just created devtool image with newer GCC and Cmake
 FROM --platform=$BUILDPLATFORM centos-devtoolset as clang14
 
 ARG DEVTOOLSET
+
+# Bring in our custom ninja build, needed for building clang.
+COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
 
 # Compile Clang 14.0.6 from source. It is needed to create BoringSSL and BPF files.
 # CentOS 7 doesn't provide it as a package unfortunately.
@@ -59,7 +93,7 @@ RUN git clone --branch llvmorg-14.0.6 --depth=1 https://github.com/llvm/llvm-pro
 -DLLVM_ENABLE_PROJECTS=\"clang;libcxx;libcxxabi\" \
 -DLLVM_ENABLE_LIBCXX=ON \
 -G \"Ninja\" ../llvm && \
-    cmake3 --build . && \
+    cmake3 --build . -j 2 && \
     cmake3 -DCMAKE_INSTALL_PREFIX=/opt/llvm -P cmake_install.cmake"' && \
     cd ../.. && \
     rm -rf llvm-project
@@ -94,6 +128,9 @@ FROM scratch AS buildbox-centos7-assets
 
 # Copy Clang into the final image.
 COPY --from=clang14 /opt/llvm /opt/llvm/
+
+# Copy ninja into the final image.
+COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
 
 # Copy custom packages into the final image.
 COPY --from=custom-packages /opt/custom-packages /opt/custom-packages/

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -93,7 +93,7 @@ RUN git clone --branch llvmorg-14.0.6 --depth=1 https://github.com/llvm/llvm-pro
 -DLLVM_ENABLE_PROJECTS=\"clang;libcxx;libcxxabi\" \
 -DLLVM_ENABLE_LIBCXX=ON \
 -G \"Ninja\" ../llvm && \
-    cmake3 --build . -j 2 && \
+    cmake3 --build . && \
     cmake3 -DCMAKE_INSTALL_PREFIX=/opt/llvm -P cmake_install.cmake"' && \
     cd ../.. && \
     rm -rf llvm-project

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -88,11 +88,11 @@ RUN git clone --branch llvmorg-14.0.6 --depth=1 https://github.com/llvm/llvm-pro
     [ "$(git rev-parse HEAD)" = 'f28c006a5895fc0e329fe15fead81e37457cb1d1' ] && \
     mkdir build && cd build/ && \
     scl enable ${DEVTOOLSET} 'bash -c "cmake3 \
--DCMAKE_BUILD_TYPE=Release \
--DCMAKE_INSTALL_PREFIX=/opt/llvm \
--DLLVM_ENABLE_PROJECTS=\"clang;libcxx;libcxxabi\" \
--DLLVM_ENABLE_LIBCXX=ON \
--G \"Ninja\" ../llvm && \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/llvm \
+    -DLLVM_ENABLE_PROJECTS=\"clang;libcxx;libcxxabi\" \
+    -DLLVM_ENABLE_LIBCXX=ON \
+    -G \"Ninja\" ../llvm && \
     cmake3 --build . && \
     cmake3 -DCMAKE_INSTALL_PREFIX=/opt/llvm -P cmake_install.cmake"' && \
     cd ../.. && \

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.2"
-boring = { version = "4.4.0", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="6559c29fd25cf4823f71b2cadf21dbaa77ec92f7", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.11.0"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { version = "4.4.0", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="6559c29fd25cf4823f71b2cadf21dbaa77ec92f7", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["v4"] }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.2"
-boring = { git = "https://github.com/gravitational/boring", rev="6559c29fd25cf4823f71b2cadf21dbaa77ec92f7", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="048c8ec0de01ab2a54a34201d787ba274d908b92", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.11.0"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { git = "https://github.com/gravitational/boring", rev="6559c29fd25cf4823f71b2cadf21dbaa77ec92f7", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="048c8ec0de01ab2a54a34201d787ba274d908b92", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["v4"] }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.2"
-boring = { git = "https://github.com/gravitational/boring", rev="048c8ec0de01ab2a54a34201d787ba274d908b92", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="83055ff0dcf6f88f58a642902b53d2592d74382e", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.11.0"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { git = "https://github.com/gravitational/boring", rev="048c8ec0de01ab2a54a34201d787ba274d908b92", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="83055ff0dcf6f88f58a642902b53d2592d74382e", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["v4"] }
 

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bitflags = "2.4.2"
-boring = { git = "https://github.com/gravitational/boring", rev="83055ff0dcf6f88f58a642902b53d2592d74382e", optional = true }
+boring = { git = "https://github.com/gravitational/boring", rev="605253d99d5e363e178bcf97e1d4622e33844cd5", optional = true }
 byteorder = "1.5.0"
 bytes = "1.4.0"
 env_logger = "0.11.0"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 sspi = { git = "https://github.com/Devolutions/sspi-rs", rev="d54bdfcafa0e10d9d78224ebacc4f2a0992a6b79", features = ["network_client"] }
 static_init = "1.0.3"
 tokio = { version = "1.35", features = ["full"] }
-tokio-boring = { git = "https://github.com/gravitational/boring", rev="83055ff0dcf6f88f58a642902b53d2592d74382e", optional = true }
+tokio-boring = { git = "https://github.com/gravitational/boring", rev="605253d99d5e363e178bcf97e1d4622e33844cd5", optional = true }
 utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["v4"] }
 


### PR DESCRIPTION
BoringSSL does not build properly on CentOS 7 without some build fixes. As these fixes are not yet upstreamed, a separate fork is being used -- https://github.com/gravitational/boring.