### PR TITLE
Prevent crashing Teleport Connect after downgrading from v15

### DIFF
--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -18,6 +18,7 @@ import React, { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 import styled from 'styled-components';
+import { Text } from 'design';
 /* eslint-disable @typescript-eslint/ban-ts-comment*/
 // @ts-ignore
 import { DocumentAccessRequests } from 'e-teleterm/ui/DocumentAccessRequests/DocumentAccessRequests';
@@ -41,7 +42,7 @@ import {
 import { DocumentGatewayKube } from 'teleterm/ui/DocumentGatewayKube';
 
 import Document from 'teleterm/ui/Document';
-import { RootClusterUri } from 'teleterm/ui/uri';
+import { RootClusterUri, isDatabaseUri } from 'teleterm/ui/uri';
 
 import { ResourcesContextProvider } from '../DocumentCluster/resourcesContext';
 
@@ -121,8 +122,21 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
     switch (doc.kind) {
       case 'doc.cluster':
         return <DocumentCluster doc={doc} visible={visible} />;
-      case 'doc.gateway':
-        return <DocumentGateway doc={doc} visible={visible} />;
+      case 'doc.gateway': {
+        if (isDatabaseUri(doc.targetUri)) {
+          return <DocumentGateway doc={doc} visible={visible} />;
+        }
+        return (
+          <Document visible={visible}>
+            <Text m="auto" mt={10} textAlign="center">
+              Cannot create a gateway for the target "{doc.targetUri}".
+              <br />
+              Only database and kube targets are supported.
+            </Text>
+          </Document>
+        );
+      }
+
       case 'doc.gateway_cli_client':
         return <DocumentGatewayCliClient doc={doc} visible={visible} />;
       case 'doc.gateway_kube':
@@ -140,7 +154,9 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
       default:
         return (
           <Document visible={visible}>
-            Document kind "{doc.kind}" is not supported
+            <Text m="auto" mt={10} textAlign="center">
+              Document kind "{doc.kind}" is not supported.
+            </Text>
           </Document>
         );
     }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -20,7 +20,7 @@ import { Trash, Unlink } from 'design/Icon';
 
 import { ExtendedTrackedConnection } from 'teleterm/ui/services/connectionTracker';
 import { ListItem } from 'teleterm/ui/components/ListItem';
-import { assertUnreachable } from 'teleterm/ui/utils';
+import { isDatabaseUri } from 'teleterm/ui/uri';
 
 import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 
@@ -105,7 +105,7 @@ export function ConnectionItem(props: ConnectionItemProps) {
                 border-radius: 4px;
               `}
             >
-              {getKindName(props.item.kind)}
+              {getKindName(props.item)}
             </span>
             <span
               css={`
@@ -138,15 +138,17 @@ export function ConnectionItem(props: ConnectionItemProps) {
   );
 }
 
-function getKindName(kind: ExtendedTrackedConnection['kind']): string {
-  switch (kind) {
+function getKindName(connection: ExtendedTrackedConnection): string {
+  switch (connection.kind) {
     case 'connection.gateway':
-      return 'DB';
+      if (isDatabaseUri(connection.targetUri)) {
+        return 'DB';
+      }
+      break;
     case 'connection.server':
       return 'SSH';
     case 'connection.kube':
       return 'KUBE';
-    default:
-      assertUnreachable(kind);
   }
+  return 'UNKNOWN';
 }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -144,11 +144,26 @@ function getKindName(connection: ExtendedTrackedConnection): string {
       if (isDatabaseUri(connection.targetUri)) {
         return 'DB';
       }
-      break;
+      return 'UNKNOWN';
     case 'connection.server':
       return 'SSH';
     case 'connection.kube':
       return 'KUBE';
+    default:
+      // The default branch is triggered when the state read from the disk
+      // contains a connection not supported by the given Connect version.
+      //
+      // For example, the user can open an app connection in Connect v15
+      // and then downgrade to a version that doesn't support apps.
+      // That connection should be shown as 'UNKNOWN' in the connection list.
+      //
+      // `connection satisfies never` checks if we handled all cases,
+      // and if not, it causes a compile-time error.
+      // It is a pure TS check.
+      //
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _ = connection satisfies never;
+
+      return 'UNKNOWN';
   }
-  return 'UNKNOWN';
 }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -156,14 +156,6 @@ function getKindName(connection: ExtendedTrackedConnection): string {
       // For example, the user can open an app connection in Connect v15
       // and then downgrade to a version that doesn't support apps.
       // That connection should be shown as 'UNKNOWN' in the connection list.
-      //
-      // `connection satisfies never` checks if we handled all cases,
-      // and if not, it causes a compile-time error.
-      // It is a pure TS check.
-      //
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _ = connection satisfies never;
-
       return 'UNKNOWN';
   }
 }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -101,7 +101,7 @@ export class TrackedConnectionOperationsFactory {
   private getConnectionGatewayOperations(
     connection: TrackedGatewayConnection
   ): TrackedConnectionOperations {
-    const { rootClusterId, leafClusterId } = routing.parseDbUri(
+    const { rootClusterId, leafClusterId } = routing.parseClusterUri(
       connection.targetUri
     ).params;
     const { rootClusterUri, leafClusterUri } = this.getClusterUris({

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -150,7 +150,7 @@ export class DocumentsService {
       origin,
     } = opts;
     const uri = routing.getDocUri({ docId: unique() });
-    const title = `${targetUser}@${targetName}`;
+    const title = targetUser ? `${targetUser}@${targetName}` : targetName;
 
     return {
       uri,

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -214,6 +214,18 @@ export const routing = {
   },
 };
 
+export function isDatabaseUri(uri: string): uri is DatabaseUri {
+  return !!routing.parseDbUri(uri);
+}
+
+export function isServerUri(uri: string): uri is ServerUri {
+  return !!routing.parseServerUri(uri);
+}
+
+export function isKubeUri(uri: string): uri is KubeUri {
+  return !!routing.parseKubeUri(uri);
+}
+
 export type Params = {
   rootClusterId?: string;
   leafClusterId?: string;


### PR DESCRIPTION
This PR handles app connections and documents created in Connect v15.

This is how it looks when an app connection is opened in v14:
<img width="1280" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/64f5488d-e2f5-419d-97cc-9e31cc539881">

Ideally, we would like to parse the app state in a tool like zod when the app launches, but it is too time consuming task for now. 
I will also backport this to v13.

Important: This will only work when downgrading from v15 to whatever the next v14 and v13 will be. If someone is on 14.0.0 and they upgrade then downgrade back to 14.0.0, they'll not benefit from it.

Changelog: Fixed a potential crash in Teleport Connect after downgrading the app from v15+