### PR TITLE
Remove extra icons from topbar

### DIFF
--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -135,7 +135,9 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
   const initial =
     username && username.length ? username.trim().charAt(0).toUpperCase() : '';
 
-  const topMenuItems = features.filter(feature => Boolean(feature.topMenuItem));
+  const topMenuItems = features.filter(
+    feature => Boolean(feature.topMenuItem) && feature.category === undefined
+  );
 
   const items = [];
 

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -23,9 +23,9 @@ import {
   CirclePlay,
   ClipboardUser,
   Cluster,
-  EqualizersVertical,
   Integrations as IntegrationsIcon,
   Laptop,
+  ListAddCheck,
   ListThin,
   Lock,
   Question,
@@ -90,7 +90,7 @@ class AccessRequests implements TeleportFeature {
 
   navigationItem = {
     title: NavTitle.AccessRequests,
-    icon: EqualizersVertical,
+    icon: ListAddCheck,
     exact: true,
     getLink() {
       return cfg.routes.accessRequest;


### PR DESCRIPTION
While introducing the topbar, we used the `topMenuItem` to pass the features we wnted to the topbar. However, the old "user nav" menu items used the same boolean. This filters the items more specifically by only using items that don't have a navigation category (used in the old sidebar).

and i fixed the OSS access requests icon 