### PR TITLE
Fix DiscoveryFetch events test

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1269,7 +1269,7 @@ func (s *Server) startDynamicWatcherUpdater() {
 // newDiscoveryConfigChangedSub creates a new subscription for DiscoveryConfig events.
 // The consumer must have an active reader on the returned channel, and start a new Poll when it returns a value.
 func (s *Server) newDiscoveryConfigChangedSub() (ch chan struct{}) {
-	chSubscription := make(chan struct{})
+	chSubscription := make(chan struct{}, 1)
 	s.triggerFetchMu.Lock()
 	s.TriggerFetchC = append(s.TriggerFetchC, chSubscription)
 	s.triggerFetchMu.Unlock()


### PR DESCRIPTION
This PR fixes a test that has been failing for some days in the Daily Flaky Test runner.

The producer either emits an event (iff the consumer is selecting for an event).

The problem is that we were using an unbuffered channel, which means that when the consumer was processing, no other notification was being sent.

So, if the producer emitted an event, it would get consumed and a Fetch would start. If the producer emitted another event, while the consumer was still processing the event, it would not wait for it to finish and the `default` branch of the `select` was selected and nothing happened. So, when the consumer finished the Fetch operation it would wait either for the next event or for the time-based-Poll to trigger a new event.

Adding a buffer to the channel, ensures that even if the consumer is processing, a new event is added and a new Fetch starts right after the Fetch operation finishes.

I've also changed the expected events to be more resilient on extra fetch events.

I was able to reproduce the flaky test with the following command:
```
go test -c -race  github.com/gravitational/teleport/lib/srv/discovery -ldflags '-w -s -I=/usr/lib64/ld-linux-x86-64.so.2'
docker run -it --cpus="0.05" --platform=linux/amd64 -v(pwd):/teleport -u1000 ubuntu:22.04 /teleport/discovery.test -test.count=1000 -test.timeout=300m -test.v -test.failfast -test.run "^TestDiscoveryDatabaseRemovingDiscoveryConfigs"
```

Using this PR's code, the failure is now gone.
