### PR TITLE
dronegen: Remove operator OCI pipeline dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1624,12 +1624,6 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- build-linux-amd64
-- build-linux-amd64-fips
-- build-linux-arm64
-- build-linux-arm64-fips
-- build-linux-arm
 steps:
 - name: Check out code
   image: docker:git
@@ -5541,6 +5535,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 29df45eb56b7b2b153b9f63f847b4d0a91a248d8f5489a2568b49da1aa19ffe5
+hmac: 1201ae30cc439265cf33baf9b9e4d964fda6cd8197989b4930a308325c2b16b3
 
 ...

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -125,13 +125,6 @@ func tagPipelines() []pipeline {
 		pipelineName: "build-oci",
 		trigger:      triggerTag,
 		buildType:    buildType{fips: false},
-		dependsOn: []string{
-			"build-linux-amd64",
-			"build-linux-amd64-fips",
-			"build-linux-arm64",
-			"build-linux-arm64-fips",
-			"build-linux-arm",
-		},
 		workflows: []ghaWorkflow{
 			{
 				name:              "release-teleport-oci.yaml",


### PR DESCRIPTION
Remove the dependencies from the pipeline for building the operator OCI 
images. The GitHub workflow called used to build both the legacy OCI images
and the operator OCI images and the dependencies were only for the legacy
images. The called workflow no longer builds the legacy images so these
dependencies are no longer needed.

Update .drone.yml with `make dronegen`.