### PR TITLE
dronegen: Re-enable arm64-fips builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -711,6 +711,79 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
+name: push-build-linux-arm64-fips
+trigger:
+  event:
+    include:
+    - push
+    exclude:
+    - pull_request
+  repo:
+    include:
+    - gravitational/*
+  branch:
+    include:
+    - master
+    - branch/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  pull: if-not-exists
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - mkdir -pv /go/cache
+  - rm -f /root/.ssh/id_rsa
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
+  pull: if-not-exists
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "build-connect=false" -input "release-target=release-arm64-fips" '
+  environment:
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
+
+---
 kind: pipeline
 type: kubernetes
 name: teleport-docker-cron-ecr
@@ -1370,6 +1443,77 @@ steps:
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
     "build-connect=false" -input "build-os-packages=true" -input "release-artifacts=true"
     -input "release-target=release-arm64" '
+  environment:
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
+name: build-linux-arm64-fips
+trigger:
+  event:
+    include:
+    - tag
+  ref:
+    include:
+    - refs/tags/v*
+  repo:
+    include:
+    - gravitational/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  pull: if-not-exists
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - mkdir -pv /go/cache
+  - rm -f /root/.ssh/id_rsa
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
+  pull: if-not-exists
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=false" -input "build-os-packages=true" -input "release-artifacts=true"
+    -input "release-target=release-arm64-fips" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -2354,6 +2498,7 @@ depends_on:
 - build-linux-amd64
 - build-linux-amd64-fips
 - build-linux-arm64
+- build-linux-arm64-fips
 - build-linux-arm
 steps:
 - name: Check out code
@@ -2418,6 +2563,7 @@ depends_on:
 - build-linux-amd64
 - build-linux-amd64-fips
 - build-linux-arm64
+- build-linux-arm64-fips
 steps:
 - name: Check out code
   image: docker:git
@@ -5389,6 +5535,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 629eccbd2728a9c39a165ab17e8bdcc710d79ebdecc8e2ed84ac546d04ae98fe
+hmac: 92a1f74b485895beb8d16112085e6e018e471a0125c526a94fdc905706a3a12f
 
 ...

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -46,8 +46,7 @@ func NewTeleportProduct(isEnterprise, isFips bool, version *ReleaseVersion) *Pro
 	workingDirectory := "/go/build"
 	name := "teleport"
 	dockerfileTarget := "teleport"
-	supportedArches := []string{"amd64"}
-	// supportedArches := []string{"amd64", "arm64"}
+	supportedArches := []string{"amd64", "arm64"}
 
 	if isEnterprise {
 		name += "-ent"
@@ -56,8 +55,7 @@ func NewTeleportProduct(isEnterprise, isFips bool, version *ReleaseVersion) *Pro
 		dockerfileTarget += "-fips"
 		name += "-fips"
 	} else {
-		supportedArches = append(supportedArches, "arm", "arm64")
-		// supportedArches = append(supportedArches, "arm")
+		supportedArches = append(supportedArches, "arm")
 	}
 
 	setupSteps, dockerfilePath, downloadProfileName := getTeleportSetupSteps(name, workingDirectory, version.ShellVersion)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -49,7 +49,7 @@ func pushPipelines() []pipeline {
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "386", fips: false}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm64", fips: false}))
-	// ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm64", fips: true}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm", fips: false}))
 	ps = append(ps, ghaWindowsPushPipeline())
 

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -40,7 +40,7 @@ func tagPipelines() []pipeline {
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "amd64", fips: true, centos7: true, buildConnect: false, buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "386", buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", fips: false, buildOSPkg: true}))
-	// ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", fips: true, buildOSPkg: true}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm64", fips: true, buildOSPkg: true}))
 	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm", buildOSPkg: true}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
@@ -52,7 +52,7 @@ func tagPipelines() []pipeline {
 			"build-linux-amd64",
 			"build-linux-amd64-fips",
 			"build-linux-arm64",
-			// "build-linux-arm64-fips",
+			"build-linux-arm64-fips",
 			"build-linux-arm",
 		},
 		workflows: []ghaWorkflow{
@@ -75,7 +75,7 @@ func tagPipelines() []pipeline {
 			"build-linux-amd64",
 			"build-linux-amd64-fips",
 			"build-linux-arm64",
-			// "build-linux-arm64-fips",
+			"build-linux-arm64-fips",
 		},
 		workflows: []ghaWorkflow{
 			{


### PR DESCRIPTION
Revert the dronegen parts of f01e4bc1f0 that disabled arm64-fips build so
we can release arm64-fips artifacts now that the build is working again.

---

https://github.com/gravitational/teleport.e/pull/3178 is the peer PR in teleport.e
that re-enables the parts of the workflows that were disabled.