### PR TITLE
Stop the page crashing when Assist is closed

### DIFF
--- a/web/packages/teleport/src/Assist/ConversationList/ConversationList.tsx
+++ b/web/packages/teleport/src/Assist/ConversationList/ConversationList.tsx
@@ -69,19 +69,21 @@ export function ConversationList(props: ConversationListProps) {
       return;
     }
 
+    const scrollRefCurrent = scrollRef.current;
+
     function onscroll() {
       const scrollPosition = scrollRef.current.scrollTop;
       const maxScrollPosition =
-        scrollRef.current.scrollHeight - scrollRef.current.clientHeight;
+        scrollRefCurrent.scrollHeight - scrollRefCurrent.clientHeight;
 
       // if the user has scrolled more than 50px from the bottom of the chat, assume they don't want the message list
       // to auto scroll.
       shouldScroll.current = scrollPosition > maxScrollPosition - 50;
     }
 
-    scrollRef.current.addEventListener('wheel', onscroll);
+    scrollRefCurrent.addEventListener('wheel', onscroll);
 
-    return () => scrollRef.current.removeEventListener('wheel', onscroll);
+    return () => scrollRefCurrent.removeEventListener('wheel', onscroll);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
`scrollRef.current` was undefined in the effect's unsubscribe function, so the page would crash as `removeEventListener` didn't exist

This copies `scrollRef.current` to a local variable to avoid this.

Fixes https://github.com/gravitational/teleport/issues/36428