### PR TITLE
Show the back arrow when hiding the navigation

### DIFF
--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -183,7 +183,7 @@ export function TopBar({ CustomLogo }: TopBarProps) {
           </Flex>
         </>
       )}
-      {feature?.hideFromNavigation && (
+      {feature?.hideNavigation && (
         <ButtonIconContainer onClick={handleBack}>
           <ArrowLeft size="medium" />
         </ButtonIconContainer>


### PR DESCRIPTION
`hideFromNavigation` was used instead of `hideNavigation`, so the arrow to go back wasn't showing when viewing TAG.

Fixes https://github.com/gravitational/access-graph/issues/387