### PR TITLE
Remove Connect build artifacts when running `make clean-ui`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,7 @@ endif
 .PHONY: clean-ui
 clean-ui:
 	rm -rf webassets/*
+	rm -rf web/packages/teleterm/build
 	find . -type d -name node_modules -prune -exec rm -rf {} \;
 
 #


### PR DESCRIPTION
Connect's artifacts should be cleaned along with all other UI artifacts.

Original request https://gravitational.slack.com/archives/C02DQ1C2BMW/p1705449562972079

I ran a [CI build](https://drone.platform.teleport.sh/gravitational/teleport/32754) to make sure that this change doesn't break anything.