### PR TITLE
sign host certs with correct CA when connecting to leaf agentless nodes

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -651,6 +651,8 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 						// matching the cluster name only
 						Where: builder.Equals(services.ResourceNameExpr, builder.String(r.ClusterName)).String(),
 					},
+					// TODO: lock down access to host certs of this cluster only?
+					types.NewRule(types.KindHostCert, services.RW()),
 				},
 			},
 		})

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -640,7 +640,7 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 					types.NewRule(types.KindInstaller, services.RO()),
 					types.NewRule(types.KindUIConfig, services.RO()),
 					types.NewRule(types.KindDatabaseService, services.RO()),
-					// this rule allows remote proxy to update the cluster's certificate authorities
+					// This rule allows remote proxies to update the cluster's certificate authorities
 					// during certificates renewal
 					{
 						Resources: []string{types.KindCertAuthority},
@@ -651,8 +651,15 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 						// matching the cluster name only
 						Where: builder.Equals(services.ResourceNameExpr, builder.String(r.ClusterName)).String(),
 					},
-					// TODO: lock down access to host certs of this cluster only?
-					types.NewRule(types.KindHostCert, services.RW()),
+					// This rule allows remote proxies to create host certificates when connecting to
+					// a leaf agentless node
+					{
+						Resources: []string{types.KindHostCert},
+						// The remote proxy should only be able to create new host certificates
+						Verbs: []string{types.VerbCreate},
+						// The remote proxy should only be able to create host certificates for this cluster
+						Where: builder.Equals(services.HostCertClusterNameExpr, builder.String(a.clusterName)).String(),
+					},
 				},
 			},
 		})

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1231,7 +1231,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	// certificate cache is created in each site (instead of creating it in
 	// reversetunnel.server and passing it along) so that the host certificate
 	// is signed by the correct certificate authority.
-	certificateCache, err := newHostCertificateCache(srv.localAuthClient)
+	certificateCache, err := newHostCertificateCache(remoteSite.remoteClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -53,6 +53,9 @@ var (
 	// CertAuthorityTypeExpr is a function call that returns
 	// cert authority type.
 	CertAuthorityTypeExpr = builder.Identifier(`system.catype()`)
+	// HostCertClusterNameExpr is the identifier that specifies
+	// the cluster name of a host certificate.
+	HostCertClusterNameExpr = builder.Identifier("host_cert.cluster_name")
 )
 
 // predicateAllEndWith is a custom function to test if a string ends with a


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/36801.

changelog: improve UX when connecting to leaf OpenSSH nodes