### PR TITLE
Polishing desktop player

### DIFF
--- a/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -524,7 +524,8 @@ exports[`connected settings false 1`] = `
       </div>
     </nav>
     <canvas
-      style="display: flex;"
+      style="display: flex; outline: none;"
+      tabindex="-1"
     />
   </div>
 </div>
@@ -832,7 +833,8 @@ exports[`connected settings true 1`] = `
       </div>
     </nav>
     <canvas
-      style="display: flex;"
+      style="display: flex; outline: none;"
+      tabindex="-1"
     />
   </div>
 </div>
@@ -1364,7 +1366,8 @@ exports[`disconnected 1`] = `
       </div>
     </div>
     <canvas
-      style="display: none;"
+      style="display: none; outline: none;"
+      tabindex="-1"
     />
   </div>
 </div>
@@ -2087,7 +2090,8 @@ exports[`processing 1`] = `
       class="c15"
     />
     <canvas
-      style="display: none;"
+      style="display: none; outline: none;"
+      tabindex="-1"
     />
   </div>
 </div>
@@ -2404,7 +2408,8 @@ exports[`tdp processing 1`] = `
       class="c15"
     />
     <canvas
-      style="display: none;"
+      style="display: none; outline: none;"
+      tabindex="-1"
     />
   </div>
 </div>

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -172,34 +172,33 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     [setPlayerStatus, setStatusText]
   );
 
-  const clientOnClientScreenSpec = (
-    cli: TdpClient,
-    canvas: HTMLCanvasElement,
-    spec: ClientScreenSpec
-  ) => {
-    const { width, height } = spec;
+  const clientOnClientScreenSpec = useCallback(
+    (_cli: TdpClient, canvas: HTMLCanvasElement, spec: ClientScreenSpec) => {
+      const { width, height } = spec;
 
-    const styledPlayer = canvas.parentElement;
-    const progressBar = styledPlayer.children.namedItem(PROGRESS_BAR_ID);
+      const styledPlayer = canvas.parentElement;
+      const progressBar = styledPlayer.children.namedItem(PROGRESS_BAR_ID);
 
-    const fullWidth = styledPlayer.clientWidth;
-    const fullHeight = styledPlayer.clientHeight - progressBar.clientHeight;
-    const originalAspectRatio = width / height;
-    const currentAspectRatio = fullWidth / fullHeight;
+      const fullWidth = styledPlayer.clientWidth;
+      const fullHeight = styledPlayer.clientHeight - progressBar.clientHeight;
+      const originalAspectRatio = width / height;
+      const currentAspectRatio = fullWidth / fullHeight;
 
-    if (originalAspectRatio > currentAspectRatio) {
-      // Use the full width of the screen and scale the height.
-      canvas.style.height = `${(fullWidth * height) / width}px`;
-    } else if (originalAspectRatio < currentAspectRatio) {
-      // Use the full height of the screen and scale the width.
-      canvas.style.width = `${(fullHeight * width) / height}px`;
-    }
+      if (originalAspectRatio > currentAspectRatio) {
+        // Use the full width of the screen and scale the height.
+        canvas.style.height = `${(fullWidth * height) / width}px`;
+      } else if (originalAspectRatio < currentAspectRatio) {
+        // Use the full height of the screen and scale the width.
+        canvas.style.width = `${(fullHeight * width) / height}px`;
+      }
 
-    canvas.width = width;
-    canvas.height = height;
+      canvas.width = width;
+      canvas.height = height;
 
-    setCanvasSizeIsSet(true);
-  };
+      setCanvasSizeIsSet(true);
+    },
+    [setCanvasSizeIsSet]
+  );
 
   useEffect(() => {
     return playerClient.shutdown;

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -73,10 +73,9 @@ export const DesktopPlayer = ({
   const isPlaying = playerStatus === StatusEnum.PLAYING;
   const isComplete = isError || playerStatus === StatusEnum.COMPLETE;
 
-  const t =
-    playerStatus === StatusEnum.COMPLETE || playerStatus === StatusEnum.ERROR
-      ? durationMs // Force progress bar to 100% when playback is complete or errored.
-      : time; // Otherwise, use the current time.
+  const t = isComplete
+    ? durationMs // Force progress bar to 100% when playback is complete or errored.
+    : time; // Otherwise, use the current time.
 
   // Hide the canvas and progress bar until the canvas' size has been fully defined.
   // This prevents visual glitches at pageload where the canvas starts out small and

--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -16,9 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import * as Icons from 'design/Icon';
-import React from 'react';
+import React, { memo } from 'react';
 import styled from 'styled-components';
+
+import * as Icons from 'design/Icon';
 
 import Slider from './Slider';
 
@@ -89,34 +90,33 @@ export type ProgressBarProps = {
   onRestart?: () => void;
 };
 
-function PlaySpeedSelector(props: {
-  disabled?: boolean;
-  onChange?: (speed: number) => void;
-}) {
-  if (!props.onChange) {
-    return null;
+const PlaySpeedSelector = memo(
+  (props: { disabled?: boolean; onChange?: (speed: number) => void }) => {
+    if (!props.onChange) {
+      return null;
+    }
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      props.onChange(parseFloat(event.target.value));
+    };
+
+    return (
+      <PlaySpeedSelectorItem
+        disabled={props.disabled}
+        onChange={handleChange}
+        defaultValue={'1.0'}
+      >
+        <option value="0.25">0.25x</option>
+        <option value="0.5">0.5x</option>
+        <option value="1.0">1.0x</option>
+        <option value="2.0">2.0x</option>
+        <option value="4.0">4.0x</option>
+        <option value="8.0">8.0x</option>
+        <option value="16.0">16.0x</option>
+      </PlaySpeedSelectorItem>
+    );
   }
-
-  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    props.onChange(parseFloat(event.target.value));
-  };
-
-  return (
-    <PlaySpeedSelectorItem
-      disabled={props.disabled}
-      onChange={handleChange}
-      defaultValue={'1.0'}
-    >
-      <option value="0.25">0.25x</option>
-      <option value="0.5">0.5x</option>
-      <option value="1.0">1.0x</option>
-      <option value="2.0">2.0x</option>
-      <option value="4.0">4.0x</option>
-      <option value="8.0">8.0x</option>
-      <option value="16.0">16.0x</option>
-    </PlaySpeedSelectorItem>
-  );
-}
+);
 
 const PlaySpeedSelectorItem = styled.select`
   margin-left: 8px;

--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import * as Icons from 'design/Icon';
 import React from 'react';
 import styled from 'styled-components';
-import * as Icons from 'design/Icon';
 
 import Slider from './Slider';
 
@@ -33,7 +33,10 @@ export default function ProgressBar(props: ProgressBarProps) {
       <ActionButton onClick={props.toggle} disabled={props.disabled}>
         <Icon />
       </ActionButton>
-      <PlaySpeedSelector onChange={props.onPlaySpeedChange} />
+      <PlaySpeedSelector
+        onChange={props.onPlaySpeedChange}
+        disabled={props.disabled}
+      />
       <TimeText>{props.time}</TimeText>
       <SliderContainer>
         <Slider
@@ -86,7 +89,10 @@ export type ProgressBarProps = {
   onRestart?: () => void;
 };
 
-function PlaySpeedSelector(props: { onChange?: (speed: number) => void }) {
+function PlaySpeedSelector(props: {
+  disabled?: boolean;
+  onChange?: (speed: number) => void;
+}) {
   if (!props.onChange) {
     return null;
   }
@@ -96,7 +102,11 @@ function PlaySpeedSelector(props: { onChange?: (speed: number) => void }) {
   };
 
   return (
-    <PlaySpeedSelectorItem onChange={handleChange} defaultValue={'1.0'}>
+    <PlaySpeedSelectorItem
+      disabled={props.disabled}
+      onChange={handleChange}
+      defaultValue={'1.0'}
+    >
       <option value="0.25">0.25x</option>
       <option value="0.5">0.5x</option>
       <option value="1.0">1.0x</option>

--- a/web/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/web/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
@@ -18,10 +18,8 @@
 
 import React, { memo, useEffect, useRef } from 'react';
 
-import { TdpClientEvent } from 'teleport/lib/tdp';
+import { TdpClientEvent, TdpClient } from 'teleport/lib/tdp';
 import { BitmapFrame } from 'teleport/lib/tdp/client';
-
-import { TdpClient } from 'teleport/lib/tdp';
 
 import type { CSSProperties } from 'react';
 import type {
@@ -55,14 +53,19 @@ function TdpClientCanvas(props: Props) {
   } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  if (canvasRef.current) {
-    // Make the canvas a focusable keyboard listener
-    // https://stackoverflow.com/a/51267699/6277051
-    // https://stackoverflow.com/a/16492878/6277051
-    canvasRef.current.tabIndex = -1;
-    canvasRef.current.style.outline = 'none';
-    canvasRef.current.focus();
-  }
+  useEffect(() => {
+    // Empty dependency array ensures this runs only once after initial render.
+    // This code will run after the component has been mounted and the canvasRef has been assigned.
+    const canvas = canvasRef.current;
+    if (canvas) {
+      // Make the canvas a focusable keyboard listener
+      // https://stackoverflow.com/a/51267699/6277051
+      // https://stackoverflow.com/a/16492878/6277051
+      canvas.tabIndex = -1;
+      canvas.style.outline = 'none';
+      canvas.focus();
+    }
+  }, []);
 
   useEffect(() => {
     if (client && clientOnPngFrame) {


### PR DESCRIPTION
This commit waits for the canvas to be fully defined before rendering the canvas and progress bar, which prevents visual glitches at pageload where the canvas starts out small and then suddenly expands to its full size (moving the progress bar down with it).

Fixes https://github.com/gravitational/teleport/issues/36781

Before:

https://github.com/gravitational/teleport/assets/13578537/c84826a9-6680-42f4-982d-d8c6d51aac78

After:

https://github.com/gravitational/teleport/assets/13578537/511e54e9-fe90-417a-8d56-5206322f8bfb

It also polishes off the error message display and fixes https://github.com/gravitational/teleport/issues/36827