### PR TITLE
Update dashboard URL in docker config comment

### DIFF
--- a/docker/teleport/config/teleport.yaml
+++ b/docker/teleport/config/teleport.yaml
@@ -3,7 +3,7 @@
 # Creates a single proxy, auth and node server.
 #
 # Things to update:
-#  1. license.pem: You only need a license from https://dashboard.goteleport.com
+#  1. license.pem: You only need a license from https://teleport.sh
 #     if you are an Enterprise customer.
 #
 teleport:


### PR DESCRIPTION
`dashboard.goteleport.com` is dead. https://teleport.sh is the correct location.