### PR TITLE
Add [disabled] Bots list view

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -938,10 +938,14 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// GET Machine ID bot by name
 	h.GET("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.getBot))
+	// GET Machine ID bots
+	h.GET("/webapi/sites/:site/machine-id/bot", h.WithClusterAuth(h.listBots))
 	// Create Machine ID bots
 	h.POST("/webapi/sites/:site/machine-id/bot", h.WithClusterAuth(h.createBot))
 	// Create bot join tokens
 	h.POST("/webapi/sites/:site/machine-id/token", h.WithClusterAuth(h.createBotJoinToken))
+	// Delete Machine ID bot
+	h.DELETE("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.deleteBot))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -36,6 +36,11 @@ const (
 	webUIFlowBotGitHubActionsSSH = "github-actions-ssh"
 )
 
+type ListBotsResponse struct {
+	// Items is a list of resources retrieved.
+	Items []*machineidv1.Bot `json:"items"`
+}
+
 type CreateBotRequest struct {
 	// BotName is the name of the bot
 	BotName string `json:"botName"`
@@ -46,6 +51,36 @@ type CreateBotRequest struct {
 	// Where multiple specified with the same name, these will be merged by the
 	// server.
 	Traits []*machineidv1.Trait `json:"traits"`
+}
+
+// listBots returns a list of bots for a given cluster site. It does not leverage pagination from the UI. Due to the
+// nature of the bot:user relationship, pagination is not yet supported. This endpoint will return all bots.
+func (h *Handler) listBots(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var items []*machineidv1.Bot
+	for pageToken := ""; ; {
+		bots, err := clt.BotServiceClient().ListBots(r.Context(), &machineidv1.ListBotsRequest{
+			PageSize:  int32(1000),
+			PageToken: pageToken,
+		})
+		// todo (michellescripts) consider returning partial results
+		if err != nil {
+			return nil, trace.Wrap(err, "error getting bots")
+		}
+		items = append(items, bots.Bots...)
+		pageToken = bots.NextPageToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	return ListBotsResponse{
+		Items: items,
+	}, nil
 }
 
 // createBot creates a bot
@@ -75,6 +110,25 @@ func (h *Handler) createBot(w http.ResponseWriter, r *http.Request, p httprouter
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "error creating bot")
+	}
+
+	return OK(), nil
+}
+
+func (h *Handler) deleteBot(_ http.ResponseWriter, r *http.Request, params httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	name := params.ByName("name")
+	if name == "" {
+		return nil, trace.BadParameter("missing bot name")
+	}
+
+	_, err = clt.BotServiceClient().DeleteBot(r.Context(), &machineidv1.DeleteBotRequest{BotName: name})
+	if err != nil {
+		return nil, trace.Wrap(err, "error deleting bot")
 	}
 
 	return OK(), nil

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -33,6 +35,68 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
+
+func TestListBots(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint(
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	created := 5
+	n := 0
+	for n < created {
+		n += 1
+		_, err := pack.clt.PostJSON(ctx, endpoint, CreateBotRequest{
+			BotName: "test-bot-" + strconv.Itoa(n),
+			Roles:   []string{""},
+		})
+		require.NoError(t, err)
+	}
+
+	response, err := pack.clt.Get(ctx, endpoint, url.Values{
+		"page_token": []string{""},  // default to the start
+		"page_size":  []string{"2"}, // is ignored
+	})
+	require.NoError(t, err)
+
+	var bots ListBotsResponse
+	require.NoError(t, json.Unmarshal(response.Bytes(), &bots), "invalid response received")
+	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code getting connectors")
+
+	assert.Len(t, bots.Items, created)
+}
+
+func TestListBots_UnauthenticatedError(t *testing.T) {
+	ctx := context.Background()
+	s := newWebSuite(t)
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint(
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	publicClt := s.client(t)
+	_, err := publicClt.Get(ctx, endpoint, url.Values{
+		"page_token": []string{""},
+		"page_size":  []string{""},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err))
+}
 
 func TestCreateBot(t *testing.T) {
 	s := newWebSuite(t)
@@ -137,6 +201,65 @@ func TestCreateBotJoinToken(t *testing.T) {
 	invalidIntegrationNameReq.IntegrationName = ""
 	_, err = pack.clt.PostJSON(ctx, endpoint, invalidIntegrationNameReq)
 	require.Error(t, err)
+}
+
+func TestDeleteBot_UnauthenticatedError(t *testing.T) {
+	ctx := context.Background()
+	s := newWebSuite(t)
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint(
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+		"testname",
+	)
+
+	publicClt := s.client(t)
+	_, err := publicClt.Delete(ctx, endpoint)
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err))
+}
+
+func TestDeleteBot(t *testing.T) {
+	botName := "bot-bravo"
+
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint(
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	// create bot to delete
+	_, err := pack.clt.PostJSON(ctx, endpoint, CreateBotRequest{
+		BotName: botName,
+		Roles:   []string{""},
+	})
+	require.NoError(t, err)
+
+	endpoint = pack.clt.Endpoint(
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+		botName,
+	)
+
+	resp, err := pack.clt.Delete(ctx, endpoint)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code(), "unexpected status code getting connectors")
 }
 
 func TestGetBotByName(t *testing.T) {

--- a/web/packages/design/src/Icon/Icons/Bots.tsx
+++ b/web/packages/design/src/Icon/Icons/Bots.tsx
@@ -1,0 +1,78 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* MIT License
+
+Copyright (c) 2020 Phosphor Icons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+import React from 'react';
+
+import { Icon, IconProps } from '../Icon';
+
+/*
+
+THIS FILE IS GENERATED. DO NOT EDIT.
+
+*/
+
+export function Bots({ size = 24, color, ...otherProps }: IconProps) {
+  return (
+    <Icon size={size} color={color} className="icon icon-users" {...otherProps}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.625 18H15.375C16.8247 18 18 16.8247 18 15.375C18 13.9253 16.8247 12.75 15.375 12.75H8.625C7.17525 12.75 6 13.9253 6 15.375C6 16.8247 7.17525 18 8.625 18ZM8.625 14.25C8.00368 14.25 7.5 14.7537 7.5 15.375C7.5 15.9963 8.00368 16.5 8.625 16.5H9.75V14.25H8.625ZM14.25 16.5H15.375C15.9963 16.5 16.5 15.9963 16.5 15.375C16.5 14.7537 15.9963 14.25 15.375 14.25H14.25V16.5ZM11.25 14.25V16.5H12.75V14.25H11.25Z"
+        fill="black"
+      />
+      <path
+        d="M7.875 11.0625C8.39277 11.0625 8.8125 10.6428 8.8125 10.125C8.8125 9.60723 8.39277 9.1875 7.875 9.1875C7.35723 9.1875 6.9375 9.60723 6.9375 10.125C6.9375 10.6428 7.35723 11.0625 7.875 11.0625Z"
+        fill="black"
+      />
+      <path
+        d="M17.0625 10.125C17.0625 10.6428 16.6428 11.0625 16.125 11.0625C15.6072 11.0625 15.1875 10.6428 15.1875 10.125C15.1875 9.60723 15.6072 9.1875 16.125 9.1875C16.6428 9.1875 17.0625 9.60723 17.0625 10.125Z"
+        fill="black"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12.75 1.5C12.75 1.08579 12.4142 0.75 12 0.75C11.5858 0.75 11.25 1.08579 11.25 1.5V4.5H5.25C3.59315 4.5 2.25 5.84315 2.25 7.5V18C2.25 19.6569 3.59315 21 5.25 21H18.75C20.4069 21 21.75 19.6569 21.75 18V7.5C21.75 5.84315 20.4069 4.5 18.75 4.5H12.75V1.5ZM5.25 6C4.42157 6 3.75 6.67157 3.75 7.5V18C3.75 18.8284 4.42157 19.5 5.25 19.5H18.75C19.5784 19.5 20.25 18.8284 20.25 18V7.5C20.25 6.67157 19.5784 6 18.75 6H5.25Z"
+        fill="black"
+      />
+    </Icon>
+  );
+}

--- a/web/packages/design/src/Icon/index.ts
+++ b/web/packages/design/src/Icon/index.ts
@@ -128,6 +128,7 @@ export { ListThin } from './Icons/ListThin';
 export { ListView } from './Icons/ListView';
 export { Lock } from './Icons/Lock';
 export { Logout } from './Icons/Logout';
+export { Bots } from './Icons/Bots';
 export { Magnifier } from './Icons/Magnifier';
 export { MagnifyingMinus } from './Icons/MagnifyingMinus';
 export { MagnifyingPlus } from './Icons/MagnifyingPlus';

--- a/web/packages/teleport/src/Bots/DeleteBot.test.tsx
+++ b/web/packages/teleport/src/Bots/DeleteBot.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, userEvent } from 'design/utils/testing';
+
+import { DeleteBot } from 'teleport/Bots/DeleteBot';
+import { DeleteBotProps } from 'teleport/Bots/types';
+
+const makeProps = (): DeleteBotProps => ({
+  attempt: { status: '' },
+  name: 'bot-007',
+  onClose: () => {},
+  onDelete: () => {},
+});
+
+test('renders', async () => {
+  const props = makeProps();
+  render(<DeleteBot {...props} />);
+
+  expect(screen.getByText('Delete Bot?')).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Yes, Delete Bot' })
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+  screen.getByText((content, node) => {
+    const hasText = node =>
+      node.textContent === 'Are you sure you want to delete Bot bot-007 ?';
+    const nodeHasText = hasText(node);
+    const childrenDontHaveText = Array.from(node.children).every(
+      child => !hasText(child)
+    );
+    return nodeHasText && childrenDontHaveText;
+  });
+});
+
+test('cancel calls onclose cb', async () => {
+  const props = makeProps();
+  const mockClose = jest.fn();
+  props.onClose = mockClose;
+  render(<DeleteBot {...props} />);
+
+  expect(mockClose).not.toHaveBeenCalled();
+  await userEvent.click(screen.queryByRole('button', { name: 'Cancel' }));
+  expect(mockClose).toHaveBeenCalled();
+});
+
+test('delete calls ondelete cb', async () => {
+  const props = makeProps();
+  const mockDelete = jest.fn();
+  props.onDelete = mockDelete;
+  render(<DeleteBot {...props} />);
+
+  expect(mockDelete).not.toHaveBeenCalled();
+  await userEvent.click(
+    screen.queryByRole('button', { name: 'Yes, Delete Bot' })
+  );
+  expect(mockDelete).toHaveBeenCalled();
+});
+
+test('disables buttons when processing', async () => {
+  const props = makeProps();
+  props.attempt = { status: 'processing' };
+  render(<DeleteBot {...props} />);
+
+  expect(
+    screen.queryByRole('button', { name: 'Yes, Delete Bot' })
+  ).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'Cancel' })).toBeDisabled();
+});
+
+test('displays error text', async () => {
+  const props = makeProps();
+  props.attempt = { status: 'failed', statusText: 'error deleting' };
+  render(<DeleteBot {...props} />);
+
+  expect(screen.getByText('error deleting')).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Bots/DeleteBot.tsx
+++ b/web/packages/teleport/src/Bots/DeleteBot.tsx
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Alert, ButtonSecondary, ButtonWarning, Text } from 'design';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/DialogConfirmation';
+
+import { DeleteBotProps } from 'teleport/Bots/types';
+
+export function DeleteBot({
+  attempt,
+  onClose,
+  name,
+  onDelete,
+}: DeleteBotProps) {
+  return (
+    <Dialog disableEscapeKeyDown={false} onClose={onClose} open={true}>
+      <DialogHeader>
+        <DialogTitle>Delete Bot?</DialogTitle>
+      </DialogHeader>
+      <DialogContent width="450px">
+        {attempt.status === 'failed' && <Alert children={attempt.statusText} />}
+        <Text typography="paragraph" mb="6">
+          Are you sure you want to delete Bot{' '}
+          <Text as="span" bold color="text.main">
+            {name}
+          </Text>{' '}
+          ?
+        </Text>
+      </DialogContent>
+      <DialogFooter>
+        <ButtonWarning
+          mr="3"
+          disabled={attempt.status === 'processing'}
+          onClick={onDelete}
+        >
+          Yes, Delete Bot
+        </ButtonWarning>
+        <ButtonSecondary
+          disabled={attempt.status === 'processing'}
+          onClick={onClose}
+        >
+          Cancel
+        </ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/Bots/List/ActionCell.tsx
+++ b/web/packages/teleport/src/Bots/List/ActionCell.tsx
@@ -1,0 +1,33 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Cell } from 'design/DataTable';
+import { MenuButton, MenuItem } from 'shared/components/MenuAction';
+
+import { BotOptionsCellProps } from 'teleport/Bots/types';
+
+export function BotOptionsCell({ onClickDelete }: BotOptionsCellProps) {
+  return (
+    <Cell align="right">
+      <MenuButton>
+        <MenuItem onClick={onClickDelete}>Delete...</MenuItem>
+      </MenuButton>
+    </Cell>
+  );
+}

--- a/web/packages/teleport/src/Bots/List/BotList.test.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from 'design/utils/testing';
+
+import { BotList } from 'teleport/Bots/List/BotList';
+import { BotListProps } from 'teleport/Bots/types';
+import { botsFixture } from 'teleport/Bots/fixtures';
+
+const makeProps = (): BotListProps => ({
+  attempt: { status: '' },
+  bots: botsFixture,
+  onClose: () => {},
+  onDelete: () => {},
+  selectedBot: null,
+  setSelectedBot: () => {},
+});
+
+test('renders table with bots', () => {
+  const props = makeProps();
+  render(<BotList {...props} />);
+
+  const rows = screen.getAllByRole('row');
+  expect(rows).toHaveLength(props.bots.length + 1);
+
+  props.bots.forEach(row => {
+    expect(screen.getByText(row.name)).toBeInTheDocument();
+    row.roles.forEach(role => {
+      expect(screen.getByText(role)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/packages/teleport/src/Bots/List/BotList.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.tsx
@@ -1,0 +1,78 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Table, { LabelCell } from 'design/DataTable';
+
+import React from 'react';
+
+import { BotOptionsCell } from 'teleport/Bots/List/ActionCell';
+
+import { BotListProps } from 'teleport/Bots/types';
+import { DeleteBot } from 'teleport/Bots/DeleteBot';
+
+export function BotList({
+  attempt,
+  bots,
+  onClose,
+  onDelete,
+  selectedBot,
+  setSelectedBot,
+}: BotListProps) {
+  return (
+    <>
+      <Table
+        data={bots}
+        columns={[
+          {
+            key: 'name',
+            headerText: 'Bot Name',
+            isSortable: true,
+          },
+          {
+            key: 'roles',
+            headerText: 'Roles',
+            isSortable: true,
+            onSort: (a: string[], b: string[]) =>
+              a.toString().localeCompare(b.toString()),
+            render: ({ roles }) => <LabelCell data={roles} />,
+          },
+          {
+            altKey: 'options-btn',
+            render: bot => (
+              <BotOptionsCell
+                bot={bot}
+                onClickDelete={() => setSelectedBot(bot)}
+              />
+            ),
+          },
+        ]}
+        emptyText="No Bots Found"
+        isSearchable
+        pagination={{ pageSize: 20 }}
+      />
+      {selectedBot && (
+        <DeleteBot
+          attempt={attempt}
+          name={selectedBot.name}
+          onClose={onClose}
+          onDelete={onDelete}
+        />
+      )}
+    </>
+  );
+}

--- a/web/packages/teleport/src/Bots/List/Bots.story.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.story.tsx
@@ -1,0 +1,39 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { botsFixture } from 'teleport/Bots/fixtures';
+import { BotList } from 'teleport/Bots/List/BotList';
+
+export default {
+  title: 'Teleport/Bots',
+};
+
+export const List = () => {
+  return (
+    <BotList
+      attempt={{ status: '' }}
+      bots={botsFixture}
+      onDelete={() => {}}
+      onClose={() => {}}
+      selectedBot={null}
+      setSelectedBot={() => {}}
+    />
+  );
+};

--- a/web/packages/teleport/src/Bots/List/Bots.test.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+
+import api from 'teleport/services/api';
+import { botsApiResponseFixture } from 'teleport/Bots/fixtures';
+
+import { Bots } from './Bots';
+
+test('fetches bots on load', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue({ ...botsApiResponseFixture });
+  render(<Bots />);
+
+  expect(screen.getByText('Bots')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(botsApiResponseFixture.items[0].metadata.name)
+    ).toBeInTheDocument();
+  });
+  expect(api.get).toHaveBeenCalled();
+});
+
+test('calls delete endpoint', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue({ ...botsApiResponseFixture });
+  jest.spyOn(api, 'delete').mockResolvedValue({});
+  render(<Bots />);
+
+  expect(screen.getByText('Bots')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(botsApiResponseFixture.items[0].metadata.name)
+    ).toBeInTheDocument();
+  });
+
+  const actionCells = screen.queryAllByRole('button', { name: 'OPTIONS' });
+  expect(actionCells).toHaveLength(botsApiResponseFixture.items.length);
+  await userEvent.click(actionCells[0]);
+
+  expect(screen.getByText('Delete...')).toBeInTheDocument();
+  await userEvent.click(screen.getByText('Delete...'));
+
+  expect(screen.getByText('Delete Bot?')).toBeInTheDocument();
+  await userEvent.click(
+    screen.queryByRole('button', { name: 'Yes, Delete Bot' })
+  );
+
+  expect(screen.queryByText('Delete Bot?')).not.toBeInTheDocument();
+  expect(api.delete).toHaveBeenCalledWith(
+    `/v1/webapi/sites/localhost/machine-id/bot/${botsApiResponseFixture.items[0].metadata.name}`
+  );
+});

--- a/web/packages/teleport/src/Bots/List/Bots.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.tsx
@@ -1,0 +1,93 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+import { Alert, Box, ButtonPrimary, Indicator } from 'design';
+
+import { useAttemptNext } from 'shared/hooks';
+
+import {
+  FeatureBox,
+  FeatureHeader,
+  FeatureHeaderTitle,
+} from 'teleport/components/Layout';
+import { BotList } from 'teleport/Bots/List/BotList';
+import { deleteBot, fetchBots } from 'teleport/services/bot/bot';
+import { FlatBot } from 'teleport/services/bot/types';
+
+export function Bots() {
+  const [bots, setBots] = useState<FlatBot[]>();
+  const [selectedBot, setSelectedBot] = useState<FlatBot>();
+  const { attempt: deleteAttempt, run: deleteRun } = useAttemptNext();
+  const { attempt: fetchAttempt, run: fetchRun } = useAttemptNext('processing');
+
+  useEffect(() => {
+    const signal = new AbortController();
+
+    async function init(signal: AbortSignal) {
+      const res = await fetchBots(signal);
+      setBots(res.bots);
+    }
+
+    fetchRun(() => init(signal.signal));
+    return () => {
+      signal.abort();
+    };
+  }, [fetchRun]);
+
+  function onDelete() {
+    deleteRun(() => deleteBot(selectedBot.name)).then(() => {
+      setBots(bots.filter(bot => bot.name !== selectedBot.name));
+      onClose();
+    });
+  }
+
+  function onClose() {
+    setSelectedBot(null);
+  }
+
+  return (
+    <FeatureBox>
+      <FeatureHeader>
+        <FeatureHeaderTitle>Bots</FeatureHeaderTitle>
+        <ButtonPrimary ml="auto" width="240px" disabled>
+          Enroll New Bot
+        </ButtonPrimary>
+      </FeatureHeader>
+      {fetchAttempt.status == 'processing' && (
+        <Box textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      )}
+      {fetchAttempt.status == 'failed' && (
+        <Alert kind="danger" children={fetchAttempt.statusText} />
+      )}
+      {fetchAttempt.status == 'success' && (
+        <BotList
+          attempt={deleteAttempt}
+          bots={bots}
+          onClose={onClose}
+          onDelete={onDelete}
+          selectedBot={selectedBot}
+          setSelectedBot={setSelectedBot}
+        />
+      )}
+    </FeatureBox>
+  );
+}

--- a/web/packages/teleport/src/Bots/List/index.ts
+++ b/web/packages/teleport/src/Bots/List/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './Bots';

--- a/web/packages/teleport/src/Bots/fixtures/index.ts
+++ b/web/packages/teleport/src/Bots/fixtures/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ApiBot, BotResponse, FlatBot } from 'teleport/services/bot/types';
+
+// nonDisplayedFields are not leveraged in the UI, so we don't explicitly set them
+const nonDisplayedFields = {
+  namespace: '',
+  description: '',
+  labels: null,
+  revision: '',
+  traits: [],
+  status: '',
+  subKind: '',
+  version: '',
+};
+
+export const botsFixture: FlatBot[] = [
+  {
+    ...nonDisplayedFields,
+    kind: 'GitHub Actions',
+    name: 'bot-github-actions',
+    roles: ['bot-bot-role'],
+  },
+  {
+    ...nonDisplayedFields,
+    kind: 'IAM',
+    name: 'bot-slack-iam',
+    roles: ['bot-iam-role'],
+  },
+  {
+    ...nonDisplayedFields,
+    kind: 'GitHub SSO',
+    name: 'github-integration',
+    roles: [],
+  },
+  {
+    ...nonDisplayedFields,
+    kind: 'Access Plugin',
+    name: 'Pagerduty',
+    roles: ['access-plugin'],
+  },
+  {
+    ...nonDisplayedFields,
+    kind: 'Terraform',
+    name: 'terraform',
+    roles: [],
+  },
+];
+
+const getEmptyApiBot = (
+  kind: string,
+  name: string,
+  roles: string[]
+): ApiBot => ({
+  kind: kind,
+  metadata: {
+    description: '',
+    labels: null,
+    name: name,
+    namespace: '',
+    revision: '',
+  },
+  spec: {
+    roles: roles,
+    traits: [],
+  },
+  status: '',
+  subKind: '',
+  version: '',
+});
+
+export const botsApiResponseFixture: BotResponse = {
+  items: [
+    {
+      ...getEmptyApiBot('GitHub Actions', 'bot-github-actions', [
+        'bot-bot-role',
+      ]),
+    },
+    {
+      ...getEmptyApiBot('IAM', 'bot-slack-iam', ['bot-iam-role']),
+    },
+    {
+      ...getEmptyApiBot('GitHub SSO', 'github-integration', []),
+    },
+    {
+      ...getEmptyApiBot('Access Plugin', 'Pagerduty', ['access-plugin']),
+    },
+    {
+      ...getEmptyApiBot('Terraform', 'terraform', []),
+    },
+  ],
+};

--- a/web/packages/teleport/src/Bots/index.ts
+++ b/web/packages/teleport/src/Bots/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// export as default for use with React.lazy
+export { Bots as default } from './List/Bots';

--- a/web/packages/teleport/src/Bots/types.ts
+++ b/web/packages/teleport/src/Bots/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Dispatch, SetStateAction } from 'react';
+import { Attempt } from 'shared/hooks/useAttemptNext';
+
+import { FlatBot } from 'teleport/services/bot/types';
+
+export type BotOptionsCellProps = {
+  bot: FlatBot;
+  onClickDelete: (bot: FlatBot) => void;
+};
+
+export type BotListProps = {
+  attempt: Attempt;
+  bots: FlatBot[];
+  onClose: () => void;
+  onDelete: () => void;
+  selectedBot: FlatBot;
+  setSelectedBot: Dispatch<SetStateAction<FlatBot>>;
+};
+
+export type DeleteBotProps = {
+  attempt: Attempt;
+  name: string;
+  onClose: () => void;
+  onDelete: () => void;
+};

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -129,6 +129,7 @@ const cfg = {
     desktops: '/web/cluster/:clusterId/desktops',
     desktop: '/web/cluster/:clusterId/desktops/:desktopName/:username',
     users: '/web/users',
+    bots: '/web/bots',
     console: '/web/cluster/:clusterId/console',
     consoleNodes: '/web/cluster/:clusterId/console/nodes',
     consoleConnect: '/web/cluster/:clusterId/console/node/:serverId/:login',
@@ -322,6 +323,9 @@ const cfg = {
     accessRequestPath: '/v1/enterprise/accessrequest/:requestId?',
 
     accessGraphFeatures: '/v1/enterprise/accessgraph/static/features.json',
+
+    botPath: '/v1/webapi/sites/:clusterId/machine-id/bot/:name',
+    botsPath: '/v1/webapi/sites/:clusterId/machine-id/bot',
   },
 
   getUserClusterPreferencesUrl(clusterId: string) {
@@ -485,6 +489,10 @@ const cfg = {
   getUsersRoute() {
     const clusterId = cfg.proxyCluster;
     return generatePath(cfg.routes.users, { clusterId });
+  },
+
+  getBotsRoute() {
+    return generatePath(cfg.routes.bots);
   },
 
   getAppsRoute(clusterId: string) {
@@ -1016,6 +1024,16 @@ const cfg = {
         ...params,
       })
     );
+  },
+
+  getBotsUrl() {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.botsPath, { clusterId });
+  },
+
+  getBotUrlWithName(name: string) {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.botPath, { clusterId, name });
   },
 
   init(backendConfig = {}) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -20,6 +20,7 @@ import React, { lazy } from 'react';
 
 import {
   AddCircle,
+  Bots as BotsIcon,
   CirclePlay,
   ClipboardUser,
   Cluster,
@@ -69,6 +70,7 @@ const Integrations = lazy(() => import('./Integrations'));
 const IntegrationEnroll = lazy(
   () => import('@gravitational/teleport/src/Integrations/Enroll')
 );
+const Bots = lazy(() => import('./Bots'));
 
 // ****************************
 // Resource Features
@@ -200,6 +202,36 @@ export class FeatureUsers implements TeleportFeature {
     exact: true,
     getLink() {
       return cfg.getUsersRoute();
+    },
+  };
+
+  getRoute() {
+    return this.route;
+  }
+}
+
+export class FeatureBots implements TeleportFeature {
+  category = NavigationCategory.Management;
+  section = ManagementSection.Access;
+
+  route = {
+    title: 'Manage Bots',
+    path: cfg.routes.bots,
+    exact: true,
+    component: Bots,
+  };
+
+  // todo (michellescripts) return flags.Bots once integrated with mcbattirola and feature is ready
+  hasAccess() {
+    return false;
+  }
+
+  navigationItem = {
+    title: NavTitle.Bots,
+    icon: BotsIcon,
+    exact: true,
+    getLink() {
+      return cfg.getBotsRoute();
     },
   };
 
@@ -571,6 +603,7 @@ export function getOSSFeatures(): TeleportFeature[] {
 
     // - Access
     new FeatureUsers(),
+    new FeatureBots(),
     new FeatureAuthConnectors(),
     new FeatureIntegrations(),
     new FeatureDiscover(),

--- a/web/packages/teleport/src/services/bot/bot.ts
+++ b/web/packages/teleport/src/services/bot/bot.ts
@@ -1,0 +1,35 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import api from 'teleport/services/api';
+import cfg from 'teleport/config';
+
+import { makeListBot } from 'teleport/services/bot/consts';
+
+import { BotList, BotResponse } from './types';
+
+export function fetchBots(signal: AbortSignal): Promise<BotList> {
+  return api.get(cfg.getBotsUrl(), signal).then((json: BotResponse) => {
+    const items = json?.items || [];
+    return { bots: items.map(makeListBot) };
+  });
+}
+
+export function deleteBot(name: string) {
+  return api.delete(cfg.getBotUrlWithName(name));
+}

--- a/web/packages/teleport/src/services/bot/consts.ts
+++ b/web/packages/teleport/src/services/bot/consts.ts
@@ -1,0 +1,41 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ApiBot, FlatBot } from 'teleport/services/bot/types';
+
+export function makeListBot(bot: ApiBot): FlatBot {
+  if (!bot?.metadata?.name) {
+    return;
+  }
+
+  return {
+    kind: bot?.kind || '',
+    status: bot?.status || '',
+    subKind: bot?.subKind || '',
+    version: bot?.version || '',
+
+    name: bot?.metadata?.name || '',
+    namespace: bot?.metadata?.namespace || '',
+    description: bot?.metadata?.description || '',
+    labels: bot?.metadata?.labels || new Map<string, string>(),
+    revision: bot?.metadata?.revision || '',
+
+    roles: bot?.spec?.roles || [],
+    traits: bot?.spec?.traits || [],
+  };
+}

--- a/web/packages/teleport/src/services/bot/index.ts
+++ b/web/packages/teleport/src/services/bot/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { fetchBots, deleteBot } from './bot';

--- a/web/packages/teleport/src/services/bot/types.ts
+++ b/web/packages/teleport/src/services/bot/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type ApiBotMetadata = {
+  description: string;
+  labels: Map<string, string>;
+  name: string;
+  namespace: string;
+  revision: string;
+};
+
+export type ApiBotSpec = {
+  roles: string[];
+  traits: ApiBotTrait[];
+};
+
+export type ApiBotTrait = {
+  name: string;
+  values: string[];
+};
+
+export type ApiBot = {
+  kind: string;
+  metadata: ApiBotMetadata;
+  spec: ApiBotSpec;
+  status: string;
+  subKind: string;
+  version: string;
+};
+
+export type BotList = {
+  bots: FlatBot[];
+};
+
+export type FlatBot = Omit<ApiBot, 'metadata' | 'spec'> &
+  ApiBotMetadata &
+  ApiBotSpec;
+
+export type BotResponse = {
+  items: ApiBot[];
+};

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -56,6 +56,7 @@ export enum NavTitle {
 
   // Access Management
   Users = 'Users',
+  Bots = 'Bots',
   Roles = 'User Roles',
   AuthConnectors = 'Auth Connectors',
   Integrations = 'Integrations',


### PR DESCRIPTION
This PR adds a new access management menu item: Bots and the ability to delete a bot from the list. Currently, it is disabled (false in Features) until we integrate the create workflows. Until then, "enroll" will also be disabled.

This PR uses the old DataTable styles rather than the new Resources look/feel. This expedites the integrations across the team; a follow-up PR will start to tackle the [new style](https://github.com/gravitational/teleport/pull/37276). We are also only showing the name, roles and options button at this time.

Pagination for bots is MVP - we will fetch all the bots in the API and return them to the UI for pagination. This is due to a limitation of our Bot Service, which needs to fetch ListUsers to get bots. The team is aware of the pitfalls of this approach and will be revisiting this in the future. I left a comment on the Bot service list method.

<img width="1776" alt="Screenshot 2024-01-19 at 11 17 09 AM" src="https://github.com/gravitational/teleport/assets/11967646/c704675a-61c0-4bc1-af68-06744f5b0200">

Supports https://github.com/gravitational/teleport/issues/34260

e-sibling: https://github.com/gravitational/teleport.e/pull/3294
