### PR TITLE
fix: Allow multiple runs TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -18,5 +18,16 @@
 
 package local
 
+import "time"
+
 // SessionDataLimiter exports sdLimiter for tests.
 var SessionDataLimiter = sdLimiter
+
+// Reset resets the limiter to its initial state.
+// Exposed for testing.
+func (l *globalSessionDataLimiter) Reset() {
+	l.mu.Lock()
+	l.scopeCount = make(map[string]int)
+	l.lastReset = time.Time{}
+	l.mu.Unlock()
+}

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -773,6 +773,7 @@ func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) 
 		local.GlobalSessionDataMaxEntries = sdMax
 		local.SessionDataLimiter.Clock = sdClock
 		local.SessionDataLimiter.ResetPeriod = sdReset
+		local.SessionDataLimiter.Reset()
 	}()
 	fakeClock := clockwork.NewFakeClock()
 	period := 1 * time.Minute // arbitrary, applied to fakeClock


### PR DESCRIPTION
The global limiter was (expectedly) keeping state between tests, which made sequential runs of TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit fail. This fixes that by resetting the limiter after those tests.

Before:

```shell
$ go test ./lib/services/local -run=TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit -count=2
--- FAIL: TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit (0.00s)
    users_test.go:799:
        	Error Trace:	/Users/alan/code/teleport/lib/services/local/users_test.go:799
        	Error:      	Received unexpected error:
        	            	too many in-flight challenges
        	Test:       	TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit
FAIL
FAIL	github.com/gravitational/teleport/lib/services/local	1.469s
FAIL
```

After:

```shell
$ go test ./lib/services/local -run=TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit -count=1000
ok  	github.com/gravitational/teleport/lib/services/local	1.533s
```

Fixes #36832.