### PR TITLE
fix: Do not panic if WebAuthn.dll is missing

### DIFF
--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -62,7 +62,7 @@ func newNativeImpl() *nativeImpl {
 		return n
 	}
 
-	v, err := checkIfDLLExistsAndGetAPIVersionNumber()
+	v, err := webAuthNGetApiVersionNumber()
 	if err != nil {
 		log.WithError(err).Debug("WebAuthnWin: failed to check version")
 		return n
@@ -183,13 +183,6 @@ func (n *nativeImpl) MakeCredential(origin string, in *makeCredentialRequest) (*
 			AttestationObject: bytesFromCBytes(out.cbAttestationObject, out.pbAttestationObject),
 		},
 	}, nil
-}
-
-// checkIfDLLExistsAndGetAPIVersionNumber checks if dll exists and tries to load
-// it's version via API call. This function makes sure to not panic if dll is
-// missing.
-func checkIfDLLExistsAndGetAPIVersionNumber() (int, error) {
-	return webAuthNGetApiVersionNumber()
 }
 
 func getErrorNameOrLastErr(in uintptr, lastError error) error {

--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -48,27 +48,36 @@ type nativeImpl struct {
 // could change during program invocation.
 // Client will be always created, even if dll is missing on system.
 func newNativeImpl() *nativeImpl {
+	n := &nativeImpl{
+		hasCompileSupport: true,
+	}
+
+	// Explicitly loading the module avoids a panic when calling DLL functions if
+	// the DLL is missing.
+	// https://github.com/gravitational/teleport/issues/36851
+	if err := modWebAuthn.Load(); err != nil {
+		log.
+			WithError(err).
+			Debug("WebAuthnWin: failed to load WebAuthn.dll (it's likely missing)")
+		return n
+	}
+
 	v, err := checkIfDLLExistsAndGetAPIVersionNumber()
 	if err != nil {
 		log.WithError(err).Debug("WebAuthnWin: failed to check version")
-		return &nativeImpl{
-			hasCompileSupport: true,
-			isAvailable:       false,
-		}
+		return n
 	}
-	uvPlatform, err := isUVPlatformAuthenticatorAvailable()
+	n.webauthnAPIVersion = v
+	n.isAvailable = v > 0
+
+	n.hasPlatformUV, err = isUVPlatformAuthenticatorAvailable()
 	if err != nil {
 		// This should not happen if dll exists, however we are fine with
 		// to proceed without uvPlatform.
 		log.WithError(err).Debug("WebAuthnWin: failed to check isUVPlatformAuthenticatorAvailable")
 	}
 
-	return &nativeImpl{
-		webauthnAPIVersion: v,
-		hasCompileSupport:  true,
-		hasPlatformUV:      uvPlatform,
-		isAvailable:        v > 0,
-	}
+	return n
 }
 
 func (n *nativeImpl) CheckSupport() CheckSupportResult {


### PR DESCRIPTION
Fix a tsh panics on Windows if WebAuthn.dll is missing.

The regression was introduced by [#34737][1].

#36851

[1]: https://github.com/gravitational/teleport/pull/34737/files#diff-74f2dde89d8f630c53bbc1e48d1b087dc6dca28c9abda810ecd64c1b163883a6L231-L233

Changelog: Fix tsh panic on Windows if WebAuthn.dll is missing