### PR TITLE
Fix the disabled state for the player's progress bar

### DIFF
--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -189,7 +189,7 @@ const StyledProgessBar = styled.div`
   .grv-slider .handle {
     background-color: ${props =>
       props.disabled
-        ? props.theme.colors.text.disabled
+        ? props.theme.colors.text.main
         : props.theme.colors.success.main};
 
     border-radius: 200px;


### PR DESCRIPTION
We were using colors with an alpha channel, which meant that you could "see through" the handle.

Before:

<img width="190" alt="Screenshot 2024-01-18 at 7 56 29 AM" src="https://github.com/gravitational/teleport/assets/7527103/e9b27355-632c-43a1-b944-9026fbad9457">

After:

<img width="156" alt="Screenshot 2024-01-18 at 7 58 46 AM" src="https://github.com/gravitational/teleport/assets/7527103/310d3100-aa96-423b-b8e0-740dfd95e900">
