### PR TITLE
fix: Do not attempt relogin on remote BadParameter errors

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -502,7 +502,7 @@ func TestListResources(t *testing.T) {
 				ResourceType: test.resourceType,
 			})
 			require.Error(t, err)
-			require.IsType(t, &trace.LimitExceededError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsLimitExceeded(err), "trace.IsLimitExceeded failed: err=%v (%T)", err, trace.Unwrap(err))
 		})
 	}
 
@@ -528,7 +528,7 @@ func testGetResources[T types.ResourceWithLabels](t *testing.T, clt *Client, kin
 		ResourceType: kind,
 	})
 	require.Error(t, err)
-	require.IsType(t, &trace.LimitExceededError{}, err.(*trace.TraceErr).OrigError())
+	require.True(t, trace.IsLimitExceeded(err), "trace.IsLimitExceeded failed: err=%v (%T)", err, trace.Unwrap(err))
 
 	// Test getting a page of resources
 	page, err := GetResourcePage[T](ctx, clt, &proto.ListResourcesRequest{
@@ -636,7 +636,7 @@ func TestGetResourcesWithFilters(t *testing.T) {
 				ResourceType: test.resourceType,
 			})
 			require.Error(t, err)
-			require.IsType(t, &trace.LimitExceededError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsLimitExceeded(err), "trace.IsLimitExceeded failed: err=%v (%T)", err, trace.Unwrap(err))
 
 			// Test getting all resources by chunks to handle limit exceeded.
 			resources, err := GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{

--- a/api/utils/grpc/interceptors/errors.go
+++ b/api/utils/grpc/interceptors/errors.go
@@ -48,12 +48,18 @@ type grpcClientStreamWrapper struct {
 
 // SendMsg wraps around ClientStream.SendMsg
 func (s *grpcClientStreamWrapper) SendMsg(m interface{}) error {
-	return trace.Unwrap(trail.FromGRPC(s.ClientStream.SendMsg(m)))
+	if err := s.ClientStream.SendMsg(m); err != nil {
+		return &RemoteError{Err: trace.Unwrap(trail.FromGRPC(s.ClientStream.SendMsg(m)))}
+	}
+	return nil
 }
 
 // RecvMsg wraps around ClientStream.RecvMsg
 func (s *grpcClientStreamWrapper) RecvMsg(m interface{}) error {
-	return trace.Unwrap(trail.FromGRPC(s.ClientStream.RecvMsg(m)))
+	if err := s.ClientStream.RecvMsg(m); err != nil {
+		return &RemoteError{Err: trace.Unwrap(trail.FromGRPC(s.ClientStream.RecvMsg(m)))}
+	}
+	return nil
 }
 
 // GRPCServerUnaryErrorInterceptor is a gRPC unary server interceptor that
@@ -63,10 +69,31 @@ func GRPCServerUnaryErrorInterceptor(ctx context.Context, req interface{}, info 
 	return resp, trace.Unwrap(trail.ToGRPC(err))
 }
 
+// RemoteError annotates server-side errors translated into trace by
+// [GRPCClientUnaryErrorInterceptor] or [GRPCClientStreamErrorInterceptor].
+type RemoteError struct {
+	// Err is the underlying error.
+	Err error
+}
+
+func (e *RemoteError) Error() string {
+	if e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+func (e *RemoteError) Unwrap() error {
+	return e.Err
+}
+
 // GRPCClientUnaryErrorInterceptor is a gRPC unary client interceptor that
 // handles converting errors to the appropriate grpc status error.
 func GRPCClientUnaryErrorInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	return trace.Unwrap(trail.FromGRPC(invoker(ctx, method, req, reply, cc, opts...)))
+	if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
+		return &RemoteError{Err: trace.Unwrap(trail.FromGRPC(err))}
+	}
+	return nil
 }
 
 // GRPCServerStreamErrorInterceptor is a gRPC server stream interceptor that
@@ -81,7 +108,7 @@ func GRPCServerStreamErrorInterceptor(srv interface{}, ss grpc.ServerStream, inf
 func GRPCClientStreamErrorInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {
-		return nil, trace.Unwrap(trail.ToGRPC(err))
+		return nil, &RemoteError{Err: trace.Unwrap(trail.ToGRPC(err))}
 	}
 	return &grpcClientStreamWrapper{s}, nil
 }

--- a/api/utils/grpc/interceptors/errors.go
+++ b/api/utils/grpc/interceptors/errors.go
@@ -16,6 +16,7 @@ package interceptors
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -58,7 +59,7 @@ func (s *grpcClientStreamWrapper) SendMsg(m interface{}) error {
 // RecvMsg wraps around ClientStream.RecvMsg
 func (s *grpcClientStreamWrapper) RecvMsg(m interface{}) error {
 	switch err := s.ClientStream.RecvMsg(m); {
-	case err == io.EOF:
+	case errors.Is(err, io.EOF):
 		// Do not wrap io.EOF errors, they are often used as stop guards for streams.
 		return err
 	case err != nil:

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -2374,11 +2374,11 @@ func TestNodesCRUD(t *testing.T) {
 
 			// GetNode should fail if node name isn't provided
 			_, err = clt.GetNode(ctx, apidefaults.Namespace, "")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
 
 			// GetNode should fail if namespace isn't provided
 			_, err = clt.GetNode(ctx, "", "node1")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
 		})
 	})
 
@@ -4206,7 +4206,8 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 
 	ctx = authz.ContextWithUser(parentCtx, admin.I)
 	_, err = client.UpsertApplicationServer(ctx, appServer)
-	require.ErrorIs(t, trace.BadParameter("only the Okta role can create app servers and apps with an Okta origin"), err)
+	require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
+	require.ErrorContains(t, err, "only the Okta role can create app servers and apps with an Okta origin")
 
 	// Okta origin should not work with instance and node roles.
 	client, err = server.NewClient(TestIdentity{
@@ -4222,7 +4223,8 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 
 	ctx = authz.ContextWithUser(parentCtx, admin.I)
 	_, err = client.UpsertApplicationServer(ctx, appServer)
-	require.ErrorIs(t, trace.BadParameter("only the Okta role can create app servers and apps with an Okta origin"), err)
+	require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
+	require.ErrorContains(t, err, "only the Okta role can create app servers and apps with an Okta origin")
 
 	// Okta origin should work with Okta role in role field.
 	node := TestIdentity{

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2327,7 +2327,7 @@ func TestGenerateCerts(t *testing.T) {
 			Format:    constants.CertificateFormatStandard,
 		})
 		require.Error(t, err)
-		require.IsType(t, &trace.AccessDeniedError{}, trace.Unwrap(err))
+		require.True(t, trace.IsAccessDenied(err), "trace.IsAccessDenied failed: err=%v (%T)", err, trace.Unwrap(err))
 
 		_, privateKeyPEM, err := utils.MarshalPrivateKey(privateKey.(crypto.Signer))
 		require.NoError(t, err)
@@ -2345,7 +2345,7 @@ func TestGenerateCerts(t *testing.T) {
 			Format:    constants.CertificateFormatStandard,
 		})
 		require.Error(t, err)
-		require.IsType(t, &trace.AccessDeniedError{}, trace.Unwrap(err))
+		require.True(t, trace.IsAccessDenied(err), "trace.IsAccessDenied failed: err=%v (%T)", err, trace.Unwrap(err))
 		require.Contains(t, err.Error(), "impersonated user can not impersonate anyone else")
 
 		// but can renew their own cert, for example set route to cluster

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -597,7 +597,7 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, 
 	for _, o := range opts {
 		o(&opt)
 	}
-	log.Debugf("Activating relogin on %v.", fnErr)
+	log.Debugf("Activating relogin on error=%q (type=%T)", fnErr, trace.Unwrap(fnErr))
 
 	if keys.IsPrivateKeyPolicyError(fnErr) {
 		privateKeyPolicy, err := keys.ParsePrivateKeyPolicyError(fnErr)
@@ -668,11 +668,14 @@ func WithBeforeLoginHook(fn func() error) RetryWithReloginOption {
 	}
 }
 
+// IsErrorResolvableWithRelogin returns true if relogin is attempted on `err`.
 func IsErrorResolvableWithRelogin(err error) bool {
 	// Assume that failed handshake is a result of expired credentials.
-	return utils.IsHandshakeFailedError(err) || utils.IsCertExpiredError(err) ||
-		trace.IsBadParameter(err) || trace.IsTrustError(err) ||
-		keys.IsPrivateKeyPolicyError(err) || IsNoCredentialsError(err)
+	return keys.IsPrivateKeyPolicyError(err) ||
+		trace.IsTrustError(err) ||
+		utils.IsCertExpiredError(err) ||
+		utils.IsHandshakeFailedError(err) ||
+		IsNoCredentialsError(err)
 }
 
 // GetProfile gets the profile for the specified proxy address, or


### PR DESCRIPTION
Attemping relogin on BadParameter error makes `tsh` retry legitimate failures, hiding those failures from users and instead drowning them in login attempts.

An example from #36749:

```shell
$ tsh mfa rm 5ci      # Attempts to remove last passwordless device, which is a failure
Tap any security key  # OK, this is part of the flow
Detected security key tap
# At this point we already got the failure, but relogin is triggered.
Enter password for Teleport user llama: # As a user I'm thinking "weird, I was already logged in"
Tap any security key        # This is the login tap
Detected security key tap
Tap any security key        # This is the "mfa rm" tap, as a user I'm more than confused now
Detected security key tap
ERROR: cannot delete last passwordless credential for user  # tsh gives up here, surfaces actual error
```

This PRs avoids such retries by skipping relogin on _all_ RPC errors. This behavior is similar to Teleport pre-#30578, which is the source for the regression.

#36749, #36850

Changelog: Fix tsh trying to relogin on fatal errors