### PR TITLE
Update colors to success.main

### DIFF
--- a/web/packages/design/src/CardSuccess/CardSuccess.jsx
+++ b/web/packages/design/src/CardSuccess/CardSuccess.jsx
@@ -25,7 +25,7 @@ import { CircleCheck } from 'design/Icon';
 export default function CardSuccess({ title, children }) {
   return (
     <Card width="540px" p={7} my={4} mx="auto" textAlign="center">
-      <CircleCheck mb={3} size={64} color="success" />
+      <CircleCheck mb={3} size={64} color="success.main" />
       {title && (
         <Text typography="h2" mb="4">
           {title}

--- a/web/packages/design/src/CardSuccess/__snapshots__/CardSuccess.test.jsx.snap
+++ b/web/packages/design/src/CardSuccess/__snapshots__/CardSuccess.test.jsx.snap
@@ -22,13 +22,8 @@ exports[`rendering of CardSuccess components 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: #00BFA6;
   margin-bottom: 16px;
-}
-
-.c2 color {
-  main: #00BFA6;
-  hover: #33CCB8;
-  active: #66D9CA;
 }
 
 <div
@@ -37,7 +32,7 @@ exports[`rendering of CardSuccess components 1`] = `
 >
   <span
     class="c2 icon icon-circlecheck"
-    color="success"
+    color="success.main"
   >
     <svg
       fill="currentColor"

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
@@ -95,7 +95,7 @@ export function CreateDatabaseDialog({
     content = (
       <>
         <Text mb={5}>
-          <Icons.Check size="small" ml={1} mr={2} color="success" />
+          <Icons.Check size="small" ml={1} mr={2} color="success.main" />
           Database "{dbName}" successfully registered
         </Text>
         <ButtonPrimary width="100%" onClick={next}>

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollDialog.tsx
@@ -80,7 +80,7 @@ export function AutoEnrollDialog({
     content = (
       <>
         <Flex mb={5}>
-          <Icons.Check size="small" ml={1} mr={2} color="success" />
+          <Icons.Check size="small" ml={1} mr={2} color="success.main" />
           <Text>
             Discovery config successfully created.
             {skipDeployment && (

--- a/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
@@ -248,7 +248,7 @@ export function CreateEc2IceDialog({
               mb={2}
               style={{ display: 'flex', textAlign: 'left', width: '100%' }}
             >
-              <Icons.Check size="small" ml={1} mr={2} color="success" />
+              <Icons.Check size="small" ml={1} mr={2} color="success.main" />
               The EC2 Instance Connect Endpoint was successfully deployed.
             </Text>
           )}
@@ -256,7 +256,7 @@ export function CreateEc2IceDialog({
             mb={5}
             style={{ display: 'flex', textAlign: 'left', width: '100%' }}
           >
-            <Icons.Check size="small" ml={1} mr={2} color="success" />
+            <Icons.Check size="small" ml={1} mr={2} color="success.main" />
             The EC2 instance [{typedAgentMeta?.node.awsMetadata.instanceId}] has
             been added to Teleport.
           </Text>

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -57,7 +57,7 @@ export function ConnectionDiagnosticResult({
   } else if (attempt.status === 'success' && diagnosis?.success) {
     $diagnosisStateComponent = (
       <TextIcon>
-        <Icons.CircleCheck size="medium" ml={1} mr={1} color="success" />
+        <Icons.CircleCheck size="medium" ml={1} mr={1} color="success.main" />
         Testing complete
       </TextIcon>
     );
@@ -120,7 +120,11 @@ export function ConnectionDiagnosticResult({
                 if (trace.status === 'success') {
                   return (
                     <TextIcon key={index}>
-                      <Icons.CircleCheck size="medium" color="success" mr={1} />
+                      <Icons.CircleCheck
+                        size="medium"
+                        color="success.main"
+                        mr={1}
+                      />
                       {trace.details}
                     </TextIcon>
                   );

--- a/web/packages/teleport/src/Discover/Shared/HintBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/HintBox.tsx
@@ -89,7 +89,7 @@ export function SuccessBox(props: { children: React.ReactNode }) {
           white-space: pre;
         `}
       >
-        <Icons.CircleCheck size="medium" color="success" />
+        <Icons.CircleCheck size="medium" color="success.main" />
       </TextIcon>
       <Box>{props.children}</Box>
     </SuccessInfo>

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/FinishDialog.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/FinishDialog.tsx
@@ -42,7 +42,7 @@ export function FinishDialog({ integration }: { integration: Integration }) {
       open={true}
     >
       <DialogHeader css={{ margin: '0 auto' }}>
-        <CircleCheck mb={4} size={60} color="success" />
+        <CircleCheck mb={4} size={60} color="success.main" />
       </DialogHeader>
       <DialogContent>
         <Text textAlign="center">

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
@@ -137,7 +137,7 @@ function renderExternalAuditStorageBadge(
           recordings using Athena and S3.
         </div>
       }
-      color="success"
+      color="success.main"
     />
   );
 }

--- a/web/packages/teleport/src/Login/__snapshots__/LoginSuccess.test.tsx.snap
+++ b/web/packages/teleport/src/Login/__snapshots__/LoginSuccess.test.tsx.snap
@@ -32,13 +32,8 @@ exports[`renders 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: #00BFA6;
   margin-bottom: 16px;
-}
-
-.c3 color {
-  main: #00BFA6;
-  hover: #33CCB8;
-  active: #66D9CA;
 }
 
 .c0 {
@@ -63,7 +58,7 @@ exports[`renders 1`] = `
   >
     <span
       class="c3 icon icon-circlecheck"
-      color="success"
+      color="success.main"
     >
       <svg
         fill="currentColor"

--- a/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.story.tsx
+++ b/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.story.tsx
@@ -32,7 +32,7 @@ export const BadgeString = () => (
     <ToolTipBadge
       children={'I am a string'}
       badgeTitle="Title"
-      color="success"
+      color="success.main"
     />
   </SomeBox>
 );
@@ -42,7 +42,7 @@ export const BadgeComp = () => (
     I'm a sample container
     <ToolTipBadge
       badgeTitle="Title"
-      color="success"
+      color="success.main"
       children={<Box p={3}>I'm a box component with too much padding</Box>}
     />
   </SomeBox>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
@@ -435,7 +435,9 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
         }
         case 'running': {
           return {
-            Icon: props => <icons.CircleCheck {...props} color="success" />,
+            Icon: props => (
+              <icons.CircleCheck {...props} color="success.main" />
+            ),
             title: 'Agent running',
           };
         }


### PR DESCRIPTION
In a [previous PR](https://github.com/gravitational/teleport/pull/36535) we updated our color theme to include more detailed `success` variations. I tried updating all the places that referenced it but missed our references where we passed a string as value. This is definitely error prone and in a future PR, we should somehow make these typesafe. 

I believe I caught all the references here and tested on storybook.

e: https://github.com/gravitational/teleport.e/pull/3191