### PR TITLE
[v15] fix: Allow multiple runs TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -18,5 +18,16 @@
 
 package local
 
+import "time"
+
 // SessionDataLimiter exports sdLimiter for tests.
 var SessionDataLimiter = sdLimiter
+
+// Reset resets the limiter to its initial state.
+// Exposed for testing.
+func (l *globalSessionDataLimiter) Reset() {
+	l.mu.Lock()
+	l.scopeCount = make(map[string]int)
+	l.lastReset = time.Time{}
+	l.mu.Unlock()
+}

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -773,6 +773,7 @@ func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) 
 		local.GlobalSessionDataMaxEntries = sdMax
 		local.SessionDataLimiter.Clock = sdClock
 		local.SessionDataLimiter.ResetPeriod = sdReset
+		local.SessionDataLimiter.Reset()
 	}()
 	fakeClock := clockwork.NewFakeClock()
 	period := 1 * time.Minute // arbitrary, applied to fakeClock


### PR DESCRIPTION
Backport #36856 to branch/v15