### PR TITLE
Web: Add more icons for plugins list

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -27,6 +27,13 @@ import openaiIcon from 'design/assets/images/icons/openai.svg';
 import jamfIcon from 'design/assets/images/icons/jamf.svg';
 import opsgenieIcon from 'design/assets/images/icons/opsgenie.svg';
 import oktaIcon from 'design/assets/images/icons/okta.svg';
+import jiraIcon from 'design/assets/images/icons/jira.svg';
+import mattermostIcon from 'design/assets/images/icons/mattermost.svg';
+import pagerdutyIcon from 'design/assets/images/icons/pagerduty.svg';
+import servicenowIcon from 'design/assets/images/icons/servicenow.svg';
+import discordIcon from 'design/assets/images/icons/discord.svg';
+import emailIcon from 'design/assets/images/icons/email.svg';
+import msteamIcon from 'design/assets/images/icons/msteams.svg';
 import Table, { Cell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import { ToolTipInfo } from 'shared/components/ToolTip';
@@ -267,6 +274,34 @@ const IconCell = ({ item }: { item: IntegrationLike }) => {
       case 'opsgenie':
         formattedText = 'Opsgenie';
         icon = <IconContainer src={opsgenieIcon} />;
+        break;
+      case 'jira':
+        formattedText = 'Jira';
+        icon = <IconContainer src={jiraIcon} />;
+        break;
+      case 'mattermost':
+        formattedText = 'Mattermost';
+        icon = <IconContainer src={mattermostIcon} />;
+        break;
+      case 'servicenow':
+        formattedText = 'ServiceNow';
+        icon = <IconContainer src={servicenowIcon} />;
+        break;
+      case 'pagerduty':
+        formattedText = 'PagerDuty';
+        icon = <IconContainer src={pagerdutyIcon} />;
+        break;
+      case 'discord':
+        formattedText = 'Discord';
+        icon = <IconContainer src={discordIcon} />;
+        break;
+      case 'email':
+        formattedText = 'Email';
+        icon = <IconContainer src={emailIcon} />;
+        break;
+      case 'msteams':
+        formattedText = 'Microsoft Teams';
+        icon = <IconContainer src={msteamIcon} />;
         break;
     }
   } else {

--- a/web/packages/teleport/src/Integrations/fixtures.ts
+++ b/web/packages/teleport/src/Integrations/fixtures.ts
@@ -97,6 +97,38 @@ export const plugins: Plugin[] = [
     statusCode: IntegrationStatusCode.Running,
     spec: {},
   },
+  {
+    resourceType: 'plugin',
+    name: 'servicenow',
+    details: '',
+    kind: 'servicenow',
+    statusCode: IntegrationStatusCode.Running,
+    spec: {},
+  },
+  {
+    resourceType: 'plugin',
+    name: 'mattermost',
+    details: '',
+    kind: 'mattermost',
+    statusCode: IntegrationStatusCode.Running,
+    spec: {},
+  },
+  {
+    resourceType: 'plugin',
+    name: 'jira',
+    details: '',
+    kind: 'jira',
+    statusCode: IntegrationStatusCode.Running,
+    spec: {},
+  },
+  {
+    resourceType: 'plugin',
+    name: 'discord',
+    details: '',
+    kind: 'discord',
+    statusCode: IntegrationStatusCode.Running,
+    spec: {},
+  },
 ];
 
 export const integrations: Integration[] = [


### PR DESCRIPTION
Trivial issue, some plugins were not provided icons for the plugins list

<img width="177" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/a6dbbe0f-526f-4ec4-a2cf-b9ab59f6b8aa">
