### PR TITLE
docs: Reflect that RSA key size for FedRAMP can be 2048, 3072, or 4096-bit

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -215,4 +215,4 @@ is emitted to the Audit Log.
 - TLS protocol version is restricted to TLS 1.2 and TLS 1.3.
 - All uses of non-compliant algorithms such as NaCl are removed and replaced with compliant algorithms such as AES-GCM.
 - Teleport is compiled with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407).
-- User, host, and CA certificates (and host keys for recording proxy mode) only use 2048-bit RSA private keys.
+- User, host, and CA certificates (and host keys for recording proxy mode) only use 2048-bit, 3072-bit, or 4096-bit RSA private keys.


### PR DESCRIPTION
Docs were outdated due to upstream Go changes.

Ref gravitational/teleport#3519
Ref golang/go#41147