### PR TITLE
Add various TopBar adjustments

### DIFF
--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -23,12 +23,15 @@ import { fonts } from '../fonts';
 
 import { SharedColors, SharedStyles } from './types';
 
+const dockedAssistWidth = 520;
 // TODO(bl-nero): use a CSS var for sidebar width and make the breakpoints work
 // by changing the minimum width on a per-view basis (Main.tsx).
 const sidebarWidth = 256;
 
 // Styles that are shared by all themes.
 export const sharedStyles: SharedStyles = {
+  dockedAssistWidth,
+  sidebarWidth,
   boxShadow: [
     '0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px rgba(0, 0, 0, 0.14), 0px 1px 3px rgba(0, 0, 0, 0.12)',
     '0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)',
@@ -45,7 +48,7 @@ export const sharedStyles: SharedStyles = {
     medium: 1024,
     large: 1280,
   },
-  topBarHeight: [48, 56, 72],
+  topBarHeight: [44, 56, 72],
   space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
   borders: [
     0,

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -274,6 +274,8 @@ type VisualisationColors = {
 };
 
 export type SharedStyles = {
+  sidebarWidth: number;
+  dockedAssistWidth: number;
   boxShadow: string[];
   breakpoints: {
     mobile: number;

--- a/web/packages/shared/setupTests.tsx
+++ b/web/packages/shared/setupTests.tsx
@@ -23,3 +23,9 @@ Object.defineProperty(globalThis, 'crypto', {
     randomUUID: () => crypt.randomUUID(),
   },
 });
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));

--- a/web/packages/teleport/src/Assist/Assist.tsx
+++ b/web/packages/teleport/src/Assist/Assist.tsx
@@ -18,6 +18,7 @@
 
 import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
+import { sharedStyles } from 'design/theme/themes/sharedStyles';
 
 import { Header } from 'teleport/Assist/Header';
 import { ConversationHistory } from 'teleport/Assist/ConversationHistory';
@@ -32,6 +33,8 @@ import { Settings } from 'teleport/Assist/Settings';
 import { ErrorBanner, ErrorList } from 'teleport/Assist/ErrorBanner';
 import { useUser } from 'teleport/User/UserContext';
 import { LandingPage } from 'teleport/Assist/LandingPage';
+
+const { dockedAssistWidth } = sharedStyles;
 
 interface AssistProps {
   onClose: () => void;
@@ -94,7 +97,7 @@ function variables(props: { viewMode: ViewMode }) {
         '--assist-border-radius': '0',
         '--assist-left': 'auto',
         '--assist-right': '0',
-        '--assist-width': '520px',
+        '--assist-width': `${dockedAssistWidth}px`,
         '--assist-height': '100vh',
         '--assist-box-shadow': 'none',
         '--assist-left-border': '1px solid rgba(0, 0, 0, 0.1)',
@@ -157,8 +160,8 @@ function sidebarVariables(props: {
     case ViewMode.Docked:
       if (props.sidebarVisible) {
         return {
-          '--conversation-width': '520px',
-          '--conversation-list-width': '520px',
+          '--conversation-width': `${dockedAssistWidth}px`,
+          '--conversation-list-width': `${dockedAssistWidth}px`,
           '--conversation-list-margin': '0',
           '--command-input-width': '380px',
           '--conversation-list-display': 'flex',
@@ -168,7 +171,7 @@ function sidebarVariables(props: {
 
       return {
         '--conversation-width': '525px',
-        '--conversation-list-width': '520px',
+        '--conversation-list-width': `${dockedAssistWidth}px`,
         '--conversation-list-margin':
           'calc((var(--conversation-list-width) * -1) - 1px)',
         '--command-input-width': '380px',
@@ -180,7 +183,17 @@ function sidebarVariables(props: {
 
 const Container = styled.div<{ docked: boolean }>`
   position: fixed;
-  top: 0;
+  ${p =>
+    p.docked
+      ? `top: ${p.theme.topBarHeight[0]}px;
+  @media screen and (min-width: ${p.theme.breakpoints.small}px) {
+    top: ${p.theme.topBarHeight[1]}px;
+  }
+  @media screen and (min-width: ${p.theme.breakpoints.large}px) {
+    top: ${p.theme.topBarHeight[2]}px;
+  }
+  `
+      : 'top: 0;'}
   left: ${p => (p.docked ? 'auto' : '0')};
   right: 0;
   bottom: 0;
@@ -192,7 +205,7 @@ const Container = styled.div<{ docked: boolean }>`
   justify-content: flex-end;
 `;
 
-const AssistContainer = styled.div`
+const AssistContainer = styled.div<{ docked: boolean }>`
   ${variables};
   ${sidebarVariables};
 
@@ -210,7 +223,17 @@ const AssistContainer = styled.div`
   position: absolute;
   width: var(--assist-width);
   max-height: calc(100vh - var(--assist-gutter) * 2);
-  height: var(--assist-height);
+  ${p =>
+    p.docked
+      ? `height: calc(100vh - ${p.theme.topBarHeight[0]}px);
+  @media screen and (min-width: ${p.theme.breakpoints.small}px) {
+    height: calc(100vh - ${p.theme.topBarHeight[1]}px);
+  }
+  @media screen and (min-width: ${p.theme.breakpoints.large}px) {
+    height: calc(100vh - ${p.theme.topBarHeight[2]}px);
+  }
+  `
+      : 'height: var(--assist-height);'}
   top: var(--assist-gutter);
   right: var(--assist-right);
   left: var(--assist-left);
@@ -342,11 +365,10 @@ function AssistContent(props: AssistProps) {
     </ErrorBanner>
   ));
 
+  const docked = preferences.assist.viewMode === ViewMode.Docked;
+
   return (
-    <Container
-      onClick={handleClose}
-      docked={preferences.assist.viewMode === ViewMode.Docked}
-    >
+    <Container onClick={handleClose} docked={docked}>
       {settingsOpen && (
         <Settings
           onClose={() => setSettingsOpen(false)}
@@ -359,6 +381,7 @@ function AssistContent(props: AssistProps) {
         onClick={handleClick}
         viewMode={preferences.assist.viewMode}
         sidebarVisible={sidebarVisible}
+        docked={docked}
       >
         <Header
           onClose={handleClose}

--- a/web/packages/teleport/src/Main/LayoutContext.tsx
+++ b/web/packages/teleport/src/Main/LayoutContext.tsx
@@ -21,21 +21,40 @@ import React, {
   PropsWithChildren,
   useContext,
   useState,
+  useEffect,
+  useRef,
 } from 'react';
 
 interface LayoutContextValue {
   hasDockedElement: boolean;
   setHasDockedElement: (value: boolean) => void;
+  currentWidth: number;
 }
 
 const LayoutContext = createContext<LayoutContextValue>(null);
 
 export function LayoutContextProvider(props: PropsWithChildren<unknown>) {
   const [hasDockedElement, setHasDockedElement] = useState(false);
+  const [currentWidth, setCurrentWidth] = useState(window.innerWidth);
+  const containerRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(entries => {
+      const container = entries[0];
+      setCurrentWidth(container?.contentRect.width || 0);
+    });
+
+    resizeObserver.observe(containerRef.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return (
-    <LayoutContext.Provider value={{ hasDockedElement, setHasDockedElement }}>
-      {props.children}
+    <LayoutContext.Provider
+      value={{ hasDockedElement, setHasDockedElement, currentWidth }}
+    >
+      <div ref={containerRef}>{props.children}</div>
     </LayoutContext.Provider>
   );
 }

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -21,6 +21,7 @@ import React, {
   Suspense,
   useEffect,
   useMemo,
+  lazy,
   useState,
   createContext,
   useContext,
@@ -34,6 +35,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 import { matchPath, useHistory } from 'react-router';
 
 import Dialog from 'design/Dialog';
+import { sharedStyles } from 'design/theme/themes/sharedStyles';
 
 import { Redirect, Route, Switch } from 'teleport/components/Router';
 import { CatchError } from 'teleport/components/CatchError';
@@ -51,6 +53,8 @@ import {
 } from 'teleport/Navigation/Navigation';
 import { NavigationCategory } from 'teleport/Navigation/categories';
 import { TopBarProps } from 'teleport/TopBar/TopBar';
+import { useUser } from 'teleport/User/UserContext';
+import { ViewMode } from 'teleport/Assist/types';
 import { QuestionnaireProps } from 'teleport/Welcome/NewCredentials';
 
 import { MainContainer } from './MainContainer';
@@ -58,6 +62,8 @@ import { OnboardDiscover } from './OnboardDiscover';
 
 import type { BannerType } from 'teleport/components/BannerList/BannerList';
 import type { LockedFeatures, TeleportFeature } from 'teleport/types';
+
+const Assist = lazy(() => import('teleport/Assist'));
 
 export interface MainProps {
   initialAlerts?: ClusterAlert[];
@@ -84,12 +90,24 @@ export function Main(props: MainProps) {
     run(() => ctx.init());
   }, []);
 
+  const { preferences } = useUser();
+  const viewMode = preferences?.assist?.viewMode;
+  const assistEnabled = ctx.getFeatureFlags().assist && ctx.assistEnabled;
+  const [showAssist, setShowAssist] = useState(false);
   const featureFlags = ctx.getFeatureFlags();
 
   const features = useMemo(
     () => props.features.filter(feature => feature.hasAccess(featureFlags)),
     [featureFlags, props.features]
   );
+  const feature = features
+    .filter(feature => Boolean(feature.route))
+    .find(f =>
+      matchPath(history.location.pathname, {
+        path: f.route.path,
+        exact: f.route.exact ?? false,
+      })
+    );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
 
@@ -168,11 +186,19 @@ export function Main(props: MainProps) {
             ? props.topBarProps.CustomLogo
             : null
         }
+        assistProps={{
+          showAssist,
+          setShowAssist,
+          assistEnabled,
+        }}
       />
       <Wrapper>
         <MainContainer>
           <Navigation />
-          <HorizontalSplit>
+          <HorizontalSplit
+            dockedView={showAssist && viewMode === ViewMode.Docked}
+            hasSidebar={feature?.category === NavigationCategory.Management}
+          >
             <ContentMinWidth>
               <BannerList
                 banners={banners}
@@ -185,6 +211,12 @@ export function Main(props: MainProps) {
               </Suspense>
             </ContentMinWidth>
           </HorizontalSplit>
+
+          {showAssist && (
+            <Suspense fallback={null}>
+              <Assist onClose={() => setShowAssist(false)} />
+            </Suspense>
+          )}
         </MainContainer>
       </Wrapper>
       {displayOnboardDiscover && (
@@ -286,7 +318,7 @@ const ContentMinWidth = ({ children }: { children: ReactNode }) => {
           display: flex;
           flex-direction: column;
           flex: 1;
-          ${enforceMinWidth ? 'min-width: 1250px;' : ''}
+          ${enforceMinWidth ? 'min-width: 1000px;' : ''}
         `}
       >
         {children}
@@ -295,10 +327,25 @@ const ContentMinWidth = ({ children }: { children: ReactNode }) => {
   );
 };
 
+function getWidth(hasSidebar: boolean, isDockedView: boolean) {
+  const { dockedAssistWidth, sidebarWidth } = sharedStyles;
+  if (hasSidebar && isDockedView) {
+    return `max-width: calc(100% - ${sidebarWidth}px - ${dockedAssistWidth}px);`;
+  }
+  if (isDockedView) {
+    return `max-width: calc(100% - ${dockedAssistWidth}px);`;
+  }
+  if (hasSidebar) {
+    return `max-width: calc(100% - ${sidebarWidth}px);`;
+  }
+  return 'max-width: 100%;';
+}
+
 export const HorizontalSplit = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+  ${props => getWidth(props.hasSidebar, props.dockedView)}
   overflow-x: auto;
 `;
 
@@ -311,5 +358,8 @@ const Wrapper = styled(Box)<{ hasDockedElement: boolean }>`
   display: flex;
   height: 100vh;
   flex-direction: column;
-  width: ${p => (p.hasDockedElement ? 'calc(100vw - 520px)' : '100vw')};
+  width: ${p =>
+    p.hasDockedElement
+      ? `calc(100vw - ${p.theme.dockedAssistWidth}px)`
+      : '100vw'};
 `;

--- a/web/packages/teleport/src/TopBar/Notifications/Notifications.test.tsx
+++ b/web/packages/teleport/src/TopBar/Notifications/Notifications.test.tsx
@@ -21,6 +21,7 @@ import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
 import { ContextProvider } from 'teleport';
 
 import {
@@ -80,7 +81,9 @@ test('due dates and overdue dates', async () => {
   render(
     <MemoryRouter>
       <ContextProvider ctx={ctx}>
-        <Notifications />
+        <LayoutContextProvider>
+          <Notifications />
+        </LayoutContextProvider>
       </ContextProvider>
     </MemoryRouter>
   );
@@ -109,7 +112,9 @@ test('no notes', async () => {
   render(
     <MemoryRouter>
       <ContextProvider ctx={ctx}>
-        <Notifications />
+        <LayoutContextProvider>
+          <Notifications />
+        </LayoutContextProvider>
       </ContextProvider>
     </MemoryRouter>
   );

--- a/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/TopBar/Notifications/Notifications.tsx
@@ -44,7 +44,7 @@ import {
 
 import { ButtonIconContainer } from '../Shared';
 
-export function Notifications() {
+export function Notifications({ iconSize = 24 }: { iconSize?: number }) {
   const ctx = useTeleport();
   useStore(ctx.storeNotifications);
 
@@ -86,7 +86,10 @@ export function Notifications() {
           data-testid="tb-note-button"
         >
           {items.length > 0 && <AttentionDot data-testid="tb-note-attention" />}
-          <NotificationIcon color={open ? 'text.main' : 'text.muted'} />
+          <NotificationIcon
+            color={open ? 'text.main' : 'text.muted'}
+            size={iconSize}
+          />
         </ButtonIconContainer>
 
         <Dropdown


### PR DESCRIPTION
This PR adds various small TopBar adjustments based on feedback from design
- Background color for the current selected topbar item is now tonal.neutral instead of tonal.primary 
![Screenshot 2024-01-18 at 6 51 16 PM](https://github.com/gravitational/teleport/assets/5201977/02e9ce80-5080-4547-ba10-fb221a2d9659)


- Assist is now below the TopBar when docked 

https://github.com/gravitational/teleport/assets/5201977/5c7f10c2-bb57-4a4e-8786-fb0ca40e7648

- Hover tooltips now only show on MainNavItems when they are in Icon only mode 

https://github.com/gravitational/teleport/assets/5201977/73cc9b9e-b5b6-4f2d-9232-f9d9555d0d03

- Icons now shrink to size 20 from 24 when below medium breakpoint. In order to do this, i added a new `currentWidth` property to our layout context that way we can interact with javascript based on media width, instead of only css. The other option to this is to add more ways to pass css (with media queries) around to components but I believe we've needed a javascript way to "know how wide we are" for awhile. other theming/style tools provide something like this. If we already have it and I've forgotten or am unaware, let me know and I'll switch this out.