### PR TITLE
Downgrade Electron to 28.1.1

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -43,7 +43,7 @@
     "@types/whatwg-url": "^11.0.1",
     "clean-webpack-plugin": "4.0.0",
     "cross-env": "5.0.5",
-    "electron": "28.1.3",
+    "electron": "28.1.1",
     "electron-notarize": "^1.2.1",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-loader": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,10 +7440,10 @@ electron-to-chromium@^1.4.535:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.551.tgz#14db6660a88f66ce095ea2657abe5653bc7f42ed"
   integrity sha512-/Ng/W/kFv7wdEHYzxdK7Cv0BHEGSkSB3M0Ssl8Ndr1eMiYeas/+Mv4cNaDqamqWx6nd2uQZfPz6g25z25M/sdw==
 
-electron@28.1.3:
-  version "28.1.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.1.3.tgz#38382a177af2fa6026b02eb4e4ebde067fb30154"
-  integrity sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==
+electron@28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.1.1.tgz#37254967e32a4a69e18378f3b1aba1475522d08d"
+  integrity sha512-HJSbGHpRl46jWCp5G4OH57KSm2F5u15tB10ixD8iFiz9dhwojqlSQTRAcjSwvga+Vqs1jv7iqwQRrolXP4DgOA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
Fixes #36865.

Electron 28.1.2 broke inter-process communication in signed macOS apps thus gutting the agent cleanup daemon in Connect My Computer (see the issue above).

I verified on a local signed build on v15 that downgrading to 28.1.1 fixes the issue. I built [15.0.0-dev.ravicious.9](https://drone.platform.teleport.sh/gravitational/teleport/32834/2/11), published the build and verified that Connect My Computer works.