### PR TITLE
Connect My Computer: Show cleanup daemon errors in terminal

### DIFF
--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
@@ -211,14 +211,28 @@ export class AgentRunner {
     agent: ChildProcess
   ) {
     agent.once('spawn', () => {
-      const cleanupDaemon = fork(this.agentCleanupDaemonPath, [
-        // agent.pid can in theory be null if the agent gets terminated before the execution gets to
-        // this point. In that case, the cleanup daemon is going to exit early.
-        agent.pid?.toString(),
-        process.pid.toString(),
-        rootClusterUri,
-        this.settings.logsDir,
-      ]);
+      const cleanupDaemon = fork(
+        this.agentCleanupDaemonPath,
+        [
+          // agent.pid can in theory be null if the agent gets terminated before the execution gets to
+          // this point. In that case, the cleanup daemon is going to exit early.
+          agent.pid?.toString(),
+          process.pid.toString(),
+          rootClusterUri,
+          this.settings.logsDir,
+        ],
+        // Inherit stderr and stdout so that any errors emitted during Node.js process startup will
+        // be visible when running Connect from a terminal.
+        //
+        // In dev mode, stdout from cleanup daemon will be visible in the terminal output but it
+        // won't be colored like other logs.
+        //
+        // It'd be better to pipe stdout and stderr instead and log them (see
+        // pipeProcessOutputIntoLogger) but this would require a more elaborate setup (pipe stdout
+        // after fork and then stop piping on successful start since agent cleanup daemon has its
+        // own logging).
+        { stdio: 'inherit' }
+      );
 
       // The cleanup daemon terminates the agent only when the parent (this process) gets
       // unexpectedly killed and loses control over the agent by orphaning it.


### PR DESCRIPTION
An agent cleanup daemon is a special process that gets spawned next to each teleport process started by Connect My Computer. If the Electron app crashes or for some reason shuts down without closing teleport processes first, an agent cleanup daemon is going to kill its designated teleport process.

An agent cleanup daemon [sets up its own logging to a file](https://github.com/gravitational/teleport/blob/b390c61444763563be42cf1d637e315019541930/web/packages/teleterm/src/agentCleanupDaemon/agentCleanupDaemon.js#L73-L96), but any error thrown before that is of course not captured there.

This PR makes it so that an agent cleanup daemon inherits stdio from the main process, meaning that if you start Connect from a terminal, you'll see any errors from agent cleanup daemon in the terminal.

This doesn't impact the core functionality of the agent cleanup daemon, which is to detect if it has been orphaned. This is done through IPC for which Node passes an additional file descriptor when forking. Thus inheriting stdio has no impact on this.