### PR TITLE
[v15] Prevent deadlock on moderated sessions when mod connection drops

### DIFF
--- a/lib/kube/proxy/streamproto/proto.go
+++ b/lib/kube/proxy/streamproto/proto.go
@@ -19,6 +19,8 @@
 package streamproto
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -74,6 +76,7 @@ type SessionStream struct {
 	closed      int32
 	MFARequired bool
 	Mode        types.SessionParticipantMode
+	isClient    bool
 }
 
 // NewSessionStream creates a new session stream.
@@ -89,6 +92,7 @@ func NewSessionStream(conn *websocket.Conn, handshake any) (*SessionStream, erro
 
 	clientHandshake, isClient := handshake.(ClientHandshake)
 	serverHandshake, ok := handshake.(ServerHandshake)
+	s.isClient = isClient
 
 	if !isClient && !ok {
 		return nil, trace.BadParameter("Handshake must be either client or server handshake, got %T", handshake)
@@ -167,6 +171,16 @@ func (s *SessionStream) readTask() {
 		if err != nil {
 			if err != io.EOF && !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
 				log.WithError(err).Warn("Failed to read message from websocket")
+			}
+
+			var closeErr *websocket.CloseError
+			// If it's a close error, we want to send a message to the stdout
+			if s.isClient && errors.As(err, &closeErr) && closeErr.Text != "" {
+				select {
+				case s.in <- []byte(fmt.Sprintf("\r\n---\r\nConnection closed: %v\r\n", closeErr.Text)):
+				case <-s.done:
+					return
+				}
 			}
 
 			return

--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -99,20 +99,36 @@ func (g *TermManager) writeToClients(p []byte) {
 	g.history = truncateFront(append(g.history, p...), maxHistoryBytes)
 
 	atomic.AddUint64(&g.countWritten, uint64(len(p)))
+	var toDelete []struct {
+		key string
+		err error
+	}
 	for key, w := range g.writers {
 		_, err := w.Write(p)
 		if err != nil {
 			if err != io.EOF {
 				log.Warnf("Failed to write to remote terminal: %v", err)
 			}
-
-			// Let term manager decide how to handle broken party writers
-			if g.OnWriteError != nil {
-				g.OnWriteError(key, err)
-			}
+			toDelete = append(
+				toDelete, struct {
+					key string
+					err error
+				}{key, err})
 
 			delete(g.writers, key)
 		}
+	}
+
+	// Let term manager decide how to handle broken party writers
+	if g.OnWriteError != nil {
+		// writeToClients is called with the lock held, so we need to release it
+		// before calling OnWriteError to avoid a deadlock if OnWriteError
+		// calls DeleteWriter/DeleteReader.
+		g.mu.Unlock()
+		for _, deleteWriter := range toDelete {
+			g.OnWriteError(deleteWriter.key, deleteWriter.err)
+		}
+		g.mu.Lock()
 	}
 }
 
@@ -217,7 +233,10 @@ func (g *TermManager) DeleteWriter(name string) {
 }
 
 func (g *TermManager) AddReader(name string, r io.Reader) {
+	// AddReader is called by goroutines so we need to hold the lock.
+	g.mu.Lock()
 	g.readerState[name] = false
+	g.mu.Unlock()
 
 	go func() {
 		for {


### PR DESCRIPTION
Backport #36882 to branch/v15

changelog: Ensure that moderated sessions do not get stuck in the event of an unexpected drop in the moderator's connection.
