### PR TITLE
chore: update azure loadtest tf module

### DIFF
--- a/assets/loadtest/azure/.terraform.lock.hcl
+++ b/assets/loadtest/azure/.terraform.lock.hcl
@@ -1,104 +1,96 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/alekc/kubectl" {
-  version     = "2.0.3"
-  constraints = ">= 2.0.3"
+provider "registry.opentofu.org/alekc/kubectl" {
+  version     = "2.0.4"
+  constraints = ">= 2.0.4"
   hashes = [
-    "h1:Gv6kXs5zudbEpLLyipTlBXkcVywnxFVaVHTYPShnwJ0=",
-    "zh:0573cc46fcdf43410114ba42a3d5bee1b2074072a5d7774e90c7ebbf279a4d9a",
-    "zh:195a5bac71df2e962c5857916aae8b0546fa283b9644b81a5579d87456b3b268",
-    "zh:19cffc851e779e3715753a312fa0dc49c5429363de9f10466dab6f0c63ad5dc1",
-    "zh:1acd66873dd114b0a433e74c1971068f44ba327f549a9784565fd26a49b2511d",
-    "zh:2e043875a2ea09fef17d165a39c305c8fb5b80990efa8eb668d41de290531b5c",
-    "zh:4a129b540ca0e45ac9b7e5fe29413e88f5c4f6d356df069962e3c73673c5a439",
-    "zh:8ffec16848393a92a4b9ed577758b396db0d898718823f49c50ebe14fc426fc5",
-    "zh:aa933d3f7603b4bf411160f23b2f0ca9d564dae143cefa526b1012aebbe814e6",
-    "zh:ad1199152300687c40863c973050bff4fc031ebca6e9e19e59053c9154d3788f",
-    "zh:b72834b595be6eafcf04c8f01c2241d5939d6bd65949b8f5bca525ef38320129",
-    "zh:d18320d9a30aa8c6124f140b7cda41b3289adefdae88a2e096aba7854b9f6a25",
-    "zh:db391acb58b3362137518db81b7fd118a14732a06094f736ff286024531990cf",
-    "zh:e9b832fda20c79b2cfb216de9a535e30579d8a02eaafe2dbf4461e2f54fe4383",
-    "zh:fc51af1d63b8bbaba36d5ee10e3b19176836ebed4f0e61b58d8d372df98d3989",
+    "h1:mCz0lOwNsFCZEcFf7DBSe6b4hZgn5piiy0mZDwRGUIU=",
+    "zh:15c227886bac78c8b8827f85595648212574ec81febc39e1055e1a6bf048fe65",
+    "zh:2211ebeeb0918dbb3587d206e32adca9e1f343a93bbffcd37d8d99bf4d8dea9a",
+    "zh:2303836cdea12ece8dbe39c2d7d30a9378fd06e9c2ebda66cbe5e01cc096ee2e",
+    "zh:3687f69e531c70845682b214888a9959b93f2be3c2531801228a4b1965d59921",
+    "zh:4dd686b4c55e2eedd80464984c9bb736c2df7a96d9dd59a692d91d09173f5f64",
+    "zh:51e29c13a87e56867b4be0b0c68da874149bf6d4014d7259b62d91162142c1bd",
+    "zh:5d9d99260f2adfb8867068a3d7644336d57cfa7710062c5221dcbb5a7ec90c7d",
+    "zh:901c19d73da6688437b19a85e3cd60e8f2090c84699e108b31953bb87f6d3141",
+    "zh:9547743606a36fa6b6748c5e2e1959b6f185730a1da53a3c351cfa0d8c096687",
+    "zh:9772a30704e69b54de5a332858a39591f52286121cffcba702346830b1c6e362",
+    "zh:b44792f99d7c90b9a364dd922f861e459ae1b1edc039f6b3078549021fec4511",
+    "zh:b5eb871ed2e39b9236dce06170b1fd5dda29f3c1d53f8e08285ccb9a4f574201",
+    "zh:e8bb4c3d9f680977b560e9dec24662650f790259b2c1311ee07a72157f6492b3",
+    "zh:f4772cfa0f9c73fdef008bb917cd268620009dc7ff270a4d819125c642b5acce",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.75.0"
-  constraints = ">= 3.75.0"
+provider "registry.opentofu.org/hashicorp/azurerm" {
+  version     = "3.87.0"
+  constraints = ">= 3.87.0"
   hashes = [
-    "h1:iUck9Rgv3uZJH6aRO3L7EMDln68BfPde+PILYGW1BN8=",
-    "zh:0d881d7b499367400ced6e315e32a1948d823309c5677a16056367001a8785ce",
-    "zh:384acba136f1b347cac7831bb4e0396a370f6664e1c1242fce42a6fc55b9db8a",
-    "zh:409a01af5d873e4ac7e62cfd8c9a27638a719394ccf6a8de89ac4a1049275c20",
-    "zh:547eab553ea24cc9079fd80093c1611d036df089385bb4a38c5db21f6126e75e",
-    "zh:714a1fc3d1485deec10f4a49be556997f8ea0cc717db78fa0613f5bee728fcd7",
-    "zh:90d197c03a3bad2a8cfa7fc2396dc1601bf08be9368d399d58ec51654201c6fb",
-    "zh:9587b44249147b0e9d7619568cf46de126ec947ca5c56a1d740d8142b89919c2",
-    "zh:9d910ae66496833d4f85a4fe6b24649f74a1624f1502f63e9ff8201f29c0c1d1",
-    "zh:9f355767fc7f5ab769a60b46e42f9498f33ee95c3833b7d95c7f7c69fe101564",
-    "zh:d11d91da699d8c62f873cdea72bc26ab40cde4f18bc88ab6583ea836fee26ecd",
-    "zh:e0f9d50274f54acc2c5e300537d96a5aa03be650cfb66249a14ed45375014c77",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "h1:nqczt1EgcQodjbxshKq4jPqNYwuX9hB52DJaJQIUEjw=",
+    "zh:2d3c1e7c3a2aedf3e827f48dc4667f5591b3be046b4c1f279ad9093212d644bc",
+    "zh:49a716728d63eb1b81b04fde072eb20a70e2882074e2a19ef1702eef3ec79b24",
+    "zh:6bd7f489cd69ec74bd33673061d37b2f6f29418ae7e71538a5a26ef05a06e7e4",
+    "zh:893f5eb2e94bf50894b493980cf9b6afc4a1187f973270ea4ba0a1a98c10e126",
+    "zh:8967e9f64033c153f7a83e9a06b1d9813f16d11efff84732490d14ccfef7a0e8",
+    "zh:8bd63aa4aea99d4d22c6c4dd2ab9211bc670c326a408dadec904a9f3ba3c8aa1",
+    "zh:8ce8ec38a86f0d708286d9115f8098278ec31be8b2cd63c80b5543bbd91310f7",
+    "zh:aee09db9b30821244e5c0e0deb972a149f6f36eb6d73379813e02c9f0ae37f73",
+    "zh:bdf7e5c7f8a0b5fa3ee7a56a678b962b37bd129f2b7acfe45d8cd7598353bfc5",
+    "zh:be7c282dfe6c0fcbed62f1ae6a6da90e81fb9bdea8aaebd9cc50589f67234478",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/helm" {
-  version     = "2.11.0"
-  constraints = ">= 2.11.0"
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.12.1"
+  constraints = ">= 2.12.1"
   hashes = [
-    "h1:AOp9vXIM4uT1c/PVwsWTPiLVGlO2SSYrfiirV5rjCMQ=",
-    "zh:013857c88f3e19a4b162344e21dc51891c4ac8b600da8391f7fb2b6d234961e1",
-    "zh:044fffa233a93cdcf8384afbe9e1ab6c9d0b5b176cbae56ff465eb9611302975",
-    "zh:208b7cdd4fa3a1b25ae817dc00a9198ef98be0ddc3a577b5b72bc0f006afb997",
-    "zh:3e8b33f56cfe387277572a92037a1ca1cbe4e3aa6b5c19a8c2431193b07f7865",
-    "zh:7dd663d5619bd71676899b05b19d36f585189fdabc6b0b03c23579524a8fd9bf",
-    "zh:ae5329cb3e5bf0b86b02e823aac3ef3bd0d4b1618ff013cd0076dca0be8322e4",
-    "zh:ba6201695b55d51bedacdb017cb8d03d7a8ada51d0168ac44fef3fa791a85ab4",
-    "zh:c61285c8b1ba10f50cf94c9dcf98f2f3b720f14906a18be71b9b422279b5d806",
-    "zh:d522d388246f38b9f329c511ec579b516d212670b954f9dab64efb27e51862af",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f92546e26b670da61437ae2cbd038427c9374ce5f7a78df52193397da90bd997",
-    "zh:f9ad1407e5c0d5e3474094491025bf100828e8c1a01acdf9591d7dd1eb59f961",
+    "h1:ajWSFsohX3kQNLs8DbQd93UJlKTUy4HnccLZ2xWCfFM=",
+    "zh:0349149992646530c33314cb973eba68757606a037017ba47e56db695d4b3afe",
+    "zh:3138ffe23c481b01419a4a21adf83538efe6e698b421c4a8f7d142b198518709",
+    "zh:44658e3070405b88fbd76161ecddde62f478dc31aaebee3b93c2f2783a6d45f9",
+    "zh:5600a3407dfb8b77da7561490157afa8ad505c864a5dd35ed8d678e9ad8378ca",
+    "zh:6445e359c813ecbb7c2edf722ed0d1f33dfb171b6a7b470f40cf1e24045b7441",
+    "zh:7973054604c7f5a51600f6e63fa0327d05b29fac2bffd222c21660cbdd2939f9",
+    "zh:7c59e2d4602ab5d9de0ba8e442ec1fc425c8f143581018d1e7f645298a124f01",
+    "zh:8c0fb411dd5de664ac5e801d70507781790c4fc196518a56966d66d0963c240c",
+    "zh:a6a988c91bbf1828a8fc55001f10c7d06c5c53dc718ee7cd6814bdfa2e6652e0",
+    "zh:b7935d7dacd7e5a91ff9d17cfb04ce88c9100e563fd88487d14519e8d8d8b2e1",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.23.0"
-  constraints = ">= 2.23.0"
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.25.2"
+  constraints = ">= 2.25.2"
   hashes = [
-    "h1:arTzD0XG/DswGCAx9JEttkSKe9RyyFW9W7UWcXF13dU=",
-    "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
-    "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
-    "zh:1347cf958ed3f3f80b3c7b3e23ddda3d6c6573a81847a8ee92b7df231c238bf6",
-    "zh:2cb18e9f5156bc1b1ee6bc580a709f7c2737d142722948f4a6c3c8efe757fa8d",
-    "zh:5506aa6f28dcca2a265ccf8e34478b5ec2cb43b867fe6d93b0158f01590fdadd",
-    "zh:6217a20686b631b1dcb448ee4bc795747ebc61b56fbe97a1ad51f375ebb0d996",
-    "zh:8accf916c00579c22806cb771e8909b349ffb7eb29d9c5468d0a3f3166c7a84a",
-    "zh:9379b0b54a0fa030b19c7b9356708ec8489e194c3b5e978df2d31368563308e5",
-    "zh:aa99c580890691036c2931841e88e7ee80d59ae52289c8c2c28ea0ac23e31520",
-    "zh:c57376d169875990ac68664d227fb69cd0037b92d0eba6921d757c3fd1879080",
-    "zh:e6068e3f94f6943b5586557b73f109debe19d1a75ca9273a681d22d1ce066579",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "h1:9ovdI6lk1kqU2uMp6pyZ8fPn2tEP0C1U4DTUSS1JlH8=",
+    "zh:38d35c069a7f5a7c360ce2ddf6da7f22fd25290f76697d5ab0adbc9e7cae4db8",
+    "zh:4b1967b873c6262d8c8f57e8cea2cd029c43912555f688cdff4f824193be4e50",
+    "zh:57e6cfda60c084bb141ea1d8f0ad5881b1bbda92dfcb090e752b09d2cc153b84",
+    "zh:5af23ccba04c2fef7cff9cb17ed5c10ac9d89098706244d1be4d2acbf44f2ae2",
+    "zh:67cd0b02deba8361b2689afe4b2f67e38ca68539a89eb88ceaef7fae6f7e6f0b",
+    "zh:7b4d1fa9d9612919e29a9424a316af6b4c5de766debd8a823b8ad0f28ac2d9c6",
+    "zh:b7a9ca5d1a734675de32c9bbdc78e8569a10aef140fe6d176efed393e64e1d71",
+    "zh:c97777211b3f46ede86fce794ab515185e1145af6a4cd57effdfcddc3cccdcf7",
+    "zh:e7921548f82f68694ad51974bad7cc6c853134a9851912a04da4cdba34eb6214",
+    "zh:fa7b37554ed32422a239b707380ae778a8918e4917a76aadd92fe559a353a10c",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.5.1"
-  constraints = ">= 3.5.1"
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = ">= 3.6.0"
   hashes = [
-    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+    "h1:6QMZ6JACl+V2t8daN5GTlw22EtG7nhc3BbkbJDw2a5M=",
+    "zh:486a1c921eab5c51a480f2eb0ad85173f207c9b7bb215f3893e58bc38d3b7c75",
+    "zh:6901b3afa4607d1e31934ba91ed2625215ada42b3518c3a9adeeac7a5f656dc3",
+    "zh:7e93752c9de710e417191353ad1a41b5a60432ab7ef4f8b556bf248297ec5e23",
+    "zh:c795d3d319e8ee7be972746b935963b7e772a6a14080261a35c03915c1f9ccb2",
+    "zh:cd4f8bcaf332828d1736c73874549c25e427737f136173c7b61e2df3db50e5d9",
+    "zh:e0103eb2e280989c3d9ffda5d6b413e8f583be21bc1d5754c6e9ca87ecc1c44a",
+    "zh:f4fbec2510322d5b7ad584a92436b5dbd0f2e897a3ec538932af59e245a4c8e4",
+    "zh:f5418842afd4aa7676e2456e425e8f573cb2b9bffd29bd7de09d91845644ab24",
+    "zh:f572a26f93d00ec42461ce478678366e570fa4497e2273f9d47f24cdfc4b42b4",
+    "zh:ff1f07c561a3f7f219b6fee1647a559933b5dd6181753e164c3978fd47a11685",
   ]
 }

--- a/assets/loadtest/azure/Makefile
+++ b/assets/loadtest/azure/Makefile
@@ -1,49 +1,55 @@
 .PHONY: nothing
 nothing:
 
-psql_fqdn = $(shell terraform output -raw psql_fqdn)
-psql_adminuser = $(shell terraform output -raw psql_adminuser)
-resource_group = $(shell terraform output -raw resource_group)
-aks_name = $(shell terraform output -raw aks_name)
-monitoring_namespace = $(shell terraform output -raw monitoring_namespace)
-monitoring_release = $(shell terraform output -raw monitoring_release)
-teleport_namespace = $(shell terraform output -raw teleport_namespace)
-teleport_release = $(shell terraform output -raw teleport_release)
+AZ = az
+KUBECTL = kubectl
+PSQL = psql
+TF = tofu
+
+aks_name = $(shell $(TF) output -raw aks_name)
+monitoring_namespace = $(shell $(TF) output -raw monitoring_namespace)
+monitoring_release = $(shell $(TF) output -raw monitoring_release)
+psql_adminuser = $(shell $(TF) output -raw psql_adminuser)
+psql_fqdn = $(shell $(TF) output -raw psql_fqdn)
+public_addr = $(shell $(TF) output -raw public_addr)
+resource_group = $(shell $(TF) output -raw resource_group)
+teleport_namespace = $(shell $(TF) output -raw teleport_namespace)
+teleport_release = $(shell $(TF) output -raw teleport_release)
 
 .PHONY: psql
 psql:
-	PGPASSWORD=$$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv) psql "host=$(psql_fqdn) user=$(psql_adminuser) sslmode=require dbname=postgres"
+	PGPASSWORD=$$($(AZ) account get-access-token --resource-type oss-rdbms --query accessToken -o tsv) $(PSQL) "host=$(psql_fqdn) user=$(psql_adminuser) sslmode=require dbname=postgres"
 
 # this will set the current-context in kubectl, unfortunately
 .PHONY: aks
 aks:
-	az aks get-credentials --resource-group "$(resource_group)" --name "$(aks_name)"
+	$(AZ) aks get-credentials --resource-group "$(resource_group)" --name "$(aks_name)"
 
 .PHONY: grafana
 grafana: aks
 	@echo Grafana will be accessible at http://127.0.0.1:8080/
-	kubectl --context "$(aks_name)" --namespace "$(monitoring_namespace)" port-forward "svc/$(monitoring_release)-grafana" 8080:http-web
+	$(KUBECTL) --context "$(aks_name)" --namespace "$(monitoring_namespace)" port-forward "svc/$(monitoring_release)-grafana" 8080:http-web
 
 .PHONY: public-addr
 public-addr:
-	@echo $(shell terraform output -raw public_addr)
+	@echo "$(public_addr)"
 
 .PHONY: create-joe
 create-joe: aks
-	kubectl --context "$(aks_name)" --namespace "$(teleport_namespace)" exec "deploy/$(teleport_release)-auth" -- tctl users add --roles=access,auditor,editor --logins=root --kubernetes-groups=system:masters joe
+	$(KUBECTL) --context "$(aks_name)" --namespace "$(teleport_namespace)" exec "deploy/$(teleport_release)-auth" -- tctl users add --roles=access,auditor,editor --logins=root --kubernetes-groups=system:masters joe
 
 .PHONY: create-token
 create-token: aks
-	kubectl --context "$(aks_name)" --namespace "$(teleport_namespace)" exec "deploy/$(teleport_release)-auth" -- tctl token add --type=node --ttl=8766h
+	$(KUBECTL) --context "$(aks_name)" --namespace "$(teleport_namespace)" exec "deploy/$(teleport_release)-auth" -- tctl token add --type=node --ttl=8766h
 
 # Recursively destroying the kube cluster and everything in it is incredibly
 # slow, recursively destroying the database will not work because the teleport
-# user owns its databases, and terraform doesn't know about the databases.
-# Instead, we delete the resource group externally, then we tell terraform to
-# forget about anything that was in the kube cluster, and then destroy the few
-# things remaining (DNS entries, optionally ACR role assignments).
+# user owns its databases, and tf doesn't know about the databases. Instead, we
+# delete the resource group externally, then we tell tf to forget about anything
+# that was in the kube cluster, and then destroy the few things remaining (DNS
+# entries, optionally ACR role assignments).
 .PHONY: destroy
 destroy:
-	if az group show --resource-group "$(resource_group)" -o none; then az group delete --resource-group "$(resource_group)"; fi
-	terraform state list | grep -e ^kubernetes_ -e ^helm_ -e ^kubectl_ | xargs terraform state rm
-	terraform destroy
+	if $(AZ) group show --resource-group "$(resource_group)" -o none; then $(AZ) group delete --resource-group "$(resource_group)"; fi
+	$(TF) state list | grep -e ^kubernetes_ -e ^helm_ -e ^kubectl_ | xargs $(TF) state rm
+	$(TF) destroy

--- a/assets/loadtest/azure/README.md
+++ b/assets/loadtest/azure/README.md
@@ -1,6 +1,6 @@
-# Terraform automation for Teleport load tests on Azure
+# OpenTofu automation for Teleport load tests on Azure
 
-This Terraform module sets up:
+This OpenTofu module sets up:
 - a resource group with a random name prefixed by `loadtest-`
 - an AKS cluster (parameters in `aks.tf`, random name prefixed by `loadtest-`)
 - cert-manager with contributor access to the az.teleportdemo.net zone
@@ -19,9 +19,9 @@ This Terraform module sets up:
 
 ## Deployment
 
-To initialize the Terraform providers, run `terraform init`. To deploy, if `az account show` returns an error, run `az login`, then edit `terraform.tfvars`, then `terraform apply`.
+To initialize the OpenTofu providers, run `tofu init`. To deploy, if `az account show` returns an error, run `az login`, then edit `terraform.tfvars`, then `tofu apply`.
 
-After deployment, `make create-user` will create a `joe` Teleport account (outputting the invite link on the terminal), `make grafana` will port forward the grafana instance at [http://127.0.0.1:8080/](http://127.0.0.1:8080/), `make psql` will open a `psql` client connected to the backend database.
+After deployment, `make create-joe` will create a `joe` Teleport account (outputting the invite link on the terminal), `make grafana` will port forward the grafana instance at [http://127.0.0.1:8080/](http://127.0.0.1:8080/), `make psql` will open a `psql` client connected to the backend database.
 
 As a result of some of these commands, or manually with `make aks`, the local kube config should be pointed at the newly created AKS cluster.
 
@@ -29,8 +29,8 @@ As a result of some of these commands, or manually with `make aks`, the local ku
 
 Parameters are sprinkled throughout the module, the main pgbk tunable is `pool_max_conns`, exposed in the chart as `databasePoolMaxConnections` (the current value of 50, in `teleport_kube.tf`, was good enough).
 
-The size of the node pool can be scaled up and down by tweaking it in `aks.tf` and running `terraform apply` again; 10k reverse tunnel nodes required about 9 Standard_D16s_v3 nodes (576GiB of total ram).
+The size of the node pool can be scaled up and down by tweaking it in `aks.tf` and running `tofu apply` again; 10k reverse tunnel nodes required about 9 Standard_D16s_v3 nodes (576GiB of total ram).
 
 ## Clean up
 
-To clean everything up, run `make destroy`. It's possible to delete just the teleport deployment (to create it again manually, say) by disabling it in `terraform.tfvars` and then running `terraform apply` again. Selectively destroying other resources is not recommended, as Terraform might get confused.
+To clean everything up, run `make destroy`. It's possible to delete just the teleport deployment (to create it again manually, say) by disabling it in `terraform.tfvars` and then running `tofu apply` again. Selectively destroying other resources is not recommended, as OpenTofu might get confused.

--- a/assets/loadtest/azure/main.tf
+++ b/assets/loadtest/azure/main.tf
@@ -2,27 +2,27 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.75.0"
+      version = ">= 3.87.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.5.1"
+      version = ">= 3.6.0"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.23.0"
+      version = ">= 2.25.2"
     }
 
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.11.0"
+      version = ">= 2.12.1"
     }
 
     kubectl = {
       source  = "alekc/kubectl"
-      version = ">= 2.0.3"
+      version = ">= 2.0.4"
     }
   }
 }


### PR DESCRIPTION
Provider versions were bumped to latest, commands are now configurable (so it's easy to use `tofu`).