### PR TITLE
Fix an issue database auto-user provisioning fails to connect a second session on MariaDB older than 10.7

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -525,7 +525,7 @@ func getCreateProcedureCommand(conn *clientConn, procedureName string) (string, 
 const (
 	// procedureVersion is a hard-coded string that is set as procedure
 	// comments to indicate the procedure version.
-	procedureVersion = "teleport-auto-user-v3"
+	procedureVersion = "teleport-auto-user-v4"
 
 	// mysqlMaxUsernameLength is the maximum username/role length for MySQL.
 	//


### PR DESCRIPTION
Fixes #36003

changelog: Fix an issue database auto-user provisioning fails to connect a second session on MariaDB older than 10.7

As pointed out by the original issue, `JSON_EQUALS` was added in 10.7. So use loop and `JSON_CONTAINS` instead.

Tested MariaDB 10.5, 10.6, 11.