### PR TITLE
helm: fix operatorn name when included by teleport-cluster chart

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
@@ -6,19 +6,23 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+This is a modified version of the default fully qualified app name helper.
+We diverge by always honouring "nameOverride" when it's set, as opposed to the
+default behaviour of shortening if `nameOverride` is included in chart name.
+This is done to avoid naming conflicts when including th chart in `teleport-cluster`
 */}}
 {{- define "teleport-cluster.operator.fullname" -}}
     {{- if .Values.fullnameOverride }}
         {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
     {{- else }}
-        {{- $name := default .Chart.Name .Values.nameOverride }}
-        {{- if contains $name .Release.Name }}
-            {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+        {{- if .Values.nameOverride }}
+            {{- printf "%s-%s" .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
         {{- else }}
-            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+            {{- if contains .Chart.Name .Release.Name }}
+                {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+            {{- else }}
+                {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
@@ -41,6 +41,17 @@ tests:
           apiVersion: v1
           name: RELEASE-NAME-operator
 
+  - it: does not shorten fullname if .Release.Name == .Chart.Name but there's a nameOverride
+    release:
+      name: teleport-operator
+    set:
+      nameOverride: teleport-operator
+    asserts:
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+          name: teleport-operator-teleport-operator
+
   - it: names the ServiceAccount according to serviceAccount.name
     set:
       serviceAccount:

--- a/examples/chart/teleport-cluster/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/templates/_helpers.tpl
@@ -89,3 +89,27 @@ teleport.dev/majorVersion: '{{ include "teleport-cluster.majorVersion" . }}'
 {{- define "teleport-cluster.auth.serviceFQDN" -}}
 {{ include "teleport-cluster.auth.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}
+
+{{/* Matches the operator template "teleport-cluster.operator.fullname" but can be
+     evaluated in a "teleport-cluster" context. */}}
+{{- define "teleport-cluster.auth.operatorFullName" -}}
+{{- if .Values.operator.fullnameOverride }}
+    {{- .Values.operator.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+    {{- if .Values.operator.nameOverride }}
+        {{- printf "%s-%s" .Release.Name .Values.operator.nameOverride | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+        {{- if contains "teleport-operator" .Release.Name }}
+            {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+        {{- else }}
+            {{- printf "%s-%s" .Release.Name "teleport-operator" | trunc 63 | trimSuffix "-" }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/* Matches the operator template "teleport-cluster.operator.serviceAccountName"
+     but can be evaluated in a "teleport-cluster" context. */}}
+{{- define "teleport-cluster.auth.operatorServiceAccountName" -}}
+{{- coalesce .Values.operator.serviceAccount.name (include "teleport-cluster.auth.operatorFullName" .) -}}
+{{- end -}}

--- a/examples/chart/teleport-cluster/templates/auth/config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/config.yaml
@@ -132,7 +132,7 @@ data:
       bot_name: operator
       kubernetes:
         allow:
-          - service_account: "{{ .Release.Namespace }}:{{ include "teleport-cluster.operator.serviceAccountName" . }}"
+          - service_account: "{{ .Release.Namespace }}:{{ include "teleport-cluster.auth.operatorServiceAccountName" . }}"
   {{- end }}
 {{- end }}
   teleport.yaml: |2

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -266,6 +266,8 @@ operator:
   #    memory: "1Gi"
   joinMethod: "kubernetes"
   token: "teleport-operator"
+  # This is needed to have a sensible name and predictible service account name.
+  nameOverride: operator
 
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/36933

This PR fixes two things:
- including `teleport-cluster.operator.serviceAccountName` from a `teleport*cluster` context led to broken names. This was fixed by adding a template in the parent chart that properly scopes the values.
- changing the `teleport-operator` chart behaviour when a nameOverride is set to avoid conflicts when installing a `teleport-cluster` release with the word "operator" in it.