### PR TITLE
Fix documentation reference to Kubernetes Verbs `get`

### DIFF
--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -538,7 +538,7 @@ the following kinds:
   | Verb | Grants access to |
   | ---- | ----------- |
   | `*` | All operations |
-  | `read` | Read a resource |
+  | `get` | Read a resource |
   | `list` | List resources |
   | `create` | Create a resource |
   | `update` | Update a resource |


### PR DESCRIPTION
This PR fixes a typo in our documentation where the verb that grants read permissions to objects was incorrectly referenced as `read` instead of `get`.