### PR TITLE
[v14] Fix documentation reference to Kubernetes Verbs `get`

### DIFF
--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -537,7 +537,7 @@ the following kinds:
   | Verb | Grants access to |
   | ---- | ----------- |
   | `*` | All operations |
-  | `read` | Read a resource |
+  | `get` | Read a resource |
   | `list` | List resources |
   | `create` | Create a resource |
   | `update` | Update a resource |


### PR DESCRIPTION
Backport #36942 to branch/v14