### PR TITLE
Fix input accent color

### DIFF
--- a/web/packages/design/src/ThemeProvider/globals.js
+++ b/web/packages/design/src/ThemeProvider/globals.js
@@ -37,6 +37,10 @@ const GlobalStyle = createGlobalStyle`
     font-family: ${props => props.theme.font};
   }
 
+  input {
+    accent-color: ${props => props.theme.colors.brand};
+  }
+
   // custom scrollbars with the ability to use the default scrollbar behavior via adding the attribute [data-scrollbar=default]
   :not([data-scrollbar="default"])::-webkit-scrollbar {
     width: 8px;

--- a/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
@@ -37,6 +37,10 @@ const GlobalStyle = createGlobalStyle`
     font-family: ${props => props.theme.font};
   }
 
+  input {
+    accent-color: ${props => props.theme.colors.brand};
+  }
+
   // remove dotted Firefox outline
   button, a {
     outline: 0;


### PR DESCRIPTION
Our checkboxes and radio buttons were correctly using theme colors if you used the <Checkbox> or <RadioGroup> components, but were not styled correctly in cases where we rendered <input> elements directly.