### PR TITLE
[v15] docs: Fix description of AMI names with <arch> addition.

### DIFF
--- a/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -155,15 +155,16 @@ cluster from scratch, so choose carefully. A good example might be something lik
 ### ami_name
 
 ```code
-$ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)"
+$ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)-x86_64"
 ```
 
 Teleport (Gravitational) automatically builds and publishes Teleport Community Edition, Enterprise, and Enterprise FIPS 140-2
 AMIs when we release a new version of Teleport. The AMI names follow the format: `teleport-<type>-<version>-<arch>`
-where `<type>` is either `oss` or `ent` (Enterprise), `version` is the version of Teleport, e.g. `(=teleport.version=)`,
+where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
-
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
+ 
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
+before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -163,8 +163,8 @@ AMIs when we release a new version of Teleport. The AMI names follow the format:
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
  
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
-before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -168,15 +168,16 @@ cluster from scratch, so choose carefully. A good example might be something lik
 ### ami_name
 
 ```code
-$ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)"
+$ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)-x86_64"
 ```
 
 Teleport (Gravitational) automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
 release a new version of Teleport. The AMI names follow the format: `teleport-<type>-<version>-<arch>`
-where `<type>` is either `oss` or `ent` (Enterprise), `version` is the version of Teleport e.g. `(=teleport.version=)`,
-and `arch` is either `x86_64` or `arm64`.
+where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
+and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
+before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -176,8 +176,8 @@ release a new version of Teleport. The AMI names follow the format: `teleport-<t
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
-before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.


### PR DESCRIPTION
Fix the names and descriptions of the AMI names now that we have two
architectures (x86_64 and arm64) for AMIs. The `<arch>` description was
added previously but was not added to the example, and the description
of the `-fips` part became incorrect or ambiguous.

Backport: https://github.com/gravitational/teleport/pull/36907