### PR TITLE
docs: Fix description of location of -fips suffix on AMIs

### DIFF
--- a/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -163,7 +163,8 @@ AMIs when we release a new version of Teleport. The AMI names follow the format:
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
  
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -163,8 +163,7 @@ AMIs when we release a new version of Teleport. The AMI names follow the format:
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
  
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
-before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -176,7 +176,8 @@ release a new version of Teleport. The AMI names follow the format: `teleport-<t
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.

--- a/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -176,8 +176,7 @@ release a new version of Teleport. The AMI names follow the format: `teleport-<t
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have `-fips` after the version,
-before the `<arch>` component, e.g. `teleport-ent-(=teleport.version=)-fips-x86_64`.
+FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
 the example `awscli` commands below. The output is in JSON format by default.


### PR DESCRIPTION
The `-fips` suffix appears after the `<arch>` component, not before as I
previously documented in 1548a43 (I saw some v15 dev builds with -fips
after the version, but they were from before <arch> was added).

This can be seen with:

    aws --region us-west-2 ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-15.0.0-alpha.5-*-fips-*'