### PR TITLE
CatchError in Connect: Provide theme when rendering caught error

### DIFF
--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -19,17 +19,14 @@
 import React from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import styled from 'styled-components';
-
-import { Failed } from 'design/CardError';
 
 import { AppInitializer } from 'teleterm/ui/AppInitializer';
 
-import CatchError from './components/CatchError';
+import { CatchError } from './components/CatchError';
+import { StyledApp } from './components/App';
 import AppContextProvider from './appContextProvider';
 import AppContext from './appContext';
-import { StaticThemeProvider, ThemeProvider } from './ThemeProvider';
-import { darkTheme } from './ThemeProvider/theme';
+import { ThemeProvider } from './ThemeProvider';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
@@ -46,23 +43,3 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
     </StyledApp>
   );
 };
-
-export const FailedApp = (props: { message: string }) => {
-  return (
-    <StyledApp>
-      <StaticThemeProvider theme={darkTheme}>
-        <Failed alignSelf={'baseline'} message={props.message} />
-      </StaticThemeProvider>
-    </StyledApp>
-  );
-};
-
-const StyledApp = styled.div`
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-`;

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -30,8 +30,8 @@ import { ThemeProvider } from './ThemeProvider';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
-    <StyledApp>
-      <CatchError>
+    <CatchError>
+      <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
             <ThemeProvider>
@@ -39,7 +39,7 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
             </ThemeProvider>
           </AppContextProvider>
         </DndProvider>
-      </CatchError>
-    </StyledApp>
+      </StyledApp>
+    </CatchError>
   );
 };

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -21,7 +21,8 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ElectronGlobals } from 'teleterm/types';
-import { App, FailedApp } from 'teleterm/ui/App';
+import { App } from 'teleterm/ui/App';
+import { FailedApp } from 'teleterm/ui/components/App';
 import AppContext from 'teleterm/ui/appContext';
 import Logger from 'teleterm/logger';
 

--- a/web/packages/teleterm/src/ui/components/App.test.tsx
+++ b/web/packages/teleterm/src/ui/components/App.test.tsx
@@ -1,6 +1,6 @@
-/*
+/**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,4 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { CatchError } from './CatchError';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { FailedApp } from './App';
+
+describe('<FailedApp>', () => {
+  it('renders (without ThemeProvider being available)', () => {
+    render(<FailedApp message="Lorem ipsum" />);
+    expect(screen.getByText('Lorem ipsum')).toBeInTheDocument();
+  });
+});

--- a/web/packages/teleterm/src/ui/components/App.tsx
+++ b/web/packages/teleterm/src/ui/components/App.tsx
@@ -1,0 +1,46 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import styled from 'styled-components';
+import { Failed } from 'design/CardError';
+
+import { StaticThemeProvider } from 'teleterm/ui/ThemeProvider';
+import { darkTheme } from 'teleterm/ui/ThemeProvider/theme';
+
+export const StyledApp = styled.div`
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const FailedApp = (props: { message: string }) => {
+  return (
+    <StyledApp>
+      {/*
+        FailedApp is used above ThemeProvider in the component hierarchy. Since it cannot depend on
+        ThemeProvider to provide a theme, it needs to use StaticThemeProvider to provide one.
+      */}
+      <StaticThemeProvider theme={darkTheme}>
+        <Failed alignSelf={'baseline'} message={props.message} />
+      </StaticThemeProvider>
+    </StyledApp>
+  );
+};

--- a/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
+++ b/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
@@ -17,11 +17,11 @@
  */
 
 import React from 'react';
-import { Failed } from 'design/CardError';
 
+import { FailedApp } from 'teleterm/ui/components/App';
 import Logger from 'teleterm/logger';
 
-export default class CatchError extends React.Component {
+export class CatchError extends React.Component {
   logger = new Logger('components/CatchError');
 
   static getDerivedStateFromError(error) {
@@ -39,7 +39,7 @@ export default class CatchError extends React.Component {
   render() {
     if (this.state.error) {
       return (
-        <Failed alignSelf={'baseline'} message={this.state.error.message} />
+        <FailedApp message={this.state.error?.message || this.state.error} />
       );
     }
 

--- a/web/packages/teleterm/src/ui/components/CatchError/CatchError.test.tsx
+++ b/web/packages/teleterm/src/ui/components/CatchError/CatchError.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Logger, { NullService } from 'teleterm/logger';
+
+import { CatchError } from './CatchError';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  // Mock console.error, otherwise the test would output noise to the terminal.
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+const ThrowError = (props: { error: any }) => {
+  throw props.error;
+};
+
+it('renders caught error (without ThemeProvider being available)', () => {
+  render(
+    <CatchError>
+      <ThrowError error={new Error('Lorem ipsum')} />
+    </CatchError>
+  );
+  expect(screen.getByText('Lorem ipsum')).toBeInTheDocument();
+  expect(console.error).toHaveBeenCalled();
+});
+
+it('works correctly when a non-Error value is thrown', () => {
+  render(
+    <CatchError>
+      <ThrowError error={'Lorem ipsum'} />
+    </CatchError>
+  );
+  expect(screen.getByText('Lorem ipsum')).toBeInTheDocument();
+  expect(console.error).toHaveBeenCalled();
+});


### PR DESCRIPTION
Fixes part of #36936.

`CatchError` acts as an error boundary. When it catches an error, it renders `Failed` from `design/CardError`.

However, since about v13, `Failed` assumes that a theme is provided through `ThemeProvider`. `CatchError` is rendered at a place in the hierarchy where `ThemeProvider` is not available. This resulted in `CatchError` crashing whenever it attempted to render a caught error.

https://github.com/gravitational/teleport/blob/1548a43c5b7dc328b946fe80b7c33496bb0f5fc7/web/packages/teleterm/src/ui/App.tsx#L34-L42

We already had a problem like this with `FailedApp` which [is rendered when an error is caught during the boot procedure of the app](https://github.com/gravitational/teleport/blob/1548a43c5b7dc328b946fe80b7c33496bb0f5fc7/web/packages/teleterm/src/ui/boot.tsx#L51-L53). We fixed that problem by using `StaticThemeProvider` within `FailedApp` (https://github.com/gravitational/teleport/pull/29046). That provider always returns the dark theme.

This PR moves `FailedApp` to a separate file so that it can be used in both `CatchError` and `boot.tsx`. It then reuses `FailedApp` in `CatchError` so that the theme is provided when rendering a caught error. It also adds regression tests to make sure that `CatchError` and `FailedApp` are rendered properly when `ThemeProvider` is not available.