### PR TITLE
Install `@protobuf-ts/plugin` in the build containers

### DIFF
--- a/buf-js.gen.yaml
+++ b/buf-js.gen.yaml
@@ -18,4 +18,11 @@ plugins:
   - name: ts
     strategy: all
     out: gen/proto/js
+    path:
+      - npm
+      - exec
+      - --yes
+      - --package=grpc_tools_node_protoc_ts@5.0.1
+      - --
+      - protoc-gen-ts
     opt: "service=grpc-node"

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -293,7 +293,8 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
 # Install JS gRPC tools.
 ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
 ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
-RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
+ARG PROTOBUF_TS_PLUGIN_VERSION  # eg, "2.9.3"
+RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION" "@protobuf-ts/plugin@$PROTOBUF_TS_PLUGIN_VERSION"
 
 # Install protoc.
 ARG PROTOC_VERSION # eg, "3.20.2"

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -21,7 +21,10 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 ARG NODE_GRPC_TOOLS_VERSION
 # eg, "5.0.1"
 ARG NODE_PROTOC_TS_VERSION
-RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
+# @protobuf-ts/plugin
+# eg, "2.9.3"
+ARG PROTOBUF_TS_PLUGIN_VERSION
+RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION" "@protobuf-ts/plugin@$PROTOBUF_TS_PLUGIN_VERSION"
 
 # protoc
 # eg, "3.20.2"

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -144,6 +144,7 @@ buildbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
+		--build-arg PROTOBUF_TS_PLUGIN_VERSION=$(PROTOBUF_TS_PLUGIN_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
 		--cache-from $(BUILDBOX) \
 		$(if $(PUSH),--push,--load) \

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -30,6 +30,7 @@ grpcbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
+		--build-arg PROTOBUF_TS_PLUGIN_VERSION=$(PROTOBUF_TS_PLUGIN_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
 		-f Dockerfile-grpcbox \
 		-t "$(GRPCBOX)" \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -19,6 +19,8 @@ DEVTOOLSET ?= devtoolset-12
 BUF_VERSION ?= v1.28.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
+# TODO(ryan): remove once Connect has migrated to the TS protobufs.
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4
 NODE_PROTOC_TS_VERSION ?= 5.0.1
+PROTOBUF_TS_PLUGIN_VERSION ?= 2.9.3
 PROTOC_VERSION ?= 3.20.3


### PR DESCRIPTION
This installs `@protobuf-ts/plugin` alongside the existing JS protobuf generation libraries so we can use it in https://github.com/gravitational/teleport/pull/37009

It also changes buf to use `npm exec` to use `protoc-gen-ts` installed by `grpc_tools_node_protoc_ts`, as it tries to pick up the `@protobuf-ts/plugin/bin/protoc-gen-ts` otherwise