### PR TITLE
Specify the path for protoc-gen-ts so it doesn't use @protobuf-ts/plugin

### DIFF
--- a/buf-js.gen.yaml
+++ b/buf-js.gen.yaml
@@ -18,5 +18,11 @@ plugins:
   - name: ts
     strategy: all
     out: gen/proto/js
-    path: /usr/local/lib/node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts
+    path:
+        - npm
+        - exec
+        - --yes
+        - --package=grpc_tools_node_protoc_ts@5.0.1
+        - --
+        - protoc-gen-ts
     opt: "service=grpc-node"

--- a/buf-js.gen.yaml
+++ b/buf-js.gen.yaml
@@ -18,4 +18,5 @@ plugins:
   - name: ts
     strategy: all
     out: gen/proto/js
+    path: /usr/local/lib/node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts
     opt: "service=grpc-node"


### PR DESCRIPTION
Once https://github.com/gravitational/teleport/pull/37010 merges, the JS protobuf generation will fail (`@protobuf-ts/plugin` and `grpc_tools_node_protoc_ts` both have binaries named `protoc-gen-ts`, and it picks up the wrong one)

This specifies the path to the correct `protoc-gen-ts`. I can't add this to #37010 because the build uses a cached Docker image which doesn't have the name collision issue, so the path doesn't exist.