### PR TITLE
[v14] Fix an issue database auto-user provisioning fails to connect a second session on MariaDB older than 10.7

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -523,7 +523,7 @@ func getCreateProcedureCommand(conn *clientConn, procedureName string) (string, 
 const (
 	// procedureVersion is a hard-coded string that is set as procedure
 	// comments to indicate the procedure version.
-	procedureVersion = "teleport-auto-user-v3"
+	procedureVersion = "teleport-auto-user-v4"
 
 	// mysqlMaxUsernameLength is the maximum username/role length for MySQL.
 	//


### PR DESCRIPTION
Backport #36938 to branch/v14

changelog: Fix an issue database auto-user provisioning fails to connect a second session on MariaDB older than 10.7
