### PR TITLE
[v14] Fix an issue AWS Redshift auto-provisioned user not deleted in drop mode

### DIFF
--- a/lib/srv/db/postgres/sql/redshift-activate-user.sql
+++ b/lib/srv/db/postgres/sql/redshift-activate-user.sql
@@ -11,7 +11,9 @@ BEGIN
     -- it, otherwise provision a new one.
     IF EXISTS (SELECT user_id FROM svv_user_grants WHERE user_name = username AND admin_option = false AND role_name = 'teleport-auto-user') THEN
         -- If the user has active connections, make sure the provided roles
-        -- match what the user currently has.
+        -- match what the user currently has. Update to pg_stat_activity is
+        -- delayed for a few hundred ms. Use stv_sessions instead:
+        -- https://docs.aws.amazon.com/redshift/latest/dg/r_STV_SESSIONS.html
         IF EXISTS (SELECT user_name FROM stv_sessions WHERE user_name = CONCAT('IAM:', username)) THEN
           SELECT INTO cur_roles_length COUNT(role_name) FROM svv_user_grants WHERE user_name = username AND admin_option=false AND role_name != 'teleport-auto-user';
           IF roles_length != cur_roles_length THEN

--- a/lib/srv/db/postgres/sql/redshift-deactivate-user.sql
+++ b/lib/srv/db/postgres/sql/redshift-deactivate-user.sql
@@ -6,7 +6,8 @@ DECLARE
 BEGIN
     -- Only deactivate if the user doesn't have other active sessions.
     -- Update to pg_stat_activity is delayed for a few hundred ms. Use
-    -- stv_sessions instead.
+    -- stv_sessions instead:
+    -- https://docs.aws.amazon.com/redshift/latest/dg/r_STV_SESSIONS.html
     IF EXISTS (SELECT user_name FROM stv_sessions WHERE user_name = CONCAT('IAM:', username)) THEN
         RAISE EXCEPTION 'TP000: User has active connections';
     ELSE

--- a/lib/srv/db/postgres/sql/redshift-delete-user.sql
+++ b/lib/srv/db/postgres/sql/redshift-delete-user.sql
@@ -3,6 +3,9 @@ LANGUAGE plpgsql
 AS $$
 BEGIN
     -- Only drop if the user doesn't have other active sessions.
+    -- Update to pg_stat_activity is delayed for a few hundred ms. Use
+    -- stv_sessions instead:
+    -- https://docs.aws.amazon.com/redshift/latest/dg/r_STV_SESSIONS.html
     IF EXISTS (SELECT user_name FROM stv_sessions WHERE user_name = CONCAT('IAM:', username)) THEN
         RAISE EXCEPTION 'TP000: User has active connections';
     ELSE

--- a/lib/srv/db/postgres/sql/redshift-delete-user.sql
+++ b/lib/srv/db/postgres/sql/redshift-delete-user.sql
@@ -3,8 +3,8 @@ LANGUAGE plpgsql
 AS $$
 BEGIN
     -- Only drop if the user doesn't have other active sessions.
-    IF EXISTS (SELECT usename FROM pg_stat_activity WHERE usename = username) THEN
-        RAISE NOTICE 'User has active connections';
+    IF EXISTS (SELECT user_name FROM stv_sessions WHERE user_name = CONCAT('IAM:', username)) THEN
+        RAISE EXCEPTION 'TP000: User has active connections';
     ELSE
         BEGIN
             EXECUTE 'DROP USER ' || QUOTE_IDENT(username);


### PR DESCRIPTION
Backport #36828 to branch/v14

changelog: Fix an issue AWS Redshift auto-provisioned user not deleted in drop mode
