### PR TITLE
Make Web Add User prompt for MFA just once

### DIFF
--- a/web/packages/teleport/src/Account/AccountNew.tsx
+++ b/web/packages/teleport/src/Account/AccountNew.tsx
@@ -28,7 +28,7 @@ import { FeatureBox } from 'teleport/components/Layout';
 import ReAuthenticate from 'teleport/components/ReAuthenticate';
 import { RemoveDialog } from 'teleport/components/MfaDeviceList';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { AuthDeviceList } from './ManageDevices/AuthDeviceList/AuthDeviceList';
 import useManageDevices, {
@@ -216,7 +216,7 @@ export function Account({
             onAuthenticated={setToken}
             onClose={hideReAuthenticate}
             actionText="registering a new device"
-            challengeScope={MFAChallengeScope.USER_SESSION}
+            challengeScope={MfaChallengeScope.USER_SESSION}
           />
         )}
         {isAddDeviceVisible && (

--- a/web/packages/teleport/src/Account/ManageDevices/ManageDevices.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/ManageDevices.tsx
@@ -30,7 +30,7 @@ import MfaDeviceList, { RemoveDialog } from 'teleport/components/MfaDeviceList';
 
 import ReAuthenticate from 'teleport/components/ReAuthenticate';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import AddDevice from './AddDevice';
 import useManageDevices, { State } from './useManageDevices';
@@ -106,7 +106,7 @@ export function ManageDevices({
           onAuthenticated={setToken}
           onClose={hideReAuthenticate}
           actionText="registering a new device"
-          challengeScope={MFAChallengeScope.USER_SESSION}
+          challengeScope={MfaChallengeScope.USER_SESSION}
         />
       )}
       {isAddDeviceVisible && (

--- a/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
@@ -20,7 +20,7 @@ import { useCallback } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import cfg, { UrlScpParams } from 'teleport/config';
-import auth, { MFAChallengeScope } from 'teleport/services/auth/auth';
+import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 export default function useGetScpUrl(addMfaToScpUrls: boolean) {
   const { setAttempt, attempt, handleError } = useAttempt('');
@@ -36,7 +36,7 @@ export default function useGetScpUrl(addMfaToScpUrls: boolean) {
       }
       try {
         let webauthn = await auth.getWebauthnResponse(
-          MFAChallengeScope.USER_SESSION
+          MfaChallengeScope.USER_SESSION
         );
         setAttempt({
           status: 'success',

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx
@@ -47,7 +47,7 @@ import {
 import { sortNodeLogins } from 'teleport/services/nodes';
 import { ApiError } from 'teleport/services/api/parseError';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { NodeMeta } from '../../useDiscover';
 
@@ -174,7 +174,7 @@ export function TestConnection(props: AgentStepProps) {
             })
           }
           onClose={cancelMfaDialog}
-          challengeScope={MFAChallengeScope.USER_SESSION}
+          challengeScope={MfaChallengeScope.USER_SESSION}
         />
       )}
       <Header>

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -25,7 +25,7 @@ import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import { generateTshLoginCommand } from 'teleport/lib/util';
 import ReAuthenticate from 'teleport/components/ReAuthenticate';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import {
   ActionButtons,
@@ -91,7 +91,7 @@ export function TestConnectionView({
         <ReAuthenticate
           onMfaResponse={res => testConnection(makeTestConnRequest(), res)}
           onClose={cancelMfaDialog}
-          challengeScope={MFAChallengeScope.USER_SESSION}
+          challengeScope={MfaChallengeScope.USER_SESSION}
         />
       )}
       <Header>Test Connection</Header>

--- a/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
@@ -28,7 +28,7 @@ import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import { generateTshLoginCommand } from 'teleport/lib/util';
 import ReAuthenticate from 'teleport/components/ReAuthenticate';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import {
   ActionButtons,
@@ -103,7 +103,7 @@ export function TestConnection({
             <ReAuthenticate
               onMfaResponse={res => testConnection(makeTestConnRequest(), res)}
               onClose={cancelMfaDialog}
-              challengeScope={MFAChallengeScope.USER_SESSION}
+              challengeScope={MfaChallengeScope.USER_SESSION}
             />
           )}
           <Header>Test Connection</Header>

--- a/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -33,7 +33,7 @@ import {
 } from 'teleport/Discover/Shared';
 import { sortNodeLogins } from 'teleport/services/nodes';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { NodeMeta } from '../../useDiscover';
 
@@ -89,7 +89,7 @@ export function TestConnection(props: AgentStepProps) {
         <ReAuthenticate
           onMfaResponse={res => testConnection(selectedOpt.value, res)}
           onClose={cancelMfaDialog}
-          challengeScope={MFAChallengeScope.USER_SESSION}
+          challengeScope={MfaChallengeScope.USER_SESSION}
         />
       )}
       <Header>Test Connection</Header>

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -21,6 +21,7 @@ import { useAttempt } from 'shared/hooks';
 
 import { User } from 'teleport/services/user';
 import useTeleport from 'teleport/useTeleport';
+import auth, { MFAChallengeScope } from 'teleport/services/auth/auth';
 
 export default function useUsers({
   InviteCollaborators,
@@ -82,11 +83,26 @@ export default function useUsers({
     });
   }
 
-  function onCreate(u: User) {
+  async function onCreate(u: User) {
+    const webauthnResponse = await auth.getWebauthnResponse(
+      MFAChallengeScope.ADMIN_ACTION,
+      true,
+      {
+        admin_action: {
+          name: 'CreateUser',
+        },
+      }
+    );
     return ctx.userService
-      .createUser(u)
+      .createUser(u, webauthnResponse)
       .then(result => setUsers([result, ...users]))
-      .then(() => ctx.userService.createResetPasswordToken(u.name, 'invite'));
+      .then(() =>
+        ctx.userService.createResetPasswordToken(
+          u.name,
+          'invite',
+          webauthnResponse
+        )
+      );
   }
 
   function onInviteCollaboratorsClose(newUsers?: User[]) {

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -21,7 +21,7 @@ import { useAttempt } from 'shared/hooks';
 
 import { User } from 'teleport/services/user';
 import useTeleport from 'teleport/useTeleport';
-import auth, { MFAChallengeScope } from 'teleport/services/auth/auth';
+import auth from 'teleport/services/auth/auth';
 
 export default function useUsers({
   InviteCollaborators,

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -84,14 +84,9 @@ export default function useUsers({
   }
 
   async function onCreate(u: User) {
-    const webauthnResponse = await auth.getWebauthnResponse(
-      MFAChallengeScope.ADMIN_ACTION,
-      true,
-      {
-        admin_action: {
-          name: 'CreateUser',
-        },
-      }
+    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(
+      'CreateUser',
+      true
     );
     return ctx.userService
       .createUser(u, webauthnResponse)

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -84,10 +84,7 @@ export default function useUsers({
   }
 
   async function onCreate(u: User) {
-    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(
-      'CreateUser',
-      true
-    );
+    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
     return ctx.userService
       .createUser(u, webauthnResponse)
       .then(result => setUsers([result, ...users]))

--- a/web/packages/teleport/src/components/ReAuthenticate/ReAuthenticate.story.tsx
+++ b/web/packages/teleport/src/components/ReAuthenticate/ReAuthenticate.story.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { State } from './useReAuthenticate';
 import { ReAuthenticate } from './ReAuthenticate';
@@ -49,5 +49,5 @@ const props: State = {
   onClose: () => null,
   auth2faType: 'on',
   actionText: 'performing this action',
-  challengeScope: MFAChallengeScope.UNSPECIFIED,
+  challengeScope: MfaChallengeScope.UNSPECIFIED,
 };

--- a/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
+++ b/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
@@ -20,7 +20,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 
 import cfg from 'teleport/config';
 import auth from 'teleport/services/auth';
-import { MFAChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import type { MfaAuthnResponse } from 'teleport/services/mfa';
 
@@ -53,7 +53,7 @@ export default function useReAuthenticate(props: Props) {
       .catch(handleError);
   }
 
-  function submitWithWebauthn(scope: MFAChallengeScope) {
+  function submitWithWebauthn(scope: MfaChallengeScope) {
     setAttempt({ status: 'processing' });
 
     if ('onMfaResponse' in props) {
@@ -119,7 +119,7 @@ type BaseProps = {
   /**
    * The MFA challenge scope of the action to perform, as defined in webauthn.proto.
    */
-  challengeScope: MFAChallengeScope;
+  challengeScope: MfaChallengeScope;
 };
 
 // MfaResponseProps defines a function

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -381,7 +381,7 @@ const cfg = {
     return cfg.auth.allowPasswordless;
   },
 
-  isAdminActionMFAEnforced() {
+  isAdminActionMfaEnforced() {
     return cfg.auth.preferredLocalMfa === 'webauthn';
   },
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -381,6 +381,10 @@ const cfg = {
     return cfg.auth.allowPasswordless;
   },
 
+  isAdminActionMFAEnforced() {
+    return cfg.auth.preferredLocalMfa === 'webauthn';
+  },
+
   getPrimaryAuthType(): PrimaryAuthType {
     if (cfg.auth.localConnectorName === 'passwordless') {
       return 'passwordless';

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -382,7 +382,7 @@ const cfg = {
   },
 
   isAdminActionMfaEnforced() {
-    return cfg.auth.preferredLocalMfa === 'webauthn';
+    return cfg.auth.second_factor === 'webauthn';
   },
 
   getPrimaryAuthType(): PrimaryAuthType {

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -31,12 +31,16 @@ const api = {
     return api.fetchJsonWithMfaAuthnRetry(url, { signal: abortSignal });
   },
 
-  post(url, data?, abortSignal?) {
-    return api.fetchJsonWithMfaAuthnRetry(url, {
-      body: JSON.stringify(data),
-      method: 'POST',
-      signal: abortSignal,
-    });
+  post(url, data?, abortSignal?, webauthnResponse?: WebauthnAssertionResponse) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        body: JSON.stringify(data),
+        method: 'POST',
+        signal: abortSignal,
+      },
+      webauthnResponse
+    );
   },
 
   postFormData(url, formData) {
@@ -58,18 +62,26 @@ const api = {
     throw new Error('data for body is not a type of FormData');
   },
 
-  delete(url, data?) {
-    return api.fetchJsonWithMfaAuthnRetry(url, {
-      body: JSON.stringify(data),
-      method: 'DELETE',
-    });
+  delete(url, data?, webauthnResponse?: WebauthnAssertionResponse) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        body: JSON.stringify(data),
+        method: 'DELETE',
+      },
+      webauthnResponse
+    );
   },
 
-  put(url, data) {
-    return api.fetchJsonWithMfaAuthnRetry(url, {
-      body: JSON.stringify(data),
-      method: 'PUT',
-    });
+  put(url, data, webauthnResponse?: WebauthnAssertionResponse) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      {
+        body: JSON.stringify(data),
+        method: 'PUT',
+      },
+      webauthnResponse
+    );
   },
 
   /**

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -17,7 +17,7 @@
  */
 
 import 'whatwg-fetch';
-import auth, { MFAChallengeScope } from 'teleport/services/auth/auth';
+import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { storageService } from '../storageService';
 import { WebauthnAssertionResponse } from '../auth';
@@ -130,7 +130,7 @@ const api = {
     let webauthnResponseForRetry;
     try {
       webauthnResponseForRetry = await auth.getWebauthnResponse(
-        MFAChallengeScope.ADMIN_ACTION
+        MfaChallengeScope.ADMIN_ACTION
       );
     } catch (err) {
       throw new Error(

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -307,16 +307,6 @@ const auth = {
     allowReuse?: boolean,
     isMFARequiredRequest?: IsMfaRequiredRequest
   ) {
-    // If the client is checking if MFA is required for an admin action,
-    // but we know admin action MFA is not enforced, return early.
-    if (
-      isMFARequiredRequest !== null &&
-      scope === MFAChallengeScope.ADMIN_ACTION &&
-      !cfg.isAdminActionMFAEnforced()
-    ) {
-      return;
-    }
-
     // TODO(Joerger): DELETE IN 16.0.0
     // the create mfa challenge endpoint below supports
     // MFARequired requests without the extra roundtrip.
@@ -337,6 +327,27 @@ const auth = {
     return auth
       .fetchWebauthnChallenge(scope, allowReuse, isMFARequiredRequest)
       .then(res => makeWebauthnAssertionResponse(res));
+  },
+
+  getWebauthnResponseForAdminAction(
+    adminActionName?: string,
+    allowReuse?: boolean
+  ) {
+    // If the client is checking if MFA is required for an admin action,
+    // but we know admin action MFA is not enforced, return early.
+    if (!cfg.isAdminActionMFAEnforced()) {
+      return;
+    }
+
+    return auth.getWebauthnResponse(
+      MFAChallengeScope.ADMIN_ACTION,
+      allowReuse,
+      {
+        admin_action: {
+          name: adminActionName,
+        },
+      }
+    );
   },
 };
 

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -329,10 +329,7 @@ const auth = {
       .then(res => makeWebauthnAssertionResponse(res));
   },
 
-  getWebauthnResponseForAdminAction(
-    adminActionName?: string,
-    allowReuse?: boolean
-  ) {
+  getWebauthnResponseForAdminAction(allowReuse?: boolean) {
     // If the client is checking if MFA is required for an admin action,
     // but we know admin action MFA is not enforced, return early.
     if (!cfg.isAdminActionMFAEnforced()) {
@@ -343,9 +340,7 @@ const auth = {
       MFAChallengeScope.ADMIN_ACTION,
       allowReuse,
       {
-        admin_action: {
-          name: adminActionName,
-        },
+        admin_action: {},
       }
     );
   },
@@ -418,10 +413,7 @@ export type IsMfaRequiredKube = {
 };
 
 export type IsMFARequiredAdminAction = {
-  admin_action: {
-    // name is the name of the admin action RPC.
-    name: string;
-  };
+  admin_action: {};
 };
 
 // MFAChallengeScope is an mfa challenge scope. Possible values are defined in mfa.proto

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -312,11 +312,18 @@ const auth = {
         if (!isMFARequired.required) {
           return;
         }
-      } catch {
-        // checking MFA requirement for admin actions is not supported by old
-        // auth servers, we expect an error instead. In this case, assume MFA is
-        // not required. Callers should fallback to retrying with MFA if needed.
-        return;
+      } catch (err) {
+        if (
+          err?.response?.status === 400 &&
+          err?.message.includes('missing target for MFA check')
+        ) {
+          // checking MFA requirement for admin actions is not supported by old
+          // auth servers, we expect an error instead. In this case, assume MFA is
+          // not required. Callers should fallback to retrying with MFA if needed.
+          return;
+        }
+
+        throw err;
       }
     }
 

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -16,15 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useAppContext } from 'teleterm/ui/appContextProvider';
-
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import { DeviceType, DeviceUsage } from 'teleport/services/mfa';
 
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
-
-import ClustersService from '../clusters/clusters';
 
 import makePasswordToken from './makePasswordToken';
 import { makeChangedUserAuthn } from './make';
@@ -413,7 +409,8 @@ export type IsMfaRequiredKube = {
 };
 
 export type IsMFARequiredAdminAction = {
-  admin_action: {};
+  // empty object.
+  admin_action: Record<string, never>;
 };
 
 // MFAChallengeScope is an mfa challenge scope. Possible values are defined in mfa.proto

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -240,7 +240,7 @@ const auth = {
 
   headlessSSOAccept(transactionId: string) {
     return auth
-      .fetchWebauthnChallenge(MFAChallengeScope.HEADLESS_LOGIN)
+      .fetchWebauthnChallenge(MfaChallengeScope.HEADLESS_LOGIN)
       .then(res => {
         const request = {
           action: 'accept',
@@ -264,16 +264,16 @@ const auth = {
   },
 
   async fetchWebauthnChallenge(
-    scope: MFAChallengeScope,
+    scope: MfaChallengeScope,
     allowReuse?: boolean,
-    isMFARequiredRequest?: IsMfaRequiredRequest
+    isMfaRequiredRequest?: IsMfaRequiredRequest
   ) {
     return auth
       .checkWebauthnSupport()
       .then(() =>
         api
           .post(cfg.api.mfaAuthnChallengePath, {
-            is_mfa_required_req: isMFARequiredRequest,
+            is_mfa_required_req: isMfaRequiredRequest,
             challenge_scope: scope,
             challenge_allow_reuse: allowReuse,
           })
@@ -286,7 +286,7 @@ const auth = {
       );
   },
 
-  createPrivilegeTokenWithWebauthn(scope: MFAChallengeScope) {
+  createPrivilegeTokenWithWebauthn(scope: MfaChallengeScope) {
     return auth.fetchWebauthnChallenge(scope).then(res =>
       api.post(cfg.api.createPrivilegeTokenPath, {
         webauthnAssertionResponse: makeWebauthnAssertionResponse(res),
@@ -299,16 +299,16 @@ const auth = {
   },
 
   async getWebauthnResponse(
-    scope: MFAChallengeScope,
+    scope: MfaChallengeScope,
     allowReuse?: boolean,
-    isMFARequiredRequest?: IsMfaRequiredRequest
+    isMfaRequiredRequest?: IsMfaRequiredRequest
   ) {
     // TODO(Joerger): DELETE IN 16.0.0
     // the create mfa challenge endpoint below supports
     // MFARequired requests without the extra roundtrip.
-    if (isMFARequiredRequest) {
+    if (isMfaRequiredRequest) {
       try {
-        const isMFARequired = await checkMfaRequired(isMFARequiredRequest);
+        const isMFARequired = await checkMfaRequired(isMfaRequiredRequest);
         if (!isMFARequired.required) {
           return;
         }
@@ -328,19 +328,19 @@ const auth = {
     }
 
     return auth
-      .fetchWebauthnChallenge(scope, allowReuse, isMFARequiredRequest)
+      .fetchWebauthnChallenge(scope, allowReuse, isMfaRequiredRequest)
       .then(res => makeWebauthnAssertionResponse(res));
   },
 
   getWebauthnResponseForAdminAction(allowReuse?: boolean) {
     // If the client is checking if MFA is required for an admin action,
     // but we know admin action MFA is not enforced, return early.
-    if (!cfg.isAdminActionMFAEnforced()) {
+    if (!cfg.isAdminActionMfaEnforced()) {
       return;
     }
 
     return auth.getWebauthnResponse(
-      MFAChallengeScope.ADMIN_ACTION,
+      MfaChallengeScope.ADMIN_ACTION,
       allowReuse,
       {
         admin_action: {},
@@ -371,7 +371,7 @@ export type IsMfaRequiredRequest =
   | IsMfaRequiredNode
   | IsMfaRequiredKube
   | IsMfaRequiredWindowsDesktop
-  | IsMFARequiredAdminAction;
+  | IsMfaRequiredAdminAction;
 
 export type IsMfaRequiredResponse = {
   required: boolean;
@@ -415,13 +415,13 @@ export type IsMfaRequiredKube = {
   };
 };
 
-export type IsMFARequiredAdminAction = {
+export type IsMfaRequiredAdminAction = {
   // empty object.
   admin_action: Record<string, never>;
 };
 
-// MFAChallengeScope is an mfa challenge scope. Possible values are defined in mfa.proto
-export enum MFAChallengeScope {
+// MfaChallengeScope is an mfa challenge scope. Possible values are defined in mfa.proto
+export enum MfaChallengeScope {
   UNSPECIFIED = 0,
   LOGIN = 1,
   PASSWORDLESS_LOGIN = 2,

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -20,6 +20,8 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import session from 'teleport/services/websession';
 
+import { WebauthnAssertionResponse } from '../auth';
+
 import makeUserContext from './makeUserContext';
 import { makeResetToken } from './makeResetToken';
 import makeUser, { makeUsers } from './makeUser';
@@ -60,13 +62,24 @@ const service = {
     return api.put(cfg.getUsersUrl(), user).then(makeUser);
   },
 
-  createUser(user: User) {
-    return api.post(cfg.getUsersUrl(), user).then(makeUser);
+  createUser(user: User, webauthnResponse?: WebauthnAssertionResponse) {
+    return api
+      .post(cfg.getUsersUrl(), user, null, webauthnResponse)
+      .then(makeUser);
   },
 
-  createResetPasswordToken(name: string, type: ResetPasswordType) {
+  createResetPasswordToken(
+    name: string,
+    type: ResetPasswordType,
+    webauthnResponse?: WebauthnAssertionResponse
+  ) {
     return api
-      .post(cfg.api.resetPasswordTokenPath, { name, type })
+      .post(
+        cfg.api.resetPasswordTokenPath,
+        { name, type },
+        null,
+        webauthnResponse
+      )
       .then(makeResetToken);
   },
 


### PR DESCRIPTION
Similar to https://github.com/gravitational/teleport/pull/36997, this PR updates adding a user from the WebUI to perform the admin action MFA ceremony upfront, allowing reuse so `CreateUser` and `CreateResetPasswordToken` only require one prompt.

This PR is also a pre-req for other similar PRs since it adds the `webauthnResponse` argument to `post/put/delete` requests.