### PR TITLE
fix EAS bootstrap script

### DIFF
--- a/lib/integrations/externalauditstorage/bootstrap.go
+++ b/lib/integrations/externalauditstorage/bootstrap.go
@@ -186,8 +186,7 @@ func createTransientBucket(ctx context.Context, clt BootstrapS3Client, bucketNam
 					Status: s3types.ExpirationStatusEnabled,
 					ID:     aws.String("ExpireNonCurrentVersionsAndDeleteMarkers"),
 					NoncurrentVersionExpiration: &s3types.NoncurrentVersionExpiration{
-						NewerNoncurrentVersions: aws.Int32(0),
-						NoncurrentDays:          aws.Int32(1),
+						NoncurrentDays: aws.Int32(1),
 					},
 					AbortIncompleteMultipartUpload: &s3types.AbortIncompleteMultipartUpload{
 						DaysAfterInitiation: aws.Int32(7),


### PR DESCRIPTION
This got broken in a dependency update https://github.com/gravitational/teleport/pull/35610 where we stopped passing `0` and started passing a pointer to `0` for the `NewerNoncurrentVersions` field. This fails validation, the value must be unset or a positive integer. We don't actually want any noncurrent versions around (we don't use them) and in my testing, leaving it unset behaves like you'd expect if it was set to 0.

fixes https://github.com/gravitational/teleport/issues/37062

no changelog because the bug never made it into a release