### PR TITLE
Reuse MFA for Deploy Database Service

### DIFF
--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -21,6 +21,8 @@ import cfg from 'teleport/config';
 
 import makeNode from '../nodes/makeNode';
 
+import auth from '../auth/auth';
+
 import {
   Integration,
   IntegrationCreateRequest,
@@ -143,21 +145,35 @@ export const integrationService = {
       });
   },
 
-  deployAwsOidcService(
+  async deployAwsOidcService(
     integrationName,
     req: AwsOidcDeployServiceRequest
   ): Promise<string> {
+    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+
     return api
-      .post(cfg.getAwsDeployTeleportServiceUrl(integrationName), req)
+      .post(
+        cfg.getAwsDeployTeleportServiceUrl(integrationName),
+        req,
+        null,
+        webauthnResponse
+      )
       .then(resp => resp.serviceDashboardUrl);
   },
 
-  deployDatabaseServices(
+  async deployDatabaseServices(
     integrationName,
     req: AwsOidcDeployDatabaseServicesRequest
   ): Promise<string> {
+    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+
     return api
-      .post(cfg.getAwsRdsDbsDeployServicesUrl(integrationName), req)
+      .post(
+        cfg.getAwsRdsDbsDeployServicesUrl(integrationName),
+        req,
+        null,
+        webauthnResponse
+      )
       .then(resp => resp.clusterDashboardUrl);
   },
 


### PR DESCRIPTION
Use reusable scoped webauthn credentials for Delete Access List.

Tested on Teleport Cloud.

Fixes https://github.com/gravitational/teleport/issues/36900