### PR TITLE
[v13] Bump shlex from 1.1.0 to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"


### PR DESCRIPTION
v13 backport of https://github.com/gravitational/teleport/pull/37056