### PR TITLE
[v15] Bump shlex from 1.2.0 to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
v15 backport of https://github.com/gravitational/teleport/pull/37056