### PR TITLE
Allowlist proxy hosts of root clusters in Connect

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -247,7 +247,7 @@ function initializeApp(): void {
         );
         dialog.showErrorBox(
           'Cannot open this link',
-          'The domain this link points to does not match any of the allowed domains. Check main.log for more details.'
+          'The domain does not match any of the allowed domains. Check main.log for more details.'
         );
       }
 

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -131,6 +131,8 @@ export class MockMainProcessClient implements MainProcessClient {
   async tryRemoveConnectMyComputerAgentBinary() {}
 
   signalUserInterfaceReadiness() {}
+
+  refreshClusterList() {}
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -187,5 +187,8 @@ export default function createMainProcessClient(): MainProcessClient {
     signalUserInterfaceReadiness(args: { success: boolean }) {
       ipcRenderer.send(WindowsManagerIpc.SignalUserInterfaceReadiness, args);
     },
+    refreshClusterList() {
+      ipcRenderer.send(MainProcessIpc.RefreshClusterList);
+    },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
+++ b/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
@@ -1,0 +1,95 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ipcMain } from 'electron';
+
+import { isAbortError } from 'shared/utils/abortError';
+
+import { proxyHostToBrowserProxyHost } from 'teleterm/services/tshd/cluster';
+import { TshdClient } from 'teleterm/services/tshd/types';
+import { Logger } from 'teleterm/types';
+import { MainProcessIpc } from 'teleterm/mainProcess/types';
+import * as tshd from 'teleterm/services/tshd/types';
+
+export type RootClusterProxyHostAllowList = Set<string>;
+
+/**
+ * Refreshes the allow list whenever the renderer process notifies the main process that the list of
+ * clusters in ClustersService got updated.
+ *
+ * The allow list includes proxy hosts of root clusters. This enables us to open links to Web UIs of
+ * clusters from within Connect.
+ *
+ * The port part of a proxy host is dropped if the port is 443. See proxyHostToBrowserProxyHost for
+ * more details.
+ */
+export function manageRootClusterProxyHostAllowList({
+  tshdClient,
+  logger,
+  allowList,
+}: {
+  tshdClient: TshdClient;
+  logger: Logger;
+  allowList: RootClusterProxyHostAllowList;
+}) {
+  let abortController: tshd.TshAbortController;
+
+  const refreshAllowList = async () => {
+    // Allow only one call to be in progress. This ensures that on subsequent calls to
+    // refreshAllowList, we always store only the most recent version of the list.
+    abortController?.abort();
+    abortController = tshdClient.createAbortController();
+
+    let rootClusters: tshd.Cluster[];
+    try {
+      rootClusters = await tshdClient.listRootClusters(abortController.signal);
+    } catch (error) {
+      if (isAbortError(error)) {
+        // Ignore abort errors. They will be logged by the gRPC client middleware.
+        return;
+      }
+
+      logger.error('Could not fetch root clusters', error);
+      // Return instead of throwing as there's nothing else we can do with the error at this place
+      // in the program.
+      return;
+    }
+
+    allowList.clear();
+    for (const rootCluster of rootClusters) {
+      let browserProxyHost: string;
+      try {
+        browserProxyHost = proxyHostToBrowserProxyHost(rootCluster.proxyHost);
+      } catch (error) {
+        logger.error(
+          'Ran into an error whin converting proxy host to browser proxy host',
+          error
+        );
+        return;
+      }
+
+      allowList.add(browserProxyHost);
+    }
+  };
+
+  refreshAllowList();
+
+  ipcMain.on(MainProcessIpc.RefreshClusterList, () => {
+    refreshAllowList();
+  });
+}

--- a/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
+++ b/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
@@ -77,7 +77,7 @@ export function manageRootClusterProxyHostAllowList({
         browserProxyHost = proxyHostToBrowserProxyHost(rootCluster.proxyHost);
       } catch (error) {
         logger.error(
-          'Ran into an error whin converting proxy host to browser proxy host',
+          'Ran into an error when converting proxy host to browser proxy host',
           error
         );
         return;

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -156,6 +156,7 @@ export type MainProcessClient = {
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
   getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
   signalUserInterfaceReadiness(args: { success: boolean }): void;
+  refreshClusterList(): void;
 };
 
 export type ChildProcessAddresses = {
@@ -267,6 +268,7 @@ export enum RendererIpc {
 export enum MainProcessIpc {
   GetRuntimeSettings = 'main-process-get-runtime-settings',
   TryRemoveConnectMyComputerAgentBinary = 'main-process-try-remove-connect-my-computer-agent-binary',
+  RefreshClusterList = 'main-process-refresh-cluster-list',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/services/tshd/cluster.test.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { proxyHostToBrowserProxyHost } from './cluster';
+
+describe('proxyHostToBrowserProxyHost', () => {
+  describe('valid inputs', () => {
+    const tests: Array<{
+      name: string;
+      input: string;
+      expectedOutput: string;
+    }> = [
+      {
+        name: 'default port',
+        input: 'cluster.example.com:443',
+        expectedOutput: 'cluster.example.com',
+      },
+      {
+        name: 'custom port',
+        input: 'example.com:3090',
+        expectedOutput: 'example.com:3090',
+      },
+      {
+        name: 'top-level domain with default port',
+        input: 'teleport-local:443',
+        expectedOutput: 'teleport-local',
+      },
+      {
+        name: 'top-level domain with custom port',
+        input: 'teleport-local:3090',
+        expectedOutput: 'teleport-local:3090',
+      },
+    ];
+
+    test.each(tests)('$name ($input)', ({ input, expectedOutput }) => {
+      expect(proxyHostToBrowserProxyHost(input)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    const tests: Array<{
+      name: string;
+      input: string;
+    }> = [
+      {
+        name: 'proxyHost includes protocol',
+        input: 'https://cluster.example.com:3090',
+      },
+      {
+        name: 'whatwg-url parsing error',
+        input: '<teleport>',
+      },
+    ];
+
+    test.each(tests)('$name ($input)', ({ input }) => {
+      expect(() => proxyHostToBrowserProxyHost(input)).toThrow(
+        /invalid proxy host/i
+      );
+    });
+  });
+});

--- a/web/packages/teleterm/src/services/tshd/cluster.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.ts
@@ -1,0 +1,55 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as whatwg from 'whatwg-url';
+
+/**
+ * Accepts a proxy host in the form of "cluster-address.example.com:3090" and returns the host as
+ * understood by browsers.
+ *
+ * The URL API in most browsers skips the port if the port matches the default port used by the
+ * protocol. This behavior can be observed both in JS and in DOM. For example:
+ *
+ *     <a href="https://example.com:443/hello-world">Example</a>
+ *
+ * becomes
+ *
+ *     <a href="https://example.com/hello-world">Example</a>
+ *
+ * The distinction is important in situations where we want to match the host reported by the
+ * browser against a host that we got from a Go service.
+ */
+export function proxyHostToBrowserProxyHost(proxyHost: string) {
+  let whatwgURL: whatwg.URL;
+
+  try {
+    whatwgURL = new whatwg.URL(`https://${proxyHost}`);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error(`Invalid proxy host ${proxyHost}`, { cause: error });
+    }
+    throw error;
+  }
+
+  // Catches cases where proxyHost itself includes a "https://" prefix.
+  if (whatwgURL.pathname !== '/') {
+    throw new Error(`Invalid proxy host ${proxyHost}`);
+  }
+
+  return whatwgURL.host;
+}

--- a/web/packages/teleterm/src/services/tshd/createAbortController.ts
+++ b/web/packages/teleterm/src/services/tshd/createAbortController.ts
@@ -36,6 +36,10 @@ export default function createAbortController(): TshAbortController {
     // function from the shared package.
     //
     // TshAbortSignal doesn't accept the event name as the first argument.
+    //
+    // TshAbortSignal still needs to have some kind of a unique property so that Connect functions
+    // can enforce on a type level that they can only accept TshAbortSignal. Regular abort signals
+    // won't work in Connect since abort signals are often passed through the context bridge.
     addEventListener(cb: (...args: any[]) => void) {
       emitter.once('abort', cb);
     },

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -159,15 +159,19 @@ export function createTshdClient(
       });
     },
 
-    async listRootClusters() {
-      const req = new api.ListClustersRequest();
-      return new Promise<types.Cluster[]>((resolve, reject) => {
-        tshd.listRootClusters(req, (err, response) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(response.toObject().clustersList as types.Cluster[]);
-          }
+    async listRootClusters(abortSignal?: types.TshAbortSignal) {
+      return withAbort(abortSignal, callRef => {
+        return new Promise<types.Cluster[]>((resolve, reject) => {
+          callRef.current = tshd.listRootClusters(
+            new api.ListClustersRequest(),
+            (err, response) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve(response.toObject().clustersList as types.Cluster[]);
+              }
+            }
+          );
         });
       });
     },

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -224,7 +224,7 @@ export type LoginPasswordlessRequest =
   Partial<apiService.LoginPasswordlessRequest.AsObject>;
 
 export type TshdClient = {
-  listRootClusters: () => Promise<Cluster[]>;
+  listRootClusters: (abortSignal?: TshAbortSignal) => Promise<Cluster[]>;
   listLeafClusters: (clusterUri: uri.RootClusterUri) => Promise<Cluster[]>;
   getKubes: (params: GetResourcesParams) => Promise<GetKubesResponse>;
   getApps: (params: GetResourcesParams) => Promise<GetAppsResponse>;

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -179,6 +179,14 @@ export interface Cluster extends apiCluster.Cluster.AsObject {
    * user is yet to log in, loggedInUser is not present.
    */
   loggedInUser?: LoggedInUser;
+  /**
+   * Address of the proxy used to connect to this cluster. Always includes port number. Present only
+   * for root clusters.
+   *
+   * @example
+   * "teleport-14-ent.example.com:3090"
+   */
+  proxyHost: string;
 }
 
 /**

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -31,7 +31,7 @@ import {
   DbType,
 } from 'shared/services/databases';
 
-import { Flex, ButtonPrimary, Text } from 'design';
+import { Flex, ButtonPrimary, Text, Link } from 'design';
 
 import * as icons from 'design/Icon';
 import Image from 'design/Image';
@@ -73,6 +73,7 @@ export function UnifiedResources(props: {
   docUri: uri.DocumentUri;
   queryParams: DocumentClusterQueryParams;
 }) {
+  const { clustersService } = useAppContext();
   const { userPreferencesAttempt, updateUserPreferences, userPreferences } =
     useUserPreferences(props.clusterUri);
   const { documentsService, rootClusterUri } = useWorkspaceContext();
@@ -108,6 +109,11 @@ export function UnifiedResources(props: {
 
   const isRootCluster = props.clusterUri === rootClusterUri;
   const canAddResources = isRootCluster && loggedInUser?.acl?.tokens.create;
+  let discoverUrl: string;
+  if (isRootCluster) {
+    const rootCluster = clustersService.findCluster(rootClusterUri);
+    discoverUrl = `https://${rootCluster.proxyHost}/web/discover`;
+  }
 
   const canUseConnectMyComputer =
     isRootCluster &&
@@ -144,6 +150,7 @@ export function UnifiedResources(props: {
       canUseConnectMyComputer={canUseConnectMyComputer}
       openConnectMyComputerDocument={openConnectMyComputerDocument}
       onResourcesRefreshRequest={onResourcesRefreshRequest}
+      discoverUrl={discoverUrl}
       // Reset the component state when query params object change.
       // JSON.stringify on the same object will always produce the same string.
       key={JSON.stringify(mergedParams)}
@@ -163,6 +170,7 @@ const Resources = memo(
     canUseConnectMyComputer: boolean;
     openConnectMyComputerDocument(): void;
     onResourcesRefreshRequest: ResourcesContext['onResourcesRefreshRequest'];
+    discoverUrl: string;
   }) => {
     const appContext = useAppContext();
 
@@ -275,6 +283,7 @@ const Resources = memo(
         NoResources={
           <NoResources
             canCreate={props.canAddResources}
+            discoverUrl={props.discoverUrl}
             canUseConnectMyComputer={props.canUseConnectMyComputer}
             onConnectMyComputerCtaClick={props.openConnectMyComputerDocument}
           />
@@ -363,6 +372,7 @@ const mapToSharedResource = (
 
 function NoResources(props: {
   canCreate: boolean;
+  discoverUrl: string | undefined;
   canUseConnectMyComputer: boolean;
   onConnectMyComputerCtaClick(): void;
 }) {
@@ -380,6 +390,11 @@ function NoResources(props: {
       </>
     );
   } else {
+    const $discoverLink = (
+      <Link href={props.discoverUrl} target="_blank">
+        the&nbsp;Teleport Web UI
+      </Link>
+    );
     $content = (
       <>
         <Image src={stack} ml="auto" mr="auto" mb={4} height="100px" />
@@ -387,9 +402,17 @@ function NoResources(props: {
           Add your first resource to Teleport
         </Text>
         <Text color="text.slightlyMuted">
-          {props.canUseConnectMyComputer
-            ? 'You can add it in the Teleport Web UI or by connecting your computer to the cluster.'
-            : 'Connect SSH servers, Kubernetes clusters, Databases and more from Teleport Web UI.'}
+          {props.canUseConnectMyComputer ? (
+            <>
+              You can add it in {$discoverLink} or by connecting your computer
+              to the cluster.
+            </>
+          ) : (
+            <>
+              Connect SSH servers, Kubernetes clusters, Databases and more from{' '}
+              {$discoverLink}.
+            </>
+          )}
         </Text>
         {props.canUseConnectMyComputer && (
           <ButtonPrimary

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { debounce } from 'shared/utils/highbar';
+
 import {
   MainProcessClient,
   ElectronGlobals,
@@ -166,6 +168,7 @@ export default class AppContext implements IAppContext {
     );
 
     this.subscribeToDeepLinkLaunch();
+    this.notifyMainProcessAboutClusterListChanges();
     this.clustersService.syncGatewaysAndCatchErrors();
     await this.clustersService.syncRootClustersAndCatchErrors();
   }
@@ -185,5 +188,24 @@ export default class AppContext implements IAppContext {
         });
       };
     }
+  }
+
+  private notifyMainProcessAboutClusterListChanges() {
+    // Debounce the notifications sent to the main process so that we don't unnecessarily send more
+    // than one notification per frame. The main process doesn't need to be notified absolutely
+    // immediately after a change in the cluster list.
+    //
+    // The clusters map in ClustersService gets updated a bunch of times during the start of the
+    // app. After each update, the renderer tells the main process to refresh the list. The main
+    // process sends a request to list root clusters and cancels any pending ones. Debouncing here
+    // helps to minimize those cancellations.
+    const refreshClusterList = debounce(
+      this.mainProcessClient.refreshClusterList,
+      16
+    );
+    this.clustersService.subscribeWithSelector(
+      state => state.clusters,
+      refreshClusterList
+    );
   }
 }

--- a/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.test.ts
+++ b/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ImmutableStore } from './immutableStore';
+
+describe('subscribeWithSelector', () => {
+  it('calls the callback only when a selected part of the state gets updated', () => {
+    const store = new TestStore();
+
+    const fooUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.foo, fooUpdatedCallback);
+
+    const barUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.bar, barUpdatedCallback);
+
+    store.setState(draft => {
+      draft.foo.set('lorem', 'ipsum');
+    });
+
+    expect(fooUpdatedCallback).toHaveBeenCalledTimes(1);
+    expect(barUpdatedCallback).not.toHaveBeenCalled();
+
+    store.setState(draft => {
+      draft.bar.set('dolor', 'sit');
+    });
+
+    expect(fooUpdatedCallback).toHaveBeenCalledTimes(1);
+    expect(barUpdatedCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the callbacks if multiple parts of the state get updated at the same time', () => {
+    const store = new TestStore();
+
+    const fooUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.foo, fooUpdatedCallback);
+
+    const barUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.bar, barUpdatedCallback);
+
+    const quuxUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.quux, quuxUpdatedCallback);
+
+    store.setState(draft => {
+      draft.foo.set('lorem', 'ipsum');
+      draft.bar.set('dolor', 'sit');
+    });
+
+    expect(fooUpdatedCallback).toHaveBeenCalledTimes(1);
+    expect(barUpdatedCallback).toHaveBeenCalledTimes(1);
+    expect(quuxUpdatedCallback).not.toHaveBeenCalled();
+  });
+});
+
+class TestStore extends ImmutableStore<{
+  foo: Map<string, string>;
+  bar: Map<string, string>;
+  quux: Map<string, string>;
+}> {
+  constructor() {
+    super();
+    this.setState(() => ({ foo: new Map(), bar: new Map(), quux: new Map() }));
+  }
+}

--- a/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.ts
+++ b/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.ts
@@ -43,4 +43,31 @@ export class ImmutableStore<T> extends Store<T> {
       }
     });
   }
+
+  /**
+   * Adds a callback which gets called only when the part of the state returned by selector is
+   * changed. selector must be pure.
+   */
+  subscribeWithSelector<SelectedState>(
+    selector: (state: T) => SelectedState,
+    callback: () => void
+  ) {
+    let selectedState = selector(this.state);
+
+    this.subscribe(() => {
+      const newSelectedState = selector(this.state);
+      // It doesn't appear to be explicitly documented anywhere, but Immer preserves object
+      // identity, so Object.is works as expected. This behavior is covered by our tests.
+      const hasSelectedStateChanged = !Object.is(
+        newSelectedState,
+        selectedState
+      );
+
+      if (hasSelectedStateChanged) {
+        callback();
+      }
+
+      selectedState = newSelectedState;
+    });
+  }
 }


### PR DESCRIPTION
In order to [allow opening links to cluster apps](https://github.com/gravitational/teleport/issues/35554), the main process in Connect must know which clusters have been added in the app. Now that [a tsh daemon client has been added to the main process](https://github.com/gravitational/teleport/pull/36692), we can get make the main process maintain a list of currently added root clusters. `setWindowOpenHandler` can use this list to allow opening links only to proxy hosts of those root clusters.

https://github.com/gravitational/teleport/issues/35554 explains why the main process cannot get the list of root clusters from the renderer. But even if the main process gets the list from the tsh daemon, how is the main process going to know that the list has changed?

To accomplish this, I set up an IPC message sent from the renderer to the main process. Since the renderer has `ClustersService`, it can subscribe to state changes in that service. Whenever the state changes, the renderer can send a message to the main process. Then the main process can get a fresh list from tsh daemon.

In future PRs, this list will be used to allow opening links to cluster apps from Connect. At the moment, I made it so that the empty state in unified resources links to Discover in the Web UI. So one way to test everything in this PR is to filter the resources to a specific resource kind that's not available in the cluster. This should show the empty state with a link to the Web UI.