### PR TITLE
[v15] feat: HSM/KMS CA rotation reminders via cluster alerts

### DIFF
--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -166,11 +166,11 @@ func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error 
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		hasUsableKeys, err := t.process.GetAuthServer().GetKeyStore().HasUsableAdditionalKeys(ctx, ca)
+		usableKeysResult, err := t.process.GetAuthServer().GetKeyStore().HasUsableAdditionalKeys(ctx, ca)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if hasUsableKeys {
+		if usableKeysResult.CAHasUsableKeys {
 			break
 		}
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6117,12 +6117,12 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 // ensureLocalAdditionalKeys adds additional trusted keys to the CA if they are not
 // already present.
 func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAuthority) error {
-	hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
+	usableKeysResult, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if hasUsableKeys {
-		// nothing to do
+	if usableKeysResult.CAHasPreferredKeyType {
+		// Nothing to do.
 		return nil
 	}
 
@@ -6131,11 +6131,11 @@ func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAut
 		return trace.Wrap(err)
 	}
 
-	// The CA still needs an update while the keystore does not have any usable
-	// keys in the CA.
+	// The CA still needs an update while the CA does not contain any keys of
+	// the preferred type.
 	needsUpdate := func(ca types.CertAuthority) (bool, error) {
-		hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
-		return !hasUsableKeys, trace.Wrap(err)
+		usableKeysResult, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
+		return !usableKeysResult.CAHasPreferredKeyType, trace.Wrap(err)
 	}
 	err = a.addAdditionalTrustedKeysAtomic(ctx, ca, newKeySet, needsUpdate)
 	if err != nil {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -484,111 +484,8 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	span.AddEvent("completed migration db_client_authority")
 
 	// generate certificate authorities if they don't exist
-	var (
-		mu         sync.Mutex
-		activeKeys [][]byte
-	)
-	g, gctx = errgroup.WithContext(ctx)
-	for _, caType := range types.CertAuthTypes {
-		caType := caType
-		g.Go(func() error {
-			ctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthority", oteltrace.WithAttributes(attribute.String("type", string(caType))))
-			defer span.End()
-
-			caID := types.CertAuthID{Type: caType, DomainName: cfg.ClusterName.GetClusterName()}
-			ca, err := asrv.Services.GetCertAuthority(ctx, caID, true)
-			if err != nil {
-				if !trace.IsNotFound(err) {
-					return trace.Wrap(err)
-				}
-
-				log.Infof("First start: generating %s certificate authority.", caID.Type)
-				if ca, err = generateAuthority(ctx, asrv, caID); err != nil {
-					return trace.Wrap(err)
-				}
-
-				if err := asrv.CreateCertAuthority(ctx, ca); err != nil {
-					return trace.Wrap(err)
-				}
-			} else {
-				// Already have a CA. Make sure the keyStore has usable keys.
-				hasUsableActiveKeys, err := asrv.keyStore.HasUsableActiveKeys(ctx, ca)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				if !hasUsableActiveKeys {
-					// This could be one of a few cases:
-					// 1. A new auth server with an HSM being added to an HA cluster.
-					// 2. A new auth server with no HSM being added to an HA cluster
-					//    where all current auth servers have HSMs.
-					// 3. An existing auth server has restarted with a new HSM configured.
-					// 4. An existing HSM auth server has restarted no HSM configured.
-					// 5. An existing HSM auth server has restarted with a new UUID.
-					if ca.GetType() == types.HostCA {
-						// We need local keys to sign the Admin identity to support
-						// tctl. For this special case we add AdditionalTrustedKeys
-						// without any active keys. These keys will not be used for
-						// any signing operations until a CA rotation. Only the Host
-						// CA is necessary to issue the Admin identity.
-						if err := asrv.ensureLocalAdditionalKeys(ctx, ca); err != nil {
-							return trace.Wrap(err)
-						}
-						// reload updated CA for below checks
-						if ca, err = asrv.Services.GetCertAuthority(ctx, caID, true); err != nil {
-							return trace.Wrap(err)
-						}
-					}
-				}
-				hasUsableActiveKeys, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				hasUsableAdditionalKeys, err := asrv.keyStore.HasUsableAdditionalKeys(ctx, ca)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				if !hasUsableActiveKeys && hasUsableAdditionalKeys {
-					log.Warn("This auth server has a newly added or removed HSM and will not " +
-						"be able to perform any signing operations. You must rotate all CAs " +
-						"before routing traffic to this auth server. See https://goteleport.com/docs/management/operations/ca-rotation/")
-				}
-				allKeyTypes := ca.AllKeyTypes()
-				numKeyTypes := len(allKeyTypes)
-				if numKeyTypes > 1 {
-					log.Warnf("%s CA contains a combination of %s and %s keys. If you are attempting to"+
-						" configure HSM or KMS support, make sure it is configured on all auth servers in"+
-						" this cluster and then perform a CA rotation: https://goteleport.com/docs/management/operations/ca-rotation/",
-						caID.Type, strings.Join(allKeyTypes[:numKeyTypes-1], ", "), allKeyTypes[numKeyTypes-1])
-				}
-			}
-
-			mu.Lock()
-			defer mu.Unlock()
-			for _, keySet := range []types.CAKeySet{ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys()} {
-				for _, sshKeyPair := range keySet.SSH {
-					activeKeys = append(activeKeys, sshKeyPair.PrivateKey)
-				}
-				for _, tlsKeyPair := range keySet.TLS {
-					activeKeys = append(activeKeys, tlsKeyPair.Key)
-				}
-				for _, jwtKeyPair := range keySet.JWT {
-					activeKeys = append(activeKeys, jwtKeyPair.PrivateKey)
-				}
-			}
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
+	if err := initializeAuthorities(ctx, asrv, &cfg); err != nil {
 		return trace.Wrap(err)
-	}
-
-	// Delete any unused keys from the keyStore. This is to avoid exhausting
-	// (or wasting) HSM resources.
-	if err := asrv.keyStore.DeleteUnusedKeys(ctx, activeKeys); err != nil {
-		// Key deletion is best-effort, log a warning if it fails and carry on.
-		// We don't want to prevent a CA rotation, which may be necessary in
-		// some cases where this would fail.
-		log.Warnf("An attempt to clean up unused HSM or KMS CA keys has failed unexpectedly: %v", err)
 	}
 
 	if lib.IsInsecureDevMode() {
@@ -626,6 +523,130 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	}
 
 	return nil
+}
+
+func initializeAuthorities(ctx context.Context, asrv *Server, cfg *InitConfig) error {
+	var (
+		mu           sync.Mutex
+		allKeysInUse [][]byte
+	)
+	usableKeysResults := make(map[types.CertAuthType]*keystore.UsableKeysResult)
+	g, gctx := errgroup.WithContext(ctx)
+	for _, caType := range types.CertAuthTypes {
+		caType := caType
+		g.Go(func() error {
+			tctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthority", oteltrace.WithAttributes(attribute.String("type", string(caType))))
+			defer span.End()
+
+			caID := types.CertAuthID{Type: caType, DomainName: cfg.ClusterName.GetClusterName()}
+			usableKeysResult, keysInUse, err := initializeAuthority(tctx, asrv, caID)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			usableKeysResults[caType] = usableKeysResult
+			allKeysInUse = append(allKeysInUse, keysInUse...)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := asrv.syncUsableKeysAlert(ctx, usableKeysResults); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Delete any unused keys from the keyStore. This is to avoid exhausting
+	// (or wasting) HSM resources.
+	if err := asrv.keyStore.DeleteUnusedKeys(ctx, allKeysInUse); err != nil {
+		// Key deletion is best-effort, log a warning if it fails and carry on.
+		// We don't want to prevent a CA rotation, which may be necessary in
+		// some cases where this would fail.
+		log.Warnf("An attempt to clean up unused HSM or KMS CA keys has failed unexpectedly: %v", err)
+	}
+	return nil
+}
+
+func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthID) (usableKeysResult *keystore.UsableKeysResult, keysInUse [][]byte, err error) {
+	ca, err := asrv.Services.GetCertAuthority(ctx, caID, true)
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		log.Infof("First start: generating %s certificate authority.", caID.Type)
+		if ca, err = generateAuthority(ctx, asrv, caID); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		if err := asrv.CreateCertAuthority(ctx, ca); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	}
+
+	// Make sure the keystore has usable keys. This is a bit redundant if the CA
+	// was just generated above, but cheap relative to generating the CA, and
+	// it's nice to get the usableKeysResult.
+	usableKeysResult, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if !usableKeysResult.CAHasUsableKeys {
+		if ca.GetType() == types.HostCA {
+			// We need to sign the local Admin identity to support auth startup
+			// and local tctl. For this special case we add new
+			// AdditionalTrustedKeys without any active keys. These keys will
+			// sign the local Admin identity but nothing else (until a CA
+			// rotation). Only the Host CA is necessary to issue the Admin
+			// identity.
+			//
+			// We can only get here if all the active keys for this CA are in an
+			// HSM or KMS that this auth is not configured to use. Because the
+			// auth will not use PKCS#11 keys created by a different host UUID,
+			// for clusters using HSM keys this includes cases where a new auth is
+			// added to an HA cluster, or an existing auth's host UUID is reset.
+			if err := asrv.ensureLocalAdditionalKeys(ctx, ca); err != nil {
+				return nil, nil, trace.Wrap(err)
+			}
+		}
+		log.Warnf("This Auth Service is configured to use %s but the %s CA contains only %s. "+
+			"No new certificates can be signed with the existing keys. "+
+			"You must perform a CA rotation to generate new keys, or adjust your configuration to use the existing keys.",
+			usableKeysResult.PreferredKeyType,
+			caID.Type,
+			strings.Join(usableKeysResult.CAKeyTypes, " and "))
+	} else if !usableKeysResult.CAHasPreferredKeyType {
+		log.Warnf("This Auth Service is configured to use %s but the %s CA contains only %s. "+
+			"New certificates will continue to be signed with raw software keys but you must perform a CA rotation to begin using %s.",
+			usableKeysResult.PreferredKeyType,
+			caID.Type,
+			strings.Join(usableKeysResult.CAKeyTypes, " and "),
+			usableKeysResult.PreferredKeyType)
+	}
+	allKeyTypes := ca.AllKeyTypes()
+	numKeyTypes := len(allKeyTypes)
+	if numKeyTypes > 1 {
+		log.Warnf("%s CA contains a combination of %s and %s keys. If you are attempting to"+
+			" configure HSM or KMS key storage, make sure it is configured on all auth servers in"+
+			" this cluster and then perform a CA rotation: https://goteleport.com/docs/management/operations/ca-rotation/",
+			caID.Type, strings.Join(allKeyTypes[:numKeyTypes-1], ", "), allKeyTypes[numKeyTypes-1])
+	}
+
+	for _, keySet := range []types.CAKeySet{ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys()} {
+		for _, sshKeyPair := range keySet.SSH {
+			keysInUse = append(keysInUse, sshKeyPair.PrivateKey)
+		}
+		for _, tlsKeyPair := range keySet.TLS {
+			keysInUse = append(keysInUse, tlsKeyPair.Key)
+		}
+		for _, jwtKeyPair := range keySet.JWT {
+			keysInUse = append(keysInUse, jwtKeyPair.PrivateKey)
+		}
+	}
+	return usableKeysResult, keysInUse, nil
 }
 
 // generateAuthority creates a new self-signed authority of the provided type

--- a/lib/auth/keystore/aws_kms.go
+++ b/lib/auth/keystore/aws_kms.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"slices"
 	"strings"
@@ -121,6 +122,12 @@ func newAWSKMSKeystore(ctx context.Context, cfg *AWSKMSConfig, logger logrus.Fie
 		clock:      cfg.clock,
 		logger:     logger,
 	}, nil
+}
+
+// keyTypeDescription returns a human-readable description of the types of keys
+// this backend uses.
+func (a *awsKMSKeystore) keyTypeDescription() string {
+	return fmt.Sprintf("AWS KMS keys in account %s and region %s", a.awsAccount, a.awsRegion)
 }
 
 // generateRSA creates a new RSA private key and returns its identifier and

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -250,135 +250,143 @@ func TestManager(t *testing.T) {
 	const clusterName = "test-cluster"
 
 	for _, backendDesc := range pack.backends {
-		manager, err := NewManager(ctx, backendDesc.config)
-		require.NoError(t, err)
+		t.Run(backendDesc.name, func(t *testing.T) {
+			manager, err := NewManager(ctx, backendDesc.config)
+			require.NoError(t, err)
 
-		// Delete all keys to clean up the test.
-		t.Cleanup(func() {
-			require.NoError(t, manager.DeleteUnusedKeys(context.Background(), nil /*activeKeys*/))
+			// Delete all keys to clean up the test.
+			t.Cleanup(func() {
+				require.NoError(t, manager.DeleteUnusedKeys(context.Background(), nil /*activeKeys*/))
+			})
+
+			sshKeyPair, err := manager.NewSSHKeyPair(ctx)
+			require.NoError(t, err)
+			require.Equal(t, backendDesc.expectedKeyType, sshKeyPair.PrivateKeyType)
+
+			tlsKeyPair, err := manager.NewTLSKeyPair(ctx, clusterName)
+			require.NoError(t, err)
+			require.Equal(t, backendDesc.expectedKeyType, tlsKeyPair.KeyType)
+
+			jwtKeyPair, err := manager.NewJWTKeyPair(ctx)
+			require.NoError(t, err)
+			require.Equal(t, backendDesc.expectedKeyType, jwtKeyPair.PrivateKeyType)
+
+			// Test a CA with multiple active keypairs. Each element of ActiveKeys
+			// includes a keypair generated above and a PKCS11 keypair with a
+			// different hostID that this manager should not be able to use.
+			ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+				Type:        types.HostCA,
+				ClusterName: clusterName,
+				ActiveKeys: types.CAKeySet{
+					SSH: []*types.SSHKeyPair{
+						testPKCS11SSHKeyPair,
+						sshKeyPair,
+					},
+					TLS: []*types.TLSKeyPair{
+						testPKCS11TLSKeyPair,
+						tlsKeyPair,
+					},
+					JWT: []*types.JWTKeyPair{
+						testPKCS11JWTKeyPair,
+						jwtKeyPair,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			// Test that the manager is able to select the correct key and get a
+			// signer.
+			sshSigner, err := manager.GetSSHSigner(ctx, ca)
+			require.NoError(t, err, trace.DebugReport(err))
+			require.Equal(t, sshKeyPair.PublicKey, ssh.MarshalAuthorizedKey(sshSigner.PublicKey()))
+
+			tlsCert, tlsSigner, err := manager.GetTLSCertAndSigner(ctx, ca)
+			require.NoError(t, err)
+			require.Equal(t, tlsKeyPair.Cert, tlsCert)
+			require.NotNil(t, tlsSigner)
+
+			jwtSigner, err := manager.GetJWTSigner(ctx, ca)
+			require.NoError(t, err, trace.DebugReport(err))
+			pubkeyPem, err := utils.MarshalPublicKey(jwtSigner)
+			require.NoError(t, err)
+			require.Equal(t, jwtKeyPair.PublicKey, pubkeyPem)
+
+			// Test what happens when the CA has only raw keys, which will be the
+			// initial state when migrating from software to a HSM/KMS backend.
+			ca, err = types.NewCertAuthority(types.CertAuthoritySpecV2{
+				Type:        types.HostCA,
+				ClusterName: clusterName,
+				ActiveKeys: types.CAKeySet{
+					SSH: []*types.SSHKeyPair{
+						testRawSSHKeyPair,
+					},
+					TLS: []*types.TLSKeyPair{
+						testRawTLSKeyPair,
+					},
+					JWT: []*types.JWTKeyPair{
+						testRawJWTKeyPair,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			// Manager should always be able to get a signer for software keys.
+			usableKeysResult, err := manager.HasUsableActiveKeys(ctx, ca)
+			require.NoError(t, err)
+			require.True(t, usableKeysResult.CAHasUsableKeys)
+			if backendDesc.expectedKeyType == types.PrivateKeyType_RAW {
+				require.True(t, usableKeysResult.CAHasPreferredKeyType)
+			} else {
+				require.False(t, usableKeysResult.CAHasPreferredKeyType)
+			}
+
+			sshSigner, err = manager.GetSSHSigner(ctx, ca)
+			require.NoError(t, err)
+			require.NotNil(t, sshSigner)
+
+			tlsCert, tlsSigner, err = manager.GetTLSCertAndSigner(ctx, ca)
+			require.NoError(t, err)
+			require.NotNil(t, tlsCert)
+			require.NotNil(t, tlsSigner)
+
+			jwtSigner, err = manager.GetJWTSigner(ctx, ca)
+			require.NoError(t, err)
+			require.NotNil(t, jwtSigner)
+
+			// Test a CA with only unusable keypairs - PKCS11 keypairs with a
+			// different hostID that this manager should not be able to use.
+			ca, err = types.NewCertAuthority(types.CertAuthoritySpecV2{
+				Type:        types.HostCA,
+				ClusterName: clusterName,
+				ActiveKeys: types.CAKeySet{
+					SSH: []*types.SSHKeyPair{
+						testPKCS11SSHKeyPair,
+					},
+					TLS: []*types.TLSKeyPair{
+						testPKCS11TLSKeyPair,
+					},
+					JWT: []*types.JWTKeyPair{
+						testPKCS11JWTKeyPair,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			// The manager should not be able to select a key.
+			usableKeysResult, err = manager.HasUsableActiveKeys(ctx, ca)
+			require.NoError(t, err)
+			require.False(t, usableKeysResult.CAHasUsableKeys)
+			require.False(t, usableKeysResult.CAHasPreferredKeyType)
+
+			_, err = manager.GetSSHSigner(ctx, ca)
+			require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
+			_, _, err = manager.GetTLSCertAndSigner(ctx, ca)
+			require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
+			_, err = manager.GetJWTSigner(ctx, ca)
+			require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 		})
-
-		sshKeyPair, err := manager.NewSSHKeyPair(ctx)
-		require.NoError(t, err)
-		require.Equal(t, backendDesc.expectedKeyType, sshKeyPair.PrivateKeyType)
-
-		tlsKeyPair, err := manager.NewTLSKeyPair(ctx, clusterName)
-		require.NoError(t, err)
-		require.Equal(t, backendDesc.expectedKeyType, tlsKeyPair.KeyType)
-
-		jwtKeyPair, err := manager.NewJWTKeyPair(ctx)
-		require.NoError(t, err)
-		require.Equal(t, backendDesc.expectedKeyType, jwtKeyPair.PrivateKeyType)
-
-		// Test a CA with multiple active keypairs. Each element of ActiveKeys
-		// includes a keypair generated above and a PKCS11 keypair with a
-		// different hostID that this manager should not be able to use.
-		ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-			Type:        types.HostCA,
-			ClusterName: clusterName,
-			ActiveKeys: types.CAKeySet{
-				SSH: []*types.SSHKeyPair{
-					testPKCS11SSHKeyPair,
-					sshKeyPair,
-				},
-				TLS: []*types.TLSKeyPair{
-					testPKCS11TLSKeyPair,
-					tlsKeyPair,
-				},
-				JWT: []*types.JWTKeyPair{
-					testPKCS11JWTKeyPair,
-					jwtKeyPair,
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		// Test that the manager is able to select the correct key and get a
-		// signer.
-		sshSigner, err := manager.GetSSHSigner(ctx, ca)
-		require.NoError(t, err, trace.DebugReport(err))
-		require.Equal(t, sshKeyPair.PublicKey, ssh.MarshalAuthorizedKey(sshSigner.PublicKey()))
-
-		tlsCert, tlsSigner, err := manager.GetTLSCertAndSigner(ctx, ca)
-		require.NoError(t, err)
-		require.Equal(t, tlsKeyPair.Cert, tlsCert)
-		require.NotNil(t, tlsSigner)
-
-		jwtSigner, err := manager.GetJWTSigner(ctx, ca)
-		require.NoError(t, err, trace.DebugReport(err))
-		pubkeyPem, err := utils.MarshalPublicKey(jwtSigner)
-		require.NoError(t, err)
-		require.Equal(t, jwtKeyPair.PublicKey, pubkeyPem)
-
-		// Test what happens when the CA has only raw keys, which will be the
-		// initial state when migrating from software to a HSM/KMS backend.
-		ca, err = types.NewCertAuthority(types.CertAuthoritySpecV2{
-			Type:        types.HostCA,
-			ClusterName: clusterName,
-			ActiveKeys: types.CAKeySet{
-				SSH: []*types.SSHKeyPair{
-					testRawSSHKeyPair,
-				},
-				TLS: []*types.TLSKeyPair{
-					testRawTLSKeyPair,
-				},
-				JWT: []*types.JWTKeyPair{
-					testRawJWTKeyPair,
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		// Manager should always be able to get a signer for software keys.
-		hasUsableKeys, err := manager.HasUsableActiveKeys(ctx, ca)
-		require.NoError(t, err)
-		require.True(t, hasUsableKeys)
-
-		sshSigner, err = manager.GetSSHSigner(ctx, ca)
-		require.NoError(t, err)
-		require.NotNil(t, sshSigner)
-
-		tlsCert, tlsSigner, err = manager.GetTLSCertAndSigner(ctx, ca)
-		require.NoError(t, err)
-		require.NotNil(t, tlsCert)
-		require.NotNil(t, tlsSigner)
-
-		jwtSigner, err = manager.GetJWTSigner(ctx, ca)
-		require.NoError(t, err)
-		require.NotNil(t, jwtSigner)
-
-		// Test a CA with only unusable keypairs - PKCS11 keypairs with a
-		// different hostID that this manager should not be able to use.
-		ca, err = types.NewCertAuthority(types.CertAuthoritySpecV2{
-			Type:        types.HostCA,
-			ClusterName: clusterName,
-			ActiveKeys: types.CAKeySet{
-				SSH: []*types.SSHKeyPair{
-					testPKCS11SSHKeyPair,
-				},
-				TLS: []*types.TLSKeyPair{
-					testPKCS11TLSKeyPair,
-				},
-				JWT: []*types.JWTKeyPair{
-					testPKCS11JWTKeyPair,
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		// The manager should not be able to select a key.
-		hasUsableKeys, err = manager.HasUsableActiveKeys(ctx, ca)
-		require.NoError(t, err)
-		require.False(t, hasUsableKeys)
-
-		_, err = manager.GetSSHSigner(ctx, ca)
-		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
-
-		_, _, err = manager.GetTLSCertAndSigner(ctx, ca)
-		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
-
-		_, err = manager.GetJWTSigner(ctx, ca)
-		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 	}
 }
 

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -102,6 +102,12 @@ func newPKCS11KeyStore(config *PKCS11Config, logger logrus.FieldLogger) (*pkcs11
 	}, nil
 }
 
+// keyTypeDescription returns a human-readable description of the types of keys
+// this backend uses.
+func (p *pkcs11KeyStore) keyTypeDescription() string {
+	return fmt.Sprintf("PKCS#11 HSM keys created by %s", p.hostUUID)
+}
+
 func (p *pkcs11KeyStore) findUnusedID() (keyID, error) {
 	if !p.isYubiHSM {
 		id, err := uuid.NewRandom()
@@ -179,7 +185,7 @@ func (p *pkcs11KeyStore) getSignerWithoutPublicKey(ctx context.Context, rawKey [
 	if t := keyType(rawKey); t != types.PrivateKeyType_PKCS11 {
 		return nil, trace.BadParameter("pkcs11KeyStore cannot get signer for key type %s", t.String())
 	}
-	keyID, err := parseKeyID(rawKey)
+	keyID, err := parsePKCS11KeyID(rawKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -208,7 +214,7 @@ func (p *pkcs11KeyStore) canSignWithKey(ctx context.Context, raw []byte, keyType
 	if keyType != types.PrivateKeyType_PKCS11 {
 		return false, nil
 	}
-	keyID, err := parseKeyID(raw)
+	keyID, err := parsePKCS11KeyID(raw)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -217,7 +223,7 @@ func (p *pkcs11KeyStore) canSignWithKey(ctx context.Context, raw []byte, keyType
 
 // deleteKey deletes the given key from the HSM
 func (p *pkcs11KeyStore) deleteKey(_ context.Context, rawKey []byte) error {
-	keyID, err := parseKeyID(rawKey)
+	keyID, err := parsePKCS11KeyID(rawKey)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -254,7 +260,7 @@ func (p *pkcs11KeyStore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 		if keyType(activeKey) != types.PrivateKeyType_PKCS11 {
 			continue
 		}
-		keyID, err := parseKeyID(activeKey)
+		keyID, err := parsePKCS11KeyID(activeKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -347,7 +353,7 @@ func (k keyID) pkcs11Key(isYubiHSM bool) ([]byte, error) {
 	return id[:], nil
 }
 
-func parseKeyID(key []byte) (keyID, error) {
+func parsePKCS11KeyID(key []byte) (keyID, error) {
 	var keyID keyID
 	if keyType(key) != types.PrivateKeyType_PKCS11 {
 		return keyID, trace.BadParameter("unable to parse invalid pkcs11 key")

--- a/lib/auth/keystore/software.go
+++ b/lib/auth/keystore/software.go
@@ -54,6 +54,12 @@ func newSoftwareKeyStore(config *SoftwareConfig, logger logrus.FieldLogger) *sof
 	}
 }
 
+// keyTypeDescription returns a human-readable description of the types of keys
+// this backend uses.
+func (s *softwareKeyStore) keyTypeDescription() string {
+	return "raw software keys"
+}
+
 // generateRSA creates a new RSA private key and returns its identifier and a
 // crypto.Signer. The returned identifier for softwareKeyStore is a pem-encoded
 // private key, and can be passed to getSigner later to get the same

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -665,7 +665,7 @@ func (a *Server) syncUsableKeysAlert(ctx context.Context, usableKeysResults map[
 			// customers if Cloud ends up enabling an HSM/KMS by default in
 			// existing configurations. It's fine to never rotate in this case
 			// and continue using software keys. But if this is an on-prem
-			// cluster where the admin manually configured and HSM or KMS, they
+			// cluster where the admin manually configured an HSM or KMS, they
 			// probably want to use it, so hopefully they'll appreciate the
 			// alert reminding them to rotate the CAs.
 			return nil

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509/pkix"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,7 +32,9 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -240,6 +243,7 @@ func (a *Server) autoRotateCertAuthorities(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	usableKeysResults := make(map[types.CertAuthType]*keystore.UsableKeysResult)
 	for _, caType := range types.CertAuthTypes {
 		ca, err := a.Services.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       caType,
@@ -257,6 +261,13 @@ func (a *Server) autoRotateCertAuthorities(ctx context.Context) error {
 				return trace.Wrap(err)
 			}
 		}
+		usableKeysResults[caType], err = a.keyStore.HasUsableActiveKeys(ctx, ca)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if err := a.syncUsableKeysAlert(ctx, usableKeysResults); err != nil {
+		return trace.Wrap(err)
 	}
 	return nil
 }
@@ -480,17 +491,18 @@ func (a *Server) startNewRotation(ctx context.Context, req rotationReq, ca types
 			// invalidating the current Admin identity.
 			newKeys = additionalKeys.Clone()
 		}
-		hasUsableAdditionalKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
+		usableKeysResult, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if !hasUsableAdditionalKeys {
-			// This auth server has no usable AdditionalTrustedKeys in this CA.
+		if !usableKeysResult.CAHasPreferredKeyType {
+			// There are no AdditionalTrustedKeys in this CA that match the
+			// configured key type of this auth server.
 			// This is one of 2 cases:
 			// 1. There are no AdditionalTrustedKeys at all.
 			// 2. There are AdditionalTrustedKeys which were added by a
-			//    different HSM-enabled auth server.
-			// In either case, we need to add newly generated local keys.
+			//    different HSM-enabled auth server or one using a different KMS.
+			// In either case, we need to add newly generated keys.
 			newLocalKeys, err := newKeySet(ctx, a.keyStore, ca.GetID())
 			if err != nil {
 				return trace.Wrap(err)
@@ -594,4 +606,85 @@ func completeRotation(clock clockwork.Clock, ca types.CertAuthority) {
 	rotation.Mode = ""
 	rotation.Schedule = types.RotationSchedule{}
 	ca.SetRotation(rotation)
+}
+
+// syncUsableKeysAlert creates a cluster alert if any of the stored CAs do not
+// contain keys matching the type of key (HSM, KMS, software) this auth server
+// is configured to use. The [usableKeysResults] arguments is expected to
+// contain the results of [keystore.(*Manager).HasUsableActiveKeys] for all CA
+// types.
+func (a *Server) syncUsableKeysAlert(ctx context.Context, usableKeysResults map[types.CertAuthType]*keystore.UsableKeysResult) error {
+	// Alert ID contains server ID because multiple auth servers can be
+	// configured differently and may be able to use different key types.
+	// If the auth servers are ephemeral, the alert will expire.
+	alertID := "ca-key-types/" + a.ServerID
+	var casWithoutPreferredKeyType []types.CertAuthType
+	unableToSign := false
+	var preferredKeyType string
+	for caType, usableKeysResult := range usableKeysResults {
+		if !usableKeysResult.CAHasPreferredKeyType {
+			casWithoutPreferredKeyType = append(casWithoutPreferredKeyType, caType)
+		}
+		if !usableKeysResult.CAHasUsableKeys {
+			unableToSign = true
+		}
+		// Should be identical for all results, just take any one.
+		preferredKeyType = usableKeysResult.PreferredKeyType
+	}
+
+	if len(casWithoutPreferredKeyType) == 0 {
+		// Every CA contains keys matching the preferred type, delete the alert
+		// if it exists.
+		if err := a.DeleteClusterAlert(ctx, alertID); err != nil && !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+		return nil
+	}
+
+	alertOptions := []types.AlertOption{
+		types.WithAlertLabel(types.AlertOnLogin, "yes"),
+		// This is called by a.runPeriodicOperations via
+		// a.autoRotateCertAuthorities on a random period between 1-2x
+		// defaults.HighResPollingPeriod, the alert will be renewed before it
+		// expires if it's still relevant.
+		types.WithAlertExpires(a.clock.Now().Add(defaults.HighResPollingPeriod * 3)),
+	}
+	msg := fmt.Sprintf(
+		"Auth Service %s is configured to use %s, but the following CAs do not contain any keys of that type: %v. ",
+		a.ServerID,
+		preferredKeyType,
+		casWithoutPreferredKeyType)
+	if unableToSign {
+		alertOptions = append(alertOptions,
+			types.WithAlertSeverity(types.AlertSeverity_HIGH),
+			types.WithAlertLabel(types.AlertPermitAll, "yes"))
+		msg += "The Auth Service is currently unable to sign certificates and degraded service is expected. "
+	} else {
+		if modules.GetModules().Features().Cloud {
+			// Don't create this alert on Cloud. This avoids alerting all
+			// customers if Cloud ends up enabling an HSM/KMS by default in
+			// existing configurations. It's fine to never rotate in this case
+			// and continue using software keys. But if this is an on-prem
+			// cluster where the admin manually configured and HSM or KMS, they
+			// probably want to use it, so hopefully they'll appreciate the
+			// alert reminding them to rotate the CAs.
+			return nil
+		}
+		alertOptions = append(alertOptions,
+			types.WithAlertSeverity(types.AlertSeverity_MEDIUM),
+			types.WithAlertLabel(types.AlertVerbPermit,
+				fmt.Sprintf("%s:%s", types.KindCertAuthority, types.VerbUpdate)))
+		msg += "The Auth Service will continue signing certificates with raw software keys. "
+	}
+	msg += "These CAs must be rotated to begin using the configured key type. " +
+		"See https://goteleport.com/docs/management/operations/ca-rotation/"
+
+	alert, err := types.NewClusterAlert("ca-key-types/"+a.ServerID, msg, alertOptions...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.UpsertClusterAlert(ctx, alert); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }

--- a/lib/services/status.go
+++ b/lib/services/status.go
@@ -30,7 +30,7 @@ type Status interface {
 	// GetClusterAlerts loads all matching cluster alerts.
 	GetClusterAlerts(ctx context.Context, query types.GetClusterAlertsRequest) ([]types.ClusterAlert, error)
 
-	// UpsertClusterAlert creates the specified alert, overwriting any preexising alert with the same ID.
+	// UpsertClusterAlert creates the specified alert, overwriting any preexisting alert with the same ID.
 	UpsertClusterAlert(ctx context.Context, alert types.ClusterAlert) error
 
 	// CreateAlertAck marks a cluster alert as acknowledged.


### PR DESCRIPTION
Backport #36780 to branch/v15

changelog: Increased visibility for necessary CA rotations when configuring HSM or KMS backing of CA keys.
