### PR TITLE
Reduce spammy reconciler messages.

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -86,7 +86,12 @@ func NewReconciler[T Reconciled](cfg ReconcilerConfig[T]) (*Reconciler[T], error
 	}
 	return &Reconciler[T]{
 		cfg: cfg,
-		log: cfg.Log,
+		// We do a WithFields here to force this into a *logrus.Entry, which has the ability to
+		// log at the Trace level. If we were to change this in ReconcilerConfig, we'd have to
+		// refactor existing code to use *logrus.Entry instead of logrus.FieldLogger, and with
+		// the eventual change to slog, it seems easier to do this for now until this can be
+		// changed to slog.
+		log: cfg.Log.WithFields(nil),
 	}, nil
 }
 
@@ -97,7 +102,7 @@ func NewReconciler[T Reconciled](cfg ReconcilerConfig[T]) (*Reconciler[T], error
 // to enable dynamically registered resources.
 type Reconciler[T Reconciled] struct {
 	cfg ReconcilerConfig[T]
-	log logrus.FieldLogger
+	log *logrus.Entry
 }
 
 // Reconcile reconciles currently registered resources with new resources and
@@ -192,6 +197,6 @@ func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources
 		return nil
 	}
 
-	r.log.Debugf("%v %v is already registered.", kind, name)
+	r.log.Tracef("%v %v is already registered.", kind, name)
 	return nil
 }


### PR DESCRIPTION
The reconciler will now log the "already registered" messages at the trace level instead of at debug, which should reduce how spammy this log entry is.

changelog: Reduced logging level for services that reconcile resources.