### PR TITLE
Add ninja-build setup to Dockerfile-centos7

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -87,9 +87,11 @@ RUN  yum install -y expat-devel \
      zlib-devel \
      && yum clean all
 
-RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64" else export BUILDARCH = "x86_64"; fi && \
-    curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-${BUILDARCH}.tar.gz | tar xz && \
-    mv cmake-3.28.1-linux-${BUILDARCH} /opt/cmake
+# mno-outline-atomics flag is needed to make the build works on ARM64 docker.
+RUN git clone --depth=1 https://github.com/Kitware/CMake.git -b v3.28.1 && \
+    cd CMake && \
+    [ "$(git rev-parse HEAD)" = '1eed682d7cca9bb2c2b0709a6c3202a3b08613b2' ] && \
+    scl enable ${DEVTOOLSET} "CFLAGS=-mno-outline-atomics ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install"
 
 ENV PATH="/opt/cmake/bin:$PATH"
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -91,7 +91,7 @@ RUN  yum install -y expat-devel \
 RUN git clone --depth=1 https://github.com/Kitware/CMake.git -b v3.28.1 && \
     cd CMake && \
     [ "$(git rev-parse HEAD)" = '1eed682d7cca9bb2c2b0709a6c3202a3b08613b2' ] && \
-    scl enable ${DEVTOOLSET} "CFLAGS=-mno-outline-atomics ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install"
+    scl enable ${DEVTOOLSET} "if [ "${BUILDARCH}" = "arm64" ]; then export CFLAGS=-mno-outline-atomics; fi &&  ./bootstrap --parallel="$(nproc)" && make -j"$(nproc)" && make install"
 
 ENV PATH="/opt/cmake/bin:$PATH"
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -87,6 +87,12 @@ RUN  yum install -y expat-devel \
      zlib-devel \
      && yum clean all
 
+RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64" else export BUILDARCH = "x86_64"; fi && \
+    curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-${BUILDARCH}.tar.gz | tar xz && \
+    mv cmake-3.28.1-linux-${BUILDARCH} /opt/cmake
+
+ENV PATH="/opt/cmake/bin:$PATH"
+
 RUN git clone --depth=1 https://github.com/ninja-build/ninja.git -b v1.11.1 && \
         cd ninja && \
         [ "$(git rev-parse HEAD)" = 'a524bf3f6bacd1b4ad85d719eed2737d8562f27a' ] && \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -71,6 +71,29 @@ RUN git clone --depth=1 https://github.com/git/git.git -b v2.42.0 && \
     make -j"$(nproc)" all && \
     DESTDIR=/opt/git make install"
 
+## NINJA-BUILD ###################################################################
+
+## ninja-build is required for building boringssl. The version included in CentOS 7 AMR64
+## is too old, so we need to build it from source.
+FROM --platform=$BUILDPLATFORM base AS ninja-build
+
+# Install additional required dependencies.
+RUN  yum install -y expat-devel \
+     gettext \
+     libcurl-devel \
+     openssl-devel \
+     pcre-devel \
+     xmlto \
+     zlib-devel \
+     && yum clean all
+
+RUN git clone --depth=1 https://github.com/ninja-build/ninja.git -b v1.11.1 && \
+        cd ninja && \
+        [ "$(git rev-parse HEAD)" = 'a524bf3f6bacd1b4ad85d719eed2737d8562f27a' ] && \
+        scl enable ${DEVTOOLSET} "cmake -Bbuild-cmake && \
+    cmake --build build-cmake -j"$(nproc)" && \
+    cmake --build build-cmake --target  install"
+
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
@@ -222,6 +245,7 @@ RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
 
 # Override the old git in /usr/local installed by yum. We need git 2+ on GitHub Actions.
 COPY --from=git2 /opt/git /
+COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
 
 # Install Go.
 ARG GOLANG_VERSION


### PR DESCRIPTION
The Dockerfile-centos7 has been updated to include the setup and installation of ninja-build. The version of ninja-build included in CentOS 7 AMR64 was too old for building boringssl, hence it needs to be built from source. Both additional dependencies and the source build steps have been added as part of this update.