### PR TITLE
Update version variables for v16-dev

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1827,8 +1827,8 @@
     },
     "teleport": {
       "git": "api/14.0.0-gd1e081e",
-      "major_version": "15",
-      "version": "15.0.0-dev",
+      "major_version": "16",
+      "version": "16.0.0-dev",
       "url": "teleport.example.com",
       "golang": "1.21",
       "plugin": {


### PR DESCRIPTION
Change the `docs/config.json` version variable values for `teleport` to reflect the fact that the `master` branch represents v16.