### PR TITLE
Fix flaky test `TestIntegrations/Disconnection/expired_cert_node_recording`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2130,6 +2130,7 @@ func testDisconnectScenarios(t *testing.T, suite *integrationTestSuite) {
 				MaxSessionTTL:         types.NewDuration(2 * time.Second),
 			},
 			disconnectTimeout: 4 * time.Second,
+			clientConfigOpts:  func(cc *helpers.ClientConfig) { cc.DisableSSHResumption = true },
 		},
 		{
 			name:          "expired cert proxy recording",


### PR DESCRIPTION
Fix flaky test by disabling ssh resumption.

Closes https://github.com/gravitational/teleport/issues/36085