### PR TITLE
Make `tctl bots add` prompt for MFA just once 

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -52,10 +52,10 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 	}
 
 	chal, err := clt.CreateAuthenticateChallenge(ctx, challengeRequest)
-	if trace.IsAccessDenied(err) {
-		// Access is denied for CreateAuthenticateChallenge when the the client user
-		// is not a local user, for example the AdminRole. Treat this as a false MFA
-		// required check.
+	if trace.IsBadParameter(err) && challengeRequest.MFARequiredCheck != nil {
+		// CreateAuthenticateChallenge returns a bad parameter error when the the client
+		// user is not a Teleport user. For example, the AdminRole. Treat this as a false
+		// MFA required check if a check was requested.
 		return nil, nil
 	} else if err != nil {
 		return nil, trace.Wrap(err)

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -52,7 +52,12 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 	}
 
 	chal, err := clt.CreateAuthenticateChallenge(ctx, challengeRequest)
-	if err != nil {
+	if trace.IsAccessDenied(err) {
+		// Access is denied for CreateAuthenticateChallenge when the the client user
+		// is not a local user, for example the AdminRole. Treat this as a false MFA
+		// required check.
+		return nil, nil
+	} else if err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -72,7 +72,6 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 
 // PerformAdminActionMFACeremony retrieves an MFA challenge from the server for an admin
 // action, prompts the user to answer the challenge, and returns the resulting MFA response.
-// An empty response will be returned if MFA is not required for the given admin action.
 func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, allowReuse bool) (*proto.MFAAuthenticateResponse, error) {
 	allowReuseExt := mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
 	if allowReuse {

--- a/api/mfa/ceremony_test.go
+++ b/api/mfa/ceremony_test.go
@@ -61,7 +61,7 @@ func TestPerformMFACeremony(t *testing.T) {
 				mfaRequired:       proto.MFARequired_MFA_REQUIRED_NO,
 			},
 			assertCeremonyResponse: func(t *testing.T, mr *proto.MFAAuthenticateResponse, err error, i ...interface{}) {
-				assert.NoError(t, err)
+				assert.Error(t, err, mfa.ErrMFANotRequired)
 				assert.Nil(t, mr)
 			},
 		}, {

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -33,9 +33,16 @@ import (
 // ResponseMetadataKey is the context metadata key for an MFA response in a gRPC request.
 const ResponseMetadataKey = "mfa_challenge_response"
 
-// ErrAdminActionMFARequired is an error indicating that an admin-level
-// API request failed due to missing MFA verification.
-var ErrAdminActionMFARequired = trace.AccessDeniedError{Message: "admin-level API request requires MFA verification"}
+var (
+	// ErrAdminActionMFARequired is an error indicating that an admin-level
+	// API request failed due to missing MFA verification.
+	ErrAdminActionMFARequired = trace.AccessDeniedError{Message: "admin-level API request requires MFA verification"}
+
+	// ErrMFANotRequired is returned by MFA ceremonies when it is discovered or
+	// inferred that the MFA ceremony is not necessary. This is usually because
+	// the server does require/support MFA for the user.
+	ErrMFANotRequired = trace.BadParameterError{Message: "re-authentication with MFA is not required"}
+)
 
 // WithCredentials can be called on a GRPC client request to attach
 // MFA credentials to the GRPC metadata for requests that require MFA,

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -54,7 +54,7 @@ func WithMFAUnaryInterceptor(clt mfa.MFACeremonyClient) grpc.UnaryClientIntercep
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"
 		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, clt, false /*allowReuse*/)
-		if ceremonyErr != nil || mfaResp == nil {
+		if ceremonyErr != nil {
 			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
 		}
 

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -54,7 +54,7 @@ func WithMFAUnaryInterceptor(clt mfa.MFACeremonyClient) grpc.UnaryClientIntercep
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"
 		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, clt, false /*allowReuse*/)
-		if ceremonyErr != nil {
+		if ceremonyErr != nil || mfaResp == nil {
 			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
 		}
 

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -995,6 +995,12 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 		Credentials: []client.Credentials{
 			client.LoadProfile(tshHome, ""),
 		},
+		MFAPromptConstructor: func(po ...mfa.PromptOpt) mfa.Prompt {
+			return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+				// return MFA not required to gracefully skip the MFA prompt.
+				return nil, &mfa.ErrMFANotRequired
+			})
+		},
 	})
 	require.NoError(t, err)
 

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -302,7 +302,7 @@ func (c *BotsCommand) addBotLegacy(ctx context.Context, client auth.ClientI) err
 // AddBot adds a new certificate renewal bot to the cluster.
 func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
-	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, "AddBot", true /*allowReuse*/)
+	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
 	if err != nil {
 		return trace.Wrap(err)
 	} else if mfaResponse != nil {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -21,6 +21,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -303,10 +304,10 @@ func (c *BotsCommand) addBotLegacy(ctx context.Context, client auth.ClientI) err
 func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
-	if err != nil {
-		return trace.Wrap(err)
-	} else if mfaResponse != nil {
+	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
+	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {
+		return trace.Wrap(err)
 	}
 
 	// Jankily call the endpoint invalidly. This lets us version check and use

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -21,6 +21,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -300,10 +301,10 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 
 	// Prompt for admin action MFA if required, allowing reuse for CreateResetPasswordToken.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
-	if err != nil {
-		return trace.Wrap(err)
-	} else if mfaResponse != nil {
+	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
+	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {
+		return trace.Wrap(err)
 	}
 
 	if _, err := client.CreateUser(ctx, user); err != nil {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -299,13 +299,11 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 	user.SetRoles(u.allowedRoles)
 
 	// Prompt for admin action MFA if required, allowing reuse for CreateResetPasswordToken.
-	if u.config.Auth.Preference.IsAdminActionMFAEnforced() {
-		mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
-		if err != nil {
-			return trace.Wrap(err)
-		} else if mfaResponse != nil {
-			ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
-		}
+	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
+	if err != nil {
+		return trace.Wrap(err)
+	} else if mfaResponse != nil {
+		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 	}
 
 	if _, err := client.CreateUser(ctx, user); err != nil {


### PR DESCRIPTION
Updates `tctl bots add` to perform the admin action MFA ceremony upfront, allowing reuse for the initial version check call to `CreateBot` as well as the follow up calls to `UpsertToken` and `CreateBot`.

Before this change it worked like this:
```
$ tctl bots add terraform --roles=terraform
MFA is required for admin-level API request: "CreateBot"
Tap any security key
Detected security key tap
MFA is required for admin-level API request: "UpsertTokenV2"
Tap any security key
Detected security key tap
MFA is required for admin-level API request: "CreateBot"
Tap any security key
Detected security key tap
```

86feaa7e6177161e2e798f33e83f67202accccb2 fixes an issue shared by the [`tctl users add` change](https://github.com/gravitational/teleport/pull/36997)