### PR TITLE
Add TeleportNamespace to back sorted label prefixes

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -826,9 +826,11 @@ const (
 	DiscoveryLabelLDAPPrefix = "ldap/"
 )
 
-// CloudLabelPrefixes are prefixes used by cloud labels, generally added when
-// using automatic discovery
-var CloudLabelPrefixes = []string{CloudAWS, CloudAzure, CloudGCP, DiscoveryLabelLDAPPrefix}
+// BackSortedLabelPrefixes are label names that we want to always be at the end of
+// the sorted labels list to reduce visual clutter. This will generally be automatically
+// discovered cloud provider labels such as azure/aks-managed-createOperationID=123123123123
+// or internal labels
+var BackSortedLabelPrefixes = []string{CloudAWS, CloudAzure, CloudGCP, DiscoveryLabelLDAPPrefix, TeleportNamespace}
 
 const (
 	// TeleportInternalLabelPrefix is the prefix used by all Teleport internal labels. Those labels

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -85,10 +85,7 @@ func (s sortedLabels) Less(i, j int) bool {
 	labelA := strings.ToLower(s[i].Name)
 	labelB := strings.ToLower(s[j].Name)
 
-	// types.CloudLabelPrefixes are label names that we want to always be at the end of
-	// the sorted labels list to reduce visual clutter. This will generally be automatically
-	// discovered cloud provider labels such as azure/aks-managed-createOperationID=123123123123
-	for _, sortName := range types.CloudLabelPrefixes {
+	for _, sortName := range types.BackSortedLabelPrefixes {
 		name := strings.ToLower(sortName)
 		if strings.Contains(labelA, name) && !strings.Contains(labelB, name) {
 			return false // labelA should be at the end

--- a/lib/web/ui/server_test.go
+++ b/lib/web/ui/server_test.go
@@ -504,8 +504,10 @@ func TestSortedLabels(t *testing.T) {
 			clusterName: "cluster1",
 			servers: []types.Server{
 				makeTestServer(t, "server1", map[string]string{
+					"teleport.dev/origin":   "config-file",
 					"aws/asdfasdf":          "hello",
 					"simple":                "value1",
+					"ultra-cool-label":      "value1",
 					"teleport.internal/app": "app1",
 				}),
 			},
@@ -514,6 +516,14 @@ func TestSortedLabels(t *testing.T) {
 					{
 						Name:  "simple",
 						Value: "value1",
+					},
+					{
+						Name:  "ultra-cool-label",
+						Value: "value1",
+					},
+					{
+						Name:  "teleport.dev/origin",
+						Value: "config-file",
 					},
 					{
 						Name:  "aws/asdfasdf",


### PR DESCRIPTION
This PR will add (and update the name) to our slice that determines which labels are sorted to the back. Originally, we only had autodiscovered cloud labels sorted to the back, but this adds `teleport.dev` to the mix. `teleport.internal` is already hidden from the labels all together so we don't need it here.

changelog: Teleport namespace label prefixes are now sorted toward the end of the labels list in the web UI