### PR TITLE
Refactor Admin Action MFA prompt

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -68,7 +68,7 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 // PerformAdminActionMFACeremony retrieves an MFA challenge from the server for an admin
 // action, prompts the user to answer the challenge, and returns the resulting MFA response.
 // An empty response will be returned if MFA is not required for the given admin action.
-func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, adminActionName string, allowReuse bool) (*proto.MFAAuthenticateResponse, error) {
+func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, allowReuse bool) (*proto.MFAAuthenticateResponse, error) {
 	allowReuseExt := mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
 	if allowReuse {
 		allowReuseExt = mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES
@@ -78,9 +78,7 @@ func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, a
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{},
 		MFARequiredCheck: &proto.IsMFARequiredRequest{
 			Target: &proto.IsMFARequiredRequest_AdminAction{
-				AdminAction: &proto.AdminAction{
-					Name: adminActionName,
-				},
+				AdminAction: &proto.AdminAction{},
 			},
 		},
 		ChallengeExtensions: &mfav1.ChallengeExtensions{
@@ -89,5 +87,5 @@ func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, a
 		},
 	}
 
-	return PerformMFACeremony(ctx, clt, challengeRequest, WithPromptReasonAdminAction(adminActionName))
+	return PerformMFACeremony(ctx, clt, challengeRequest, WithPromptReasonAdminAction())
 }

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -77,7 +77,7 @@ func WithPromptReason(hint string) PromptOpt {
 
 // WithPromptReasonAdminAction sets the prompt's PromptReason field to a standard admin action message.
 func WithPromptReasonAdminAction() PromptOpt {
-	adminMFAPromptReason := "This is an admin-level action and requires MFA to complete"
+	const adminMFAPromptReason = "This is an admin-level action and requires MFA to complete"
 	return WithPromptReason(adminMFAPromptReason)
 }
 

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -76,8 +76,8 @@ func WithPromptReason(hint string) PromptOpt {
 }
 
 // WithPromptReasonAdminAction sets the prompt's PromptReason field to a standard admin action message.
-func WithPromptReasonAdminAction(actionName string) PromptOpt {
-	adminMFAPromptReason := fmt.Sprintf("MFA is required for admin-level API request: %q", actionName)
+func WithPromptReasonAdminAction() PromptOpt {
+	adminMFAPromptReason := fmt.Sprint("This is an admin-level action and requires MFA to complete")
 	return WithPromptReason(adminMFAPromptReason)
 }
 

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -77,7 +77,7 @@ func WithPromptReason(hint string) PromptOpt {
 
 // WithPromptReasonAdminAction sets the prompt's PromptReason field to a standard admin action message.
 func WithPromptReasonAdminAction() PromptOpt {
-	adminMFAPromptReason := fmt.Sprint("This is an admin-level action and requires MFA to complete")
+	adminMFAPromptReason := "This is an admin-level action and requires MFA to complete"
 	return WithPromptReason(adminMFAPromptReason)
 }
 

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport/api/mfa"
@@ -48,10 +49,11 @@ func WithMFAUnaryInterceptor(clt mfa.MFACeremonyClient) grpc.UnaryClientIntercep
 		// we just want the method name.
 		splitMethod := strings.Split(method, "/")
 		readableMethodName := splitMethod[len(splitMethod)-1]
+		logrus.Debugf("Retrying API request %q with Admin MFA", readableMethodName)
 
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"
-		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, clt, readableMethodName, false /*allowReuse*/)
+		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, clt, false /*allowReuse*/)
 		if ceremonyErr != nil {
 			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
 		}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -300,7 +300,7 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 
 	// Prompt for admin action MFA if required, allowing reuse for CreateResetPasswordToken.
 	if u.config.Auth.Preference.IsAdminActionMFAEnforced() {
-		mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, "CreateUser", true /*allowReuse*/)
+		mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
 		if err != nil {
 			return trace.Wrap(err)
 		} else if mfaResponse != nil {


### PR DESCRIPTION
Rephrase Admin Action MFA prompt to not leak implementation details and confuse users. I also moved the RPC name to a debug log.

```
> tctl -d users add dev4 --roles=dev
2024-01-23T14:32:13-08:00 DEBU             Retrying API request "CreateUser" with Admin MFA interceptors/mfa.go:52
This is an admin-level action and requires MFA to complete
Tap any security key
```