### PR TITLE
[v14] Fix a bug causing the webUI to be unusable if automatic upgrades are misconfigured

### DIFF
--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -179,26 +179,28 @@ func (c *Channel) GetCritical(ctx context.Context) (bool, error) {
 	return c.criticalTrigger.CanStart(ctx, nil)
 }
 
+var newDefaultChannel = sync.OnceValues[*Channel, error](
+	func() (*Channel, error) {
+		forwardURL := GetChannel()
+		if forwardURL == "" {
+			forwardURL = stableCloudVersionBaseURL
+		}
+		defaultChannel := &Channel{
+			ForwardURL: forwardURL,
+		}
+		if err := defaultChannel.CheckAndSetDefaults(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return defaultChannel, nil
+	})
+
 // NewDefaultChannel creates a default automatic upgrade channel
 // It looks up the environment variable, and if not found uses the default
 // base URL. This default channel can be used in the proxy (to back its own version server)
 // or in other Teleport process such as integration services deploying and
 // updating teleport agents.
 func NewDefaultChannel() (*Channel, error) {
-	return sync.OnceValues[*Channel, error](
-		func() (*Channel, error) {
-			forwardURL := GetChannel()
-			if forwardURL == "" {
-				forwardURL = stableCloudVersionBaseURL
-			}
-			defaultChannel := &Channel{
-				ForwardURL: forwardURL,
-			}
-			if err := defaultChannel.CheckAndSetDefaults(); err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return defaultChannel, nil
-		})()
+	return newDefaultChannel()
 }
 
 func parseMajorFromVersionString(v string) (int, error) {

--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -195,9 +195,10 @@ var newDefaultChannel = sync.OnceValues[*Channel, error](
 	})
 
 // NewDefaultChannel creates a default automatic upgrade channel
-// It looks up the environment variable, and if not found uses the default
-// base URL. This default channel can be used in the proxy (to back its own version server)
-// or in other Teleport process such as integration services deploying and
+// It looks up the TELEPORT_AUTOMATIC_UPGRADES_CHANNEL environment variable for
+// backward compatibility, and if not found uses the default base URL.
+// This default channel can be used in the proxy (to back its own version server)
+// or in other Teleport processes such as integration services deploying and
 // updating teleport agents.
 func NewDefaultChannel() (*Channel, error) {
 	return newDefaultChannel()

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1571,9 +1571,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	var automaticUpgradesTargetVersion string
 	if automaticUpgradesEnabled {
 		automaticUpgradesTargetVersion, err = h.cfg.AutomaticUpgradesChannels.DefaultVersion(r.Context())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		h.log.WithError(err).Error("Cannot read target version")
 	}
 
 	webCfg := webclient.WebConfig{


### PR DESCRIPTION
Backport #37091 to branch/v14

changelog: Fix a bug that was breaking webUI if automatic upgrades are misconfigured.
