### PR TITLE
[v13] Fix a bug causing the webUI to be unusable if automatic upgrades are misconfigured

### DIFF
--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/mod/semver"

--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -20,11 +20,12 @@ package automaticupgrades
 
 import (
 	"context"
-	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/mod/semver"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/lib/automaticupgrades/channel.go
+++ b/lib/automaticupgrades/channel.go
@@ -178,23 +178,29 @@ func (c *Channel) GetCritical(ctx context.Context) (bool, error) {
 	return c.criticalTrigger.CanStart(ctx, nil)
 }
 
+var newDefaultChannel = sync.OnceValues[*Channel, error](
+	func() (*Channel, error) {
+		forwardURL := GetChannel()
+		if forwardURL == "" {
+			forwardURL = stableCloudVersionBaseURL
+		}
+		defaultChannel := &Channel{
+			ForwardURL: forwardURL,
+		}
+		if err := defaultChannel.CheckAndSetDefaults(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return defaultChannel, nil
+	})
+
 // NewDefaultChannel creates a default automatic upgrade channel
-// It looks up the environment variable, and if not found uses the default
-// base URL. This default channel can be used in the proxy (to back its own version server)
-// or in other Teleport process such as integration services deploying and
+// It looks up the TELEPORT_AUTOMATIC_UPGRADES_CHANNEL environment variable for
+// backward compatibility, and if not found uses the default base URL.
+// This default channel can be used in the proxy (to back its own version server)
+// or in other Teleport processes such as integration services deploying and
 // updating teleport agents.
 func NewDefaultChannel() (*Channel, error) {
-	forwardURL := GetChannel()
-	if forwardURL == "" {
-		forwardURL = stableCloudVersionBaseURL
-	}
-	defaultChannel := &Channel{
-		ForwardURL: forwardURL,
-	}
-	if err := defaultChannel.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return defaultChannel, nil
+	return newDefaultChannel()
 }
 
 func parseMajorFromVersionString(v string) (int, error) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1492,9 +1492,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	var automaticUpgradesTargetVersion string
 	if automaticUpgradesEnabled {
 		automaticUpgradesTargetVersion, err = h.cfg.AutomaticUpgradesChannels.DefaultVersion(r.Context())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		h.log.WithError(err).Error("Cannot read target version")
 	}
 
 	webCfg := webclient.WebConfig{


### PR DESCRIPTION
Manual backport of https://github.com/gravitational/teleport/pull/37091 to `branch/v13`

changelog: Fixed webUI if automatic upgrades are misconfigured.