### PR TITLE
Update Admin Action MFA enforcment

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -328,9 +328,9 @@ func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
 }
 
 // IsAdminActionMFAEnforced checks if admin action MFA is enforced. Currently, the only
-// prerequisite for admin action MFA enforcement is whether Webauthn is enabled.
+// prerequisite for admin action MFA enforcement is whether Webauthn is enforced.
 func (c *AuthPreferenceV2) IsAdminActionMFAEnforced() bool {
-	return c.IsSecondFactorWebauthnAllowed()
+	return c.Spec.SecondFactor == constants.SecondFactorWebauthn
 }
 
 // GetConnectorName gets the name of the OIDC or SAML connector to use. If

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -432,6 +433,16 @@ func (a *authorizer) checkAdminActionVerification(ctx context.Context, authConte
 }
 
 func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, authContext *Context) (bool, error) {
+	// Provide a way to turn off admin MFA requirements in case expected functionality
+	// is disrupted by this requirement, such as for integrations essential to a user
+	// which do not yet make use of a machine ID / AdminRole impersonated identity.
+	//
+	// TODO(Joerger): once we have fully transitioned to requiring machine ID for
+	// integrations and ironed out any bugs with admin MFA, this env var should be removed.
+	if os.Getenv("TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS") == "yes" {
+		return false, nil
+	}
+
 	// Builtin roles do not require MFA to perform admin actions.
 	switch authContext.Identity.(type) {
 	case BuiltinRole, RemoteBuiltinRole:

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -910,7 +910,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 
 	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOptional,
+		SecondFactor: constants.SecondFactorWebauthn,
 		Webauthn: &types.Webauthn{
 			RPID: "localhost",
 		},


### PR DESCRIPTION
Relax Admin Action MFA enforcement to only apply to clusters with `second_factor: webauthn`, where we can be 100% positive that all potential users have a WebAuthn key registered. This avoids issues where WebAuthn is configured, but some users only have otp devices registered, which is in some cases a default setup.

Additionally, this PR adds an escape hatch to disable admin action MFA - `TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS`. This may be used by users who have existing integrations not yet making use of Machine ID, or in cases where an uncommon/untested flow is broken by the admin action MFA enforcement. This flag will likely be removed at a later date once Admin Action MFA enforcement is in a more stable position.

Changelog: MFA is enforced for admin actions on clusters where WebAuthn is required. This applies to adding users, adding trusted devices, reviewing access requests, among many others. You can set TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS=yes environment variable on Teleport auth to temporarily disable MFA enforcement for admin actions. The environment variable will be removed in Teleport 16.

