### PR TITLE
[v15] dronegen: Remove operator OCI pipeline dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1480,11 +1480,6 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- build-linux-amd64
-- build-linux-amd64-fips
-- build-linux-arm64
-- build-linux-arm
 steps:
 - name: Check out code
   image: docker:git
@@ -5394,6 +5389,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 8e9f95b945748bf4403596a258adf687a3627396d8db24a7b0c4fa8756c141f4
+hmac: 629eccbd2728a9c39a165ab17e8bdcc710d79ebdecc8e2ed84ac546d04ae98fe
 
 ...

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -125,13 +125,6 @@ func tagPipelines() []pipeline {
 		pipelineName: "build-oci",
 		trigger:      triggerTag,
 		buildType:    buildType{fips: false},
-		dependsOn: []string{
-			"build-linux-amd64",
-			"build-linux-amd64-fips",
-			"build-linux-arm64",
-			// "build-linux-arm64-fips",
-			"build-linux-arm",
-		},
 		workflows: []ghaWorkflow{
 			{
 				name:              "release-teleport-oci.yaml",


### PR DESCRIPTION
Remove the dependencies from the pipeline for building the operator OCI 
images. The GitHub workflow called used to build both the legacy OCI images
and the operator OCI images and the dependencies were only for the legacy
images. The called workflow no longer builds the legacy images so these
dependencies are no longer needed.

Update .drone.yml with `make dronegen`.

Backport: https://github.com/gravitational/teleport/pull/36789