### PR TITLE
[v15] Add missing lock in resumption client reconnection loop (#37152)

### DIFF
--- a/lib/resumption/client.go
+++ b/lib/resumption/client.go
@@ -204,6 +204,7 @@ func runClientResumableUnlocking(ctx context.Context, resumableConn *Conn, first
 				return
 			}
 
+			resumableConn.mu.Lock()
 			const isNotFirstConn = false
 			detached = goAttachResumableUnlocking(resumableConn, newConn, isNotFirstConn)
 


### PR DESCRIPTION
Backport of #37152 to branch/v15
