### PR TITLE
[v14] `tsh proxy kube` should support Machine ID credentials

### DIFF
--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -721,6 +721,12 @@ func KeyFromIdentityFile(identityPath, proxyHost, clusterName string) (*client.K
 		if parsedIdent.RouteToApp.Name != "" {
 			key.AppTLSCerts[parsedIdent.RouteToApp.Name] = ident.Certs.TLS
 		}
+
+		// If this identity file has any kubernetes certs, copy it into the
+		// KubeTLSCerts map.
+		if parsedIdent.KubernetesCluster != "" {
+			key.KubeTLSCerts[parsedIdent.KubernetesCluster] = ident.Certs.TLS
+		}
 	} else {
 		key.Username, err = key.CertUsername()
 		if err != nil {

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -69,7 +69,7 @@ func newSelfSignedCA(priv crypto.Signer) (*tlsca.CertAuthority, auth.TrustedCert
 	}, nil
 }
 
-func newClientKey(t *testing.T) *client.Key {
+func newClientKey(t *testing.T, modifiers ...func(*tlsca.Identity)) *client.Key {
 	privateKey, err := testauthority.New().GeneratePrivateKey()
 	require.NoError(t, err)
 
@@ -81,6 +81,9 @@ func newClientKey(t *testing.T) *client.Key {
 	identity := tlsca.Identity{
 		Username: "testuser",
 		Groups:   []string{"groups"},
+	}
+	for _, mod := range modifiers {
+		mod(&identity)
 	}
 
 	subject, err := identity.Subject()
@@ -370,23 +373,48 @@ func TestKeyFromIdentityFile(t *testing.T) {
 	const proxyHost = "proxy.example.com"
 	const cluster = "cluster"
 
-	// parsed key is unchanged from original with proxy and cluster provided.
-	parsedKey, err := KeyFromIdentityFile(identityFilePath, proxyHost, cluster)
-	key.ClusterName = cluster
-	key.ProxyHost = proxyHost
-	require.NoError(t, err)
-	require.Equal(t, key, parsedKey)
+	t.Run("parsed key unchanged when both proxy and cluster provided", func(t *testing.T) {
+		// parsed key is unchanged from original with proxy and cluster provided.
+		parsedKey, err := KeyFromIdentityFile(identityFilePath, proxyHost, cluster)
+		key.ClusterName = cluster
+		key.ProxyHost = proxyHost
+		require.NoError(t, err)
+		require.Equal(t, key, parsedKey)
+	})
 
-	// Identity file's cluster name defaults to root cluster name.
-	parsedKey, err = KeyFromIdentityFile(identityFilePath, proxyHost, "")
-	key.ClusterName = "root"
-	require.NoError(t, err)
-	require.Equal(t, key, parsedKey)
+	t.Run("cluster name defaults if not provided", func(t *testing.T) {
+		// Identity file's cluster name defaults to root cluster name.
+		parsedKey, err := KeyFromIdentityFile(identityFilePath, proxyHost, "")
+		key.ClusterName = "root"
+		require.NoError(t, err)
+		require.Equal(t, key, parsedKey)
+	})
 
-	// Returns error if proxy host is not provided.
-	_, err = KeyFromIdentityFile(identityFilePath, "", "")
-	require.Error(t, err)
-	require.True(t, trace.IsBadParameter(err))
+	t.Run("proxy host not provided", func(t *testing.T) {
+		// Returns error if proxy host is not provided.
+		_, err = KeyFromIdentityFile(identityFilePath, "", "")
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+	})
+
+	t.Run("kubernetes certificate loaded", func(t *testing.T) {
+		k8sCluster := "my-cluster"
+		identityFilePath := filepath.Join(t.TempDir(), "out")
+		key := newClientKey(t, func(params *tlsca.Identity) {
+			params.KubernetesCluster = k8sCluster
+		})
+		_, err := Write(context.Background(), WriteConfig{
+			OutputPath:           identityFilePath,
+			Format:               FormatFile,
+			Key:                  key,
+			OverwriteDestination: true,
+		})
+		require.NoError(t, err)
+		parsedKey, err := KeyFromIdentityFile(identityFilePath, proxyHost, cluster)
+		require.NoError(t, err)
+		require.NotNil(t, parsedKey.KubeTLSCerts[k8sCluster])
+		require.Equal(t, key.TLSCert, parsedKey.KubeTLSCerts[k8sCluster])
+	})
 }
 
 func TestNewClientStoreFromIdentityFile(t *testing.T) {

--- a/lib/tbot/tshwrap/wrap.go
+++ b/lib/tbot/tshwrap/wrap.go
@@ -220,9 +220,6 @@ func GetEnvForTSH(destPath string) (map[string]string, error) {
 	env[client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.HostCA))] = filepath.Join(destPath, config.HostCAPath)
 	env[client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.DatabaseCA))] = filepath.Join(destPath, config.DatabaseCAPath)
 
-	// TODO(timothyb89): Kubernetes support. We don't generate kubeconfigs yet, so we have
-	// nothing to give tsh for now.
-
 	return env, nil
 }
 


### PR DESCRIPTION
Backport #36914 to branch/v14

changelog: Adds `tbot proxy kube` to support connecting to Kubernetes clusters using Machine ID when the Proxy is behind a L7 LB.
