### PR TITLE
OpsGenie no longer support POST requests for /v2/schedules/{name}/on-calls

### DIFF
--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -236,7 +236,7 @@ func (og Client) GetOnCall(ctx context.Context, scheduleName string) (Responders
 			"flat": "true",
 		}).
 		SetResult(&result).
-		Post("v2/schedules/{scheduleName}/on-calls")
+		Get("v2/schedules/{scheduleName}/on-calls")
 	if err != nil {
 		return RespondersResult{}, trace.Wrap(err)
 	}


### PR DESCRIPTION
https://docs.opsgenie.com/docs/who-is-on-call-api#get-on-calls

```
$  curl -s "https://api.opsgenie.com/v2/schedules/ScheduleName/on-calls?apiKey=$(cat apikey)&scheduleIdentifierType=name" | jq
{
  "data": {
    "_parent": {
      ...
    },
    "onCallRecipients": [
      "me@example.com"
    ]
  },
  ...
}
```

```
$  curl -X POST -s "https://api.opsgenie.com/v2/schedules/ScheduleName/on-calls?apiKey=$(cat apikey)&scheduleIdentifierType=name" | jq
{
  "message": "Request method 'POST' is not supported",
  ...
}
```