### PR TITLE
[v12] docs: bump cloud version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1680,7 +1680,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "14.3.0",
+      "version": "14.3.3",
       "major_version": "14",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
backport docs version bump: https://github.com/gravitational/teleport/pull/36752