### PR TITLE
integrations/operator: bring back TeleportRole in the v6 API

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
@@ -1210,6 +1210,1204 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v6
+    schema:
+      openAPIV3Schema:
+        description: Role is the Schema for the roles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Role resource definition v6 from Teleport
+            properties:
+              allow:
+                description: Allow is the set of conditions evaluated to grant access.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via {{ `{{external.trait_name}}` }}
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              deny:
+                description: Deny is the set of conditions evaluated to deny access.
+                  Deny takes priority over allow.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via {{ `{{external.trait_name}}` }}
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              options:
+                description: Options is for OpenSSH options like agent forwarding.
+                properties:
+                  cert_extensions:
+                    description: CertExtensions specifies the key/values
+                    items:
+                      properties:
+                        mode:
+                          description: Mode is the type of extension to be used --
+                            currently critical-option is not supported
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: Name specifies the key to be used in the cert
+                            extension.
+                          type: string
+                        type:
+                          description: Type represents the certificate type being
+                            extended, only ssh is supported at this time.
+                          x-kubernetes-int-or-string: true
+                        value:
+                          description: Value specifies the value to be used in the
+                            cert extension.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  cert_format:
+                    description: CertificateFormat defines the format of the user
+                      certificate to allow compatibility with older versions of OpenSSH.
+                    type: string
+                  client_idle_timeout:
+                    description: ClientIdleTimeout sets disconnect clients on idle
+                      timeout behavior, if set to 0 means do not disconnect, otherwise
+                      is set to the idle duration.
+                    format: duration
+                    type: string
+                  create_db_user:
+                    description: CreateDatabaseUser enabled automatic database user
+                      creation.
+                    type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off.
+                    x-kubernetes-int-or-string: true
+                  create_desktop_user:
+                    description: CreateDesktopUser allows users to be automatically
+                      created on a Windows desktop
+                    type: boolean
+                  create_host_user:
+                    description: CreateHostUser allows users to be automatically created
+                      on a host
+                    type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    x-kubernetes-int-or-string: true
+                  desktop_clipboard:
+                    description: DesktopClipboard indicates whether clipboard sharing
+                      is allowed between the user's workstation and the remote desktop.
+                      It defaults to true unless explicitly set to false.
+                    type: boolean
+                  desktop_directory_sharing:
+                    description: DesktopDirectorySharing indicates whether directory
+                      sharing is allowed between the user's workstation and the remote
+                      desktop. It defaults to false unless explicitly set to true.
+                    type: boolean
+                  device_trust_mode:
+                    description: DeviceTrustMode is the device authorization mode
+                      used for the resources associated with the role. See DeviceTrust.Mode.
+                      Reserved for future use, not yet used by Teleport.
+                    type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert sets disconnect clients on
+                      expired certificates.
+                    type: boolean
+                  enhanced_recording:
+                    description: BPF defines what events to record for the BPF-based
+                      session recorder.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  forward_agent:
+                    description: ForwardAgent is SSH agent forwarding.
+                    type: boolean
+                  idp:
+                    description: IDP is a set of options related to accessing IdPs
+                      within Teleport. Requires Teleport Enterprise.
+                    nullable: true
+                    properties:
+                      saml:
+                        description: SAML are options related to the Teleport SAML
+                          IdP.
+                        nullable: true
+                        properties:
+                          enabled:
+                            description: Enabled is set to true if this option allows
+                              access to the Teleport SAML IdP.
+                            type: boolean
+                        type: object
+                    type: object
+                  lock:
+                    description: Lock specifies the locking mode (strict|best_effort)
+                      to be applied with the role.
+                    type: string
+                  max_connections:
+                    description: MaxConnections defines the maximum number of concurrent
+                      connections a user may hold.
+                    format: int64
+                    type: integer
+                  max_kubernetes_connections:
+                    description: MaxKubernetesConnections defines the maximum number
+                      of concurrent Kubernetes sessions a user may hold.
+                    format: int64
+                    type: integer
+                  max_session_ttl:
+                    description: MaxSessionTTL defines how long a SSH session can
+                      last for.
+                    format: duration
+                    type: string
+                  max_sessions:
+                    description: MaxSessions defines the maximum number of concurrent
+                      sessions per connection.
+                    format: int64
+                    type: integer
+                  permit_x11_forwarding:
+                    description: PermitX11Forwarding authorizes use of X11 forwarding.
+                    type: boolean
+                  pin_source_ip:
+                    description: PinSourceIP forces the same client IP for certificate
+                      generation and usage
+                    type: boolean
+                  port_forwarding:
+                    description: PortForwarding defines if the certificate will have
+                      "permit-port-forwarding" in the certificate. PortForwarding
+                      is "yes" if not set, that's why this is a pointer
+                    type: boolean
+                  record_session:
+                    description: RecordDesktopSession indicates whether desktop access
+                      sessions should be recorded. It defaults to true unless explicitly
+                      set to false.
+                    nullable: true
+                    properties:
+                      default:
+                        description: Default indicates the default value for the services.
+                        type: string
+                      desktop:
+                        description: Desktop indicates whether desktop sessions should
+                          be recorded. It defaults to true unless explicitly set to
+                          false.
+                        type: boolean
+                      ssh:
+                        description: SSH indicates the session mode used on SSH sessions.
+                        type: string
+                    type: object
+                  request_access:
+                    description: RequestAccess defines the access request strategy
+                      (optional|note|always) where optional is the default.
+                    type: string
+                  request_prompt:
+                    description: RequestPrompt is an optional message which tells
+                      users what they aught to request.
+                    type: string
+                  require_session_mfa:
+                    description: RequireMFAType is the type of MFA requirement enforced
+                      for this user.
+                    x-kubernetes-int-or-string: true
+                  ssh_file_copy:
+                    description: SSHFileCopy indicates whether remote file operations
+                      via SCP or SFTP are allowed over an SSH session. It defaults
+                      to true unless explicitly set to false.
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: Status defines the observed state of the Teleport resource
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              teleportResourceID:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1210,6 +1210,1204 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v6
+    schema:
+      openAPIV3Schema:
+        description: Role is the Schema for the roles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Role resource definition v6 from Teleport
+            properties:
+              allow:
+                description: Allow is the set of conditions evaluated to grant access.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via `{{external.trait_name}}`
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              deny:
+                description: Deny is the set of conditions evaluated to deny access.
+                  Deny takes priority over allow.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via `{{external.trait_name}}`
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              options:
+                description: Options is for OpenSSH options like agent forwarding.
+                properties:
+                  cert_extensions:
+                    description: CertExtensions specifies the key/values
+                    items:
+                      properties:
+                        mode:
+                          description: Mode is the type of extension to be used --
+                            currently critical-option is not supported
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: Name specifies the key to be used in the cert
+                            extension.
+                          type: string
+                        type:
+                          description: Type represents the certificate type being
+                            extended, only ssh is supported at this time.
+                          x-kubernetes-int-or-string: true
+                        value:
+                          description: Value specifies the value to be used in the
+                            cert extension.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  cert_format:
+                    description: CertificateFormat defines the format of the user
+                      certificate to allow compatibility with older versions of OpenSSH.
+                    type: string
+                  client_idle_timeout:
+                    description: ClientIdleTimeout sets disconnect clients on idle
+                      timeout behavior, if set to 0 means do not disconnect, otherwise
+                      is set to the idle duration.
+                    format: duration
+                    type: string
+                  create_db_user:
+                    description: CreateDatabaseUser enabled automatic database user
+                      creation.
+                    type: boolean
+                  create_db_user_mode:
+                    description: CreateDatabaseUserMode allows users to be automatically
+                      created on a database when not set to off.
+                    x-kubernetes-int-or-string: true
+                  create_desktop_user:
+                    description: CreateDesktopUser allows users to be automatically
+                      created on a Windows desktop
+                    type: boolean
+                  create_host_user:
+                    description: CreateHostUser allows users to be automatically created
+                      on a host
+                    type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    x-kubernetes-int-or-string: true
+                  desktop_clipboard:
+                    description: DesktopClipboard indicates whether clipboard sharing
+                      is allowed between the user's workstation and the remote desktop.
+                      It defaults to true unless explicitly set to false.
+                    type: boolean
+                  desktop_directory_sharing:
+                    description: DesktopDirectorySharing indicates whether directory
+                      sharing is allowed between the user's workstation and the remote
+                      desktop. It defaults to false unless explicitly set to true.
+                    type: boolean
+                  device_trust_mode:
+                    description: DeviceTrustMode is the device authorization mode
+                      used for the resources associated with the role. See DeviceTrust.Mode.
+                      Reserved for future use, not yet used by Teleport.
+                    type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert sets disconnect clients on
+                      expired certificates.
+                    type: boolean
+                  enhanced_recording:
+                    description: BPF defines what events to record for the BPF-based
+                      session recorder.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  forward_agent:
+                    description: ForwardAgent is SSH agent forwarding.
+                    type: boolean
+                  idp:
+                    description: IDP is a set of options related to accessing IdPs
+                      within Teleport. Requires Teleport Enterprise.
+                    nullable: true
+                    properties:
+                      saml:
+                        description: SAML are options related to the Teleport SAML
+                          IdP.
+                        nullable: true
+                        properties:
+                          enabled:
+                            description: Enabled is set to true if this option allows
+                              access to the Teleport SAML IdP.
+                            type: boolean
+                        type: object
+                    type: object
+                  lock:
+                    description: Lock specifies the locking mode (strict|best_effort)
+                      to be applied with the role.
+                    type: string
+                  max_connections:
+                    description: MaxConnections defines the maximum number of concurrent
+                      connections a user may hold.
+                    format: int64
+                    type: integer
+                  max_kubernetes_connections:
+                    description: MaxKubernetesConnections defines the maximum number
+                      of concurrent Kubernetes sessions a user may hold.
+                    format: int64
+                    type: integer
+                  max_session_ttl:
+                    description: MaxSessionTTL defines how long a SSH session can
+                      last for.
+                    format: duration
+                    type: string
+                  max_sessions:
+                    description: MaxSessions defines the maximum number of concurrent
+                      sessions per connection.
+                    format: int64
+                    type: integer
+                  permit_x11_forwarding:
+                    description: PermitX11Forwarding authorizes use of X11 forwarding.
+                    type: boolean
+                  pin_source_ip:
+                    description: PinSourceIP forces the same client IP for certificate
+                      generation and usage
+                    type: boolean
+                  port_forwarding:
+                    description: PortForwarding defines if the certificate will have
+                      "permit-port-forwarding" in the certificate. PortForwarding
+                      is "yes" if not set, that's why this is a pointer
+                    type: boolean
+                  record_session:
+                    description: RecordDesktopSession indicates whether desktop access
+                      sessions should be recorded. It defaults to true unless explicitly
+                      set to false.
+                    nullable: true
+                    properties:
+                      default:
+                        description: Default indicates the default value for the services.
+                        type: string
+                      desktop:
+                        description: Desktop indicates whether desktop sessions should
+                          be recorded. It defaults to true unless explicitly set to
+                          false.
+                        type: boolean
+                      ssh:
+                        description: SSH indicates the session mode used on SSH sessions.
+                        type: string
+                    type: object
+                  request_access:
+                    description: RequestAccess defines the access request strategy
+                      (optional|note|always) where optional is the default.
+                    type: string
+                  request_prompt:
+                    description: RequestPrompt is an optional message which tells
+                      users what they aught to request.
+                    type: string
+                  require_session_mfa:
+                    description: RequireMFAType is the type of MFA requirement enforced
+                      for this user.
+                    x-kubernetes-int-or-string: true
+                  ssh_file_copy:
+                    description: SSHFileCopy indicates whether remote file operations
+                      via SCP or SFTP are allowed over an SSH session. It defaults
+                      to true unless explicitly set to false.
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: Status defines the observed state of the Teleport resource
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              teleportResourceID:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -87,6 +87,8 @@ func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGenerator
 		{name: "UserV2"},
 		// Role V5 is using the RoleV6 message
 		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5)}},
+		// For backward compatibility in v15, it actually creates v5 roles though.
+		{name: "RoleV6"},
 		// Role V6 and V7 have their own Kubernetes kind
 		{name: "RoleV6", opts: []resourceSchemaOption{withVersionInKindOverride()}},
 		// Role V7 is using the RoleV6 message

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
@@ -1206,6 +1206,1200 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v6
+    schema:
+      openAPIV3Schema:
+        description: Role is the Schema for the roles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Role resource definition v6 from Teleport
+            properties:
+              allow:
+                description: Allow is the set of conditions evaluated to grant access.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via `{{external.trait_name}}`
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              deny:
+                description: Deny is the set of conditions evaluated to deny access.
+                  Deny takes priority over allow.
+                properties:
+                  app_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: AppLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
+                  aws_role_arns:
+                    description: AWSRoleARNs is a list of AWS role ARNs this role
+                      is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  azure_identities:
+                    description: AzureIdentities is a list of Azure identities this
+                      role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  cluster_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: ClusterLabels is a map of node labels (used to dynamically
+                      grant access to clusters).
+                    type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
+                  db_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseLabels are used in RBAC system to allow/deny
+                      access to databases.
+                    type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
+                  db_names:
+                    description: DatabaseNames is a list of database names this role
+                      is allowed to connect to.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_roles:
+                    description: DatabaseRoles is a list of databases roles for automatic
+                      user creation.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  db_service_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: DatabaseServiceLabels are used in RBAC system to
+                      allow/deny access to Database Services.
+                    type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
+                  db_users:
+                    description: DatabaseUsers is a list of databases users this role
+                      is allowed to connect as.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  desktop_groups:
+                    description: DesktopGroups is a list of groups for created desktop
+                      users to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  gcp_service_accounts:
+                    description: GCPServiceAccounts is a list of GCP service accounts
+                      this role is allowed to assume.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  group_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: GroupLabels is a map of labels used as part of the
+                      RBAC system.
+                    type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
+                  host_groups:
+                    description: HostGroups is a list of groups for created users
+                      to be added to
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  host_sudoers:
+                    description: HostSudoers is a list of entries to include in a
+                      users sudoer file
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  impersonate:
+                    description: Impersonate specifies what users and roles this role
+                      is allowed to impersonate by issuing certificates or other possible
+                      means.
+                    nullable: true
+                    properties:
+                      roles:
+                        description: Roles is a list of resources this role is allowed
+                          to impersonate
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      users:
+                        description: Users is a list of resources this role is allowed
+                          to impersonate, could be an empty list or a Wildcard pattern
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where specifies optional advanced matcher
+                        type: string
+                    type: object
+                  join_sessions:
+                    description: JoinSessions specifies policies to allow users to
+                      join other sessions.
+                    items:
+                      properties:
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is a list of permitted participant modes
+                            for this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        roles:
+                          description: Roles is a list of roles that you can join
+                            the session of.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  kubernetes_groups:
+                    description: KubeGroups is a list of kubernetes groups
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  kubernetes_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: KubernetesLabels is a map of kubernetes cluster labels
+                      used for RBAC.
+                    type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
+                  kubernetes_resources:
+                    description: KubernetesResources is the Kubernetes Resources this
+                      Role grants access to.
+                    items:
+                      properties:
+                        kind:
+                          description: Kind specifies the Kubernetes Resource type.
+                            At the moment only "pod" is supported.
+                          type: string
+                        name:
+                          description: Name is the resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: Namespace is the resource namespace. It supports
+                            wildcards.
+                          type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    type: array
+                  kubernetes_users:
+                    description: KubeUsers is an optional kubernetes users to impersonate
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  logins:
+                    description: Logins is a list of *nix system logins.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  node_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: NodeLabels is a map of node labels (used to dynamically
+                      grant access to nodes).
+                    type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
+                  request:
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Annotations is a collection of annotations to
+                          be programmatically appended to pending access requests
+                          at the time of their creation. These annotations serve as
+                          a mechanism to propagate extra information to plugins.  Since
+                          these annotations support variable interpolation syntax,
+                          they also offer a mechanism for forwarding claims from an
+                          external identity provider, to a plugin via `{{external.trait_name}}`
+                          style substitutions.
+                        type: object
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
+                      roles:
+                        description: Roles is the name of roles which will match the
+                          request rule.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      search_as_roles:
+                        description: SearchAsRoles is a list of extra roles which
+                          should apply to a user while they are searching for resources
+                          as part of a Resource Access Request, and defines the underlying
+                          roles which will be requested as part of any Resource Access
+                          Request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      suggested_reviewers:
+                        description: SuggestedReviewers is a list of reviewer suggestions.  These
+                          can be teleport usernames, but that is not a requirement.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      thresholds:
+                        description: Thresholds is a list of thresholds, one of which
+                          must be met in order for reviews to trigger a state-transition.  If
+                          no thresholds are provided, a default threshold of 1 for
+                          approval and denial is used.
+                        items:
+                          properties:
+                            approve:
+                              description: Approve is the number of matching approvals
+                                needed for state-transition.
+                              format: int32
+                              type: integer
+                            deny:
+                              description: Deny is the number of denials needed for
+                                state-transition.
+                              format: int32
+                              type: integer
+                            filter:
+                              description: Filter is an optional predicate used to
+                                determine which reviews count toward this threshold.
+                              type: string
+                            name:
+                              description: Name is the optional human-readable name
+                                of the threshold.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  require_session_join:
+                    description: RequireSessionJoin specifies policies for required
+                      users to start a session.
+                    items:
+                      properties:
+                        count:
+                          description: Count is the amount of people that need to
+                            be matched for this policy to be fulfilled.
+                          format: int32
+                          type: integer
+                        filter:
+                          description: Filter is a predicate that determines what
+                            users count towards this policy.
+                          type: string
+                        kinds:
+                          description: Kinds are the session kinds this policy applies
+                            to.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        modes:
+                          description: Modes is the list of modes that may be used
+                            to fulfill this policy.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        name:
+                          description: Name is the name of the policy.
+                          type: string
+                        on_leave:
+                          description: OnLeave is the behaviour that's used when the
+                            policy is no longer fulfilled for a live session.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  review_requests:
+                    description: ReviewRequests defines conditions for submitting
+                      access reviews.
+                    nullable: true
+                    properties:
+                      claims_to_roles:
+                        description: ClaimsToRoles specifies a mapping from claims
+                          (traits) to teleport roles.
+                        items:
+                          properties:
+                            claim:
+                              description: Claim is a claim name.
+                              type: string
+                            roles:
+                              description: Roles is a list of static teleport roles
+                                to match.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            value:
+                              description: Value is a claim value to match.
+                              type: string
+                          type: object
+                        type: array
+                      preview_as_roles:
+                        description: PreviewAsRoles is a list of extra roles which
+                          should apply to a reviewer while they are viewing a Resource
+                          Access Request for the purposes of viewing details such
+                          as the hostname and labels of requested resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is the name of roles which may be reviewed.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      where:
+                        description: Where is an optional predicate which further
+                          limits which requests are reviewable.
+                        type: string
+                    type: object
+                  rules:
+                    description: Rules is a list of rules and their access levels.
+                      Rules are a high level construct used for access control.
+                    items:
+                      properties:
+                        actions:
+                          description: Actions specifies optional actions taken when
+                            this rule matches
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: Resources is a list of resources
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        verbs:
+                          description: Verbs is a list of verbs
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        where:
+                          description: Where specifies optional advanced matcher
+                          type: string
+                      type: object
+                    type: array
+                  windows_desktop_labels:
+                    additionalProperties:
+                      x-kubernetes-preserve-unknown-fields: true
+                    description: WindowsDesktopLabels are used in the RBAC system
+                      to allow/deny access to Windows desktops.
+                    type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
+                  windows_desktop_logins:
+                    description: WindowsDesktopLogins is a list of desktop login names
+                      allowed/denied for Windows desktops.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              options:
+                description: Options is for OpenSSH options like agent forwarding.
+                properties:
+                  cert_extensions:
+                    description: CertExtensions specifies the key/values
+                    items:
+                      properties:
+                        mode:
+                          description: Mode is the type of extension to be used --
+                            currently critical-option is not supported
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: Name specifies the key to be used in the cert
+                            extension.
+                          type: string
+                        type:
+                          description: Type represents the certificate type being
+                            extended, only ssh is supported at this time.
+                          x-kubernetes-int-or-string: true
+                        value:
+                          description: Value specifies the value to be used in the
+                            cert extension.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  cert_format:
+                    description: CertificateFormat defines the format of the user
+                      certificate to allow compatibility with older versions of OpenSSH.
+                    type: string
+                  client_idle_timeout:
+                    description: ClientIdleTimeout sets disconnect clients on idle
+                      timeout behavior, if set to 0 means do not disconnect, otherwise
+                      is set to the idle duration.
+                    format: duration
+                    type: string
+                  create_db_user:
+                    description: CreateDatabaseUser enabled automatic database user
+                      creation.
+                    type: boolean
+                  create_desktop_user:
+                    description: CreateDesktopUser allows users to be automatically
+                      created on a Windows desktop
+                    type: boolean
+                  create_host_user:
+                    description: CreateHostUser allows users to be automatically created
+                      on a host
+                    type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    x-kubernetes-int-or-string: true
+                  desktop_clipboard:
+                    description: DesktopClipboard indicates whether clipboard sharing
+                      is allowed between the user's workstation and the remote desktop.
+                      It defaults to true unless explicitly set to false.
+                    type: boolean
+                  desktop_directory_sharing:
+                    description: DesktopDirectorySharing indicates whether directory
+                      sharing is allowed between the user's workstation and the remote
+                      desktop. It defaults to false unless explicitly set to true.
+                    type: boolean
+                  device_trust_mode:
+                    description: DeviceTrustMode is the device authorization mode
+                      used for the resources associated with the role. See DeviceTrust.Mode.
+                      Reserved for future use, not yet used by Teleport.
+                    type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert sets disconnect clients on
+                      expired certificates.
+                    type: boolean
+                  enhanced_recording:
+                    description: BPF defines what events to record for the BPF-based
+                      session recorder.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  forward_agent:
+                    description: ForwardAgent is SSH agent forwarding.
+                    type: boolean
+                  idp:
+                    description: IDP is a set of options related to accessing IdPs
+                      within Teleport. Requires Teleport Enterprise.
+                    nullable: true
+                    properties:
+                      saml:
+                        description: SAML are options related to the Teleport SAML
+                          IdP.
+                        nullable: true
+                        properties:
+                          enabled:
+                            description: Enabled is set to true if this option allows
+                              access to the Teleport SAML IdP.
+                            type: boolean
+                        type: object
+                    type: object
+                  lock:
+                    description: Lock specifies the locking mode (strict|best_effort)
+                      to be applied with the role.
+                    type: string
+                  max_connections:
+                    description: MaxConnections defines the maximum number of concurrent
+                      connections a user may hold.
+                    format: int64
+                    type: integer
+                  max_kubernetes_connections:
+                    description: MaxKubernetesConnections defines the maximum number
+                      of concurrent Kubernetes sessions a user may hold.
+                    format: int64
+                    type: integer
+                  max_session_ttl:
+                    description: MaxSessionTTL defines how long a SSH session can
+                      last for.
+                    format: duration
+                    type: string
+                  max_sessions:
+                    description: MaxSessions defines the maximum number of concurrent
+                      sessions per connection.
+                    format: int64
+                    type: integer
+                  permit_x11_forwarding:
+                    description: PermitX11Forwarding authorizes use of X11 forwarding.
+                    type: boolean
+                  pin_source_ip:
+                    description: PinSourceIP forces the same client IP for certificate
+                      generation and usage
+                    type: boolean
+                  port_forwarding:
+                    description: PortForwarding defines if the certificate will have
+                      "permit-port-forwarding" in the certificate. PortForwarding
+                      is "yes" if not set, that's why this is a pointer
+                    type: boolean
+                  record_session:
+                    description: RecordDesktopSession indicates whether desktop access
+                      sessions should be recorded. It defaults to true unless explicitly
+                      set to false.
+                    nullable: true
+                    properties:
+                      default:
+                        description: Default indicates the default value for the services.
+                        type: string
+                      desktop:
+                        description: Desktop indicates whether desktop sessions should
+                          be recorded. It defaults to true unless explicitly set to
+                          false.
+                        type: boolean
+                      ssh:
+                        description: SSH indicates the session mode used on SSH sessions.
+                        type: string
+                    type: object
+                  request_access:
+                    description: RequestAccess defines the access request strategy
+                      (optional|note|always) where optional is the default.
+                    type: string
+                  request_prompt:
+                    description: RequestPrompt is an optional message which tells
+                      users what they aught to request.
+                    type: string
+                  require_session_mfa:
+                    description: RequireMFAType is the type of MFA requirement enforced
+                      for this user.
+                    x-kubernetes-int-or-string: true
+                  ssh_file_copy:
+                    description: SSHFileCopy indicates whether remote file operations
+                      via SCP or SFTP are allowed over an SSH session. It defaults
+                      to true unless explicitly set to false.
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: Status defines the observed state of the Teleport resource
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              teleportResourceID:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Reverts the `TeleportRole` removal from the `resources.teleport.dev/v6` API that happened in https://github.com/gravitational/teleport/pull/36715 for backward compatibility.

Creating role via this API doesn't have the expected behaviour (creates roles v5) but we have users relying on this behaviour.

We will definitely fix this in v16 by removing `TeleportRole` entirely.