### PR TITLE
Fix an issue selecting MySQL database is not reflected in the audit logs

### DIFF
--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -362,6 +362,12 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 			return
 
 		case *protocol.InitDB:
+			// Update DatabaseName when switching to another so the audit logs
+			// are up to date. E.g.:
+			// mysql> use foo;
+			// mysql> select * from users;
+			sessionCtx.DatabaseName = pkt.SchemaName()
+
 			e.Audit.EmitEvent(e.Context, makeInitDBEvent(sessionCtx, pkt))
 		case *protocol.CreateDB:
 			e.Audit.EmitEvent(e.Context, makeCreateDBEvent(sessionCtx, pkt))


### PR DESCRIPTION
Fixes #5903 

changelog: Fix an issue selecting MySQL database is not reflected in the audit logs

Example:
<img width="781" alt="Screenshot 2024-01-24 at 11 10 45 AM" src="https://github.com/gravitational/teleport/assets/12417665/c6b09ada-a366-4def-8dd5-04d7f4786d24">
