### PR TITLE
Add docs for application access in Teleport Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -64,6 +64,102 @@ The top bar of Teleport Connect consists of:
 The **status bar** at the bottom displays **cluster breadcrumbs** in the bottom left, indicating
 which cluster the current tab is bound to, and the **Share Feedback** button in the bottom right.
 
+## Connecting to an SSH server
+
+1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
+   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+1. Look for the SSH server you want to connect to and click the Connect button to the right.
+1. Select or enter the SSH user you wish to log in as and press `Enter`.
+
+A new tab will open with a shell session on the chosen server.
+
+Alternatively, you can look for the server in the search bar and press `Enter` to connect to it.
+
+## Opening a local terminal
+
+To open a terminal with a local shell session, either select "Open new terminal" from the additional
+actions menu or press <span style="white-space: nowrap;">`Ctrl/Cmd + Shift + T`</span>.
+
+Any tsh command executed within the tab targets the current cluster. Teleport Connect accomplishes
+this by setting the environment variables `TELEPORT_PROXY` and `TELEPORT_CLUSTER` for the session.
+Additionally, Teleport Connect prepends the `PATH`/`Path` environment variable in the session with the
+directory containing the tsh binary, even if [tsh is not globally available](#using-tsh-outside-of-teleport-connect).
+
+When using [trusted clusters](../management/admin/trustedclusters.mdx), the cluster selector allows
+you to determine which cluster the shell session will be bound to. The selected cluster will be
+reflected in both the tab title and the status bar.
+
+## Connecting to a Kubernetes cluster
+
+1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
+   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+1. Select the Kubes section.
+1. Look for the cluster you wish to connect to and click the Connect button to the right.
+
+Alternatively, you can look for the cluster in the search bar and press `Enter`
+to connect to it.
+
+A new local terminal tab will open which is preconfigured with the `KUBECONFIG`
+environment variable pointing to a configuration for the specified cluster. Any
+tools that respect the `KUBECONFIG` environment variable (`kubectl`, `helm`,
+etc.) will work without additional configuration. To identify the path to this
+config for use in other tools, inspect the value of the `KUBECONFIG`
+environment variable.
+
+The value of the `KUBECONFIG` environment variable will persist between app
+restarts, but this configuration file will not be available or usable when the
+Kubernetes cluster is removed from the connection list in the top left, or when
+Teleport Connect is closed.
+
+## Connecting to a database
+
+1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
+  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+1. Select the Databases section.
+1. Look for the database server you wish to connect to and click the Connect button to the right.
+1. Select or enter the database user you wish to use and press `Enter`.
+
+A new tab will open with a new connection established between your device and the database server.
+
+Alternatively, you can look for the database in the search bar and press `Enter` to connect to it.
+
+This connection will remain active until you click the Close Connection button or close Teleport
+Connect. The port number will persist between app restarts—you can set up your favorite client
+without worrying about the port suddenly changing.
+
+### With a GUI client
+
+To connect with a GUI client, follow the instructions in the database connection tab under the
+Connect with GUI section.
+
+### With a CLI client
+
+The database connection tab shows the command that can be used to connect to the database. You can
+modify the database name of the connection and then click the Run button to open a new terminal tab
+with that command executed.
+
+## Connecting to multiple clusters
+
+Teleport Connect allows you to log in to multiple clusters at the same time. After logging in to
+your first cluster, open the profile selector at the top right and click the *+Add another cluster*
+button. You can switch between active profiles in multiple ways:
+
+1. Click at the profile selector button at the top right.
+1. Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
+1. Select a connection from the connection list at the top to automatically switch to the right profile.
+
+At the moment Teleport Connect supports only one user per cluster. To log in as a different user,
+log out of the cluster first.
+
+## Restarting and reconnecting
+
+Before closing, Teleport Connect will remember the tabs that you had open at the end of the session.
+Next time you open the app, Connect will ask you if you want to reopen those tabs. If you agree,
+Connect will restore connections to all resources that were active before you closed the app.
+
+When restoring terminal tabs, Teleport Connect doesn't attempt to re-execute commands that were in
+progress when the app was closed. It will only restore the working directory for those tabs.
+
 ## Connect My Computer
 
 Connect My Computer makes it possible to add your personal machine to a Teleport cluster in just a
@@ -234,101 +330,6 @@ $ tctl nodes ls -v --query='labels["teleport.dev/connect-my-computer/owner"] != 
 $ tctl lock --server-id=<Var name="Node UUID" /> --message="Using Connect My Computer is forbidden"
 ```
 
-## Connecting to an SSH server
-
-1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Look for the SSH server you want to connect to and click the Connect button to the right.
-1. Select or enter the SSH user you wish to log in as and press `Enter`.
-
-A new tab will open with a shell session on the chosen server.
-
-Alternatively, you can look for the server in the search bar and press `Enter` to connect to it.
-
-## Opening a local terminal
-
-To open a terminal with a local shell session, either select "Open new terminal" from the additional
-actions menu or press <span style="white-space: nowrap;">`Ctrl/Cmd + Shift + T`</span>.
-
-Any tsh command executed within the tab targets the current cluster. Teleport Connect accomplishes
-this by setting the environment variables `TELEPORT_PROXY` and `TELEPORT_CLUSTER` for the session.
-Additionally, Teleport Connect prepends the `PATH`/`Path` environment variable in the session with the
-directory containing the tsh binary, even if [tsh is not globally available](#using-tsh-outside-of-teleport-connect).
-
-When using [trusted clusters](../management/admin/trustedclusters.mdx), the cluster selector allows
-you to determine which cluster the shell session will be bound to. The selected cluster will be
-reflected in both the tab title and the status bar.
-
-## Connecting to a Kubernetes cluster
-
-1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Select the Kubes section.
-1. Look for the cluster you wish to connect to and click the Connect button to the right.
-
-Alternatively, you can look for the cluster in the search bar and press `Enter`
-to connect to it.
-
-A new local terminal tab will open which is preconfigured with the `KUBECONFIG`
-environment variable pointing to a configuration for the specified cluster. Any
-tools that respect the `KUBECONFIG` environment variable (`kubectl`, `helm`,
-etc.) will work without additional configuration. To identify the path to this
-config for use in other tools, inspect the value of the `KUBECONFIG`
-environment variable.
-
-The value of the `KUBECONFIG` environment variable will persist between app
-restarts, but this configuration file will not be available or usable when the
-Kubernetes cluster is removed from the connection list in the top left, or when
-Teleport Connect is closed.
-
-## Connecting to a database
-
-1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
-  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Select the Databases section.
-1. Look for the database server you wish to connect to and click the Connect button to the right.
-1. Select or enter the database user you wish to use and press `Enter`.
-
-A new tab will open with a new connection established between your device and the database server.
-
-Alternatively, you can look for the database in the search bar and press `Enter` to connect to it.
-
-This connection will remain active until you click the Close Connection button or close Teleport
-Connect. The port number will persist between app restarts—you can set up your favorite client
-without worrying about the port suddenly changing.
-
-### With a GUI client
-
-To connect with a GUI client, follow the instructions in the database connection tab under the
-Connect with GUI section.
-
-### With a CLI client
-
-The database connection tab shows the command that can be used to connect to the database. You can
-modify the database name of the connection and then click the Run button to open a new terminal tab
-with that command executed.
-
-## Connecting to multiple clusters
-
-Teleport Connect allows you to log in to multiple clusters at the same time. After logging in to
-your first cluster, open the profile selector at the top right and click the *+Add another cluster*
-button. You can switch between active profiles in multiple ways:
-
-1. Click at the profile selector button at the top right.
-1. Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
-1. Select a connection from the connection list at the top to automatically switch to the right profile.
-
-At the moment Teleport Connect supports only one user per cluster. To log in as a different user,
-log out of the cluster first.
-
-## Restarting and reconnecting
-
-Before closing, Teleport Connect will remember the tabs that you had open at the end of the session.
-Next time you open the app, Connect will ask you if you want to reopen those tabs. If you agree,
-Connect will restore connections to all resources that were active before you closed the app.
-
-When restoring terminal tabs, Teleport Connect doesn't attempt to re-execute commands that were in
-progress when the app was closed. It will only restore the working directory for those tabs.
 
 ## Using tsh outside of Teleport Connect
 

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -3,8 +3,8 @@ title: Using Teleport Connect
 description: Using Teleport Connect
 ---
 
-Teleport Connect provides easy and secure access to SSH servers, databases, and Kubernetes clusters,
-with support for other resources coming in the future.
+Teleport Connect provides easy and secure access to SSH servers, databases, applications, and
+Kubernetes clusters.
 
 ![resources tab in Teleport Connect](../../img/use-teleport/connect-cluster@2x.png)
 
@@ -135,6 +135,42 @@ Connect with GUI section.
 The database connection tab shows the command that can be used to connect to the database. You can
 modify the database name of the connection and then click the Run button to open a new terminal tab
 with that command executed.
+
+## Connecting to an application
+
+Teleport Connect supports launching HTTP applications in the browser, as well as creating
+authenticated tunnels for HTTP and TCP applications. Access to AWS or SAML applications is currently
+not supported – please use tsh or the Web UI instead.
+
+### Launching an application in the browser
+
+1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
+  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+1. Look for the application you wish to open and click the Launch button.
+
+Alternatively, you can look for the application in the search bar and press `Enter` to launch it in
+the browser.
+
+### Creating an authenticated tunnel
+
+1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
+  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+1. Look for the application you wish to connect to.
+  - For TCP applications, click the Connect button.
+  - For HTTP applications, click the chevron next to the Launch button and select Set up connection.
+
+Alternatively, you can look for a TCP application in the search bar and press `Enter` to launch it
+in the browser.
+
+A new tab will open with a new connection established between your device and the application.
+
+This connection will remain active until you click the Close Connection button or close Teleport
+Connect. The port number will persist between app restarts—you can set up your favorite client
+without worrying about the port suddenly changing.
+
+The application connection tab shows an example command that can be used to query the application.
+Requests sent under the displayed address will be proxied through an authenticated tunnel to the
+application.
 
 ## Connecting to multiple clusters
 

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -68,7 +68,7 @@ which cluster the current tab is bound to, and the **Share Feedback** button in 
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
    You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Look for the SSH server you want to connect to and click the Connect button to the right.
+1. Look for the SSH server you want to connect to and click the Connect button.
 1. Select or enter the SSH user you wish to log in as and press `Enter`.
 
 A new tab will open with a shell session on the chosen server.
@@ -93,8 +93,7 @@ reflected in both the tab title and the status bar.
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
    You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Select the Kubes section.
-1. Look for the cluster you wish to connect to and click the Connect button to the right.
+1. Look for the cluster you wish to connect to and click the Connect button.
 
 Alternatively, you can look for the cluster in the search bar and press `Enter`
 to connect to it.
@@ -115,8 +114,7 @@ Teleport Connect is closed.
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Select the Databases section.
-1. Look for the database server you wish to connect to and click the Connect button to the right.
+1. Look for the database server you wish to connect to and click the Connect button.
 1. Select or enter the database user you wish to use and press `Enter`.
 
 A new tab will open with a new connection established between your device and the database server.

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -138,9 +138,12 @@ with that command executed.
 
 ## Connecting to an application
 
-Teleport Connect supports launching HTTP applications in the browser, as well as creating
-authenticated tunnels for HTTP and TCP applications. Access to AWS or SAML applications is currently
-not supported – please use tsh or the Web UI instead.
+Teleport Connect supports launching applications in the browser, as well as creating
+authenticated tunnels for HTTP and TCP applications.
+
+When it comes to [cloud APIs secured with Application Access](../application-access/cloud-apis.mdx),
+Teleport Connect supports launching the AWS console in the browser, but all other CLI applications
+can be used only through tsh in [a local terminal tab](#opening-a-local-terminal).
 
 ### Launching an application in the browser
 

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -149,7 +149,8 @@ can be used only through tsh in [a local terminal tab](#opening-a-local-terminal
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Look for the application you wish to open and click the Launch button.
+1. Look for the application you wish to open and click the Launch button (HTTP apps and AWS console)
+   or the Login button (SAML apps).
 
 Alternatively, you can look for the application in the search bar and press `Enter` to launch it in
 the browser.
@@ -160,10 +161,11 @@ the browser.
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
 1. Look for the application you wish to connect to.
   - For TCP applications, click the Connect button.
-  - For HTTP applications, click the chevron next to the Launch button and select Set up connection.
+  - For HTTP applications, click the three dots next to the Launch button and select Set up
+    connection.
 
-Alternatively, you can look for a TCP application in the search bar and press `Enter` to launch it
-in the browser.
+Alternatively, you can look for a TCP application in the search bar and press `Enter` to set up a
+connection to it.
 
 A new tab will open with a new connection established between your device and the application.
 

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -139,7 +139,7 @@ with that command executed.
 ## Connecting to an application
 
 Teleport Connect supports launching applications in the browser, as well as creating
-authenticated tunnels for HTTP and TCP applications.
+authenticated tunnels for web and TCP applications.
 
 When it comes to [cloud APIs secured with Application Access](../application-access/cloud-apis.mdx),
 Teleport Connect supports launching the AWS console in the browser, but all other CLI applications
@@ -149,7 +149,7 @@ can be used only through tsh in [a local terminal tab](#opening-a-local-terminal
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-1. Look for the application you wish to open and click the Launch button (HTTP apps and AWS console)
+1. Look for the application you wish to open and click the Launch button (web apps and AWS console)
    or the Login button (SAML apps).
 
 Alternatively, you can look for the application in the search bar and press `Enter` to launch it in
@@ -161,7 +161,7 @@ the browser.
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
 1. Look for the application you wish to connect to.
   - For TCP applications, click the Connect button.
-  - For HTTP applications, click the three dots next to the Launch button and select Set up
+  - For web applications, click the three dots next to the Launch button and select Set up
     connection.
 
 Alternatively, you can look for a TCP application in the search bar and press `Enter` to set up a

--- a/docs/pages/includes/teleport-connect-telemetry.mdx
+++ b/docs/pages/includes/teleport-connect-telemetry.mdx
@@ -1,7 +1,7 @@
 When you first start the app, Teleport Connect asks for permission to collect and send telemetry data.
 This includes tracking events such as:
 - Logging in to a cluster
-- Starting an SSH, database, or Kubernetes session
+- Starting an SSH, database, application, or Kubernetes session
 - File transfer during an SSH session
 - Creating an Access Request
 - Reviewing an Access Request
@@ -13,7 +13,7 @@ On login, we also collect some device-related data:
 - App version
 - Processor architecture
 
-Additionally, we ask for a job role (answer is optional).
+Additionally, we ask for a job role (the answer is optional).
 
 The full list of events and collected data is defined as [protocol buffer messages in the Teleport source](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/proto/prehog/v1alpha/connect.proto).
 We do not track the details of those events but merely that the given event took place. Each event includes the cluster

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -96,9 +96,8 @@ export function AppGateway(props: {
       <Text>
         The connection is made through an authenticated proxy so no extra
         credentials are necessary. See{' '}
-        {/*TODO(gzdunek): Replace with Teleport Connect App access docs.*/}
         <Link
-          href="https://goteleport.com/docs/application-access/guides/tcp/#step-34-start-app-proxy"
+          href="https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-an-application"
           target="_blank"
         >
           the documentation


### PR DESCRIPTION
The PR with UI for launching web apps is still in progress (https://github.com/gravitational/teleport/pull/37246), but here's how it's going to look like in the app. Starting gateways is already possible.

Best reviewed commit-by-commit, as I cleanup up the other sections before adding the new one about app access. I'll prepare a separate PR that updates screenshots to reflect changes brought by unified resources in v15.


https://github.com/gravitational/teleport/assets/27113/b7f3097f-b9d2-455c-a8f6-991cf2b4dba1

