### PR TITLE
integrations/operator: add ignore and keep flags for CRs

### DIFF
--- a/integrations/operator/controllers/resources/utils.go
+++ b/integrations/operator/controllers/resources/utils.go
@@ -21,6 +21,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/gravitational/trace"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -168,4 +169,19 @@ func GetUnstructuredObjectFromGVK(gvk schema.GroupVersionKind) (*unstructured.Un
 	obj := unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 	return &obj, nil
+}
+
+// checkAnnotationFlag checks is the Kubernetes resource is annotated with a
+// flag and parses its value. Returns the default value if the flag is missing
+// or the annotation value cannot be parsed.
+func checkAnnotationFlag(object kclient.Object, flagName string, defaultValue bool) bool {
+	annotation, ok := object.GetAnnotations()[flagName]
+	if !ok {
+		return defaultValue
+	}
+	value, err := strconv.ParseBool(annotation)
+	if err != nil {
+		return defaultValue
+	}
+	return value
 }

--- a/integrations/operator/controllers/resources/utils_test.go
+++ b/integrations/operator/controllers/resources/utils_test.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,6 +93,74 @@ func TestCheckOwnership(t *testing.T) {
 			require.Equal(t, ConditionTypeTeleportResourceOwned, condition.Type)
 			require.Equal(t, tc.expectedConditionStatus, condition.Status)
 			require.Equal(t, tc.expectedConditionReason, condition.Reason)
+		})
+	}
+}
+
+func TestCheckAnnotationFlag(t *testing.T) {
+	testFlag := "foo"
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		defaultValue   bool
+		expectedOutput bool
+	}{
+		{
+			name:           "flag set true, default true",
+			annotations:    map[string]string{testFlag: "true"},
+			defaultValue:   true,
+			expectedOutput: true,
+		},
+		{
+			name:           "flag set false, default true",
+			annotations:    map[string]string{testFlag: "false"},
+			defaultValue:   true,
+			expectedOutput: false,
+		},
+		{
+			name:           "flag set true, default false",
+			annotations:    map[string]string{testFlag: "true"},
+			defaultValue:   false,
+			expectedOutput: true,
+		},
+		{
+			name:           "flag set false, default false",
+			annotations:    map[string]string{testFlag: "false"},
+			defaultValue:   false,
+			expectedOutput: false,
+		},
+		{
+			name:           "flag missing, default true",
+			annotations:    map[string]string{},
+			defaultValue:   true,
+			expectedOutput: true,
+		},
+		{
+			name:           "flag missing, default false",
+			annotations:    map[string]string{},
+			defaultValue:   false,
+			expectedOutput: false,
+		},
+		{
+			name:           "flag malformed, default true",
+			annotations:    map[string]string{testFlag: "malformed"},
+			defaultValue:   true,
+			expectedOutput: true,
+		},
+		{
+			name:           "flag malformed, default false",
+			annotations:    map[string]string{testFlag: "malformed"},
+			defaultValue:   false,
+			expectedOutput: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			obj := &unstructured.Unstructured{}
+			obj.SetAnnotations(tt.annotations)
+			require.Equal(t, tt.expectedOutput, checkAnnotationFlag(obj, testFlag, tt.defaultValue))
 		})
 	}
 }

--- a/integrations/operator/controllers/resources/utils_test.go
+++ b/integrations/operator/controllers/resources/utils_test.go
@@ -19,11 +19,11 @@
 package resources
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/gravitational/teleport/api/types"
 )


### PR DESCRIPTION
Adds a couple of annotations to the operator:
- `teleport.dev/ignore` to block the operator from reconciling a resource entirely.
- `teleport.dev/keep` to keep the Teleport resource after the CR gets deleted. This is here to make resource version upgrades easier.

Part of https://github.com/gravitational/teleport/issues/20261

changelog: add `teleport.dev/ignore` and `teleport.dev/keep` annotations to the Kubernetes operator