### PR TITLE
Fail if RemoteFX is not enabled

### DIFF
--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -32,6 +32,11 @@ use log::{debug, warn};
 use wasm_bindgen::{prelude::*, Clamped};
 use web_sys::ImageData;
 
+use ironrdp_pdu::cursor::ReadCursor;
+use ironrdp_pdu::decode_cursor;
+use ironrdp_pdu::fast_path::UpdateCode::{Bitmap, SurfaceCommands};
+use ironrdp_pdu::fast_path::{FastPathHeader, FastPathUpdatePdu};
+
 #[wasm_bindgen]
 pub fn init_wasm_log(log_level: &str) {
     use tracing::Level;
@@ -144,6 +149,7 @@ fn create_image_data_from_image_and_region(
 pub struct FastPathProcessor {
     fast_path_processor: IronRdpFastPathProcessor,
     image: DecodedImage,
+    remote_fx_check_required: bool,
 }
 
 #[wasm_bindgen]
@@ -161,6 +167,7 @@ impl FastPathProcessor {
             }
             .build(),
             image: DecodedImage::new(PixelFormat::RgbA32, width, height),
+            remote_fx_check_required: true,
         }
     }
 
@@ -178,6 +185,8 @@ impl FastPathProcessor {
         draw_cb: &js_sys::Function,
         respond_cb: &js_sys::Function,
     ) -> Result<(), JsValue> {
+        self.check_remote_fx(tdp_fast_path_frame)?;
+
         let (rdp_responses, client_updates) = {
             let mut output = WriteBuf::new();
 
@@ -238,6 +247,31 @@ impl FastPathProcessor {
         }
 
         Ok(())
+    }
+
+    /// check_remote_fx check if each fast path frame is RemoteFX frame, if we find bitmap frame
+    /// (i.e. RemoteFX is not enabled on the server) we return error with helpful message
+    fn check_remote_fx(&mut self, tdp_fast_path_frame: &[u8]) -> Result<(), JsValue> {
+        if !self.remote_fx_check_required {
+            return Ok(());
+        }
+        debug!("RemoteFX check");
+        // we have to, at least partially, parse frame to check update code,
+        // code here is copied from fast_path::Processor::process
+        let mut input = ReadCursor::new(tdp_fast_path_frame);
+        decode_cursor::<FastPathHeader>(&mut input)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+        let update_pdu = decode_cursor::<FastPathUpdatePdu<'_>>(&mut input)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+        match update_pdu.update_code {
+            SurfaceCommands => {
+                self.remote_fx_check_required = false;
+                Ok(())
+            }
+            Bitmap => Err(JsValue::from_str("RemoteFX is not enabled")),
+            _ => Ok(()),
+        }
     }
 
     fn apply_image_to_canvas(

--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -271,7 +271,7 @@ impl FastPathProcessor {
             }
             Bitmap => Err(JsValue::from_str(concat!(
                 "Teleport requires the RemoteFX codec for Windows desktop sessions, ",
-                "but it is not curently enabled. For detailed instructions, see:\n",
+                "but it is not currently enabled. For detailed instructions, see:\n",
                 "https://goteleport.com/docs/ver/15.x/desktop-access/active-directory-manual/#enable-remotefx"
             ))),
             _ => Ok(()),

--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -255,7 +255,7 @@ impl FastPathProcessor {
         if !self.remote_fx_check_required {
             return Ok(());
         }
-        debug!("RemoteFX check");
+
         // we have to, at least partially, parse frame to check update code,
         // code here is copied from fast_path::Processor::process
         let mut input = ReadCursor::new(tdp_fast_path_frame);

--- a/web/packages/teleport/src/ironrdp/src/lib.rs
+++ b/web/packages/teleport/src/ironrdp/src/lib.rs
@@ -269,7 +269,11 @@ impl FastPathProcessor {
                 self.remote_fx_check_required = false;
                 Ok(())
             }
-            Bitmap => Err(JsValue::from_str("RemoteFX is not enabled")),
+            Bitmap => Err(JsValue::from_str(concat!(
+                "Teleport requires the RemoteFX codec for Windows desktop sessions, ",
+                "but it is not curently enabled. For detailed instructions, see:\n",
+                "https://goteleport.com/docs/ver/15.x/desktop-access/active-directory-manual/#enable-remotefx"
+            ))),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
We now basically require RemoteFX to be enabled on Windows host, if you don't do it performance will suffer and there'll be a lot of visual artifacts. 
With this change we'll show error in such case instead of letting the user work with subpar UX.

![Zrzut ekranu 2024-01-24 o 00 47 38](https://github.com/gravitational/teleport/assets/3896475/652ea41b-9201-4544-958b-8ad0e76c449f)

