### PR TITLE
[v15] Update Admin Action MFA enforcment

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -328,9 +328,9 @@ func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
 }
 
 // IsAdminActionMFAEnforced checks if admin action MFA is enforced. Currently, the only
-// prerequisite for admin action MFA enforcement is whether Webauthn is enabled.
+// prerequisite for admin action MFA enforcement is whether Webauthn is enforced.
 func (c *AuthPreferenceV2) IsAdminActionMFAEnforced() bool {
-	return c.IsSecondFactorWebauthnAllowed()
+	return c.Spec.SecondFactor == constants.SecondFactorWebauthn
 }
 
 // GetConnectorName gets the name of the OIDC or SAML connector to use. If

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -910,7 +910,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 
 	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOptional,
+		SecondFactor: constants.SecondFactorWebauthn,
 		Webauthn: &types.Webauthn{
 			RPID: "localhost",
 		},


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/37136 to branch/v15

Depends on https://github.com/gravitational/teleport/pull/37198

Changelog: MFA is enforced for admin actions on clusters where WebAuthn is required. This applies to adding users, adding trusted devices, reviewing access requests, among many others. You can set TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS=yes environment variable on Teleport auth to temporarily disable MFA enforcement for admin actions. The environment variable will be removed in Teleport 16.