### PR TITLE
[v14] docs: update signature urls to use cdn.teleport.dev

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -39,7 +39,7 @@ your operating environment and package manager or from compressed archive (tarba
 For example, you can download and install from the compressed archive by running the following commands:
 
 ```code
-$ curl https://get.gravitational.com/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
 <checksum> <filename>
 $ curl -O https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -79,7 +79,7 @@ We'll reference the exported file(s) later when configuring the plugin.
 <Tabs>
 <TabItem label="Download">
   ```code
-  $ curl -L https://get.gravitational.com/teleport-access-mattermost-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ curl -L https://cdn.teleport.dev/teleport-access-mattermost-v(=teleport.version=)-linux-amd64-bin.tar.gz
   $ tar -xzf teleport-access-mattermost-v(=teleport.version=)-linux-amd64-bin.tar.gz
   $ cd teleport-access-mattermost
   $ ./install

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -2,7 +2,7 @@
 <TabItem label="Linux">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```
@@ -15,7 +15,7 @@ architecture, you can build from source.
 <TabItem label="macOS">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
 $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -133,7 +133,7 @@ value (`amd64`, `arm64`, or `arm`). All example commands using this variable
 will update after one is filled out.
 
 ```code
-$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256
 # <checksum> <filename>
 $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
 $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
@@ -147,7 +147,7 @@ For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
 will be slightly different:
 
 ```code
-$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
 # <checksum> <filename>
 $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz

--- a/docs/pages/includes/install-windows-tsh.mdx
+++ b/docs/pages/includes/install-windows-tsh.mdx
@@ -2,7 +2,7 @@
   # Set the TLS level to TLS 1.2 (required on Windows Server 2016 and lower)
   $ [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   # Get the expected checksum for the Windows tsh package
-  $ $Resp = Invoke-WebRequest https://get.gravitational.com/teleport-v{{ version }}-windows-amd64-bin.zip.sha256
+  $ $Resp = Invoke-WebRequest https://cdn.teleport.dev/teleport-v{{ version }}-windows-amd64-bin.zip.sha256
   # PowerShell will return the binary representation of the response content
   # by default, so you need to convert it to a string
   $ [System.Text.Encoding]::UTF8.getstring($Resp.Content)

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -6,7 +6,7 @@ plugins from source. You can run the plugin from a remote host or your local
 development machine.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://cdn.teleport.dev/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -504,7 +504,7 @@ $ export version=v(=teleport.version=)
 $ export os=linux
 # '386' 'arm' on linux or 'amd64' for all distros
 $ export arch=amd64
-$ curl https://get.gravitational.com/teleport-$version-$os-$arch-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-$version-$os-$arch-bin.tar.gz.sha256
 # <checksum> <filename>
 ```
 


### PR DESCRIPTION
Backport #37205 to branch/v14