### PR TITLE
Update link to SOC 2 report

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/soc2.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/soc2.mdx
@@ -4,15 +4,10 @@ description: How to configure SOC 2-compliant access to SSH, Kubernetes, databas
 h1: SOC 2 Compliance for SSH, Kubernetes, Databases, Desktops, and Web Apps
 ---
 
-Teleport is designed to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high
-level overview of how Teleport can be used to help your company to become SOC 2 compliant.
+Teleport is designed and independently audited to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high level overview of how Teleport can be used to help your company to become SOC 2 compliant.
 
-<Notice type="warning">
-
-  SOC 2 compliance features are only available for Teleport Enterprise and
-  Teleport Enterprise Cloud.
-
-</Notice>
+## Teleport SOC 2 Certification
+(!docs/pages/includes/soc2.mdx!)
 
 ## Achieving SOC 2 Compliance with Teleport
 SOC 2 or Service Organization Controls were developed by the American Institute of CPAs (AICPA). They are based on five trust services criteria: security, availability, processing integrity, confidentiality, and privacy.

--- a/docs/pages/includes/soc2.mdx
+++ b/docs/pages/includes/soc2.mdx
@@ -6,7 +6,7 @@ The audit report covers:
 - Teleport Enterprise, self-hosted
 - Teleport Enterprise, cloud-hosted (SaaS)
 
-The SOC 2 report is available for download at
-[trust.goteleport.com](https://trust.goteleport.com).
+Paying customers and prospects under NDA may download the SOC 2 report at
+[trust.goteleport.com](https://trust.goteleport.com/d/teleport-access-platform-soc-2-type-ii-hipaa/LP5ypb).
 
 For any other questions, reach out to https://goteleport.com/cloud/sales.


### PR DESCRIPTION
We can deeplink to the most current version of the report instead of the general trust page.  Furthermore, our compliance-frameworks/soc2 page is the top google result for Teleport SOC 2, so we want to make sure to link to the report from it.

This was an improvement specifically requested by our vendor who helps address customer compliance questions.