### PR TITLE
[v15] build: Fix arm build due to growth of binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ CC=arm-linux-gnueabihf-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s -debugtramp=2 $(KUBECTL_SETVERSION)' -trimpath -buildmode=pie
+BUILDFLAGS = $(ADDFLAGS) -ldflags '-extldflags "-Wl,--long-plt" -w -s -debugtramp=2 $(KUBECTL_SETVERSION)' -trimpath -buildmode=pie
 endif
 endif # OS == linux
 


### PR DESCRIPTION
The arm build for Teleport Enterprise has started failing due to its
size, resulting in the following error during the build:

    /opt/go/pkg/tool/linux_amd64/link: running arm-linux-gnueabihf-gcc failed: exit status 1
    /usr/lib/gcc-cross/arm-linux-gnueabihf/10/../../../../arm-linux-gnueabihf/bin/ld: BFD (GNU Binutils for Debian) 2.35.2 assertion fail ../../bfd/elf32-arm.c:9876
    [...]

Adding the `--long-plt` option to the linker allows the build to work
again.

Update the `e` ref to bring in the enterprise version of this change.

Link: https://sourceware.org/legacy-ml/binutils/2014-02/msg00053.html
Backport: https://github.com/gravitational/teleport/pull/37150