### PR TITLE
Fix HSM tests

### DIFF
--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -51,7 +51,7 @@ func HSMTestConfig(t *testing.T) Config {
 		t.Log("Running test with SoftHSM")
 		return cfg
 	}
-	t.Fatal("No HSM available for test")
+	t.Skip("No HSM available for test")
 	return Config{}
 }
 

--- a/lib/utils/listener.go
+++ b/lib/utils/listener.go
@@ -29,9 +29,11 @@ import (
 func GetListenerFile(listener net.Listener) (*os.File, error) {
 	switch t := listener.(type) {
 	case *net.TCPListener:
-		return t.File()
+		f, err := t.File()
+		return f, trace.Wrap(err)
 	case *net.UnixListener:
-		return t.File()
+		f, err := t.File()
+		return f, trace.Wrap(err)
 	}
 	return nil, trace.BadParameter("unsupported listener: %T", listener)
 }


### PR DESCRIPTION
This PR fixes the current flakiness of TestHSMMigrate and TestHSMDualAuthRotation.

I finally managed consistently to reproduce the errors we were seeing in CI by hacking lib/utils.LoadBalancer to introduce intermittent network errors. I found that connection problems to auth at certain times during proxy startup can cause the proxy process to exit without recovering. This is fairly likely to happen when a proxy is connected to two auth servers behind a load balancer, and they all reload ~simultaneously due to a CA rotation. The rough timeline to trigger the error is:

1. auth1 starts a rotation and reloads itself
1. proxy detects the rotation and triggers a reload
1. proxy connects to auth2 and gets a client
1. proxy starts proxy.init with the auth2 client
1. auth2 detects the rotation and triggers a reload
1. proxy.init fails and the proxy exits without recovering

The tests were relying on the proxy to always reload successfully during CA rotations. Whenever the tests flaked, the proxy was not reaching a ready state, and the logs match those I was able to reproduce.

This got markedly worse after https://github.com/gravitational/teleport/pull/36549, now that an auth no longer needs to be removed from the load balancer during a migration and the test was updated to reflect that.

We could arguably call this a product bug because the proxy is usually tolerant of temporarily losing a connection to Auth, but it seems non-trivial to recover from errors during a proxy reload. At that point there is already an old and new proxy running, the new one has failed to start and the old one hasn't completely shut down, it's not obvious what should be done. Currently the proxy process will exit and the systemd service should reload the process at that point.

For now, I have modified the HSM integration tests to avoid relying on any non-auth Teleport service reloads in any tests that use 2 auths behind a load balancer.

The changes in lib/auth/init.go fix a bug I found after re-enabling TestHSMDualAuthRotation, which I introduced in https://github.com/gravitational/teleport/pull/36780

Fixes https://github.com/gravitational/teleport/issues/14172
Fixes https://github.com/gravitational/teleport/issues/20217

