### PR TITLE
Use more natural search bar scrolling

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -79,8 +79,7 @@ export function ResultList<T>(props: ResultListProps<T>) {
   useEffect(() => {
     // This needs to happen directly in `useEffect` because it gives us a guarantee
     // that activeIndex matches the activeItemRef.
-    // `false` - bottom of the element will be aligned to the bottom of the visible area of the scrollable ancestor
-    activeItemRef.current?.scrollIntoView(false);
+    activeItemRef.current?.scrollIntoView({ block: 'nearest' });
 
     const handleArrowKey = (e: KeyboardEvent, nudge: number) => {
       const next = getNext(activeItemIndex + nudge, items.length);


### PR DESCRIPTION
Previously the selected element was aligned at the bottom of its ancestor. This worked fine when scrolling down, but not for the opposite direction (the list was scrolling even if it didn't have to).

By using `{block: "nearest"}`, the selected element:
* is aligned at the top of its ancestor if you're currently below it.
* is aligned at the bottom of its ancestor if you're currently above it.
* stays put, if it's already in view.