### PR TITLE
Move TokenLenBytes to defaults package

### DIFF
--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -185,7 +185,7 @@ func TestStartAccountRecovery(t *testing.T) {
 			// Test token returned correct byte length.
 			bytes, err := hex.DecodeString(startToken.GetName())
 			require.NoError(t, err)
-			require.Len(t, bytes, RecoveryTokenLenBytes)
+			require.Len(t, bytes, defaults.RecoveryTokenLenBytes)
 
 			// Test expired token.
 			fakeClock.Advance(defaults.RecoveryStartTokenTTL)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4368,15 +4368,15 @@ func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionReque
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	token, err := utils.CryptoRandomHex(SessionTokenBytes)
+	token, err := utils.CryptoRandomHex(defaults.SessionTokenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	bearerToken, err := utils.CryptoRandomHex(SessionTokenBytes)
+	bearerToken, err := utils.CryptoRandomHex(defaults.SessionTokenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	bearerTokenTTL := min(sessionTTL, BearerTokenTTL)
+	bearerTokenTTL := min(sessionTTL, defaults.BearerTokenTTL)
 
 	startTime := a.clock.Now()
 	if !req.LoginTime.IsZero() {
@@ -6434,18 +6434,9 @@ func (k *authKeepAliver) Close() error {
 }
 
 const (
-	// BearerTokenTTL specifies standard bearer token to exist before
-	// it has to be renewed by the client
-	BearerTokenTTL = 10 * time.Minute
-
 	// TokenLenBytes is len in bytes of the invite token
+	// TODO(marco): remove const block when e/ code is no longer using it.
 	TokenLenBytes = 16
-
-	// RecoveryTokenLenBytes is len in bytes of a user token for recovery.
-	RecoveryTokenLenBytes = 32
-
-	// SessionTokenBytes is the number of bytes of a web or application session.
-	SessionTokenBytes = 32
 )
 
 // githubClient is internal structure that stores Github OAuth 2client and its config

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -736,7 +736,7 @@ func generateTestToken(
 	auth tokenCreatorAndDeleter,
 ) string {
 	t.Helper()
-	token, err := utils.CryptoRandomHex(TokenLenBytes)
+	token, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	require.NoError(t, err)
 
 	pt, err := types.NewProvisionToken(token, roles, expires)
@@ -2271,7 +2271,7 @@ func TestNewWebSession(t *testing.T) {
 		LoginTime:  p.a.clock.Now().UTC(),
 		SessionTTL: apidefaults.CertDuration,
 	}
-	bearerTokenTTL := min(req.SessionTTL, BearerTokenTTL)
+	bearerTokenTTL := min(req.SessionTTL, defaults.BearerTokenTTL)
 
 	ws, err := p.a.NewWebSession(ctx, req)
 	require.NoError(t, err)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -136,7 +136,7 @@ func (a *Server) CreateGithubAuthRequest(ctx context.Context, req types.GithubAu
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	req.StateToken, err = utils.CryptoRandomHex(TokenLenBytes)
+	req.StateToken, err = utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/machineid/machineidv1/bot_service_legacy.go
+++ b/lib/auth/machineid/machineidv1/bot_service_legacy.go
@@ -103,7 +103,7 @@ func (bs *BotService) checkOrCreateBotToken(ctx context.Context, req *proto.Crea
 		return token, nil
 	}
 
-	tokenName, err := utils.CryptoRandomHex(16)
+	tokenName, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -97,11 +98,11 @@ func (a *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 	}
 
 	// Create services.WebSession for this session.
-	sessionID, err := utils.CryptoRandomHex(SessionTokenBytes)
+	sessionID, err := utils.CryptoRandomHex(defaults.SessionTokenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	bearer, err := utils.CryptoRandomHex(SessionTokenBytes)
+	bearer, err := utils.CryptoRandomHex(defaults.SessionTokenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -324,7 +325,7 @@ func (a *Server) CreateSnowflakeSession(ctx context.Context, req types.CreateSno
 	ttl := checker.AdjustSessionTTL(identity.Expires.Sub(a.clock.Now()))
 
 	// Create services.WebSession for this session.
-	sessionID, err := utils.CryptoRandomHex(SessionTokenBytes)
+	sessionID, err := utils.CryptoRandomHex(defaults.SessionTokenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -300,9 +300,9 @@ func (a *Server) newUserToken(req CreateUserTokenRequest) (types.UserToken, erro
 	var err error
 	var proxyHost string
 
-	tokenLenBytes := TokenLenBytes
+	tokenLenBytes := defaults.TokenLenBytes
 	if req.Type == UserTokenTypeRecoveryStart {
-		tokenLenBytes = RecoveryTokenLenBytes
+		tokenLenBytes = defaults.RecoveryTokenLenBytes
 	}
 
 	tokenID, err := utils.CryptoRandomHex(tokenLenBytes)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -187,6 +187,19 @@ const (
 	// ResetPasswordLength is the length of the reset user password
 	ResetPasswordLength = 16
 
+	// BearerTokenTTL specifies standard bearer token to exist before
+	// it has to be renewed by the client
+	BearerTokenTTL = 10 * time.Minute
+
+	// TokenLenBytes is len in bytes of the invite token
+	TokenLenBytes = 16
+
+	// RecoveryTokenLenBytes is len in bytes of a user token for recovery.
+	RecoveryTokenLenBytes = 32
+
+	// SessionTokenBytes is the number of bytes of a web or application session.
+	SessionTokenBytes = 32
+
 	// ProvisioningTokenTTL is a the default TTL for server provisioning
 	// tokens. When a user generates a token without an explicit TTL, this
 	// value is used.

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -47,8 +47,8 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/auth"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -138,7 +138,7 @@ func (d *defaultEnrollEKSClustersClient) CheckAgentAlreadyInstalled(clientGetter
 func getToken(ctx context.Context, clock clockwork.Clock, tokenCreator TokenCreator) (string, string, error) {
 	const eksJoinTokenTTL = 30 * time.Minute
 
-	tokenName, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+	tokenName, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	libauth "github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -417,7 +416,7 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 		return "", trace.Wrap(err)
 	}
 	a.cfg.Log.Debugf("Generating GCP user password for %s.", sessionCtx)
-	token, err := utils.CryptoRandomHex(libauth.TokenLenBytes)
+	token, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -35,7 +35,6 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/connectmycomputer"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -290,7 +289,7 @@ func NewTokenProvisioner(cfg *TokenProvisionerConfig) *TokenProvisioner {
 
 // CreateNodeToken creates a node join token that is valid for 5 minutes.
 func (t *TokenProvisioner) CreateNodeToken(ctx context.Context, provisioner Provisioner, cluster *clusters.Cluster) (string, error) {
-	tokenName, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+	tokenName, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5300,7 +5300,7 @@ func TestWebSessionsRenewDoesNotBreakExistingTerminalSession(t *testing.T) {
 	// This will allow the new session to have a more plausible
 	// expiration
 	const delta = 30 * time.Second
-	env.clock.Advance(auth.BearerTokenTTL - delta)
+	env.clock.Advance(defaults.BearerTokenTTL - delta)
 
 	// Renew the session using the 1st proxy
 	resp := pack1.renewSession(context.Background(), t)
@@ -5334,7 +5334,7 @@ func TestWebSessionsRenewAllowsOldBearerTokenToLinger(t *testing.T) {
 	// Advance the time before renewing the session.
 	// This will allow the new session to have a more plausible
 	// expiration
-	env.clock.Advance(auth.BearerTokenTTL - delta)
+	env.clock.Advance(defaults.BearerTokenTTL - delta)
 
 	// make sure we can use client to make authenticated requests
 	// before we issue this request, we will recover session id and bearer token

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/utils"
@@ -59,7 +59,7 @@ func (h *Handler) startAppAuthExchange(w http.ResponseWriter, r *http.Request, p
 	if q.Get("state") == "" {
 		// secretToken is the token we will look for in both the cookie
 		// and in the request "state" query param.
-		secretToken, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+		secretToken, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			h.log.WithError(err).Debug("Failed to generate token required for app auth exchange")
 			return trace.AccessDenied("access denied")
@@ -71,7 +71,7 @@ func (h *Handler) startAppAuthExchange(w http.ResponseWriter, r *http.Request, p
 		// This prevents a race condition (state token mismatch error)
 		// where we can overwrite existing cookie (with the same name) with a
 		// different token value eg: launch app in multiple tabs in quick succession
-		cookieIdentifier, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+		cookieIdentifier, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			h.log.WithError(err).Debug("Failed to generate an UID for the app auth state cookie")
 			return trace.AccessDenied("access denied")
@@ -95,7 +95,7 @@ func (h *Handler) startAppAuthExchange(w http.ResponseWriter, r *http.Request, p
 
 	// Continue the auth exchange.
 
-	nonce, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+	nonce, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		h.log.WithError(err).Debug("Failed to create a random nonce for the app redirection HTML inline script")
 		return trace.AccessDenied("access denied")

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	dbiam "github.com/gravitational/teleport/lib/srv/db/common/iam"
 	"github.com/gravitational/teleport/lib/utils"
@@ -561,7 +561,7 @@ func strPtr(str string) *string {
 func generateProvisionToken(t *testing.T, role types.SystemRole, expiresAt time.Time) (types.ProvisionToken, string) {
 	t.Helper()
 
-	token, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+	token, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	require.NoError(t, err)
 
 	pt, err := types.NewProvisionToken(token, types.SystemRoles{role}, expiresAt)

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/modules"
@@ -163,7 +162,7 @@ func (h *Handler) createTokenHandle(w http.ResponseWriter, r *http.Request, para
 			}, nil
 		}
 	default:
-		tokenName, err = utils.CryptoRandomHex(auth.TokenLenBytes)
+		tokenName, err = utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -535,7 +534,7 @@ func validateJoinToken(token string) error {
 	if err != nil {
 		return trace.BadParameter("invalid token %q", token)
 	}
-	if len(decodedToken) != auth.TokenLenBytes {
+	if len(decodedToken) != defaults.TokenLenBytes {
 		return trace.BadParameter("invalid token %q", decodedToken)
 	}
 

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -330,7 +330,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	var token types.ProvisionToken
 	if c.tokenID == "" {
 		// If there's no token specified, generate one
-		tokenName, err := utils.CryptoRandomHex(16)
+		tokenName, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -146,7 +146,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client auth.ClientI) error {
 
 	token := c.token
 	if c.token == "" {
-		token, err = utils.CryptoRandomHex(auth.TokenLenBytes)
+		token, err = utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			return trace.WrapWithMessage(err, "generating token value")
 		}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -173,7 +173,7 @@ func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
 
 	token := c.value
 	if c.value == "" {
-		token, err = utils.CryptoRandomHex(auth.TokenLenBytes)
+		token, err = utils.CryptoRandomHex(defaults.TokenLenBytes)
 		if err != nil {
 			return trace.Wrap(err, "generating token value")
 		}

--- a/tool/tsh/common/app_gcp.go
+++ b/tool/tsh/common/app_gcp.go
@@ -34,8 +34,8 @@ import (
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -134,7 +134,7 @@ func getGCPSecret() (string, error) {
 		return secret, nil
 	}
 
-	return utils.CryptoRandomHex(auth.TokenLenBytes)
+	return utils.CryptoRandomHex(defaults.TokenLenBytes)
 }
 
 // StartLocalProxies sets up local proxies for serving GCP clients.


### PR DESCRIPTION
Some consts in the `auth` package are used in a lot of other packages. This increases the probality of getting a cyclic dependency error.

This PR moves some of those consts to the defaults package and updates all the required locations of their usage.

Only one is missing in the `/e/` repo, which I'm going to open a PR for it.
After merging, we can also remove the `lib/auth.TokenLenBytes`

Related: https://github.com/gravitational/teleport/issues/37245