### PR TITLE
[v15] Fix AccessList proto 0 time mapping to epoch

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1
 
 import (
+	"time"
+
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"time"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -242,3 +242,27 @@ func newAccessList(t *testing.T, name string) *accesslist.AccessList {
 	require.NoError(t, err)
 	return accessList
 }
+
+func TestNextAuditDateZeroTime(t *testing.T) {
+	// When a proto message without expiration is converted to an AL
+	// we expect next audit date to be mapped to golang's zero time. Then
+	// AccessList.CheckAndSetDefaults will set a time in the future based on
+	// the recurrence rules.
+	accessList := ToProto(newAccessList(t, "access-list"))
+	accessList.Spec.Audit.NextAuditDate = nil
+	converted, err := FromProto(accessList)
+
+	require.NoError(t, err)
+	require.False(
+		t,
+		converted.Spec.Audit.NextAuditDate.Unix() == 0,
+		"next audit date should not be epoch",
+	)
+
+	converted.Spec.Audit.NextAuditDate = time.Time{}
+	// When an Access List without next audit date is converted to protobuf
+	// it should be nil.
+	convertedTwice := ToProto(converted)
+
+	require.Nil(t, convertedTwice.Spec.Audit.NextAuditDate)
+}

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -253,9 +253,9 @@ func TestNextAuditDateZeroTime(t *testing.T) {
 	converted, err := FromProto(accessList)
 
 	require.NoError(t, err)
-	require.False(
+	require.NotZero(
 		t,
-		converted.Spec.Audit.NextAuditDate.Unix() == 0,
+		converted.Spec.Audit.NextAuditDate.Unix(),
 		"next audit date should not be epoch",
 	)
 


### PR DESCRIPTION
Backport #36810 to branch/v15

changelog: Fix Terraform provider creating AccessLists with next audit date set to Epoch
