### PR TITLE
Improve error message when reading certs

### DIFF
--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -228,8 +228,11 @@ func ReadCertificates(certificateChainBytes []byte) ([]*x509.Certificate, error)
 
 	for {
 		certificateBlock, remainingBytes = pem.Decode(remainingBytes)
-		if certificateBlock == nil || certificateBlock.Type != pemBlockCertificate {
+		if certificateBlock == nil {
 			return nil, trace.NotFound("no PEM data found")
+		}
+		if t := certificateBlock.Type; t != pemBlockCertificate {
+			return nil, trace.BadParameter("expecting certificate, but found %v", t)
 		}
 		certificates = append(certificates, certificateBlock.Bytes)
 


### PR DESCRIPTION
If you mistakenly point `cert_file` at a private key instead of a cert, you would say a "no PEM data found" error. This is misleading, as there is PEM data, it is just not the correct type.