### PR TITLE
AWS OIDC: remove config dependency in DeployService

### DIFF
--- a/lib/integrations/awsoidc/deploydatabaseservice.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice.go
@@ -65,9 +65,9 @@ type DeployDatabaseServiceRequest struct {
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
 	ResourceCreationTags AWSTags
 
-	// DeployServiceConfigString creates a teleport.yaml configuration that the agent
+	// CreateDeployServiceConfig creates a teleport.yaml configuration that the agent
 	// deployed in a ECS Cluster (using Fargate) will use.
-	DeployServiceConfigString func(proxyHostPort, iamToken string, resourceMatcherLabels types.Labels) (string, error)
+	CreateDeployServiceConfig func(proxyHostPort, iamToken string, resourceMatcherLabels types.Labels) (string, error)
 
 	// ecsClusterName is the ECS Cluster Name to be used.
 	// It is based on the Teleport Cluster's Name.
@@ -123,8 +123,8 @@ func (r *DeployDatabaseServiceRequest) CheckAndSetDefaults() error {
 		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
-	if r.DeployServiceConfigString == nil {
-		return trace.BadParameter("deploy service config is required")
+	if r.CreateDeployServiceConfig == nil {
+		return trace.BadParameter("create deploy service config is required")
 	}
 
 	r.ecsClusterName = normalizeECSClusterName(r.TeleportClusterName)
@@ -226,7 +226,7 @@ func DeployDatabaseService(ctx context.Context, clt DeployServiceClient, req Dep
 	}
 
 	for _, deployment := range req.Deployments {
-		teleportConfigString, err := req.DeployServiceConfigString(
+		teleportConfigString, err := req.CreateDeployServiceConfig(
 			req.ProxyServerHostPort,
 			req.teleportIAMTokenNameForTask,
 			types.Labels{

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -31,12 +31,15 @@ import (
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	awsV1Http "github.com/aws/smithy-go/transport/http"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 )
 
 func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
@@ -56,6 +59,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				SubnetIDs:        []string{"subnet-1", "subnet-2"},
 				SecurityGroupIDs: []string{"sg-1", "sg-2"},
 			}},
+			DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 		}
 	}
 
@@ -158,6 +162,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				}},
 				ecsClusterName:              "mycluster-teleport",
 				teleportIAMTokenNameForTask: "discover-aws-oidc-iam-token",
+				DeployServiceConfigString:   deployserviceconfig.GenerateTeleportConfigString,
 			},
 		},
 	} {
@@ -170,7 +175,12 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				return
 			}
 			if tt.expected != nil {
-				require.Equal(t, *tt.expected, r)
+				require.Empty(t, cmp.Diff(
+					*tt.expected,
+					r,
+					cmpopts.IgnoreFields(DeployDatabaseServiceRequest{}, "DeployServiceConfigString"),
+					cmpopts.IgnoreUnexported(DeployDatabaseServiceRequest{}),
+				))
 			}
 		})
 	}
@@ -393,6 +403,7 @@ func TestDeployDatabaseService(t *testing.T) {
 					SubnetIDs: []string{"subnet-1", "subnet-2"},
 				},
 			},
+			DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 		})
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %+v", err)
 	})
@@ -418,6 +429,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
+				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)
@@ -462,6 +474,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
+				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)
@@ -524,6 +537,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
+				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -59,7 +59,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				SubnetIDs:        []string{"subnet-1", "subnet-2"},
 				SecurityGroupIDs: []string{"sg-1", "sg-2"},
 			}},
-			DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+			CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 		}
 	}
 
@@ -162,7 +162,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				}},
 				ecsClusterName:              "mycluster-teleport",
 				teleportIAMTokenNameForTask: "discover-aws-oidc-iam-token",
-				DeployServiceConfigString:   deployserviceconfig.GenerateTeleportConfigString,
+				CreateDeployServiceConfig:   deployserviceconfig.GenerateTeleportConfigString,
 			},
 		},
 	} {
@@ -178,7 +178,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 				require.Empty(t, cmp.Diff(
 					*tt.expected,
 					r,
-					cmpopts.IgnoreFields(DeployDatabaseServiceRequest{}, "DeployServiceConfigString"),
+					cmpopts.IgnoreFields(DeployDatabaseServiceRequest{}, "CreateDeployServiceConfig"),
 					cmpopts.IgnoreUnexported(DeployDatabaseServiceRequest{}),
 				))
 			}
@@ -403,7 +403,7 @@ func TestDeployDatabaseService(t *testing.T) {
 					SubnetIDs: []string{"subnet-1", "subnet-2"},
 				},
 			},
-			DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+			CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 		})
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %+v", err)
 	})
@@ -429,7 +429,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
-				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+				CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)
@@ -474,7 +474,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
-				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+				CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)
@@ -537,7 +537,7 @@ func TestDeployDatabaseService(t *testing.T) {
 						SubnetIDs: []string{"subnet-1", "subnet-2"},
 					},
 				},
-				DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+				CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 			},
 		)
 		require.NoError(t, err)

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -163,6 +163,10 @@ type DeployServiceRequest struct {
 	// Eg, 13.2.0
 	// Optional. Defaults to the current version.
 	TeleportVersionTag string
+
+	// DeployServiceConfigString creates a teleport.yaml configuration that the agent
+	// deployed in a ECS Cluster (using Fargate) will use.
+	DeployServiceConfigString func(proxyHostPort, iamToken string, resourceMatcherLabels types.Labels) (string, error)
 }
 
 // normalizeECSResourceName converts a name into a valid ECS Resource Name.
@@ -266,6 +270,10 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 
 	if len(r.DatabaseResourceMatcherLabels) == 0 {
 		return trace.BadParameter("at least one agent matcher label is required")
+	}
+
+	if r.DeployServiceConfigString == nil {
+		return trace.BadParameter("deploy service config is required")
 	}
 
 	return nil
@@ -433,12 +441,7 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 		return nil, trace.Wrap(err)
 	}
 
-	teleportConfigString, err := generateTeleportConfigString(generateTeleportConfigParams{
-		ProxyServerHostPort:           req.ProxyServerHostPort,
-		TeleportIAMTokenName:          req.TeleportIAMTokenName,
-		DeploymentMode:                req.DeploymentMode,
-		DatabaseResourceMatcherLabels: req.DatabaseResourceMatcherLabels,
-	})
+	teleportConfigString, err := req.DeployServiceConfigString(req.ProxyServerHostPort, req.TeleportIAMTokenName, req.DatabaseResourceMatcherLabels)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -23,11 +23,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 )
 
 func TestDeployServiceRequest(t *testing.T) {
@@ -45,6 +47,7 @@ func TestDeployServiceRequest(t *testing.T) {
 			IntegrationName:               "teleportdev",
 			DeploymentMode:                DatabaseServiceDeploymentMode,
 			DatabaseResourceMatcherLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DeployServiceConfigString:     deployserviceconfig.GenerateTeleportConfigString,
 		}
 	}
 
@@ -156,6 +159,7 @@ func TestDeployServiceRequest(t *testing.T) {
 				},
 				DeploymentMode:                DatabaseServiceDeploymentMode,
 				DatabaseResourceMatcherLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				DeployServiceConfigString:     deployserviceconfig.GenerateTeleportConfigString,
 			},
 		},
 	} {
@@ -168,7 +172,7 @@ func TestDeployServiceRequest(t *testing.T) {
 				return
 			}
 
-			require.Empty(t, cmp.Diff(tt.reqWithDefaults, r))
+			require.Empty(t, cmp.Diff(tt.reqWithDefaults, r, cmpopts.IgnoreFields(DeployServiceRequest{}, "DeployServiceConfigString")))
 		})
 	}
 }

--- a/lib/integrations/awsoidc/deployservice_vcr_test.go
+++ b/lib/integrations/awsoidc/deployservice_vcr_test.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 )
 
 func TestDeployDBService(t *testing.T) {
@@ -97,6 +98,7 @@ func TestDeployDBService(t *testing.T) {
 			DatabaseResourceMatcherLabels: types.Labels{
 				types.Wildcard: []string{types.Wildcard},
 			},
+			DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 		}
 	}
 

--- a/lib/integrations/awsoidc/deployserviceconfig/deployservice_config_test.go
+++ b/lib/integrations/awsoidc/deployserviceconfig/deployservice_config_test.go
@@ -16,22 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package awsoidc
+package deployserviceconfig
 
 import (
 	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestDeployServiceConfig(t *testing.T) {
 	t.Run("ensure log level is set to debug", func(t *testing.T) {
-		base64Config, err := generateTeleportConfigString(generateTeleportConfigParams{
-			ProxyServerHostPort:  "host:port",
-			TeleportIAMTokenName: "iam-token",
-			DeploymentMode:       DatabaseServiceDeploymentMode,
-		})
+		base64Config, err := GenerateTeleportConfigString("host:port", "iam-token", types.Labels{})
 		require.NoError(t, err)
 
 		// Config must have the following string:

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -243,7 +243,7 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 		TeleportVersionTag:        teleportVersionTag,
 		IntegrationName:           awsClientReq.IntegrationName,
 		Deployments:               deployments,
-		DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
+		CreateDeployServiceConfig: deployserviceconfig.GenerateTeleportConfigString,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
@@ -176,6 +177,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 		DeploymentMode:                req.DeploymentMode,
 		IntegrationName:               awsClientReq.IntegrationName,
 		DatabaseResourceMatcherLabels: databaseAgentMatcherLabels,
+		DeployServiceConfigString:     deployserviceconfig.GenerateTeleportConfigString,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -234,13 +236,14 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 	}
 
 	deployServiceResp, err := awsoidc.DeployDatabaseService(ctx, deployServiceClient, awsoidc.DeployDatabaseServiceRequest{
-		Region:              req.Region,
-		TaskRoleARN:         req.TaskRoleARN,
-		ProxyServerHostPort: h.PublicProxyAddr(),
-		TeleportClusterName: h.auth.clusterName,
-		TeleportVersionTag:  teleportVersionTag,
-		IntegrationName:     awsClientReq.IntegrationName,
-		Deployments:         deployments,
+		Region:                    req.Region,
+		TaskRoleARN:               req.TaskRoleARN,
+		ProxyServerHostPort:       h.PublicProxyAddr(),
+		TeleportClusterName:       h.auth.clusterName,
+		TeleportVersionTag:        teleportVersionTag,
+		IntegrationName:           awsClientReq.IntegrationName,
+		Deployments:               deployments,
+		DeployServiceConfigString: deployserviceconfig.GenerateTeleportConfigString,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Currently the DeployService and DeployDatabaseService require the `config` package to create a `teleport.yaml` configuration that is used to start the `teleport` process on the ECS containers.

We are refactoring the AWS OIDC actions to use a gRPC Service.
Importing the `config` package makes this refactoring a bit difficult because of a cyclic dependency: `awsoidc` requires `config` which requires `auth` which requires the `awsoidc service` which requires the `awsoidc` package.

This PR removes the usage of the `config` package in `awsoidc` package.


Context: https://github.com/gravitational/teleport/issues/37245