### PR TITLE
[v12] update web install node script to use cdn.teleport.dev for downloads

### DIFF
--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -891,7 +891,7 @@ func TestJoinScript(t *testing.T) {
 	}
 
 	t.Run("direct download links", func(t *testing.T) {
-		getGravitationalTeleportLinkRegex := regexp.MustCompile(`https://get\.gravitational\.com/\${TELEPORT_PACKAGE_NAME}[-_]v?\${TELEPORT_VERSION}`)
+		getGravitationalTeleportLinkRegex := regexp.MustCompile(`https://cnd\.teleport\.dev/\${TELEPORT_PACKAGE_NAME}[-_]v?\${TELEPORT_VERSION}`)
 
 		t.Run("oss", func(t *testing.T) {
 			// Using the OSS Version, all the links must contain only teleport as package name.
@@ -900,9 +900,9 @@ func TestJoinScript(t *testing.T) {
 
 			matches := getGravitationalTeleportLinkRegex.FindAllString(script, -1)
 			require.ElementsMatch(t, matches, []string{
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}",
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}",
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}",
 			})
 			require.Contains(t, script, "TELEPORT_PACKAGE_NAME='teleport'")
 			require.Contains(t, script, "TELEPORT_ARCHIVE_PATH='teleport'")
@@ -916,9 +916,9 @@ func TestJoinScript(t *testing.T) {
 
 			matches := getGravitationalTeleportLinkRegex.FindAllString(script, -1)
 			require.ElementsMatch(t, matches, []string{
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}",
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}",
-				"https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}",
+				"https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}",
 			})
 			require.Contains(t, script, "TELEPORT_PACKAGE_NAME='teleport-ent'")
 			require.Contains(t, script, "TELEPORT_ARCHIVE_PATH='teleport-ent'")

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -891,7 +891,7 @@ func TestJoinScript(t *testing.T) {
 	}
 
 	t.Run("direct download links", func(t *testing.T) {
-		getGravitationalTeleportLinkRegex := regexp.MustCompile(`https://cnd\.teleport\.dev/\${TELEPORT_PACKAGE_NAME}[-_]v?\${TELEPORT_VERSION}`)
+		getGravitationalTeleportLinkRegex := regexp.MustCompile(`https://cdn\.teleport\.dev/\${TELEPORT_PACKAGE_NAME}[-_]v?\${TELEPORT_VERSION}`)
 
 		t.Run("oss", func(t *testing.T) {
 			// Using the OSS Version, all the links must contain only teleport as package name.

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -763,7 +763,7 @@ fi
 install_from_file() {
     # select correct URL/installation method based on distro
     if [[ ${TELEPORT_FORMAT} == "tarball" ]]; then
-        URL="https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
+        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
 
         # check that needed tools are installed
         check_exists_fatal curl tar
@@ -788,7 +788,7 @@ install_from_file() {
         elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
             DEB_ARCH="arm64"
         fi
-        URL="https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
+        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
         check_deb_not_already_installed
         # check that needed tools are installed
         check_exists_fatal curl dpkg
@@ -810,7 +810,7 @@ install_from_file() {
         elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
             RPM_ARCH="arm64"
         fi
-        URL="https://get.gravitational.com/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
+        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
         check_rpm_not_already_installed
         # check for package managers
         if check_exists dnf; then


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/37206 to branch/v12