### PR TITLE
Fix operator role controller

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -11,6 +11,10 @@ rules:
     resources:
       - teleportroles
       - teleportroles/status
+      - teleportrolesv6
+      - teleportrolesv6/status
+      - teleportrolesv7
+      - teleportrolesv7/status
       - teleportusers
       - teleportusers/status
       - teleportgithubconnectors

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -46,13 +46,13 @@ func (r roleClient) Get(ctx context.Context, name string) (types.Role, error) {
 
 // Create creates a Teleport role
 func (r roleClient) Create(ctx context.Context, role types.Role) error {
-	_, err := r.teleportClient.CreateRole(ctx, role)
+	_, err := r.teleportClient.UpsertRole(ctx, role)
 	return trace.Wrap(err)
 }
 
 // Update updates a Teleport role
 func (r roleClient) Update(ctx context.Context, role types.Role) error {
-	_, err := r.teleportClient.UpdateRole(ctx, role)
+	_, err := r.teleportClient.UpsertRole(ctx, role)
 	return trace.Wrap(err)
 }
 

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -40,7 +39,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = resources.Scheme
 	setupLog = ctrl.Log.WithName("setup")
 )
 


### PR DESCRIPTION
Last PR before the huge v15 backport. I tested with everything glued together and found several issues:
- the `teleport-operator` Helm chart was not granting the required permissions for the operator to reconcile teleportrolesv6 and telpeortrolesv7
- the manager was using a default scheme instead of our singleton one. This broke the status updates as the types were missing in the scheme.
- Role CRUD methods were mistakenly replaced from UpsertRole to Create/Update which are not available in v15. I reverted to UpsertRole.

After this PR, I will create a single backport of everything in `integrations/operator` from `master` to `branch/v15`. I'll also send a second PR adding both documentation (replacing TeleportRole with TeleportRolev7) and a changelog entry for the standalone operator.

Part of https://github.com/gravitational/teleport/issues/20261