### PR TITLE
Add in conditional updates to access lists.

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -189,7 +189,12 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 				ownerMap[owner.Name] = struct{}{}
 			}
 
-			upserted, err = a.service.UpsertResource(ctx, accessList)
+			if oldAccessList == nil {
+				upserted, err = a.service.UpsertResource(ctx, accessList)
+				return trace.Wrap(err)
+			}
+
+			upserted, err = a.service.ConditionallyUpdateResource(ctx, accessList)
 			return trace.Wrap(err)
 		})
 	}
@@ -440,7 +445,12 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 				member.SetRevision(upserted.GetRevision())
 			}
 
-			accessList, err = a.service.UpsertResource(ctx, accessList)
+			if oldAccessList == nil {
+				accessList, err = a.service.UpsertResource(ctx, accessList)
+				return trace.Wrap(err)
+			}
+
+			accessList, err = a.service.ConditionallyUpdateResource(ctx, accessList)
 			return trace.Wrap(err)
 		})
 	}

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -233,6 +233,15 @@ func TestGenericCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 	))
 
+	// Conditonally update resource.
+	r1Rev := r1.GetRevision()
+	r1.SetRevision("bad-revision")
+	_, err = service.ConditionallyUpdateResource(ctx, r1)
+	require.Error(t, err)
+	r1.SetRevision(r1Rev)
+	r1, err = service.ConditionallyUpdateResource(ctx, r1)
+	require.NoError(t, err)
+
 	// Update and swap a value
 	r2, err = service.UpdateAndSwapResource(ctx, r2.GetName(), func(tr *testResource) error {
 		tr.SetStaticLabels(map[string]string{"updateandswap": "labelvalue"})
@@ -264,6 +273,12 @@ func TestGenericCRUD(t *testing.T) {
 
 		return nil
 	})
+	require.NoError(t, err)
+
+	// Conditionally delete resource.
+	err = service.ConditionallyDeleteResource(ctx, r1.GetName(), "bad-revision")
+	require.Error(t, err)
+	err = service.ConditionallyDeleteResource(ctx, r1.GetName(), r1.GetRevision())
 	require.NoError(t, err)
 
 	// Delete all resources.


### PR DESCRIPTION
Access lists will now support conditional updates, which will ensure that access lists are only updated if they are operating on the most recent data.