### PR TITLE
[Web] Fix white screen when exiting a Desktop recorded session

### DIFF
--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -205,7 +205,9 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
   );
 
   useEffect(() => {
-    return playerClient.shutdown;
+    return () => {
+      playerClient.shutdown();
+    };
   }, [playerClient]);
 
   return {


### PR DESCRIPTION
### Purpose

This PR resolves https://github.com/gravitational/teleport/issues/36817

Fixes a bug that crashed the WebUI when clicking the "Home" button on a recorded Desktop session.

This bug was caused due to our cleanup function for exiting the Desktop player not being written correctly.