### PR TITLE
Fix WebAuthn scope for device management and account recovery

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3044,7 +3044,8 @@ func (a *Server) CreateRegisterChallenge(ctx context.Context, req *proto.CreateR
 			return nil, trace.Wrap(err)
 		}
 
-		if _, err := a.validateMFAAuthResponseForRegister(ctx, req.ExistingMFAResponse, username); err != nil {
+		requiredExt := &mfav1.ChallengeExtensions{Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_MANAGE_DEVICES}
+		if _, err := a.validateMFAAuthResponseForRegister(ctx, req.ExistingMFAResponse, username, requiredExt); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -5919,7 +5920,7 @@ func groupByDeviceType(devs []*types.MFADevice, groupWebauthn bool) devicesByTyp
 // The hasDevices response value can only be trusted in the absence of errors.
 //
 // Use only for registration purposes.
-func (a *Server) validateMFAAuthResponseForRegister(ctx context.Context, resp *proto.MFAAuthenticateResponse, username string) (hasDevices bool, err error) {
+func (a *Server) validateMFAAuthResponseForRegister(ctx context.Context, resp *proto.MFAAuthenticateResponse, username string, requiredExtensions *mfav1.ChallengeExtensions) (hasDevices bool, err error) {
 	// Let users without a useable device go through registration.
 	if resp == nil || (resp.GetTOTP() == nil && resp.GetWebauthn() == nil) {
 		devices, err := a.Services.GetMFADevices(ctx, username, false /* withSecrets */)
@@ -5948,8 +5949,7 @@ func (a *Server) validateMFAAuthResponseForRegister(ctx context.Context, resp *p
 	}
 
 	if err := a.WithUserLock(ctx, username, func() error {
-		requiredExt := &mfav1.ChallengeExtensions{Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_MANAGE_DEVICES}
-		_, err := a.ValidateMFAAuthResponse(ctx, resp, username, requiredExt)
+		_, err := a.ValidateMFAAuthResponse(ctx, resp, username, requiredExtensions)
 		return err
 	}); err != nil {
 		return false, trace.Wrap(err)

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
@@ -470,7 +471,8 @@ func (a *Server) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePriv
 	}
 
 	tokenKind := UserTokenTypePrivilege
-	switch hasDevices, err := a.validateMFAAuthResponseForRegister(ctx, req.GetExistingMFAResponse(), username); {
+	requiredExt := &mfav1.ChallengeExtensions{Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_MANAGE_DEVICES}
+	switch hasDevices, err := a.validateMFAAuthResponseForRegister(ctx, req.GetExistingMFAResponse(), username, requiredExt); {
 	case err != nil:
 		return nil, trace.Wrap(err)
 	case !hasDevices:

--- a/web/packages/teleport/src/Account/AccountNew.tsx
+++ b/web/packages/teleport/src/Account/AccountNew.tsx
@@ -244,7 +244,7 @@ export function Account({
             onAuthenticated={setToken}
             onClose={hideReAuthenticate}
             actionText="registering a new device"
-            challengeScope={MfaChallengeScope.USER_SESSION}
+            challengeScope={MfaChallengeScope.MANAGE_DEVICES}
           />
         )}
         {isAddDeviceVisible && (

--- a/web/packages/teleport/src/Account/ManageDevices/ManageDevices.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/ManageDevices.tsx
@@ -106,7 +106,7 @@ export function ManageDevices({
           onAuthenticated={setToken}
           onClose={hideReAuthenticate}
           actionText="registering a new device"
-          challengeScope={MfaChallengeScope.USER_SESSION}
+          challengeScope={MfaChallengeScope.MANAGE_DEVICES}
         />
       )}
       {isAddDeviceVisible && (


### PR DESCRIPTION
Fixes the set/enforced WebAuthn scope for device management and account recovery.

Fixes https://github.com/gravitational/teleport/issues/37298
Fixes https://github.com/gravitational/teleport/issues/37299