### PR TITLE
AWS OIDC: remove config dependency in ExternalAuditStorage

### DIFF
--- a/api/types/externalauditstorage/config/config.go
+++ b/api/types/externalauditstorage/config/config.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// IntegrationConfExternalAuditStorage contains the arguments of the
+// `teleport integration configure externalauditstorage` command
+type IntegrationConfExternalAuditStorage struct {
+	// Bootstrap is whether to bootstrap infrastructure (default: false).
+	Bootstrap bool
+	// Region is the AWS Region used.
+	Region string
+	// Role is the AWS IAM Role associated with the OIDC integration.
+	Role string
+	// Policy is the name to use for the IAM policy.
+	Policy string
+	// SessionRecordingsURI is the S3 URI where session recordings are stored.
+	SessionRecordingsURI string
+	// AuditEventsURI is the S3 URI where audit events are stored.
+	AuditEventsURI string
+	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
+	AthenaResultsURI string
+	// AthenaWorkgroup is the name of the Athena workgroup used.
+	AthenaWorkgroup string
+	// GlueDatabase is the name of the Glue database used.
+	GlueDatabase string
+	// GlueTable is the name of the Glue table used.
+	GlueTable string
+	// Partition is the AWS partition to use (default: aws).
+	Partition string
+}

--- a/api/types/externalauditstorage/config/config.go
+++ b/api/types/externalauditstorage/config/config.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package config
 
-// IntegrationConfExternalAuditStorage contains the arguments of the
-// `teleport integration configure externalauditstorage` command
-type IntegrationConfExternalAuditStorage struct {
+// ExternalAuditStorageConfiguration contains the arguments to configure the
+// External Audit Storage.
+type ExternalAuditStorageConfiguration struct {
 	// Bootstrap is whether to bootstrap infrastructure (default: false).
 	Bootstrap bool
 	// Region is the AWS Region used.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	extauditconfig "github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -226,7 +225,7 @@ type CommandLineFlags struct {
 
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
-	IntegrationConfExternalAuditStorageArguments extauditconfig.ExternalAuditStorageConfiguration
+	IntegrationConfExternalAuditStorageArguments servicecfg.ExternalAuditStorageConfiguration
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -226,7 +226,7 @@ type CommandLineFlags struct {
 
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
-	IntegrationConfExternalAuditStorageArguments extauditconfig.IntegrationConfExternalAuditStorage
+	IntegrationConfExternalAuditStorageArguments extauditconfig.ExternalAuditStorageConfiguration
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -283,33 +283,6 @@ type IntegrationConfListDatabasesIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
-}
-
-// IntegrationConfExternalAuditStorage contains the arguments of the
-// `teleport integration configure externalauditstorage` command
-type IntegrationConfExternalAuditStorage struct {
-	// Bootstrap is whether to bootstrap infrastructure (default: false).
-	Bootstrap bool
-	// Region is the AWS Region used.
-	Region string
-	// Role is the AWS IAM Role associated with the OIDC integration.
-	Role string
-	// Policy is the name to use for the IAM policy.
-	Policy string
-	// SessionRecordingsURI is the S3 URI where session recordings are stored.
-	SessionRecordingsURI string
-	// AuditEventsURI is the S3 URI where audit events are stored.
-	AuditEventsURI string
-	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
-	AthenaResultsURI string
-	// AthenaWorkgroup is the name of the Athena workgroup used.
-	AthenaWorkgroup string
-	// GlueDatabase is the name of the Glue database used.
-	GlueDatabase string
-	// GlueTable is the name of the Glue table used.
-	GlueTable string
-	// Partition is the AWS partition to use (default: aws).
-	Partition string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	extauditconfig "github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -225,7 +226,7 @@ type CommandLineFlags struct {
 
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
-	IntegrationConfExternalAuditStorageArguments IntegrationConfExternalAuditStorage
+	IntegrationConfExternalAuditStorageArguments extauditconfig.IntegrationConfExternalAuditStorage
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config.go
@@ -30,9 +30,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/config"
 )
 
 // ConfigureExternalAuditStorageClient is an interface for the AWS client methods

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config.go
@@ -67,7 +67,7 @@ func (d *DefaultConfigureExternalAuditStorageClient) GetCallerIdentity(ctx conte
 func ConfigureExternalAuditStorage(
 	ctx context.Context,
 	clt ConfigureExternalAuditStorageClient,
-	params *config.IntegrationConfExternalAuditStorage,
+	params *config.ExternalAuditStorageConfiguration,
 ) error {
 	fmt.Println("\nConfiguring necessary IAM permissions for External Audit Storage")
 

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config.go
@@ -30,9 +30,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 // ConfigureExternalAuditStorageClient is an interface for the AWS client methods
@@ -67,7 +67,7 @@ func (d *DefaultConfigureExternalAuditStorageClient) GetCallerIdentity(ctx conte
 func ConfigureExternalAuditStorage(
 	ctx context.Context,
 	clt ConfigureExternalAuditStorageClient,
-	params *config.ExternalAuditStorageConfiguration,
+	params *servicecfg.ExternalAuditStorageConfiguration,
 ) error {
 	fmt.Println("\nConfiguring necessary IAM permissions for External Audit Storage")
 

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -42,7 +42,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc                 string
-		params               *config.IntegrationConfExternalAuditStorage
+		params               *config.ExternalAuditStorageConfiguration
 		stsAccount           string
 		existingRolePolicies map[string]map[string]string
 		expectedRolePolicies map[string]map[string]string
@@ -51,7 +51,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		{
 			// A passing case with the account from sts:GetCallerIdentity
 			desc: "passing",
-			params: &config.IntegrationConfExternalAuditStorage{
+			params: &config.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -131,7 +131,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "alternate partition and region",
-			params: &config.IntegrationConfExternalAuditStorage{
+			params: &config.ExternalAuditStorageConfiguration{
 				Partition:            "aws-cn",
 				Region:               "cn-north-1",
 				Role:                 "test-role",
@@ -211,7 +211,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "bad uri",
-			params: &config.IntegrationConfExternalAuditStorage{
+			params: &config.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -233,7 +233,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "role not found",
-			params: &config.IntegrationConfExternalAuditStorage{
+			params: &config.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "bad-role",

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -28,10 +28,9 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gravitational/teleport/api/types/externalauditstorage/config"
 )
 
 // TestConfigureExternalAuditStorage tests that ConfigureExternalAuditStorage
@@ -42,7 +41,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc                 string
-		params               *config.ExternalAuditStorageConfiguration
+		params               *servicecfg.ExternalAuditStorageConfiguration
 		stsAccount           string
 		existingRolePolicies map[string]map[string]string
 		expectedRolePolicies map[string]map[string]string
@@ -51,7 +50,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		{
 			// A passing case with the account from sts:GetCallerIdentity
 			desc: "passing",
-			params: &config.ExternalAuditStorageConfiguration{
+			params: &servicecfg.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -131,7 +130,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "alternate partition and region",
-			params: &config.ExternalAuditStorageConfiguration{
+			params: &servicecfg.ExternalAuditStorageConfiguration{
 				Partition:            "aws-cn",
 				Region:               "cn-north-1",
 				Role:                 "test-role",
@@ -211,7 +210,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "bad uri",
-			params: &config.ExternalAuditStorageConfiguration{
+			params: &servicecfg.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -233,7 +232,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "role not found",
-			params: &config.ExternalAuditStorageConfiguration{
+			params: &servicecfg.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "bad-role",

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -28,9 +28,10 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/go-cmp/cmp"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 // TestConfigureExternalAuditStorage tests that ConfigureExternalAuditStorage

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/api/types/externalauditstorage/config"
 )
 
 // TestConfigureExternalAuditStorage tests that ConfigureExternalAuditStorage

--- a/lib/service/servicecfg/externalauditstorage.go
+++ b/lib/service/servicecfg/externalauditstorage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package servicecfg
 
 // ExternalAuditStorageConfiguration contains the arguments to configure the
 // External Audit Storage.

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -45,7 +45,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
-	extauditconfig "github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/configurators"
@@ -1059,7 +1058,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params extauditconfig.ExternalAuditStorageConfiguration) error {
+func onIntegrationConfExternalAuditCmd(params servicecfg.ExternalAuditStorageConfiguration) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
+	extauditconfig "github.com/gravitational/teleport/api/types/externalauditstorage/config"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/configurators"
@@ -1058,7 +1059,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params config.IntegrationConfExternalAuditStorage) error {
+func onIntegrationConfExternalAuditCmd(params extauditconfig.IntegrationConfExternalAuditStorage) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1059,7 +1059,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params extauditconfig.IntegrationConfExternalAuditStorage) error {
+func onIntegrationConfExternalAuditCmd(params extauditconfig.ExternalAuditStorageConfiguration) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {


### PR DESCRIPTION
Currently the ExternalAuditStorage methods require the `config` package to re-use the configuration struct used in `teleport integration configure`

We are refactoring the AWS OIDC actions to use a gRPC Service. Importing the `config` package makes this refactoring a bit difficult because of a cycling dependency: `awsoidc` requires `config` which requires `auth` which will require the `awsoidc service` which requires the `awsoidc` package.

This PR removes the usage of the `config` package in `awsoidc` package.

Context: https://github.com/gravitational/teleport/issues/37245