### PR TITLE
Remove unused const in `auth` - TokenLenBytes

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6414,12 +6414,6 @@ func (k *authKeepAliver) Close() error {
 	return nil
 }
 
-const (
-	// TokenLenBytes is len in bytes of the invite token
-	// TODO(marco): remove const block when e/ code is no longer using it.
-	TokenLenBytes = 16
-)
-
 // githubClient is internal structure that stores Github OAuth 2client and its config
 type githubClient struct {
 	client *oauth2.Client


### PR DESCRIPTION
This const is no longer used because it was moved to defaults package. It was kept to ensure `/e/` didn't break.

Can only be merged after https://github.com/gravitational/teleport.e/pull/3246 is merged.