### PR TITLE
[v14] Always close io.Pipe when io.Copy is done (PostgresSQL engine)

### DIFF
--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -417,8 +417,6 @@ func (e *Engine) receiveFromServer(serverConn *pgconn.PgConn, serverErrCh chan<-
 	// parse and count the messages from the server in a separate goroutine,
 	// operating on a copy of the server message stream. the copy is arranged below.
 	copyReader, copyWriter := io.Pipe()
-	defer copyWriter.Close()
-
 	closeChan := make(chan struct{})
 
 	go func() {
@@ -459,6 +457,7 @@ func (e *Engine) receiveFromServer(serverConn *pgconn.PgConn, serverErrCh chan<-
 		log.WithError(err).Warn("Server -> Client copy finished with unexpected error.")
 	}
 
+	copyWriter.Close()
 	<-closeChan
 
 	serverErrCh <- trace.Wrap(err)

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -457,6 +457,11 @@ func (e *Engine) receiveFromServer(serverConn *pgconn.PgConn, serverErrCh chan<-
 		log.WithError(err).Warn("Server -> Client copy finished with unexpected error.")
 	}
 
+	// We need to close the writer half of the pipe to notify the analysis
+	// goroutine that the connection is done. This will result in the goroutine
+	// receiving an io.ErrClosedPipe error, which will cause it to finish its
+	// execution. After that, wait until the closeChan is closed to ensure the
+	// goroutine is completed, avoiding data races.
 	copyWriter.Close()
 	<-closeChan
 


### PR DESCRIPTION
Backport #37220 to branch/v14

changelog: Fix goroutine leak on PostgreSQL access.
