### PR TITLE
Update usage docs with the reporting endpoint

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -192,6 +192,7 @@
     "Swic",
     "Swicm",
     "TCPS",
+    "teleportinfra",
     "TELEPORTING",
     "TENANTID",
     "TESTDEVICE",

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -10,7 +10,7 @@ the billing metrics we calculate.
 ## Anonymized usage data
 
 The commercial editions of Teleport send anonymized information to Teleport's
-cloud infrastructure at `https://reporting-teleport.teleportinfra.sh`.
+cloud infrastructure at `reporting-teleport.teleportinfra.sh`.
 This information contains the following:
 
 - Teleport license identifier.

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -10,7 +10,8 @@ the billing metrics we calculate.
 ## Anonymized usage data
 
 The commercial editions of Teleport send anonymized information to Teleport's
-cloud infrastructure. This information contains the following:
+cloud infrastructure at `https://reporting-teleport.teleportinfra.sh`.
+This information contains the following:
 
 - Teleport license identifier.
 - Anonymized cluster name and Teleport Auth Service host ID.


### PR DESCRIPTION
adding the actual reporting endpoint to our public docs for customers who need to whitelist a specific outbound reporting endpoint