### PR TITLE
document role versions 5, 6 and 7

### DIFF
--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -103,6 +103,38 @@ Roles govern access to databases, SSH servers, Kubernetes clusters, web services
 
 (!docs/pages/includes/role-spec.mdx!)
 
+### Role versions
+
+Versions 5, 6 and 7 of the Teleport role resource have different behaviors when
+accessing Kubernetes resources.
+{/*lint ignore messaging*/}
+Roles not [granting Kubernetes access](../kubernetes-access/introduction.mdx) are
+equivalent in the three versions.
+
+Roles v5 and v6 can only restrict actions on pods (e.g. executing in them).
+Role v7 supports restricting all common resource kinds (
+see [the `kubernetes_resource` documentation](../kubernetes-access/controls.mdx#kubernetes_resources)
+for a complete list).
+
+When no `kubernetes_resource` is set:
+- Roles v5 and v7 grant all access by default
+- Roles v6 blocks pod execution by default, this was reverted by roles v7 to improve the user experience.
+
+{/* This table is cursed. Our current docs engine doesn't support HTML tables
+(due to SSR and the rehydration process). We have dto do everything inlined in
+markdown. Some HTML character codes are used to render specific chars like {}
+or to avoid line breaks in the middle fo the YAML. Whitespaces before br tags
+are required.*/}
+
+| Allow rule                                                                                                                                                                                                                                                                | Role v5                                                                                                           | Role v6                                                                                                           | Role v7                                                                                                                                                                                               |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <pre>kubernetes_groups: <br/>  - "system:masters" <br/>kubernetes_labels: &#123;&#125; <br/>kubernetes_resources:&nbsp;[]<br/></pre>                                                                                                                                      | ❌ no access                                                                                                       | ❌ no access                                                                                                       | ❌ no access                                                                                                                                                                                           |
+| <pre>kubernetes_groups: <br/>  - "system:masters" <br/>kubernetes_labels: <br/>  env: ["dev"] <br/>kubernetes_resources:&nbsp;[]<br/></pre>                                                                                                                               | ✅ full access to `dev` clusters                                                                                   | ❌ cannot exec in pods <br/> ✅ can access other <br/>resources like `secrets`                                      | ✅ full access to `dev` clusters                                                                                                                                                                       |
+| <pre>kubernetes_groups: <br/>  - "system:masters" <br/>kubernetes_labels: <br/>  env: ["dev"] <br/>kubernetes_resources: <br/>  - name: "&ast;" <br/>    kind: pod <br/>    namespace: "foo"</pre>                                                                        | ✅ can exec in pods in `foo` <br/>✅ can access `secrets` in all namespaces. <br/>❌ cannot exec in other namespaces | ✅ can exec in pods in `foo` <br/>✅ can access `secrets` in all namespaces. <br/>❌ cannot exec in other namespaces | ✅ can exec in pods in `foo` <br/>❌ cannot access `secrets` in all namespaces <br/>❌ cannot exec in other namespaces                                                                                   |
+| <pre>kubernetes_groups: <br/>  - "system:masters" <br/>kubernetes_labels: <br/>  env: ["dev"] <br/>kubernetes_resources: <br/>  - name: "&ast;" <br/>    kind: pod <br/>    namespace: "foo" <br/>  - name: "&ast;" <br/>    kind: secret <br/>    namespace: "foo"</pre> | ⚠️ not supported                                                                                                  | ⚠️ not supported                                                                                                  | ✅ can exec in pods in `foo` <br/>✅ can access `secrets` in `foo` <br/>❌ cannot exec in other namespaces <br/>❌ cannot access `secrets` in other namespaces <br/>❌ cannot access `configmaps` in `foo` |
+| <pre>kubernetes_groups: <br/>  - "system:masters" <br/>kubernetes_labels: <br/>  env: ["dev"] <br/>kubernetes_resources: <br/>  - kind: "namespace" <br/>    name: "foo"</pre>                                                                                            | ⚠️ not supported                                                                                                  | ⚠️ not supported                                                                                                  | ✅ full access in namespace `foo` <br/>❌ cannot access other namespaces                                                                                                                                |
+
+
 ## Windows desktop
 
 In most cases, Teleport will register `windows_desktop` resources automatically


### PR DESCRIPTION
This PR adds a few examples demonstrating how the role version and `kubernetes_resources` interact with each other.