### PR TITLE
Properly display username in mfa auth audit log events

### DIFF
--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -745,20 +745,18 @@ export const formatters: Formatters = {
   [eventCodes.CREATE_MFA_AUTH_CHALLENGE]: {
     type: 'mfa_auth_challenge.create',
     desc: 'MFA Authentication Attempt',
-    format: ({ updated_by }) =>
-      `User [${updated_by}] requested an MFA authentication challenge`,
+    format: ({ user }) =>
+      `User [${user}] requested an MFA authentication challenge`,
   },
   [eventCodes.VALIDATE_MFA_AUTH_RESPONSE]: {
     type: 'mfa_auth_challenge.validate',
     desc: 'MFA Authentication Success',
-    format: ({ updated_by }) =>
-      `User [${updated_by}] completed MFA authentication`,
+    format: ({ user }) => `User [${user}] completed MFA authentication`,
   },
   [eventCodes.VALIDATE_MFA_AUTH_RESPONSEFAILURE]: {
     type: 'mfa_auth_challenge.validate',
     desc: 'MFA Authentication Failure',
-    format: ({ updated_by }) =>
-      `User [${updated_by}] failed MFA authentication`,
+    format: ({ user }) => `User [${user}] failed MFA authentication`,
   },
   [eventCodes.ROLE_CREATED]: {
     type: 'role.created',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1491,19 +1491,19 @@ export type RawEvents = {
   [eventCodes.CREATE_MFA_AUTH_CHALLENGE]: RawEvent<
     typeof eventCodes.CREATE_MFA_AUTH_CHALLENGE,
     {
-      updated_by: string;
+      user: string;
     }
   >;
   [eventCodes.VALIDATE_MFA_AUTH_RESPONSE]: RawEvent<
     typeof eventCodes.VALIDATE_MFA_AUTH_RESPONSE,
     {
-      updated_by: string;
+      user: string;
     }
   >;
   [eventCodes.VALIDATE_MFA_AUTH_RESPONSEFAILURE]: RawEvent<
     typeof eventCodes.VALIDATE_MFA_AUTH_RESPONSEFAILURE,
     {
-      updated_by: string;
+      user: string;
     }
   >;
 };


### PR DESCRIPTION
Before:
![image](https://github.com/gravitational/teleport/assets/16672031/49fc0342-4440-4c63-935d-0fb9f4c0e9cf)

After:
![image](https://github.com/gravitational/teleport/assets/16672031/1b451293-cf61-4ea6-b71b-bbd5aad4a7ab)