### PR TITLE
Refactor admin MFA ceremony - don't create an MFA challenge the client can't solve

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -480,7 +480,7 @@ func (c *Client) dialGRPC(ctx context.Context, addr string) error {
 			otelUnaryClientInterceptor(),
 			metadata.UnaryClientInterceptor,
 			interceptors.GRPCClientUnaryErrorInterceptor,
-			interceptors.WithMFAUnaryInterceptor(c),
+			interceptors.WithMFAUnaryInterceptor(c.PerformMFACeremony),
 			breaker.UnaryClientInterceptor(cb),
 		),
 		grpc.WithChainStreamInterceptor(

--- a/api/client/mfa.go
+++ b/api/client/mfa.go
@@ -31,7 +31,7 @@ import (
 func (c *Client) PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
 	// Don't attempt the MFA ceremony if we can't prompt for a response.
 	if c.c.MFAPromptConstructor == nil {
-		return nil, trace.BadParameter("missing MFAPromptConstructor field, client cannot perform MFA ceremony")
+		return nil, trace.Wrap(&mfa.ErrMFANotSupported, "missing MFAPromptConstructor field, client cannot perform MFA ceremony")
 	}
 
 	return mfa.PerformMFACeremony(ctx, c, challengeRequest, promptOpts...)
@@ -40,7 +40,7 @@ func (c *Client) PerformMFACeremony(ctx context.Context, challengeRequest *proto
 // PromptMFA prompts the user for MFA. Implements [mfa.MFACeremonyClient].
 func (c *Client) PromptMFA(ctx context.Context, chal *proto.MFAAuthenticateChallenge, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
 	if c.c.MFAPromptConstructor == nil {
-		return nil, trace.BadParameter("missing MFAPromptConstructor field, client cannot prompt for MFA")
+		return nil, trace.Wrap(&mfa.ErrMFANotSupported, "missing MFAPromptConstructor field, client cannot prompt for MFA")
 	}
 
 	return c.c.MFAPromptConstructor(promptOpts...).Run(ctx, chal)

--- a/api/client/mfa.go
+++ b/api/client/mfa.go
@@ -25,7 +25,19 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 )
 
-// PromptMFA prompts the user for MFA.
+// PerformMFACeremony retrieves an MFA challenge from the server with the given challenge extensions
+// and prompts the user to answer the challenge with the given promptOpts, and ultimately returning
+// an MFA challenge response for the user.
+func (c *Client) PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	// Don't attempt the MFA ceremony if we can't prompt for a response.
+	if c.c.MFAPromptConstructor == nil {
+		return nil, trace.BadParameter("missing MFAPromptConstructor field, client cannot perform MFA ceremony")
+	}
+
+	return mfa.PerformMFACeremony(ctx, c, challengeRequest, promptOpts...)
+}
+
+// PromptMFA prompts the user for MFA. Implements [mfa.MFACeremonyClient].
 func (c *Client) PromptMFA(ctx context.Context, chal *proto.MFAAuthenticateChallenge, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
 	if c.c.MFAPromptConstructor == nil {
 		return nil, trace.BadParameter("missing MFAPromptConstructor field, client cannot prompt for MFA")

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -53,10 +53,10 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 	chal, err := clt.CreateAuthenticateChallenge(ctx, challengeRequest)
 	if err != nil {
 		// CreateAuthenticateChallenge returns a bad parameter error when the the client
-		// user is not a Teleport user. For example, the AdminRole. Treat this as a false
-		// MFA required check if a check was requested.
+		// user is not a Teleport user - for example, the AdminRole. Treat this as an MFA
+		// not supported error so the client knows when it can be ignored.
 		if trace.IsBadParameter(err) {
-			return nil, &ErrMFANotRequired
+			return nil, &ErrMFANotSupported
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -70,9 +70,11 @@ func PerformMFACeremony(ctx context.Context, clt MFACeremonyClient, challengeReq
 	return clt.PromptMFA(ctx, chal, promptOpts...)
 }
 
+type MFACeremony func(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...PromptOpt) (*proto.MFAAuthenticateResponse, error)
+
 // PerformAdminActionMFACeremony retrieves an MFA challenge from the server for an admin
 // action, prompts the user to answer the challenge, and returns the resulting MFA response.
-func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, allowReuse bool) (*proto.MFAAuthenticateResponse, error) {
+func PerformAdminActionMFACeremony(ctx context.Context, mfaCeremony MFACeremony, allowReuse bool) (*proto.MFAAuthenticateResponse, error) {
 	allowReuseExt := mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
 	if allowReuse {
 		allowReuseExt = mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES
@@ -91,5 +93,5 @@ func PerformAdminActionMFACeremony(ctx context.Context, clt MFACeremonyClient, a
 		},
 	}
 
-	return PerformMFACeremony(ctx, clt, challengeRequest, WithPromptReasonAdminAction())
+	return mfaCeremony(ctx, challengeRequest, WithPromptReasonAdminAction())
 }

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -39,9 +39,13 @@ var (
 	ErrAdminActionMFARequired = trace.AccessDeniedError{Message: "admin-level API request requires MFA verification"}
 
 	// ErrMFANotRequired is returned by MFA ceremonies when it is discovered or
-	// inferred that the MFA ceremony is not necessary. This is usually because
-	// the server does require/support MFA for the user.
+	// inferred that an MFA ceremony is not required by the server.
 	ErrMFANotRequired = trace.BadParameterError{Message: "re-authentication with MFA is not required"}
+
+	// ErrMFANotSupported is returned by MFA ceremonies when the client does not
+	// support MFA ceremonies, or the server does not support MFA ceremonies for
+	// the client user.
+	ErrMFANotSupported = trace.BadParameterError{Message: "re-authentication with MFA is not supported for this client"}
 )
 
 // WithCredentials can be called on a GRPC client request to attach

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -31,7 +31,7 @@ import (
 // to the rpc call when an MFA response is provided through the context. Additionally,
 // when the call returns an error that indicates that MFA is required, this interceptor
 // will prompt for MFA using the given mfaCeremony and retry.
-func WithMFAUnaryInterceptor(clt mfa.MFACeremonyClient) grpc.UnaryClientInterceptor {
+func WithMFAUnaryInterceptor(mfaCeremony mfa.MFACeremony) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		// Check for MFA response passed through the context.
 		if mfaResp, err := mfa.MFAResponseFromContext(ctx); err == nil {
@@ -53,7 +53,7 @@ func WithMFAUnaryInterceptor(clt mfa.MFACeremonyClient) grpc.UnaryClientIntercep
 
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"
-		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, clt, false /*allowReuse*/)
+		mfaResp, ceremonyErr := mfa.PerformAdminActionMFACeremony(ctx, mfaCeremony, false /*allowReuse*/)
 		if ceremonyErr != nil {
 			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
 		}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -997,6 +997,8 @@ type ClientI interface {
 	// but may result in confusing behavior if it is used outside of those contexts.
 	GetSSHTargets(ctx context.Context, req *proto.GetSSHTargetsRequest) (*proto.GetSSHTargetsResponse, error)
 
-	// PromptMFA prompts the user for MFA.
-	PromptMFA(ctx context.Context, chal *proto.MFAAuthenticateChallenge, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
+	// PerformMFACeremony retrieves an MFA challenge from the server with the given challenge extensions
+	// and prompts the user to answer the challenge with the given promptOpts, and ultimately returning
+	// an MFA challenge response for the user.
+	PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
 }

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -306,7 +306,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
-	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {
+	} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -303,7 +303,7 @@ func (c *BotsCommand) addBotLegacy(ctx context.Context, client auth.ClientI) err
 // AddBot adds a new certificate renewal bot to the cluster.
 func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
-	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
+	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -300,7 +300,7 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 	user.SetRoles(u.allowedRoles)
 
 	// Prompt for admin action MFA if required, allowing reuse for CreateResetPasswordToken.
-	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client, true /*allowReuse*/)
+	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -303,7 +303,7 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
 		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
-	} else if !errors.Is(err, &mfa.ErrMFANotRequired) {
+	} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
After https://github.com/gravitational/teleport/pull/36996/files, clients which don't have an MFA prompt constructor (like in the WebUI) would create an MFA auth challenge before realizing it can't prompt for a response. This would lead to two challenges being created back to back (one from the failure and one from the admin action mfa retry). This refactor removes the first unused challenge creation.

```
2024-01-26T12:44:50-08:00 DEBU             Retrying API request "UpdateUser" with Admin MFA interceptors/mfa.go:52
2024-01-26T12:44:50-08:00 INFO [AUDIT]     mfa_auth_challenge.create challenge_allow_reuse:false challenge_scope:CHALLENGE_SCOPE_ADMIN_ACTION cluster_name:root.example.com code:T1015I ei:0 event:mfa_auth_challenge.create time:2024-01-26T20:44:50.704Z uid:ab1dc476-99b4-4fd2-ace3-4206ff2d1e53 user:dev user_kind:1 events/emitter.go:278
2024-01-26T12:44:50-08:00 INFO [AUDIT]     mfa_auth_challenge.create challenge_allow_reuse:false challenge_scope:CHALLENGE_SCOPE_ADMIN_ACTION cluster_name:root.example.com code:T1015I ei:0 event:mfa_auth_challenge.create time:2024-01-26T20:44:50.709Z uid:ec57bdc3-e1a0-4cd5-9738-8c9c241f95a9 user:dev user_kind:1 events/emitter.go:278
2024-01-26T12:45:05-08:00 INFO [AUDIT]     mfa_auth_challenge.validate challenge_allow_reuse:false challenge_scope:CHALLENGE_SCOPE_ADMIN_ACTION cluster_name:root.example.com code:T1016I ei:0 event:mfa_auth_challenge.validate mfa_device_name:webauthn-device mfa_device_type:WebAuthn mfa_device_uuid:42c0f1f1-11b0-4142-abe5-0e299c46d9d1 success:true time:2024-01-26T20:45:05.681Z uid:12dea516-c0ac-4b57-a294-4ee67e66dfa0 user:dev user_kind:1 events/emitter.go:278
```

Note: this doesn't cause any bugs that I know of, just a useless roundtrip and audit log spam.