### PR TITLE
Fix Web Edit User

### DIFF
--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -125,9 +125,6 @@ type mfaResponseContextKey struct{}
 
 // ContextWithMFAResponse embeds the MFA response in the context.
 func ContextWithMFAResponse(ctx context.Context, mfaResp *proto.MFAAuthenticateResponse) context.Context {
-	if mfaResp == nil {
-		return ctx
-	}
 	return context.WithValue(ctx, mfaResponseContextKey{}, mfaResp)
 }
 

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -159,6 +159,8 @@ func updateUser(r *http.Request, m userAPIGetter, createdBy string) (*ui.User, e
 	// Remove the MFA resp from the context before getting the user.
 	// Otherwise, it will be consumed before the Update which actually
 	// requires the MFA.
+	// TODO(Joerger): Explicitly provide MFA response only where it is
+	// needed instead of removing it like this.
 	getUserCtx := mfa.ContextWithMFAResponse(r.Context(), nil)
 	user, err := m.GetUser(getUserCtx, req.Name, false)
 	if err != nil {


### PR DESCRIPTION
Fixes a regression where updating a user in the WebUI would return an access denied error even with MFA provided. Caused by https://github.com/gravitational/teleport/pull/36996.

This is a temporary fix, and the long term solution will be to pass the MFA response explicitly for admin actions from the Web server, instead of stripping it out of the context for non-admin actions.