### PR TITLE
Use cache for listing app sessions

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -973,6 +973,9 @@ type Cache interface {
 	// GetAppSession gets an application web session.
 	GetAppSession(context.Context, types.GetAppSessionRequest) (types.WebSession, error)
 
+	// ListAppSessions returns a page of application web sessions.
+	ListAppSessions(ctx context.Context, pageSize int, pageToken, user string) ([]types.WebSession, string, error)
+
 	// GetSnowflakeSession gets a Snowflake web session.
 	GetSnowflakeSession(context.Context, types.GetSnowflakeSessionRequest) (types.WebSession, error)
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2292,6 +2292,19 @@ func (c *Cache) GetAppSession(ctx context.Context, req types.GetAppSessionReques
 	return sess, trace.Wrap(err)
 }
 
+// ListAppSessions returns a page of application web sessions.
+func (c *Cache) ListAppSessions(ctx context.Context, pageSize int, pageToken, user string) ([]types.WebSession, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListAppSessions")
+	defer span.End()
+
+	rg, err := readCollectionCache(c, c.collections.appSessions)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.reader.ListAppSessions(ctx, pageSize, pageToken, user)
+}
+
 // GetSnowflakeSession gets Snowflake web session.
 func (c *Cache) GetSnowflakeSession(ctx context.Context, req types.GetSnowflakeSessionRequest) (types.WebSession, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetSnowflakeSession")

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1466,6 +1466,7 @@ func (appSessionExecutor) getReader(cache *Cache, cacheOK bool) appSessionGetter
 
 type appSessionGetter interface {
 	GetAppSession(ctx context.Context, req types.GetAppSessionRequest) (types.WebSession, error)
+	ListAppSessions(ctx context.Context, pageSize int, pageToken, user string) ([]types.WebSession, string, error)
 }
 
 var _ executor[types.WebSession, appSessionGetter] = appSessionExecutor{}


### PR DESCRIPTION
ListAppSessions was never added to the `auth.Cache` interface or implemented by `cache.Cache` which means all session listing was using the backend as the data source. This could cause backend throttling if the number of sessions was large enough.


changelog: Prevent backend throttling caused by a large number of app sessions