### PR TITLE
Change Labs invite

### DIFF
--- a/docs/pages/application-access/introduction.mdx
+++ b/docs/pages/application-access/introduction.mdx
@@ -51,7 +51,7 @@ These guides explain how to protect internal applications with Teleport:
 - [TCP App Access](./guides/tcp.mdx): How to access plain TCP apps with Teleport.
 - [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport.
 - [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
-- [Interactive Lab](https://play.instruqt.com/teleport/invite/rgvuva4gzkon): Try Teleport using our guided Teleport application access lab.
+- [Interactive Lab](https://goteleport.com/labs/): Try Teleport using our guided Teleport application access lab.
 
 ## Automatically enroll Kubernetes applications 
 

--- a/docs/pages/includes/application-access/aws-database-prerequisites.mdx
+++ b/docs/pages/includes/application-access/aws-database-prerequisites.mdx
@@ -9,7 +9,7 @@
 - (!docs/pages/includes/tctl.mdx!)
 
 <Admonition type="tip" title="Not yet a Teleport user?">
-If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../../application-access/getting-started.mdx) or try our Teleport application access [interactive learning track](https://play.instruqt.com/teleport/invite/rgvuva4gzkon).
+If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../../application-access/getting-started.mdx) or try our Teleport application access [interactive learning track](https://goteleport.com/labs/).
 </Admonition>
 
 We will assume your Teleport cluster is accessible at `teleport.example.com` and `*.teleport.example.com`. You can substitute the address of your Teleport Proxy Service. (For Teleport Cloud customers, this will be similar to `mytenant.teleport.sh`.)


### PR DESCRIPTION
This PR changes the invite link to our labs page, since I found that this link was letting anonymous users into the labs. 