### PR TITLE
[v15] Allow setting metadata via `types.SAMLConnector` interface

### DIFF
--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -34,6 +34,9 @@ type SAMLConnector interface {
 	// ResourceWithSecrets provides common methods for objects
 	ResourceWithSecrets
 	ResourceWithOrigin
+
+	// SetMetadata sets the connector metadata
+	SetMetadata(Metadata)
 	// GetDisplay returns display - friendly name for this provider.
 	GetDisplay() string
 	// SetDisplay sets friendly name for this provider.
@@ -247,6 +250,11 @@ func (o *SAMLConnectorV2) SetDisplay(display string) {
 // GetMetadata returns object metadata
 func (o *SAMLConnectorV2) GetMetadata() Metadata {
 	return o.Metadata
+}
+
+// SetMetadata sets object metadata
+func (o *SAMLConnectorV2) SetMetadata(m Metadata) {
+	o.Metadata = m
 }
 
 // Origin returns the origin value of the resource.


### PR DESCRIPTION
Backport #37309 to branch/v15