### PR TITLE
Use MoreVert instead of ChevronDown for web app button in Connect

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -20,8 +20,11 @@ import * as tsh from './types';
 
 import type { App } from 'teleterm/ui/services/clusters';
 
+export const rootClusterUri = '/clusters/teleport-local';
+export const leafClusterUri = `${rootClusterUri}/leaves/leaf`;
+
 export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
-  uri: '/clusters/teleport-local/servers/1234abcd-1234-abcd-1234-abcd1234abcd',
+  uri: `${rootClusterUri}/servers/1234abcd-1234-abcd-1234-abcd1234abcd`,
   tunnel: false,
   name: '1234abcd-1234-abcd-1234-abcd1234abcd',
   hostname: 'foo',
@@ -31,8 +34,9 @@ export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
   ...props,
 });
 
-export const databaseUri = '/clusters/teleport-local/dbs/foo';
-export const kubeUri = '/clusters/teleport-local/kubes/foo';
+export const databaseUri = `${rootClusterUri}/dbs/foo`;
+export const kubeUri = `${rootClusterUri}/kubes/foo`;
+export const appUri = `${rootClusterUri}/apps/foo`;
 
 export const makeDatabase = (
   props: Partial<tsh.Database> = {}
@@ -51,7 +55,7 @@ export const makeDatabase = (
 export const makeKube = (props: Partial<tsh.Kube> = {}): tsh.Kube => ({
   name: 'foo',
   labels: [],
-  uri: '/clusters/bar/kubes/foo',
+  uri: `${rootClusterUri}/kubes/foo`,
   ...props,
 });
 
@@ -65,7 +69,7 @@ export const makeApp = (props: Partial<tsh.App> = {}): App => ({
   publicAddr: 'local-app.example.com:3000',
   fqdn: 'local-app.example.com:3000',
   samlApp: false,
-  uri: '/clusters/bar/apps/foo',
+  uri: appUri,
   addrWithProtocol: 'tcp://local-app.example.com:3000',
   awsRoles: [],
   ...props,
@@ -77,7 +81,7 @@ export const makeLabelsList = (labels: Record<string, string>): tsh.Label[] =>
 export const makeRootCluster = (
   props: Partial<tsh.Cluster> = {}
 ): tsh.Cluster => ({
-  uri: '/clusters/teleport-local',
+  uri: rootClusterUri,
   name: 'teleport-local',
   connected: true,
   leaf: false,
@@ -91,7 +95,7 @@ export const makeRootCluster = (
 export const makeLeafCluster = (
   props: Partial<tsh.Cluster> = {}
 ): tsh.Cluster => ({
-  uri: '/clusters/teleport-local/leaves/leaf',
+  uri: leafClusterUri,
   name: 'teleport-local-leaf',
   connected: true,
   leaf: true,
@@ -267,7 +271,7 @@ export const makeAppGateway = (
 ): tsh.Gateway => ({
   uri: '/gateways/bar',
   targetName: 'sales-production',
-  targetUri: '/clusters/bar/apps/foo',
+  targetUri: appUri,
   localAddress: 'localhost',
   localPort: '1337',
   targetSubresourceName: 'bar',

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -51,6 +51,10 @@ export function ActionButtons() {
           <Text>Web app</Text>
           <HttpApp />
         </Box>
+        <Box>
+          <Text>AWS console</Text>
+          <AwsConsole />
+        </Box>
       </Flex>
       <Box>
         <Text>Server</Text>
@@ -104,6 +108,33 @@ function HttpApp() {
       <ConnectAppActionButton
         app={makeApp({
           endpointUri: 'http://localhost:3000',
+          uri: `${testCluster.uri}/apps/bar`,
+        })}
+      />
+    </MockAppContextProvider>
+  );
+}
+
+function AwsConsole() {
+  const appContext = new MockAppContext();
+  const testCluster = makeRootCluster();
+  appContext.workspacesService.setState(d => {
+    d.rootClusterUri = testCluster.uri;
+  });
+  appContext.clustersService.setState(d => {
+    d.clusters.set(testCluster.uri, testCluster);
+  });
+
+  return (
+    <MockAppContextProvider appContext={appContext}>
+      <ConnectAppActionButton
+        app={makeApp({
+          endpointUri: 'cloud://localhost:3000',
+          awsConsole: true,
+          awsRoles: [
+            { arn: 'foo', display: 'foo', name: 'foo' },
+            { arn: 'bar', display: 'bar', name: 'bar' },
+          ],
           uri: `${testCluster.uri}/apps/bar`,
         })}
       />

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -129,7 +129,7 @@ function AwsConsole() {
     <MockAppContextProvider appContext={appContext}>
       <ConnectAppActionButton
         app={makeApp({
-          endpointUri: 'cloud://localhost:3000',
+          endpointUri: 'https://localhost:3000',
           awsConsole: true,
           awsRoles: [
             { arn: 'foo', display: 'foo', name: 'foo' },

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -20,7 +20,7 @@ import React, { useState, useRef } from 'react';
 import { MenuLogin, MenuLoginProps } from 'shared/components/MenuLogin';
 import { AwsLaunchButton } from 'shared/components/AwsLaunchButton';
 import { ButtonBorder, MenuItem, Flex } from 'design';
-import { ChevronDown } from 'design/Icon';
+import * as icons from 'design/Icon';
 import Menu from 'design/Menu';
 
 import {
@@ -266,7 +266,11 @@ function AppButton(props: {
           size="small"
           onClick={() => setIsOpen(true)}
         >
-          <ChevronDown size="small" color="text.slightlyMuted" />
+          {/*
+            Using MoreVert instead of ChevronDown to make this button visually distinct from the
+            button that launches an AWS app.
+          */}
+          <icons.MoreVert size="small" color="text.slightlyMuted" />
         </ButtonBorder>
         <Menu
           anchorEl={ref.current}

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -32,6 +32,8 @@ import {
   makeServer,
   makeDatabase,
   makeKube,
+  rootClusterUri,
+  leafClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
 
 import { ResourcesService } from 'teleterm/ui/services/resources';
@@ -49,12 +51,12 @@ export default {
 };
 
 const rootClusterDoc = makeDocumentCluster({
-  clusterUri: '/clusters/localhost',
+  clusterUri: rootClusterUri,
   uri: '/docs/123',
 });
 
 const leafClusterDoc = makeDocumentCluster({
-  clusterUri: '/clusters/localhost/leaves/foo',
+  clusterUri: leafClusterUri,
   uri: '/docs/456',
 });
 
@@ -211,7 +213,7 @@ export const OnlineLoadedResources = () => {
           {
             kind: 'server',
             resource: makeServer({
-              uri: '/clusters/foo/servers/1234',
+              uri: `${rootClusterUri}/servers/1234`,
               hostname: 'bar',
               tunnel: true,
             }),

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -235,7 +235,7 @@ export const OnlineLoadedResources = () => {
             resource: {
               ...makeApp(),
               name: 'AWS console',
-              endpointUri: 'cloud://localhost:8080',
+              endpointUri: 'https://localhost:8080',
               awsConsole: true,
               awsRoles: [
                 { arn: 'foo', display: 'foo', name: 'foo' },

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -32,6 +32,7 @@ import {
   makeServer,
   makeDatabase,
   makeKube,
+  makeApp,
   rootClusterUri,
   leafClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
@@ -220,6 +221,28 @@ export const OnlineLoadedResources = () => {
           },
           { kind: 'database', resource: makeDatabase() },
           { kind: 'kube', resource: makeKube() },
+          { kind: 'app', resource: { ...makeApp(), name: 'TCP app' } },
+          {
+            kind: 'app',
+            resource: {
+              ...makeApp(),
+              name: 'HTTP app',
+              endpointUri: 'http://localhost:8080',
+            },
+          },
+          {
+            kind: 'app',
+            resource: {
+              ...makeApp(),
+              name: 'AWS console',
+              endpointUri: 'cloud://localhost:8080',
+              awsConsole: true,
+              awsRoles: [
+                { arn: 'foo', display: 'foo', name: 'foo' },
+                { arn: 'bar', display: 'bar', name: 'bar' },
+              ],
+            },
+          },
         ],
         totalCount: 4,
         nextKey: '',


### PR DESCRIPTION
#37323 adds AWS apps to Connect and with them comes a third variation of a button for launching apps in Connect. Take a look at the last three items in the before screenshot.

The buttons for the HTTP app and the AWS app look almost the same, bar a vertical bar. Clicking on the AWS button opens a list of IAM roles to choose from (similar to clicking the button for the SSH node which opens a list of logins). The button for the HTTP app on the other hand opens a menu of additional actions, similar to additional actions in the top bar or in the Connect My Computer tab.

To make those two buttons more visually distinct, this PR changes the icon for the HTTP app from a chevron to vertical dots, mirroring other buttons in the app that display additional actions.

| Before | After |
| --- | --- |
| <img width="574" alt="before" src="https://github.com/gravitational/teleport/assets/27113/389b12ff-ffe5-494e-91c7-22d99ae1be27"> | <img width="574" alt="after" src="https://github.com/gravitational/teleport/assets/27113/6ff2a2b1-672c-44c2-8bae-17a6f187f5d3"> |

The screenshots come from the DocumentCluster story.