### PR TITLE
Set the content's correct width when the navigation is hidden

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -178,6 +178,9 @@ export function Main(props: MainProps) {
   const requiresOnboarding =
     onboard && !onboard.hasResource && !onboard.notified;
   const displayOnboardDiscover = requiresOnboarding && showOnboardDiscover;
+  const hasSidebar =
+    feature?.category === NavigationCategory.Management &&
+    !feature?.hideNavigation;
 
   return (
     <FeaturesContextProvider value={features}>
@@ -198,7 +201,7 @@ export function Main(props: MainProps) {
           <Navigation />
           <HorizontalSplit
             dockedView={showAssist && viewMode === AssistViewMode.DOCKED}
-            hasSidebar={feature?.category === NavigationCategory.Management}
+            hasSidebar={hasSidebar}
           >
             <ContentMinWidth>
               <BannerList


### PR DESCRIPTION
`hasSidebar` didn't take into account `feature.hideNavigation` which made TAG have a gap on the right hand side

<img width="3312" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/52df29f6-e90e-4f5b-ab69-ac6824b3fc30">

This change sets `hasSidebar` to false when `feature.hideNavigation` is `true`

Fixes https://github.com/gravitational/access-graph/issues/418