### PR TITLE
Skip empty or invalid proxy hosts during allowlisting

### DIFF
--- a/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
+++ b/web/packages/teleterm/src/mainProcess/rootClusterProxyHostAllowList.ts
@@ -72,6 +72,10 @@ export function manageRootClusterProxyHostAllowList({
 
     allowList.clear();
     for (const rootCluster of rootClusters) {
+      if (!rootCluster.proxyHost) {
+        continue;
+      }
+
       let browserProxyHost: string;
       try {
         browserProxyHost = proxyHostToBrowserProxyHost(rootCluster.proxyHost);
@@ -80,7 +84,7 @@ export function manageRootClusterProxyHostAllowList({
           'Ran into an error when converting proxy host to browser proxy host',
           error
         );
-        return;
+        continue;
       }
 
       allowList.add(browserProxyHost);


### PR DESCRIPTION
The main process of the Electron app in Connect needs to maintain a list of hosts of the currently added proxies. This is in order to allow opening new browser windows to those proxies but not other, potentially malicious domains in case an attacker gains control of the renderer process.

`proxyHost` is empty when the customer adds a new cluster in the app but are yet to log in. The current code throws on empty proxy hosts which doesn't crash the app, but it completely clears the allowlist.

Instead, clusters with empty `proxyHost` should be skipped. Similarly, if there's an error when parsing a proxy host, we should just reject that proxy host and still process others.