### PR TITLE
[v15] Fix an issue `tsh` uses wrong default username for auto-user provisioning enabled databases in remote clusters

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -598,7 +598,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 
 	// The user is prefixed with "remote-" and suffixed with cluster name with
 	// the hope that it does not match a real local user.
-	user, err := types.NewUser(fmt.Sprintf("remote-%v-%v", u.Username, u.ClusterName))
+	user, err := types.NewUser(services.UsernameForRemoteCluster(u.Username, u.ClusterName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -349,7 +349,7 @@ func NewAccessCheckerForRemoteCluster(ctx context.Context, localAccessInfo *Acce
 	}
 
 	remoteAccessInfo := &AccessInfo{
-		Username: localAccessInfo.Username,
+		Username: remoteUser.GetName(),
 		Traits:   remoteUser.GetTraits(),
 		// Will fill this in with the names of the remote/mapped roles we got
 		// from GetCurrentUserRoles.

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -7697,6 +7697,23 @@ func (u mockCurrentUser) GetName() string {
 	return "mockCurrentUser"
 }
 
+func (u mockCurrentUser) toRemoteUserFromCluster(localClusterName string) types.User {
+	return mockRemoteUser{
+		mockCurrentUser:  u,
+		localClusterName: localClusterName,
+	}
+}
+
+type mockRemoteUser struct {
+	mockCurrentUser
+	localClusterName string
+}
+
+// GetName returns the username from the remote cluster's view.
+func (u mockRemoteUser) GetName() string {
+	return UsernameForRemoteCluster(u.mockCurrentUser.GetName(), u.localClusterName)
+}
+
 func TestNewAccessCheckerForRemoteCluster(t *testing.T) {
 	user := mockCurrentUser{
 		roles: []string{"dev", "admin"},
@@ -7718,12 +7735,12 @@ func TestNewAccessCheckerForRemoteCluster(t *testing.T) {
 			"dev":   devRole,
 			"admin": adminRole,
 		},
-		currentUser: user,
+		currentUser: user.toRemoteUserFromCluster("localCluster"),
 	}
 
-	accessInfo := AccessInfoFromUserState(user)
-	require.Equal(t, "mockCurrentUser", accessInfo.Username)
-	accessChecker, err := NewAccessCheckerForRemoteCluster(context.Background(), accessInfo, "clustername", currentUserRoleGetter)
+	localAccessInfo := AccessInfoFromUserState(user)
+	require.Equal(t, "mockCurrentUser", localAccessInfo.Username)
+	accessChecker, err := NewAccessCheckerForRemoteCluster(context.Background(), localAccessInfo, "remoteCluster", currentUserRoleGetter)
 	require.NoError(t, err)
 
 	// After sort: "admin","default-implicit-role","dev"
@@ -7733,6 +7750,16 @@ func TestNewAccessCheckerForRemoteCluster(t *testing.T) {
 	require.Contains(t, roles, devRole, "devRole not found in roleSet")
 	require.Contains(t, roles, adminRole, "adminRole not found in roleSet")
 	require.Equal(t, []string{"currentUserTraitLogin"}, roles[2].GetLogins(types.Allow))
+
+	mustHaveUsername(t, accessChecker, "remote-mockCurrentUser-localCluster")
+}
+
+func mustHaveUsername(t *testing.T, access AccessChecker, wantUsername string) {
+	t.Helper()
+
+	accessImpl, ok := access.(*accessChecker)
+	require.True(t, ok)
+	require.Equal(t, wantUsername, accessImpl.info.Username)
 }
 
 func TestRoleSet_GetAccessState(t *testing.T) {

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -21,6 +21,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -137,4 +138,10 @@ func MarshalUser(user types.User, opts ...MarshalOption) ([]byte, error) {
 	default:
 		return nil, trace.BadParameter("unrecognized user version %T", user)
 	}
+}
+
+// Returns an username that is prefixed with "remote-" and suffixed with
+// cluster name with the hope that it does not match a real local user.
+func UsernameForRemoteCluster(localUsername, localClusterName string) string {
+	return fmt.Sprintf("remote-%v-%v", localUsername, localClusterName)
 }

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -140,8 +140,9 @@ func MarshalUser(user types.User, opts ...MarshalOption) ([]byte, error) {
 	}
 }
 
-// Returns an username that is prefixed with "remote-" and suffixed with
-// cluster name with the hope that it does not match a real local user.
+// UsernameForRemoteCluster returns an username that is prefixed with "remote-"
+// and suffixed with cluster name with the hope that it does not match a real
+// local user.
 func UsernameForRemoteCluster(localUsername, localClusterName string) string {
 	return fmt.Sprintf("remote-%v-%v", localUsername, localClusterName)
 }

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
@@ -93,4 +95,28 @@ func (c *Session) WithUserAndDatabase(user string, defaultDatabase string) *Sess
 	copy := c.WithUser(user)
 	copy.DatabaseName = defaultDatabase
 	return copy
+}
+
+// CheckUsernameForAutoUserProvisioning checks the username when using
+// auto-provisioning.
+//
+// When using auto-provisioning, force the database username to be same
+// as Teleport username. If it's not provided explicitly, some database
+// clients get confused and display incorrect username.
+func (c *Session) CheckUsernameForAutoUserProvisioning() error {
+	if !c.AutoCreateUserMode.IsEnabled() {
+		return nil
+	}
+
+	if c.DatabaseUser == c.Identity.Username {
+		return nil
+	}
+
+	if c.AuthContext != nil && authz.IsRemoteUser(*c.AuthContext) {
+		return trace.AccessDenied("please use your mapped remote username (%q) to connect instead of %q",
+			c.Identity.Username, c.DatabaseUser)
+	}
+
+	return trace.AccessDenied("please use your Teleport username (%q) to connect instead of %q",
+		c.Identity.Username, c.DatabaseUser)
 }

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -22,9 +22,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -223,12 +223,10 @@ func (e *Engine) processHandshakeResponse(ctx context.Context, respMessage proto
 // authorizeConnection does authorization check for MongoDB connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context, sessionCtx *common.Session) error {
-	if sessionCtx.AutoCreateUserMode.IsEnabled() {
-		if sessionCtx.DatabaseUser != sessionCtx.Identity.Username {
-			return trace.AccessDenied("please use your Teleport username (%q) to connect instead of %q",
-				sessionCtx.Identity.Username, sessionCtx.DatabaseUser)
-		}
+	if err := sessionCtx.CheckUsernameForAutoUserProvisioning(); err != nil {
+		return trace.Wrap(err)
 	}
+
 	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -174,14 +174,8 @@ func (e *Engine) updateServerVersion(sessionCtx *common.Session, serverConn *cli
 
 // checkAccess does authorization check for MySQL connection about to be established.
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	// When using auto-provisioning, force the database username to be same
-	// as Teleport username. If it's not provided explicitly, some database
-	// clients get confused and display incorrect username.
-	if sessionCtx.AutoCreateUserMode.IsEnabled() {
-		if sessionCtx.DatabaseUser != sessionCtx.Identity.Username {
-			return trace.AccessDenied("please use your Teleport username (%q) to connect instead of %q",
-				sessionCtx.Identity.Username, sessionCtx.DatabaseUser)
-		}
+	if err := sessionCtx.CheckUsernameForAutoUserProvisioning(); err != nil {
+		return trace.Wrap(err)
 	}
 
 	authPref, err := e.Auth.GetAuthPreference(ctx)

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -225,14 +225,8 @@ func (e *Engine) handleStartup(client *pgproto3.Backend, sessionCtx *common.Sess
 }
 
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	// When using auto-provisioning, force the database username to be same
-	// as Teleport username. If it's not provided explicitly, some database
-	// clients (e.g. psql) get confused and display incorrect username.
-	if sessionCtx.AutoCreateUserMode.IsEnabled() {
-		if sessionCtx.DatabaseUser != sessionCtx.Identity.Username {
-			return trace.AccessDenied("please use your Teleport username (%q) to connect instead of %q",
-				sessionCtx.Identity.Username, sessionCtx.DatabaseUser)
-		}
+	if err := sessionCtx.CheckUsernameForAutoUserProvisioning(); err != nil {
+		return trace.Wrap(err)
 	}
 	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -887,18 +887,6 @@ func (d *databaseInfo) checkAndSetDefaults(cf *CLIConf, tc *client.TeleportClien
 		return nil
 	}
 
-	// If database has admin user defined, we're most likely using automatic
-	// user provisioning so default to Teleport username unless database
-	// username was provided explicitly.
-	if needDBUser && db.GetAdminUser().Name != "" {
-		log.Debugf("Defaulting to Teleport username %q as database username.", tc.Username)
-		d.Username = tc.Username
-		needDBUser = false
-	}
-	if !needDBUser && !needDBName {
-		return nil
-	}
-
 	var proxy *client.ProxyClient
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
 		proxy, err = tc.ConnectToProxy(cf.Context)
@@ -1144,6 +1132,8 @@ func getDefaultDBUser(db types.Database, checker services.AccessChecker) (string
 		// ref: https://redis.io/commands/auth
 		extraUsers = append(extraUsers, defaults.DefaultRedisUsername)
 	}
+	// Note that EnumerateDatabaseUsers also calculates the username when
+	// auto-user provisioning is enabled for this database.
 	dbUsers, err := checker.EnumerateDatabaseUsers(db, extraUsers...)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -236,12 +236,14 @@ func onProxyCommandDB(cf *CLIConf) error {
 
 	} else {
 		err = dbProxyTpl.Execute(os.Stdout, map[string]any{
-			"database":   dbInfo.ServiceName,
-			"address":    listener.Addr().String(),
-			"ca":         profile.CACertPathForCluster(rootCluster),
-			"cert":       profile.DatabaseCertPathForCluster(cf.SiteName, dbInfo.ServiceName),
-			"key":        profile.KeyPath(),
-			"randomPort": randomPort,
+			"database":     dbInfo.ServiceName,
+			"address":      listener.Addr().String(),
+			"ca":           profile.CACertPathForCluster(rootCluster),
+			"cert":         profile.DatabaseCertPathForCluster(cf.SiteName, dbInfo.ServiceName),
+			"key":          profile.KeyPath(),
+			"randomPort":   randomPort,
+			"databaseUser": dbInfo.Username,
+			"databaseName": dbInfo.Database,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -660,6 +662,10 @@ Use the following credentials to connect to the {{.database}} proxy:
   ca_file={{.ca}}
   cert_file={{.cert}}
   key_file={{.key}}
+  db_user={{.databaseUser}}
+{{if .databaseName}}  db_name={{.databaseName}}
+{{end -}}
+
 `))
 
 var templateFunctions = map[string]any{

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -663,7 +663,7 @@ Use the following credentials to connect to the {{.database}} proxy:
   cert_file={{.cert}}
   key_file={{.key}}
 
-Your database user is "{{.databaseUser}}".{{if .databaseName}} The target database name is "{{.databaseName}}"".{{end}}
+Your database user is "{{.databaseUser}}".{{if .databaseName}} The target database name is "{{.databaseName}}".{{end}}
 
 `))
 

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -662,9 +662,8 @@ Use the following credentials to connect to the {{.database}} proxy:
   ca_file={{.ca}}
   cert_file={{.cert}}
   key_file={{.key}}
-  db_user={{.databaseUser}}
-{{if .databaseName}}  db_name={{.databaseName}}
-{{end -}}
+
+Your database user is "{{.databaseUser}}".{{if .databaseName}} The target database name is "{{.databaseName}}"".{{end}}
 
 `))
 


### PR DESCRIPTION
Backport #37274 to branch/v15

changelog: Fix an issue `tsh` uses wrong default username for auto-user provisioning enabled databases in remote clusters
