### PR TITLE
[v13] Fix last good identity not being used by tbot if token is not configured

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -355,12 +355,16 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 				fetchNewIdentity = hasTokenChanged(ident.TokenHashBytes, configTokenHashBytes)
 			} else {
 				// we failed to get the token, we'll continue on trying to use the existing identity
-				b.log.WithError(err).Error("There was an error loading the token")
-
+				b.log.WithError(err).Error(
+					"There was an error loading the configured token, using the last good identity",
+				)
 				fetchNewIdentity = false
-
-				b.log.Info("Using the last good identity")
 			}
+		} else {
+			// No token configured to compare against, so let's just use the
+			// existing identity.
+			b.log.Info("No token configured, using the last good identity")
+			fetchNewIdentity = false
 		}
 
 		if !fetchNewIdentity {


### PR DESCRIPTION
This bug only impacts the v13 series of releases as it looks like my v14 refactor which simplified much of this logic already resolved this bug :D

Closes https://github.com/gravitational/teleport/issues/37434

changelog: tbot now correctly uses the last good persisted identity if `--join-token` has not been specified.