### PR TITLE
Add additional selected routes to navigation items

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -38,8 +38,7 @@ const NavigationContainer = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0px 1px 1px rgba(0, 0, 0, 0.14), 0px 1px 3px rgba(0, 0, 0, 0.12);
+  border-right: 1px solid ${p => p.theme.colors.spotBackground[1]};
 `;
 
 const CategoriesContainer = styled.div`

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -130,15 +130,11 @@ export function TopBar({ CustomLogo, assistProps }: TopBarProps) {
             />
 
             {topBarLinks.map(({ topMenuItem, navigationItem }) => {
-              const additionalSelectedRoutes =
-                navigationItem.addAdditionalSelectedRoutes?.(clusterId) || [];
+              const link = navigationItem.getLink(clusterId);
+              const currentPath = history.location.pathname;
               const selected =
-                history.location.pathname.includes(
-                  navigationItem.getLink(clusterId)
-                ) ||
-                additionalSelectedRoutes.some(additionalNavPath =>
-                  history.location.pathname.includes(additionalNavPath)
-                );
+                navigationItem.isSelected?.(clusterId, currentPath) ||
+                history.location.pathname.includes(link);
               return (
                 <NavigationButton
                   key={topMenuItem.title}

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -130,9 +130,15 @@ export function TopBar({ CustomLogo, assistProps }: TopBarProps) {
             />
 
             {topBarLinks.map(({ topMenuItem, navigationItem }) => {
-              const selected = history.location.pathname.includes(
-                navigationItem.getLink(clusterId)
-              );
+              const additionalSelectedRoutes =
+                navigationItem.addAdditionalSelectedRoutes?.(clusterId) || [];
+              const selected =
+                history.location.pathname.includes(
+                  navigationItem.getLink(clusterId)
+                ) ||
+                additionalSelectedRoutes.some(additionalNavPath =>
+                  history.location.pathname.includes(additionalNavPath)
+                );
               return (
                 <NavigationButton
                   key={topMenuItem.title}
@@ -183,7 +189,7 @@ export const TopBarContainer = styled(TopNav)`
   overflow-x: none;
   flex-shrink: 0;
   z-index: 10;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.spotBackground[0]};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.spotBackground[1]};
 
   height: ${p => p.theme.topBarHeight[0]}px;
   @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
@@ -192,9 +198,6 @@ export const TopBarContainer = styled(TopNav)`
   @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
     height: ${p => p.theme.topBarHeight[2]}px;
   }
-
-  box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.12),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.2);
 `;
 
 const TeleportLogo = ({ CustomLogo }: TopBarProps) => {

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -36,6 +36,12 @@ export interface TeleportFeatureNavigationItem {
   exact?: boolean;
   getLink?(clusterId: string): string;
   isExternalLink?: boolean;
+  /*
+   * addAdditionalSelectedRoutes is used when a navigation item should be displayed as "selected"
+   * with additional routes that are different from it's path. For example, the top bar should
+   * show "Access Requests" selected when on the Review Requests page and the New Request page
+   */
+  addAdditionalSelectedRoutes?: (clusterId: string) => string[];
 }
 
 export enum NavTitle {

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -37,11 +37,10 @@ export interface TeleportFeatureNavigationItem {
   getLink?(clusterId: string): string;
   isExternalLink?: boolean;
   /*
-   * addAdditionalSelectedRoutes is used when a navigation item should be displayed as "selected"
-   * with additional routes that are different from it's path. For example, the top bar should
-   * show "Access Requests" selected when on the Review Requests page and the New Request page
+   * isSelected is an option function provided to allow more control over whether this feature is
+   * in the "selected" state in the navigation
    */
-  addAdditionalSelectedRoutes?: (clusterId: string) => string[];
+  isSelected?: (clusterId: string, pathname: string) => boolean;
 }
 
 export enum NavTitle {


### PR DESCRIPTION
e: https://github.com/gravitational/teleport.e/pull/3280

This PR will add an optional prop to our `navigationItem` type. The purpose of this prop is to allow us to show our navigation buttons "selected" state in more routes than its navigation path. For now, this is only used in access requests where we want the button to send them to the 'review requests' page, but also have it shown as selected in the 'new request' page. There is an e PR that takes advantage of this new prop.

Additionally, I've removed the box shadow from the topbar and navigation bar as directed by design and updated the border color.