### PR TITLE
[v15] Update docs version mentions to reflect v15

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -255,7 +255,6 @@ Make sure that the touch and PIN policy satisfy the hardware key requirement for
 
 This error is returned by the Auth and Proxy services if a user does not meet the required private key policy. 
 Both `tsh` and Teleport Connect automatically catch these errors and require the user to sign in again with a valid hardware-based private key. 
-If you see this error, make sure that your client is up to date (v11.0.0+).
 
 ### `ERROR: authenticating with management key: auth challenge: smart card error 6982: security status not satisfied`
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -121,13 +121,6 @@ Teleport configuration as below:
   </TabItem>
 </Tabs>
 
-<Details
-  title="Using U2F?"
-  opened={true}
->
-  Starting on Teleport v10, WebAuthn replaces U2F. See the [U2F](#u2f) section.
-</Details>
-
 ### `webauthn` fields definitions
 
 `rp_id` is the public domain of the Teleport Proxy Service, *excluding* protocol

--- a/docs/pages/access-controls/login-rules.mdx
+++ b/docs/pages/access-controls/login-rules.mdx
@@ -7,8 +7,7 @@ layout: tocless-doc
 When users log in to your Teleport cluster with a configured SSO provider,
 **Login Rules** can transform the traits provided by your IdP to meet your needs
 for configuring access within Teleport.
-Login Rules are a feature of Teleport Enterprise and they are available starting
-from Teleport `v11.3.1`.
+Login Rules are a feature of Teleport Enterprise.
 
 Some use cases for Login Rules are:
 

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -17,9 +17,6 @@ description: How to configure Teleport database access with AWS Keyspaces (Apach
 
 ## Prerequisites
 
-Database access for AWS Keyspaces (Apache Cassandra) is available starting from
-Teleport `v11.0`.
-
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS Account with AWS Keyspaces database and permissions to create and attach IAM policies

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -17,9 +17,6 @@ description: How to configure Teleport database access with Cassandra and Scylla
 
 ## Prerequisites
 
-Database access for Cassandra & ScyllaDB is available starting from Teleport
-`v11.0`.
-
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - Self-hosted Cassandra or ScyllaDB instance.

--- a/docs/pages/deploy-a-cluster/helm-deployments/migration-v12.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/migration-v12.mdx
@@ -6,6 +6,8 @@ description: How to upgrade to teleport-cluster Helm chart version 12
 This guide covers the major changes of the `teleport-cluster` v12 chart
 and how to upgrade existing releases from version 11 to version 12.
 
+{/*TODO(ptgott): Remove this guide in v16*/}
+
 ## Changes summary
 
 The main changes in version 12 of the `teleport-cluster` chart are:

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -60,11 +60,6 @@ Yes, Teleport supports [Headless WebAuthn authentication](./access-controls/guid
 which allows you to perform operations like `tsh ssh` or `tsh scp` from remote systems where you
 are not logged in to Teleport or may not have access to a browser.
 
-## I'm getting `ssh: subsystem request failed` while I try to copy files, what to do?
-
-Make sure that all Teleport components are at least at version 10.3.0. Older versions
-don't support the SFTP protocol, and it's enabled by default in `tsh` v11.0.0 and OpenSSH v9.0.
-
 ## `tsh` is very slow on Windows, what to do?
 
 If your host machine is joined to an Active Directory domain, you might find user lookups take a
@@ -107,9 +102,9 @@ Here are the major versions of Teleport and their support windows:
 
 | Release | Release Date       | EOL            | Minimum `tsh` version |
 |---------|--------------------|----------------|-----------------------|
+| v15.0   | January 29, 2024   | January 2025   | v14.0.0               |
 | v14.0   | September 20, 2023 | September 2024 | v13.0.0               |
 | v13.0   | May 8, 2023        | May 2024       | v12.0.0               |
-| v12.0   | February 6, 2023   | February 2024  | v11.0.0               |
 
 ### Version compatibility
 


### PR DESCRIPTION
Backports #37094

* Update docs version mentions to reflect v15

- Remove mentions of pre-v12 versions. We mention the version prior to the earliest supported version in case some users still need to upgrade.

  This includes removing the Helm migration guide from v11 to v12. The idea is that Teleport users should be on v12 already (the earliest supported version before we released v15), so this guide should not be needed.

- Updated the supported version table in the FAQ.

* Respond to feedback

Restore the v12 migration guide with a note to remove it in v16.