### PR TITLE
helm: increase `teleport-cluster` proxy termination timeout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,12 @@ The operator now joins using a Kubernetes ServiceAccount token. To validate the
 token, the Teleport Auth Service must have access to the `TokenReview` API.
 The chart configures this for you since v12, unless you disabled `rbac` creation.
 
+The chart now sets a termination grace period of 210 seconds on proxy pods. This
+significantly slows down proxy rollouts but reduces disruption for ongoing SSH
+sessions. If you are setting the `--wait`, `--atomic` Helm flags or are creating
+Helm releases via Terraform, you must increase Helm's timeout. A rule of thumb
+would be 5 minutes per proxy replica.
+
 ### Other changes
 
 #### Increased password length

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -238,6 +238,23 @@ proxy:
           cert_file: /my-custom-mount/cert.pem
 ```
 
+### `proxy.terminationGracePeriodSeconds`
+
+`proxy.terminationGracePeriodSeconds` overrides the default
+terminationGracePeriod (60 seconds). This significantly slows down proxy
+rollouts as proxies will wait for up to 3 minutes for the connections to be
+drained. However, this reduces the disruption for SSH connections in case of
+rollout. Since Teleport 15, the clients try to reopen SSH connections in the
+background. If we wait 3 minutes (plus 30sec of pre-stop hook), all v15 SSH
+clients will be steered to other proxies before teleport exits, causing no
+disruption.
+
+If slow rollouts are an issue, you can reduce this value to 60s:
+```yaml
+proxy:
+ terminationGracePeriodSeconds: 60
+```
+
 ## `authentication`
 
 ### `authentication.type`
@@ -1908,3 +1925,15 @@ Kubernetes timeouts for the liveness and readiness probes.
   ```yaml
   probeTimeoutSeconds: 5
   ```
+
+## `terminationGracePeriodSeconds`
+
+`terminationGracePeriodSeconds` configures the
+Kubernetes [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution)
+for pods deployed by the chart.
+
+This value is [overridden for proxy pods](#proxyterminationgraceperiodseconds)
+to reduce disruption during proxy rollouts.
+
+This value must be greater than 30 seconds, as pods are waiting 30 seconds in a
+preStop hook.

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -129,7 +129,7 @@ should set nodeSelector when set in values:
       environment: security
       role: bastion
     serviceAccountName: RELEASE-NAME-proxy
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 210
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -245,7 +245,7 @@ should set resources when set in values:
       image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
       name: wait-auth-update
     serviceAccountName: RELEASE-NAME-proxy
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 210
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -353,7 +353,7 @@ should set securityContext for initContainers when set in values:
         runAsNonRoot: true
         runAsUser: 99
     serviceAccountName: RELEASE-NAME-proxy
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 210
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -461,7 +461,7 @@ should set securityContext when set in values:
         runAsNonRoot: true
         runAsUser: 99
     serviceAccountName: RELEASE-NAME-proxy
-    terminationGracePeriodSeconds: 60
+    terminationGracePeriodSeconds: 210
     volumes:
     - name: proxy-serviceaccount-token
       projected:

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -107,6 +107,21 @@ proxy:
   #         cert_file: /my-custom-mount/cert.pem
   teleportConfig: {}
 
+  # proxy.terminationGracePeriodSeconds overrides the default terminationGracePeriod (60 seconds).
+  # This significantly slows down proxy rollouts as proxies will wait for up to
+  # 3 minutes for the connections to be drained. However, this reduces the disruption
+  # for SSH connections in case of rollout. Since Teleport 15, the clients try to
+  # reopen SSH connections in the background. If we wait 3 minutes (plus 30sec
+  # of pre-stop hook), all v15 SSH clients will be steered to other proxies before
+  # teleport exits, causing no disruption.
+  #
+  # If slow rollouts are an issue, you can reduce this value to 60s:
+  # ```yaml
+  # proxy:
+  #  terminationGracePeriodSeconds: 60
+  # ```
+  terminationGracePeriodSeconds: 210
+
 authentication:
   # Default authentication type. Possible values are 'local' and 'github' for OSS, plus 'oidc' and 'saml' for Enterprise.
   type: local
@@ -694,4 +709,5 @@ probeTimeoutSeconds: 1
 # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
 #
 # This should be greater than 30 seconds as pods are waiting 30 seconds in a preStop hook.
+# This value is overridden by default for proxy pods to reduce disruption during proxy rollouts.
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Starting with Teleport 15, SSH clients attempt to re-establish their SSH connection every 3 minutes.
When rolling out proxies, we can wait up to 3 minutes to wait for all connections to be re-established to some other proxy. This helps reduce disruption a lot for all SSH sessions.

This change has drawbacks (slower proxy rollout) but offers a better UX by default. If needed it can be reverted by setting `proxy.terminationGracePeriodSeconds`.

changelog: helm: increase the proxy termination grace period to 3 minutes to rollout without disrupting SSH sessions.