### PR TITLE
[v14] helm: make proxies replicable when usign an ingress

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -990,7 +990,8 @@ is not supported with multiple replicas.
 ### For proxy pods
 
 Proxy pods need to be provided a certificate to be replicated (via either
-`tls.existingSecretName` or `highAvailability.certManager`).
+`tls.existingSecretName` or `highAvailability.certManager`) or be exposed
+via an ingress (`ingress.enabled`).
 If proxy pods are replicable, they will default to 2 replicas,
 even if `highAvailability.replicaCount` is 1. To force a single proxy replica,
 set `proxy.highAvailability.replicaCount: 1`.

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
-{{- $replicable := or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName -}}
+{{- $replicable := or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName $proxy.ingress.enabled -}}
 {{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
 # Deployment is {{ if not $replicable }}not {{end}}replicable
 {{- if and $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -87,6 +87,18 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should have multiple replicas by default when an ingress is terminating TLS
+    template: proxy/deployment.yaml
+    set:
+      clusterName: helm-lint.example.com
+      proxyListenerMode: multiplex
+      ingress:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
   - it: should set affinity when set in values
     template: proxy/deployment.yaml
     set:

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -442,7 +442,8 @@ azure:
 #   is not supported with multiple replicas.
 # For proxy pods:
 #   Proxy pods need to be provided a certificate to be replicated (either via
-#  `tls.existingSecretName` or via `highAvailability.certManager`).
+#  `tls.existingSecretName` or via `highAvailability.certManager`) or be exposed
+#   via an ingress (`ingress.enabled`).
 #   If proxy pods are replicable, they will default to 2 replicas,
 #   even if `highAvailability.replicaCount` is 1. To force a single proxy replica,
 #   set `proxy.highAvailability.replicaCount: 1`.


### PR DESCRIPTION
Backport #37430 to branch/v14

changelog: Allow to replicate proxy pods when using an ingress in the `teleport-cluster` Helm chart.
