### PR TITLE
deduplicate remote role mappings

### DIFF
--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -179,6 +178,14 @@ func TestRoleMap(t *testing.T) {
 			},
 		},
 		{
+			name:   "mapping is deduplicated",
+			remote: []string{"role1", "role2"},
+			local:  []string{"foo"},
+			roleMap: types.RoleMap{
+				{Remote: "*", Local: []string{"foo"}},
+			},
+		},
+		{
 			name:   "different expand groups can be referred",
 			remote: []string{"remote-devs"},
 			local:  []string{"remote-devs", "devs"},
@@ -197,7 +204,7 @@ func TestRoleMap(t *testing.T) {
 				require.IsType(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(local, tc.local))
+				require.ElementsMatch(t, tc.local, local)
 			}
 		})
 	}

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -104,6 +104,7 @@ func MapRoles(r types.RoleMap, remoteRoles []string) ([]string, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	seen := make(map[string]struct{})
 	var outRoles []string
 	// when no remote roles are specified, assume that
 	// there is a single empty remote role (that should match wildcards)
@@ -124,9 +125,14 @@ func MapRoles(r types.RoleMap, remoteRoles []string) ([]string, error) {
 				case err == nil:
 					// empty replacement can occur when $2 expand refers
 					// to non-existing capture group in match expression
-					if replacement != "" {
-						outRoles = append(outRoles, replacement)
+					if replacement == "" {
+						continue
 					}
+					if _, ok := seen[replacement]; ok {
+						continue
+					}
+					seen[replacement] = struct{}{}
+					outRoles = append(outRoles, replacement)
 				case trace.IsNotFound(err):
 					continue
 				default:


### PR DESCRIPTION
This PR just deduplicates roles mapped from a remote cluster to local roles.

We already deduplicate roles in `UserV2.SetRoles`, but we didn't when creating the access checker, so duplicate roles would be fetched/checked for access. I'm not aware of this causing any issues, but it's easy to avoid the redundant access fetch/checks by deduplicating the role mapping we return.