### PR TITLE
memory backend atomic write impl

### DIFF
--- a/lib/backend/memory/atomicwrite.go
+++ b/lib/backend/memory/atomicwrite.go
@@ -1,0 +1,114 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package memory
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// AtomicWrite executes a batch of conditional actions atomically s.t. all actions happen if all
+// conditions are met, but no actions happen if any condition fails to hold.
+func (m *Memory) AtomicWrite(ctx context.Context, condacts []backend.ConditionalAction) (revision string, err error) {
+	if err := backend.ValidateAtomicWrite(condacts); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+	if m.Mirror {
+		return "", trace.Errorf("atomic write not supported by mirror-mode memory backend")
+	}
+
+	m.removeExpired()
+
+	revision = backend.CreateRevision()
+	var includesPut bool
+	var events []backend.Event
+
+	for _, ca := range condacts {
+		switch ca.Condition.Kind {
+		case backend.KindWhatever:
+			// no comparison to assert
+		case backend.KindExists:
+			if !m.tree.Has(&btreeItem{Item: backend.Item{Key: ca.Key}}) {
+				return "", trace.Wrap(backend.ErrConditionFailed)
+			}
+		case backend.KindNotExists:
+			if m.tree.Has(&btreeItem{Item: backend.Item{Key: ca.Key}}) {
+				return "", trace.Wrap(backend.ErrConditionFailed)
+			}
+		case backend.KindRevision:
+			item, found := m.tree.Get(&btreeItem{Item: backend.Item{
+				Key: ca.Key,
+			}})
+			if !found || item.Item.Revision != ca.Condition.Revision {
+				return "", trace.Wrap(backend.ErrConditionFailed)
+			}
+		default:
+			return "", trace.BadParameter("unexpected condition kind %v in conditional action against key %q", ca.Condition.Kind, ca.Key)
+		}
+
+		switch ca.Action.Kind {
+		case backend.KindNop:
+			// no action to be taken
+		case backend.KindPut:
+			includesPut = true
+			event := backend.Event{
+				Type: types.OpPut,
+				Item: ca.Action.Item,
+			}
+			event.Item.Key = ca.Key
+			event.Item.ID = m.generateID()
+			event.Item.Revision = revision
+			events = append(events, event)
+		case backend.KindDelete:
+			if m.tree.Has(&btreeItem{Item: backend.Item{Key: ca.Key}}) {
+				// only bother creating delete event if there is actually an
+				// item to delete.
+				event := backend.Event{
+					Type: types.OpDelete,
+					Item: backend.Item{
+						Key: ca.Key,
+					},
+				}
+				events = append(events, event)
+			}
+		default:
+			return "", trace.BadParameter("unexpected action kind %v in conditional action against key %q", ca.Action.Kind, ca.Key)
+		}
+	}
+
+	for _, event := range events {
+		m.processEvent(event)
+		if !m.EventsOff {
+			m.buf.Emit(event)
+		}
+	}
+
+	if !includesPut {
+		return "", nil
+	}
+
+	return revision, nil
+}

--- a/lib/backend/memory/atomicwrite_test.go
+++ b/lib/backend/memory/atomicwrite_test.go
@@ -1,0 +1,78 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package memory
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/test"
+)
+
+// newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
+// it will be integrated into the main backend interface and we can get rid of this separate helper.
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+	cfg, err := test.ApplyOptions(options)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if cfg.MirrorMode {
+		// atomic write does not support mirror mode
+		return nil, nil, test.ErrMirrorNotSupported
+	}
+
+	if cfg.ConcurrentBackend != nil {
+		switch bk := cfg.ConcurrentBackend.(type) {
+		case *Memory:
+			return bk, nil, nil
+		case test.AtomicWriteShim:
+			if _, ok := bk.AtomicWriterBackend.(*Memory); !ok {
+				return nil, nil, trace.BadParameter("target is not a Memory backend (%T)", cfg.ConcurrentBackend)
+			}
+			return bk, nil, nil
+		default:
+			return nil, nil, trace.BadParameter("target is not a Memory backend (%T)", cfg.ConcurrentBackend)
+		}
+	}
+
+	clock := clockwork.NewFakeClock()
+	mem, err := New(Config{
+		Clock: clock,
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return mem, clock, nil
+}
+
+// TestAtomicWriteSuite runs the main atomic write test suite.
+func TestAtomicWriteSuite(t *testing.T) {
+	test.RunAtomicWriteComplianceSuite(t, newAtomicWriteTestBackend)
+}
+
+// TestAtomicWriteShim runs the classic test suite using a shim that reimplements all single-item writes as calls
+// to AtomicWrite.
+func TestAtomicWriteShim(t *testing.T) {
+	test.RunBackendComplianceSuiteWithAtomicWriteShim(t, newAtomicWriteTestBackend)
+}

--- a/lib/backend/test/atomicwrite_shim.go
+++ b/lib/backend/test/atomicwrite_shim.go
@@ -42,7 +42,7 @@ func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Atomi
 			return nil, nil, trace.Wrap(err)
 		}
 
-		return atomicWriteShim{
+		return AtomicWriteShim{
 			AtomicWriterBackend: bk,
 			sentinel:            []byte(uuid.New().String()),
 		}, clock, nil
@@ -50,7 +50,7 @@ func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Atomi
 }
 
 // atomciWriteShim reimplements all single-write backend methods as calls to AtomicWrite.
-type atomicWriteShim struct {
+type AtomicWriteShim struct {
 	backend.AtomicWriterBackend
 	sentinel []byte
 }
@@ -58,7 +58,7 @@ type atomicWriteShim struct {
 // sca builds a sentinel conditional action to be added to calls to AtomicWrite to force them to
 // all contain multiple conditional actions. This is a trick used to avoid being routed to an
 // optimized impl (e.g. translating a Whatever/Put into a standard Backend.Put).
-func (a atomicWriteShim) sca() backend.ConditionalAction {
+func (a AtomicWriteShim) sca() backend.ConditionalAction {
 	return backend.ConditionalAction{
 		Key:       a.sentinel,
 		Condition: backend.NotExists(),
@@ -67,7 +67,7 @@ func (a atomicWriteShim) sca() backend.ConditionalAction {
 }
 
 // Create creates item if it does not exist
-func (a atomicWriteShim) Create(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (a AtomicWriteShim) Create(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{
@@ -90,7 +90,7 @@ func (a atomicWriteShim) Create(ctx context.Context, i backend.Item) (*backend.L
 
 // Put puts value into backend (creates if it does not
 // exists, updates it otherwise)
-func (a atomicWriteShim) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (a AtomicWriteShim) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{
@@ -111,7 +111,7 @@ func (a atomicWriteShim) Put(ctx context.Context, i backend.Item) (*backend.Leas
 
 // CompareAndSwap compares item with existing item
 // and replaces is with replaceWith item
-func (a atomicWriteShim) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
+func (a AtomicWriteShim) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
 	const casRetries = 16
 
 	for i := 0; i < casRetries; i++ {
@@ -156,7 +156,7 @@ func (a atomicWriteShim) CompareAndSwap(ctx context.Context, expected backend.It
 }
 
 // Update updates value in the backend
-func (a atomicWriteShim) Update(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (a AtomicWriteShim) Update(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{
@@ -182,7 +182,7 @@ func (a atomicWriteShim) Update(ctx context.Context, i backend.Item) (*backend.L
 
 // Delete deletes item by key, returns NotFound error
 // if item does not exist
-func (a atomicWriteShim) Delete(ctx context.Context, key []byte) error {
+func (a AtomicWriteShim) Delete(ctx context.Context, key []byte) error {
 	_, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{
@@ -201,7 +201,7 @@ func (a atomicWriteShim) Delete(ctx context.Context, key []byte) error {
 
 // ConditionalUpdate updates the value in the backend if the revision of the [backend.Item] matches
 // the stored revision.
-func (a atomicWriteShim) ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (a AtomicWriteShim) ConditionalUpdate(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	rev, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{
@@ -226,7 +226,7 @@ func (a atomicWriteShim) ConditionalUpdate(ctx context.Context, i backend.Item) 
 }
 
 // ConditionalDelete deletes the item by key if the revision matches the stored revision.
-func (a atomicWriteShim) ConditionalDelete(ctx context.Context, key []byte, revision string) error {
+func (a AtomicWriteShim) ConditionalDelete(ctx context.Context, key []byte, revision string) error {
 	_, err := a.AtomicWrite(ctx, []backend.ConditionalAction{
 		a.sca(),
 		{


### PR DESCRIPTION
This PR implements the `AtomicWrite` API for the memory backend.

See https://github.com/gravitational/teleport/pull/36086 for general discussion of the `AtomicWrite` API.