### PR TITLE
sqlite atomic write impl

### DIFF
--- a/lib/backend/lite/atomicwrite.go
+++ b/lib/backend/lite/atomicwrite.go
@@ -1,0 +1,110 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package lite
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+func (l *Backend) AtomicWrite(ctx context.Context, condacts []backend.ConditionalAction) (revision string, err error) {
+	if err := backend.ValidateAtomicWrite(condacts); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	revision = backend.CreateRevision()
+	var includesPut bool
+
+	err = l.inTransaction(ctx, func(tx *sql.Tx) error {
+		for _, ca := range condacts {
+			switch ca.Condition.Kind {
+			case backend.KindWhatever:
+				// no comparison to assert
+			case backend.KindExists:
+				var item backend.Item
+				if err := l.getInTransaction(ctx, ca.Key, tx, &item); err != nil {
+					if trace.IsNotFound(err) {
+						return trace.Wrap(backend.ErrConditionFailed)
+					}
+					return trace.Wrap(err)
+				}
+			case backend.KindNotExists:
+				var item backend.Item
+				err := l.getInTransaction(ctx, ca.Key, tx, &item)
+				if !trace.IsNotFound(err) {
+					if err == nil {
+						return trace.Wrap(backend.ErrConditionFailed)
+					}
+					return trace.Wrap(err)
+				}
+			case backend.KindRevision:
+				var item backend.Item
+				if err := l.getInTransaction(ctx, ca.Key, tx, &item); err != nil {
+					if trace.IsNotFound(err) {
+						return trace.Wrap(backend.ErrConditionFailed)
+					}
+					return trace.Wrap(err)
+				}
+				if item.Revision != ca.Condition.Revision {
+					return trace.Wrap(backend.ErrConditionFailed)
+				}
+			default:
+				return trace.BadParameter("unexpected condition kind %v in conditional action against key %q", ca.Condition.Kind, ca.Key)
+			}
+		}
+
+		for _, ca := range condacts {
+			switch ca.Action.Kind {
+			case backend.KindNop:
+				// no action to be taken
+			case backend.KindPut:
+				includesPut = true
+				// modify a shallow copy of item to avoid mutating condacts.
+				item := ca.Action.Item
+				item.Key = ca.Key
+				item.Revision = revision
+				if err := l.putInTransaction(ctx, item, tx); err != nil {
+					return trace.Wrap(err)
+				}
+			case backend.KindDelete:
+				if err := l.deleteInTransaction(ctx, ca.Key, tx); err != nil && !trace.IsNotFound(err) {
+					return trace.Wrap(err)
+				}
+			default:
+				return trace.BadParameter("unexpected action kind %v in conditional action against key %q", ca.Action.Kind, ca.Key)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if !includesPut {
+		return "", nil
+	}
+
+	return revision, nil
+}

--- a/lib/backend/lite/atomicwrite_test.go
+++ b/lib/backend/lite/atomicwrite_test.go
@@ -1,0 +1,75 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package lite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/test"
+)
+
+// newAtomicWriteTestBackendBuilder builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
+// it will be integrated into the main backend interface and we can get rid of this separate helper.
+func newAtomicWriteTestBackendBuilder(t *testing.T) func(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+	return func(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+		clock := clockwork.NewFakeClock()
+
+		cfg, err := test.ApplyOptions(options)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if cfg.ConcurrentBackend != nil {
+			return nil, nil, test.ErrConcurrentAccessNotSupported
+		}
+
+		if cfg.MirrorMode {
+			return nil, nil, test.ErrMirrorNotSupported
+		}
+
+		backend, err := NewWithConfig(context.Background(), Config{
+			Path:             t.TempDir(),
+			PollStreamPeriod: 300 * time.Millisecond,
+			Clock:            clock,
+		})
+
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		return backend, clock, nil
+	}
+}
+
+// TestAtomicWriteSuite runs the main atomic write test suite.
+func TestAtomicWriteSuite(t *testing.T) {
+	test.RunAtomicWriteComplianceSuite(t, newAtomicWriteTestBackendBuilder(t))
+}
+
+// TestAtomicWriteShim runs the classic test suite using a shim that reimplements all single-item writes as calls
+// to AtomicWrite.
+func TestAtomicWriteShim(t *testing.T) {
+	test.RunBackendComplianceSuiteWithAtomicWriteShim(t, newAtomicWriteTestBackendBuilder(t))
+}


### PR DESCRIPTION
This PR implements the `AtomicWrite` API for sqlite.

See https://github.com/gravitational/teleport/pull/36086 for general discussion of the `AtomicWrite` API.