### PR TITLE
[v13] Remove assigning by default first alphabetical kube cluster to a user.

### DIFF
--- a/integration/kube/fixtures.go
+++ b/integration/kube/fixtures.go
@@ -41,6 +41,7 @@ type ProxyConfig struct {
 	PinnedIP            string
 	KubeUsers           []string
 	KubeGroups          []string
+	KubeCluster         string
 	Impersonation       *rest.ImpersonationConfig
 	RouteToCluster      string
 	CustomTLSServerName string
@@ -91,13 +92,20 @@ func ProxyClient(cfg ProxyConfig) (*kubernetes.Clientset, *rest.Config, error) {
 		return nil, nil, trace.Wrap(err)
 	}
 
+	kubeServers, _ := authServer.GetKubernetesServers(ctx)
+	kubeCluster := cfg.KubeCluster
+	if cfg.KubeCluster == "" && len(kubeServers) > 0 {
+		kubeCluster = kubeServers[0].GetCluster().GetName()
+	}
+
 	id := tlsca.Identity{
-		Username:         cfg.Username,
-		Groups:           user.GetRoles(),
-		KubernetesUsers:  cfg.KubeUsers,
-		KubernetesGroups: cfg.KubeGroups,
-		RouteToCluster:   cfg.RouteToCluster,
-		PinnedIP:         cfg.PinnedIP,
+		Username:          cfg.Username,
+		Groups:            user.GetRoles(),
+		KubernetesUsers:   cfg.KubeUsers,
+		KubernetesGroups:  cfg.KubeGroups,
+		RouteToCluster:    cfg.RouteToCluster,
+		KubernetesCluster: kubeCluster,
+		PinnedIP:          cfg.PinnedIP,
 	}
 	subj, err := id.Subject()
 	if err != nil {

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -676,6 +676,7 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 		T:              main,
 		Username:       username,
 		KubeGroups:     mainKubeGroups,
+		KubeCluster:    clusterAux,
 		Impersonation:  &rest.ImpersonationConfig{UserName: "bob", Groups: []string{kube.TestImpersonationGroup}},
 		RouteToCluster: clusterAux,
 	})
@@ -690,6 +691,7 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 		T:              main,
 		Username:       username,
 		KubeGroups:     mainKubeGroups,
+		KubeCluster:    clusterAux,
 		RouteToCluster: clusterAux,
 	})
 	require.NoError(t, err)

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -371,6 +371,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+		KubeCluster:         "root.example.com",
 		CustomTLSServerName: localK8SNI,
 		TargetAddress:       suite.root.Config.Proxy.WebAddr,
 	})
@@ -489,6 +490,7 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+		KubeCluster:         "gke_project_europecentral2a_cluster1",
 		CustomTLSServerName: localK8SNI,
 		TargetAddress:       suite.root.Config.Proxy.WebAddr,
 		RouteToCluster:      suite.leaf.Secrets.SiteName,
@@ -608,6 +610,7 @@ func TestKubeIPPinning(t *testing.T) {
 				PinnedIP:            tc.pinnedIP,
 				KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 				KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+				KubeCluster:         kubeClusterName,
 				CustomTLSServerName: kubeCluster,
 				TargetAddress:       suite.root.Config.Proxy.WebAddr,
 				RouteToCluster:      tc.routeToCluster,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2445,16 +2445,13 @@ func generateCert(a *Server, req certRequest, caType types.CertAuthType) (*proto
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	// Only validate/default kubernetes cluster name for the current teleport
-	// cluster. If this cert is targeting a trusted teleport cluster, leave all
-	// the kubernetes cluster validation up to them.
-	if req.routeToCluster == clusterName {
-		req.kubernetesCluster, err = kubeutils.CheckOrSetKubeCluster(a.closeCtx, a, req.kubernetesCluster, clusterName)
-		if err != nil {
-			if !trace.IsNotFound(err) {
-				return nil, trace.Wrap(err)
-			}
-			log.Debug("Failed setting default kubernetes cluster for user login (user did not provide a cluster); leaving KubernetesCluster extension in the TLS certificate empty")
+	// Ensure that the Kubernetes cluster name specified in the request exists
+	// when the certificate is intended for a local Kubernetes cluster.
+	// If the certificate is targeting a trusted Teleport cluster, it is the
+	// responsibility of the cluster to ensure its existence.
+	if req.routeToCluster == clusterName && req.kubernetesCluster != "" {
+		if err := kubeutils.CheckKubeCluster(a.closeCtx, a, req.kubernetesCluster); err != nil {
+			return nil, trace.Wrap(err)
 		}
 	}
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -362,8 +362,6 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, *gotID, wantID)
 
-	// Register a kubernetes cluster to verify the defaulting logic in TLS cert
-	// generation.
 	kubeCluster, err := types.NewKubernetesClusterV3(
 		types.Metadata{
 			Name: "root-kube-cluster",
@@ -408,8 +406,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, *gotID, wantID)
 
-	// Login without specifying kube cluster. A registered one should be picked
-	// automatically.
+	// Login without specifying kube cluster. Kube cluster in the certificate should be empty.
 	resp, err = s.a.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
 		AuthenticateUserRequest: AuthenticateUserRequest{
 			Username:  user,
@@ -427,16 +424,15 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
 	require.NoError(t, err)
 	wantID = tlsca.Identity{
-		Username:          user,
-		Groups:            []string{role.GetName()},
-		Principals:        []string{user, teleport.SSHSessionJoinPrincipal},
-		KubernetesUsers:   []string{user},
-		KubernetesGroups:  []string{"system:masters"},
-		KubernetesCluster: "root-kube-cluster",
-		Expires:           gotTLSCert.NotAfter,
-		RouteToCluster:    s.clusterName.GetClusterName(),
-		TeleportCluster:   s.clusterName.GetClusterName(),
-		PrivateKeyPolicy:  keys.PrivateKeyPolicyNone,
+		Username:         user,
+		Groups:           []string{role.GetName()},
+		Principals:       []string{user, teleport.SSHSessionJoinPrincipal},
+		KubernetesUsers:  []string{user},
+		KubernetesGroups: []string{"system:masters"},
+		Expires:          gotTLSCert.NotAfter,
+		RouteToCluster:   s.clusterName.GetClusterName(),
+		TeleportCluster:  s.clusterName.GetClusterName(),
+		PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)
@@ -473,8 +469,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, *gotID, wantID)
 
-	// Login without specifying kube cluster. A registered one should be picked
-	// automatically.
+	// Login without specifying kube cluster. Kube cluster in the certificate should be empty.
 	resp, err = s.a.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
 		AuthenticateUserRequest: AuthenticateUserRequest{
 			Username:  user,
@@ -492,16 +487,15 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
 	require.NoError(t, err)
 	wantID = tlsca.Identity{
-		Username:          user,
-		Groups:            []string{role.GetName()},
-		Principals:        []string{user, teleport.SSHSessionJoinPrincipal},
-		KubernetesUsers:   []string{user},
-		KubernetesGroups:  []string{"system:masters"},
-		KubernetesCluster: "root-kube-cluster",
-		Expires:           gotTLSCert.NotAfter,
-		RouteToCluster:    s.clusterName.GetClusterName(),
-		TeleportCluster:   s.clusterName.GetClusterName(),
-		PrivateKeyPolicy:  keys.PrivateKeyPolicyNone,
+		Username:         user,
+		Groups:           []string{role.GetName()},
+		Principals:       []string{user, teleport.SSHSessionJoinPrincipal},
+		KubernetesUsers:  []string{user},
+		KubernetesGroups: []string{"system:masters"},
+		Expires:          gotTLSCert.NotAfter,
+		RouteToCluster:   s.clusterName.GetClusterName(),
+		TeleportCluster:  s.clusterName.GetClusterName(),
+		PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
 	require.NoError(t, err)

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -82,7 +82,6 @@ import (
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
-	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -781,27 +780,12 @@ func (f *Forwarder) setupContext(ctx context.Context, authCtx authz.Context, req
 		return nil, trace.AccessDenied("access denied: remote user can not access remote cluster")
 	}
 
-	kubeCluster := identity.KubernetesCluster
-	// Only set a default kube cluster if the user is not accessing a specific cluster.
-	// The check for kubeCluster != "" is happens in the next code section.
-	if !isRemoteCluster && kubeCluster == "" {
-		kc, err := kubeutils.CheckOrSetKubeCluster(ctx, f.cfg.CachingAuthClient, identity.KubernetesCluster, teleportClusterName)
-		if err != nil {
-			if !trace.IsNotFound(err) {
-				return nil, trace.Wrap(err)
-			}
-			// Fallback for old clusters and old user certs. Assume that the
-			// user is trying to access the default cluster name.
-			kubeCluster = teleportClusterName
-		} else {
-			kubeCluster = kc
-		}
-	}
-
 	var (
 		kubeServers []types.KubeServer
 		err         error
 	)
+
+	kubeCluster := identity.KubernetesCluster
 	// Only check k8s principals for local clusters.
 	//
 	// For remote clusters, everything will be remapped to new roles on the
@@ -809,7 +793,7 @@ func (f *Forwarder) setupContext(ctx context.Context, authCtx authz.Context, req
 	if !isRemoteCluster {
 		kubeServers, err = f.getKubernetesServersForKubeCluster(ctx, kubeCluster)
 		if err != nil || len(kubeServers) == 0 {
-			return nil, trace.NotFound("cluster %q not found", kubeCluster)
+			return nil, trace.NotFound("Kubernetes cluster %q not found", kubeCluster)
 		}
 	}
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -211,12 +211,13 @@ func TestAuthenticate(t *testing.T) {
 		wantAuthErr bool
 	}{
 		{
-			desc:           "local user and cluster with active access request",
-			user:           authz.LocalUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
-			tunnel:         tun,
+			desc:              "local user and cluster with active access request",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -264,12 +265,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:           "local user and cluster",
-			user:           authz.LocalUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
-			tunnel:         tun,
+			desc:              "local user and cluster",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -340,12 +342,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:           "local user and cluster, no kubeconfig",
-			user:           authz.LocalUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  false,
-			tunnel:         tun,
+			desc:              "local user and cluster, no kubeconfig",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     false,
+			tunnel:            tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -384,12 +387,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:           "remote user and local cluster",
-			user:           authz.RemoteUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
-			tunnel:         tun,
+			desc:              "remote user and local cluster",
+			user:              authz.RemoteUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -428,13 +432,14 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:           "remote user and local cluster with active request id",
-			user:           authz.RemoteUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
-			tunnel:         tun,
-			activeRequests: activeAccessRequests,
+			desc:              "remote user and local cluster with active request id",
+			user:              authz.RemoteUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			activeRequests:    activeAccessRequests,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -534,13 +539,14 @@ func TestAuthenticate(t *testing.T) {
 			wantAuthErr: true,
 		},
 		{
-			desc:           "kube users passed in request",
-			user:           authz.LocalUser{},
-			roleKubeUsers:  []string{"kube-user-a", "kube-user-b"},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
-			tunnel:         tun,
+			desc:              "kube users passed in request",
+			user:              authz.LocalUser{},
+			roleKubeUsers:     []string{"kube-user-a", "kube-user-b"},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -596,11 +602,12 @@ func TestAuthenticate(t *testing.T) {
 			wantAuthErr: true,
 		},
 		{
-			desc:           "local user and cluster, no tunnel",
-			user:           authz.LocalUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "local",
-			haveKubeCreds:  true,
+			desc:              "local user and cluster, no tunnel",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -215,29 +215,18 @@ func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {
 	return []types.KubeCluster(sorted)
 }
 
-// CheckOrSetKubeCluster validates kubeClusterName if it's set, or a sane
-// default based on registered clusters.
-//
-// If no clusters are registered, a NotFound error is returned.
-func CheckOrSetKubeCluster(ctx context.Context, p KubeServicesPresence, kubeClusterName, teleportClusterName string) (string, error) {
+// CheckKubeCluster validates kubeClusterName is registered with this Teleport cluster.
+func CheckKubeCluster(ctx context.Context, p KubeServicesPresence, kubeClusterName string) error {
+	if kubeClusterName == "" {
+		return trace.BadParameter("kube cluster name should not be empty.")
+	}
 	kubeClusterNames, err := KubeClusterNames(ctx, p)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return trace.Wrap(err, "failed to get list of available Kubernetes clusters.")
 	}
-	if kubeClusterName != "" {
-		if !slices.Contains(kubeClusterNames, kubeClusterName) {
-			return "", trace.BadParameter("kubernetes cluster %q is not registered in this teleport cluster; you can list registered kubernetes clusters using 'tsh kube ls'", kubeClusterName)
-		}
-		return kubeClusterName, nil
+	if !slices.Contains(kubeClusterNames, kubeClusterName) {
+		return trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'", kubeClusterName)
 	}
-	// Default is the cluster with a name matching the Teleport cluster
-	// name (for backwards-compatibility with pre-5.0 behavior) or the
-	// first name alphabetically.
-	if len(kubeClusterNames) == 0 {
-		return "", trace.NotFound("no kubernetes clusters registered")
-	}
-	if slices.Contains(kubeClusterNames, teleportClusterName) {
-		return teleportClusterName, nil
-	}
-	return kubeClusterNames[0], nil
+
+	return nil
 }

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -25,91 +25,52 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-func TestCheckOrSetKubeCluster(t *testing.T) {
+func TestCheckKubeCluster(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := context.Background()
+
+	kubeServers := []types.KubeServer{
+		kubeServer(t, "k8s-1", "server1", "uuuid"),
+		kubeServer(t, "k8s-2", "server1", "uuuid"),
+		kubeServer(t, "k8s-3", "server1", "uuuid"),
+		kubeServer(t, "k8s-4", "server1", "uuuid"),
+	}
 
 	tests := []struct {
 		desc        string
 		services    []types.KubeServer
 		kubeCluster string
-		teleCluster string
-		want        string
 		assertErr   require.ErrorAssertionFunc
 	}{
 		{
-			desc: "valid cluster name",
-			services: []types.KubeServer{
-				kubeServer(t, "k8s-1", "server1", "uuuid"),
-				kubeServer(t, "k8s-2", "server1", "uuuid"),
-				kubeServer(t, "k8s-3", "server2", "uuuid2"),
-				kubeServer(t, "k8s-4", "server2", "uuuid2"),
-			},
+			desc:        "valid cluster name",
+			services:    kubeServers,
 			kubeCluster: "k8s-4",
-			teleCluster: "zzz-tele-cluster",
-			want:        "k8s-4",
 			assertErr:   require.NoError,
 		},
 		{
-			desc: "invalid cluster name",
-			services: []types.KubeServer{
-				kubeServer(t, "k8s-1", "server1", "uuuid"),
-				kubeServer(t, "k8s-2", "server1", "uuuid"),
-				kubeServer(t, "k8s-3", "server2", "uuuid2"),
-				kubeServer(t, "k8s-4", "server2", "uuuid2"),
-			},
+			desc:        "invalid cluster name",
+			services:    kubeServers,
 			kubeCluster: "k8s-5",
-			teleCluster: "zzz-tele-cluster",
 			assertErr:   require.Error,
 		},
 		{
 			desc:        "no registered clusters",
 			services:    []types.KubeServer{},
 			kubeCluster: "k8s-1",
-			teleCluster: "zzz-tele-cluster",
 			assertErr:   require.Error,
 		},
 		{
-			desc:        "no registered clusters and empty cluster provided",
-			services:    []types.KubeServer{},
+			desc:        "empty cluster provided",
+			services:    kubeServers,
 			kubeCluster: "",
-			teleCluster: "zzz-tele-cluster",
 			assertErr:   require.Error,
-		},
-		{
-			desc: "no cluster provided, default to first alphabetically",
-			services: []types.KubeServer{
-				kubeServer(t, "k8s-1", "server1", "uuuid"),
-				kubeServer(t, "k8s-2", "server1", "uuuid"),
-				kubeServer(t, "k8s-3", "server2", "uuuid2"),
-				kubeServer(t, "k8s-4", "server2", "uuuid2"),
-			},
-			kubeCluster: "",
-			teleCluster: "zzz-tele-cluster",
-			want:        "k8s-1",
-			assertErr:   require.NoError,
-		},
-		{
-			desc: "no cluster provided, default to teleport cluster name",
-			services: []types.KubeServer{
-				kubeServer(t, "k8s-1", "server1", "uuuid"),
-				kubeServer(t, "k8s-2", "server1", "uuuid"),
-				kubeServer(t, "k8s-3", "server2", "uuuid2"),
-
-				kubeServer(t, "zzz-tele-cluster", "server2", "uuuid2"),
-				kubeServer(t, "k8s-4", "server2", "uuuid2"),
-			},
-			kubeCluster: "",
-			teleCluster: "zzz-tele-cluster",
-			want:        "zzz-tele-cluster",
-			assertErr:   require.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := CheckOrSetKubeCluster(ctx, mockKubeServicesPresence(tt.services), tt.kubeCluster, tt.teleCluster)
+			err := CheckKubeCluster(ctx, mockKubeServicesPresence(tt.services), tt.kubeCluster)
 			tt.assertErr(t, err)
-			require.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -947,6 +947,9 @@ func (a *AuthCommand) checkLeafCluster(clusterAPI auth.ClientI) error {
 }
 
 func (a *AuthCommand) checkKubeCluster(ctx context.Context, clusterAPI auth.ClientI) error {
+	if a.kubeCluster == "" {
+		return nil
+	}
 	if a.outputFormat != identityfile.FormatKubernetes && a.kubeCluster != "" {
 		// User set --kube-cluster-name but it's not actually used for the chosen --format.
 		// Print a warning but continue.
@@ -966,10 +969,10 @@ func (a *AuthCommand) checkKubeCluster(ctx context.Context, clusterAPI auth.Clie
 		return nil
 	}
 
-	a.kubeCluster, err = kubeutils.CheckOrSetKubeCluster(ctx, clusterAPI, a.kubeCluster, a.leafCluster)
-	if err != nil && !trace.IsNotFound(err) {
+	if err := kubeutils.CheckKubeCluster(ctx, clusterAPI, a.kubeCluster); err != nil {
 		return trace.Wrap(err)
 	}
+
 	return nil
 }
 

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -494,7 +494,6 @@ func TestCheckKubeCluster(t *testing.T) {
 			leafCluster:        teleportCluster,
 			registeredClusters: []*types.KubernetesClusterV3{{Metadata: types.Metadata{Name: "foo"}}},
 			outputFormat:       identityfile.FormatKubernetes,
-			want:               "foo",
 			assertErr:          require.NoError,
 		},
 		{
@@ -554,7 +553,9 @@ func TestCheckKubeCluster(t *testing.T) {
 			}
 			err := a.checkKubeCluster(context.Background(), client)
 			tt.assertErr(t, err)
-			require.Equal(t, tt.want, a.kubeCluster)
+			if err == nil {
+				require.Equal(t, tt.want, a.kubeCluster)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/37242 to branch/v13

Manual backport (conflicts in tests).

changelog: Do not add alphabetically first Kube cluster's name to a user certificate on login.