### PR TITLE
Support SAML apps in Connect

### DIFF
--- a/web/packages/shared/components/AwsLaunchButton.tsx
+++ b/web/packages/shared/components/AwsLaunchButton.tsx
@@ -42,7 +42,7 @@ export class AwsLaunchButton extends React.Component<Props> {
 
   render() {
     const { open } = this.state;
-    const { awsRoles, getLaunchUrl } = this.props;
+    const { awsRoles, getLaunchUrl, onLaunchUrl } = this.props;
     return (
       <>
         <ButtonBorder
@@ -76,6 +76,7 @@ export class AwsLaunchButton extends React.Component<Props> {
           <RoleItemList
             awsRoles={awsRoles}
             getLaunchUrl={getLaunchUrl}
+            onLaunchUrl={onLaunchUrl}
             closeMenu={this.onClose}
           />
         </Menu>
@@ -88,6 +89,7 @@ function RoleItemList({
   awsRoles,
   getLaunchUrl,
   closeMenu,
+  onLaunchUrl,
 }: Props & { closeMenu: () => void }) {
   const awsRoleItems = awsRoles.map((item, key) => {
     const { display, arn } = item;
@@ -101,7 +103,10 @@ function RoleItemList({
         href={launchUrl}
         target="_blank"
         title={display}
-        onClick={closeMenu}
+        onClick={() => {
+          closeMenu();
+          onLaunchUrl?.(item.arn);
+        }}
       >
         <Text style={{ maxWidth: '25ch' }}>{display}</Text>
       </StyledMenuItem>
@@ -135,6 +140,7 @@ function RoleItemList({
 type Props = {
   awsRoles: AwsRole[];
   getLaunchUrl(arn: string): string;
+  onLaunchUrl?(arn: string): void;
 };
 
 const StyledMenuItem = styled(MenuItem)(

--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -18,7 +18,7 @@
 
 import { App, Cluster } from 'teleterm/services/tshd/types';
 
-/** Returns a URL that can be used to open the web app in the browser. */
+/** Returns a URL that opens the web app in the browser. */
 export function getWebAppLaunchUrl({
   app,
   cluster,
@@ -36,7 +36,7 @@ export function getWebAppLaunchUrl({
   return `https://${rootCluster.proxyHost}/web/launch/${fqdn}/${cluster.name}/${publicAddr}`;
 }
 
-/** Returns a URL that can be used to open the AWS app in the browser. */
+/** Returns a URL that opens the AWS app in the browser. */
 export function getAwsAppLaunchUrl({
   app,
   cluster,
@@ -56,6 +56,22 @@ export function getAwsAppLaunchUrl({
   return `https://${rootCluster.proxyHost}/web/launch/${fqdn}/${
     cluster.name
   }/${publicAddr}/${encodeURIComponent(arn)}`;
+}
+
+/** Returns a URL that triggers IdP-initiated SSO for SAML Application. */
+export function getSamlAppSsoUrl({
+  app,
+  rootCluster,
+}: {
+  app: App;
+  rootCluster: Cluster;
+}): string {
+  if (!app.samlApp) {
+    return '';
+  }
+  return `https://${
+    rootCluster.proxyHost
+  }/enterprise/saml-idp/login/${encodeURIComponent(app.name)}`;
 }
 
 export function isWebApp(app: App): boolean {

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -59,7 +59,7 @@ export const makeKube = (props: Partial<tsh.Kube> = {}): tsh.Kube => ({
   ...props,
 });
 
-export const makeApp = (props: Partial<tsh.App> = {}): App => ({
+export const makeApp = (props: Partial<App> = {}): App => ({
   name: 'foo',
   labels: [],
   endpointUri: 'tcp://localhost:3000',

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -55,6 +55,10 @@ export function ActionButtons() {
           <Text>AWS console</Text>
           <AwsConsole />
         </Box>
+        <Box>
+          <Text>SAML app</Text>
+          <SamlApp />
+        </Box>
       </Flex>
       <Box>
         <Text>Server</Text>
@@ -135,6 +139,29 @@ function AwsConsole() {
             { arn: 'foo', display: 'foo', name: 'foo' },
             { arn: 'bar', display: 'bar', name: 'bar' },
           ],
+          uri: `${testCluster.uri}/apps/bar`,
+        })}
+      />
+    </MockAppContextProvider>
+  );
+}
+
+function SamlApp() {
+  const appContext = new MockAppContext();
+  const testCluster = makeRootCluster();
+  appContext.workspacesService.setState(d => {
+    d.rootClusterUri = testCluster.uri;
+  });
+  appContext.clustersService.setState(d => {
+    d.clusters.set(testCluster.uri, testCluster);
+  });
+
+  return (
+    <MockAppContextProvider appContext={appContext}>
+      <ConnectAppActionButton
+        app={makeApp({
+          endpointUri: 'https://localhost:3000',
+          samlApp: true,
           uri: `${testCluster.uri}/apps/bar`,
         })}
       />

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -230,6 +230,7 @@ function AppButton(props: {
             arn,
           })
         }
+        onLaunchUrl={props.onLaunchUrl}
       />
     );
   }
@@ -238,7 +239,7 @@ function AppButton(props: {
     return (
       <ButtonBorder
         size="small"
-        onClick={props.connect}
+        onClick={props.onLaunchUrl}
         textTransform="none"
         title="Log in to the app in the browser"
         href={getSamlAppSsoUrl({

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -47,6 +47,7 @@ import {
   getWebAppLaunchUrl,
   isWebApp,
   getAwsAppLaunchUrl,
+  getSamlAppSsoUrl,
 } from 'teleterm/services/tshd/app';
 
 export function ConnectServerActionButton(props: {
@@ -230,6 +231,24 @@ function AppButton(props: {
           })
         }
       />
+    );
+  }
+
+  if (props.app.samlApp) {
+    return (
+      <ButtonBorder
+        size="small"
+        onClick={props.connect}
+        textTransform="none"
+        title="Log in to app in the browser"
+        href={getSamlAppSsoUrl({
+          app: props.app,
+          rootCluster: props.rootCluster,
+        })}
+        target="_blank"
+      >
+        Login
+      </ButtonBorder>
     );
   }
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -240,6 +240,7 @@ function AppButton(props: {
       <ButtonBorder
         size="small"
         onClick={props.onLaunchUrl}
+        as="a"
         textTransform="none"
         title="Log in to the app in the browser"
         href={getSamlAppSsoUrl({

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -240,7 +240,7 @@ function AppButton(props: {
         size="small"
         onClick={props.connect}
         textTransform="none"
-        title="Log in to app in the browser"
+        title="Log in to the app in the browser"
         href={getSamlAppSsoUrl({
           app: props.app,
           rootCluster: props.rootCluster,
@@ -266,7 +266,7 @@ function AppButton(props: {
           })}
           onClick={props.onLaunchUrl}
           target="_blank"
-          title="Launch app in the browser"
+          title="Launch the app in the browser"
           css={`
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -243,6 +243,17 @@ export const OnlineLoadedResources = () => {
               ],
             },
           },
+          {
+            kind: 'app',
+            resource: {
+              ...makeApp(),
+              name: 'SAML app',
+              desc: 'SAML Application',
+              publicAddr: '',
+              endpointUri: '',
+              samlApp: true,
+            },
+          },
         ],
         totalCount: 4,
         nextKey: '',

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -769,9 +769,9 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
         <Text typography="body1">
           {isWebApp(app) || app.awsConsole || app.samlApp ? (
             app.samlApp ? (
-              <>Log in to {$appName} app in the browser</>
+              <>Log in to {$appName} in the browser</>
             ) : (
-              <>Launch {$appName} app in the browser</>
+              <>Launch {$appName} in the browser</>
             )
           ) : (
             <>Set up an app connection to {$appName}</>

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -50,6 +50,7 @@ import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { isWebApp } from 'teleterm/services/tshd/app';
+import { App } from 'teleterm/ui/services/clusters';
 
 import { SearchAction } from '../actions';
 import { useSearchContext } from '../SearchContext';
@@ -766,17 +767,7 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
         flexWrap="wrap"
         gap={1}
       >
-        <Text typography="body1">
-          {isWebApp(app) || app.awsConsole || app.samlApp ? (
-            app.samlApp ? (
-              <>Log in to {$appName} in the browser</>
-            ) : (
-              <>Launch {$appName} in the browser</>
-            )
-          ) : (
-            <>Set up an app connection to {$appName}</>
-          )}
-        </Text>
+        <Text typography="body1">{getAppItemCopy($appName, app)}</Text>
         <Box ml="auto">
           <Text typography="body2" fontSize={0}>
             {props.getOptionalClusterName(app.uri)}
@@ -797,6 +788,16 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
       )}
     </IconAndContent>
   );
+}
+
+function getAppItemCopy($appName: React.JSX.Element, app: App) {
+  if (app.samlApp) {
+    return <>Log in to {$appName} in the browser</>;
+  }
+  if (isWebApp(app) || app.awsConsole) {
+    return <>Launch {$appName} in the browser</>;
+  }
+  return <>Set up an app connection to {$appName}</>;
 }
 
 export function KubeItem(props: SearchResultItem<SearchResultKube>) {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -730,7 +730,7 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
     </strong>
   );
 
-  const $resourceFields = (
+  const $resourceFields = (app.addrWithProtocol || app.desc) && (
     <ResourceFields>
       {app.addrWithProtocol && (
         <span
@@ -767,8 +767,12 @@ export function AppItem(props: SearchResultItem<SearchResultApp>) {
         gap={1}
       >
         <Text typography="body1">
-          {isWebApp(app) || app.awsConsole ? (
-            <>Launch {$appName} app in the browser</>
+          {isWebApp(app) || app.awsConsole || app.samlApp ? (
+            app.samlApp ? (
+              <>Log in to {$appName} app in the browser</>
+            ) : (
+              <>Launch {$appName} app in the browser</>
+            )
           ) : (
             <>Set up an app connection to {$appName}</>
           )}

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -169,6 +169,41 @@ const SearchResultItems = () => {
     makeResourceResult({
       kind: 'app',
       resource: makeApp({
+        uri: `${clusterUri}/apps/web-app`,
+        name: 'web-app',
+        endpointUri: 'http://localhost:3000',
+        addrWithProtocol: 'http://local-app.example.com:3000',
+        desc: '',
+        labels: makeLabelsList({
+          access: 'cloudwatch-metrics,ec2,s3,cloudtrail',
+          'aws/Environment': 'demo-13-biz',
+          'aws/Owner': 'foobar',
+          env: 'dev',
+          'teleport.dev/origin': 'config-file',
+        }),
+      }),
+    }),
+    makeResourceResult({
+      kind: 'app',
+      resource: makeApp({
+        uri: `${clusterUri}/apps/saml-app`,
+        name: 'saml-app',
+        endpointUri: '',
+        addrWithProtocol: '',
+        samlApp: true,
+        desc: 'SAML Application',
+        labels: makeLabelsList({
+          access: 'cloudwatch-metrics,ec2,s3,cloudtrail',
+          'aws/Environment': 'demo-13-biz',
+          'aws/Owner': 'foobar',
+          env: 'dev',
+          'teleport.dev/origin': 'config-file',
+        }),
+      }),
+    }),
+    makeResourceResult({
+      kind: 'app',
+      resource: makeApp({
         uri: `${clusterUri}/apps/no-desc`,
         name: 'no-desc',
         desc: '',

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { connectToApp } from 'teleterm/ui/services/workspacesService';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeApp, makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { IAppContext } from 'teleterm/ui/types';
+
+describe('launches URL in the browser for', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('web app if requested', async () => {
+    jest.spyOn(window, 'open').mockImplementation();
+    const appContext = new MockAppContext();
+    setTestCluster(appContext);
+    const app = makeApp({
+      endpointUri: 'http://localhost:3000',
+    });
+
+    await connectToApp(
+      appContext,
+      app,
+      { origin: 'resource_table' },
+      {
+        launchInBrowserIfWebApp: true,
+      }
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000',
+      '_blank',
+      'noreferrer,noopener'
+    );
+  });
+
+  it('saml app', async () => {
+    jest.spyOn(window, 'open').mockImplementation();
+    const appContext = new MockAppContext();
+    setTestCluster(appContext);
+    const app = makeApp({ samlApp: true });
+
+    await connectToApp(appContext, app, { origin: 'resource_table' });
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://teleport-local:3080/enterprise/saml-idp/login/foo',
+      '_blank',
+      'noreferrer,noopener'
+    );
+  });
+
+  it('aws app', async () => {
+    jest.spyOn(window, 'open').mockImplementation();
+    const appContext = new MockAppContext();
+    setTestCluster(appContext);
+    const app = makeApp({ awsConsole: true });
+
+    await connectToApp(
+      appContext,
+      app,
+      { origin: 'resource_table' },
+      { launchInBrowserIfWebApp: true, arnForAwsApp: 'foo-arn' }
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      'https://teleport-local:3080/web/launch/local-app.example.com:3000/teleport-local/local-app.example.com:3000/foo-arn',
+      '_blank',
+      'noreferrer,noopener'
+    );
+  });
+});
+
+test.each([
+  {
+    name: 'creates tunnel for a tcp app',
+    app: makeApp({
+      endpointUri: 'tcp://localhost:3000',
+    }),
+  },
+  {
+    name: 'creates tunnel for a web app by default',
+    app: makeApp({
+      endpointUri: 'http://localhost:3000',
+    }),
+  },
+])('$name', async ({ app }) => {
+  const appContext = new MockAppContext();
+  setTestCluster(appContext);
+
+  await connectToApp(appContext, app, { origin: 'resource_table' });
+  const documents = appContext.workspacesService
+    .getActiveWorkspaceDocumentService()
+    .getGatewayDocuments();
+  expect(documents).toHaveLength(1);
+  expect(documents[0]).toEqual({
+    gatewayUri: undefined,
+    kind: 'doc.gateway',
+    origin: 'resource_table',
+    port: undefined,
+    status: '',
+    targetName: 'foo',
+    targetSubresourceName: undefined,
+    targetUri: '/clusters/teleport-local/apps/foo',
+    targetUser: '',
+    title: 'foo',
+    uri: expect.any(String),
+  });
+});
+
+test('cloud app triggers alert', async () => {
+  jest.spyOn(window, 'alert').mockImplementation();
+  const appContext = new MockAppContext();
+  setTestCluster(appContext);
+  const app = makeApp({
+    endpointUri: 'cloud://localhost:3000',
+  });
+
+  await connectToApp(appContext, app, { origin: 'resource_table' });
+  expect(window.alert).toHaveBeenCalledWith(
+    'Cloud apps are supported only in tsh.'
+  );
+});
+
+function setTestCluster(appContext: IAppContext): void {
+  const testCluster = makeRootCluster();
+  appContext.workspacesService.setState(d => {
+    d.rootClusterUri = testCluster.uri;
+  });
+  appContext.clustersService.setState(d => {
+    d.clusters.set(testCluster.uri, testCluster);
+  });
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -26,7 +26,7 @@ describe('launching an app in the browser for', () => {
     jest.clearAllMocks();
   });
 
-  it('web app (if requested)', async () => {
+  test('web app (if requested)', async () => {
     jest.spyOn(window, 'open').mockImplementation();
     const appContext = new MockAppContext();
     setTestCluster(appContext);
@@ -49,7 +49,7 @@ describe('launching an app in the browser for', () => {
     );
   });
 
-  it('saml app', async () => {
+  test('saml app', async () => {
     jest.spyOn(window, 'open').mockImplementation();
     const appContext = new MockAppContext();
     setTestCluster(appContext);
@@ -64,7 +64,7 @@ describe('launching an app in the browser for', () => {
     );
   });
 
-  it('aws app', async () => {
+  test('aws app', async () => {
     jest.spyOn(window, 'open').mockImplementation();
     const appContext = new MockAppContext();
     setTestCluster(appContext);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -21,12 +21,12 @@ import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeApp, makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { IAppContext } from 'teleterm/ui/types';
 
-describe('launches URL in the browser for', () => {
+describe('launching an app in the browser for', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('web app if requested', async () => {
+  it('web app (if requested)', async () => {
     jest.spyOn(window, 'open').mockImplementation();
     const appContext = new MockAppContext();
     setTestCluster(appContext);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -24,6 +24,7 @@ import {
   getWebAppLaunchUrl,
   isWebApp,
   getAwsAppLaunchUrl,
+  getSamlAppSsoUrl,
 } from 'teleterm/services/tshd/app';
 
 import { DocumentOrigin } from './types';
@@ -41,11 +42,16 @@ export async function connectToApp(
   const rootCluster = ctx.clustersService.findCluster(rootClusterUri);
   const cluster = ctx.clustersService.findClusterByResource(target.uri);
 
-  //TODO(gzdunek): Add regular dialogs for connecting to unsupported apps (non HTTP/TCP)
-  // that will explain that the user can connect via tsh/Web UI to them.
-  // These dialogs should provide instructions, just like those in the Web UI for database access.
   if (target.samlApp) {
-    alert('SAML apps are supported only in Web UI.');
+    launchAppInBrowser(
+      ctx,
+      target,
+      getSamlAppSsoUrl({
+        app: target,
+        rootCluster,
+      }),
+      telemetry
+    );
     return;
   }
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/35554.
Since there is still some time left before the release, I added support for SAML apps. We will get feature parity with Web UI.

The implementation is simple, we just need to construct a correct URL, similarly to Web and AWS apps.
The `Login` buttons looks the same as in Web UI:
<img width="562" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/6a0052c3-58a0-4a34-a362-217da3a6e7f6">

I tested it with my SAML app (set up as described here https://goteleport.com/docs/access-controls/idps/saml-guide). Unfortunately, I got some errors, but it looks like a samltest.id problem (it worked for me some time ago). The URL is the same as in Web UI.
