### PR TITLE
Prevent flash of card view when switching between tabs in Connect

### DIFF
--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -18,6 +18,7 @@
 
 import React, {
   useEffect,
+  useLayoutEffect,
   useState,
   useCallback,
   Children,
@@ -369,9 +370,19 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
   const expandAllLabels =
     unifiedResourcePreferences.labelsViewMode === LabelsViewMode.EXPANDED;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
+
+      // In Connect, when a tab becomes active, its outermost DOM element switches from `display:
+      // none` to `display: flex`. This callback is then fired with the width reported as zero.
+      //
+      // As such, when checking whether to force the card view or not, we should consider only
+      // values other than zero.
+      if (container.contentRect.width === 0) {
+        return;
+      }
+
       if (container.contentRect.width <= FORCE_CARD_VIEW_BREAKPOINT) {
         setForceCardView(true);
       } else {

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -20,6 +20,7 @@ import React, {
   ReactNode,
   Suspense,
   useEffect,
+  useLayoutEffect,
   useMemo,
   lazy,
   useState,
@@ -309,8 +310,23 @@ type MinWidthContextState = {
 
 const ContentMinWidthContext = createContext<MinWidthContextState>(null);
 
+/**
+ * @deprecated Use useNoMinWidth instead.
+ */
 export const useContentMinWidthContext = () =>
   useContext(ContentMinWidthContext);
+
+export const useNoMinWidth = () => {
+  const { setEnforceMinWidth } = useContext(ContentMinWidthContext);
+
+  useLayoutEffect(() => {
+    setEnforceMinWidth(false);
+
+    return () => {
+      setEnforceMinWidth(true);
+    };
+  }, []);
+};
 
 const ContentMinWidth = ({ children }: { children: ReactNode }) => {
   const [enforceMinWidth, setEnforceMinWidth] = useState(true);

--- a/web/packages/teleport/src/Main/index.ts
+++ b/web/packages/teleport/src/Main/index.ts
@@ -19,6 +19,7 @@
 export {
   Main as default,
   useContentMinWidthContext,
+  useNoMinWidth,
   HorizontalSplit,
   StyledIndicator,
 } from './Main';

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Flex } from 'design';
 import { Danger } from 'design/Alert';
@@ -41,7 +41,7 @@ import {
   FeatureHeaderTitle,
   FeatureBox,
 } from 'teleport/components/Layout';
-import { useContentMinWidthContext } from 'teleport/Main';
+import { useNoMinWidth } from 'teleport/Main';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 import { SearchResource } from 'teleport/Discover/SelectResource';
 import { encodeUrlQueryParams } from 'teleport/components/hooks/useUrlFiltering';
@@ -98,15 +98,7 @@ function ClusterResources({
   const teleCtx = useTeleport();
   const flags = teleCtx.getFeatureFlags();
 
-  const { setEnforceMinWidth } = useContentMinWidthContext();
-
-  useEffect(() => {
-    setEnforceMinWidth(false);
-
-    return () => {
-      setEnforceMinWidth(true);
-    };
-  }, []);
+  useNoMinWidth();
 
   const pinningNotSupported = storageService.arePinnedResourcesDisabled();
   const {


### PR DESCRIPTION
It also switches from `useEffect` to `useLayoutEffect` which is arguably better for effects which are purely DOM-based.

* https://kentcdodds.com/blog/useeffect-vs-uselayouteffect
* https://react.dev/reference/react/useLayoutEffect

In case of `useNoMinWidth`, `useLayoutEffect` makes it so that when `UnifiedResources` gets rendered, `setEnforceMinWidth(false)` gets called before the browser paint and this triggers a synchronous re-render. This means that the user won't ever see the content of a component like `UnifiedResources` with min-width set.

At the moment this doesn't make a meaningful difference, but the effect of using `useEffect` will compound over time. That's also why I refactored the hook a little bit so that callsites always use `useLayoutEffect` instead, without having to worry about these details.

https://github.com/gravitational/teleport/assets/27113/3e2a9499-3bbf-494e-9ee8-abaab038ce9a


https://github.com/gravitational/teleport/assets/27113/23db2973-a6b7-4d72-a17e-49f0f647f6ab