### PR TITLE
[v13] Update loader-utils to 2.0.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10177,16 +10177,7 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
-
-loader-utils@^2.0.4:
+loader-utils@^2.0.0, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==


### PR DESCRIPTION
This update for v13 is needed to address CVE-2022-37599 CVE-2022-37603 CVE-2022-37601.  This update was missed on only v13 it appears, but highlighted in our `sec-scan` repos:
* https://github.com/gravitational/teleport-sec-scan-3/security/dependabot/59
* https://github.com/gravitational/teleport-sec-scan-3/security/dependabot/62
* https://github.com/gravitational/teleport-sec-scan-3/security/dependabot/64