### PR TITLE
Athena Events: log execution duration

### DIFF
--- a/lib/events/athena/querier.go
+++ b/lib/events/athena/querier.go
@@ -389,11 +389,15 @@ func (q *querier) searchEvents(ctx context.Context, req searchEventsRequest) ([]
 		return nil, "", trace.Wrap(err)
 	}
 
-	q.logger.WithField("query", query).
-		WithField("params", params).
-		WithField("startKey", req.startKey).
-		Debug("Executing events query on Athena")
-
+	startTime := time.Now()
+	defer func() {
+		q.logger.WithFields(log.Fields{
+			"query":    query,
+			"params":   params,
+			"startKey": req.startKey,
+			"duration": time.Since(startTime),
+		}).Debug("Executed events query on Athena")
+	}()
 	queryId, err := q.startQueryExecution(ctx, query, params)
 	if err != nil {
 		return nil, "", trace.Wrap(err)


### PR DESCRIPTION
This PR changes the log message to be emitted after the query finishes so that we can also log its duration.

Related:

* [Slack discussion](https://gravitational.slack.com/archives/C01TYKHFVTQ/p1706632546341509?thread_ts=1706625685.151829&cid=C01TYKHFVTQ)