### PR TITLE
[v15]  Read the bearer token over websocket endpoints instead of query parameter #37520 

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -76,9 +76,6 @@ var (
 
 		// TestAdminActionMFA takes longer than 6 seconds to run.
 		"TestAdminActionMFA",
-
-		// TestTerminal takes 11 seconds to run.
-		"TestTerminal",
 	}
 )
 

--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -76,6 +76,9 @@ var (
 
 		// TestAdminActionMFA takes longer than 6 seconds to run.
 		"TestAdminActionMFA",
+
+		// TestTerminal takes 11 seconds to run.
+		"TestTerminal",
 	}
 )
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 	"github.com/gravitational/oxy/ratelimit"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -719,7 +720,10 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/locks/:uuid", h.WithClusterAuth(h.deleteClusterLock))
 
 	// active sessions handlers
-	h.GET("/webapi/sites/:site/connect", h.WithClusterAuth(h.siteNodeConnect))                     // connect to an active session (via websocket)
+	// Deprecated: The connect/ws variant should be used instead.
+	// TODO(lxea): DELETE in v16
+	h.GET("/webapi/sites/:site/connect", h.WithClusterAuthWS(false, h.siteNodeConnect))            // connect to an active session (via websocket)
+	h.GET("/webapi/sites/:site/connect/ws", h.WithClusterAuthWS(true, h.siteNodeConnect))          // connect to an active session (via websocket, with auth over websocket)
 	h.GET("/webapi/sites/:site/sessions", h.WithClusterAuth(h.clusterActiveAndPendingSessionsGet)) // get list of active and pending sessions
 
 	// Audit events handlers.
@@ -827,7 +831,11 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/desktopservices", h.WithClusterAuth(h.clusterDesktopServicesGet))
 	h.GET("/webapi/sites/:site/desktops/:desktopName", h.WithClusterAuth(h.getDesktopHandle))
 	// GET /webapi/sites/:site/desktops/:desktopName/connect?access_token=<bearer_token>&username=<username>&width=<width>&height=<height>
-	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuth(h.desktopConnectHandle))
+	// Deprecated: The connect/ws variant should be used instead.
+	// TODO(lxea): DELETE in v16
+	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuthWS(false, h.desktopConnectHandle))
+	// GET /webapi/sites/:site/desktops/:desktopName/connect?username=<username>&width=<width>&height=<height>
+	h.GET("/webapi/sites/:site/desktops/:desktopName/connect/ws", h.WithClusterAuthWS(true, h.desktopConnectHandle))
 	// GET /webapi/sites/:site/desktopplayback/:sid?access_token=<bearer_token>
 	h.GET("/webapi/sites/:site/desktopplayback/:sid", h.WithClusterAuth(h.desktopPlaybackHandle))
 	h.GET("/webapi/sites/:site/desktops/:desktopName/active", h.WithClusterAuth(h.desktopIsActive))
@@ -888,7 +896,11 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/user-groups", h.WithClusterAuth(h.getUserGroups))
 
 	// WebSocket endpoint for the chat conversation
-	h.GET("/webapi/sites/:site/assistant", h.WithClusterAuth(h.assistant))
+	// Deprecated: The connect/ws variant should be used instead.
+	// TODO(lxea): DELETE in v16
+	h.GET("/webapi/sites/:site/assistant", h.WithClusterAuthWS(false, h.assistant))
+	// WebSocket endpoint for the chat conversation, websocket auth
+	h.GET("/webapi/sites/:site/assistant/ws", h.WithClusterAuthWS(true, h.assistant))
 
 	// Sets the title for the conversation.
 	h.POST("/webapi/assistant/conversations/:conversation_id/title", h.WithAuth(h.setAssistantTitle))
@@ -907,7 +919,11 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/assistant/conversations/:conversation_id", h.WithAuth(h.getAssistantConversationByID))
 
 	// Allows executing an arbitrary command on multiple nodes.
-	h.GET("/webapi/command/:site/execute", h.WithClusterAuth(h.executeCommand))
+	// Deprecated: The execute/ws variant should be used instead.
+	// TODO(lxea): DELETE in v16
+	h.GET("/webapi/command/:site/execute", h.WithClusterAuthWS(false, h.executeCommand))
+	// Allows executing an arbitrary command on multiple nodes, websocket auth.
+	h.GET("/webapi/command/:site/execute/ws", h.WithClusterAuthWS(true, h.executeCommand))
 
 	// Fetches the user's preferences
 	h.GET("/webapi/user/preferences", h.WithAuth(h.getUserPreferences))
@@ -2920,6 +2936,7 @@ func (h *Handler) siteNodeConnect(
 	p httprouter.Params,
 	sessionCtx *SessionContext,
 	site reversetunnelclient.RemoteSite,
+	ws *websocket.Conn,
 ) (interface{}, error) {
 	q := r.URL.Query()
 	params := q.Get("params")
@@ -3012,6 +3029,7 @@ func (h *Handler) siteNodeConnect(
 		PROXYSigner:        h.cfg.PROXYSigner,
 		Tracker:            tracker,
 		PresenceChecker:    h.cfg.PresenceChecker,
+		WebsocketConn:      ws,
 	}
 
 	term, err := NewTerminal(ctx, terminalConfig)
@@ -3710,6 +3728,9 @@ type ContextHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Pa
 // ClusterHandler is a authenticated handler that is called for some existing remote cluster
 type ClusterHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error)
 
+// ClusterWebsocketHandler is a authenticated websocket handler that is called for some existing remote cluster
+type ClusterWebsocketHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite, ws *websocket.Conn) (interface{}, error)
+
 // WithClusterAuth wraps a ClusterHandler to ensure that a request is authenticated to this proxy
 // (the same as WithAuth), as well as to grab the remoteSite (which can represent this local cluster
 // or a remote trusted cluster) as specified by the ":site" url parameter.
@@ -3724,12 +3745,72 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 	})
 }
 
+// WithClusterAuthWS wraps a ClusterWebsocketHandler to ensure that a request is authenticated
+// to this proxy via websocket if websocketAuth is true, or via query parameter if false (the same as WithAuth), as
+// well as to grab the remoteSite (which can represent this local cluster or a remote trusted cluster)
+// as specified by the ":site" url parameter.
+//
+// TODO(lxea): remove the 'websocketAuth' bool once the deprecated websocket handlers are removed
+func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandler) httprouter.Handle {
+	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
+		if websocketAuth {
+			sctx, ws, site, err := h.authenticateWSRequestWithCluster(w, r, p)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			defer ws.Close()
+			return fn(w, r, p, sctx, site, ws)
+		}
+
+		sctx, site, err := h.authenticateRequestWithCluster(w, r, p)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		upgrader := websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin:     func(r *http.Request) bool { return true },
+		}
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			const errMsg = "Error upgrading to websocket"
+			h.log.WithError(err).Error(errMsg)
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return nil, nil
+		}
+
+		defer ws.Close()
+		return fn(w, r, p, sctx, site, ws)
+	})
+}
+
+// authenticateWSRequestWithCluster ensures that a request is
+// authenticated to this proxy via websocket, returning the
+// *SessionContext (same as AuthenticateRequest), and also grabs the
+// remoteSite (which can represent this local cluster or a remote
+// trusted cluster) as specified by the ":site" url parameter.
+func (h *Handler) authenticateWSRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, *websocket.Conn, reversetunnelclient.RemoteSite, error) {
+	sctx, ws, err := h.AuthenticateRequestWS(w, r)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	site, err := h.getSiteByParams(sctx, p)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	return sctx, ws, site, nil
+}
+
 // authenticateRequestWithCluster ensures that a request is authenticated
 // to this proxy, returning the *SessionContext (same as AuthenticateRequest),
 // and also grabs the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnelclient.RemoteSite, error) {
 	sctx, err := h.AuthenticateRequest(w, r, true)
+
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -4047,9 +4128,7 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 	return trace.Wrap(err)
 }
 
-// AuthenticateRequest authenticates request using combination of a session cookie
-// and bearer token
-func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, checkBearerToken bool) (*SessionContext, error) {
+func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*SessionContext, error) {
 	const missingCookieMsg = "missing session cookie"
 	cookie, err := r.Cookie(websession.CookieName)
 	if err != nil || (cookie != nil && cookie.Value == "") {
@@ -4063,6 +4142,17 @@ func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, ch
 	if err != nil {
 		websession.ClearCookie(w)
 		return nil, trace.AccessDenied("need auth")
+	}
+
+	return sctx, nil
+}
+
+// AuthenticateRequest authenticates request using combination of a session cookie
+// and bearer token
+func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, checkBearerToken bool) (*SessionContext, error) {
+	sctx, err := h.validateCookie(w, r)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	if checkBearerToken {
 		creds, err := roundtrip.ParseAuthHeaders(r)
@@ -4114,6 +4204,68 @@ func contextWithMFAResponseFromRequestHeader(ctx context.Context, requestHeader 
 	}
 
 	return ctx, nil
+}
+
+type wsBearerToken struct {
+	Token string `json:"token"`
+}
+
+type wsStatus struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+var wsIODeadline = time.Second * 4
+
+// AuthenticateRequest authenticates request using combination of a session cookie
+// and bearer token retrieved from a websocket
+func (h *Handler) AuthenticateRequestWS(w http.ResponseWriter, r *http.Request) (*SessionContext, *websocket.Conn, error) {
+	ctx, err := h.validateCookie(w, r)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return nil, nil, trace.ConnectionProblem(err, "Error upgrading to websocket: %v", err)
+	}
+	if err := ws.SetReadDeadline(deadlineForInterval(wsIODeadline)); err != nil {
+		log.WithError(err).Error("Error setting websocket read deadline")
+		return nil, nil, trace.ConnectionProblem(err, "Error setting websocket read deadline: %v", err)
+	}
+
+	var t wsBearerToken
+	if err := ws.ReadJSON(&t); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if err := ctx.validateBearerToken(r.Context(), t.Token); err != nil {
+		ws.WriteJSON(wsStatus{
+			Type:    "create_session_response",
+			Status:  "error",
+			Message: "invalid token",
+		})
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if err := ws.WriteJSON(wsStatus{
+		Type:   "create_session_response",
+		Status: "ok",
+	}); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if err := ws.SetReadDeadline(time.Time{}); err != nil {
+		log.WithError(err).Error("Error setting websocket read deadline")
+		return nil, nil, trace.ConnectionProblem(err, "Error setting websocket read deadline: %v", err)
+	}
+
+	return ctx, ws, nil
 }
 
 // ProxyWithRoles returns a reverse tunnel proxy verifying the permissions

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3773,7 +3773,7 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 			}
 			env, err := errEnvelope.Marshal()
 			if err != nil {
-				h.log.WithError(err).Error("error marshalling proto")
+				h.log.WithError(err).Error("error marshaling proto")
 				return nil, nil
 			}
 			if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
@@ -3807,7 +3807,7 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 		}
 		env, err := errEnvelope.Marshal()
 		if err != nil {
-			h.log.WithError(err).Error("error marshalling proto")
+			h.log.WithError(err).Error("error marshaling proto")
 			return nil, nil
 		}
 		if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3745,6 +3745,12 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 	})
 }
 
+// WSError is used to write errors that previously occurred before a
+// websocket got upgraded
+type WSError struct {
+	Error string `json:"error"`
+}
+
 // WithClusterAuthWS wraps a ClusterWebsocketHandler to ensure that a request is authenticated
 // to this proxy via websocket if websocketAuth is true, or via query parameter if false (the same as WithAuth), as
 // well as to grab the remoteSite (which can represent this local cluster or a remote trusted cluster)
@@ -3760,7 +3766,11 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 			}
 
 			defer ws.Close()
-			return fn(w, r, p, sctx, site, ws)
+			_, err = fn(w, r, p, sctx, site, ws)
+			if err := ws.WriteJSON(WSError{Error: err.Error()}); err != nil {
+				h.log.WithError(err).Error("error writing json")
+			}
+			return nil, nil
 		}
 
 		sctx, site, err := h.authenticateRequestWithCluster(w, r, p)
@@ -3781,7 +3791,11 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 		}
 
 		defer ws.Close()
-		return fn(w, r, p, sctx, site, ws)
+		_, err = fn(w, r, p, sctx, site, ws)
+		if err := ws.WriteJSON(WSError{Error: err.Error()}); err != nil {
+			h.log.WithError(err).Error("error writing json")
+		}
+		return nil, nil
 	})
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3745,12 +3745,6 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 	})
 }
 
-// WSError is used to write errors that previously occurred before a
-// websocket got upgraded
-type WSError struct {
-	Error string `json:"error"`
-}
-
 // WithClusterAuthWS wraps a ClusterWebsocketHandler to ensure that a request is authenticated
 // to this proxy via websocket if websocketAuth is true, or via query parameter if false (the same as WithAuth), as
 // well as to grab the remoteSite (which can represent this local cluster or a remote trusted cluster)
@@ -3766,18 +3760,21 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 			}
 
 			defer ws.Close()
-			_, err = fn(w, r, p, sctx, site, ws)
-			errEnvelope := Envelope{
-				Type:    defaults.WebsocketError,
-				Payload: err.Error(),
-			}
-			env, err := errEnvelope.Marshal()
-			if err != nil {
-				h.log.WithError(err).Error("error marshaling proto")
-				return nil, nil
-			}
-			if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
-				h.log.WithError(err).Error("error writing proto")
+
+			if _, err := fn(w, r, p, sctx, site, ws); err != nil {
+				errEnvelope := Envelope{
+					Type:    defaults.WebsocketError,
+					Payload: err.Error(),
+				}
+				env, err := errEnvelope.Marshal()
+				if err != nil {
+					h.log.WithError(err).Error("error marshaling proto")
+					return nil, nil
+				}
+				if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
+					h.log.WithError(err).Error("error writing proto")
+					return nil, nil
+				}
 			}
 			return nil, nil
 		}
@@ -3800,18 +3797,20 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 		}
 
 		defer ws.Close()
-		_, err = fn(w, r, p, sctx, site, ws)
-		errEnvelope := Envelope{
-			Type:    defaults.WebsocketError,
-			Payload: err.Error(),
-		}
-		env, err := errEnvelope.Marshal()
-		if err != nil {
-			h.log.WithError(err).Error("error marshaling proto")
-			return nil, nil
-		}
-		if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
-			h.log.WithError(err).Error("error writing proto")
+		if _, err := fn(w, r, p, sctx, site, ws); err != nil {
+			errEnvelope := Envelope{
+				Type:    defaults.WebsocketError,
+				Payload: err.Error(),
+			}
+			env, err := errEnvelope.Marshal()
+			if err != nil {
+				h.log.WithError(err).Error("error marshaling proto")
+				return nil, nil
+			}
+			if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
+				h.log.WithError(err).Error("error writing proto")
+				return nil, nil
+			}
 		}
 		return nil, nil
 	})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3767,8 +3767,17 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 
 			defer ws.Close()
 			_, err = fn(w, r, p, sctx, site, ws)
-			if err := ws.WriteJSON(WSError{Error: err.Error()}); err != nil {
-				h.log.WithError(err).Error("error writing json")
+			errEnvelope := Envelope{
+				Type:    defaults.WebsocketError,
+				Payload: err.Error(),
+			}
+			env, err := errEnvelope.Marshal()
+			if err != nil {
+				h.log.WithError(err).Error("error marshalling proto")
+				return nil, nil
+			}
+			if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
+				h.log.WithError(err).Error("error writing proto")
 			}
 			return nil, nil
 		}
@@ -3792,8 +3801,17 @@ func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandl
 
 		defer ws.Close()
 		_, err = fn(w, r, p, sctx, site, ws)
-		if err := ws.WriteJSON(WSError{Error: err.Error()}); err != nil {
-			h.log.WithError(err).Error("error writing json")
+		errEnvelope := Envelope{
+			Type:    defaults.WebsocketError,
+			Payload: err.Error(),
+		}
+		env, err := errEnvelope.Marshal()
+		if err != nil {
+			h.log.WithError(err).Error("error marshalling proto")
+			return nil, nil
+		}
+		if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
+			h.log.WithError(err).Error("error writing proto")
 		}
 		return nil, nil
 	})

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1372,7 +1372,7 @@ func TestSiteNodeConnectInvalidSessionID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	res := <-result
-	require.NotNil(t, res)
+	require.Error(t, res)
 }
 
 func TestResolveServerHostPort(t *testing.T) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1360,8 +1360,11 @@ func TestSiteNodeConnectInvalidSessionID(t *testing.T) {
 		proxy:     s.webServer.Listener.Addr().String(),
 		sessionID: "/../../../foo",
 	})
-	require.Error(t, err)
-	require.Nil(t, term)
+	require.NoError(t, err)
+	var wsError WSError
+	err = term.ws.ReadJSON(&wsError)
+	require.NoError(t, err)
+	require.Equal(t, "/../../../foo is not a valid UUID", wsError.Error)
 }
 
 func TestResolveServerHostPort(t *testing.T) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7348,24 +7348,6 @@ func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, e
 	return nil, nil
 }
 
-type terminalOpt func(t *TerminalRequest)
-
-func withSessionID(sid session.ID) terminalOpt {
-	return func(t *TerminalRequest) { t.SessionID = sid }
-}
-
-func withServer(target string) terminalOpt {
-	return func(t *TerminalRequest) { t.Server = target }
-}
-
-func withKeepaliveInterval(d time.Duration) terminalOpt {
-	return func(t *TerminalRequest) { t.KeepAliveInterval = d }
-}
-
-func withParticipantMode(m types.SessionParticipantMode) terminalOpt {
-	return func(t *TerminalRequest) { t.ParticipantMode = m }
-}
-
 func waitForOutputWithDuration(r io.Reader, substr string, timeout time.Duration) error {
 	timeoutCh := time.After(timeout)
 

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -128,6 +128,7 @@ func (h *Handler) executeCommand(
 	_ httprouter.Params,
 	sessionCtx *SessionContext,
 	site reversetunnelclient.RemoteSite,
+	rawWS *websocket.Conn,
 ) (any, error) {
 	q := r.URL.Query()
 	params := q.Get("params")
@@ -170,20 +171,6 @@ func (h *Handler) executeCommand(
 	}
 
 	clusterName := site.GetName()
-
-	upgrader := websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
-	}
-
-	rawWS, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		errMsg := "Error upgrading to websocket"
-		h.log.WithError(err).Error(errMsg)
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return nil, nil
-	}
 
 	defer func() {
 		rawWS.WriteMessage(websocket.CloseMessage, nil)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -142,6 +142,7 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 		participantMode: cfg.ParticipantMode,
 		tracker:         cfg.Tracker,
 		presenceChecker: cfg.PresenceChecker,
+		websocketConn:   cfg.WebsocketConn,
 	}, nil
 }
 
@@ -191,6 +192,8 @@ type TerminalHandlerConfig struct {
 	PresenceChecker PresenceChecker
 	// Clock allows interaction with time.
 	Clock clockwork.Clock
+	// WebsocketConn is the active websocket connection
+	WebsocketConn *websocket.Conn
 }
 
 func (t *TerminalHandlerConfig) CheckAndSetDefaults() error {
@@ -317,6 +320,9 @@ type TerminalHandler struct {
 
 	// clock used to interact with time.
 	clock clockwork.Clock
+
+	// websocketConn is the active websocket connection
+	websocketConn *websocket.Conn
 }
 
 // ServeHTTP builds a connection to the remote node and then pumps back two types of
@@ -328,21 +334,9 @@ func (t *TerminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.ctx.AddClosers(t)
 	defer t.ctx.RemoveCloser(t)
 
-	upgrader := websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
-	}
+	ws := t.websocketConn
 
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		errMsg := "Error upgrading to websocket"
-		t.log.WithError(err).Error(errMsg)
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
-
-	err = ws.SetReadDeadline(deadlineForInterval(t.keepAliveInterval))
+	err := ws.SetReadDeadline(deadlineForInterval(t.keepAliveInterval))
 	if err != nil {
 		t.log.WithError(err).Error("Error setting websocket readline")
 		return

--- a/web/packages/teleport/src/Console/consoleContext.tsx
+++ b/web/packages/teleport/src/Console/consoleContext.tsx
@@ -24,7 +24,7 @@ import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import webSession from 'teleport/services/websession';
 import history from 'teleport/services/history';
 import cfg, { UrlResourcesParams, UrlSshParams } from 'teleport/config';
-import { getAccessToken, getHostName } from 'teleport/services/api';
+import { getHostName } from 'teleport/services/api';
 import Tty from 'teleport/lib/term/tty';
 import TtyAddressResolver from 'teleport/lib/term/ttyAddressResolver';
 import serviceSession, {
@@ -197,7 +197,6 @@ export default class ConsoleContext {
 
     const ttyUrl = cfg.api.ttyWsAddr
       .replace(':fqdn', getHostName())
-      .replace(':token', getAccessToken())
       .replace(':clusterId', clusterId)
       .replace(':traceparent', carrier['traceparent']);
 

--- a/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -30,7 +30,7 @@ import {
   PngFrame,
   SyncKeys,
 } from 'teleport/lib/tdp/codec';
-import { getAccessToken, getHostName } from 'teleport/services/api';
+import { getHostName } from 'teleport/services/api';
 import cfg from 'teleport/config';
 import { Sha256Digest } from 'teleport/lib/util';
 
@@ -85,7 +85,6 @@ export default function useTdpClientCanvas(props: Props) {
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
       .replace(':desktopName', desktopName)
-      .replace(':token', getAccessToken())
       .replace(':username', username);
 
     setTdpClient(new TdpClient(addr));

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -157,7 +157,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     const url = cfg.api.desktopPlaybackWsAddr
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
-      .replace(':sid', sid)
+      .replace(':sid', sid);
     return new PlayerClient({ url, setTime, setPlayerStatus, setStatusText });
   }, [clusterId, sid, setTime, setPlayerStatus]);
 

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -23,7 +23,7 @@ import { Indicator, Box, Alert, Flex } from 'design';
 import cfg from 'teleport/config';
 import { StatusEnum, formatDisplayTime } from 'teleport/lib/player';
 import { PlayerClient, TdpClient } from 'teleport/lib/tdp';
-import { getAccessToken, getHostName } from 'teleport/services/api';
+import { getHostName } from 'teleport/services/api';
 import TdpClientCanvas from 'teleport/components/TdpClientCanvas';
 
 import ProgressBar from './ProgressBar';
@@ -158,7 +158,6 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
       .replace(':sid', sid)
-      .replace(':token', getAccessToken());
     return new PlayerClient({ url, setTime, setPlayerStatus, setStatusText });
   }, [clusterId, sid, setTime, setPlayerStatus]);
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -196,12 +196,12 @@ const cfg = {
     desktopServicesPath: `/v1/webapi/sites/:clusterId/desktopservices?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
     desktopPath: `/v1/webapi/sites/:clusterId/desktops/:desktopName`,
     desktopWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/desktops/:desktopName/connect?access_token=:token&username=:username',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/desktops/:desktopName/connect/ws?username=:username',
     desktopPlaybackWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/desktopplayback/:sid?access_token=:token',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/desktopplayback/:sid/ws',
     desktopIsActive: '/v1/webapi/sites/:clusterId/desktops/:desktopName/active',
     ttyWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/connect?access_token=:token&params=:params&traceparent=:traceparent',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/connect?params=:params&traceparent=:traceparent',
     ttyPlaybackWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/ttyplayback/:sid?access_token=:token', // TODO(zmb3): get token out of URL
     activeAndPendingSessionsPath: '/v1/webapi/sites/:clusterId/sessions',
@@ -310,11 +310,11 @@ const cfg = {
       '/v1/webapi/assistant/conversations/:conversationId/title',
     assistGenerateSummaryPath: '/v1/webapi/assistant/title/summary',
     assistConversationWebSocketPath:
-      'wss://:hostname/v1/webapi/sites/:clusterId/assistant',
+      'wss://:hostname/v1/webapi/sites/:clusterId/assistant/ws',
     assistConversationHistoryPath:
       '/v1/webapi/assistant/conversations/:conversationId',
     assistExecuteCommandWebSocketPath:
-      'wss://:hostname/v1/webapi/command/:clusterId/execute',
+      'wss://:hostname/v1/webapi/command/:clusterId/execute/ws',
     userPreferencesPath: '/v1/webapi/user/preferences',
     userClusterPreferencesPath: '/v1/webapi/user/preferences/:clusterId',
 
@@ -857,12 +857,10 @@ const cfg = {
   getAssistConversationWebSocketUrl(
     hostname: string,
     clusterId: string,
-    accessToken: string,
     conversationId: string
   ) {
     const searchParams = new URLSearchParams();
 
-    searchParams.set('access_token', accessToken);
     searchParams.set('conversation_id', conversationId);
 
     return (
@@ -876,12 +874,10 @@ const cfg = {
   getAssistActionWebSocketUrl(
     hostname: string,
     clusterId: string,
-    accessToken: string,
     action: string
   ) {
     const searchParams = new URLSearchParams();
 
-    searchParams.set('access_token', accessToken);
     searchParams.set('action', action);
 
     return (
@@ -901,12 +897,10 @@ const cfg = {
   getAssistExecuteCommandUrl(
     hostname: string,
     clusterId: string,
-    accessToken: string,
     params: Record<string, string>
   ) {
     const searchParams = new URLSearchParams();
 
-    searchParams.set('access_token', accessToken);
     searchParams.set('params', JSON.stringify(params));
 
     return (

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -201,7 +201,7 @@ const cfg = {
       'wss://:fqdn/v1/webapi/sites/:clusterId/desktopplayback/:sid/ws',
     desktopIsActive: '/v1/webapi/sites/:clusterId/desktops/:desktopName/active',
     ttyWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/connect?params=:params&traceparent=:traceparent',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/connect/ws?params=:params&traceparent=:traceparent',
     ttyPlaybackWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/ttyplayback/:sid?access_token=:token', // TODO(zmb3): get token out of URL
     activeAndPendingSessionsPath: '/v1/webapi/sites/:clusterId/sessions',

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -19,7 +19,9 @@
 import Logger from 'shared/libs/logger';
 
 import { EventEmitterWebAuthnSender } from 'teleport/lib/EventEmitterWebAuthnSender';
+import { getAccessToken } from 'teleport/services/api';
 import { WebauthnAssertionResponse } from 'teleport/services/auth';
+import { WebsocketStatus } from 'teleport/types';
 
 import { EventType, TermEvent, WebsocketCloseCode } from './enums';
 import { Protobuf, MessageTypeEnum } from './protobuf';
@@ -39,6 +41,7 @@ class Tty extends EventEmitterWebAuthnSender {
   _addressResolver = null;
   _proto = new Protobuf();
   _pendingUploads = {};
+  _authenticated = false;
 
   constructor(addressResolver, props = {}) {
     super();
@@ -52,6 +55,7 @@ class Tty extends EventEmitterWebAuthnSender {
     this._onOpenConnection = this._onOpenConnection.bind(this);
     this._onCloseConnection = this._onCloseConnection.bind(this);
     this._onMessage = this._onMessage.bind(this);
+    this._onAuthMessage = this._onAuthMessage.bind(this);
   }
 
   disconnect(closeCode = WebsocketCloseCode.NORMAL) {
@@ -65,7 +69,7 @@ class Tty extends EventEmitterWebAuthnSender {
     this.socket = new WebSocket(connStr);
     this.socket.binaryType = 'arraybuffer';
     this.socket.onopen = this._onOpenConnection;
-    this.socket.onmessage = this._onMessage;
+    this.socket.onmessage = this._onAuthMessage;
     this.socket.onclose = this._onCloseConnection;
   }
 
@@ -166,6 +170,7 @@ class Tty extends EventEmitterWebAuthnSender {
   _onOpenConnection() {
     this.emit('open');
     logger.info('websocket is open');
+    this.socket.send(JSON.stringify({ token: getAccessToken() }));
   }
 
   _onCloseConnection(e) {
@@ -174,10 +179,32 @@ class Tty extends EventEmitterWebAuthnSender {
     this.socket.onclose = null;
     this.socket = null;
     this.emit(TermEvent.CONN_CLOSE, e);
+    this._authenticated = false;
     logger.info('websocket is closed');
   }
 
+  _onAuthMessage(ev) {
+    const authResponse = JSON.parse(ev.data) as WebsocketStatus;
+    if (authResponse.type != 'create_session_response') {
+      this.socket.close();
+      console.log('invalid auth response type: ' + authResponse.message);
+      return;
+    }
+    if (authResponse.status == 'error') {
+      this.socket.close();
+      console.log(
+        'auth error connecting to websocket: ' + authResponse.message
+      );
+      return;
+    }
+    this._authenticated = true;
+  }
+
   _onMessage(ev) {
+    if (!this._authenticated) {
+      this._onAuthMessage(ev);
+      return;
+    }
     try {
       const uintArray = new Uint8Array(ev.data);
       const msg = this._proto.decode(uintArray);

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -69,7 +69,7 @@ class Tty extends EventEmitterWebAuthnSender {
     this.socket = new WebSocket(connStr);
     this.socket.binaryType = 'arraybuffer';
     this.socket.onopen = this._onOpenConnection;
-    this.socket.onmessage = this._onAuthMessage;
+    this.socket.onmessage = this._onMessage;
     this.socket.onclose = this._onCloseConnection;
   }
 

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -197,3 +197,11 @@ export enum RecommendationStatus {
   Notify = 'NOTIFY',
   Done = 'DONE',
 }
+
+// WebsocketStatus is used to indicate the auth status from a
+// websocket connection
+export type WebsocketStatus = {
+  type: string;
+  status: string;
+  message: string;
+};


### PR DESCRIPTION
Backport #37520 

Changelog: Read bearer token via websocket on websocket endpoints