### PR TITLE
[v15] chore: Bump OpenSSL to 3.0.13

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -46,9 +46,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.12 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.13 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'c3cc0f1386b0544383a61244a4beeb762b67498f' ] && \
+    [ "$(git rev-parse HEAD)" = '85cf92f55d9e2ac5aacf92bedd33fb890b9f8b4c' ] && \
     ./config --release -fPIC --libdir=/usr/local/lib && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -106,9 +106,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 # Specific install arguments used to skip docs.
 # Note that FIPS is enabled as part of this build, but it is unused without the
 # necessary configuration (which is included as part of the separate FIPS buildbox).
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.12 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.13 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'c3cc0f1386b0544383a61244a4beeb762b67498f' ] && \
+    [ "$(git rev-parse HEAD)" = '85cf92f55d9e2ac5aacf92bedd33fb890b9f8b4c' ] && \
     ./config enable-fips --release -fPIC --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw install_ssldirs install_fips

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -23,8 +23,8 @@ fi
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=openssl-3.0.12
-readonly CRYPTO_COMMIT=c3cc0f1386b0544383a61244a4beeb762b67498f
+readonly CRYPTO_VERSION=openssl-3.0.13
+readonly CRYPTO_COMMIT=85cf92f55d9e2ac5aacf92bedd33fb890b9f8b4c
 readonly FIDO2_VERSION=1.13.0
 readonly FIDO2_COMMIT=486a8f8667e42f55cee2bba301b41433cacec830
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.12
+Version: 3.0.13
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.12
+Version: 3.0.13
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Backport #37533 to branch/v15

changelog: Update OpenSSL to 3.0.13
