### PR TITLE
[v13] chore: Update Go toolchain to 1.21.6

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -39,8 +39,5 @@ jobs:
           go-version-file: api/go.mod
           cache-dependency-path: api/go.sum
 
-      - name: Init workspace
-        run: go work init . ./api/
-        
       - name: Build
-        run: go build ./api/...
+        run: cd api; go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,7 @@ output:
   uniq-by-line: false
 
 run:
-  go: '1.20'
+  go: '1.21'
   build-tags: []
   skip-dirs:
     - (^|/)node_modules/

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.20
+FROM docker.io/golang:1.21
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,7 +1,7 @@
 # Keep all tool versions in one place.
 # This file can be included in other Makefiles to avoid duplication.
 
-GOLANG_VERSION ?= go1.20.13
+GOLANG_VERSION ?= go1.21.0
 
 NODE_VERSION ?= 18.18.2
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,7 +1,7 @@
 # Keep all tool versions in one place.
 # This file can be included in other Makefiles to avoid duplication.
 
-GOLANG_VERSION ?= go1.21.0
+GOLANG_VERSION ?= go1.21.6
 
 NODE_VERSION ?= 18.18.2
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -1925,7 +1925,7 @@
     "teleport": {
       "major_version": "13",
       "version": "13.4.15",
-      "golang": "1.20",
+      "golang": "1.21",
       "plugin": {
         "version": "13.4.15"
       },

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -727,6 +727,10 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 
+	// Go 1.21 changed the default behavior of TLS servers.
+	// See https://go.dev/doc/go1.21#crypto/tls.
+	tlsConfig.SessionTicketsDisabled = true
+
 	accessPoint, err := NewAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.AuditLog)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -727,10 +727,6 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 
-	// Go 1.21 changed the default behavior of TLS servers.
-	// See https://go.dev/doc/go1.21#crypto/tls.
-	tlsConfig.SessionTicketsDisabled = true
-
 	accessPoint, err := NewAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.AuditLog)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -445,7 +445,7 @@ func TestAutoRotation(t *testing.T) {
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "bad certificate")
+	require.ErrorContains(t, err, "certificate")
 
 	// new clients work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -617,7 +617,7 @@ func TestManualRotation(t *testing.T) {
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "bad certificate")
+	require.ErrorContains(t, err, "certificate")
 
 	// new clients work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -712,7 +712,7 @@ func TestRollback(t *testing.T) {
 
 	// clients with new creds will no longer work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "bad certificate")
+	require.ErrorContains(t, err, "certificate")
 
 	// clients with old creds will still work
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -83,7 +83,7 @@ func TestStart(t *testing.T) {
 				return &tls.Config{InsecureSkipVerify: true}
 			},
 			connReadExpectationFunc: func(t *testing.T, connReadErr error) {
-				require.ErrorContains(t, connReadErr, "tls: bad certificate")
+				require.ErrorContains(t, connReadErr, "tls:")
 			},
 		},
 		{
@@ -94,7 +94,7 @@ func TestStart(t *testing.T) {
 				return &tls.Config{InsecureSkipVerify: true}
 			},
 			connReadExpectationFunc: func(t *testing.T, connReadErr error) {
-				require.ErrorContains(t, connReadErr, "tls: bad certificate")
+				require.ErrorContains(t, connReadErr, "tls:")
 			},
 		},
 	}


### PR DESCRIPTION
Update the Go toolchain in preparation for Go 1.22 (and, consequently, the Go 1.20 EOL).

Backports, to various degrees, #30180, #30201, #30525 and #31505.

Changelog: Updated Go to 1.21.6.