### PR TITLE
Refactor authz package helper methods - `AuthorizeWith*`

### DIFF
--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -106,8 +106,12 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 
 // CreateAssistantConversation creates a new conversation entry in the backend.
 func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.CreateAssistantConversationRequest) (*assist.CreateAssistantConversationResponse, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbCreate)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -121,8 +125,12 @@ func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.C
 
 // UpdateAssistantConversationInfo updates the conversation info for a conversation.
 func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assist.UpdateAssistantConversationInfoRequest) (*emptypb.Empty, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbUpdate)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -140,8 +148,12 @@ func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assi
 
 // GetAssistantConversations returns all conversations started by a user.
 func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.GetAssistantConversationsRequest) (*assist.GetAssistantConversationsResponse, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbList)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -155,8 +167,12 @@ func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.Get
 
 // DeleteAssistantConversation deletes a conversation entry and associated messages from the backend.
 func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.DeleteAssistantConversationRequest) (*emptypb.Empty, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbDelete)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -169,8 +185,12 @@ func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.D
 
 // GetAssistantMessages returns all messages with given conversation ID.
 func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssistantMessagesRequest) (*assist.GetAssistantMessagesResponse, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbRead)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -184,8 +204,12 @@ func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssis
 
 // CreateAssistantMessage adds the message to the backend.
 func (a *Service) CreateAssistantMessage(ctx context.Context, req *assist.CreateAssistantMessageRequest) (*emptypb.Empty, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbCreate)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -243,8 +267,12 @@ func (a *Service) GetAssistantEmbeddings(ctx context.Context, msg *assist.GetAss
 		return nil, trace.BadParameter("resource kind %v is not supported", msg.Kind)
 	}
 
-	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, msg.Kind, types.VerbRead, types.VerbList)
+	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, msg.Kind, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -111,7 +111,7 @@ func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.C
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -130,7 +130,7 @@ func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -153,7 +153,7 @@ func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.Get
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -172,7 +172,7 @@ func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.D
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -190,7 +190,7 @@ func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssis
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -209,7 +209,7 @@ func (a *Service) CreateAssistantMessage(ctx context.Context, req *assist.Create
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindAssistant, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -272,7 +272,7 @@ func (a *Service) GetAssistantEmbeddings(ctx context.Context, msg *assist.GetAss
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, msg.Kind, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, msg.Kind, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -96,8 +96,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 // ListDiscoveryConfigs returns a paginated list of all DiscoveryConfig resources.
 func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfigv1.ListDiscoveryConfigsRequest) (*discoveryconfigv1.ListDiscoveryConfigsResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbRead, types.VerbList)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -119,8 +123,12 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 
 // GetDiscoveryConfig returns the specified DiscoveryConfig resource.
 func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.GetDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -134,8 +142,12 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 
 // CreateDiscoveryConfig creates a new DiscoveryConfig resource.
 func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.CreateDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbCreate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -154,8 +166,12 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // UpdateDiscoveryConfig updates an existing DiscoveryConfig.
 func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.UpdateDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -174,8 +190,12 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // UpsertDiscoveryConfig creates or updates a DiscoveryConfig.
 func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.UpsertDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -194,8 +214,12 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // DeleteDiscoveryConfig removes the specified DiscoveryConfig resource.
 func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.DeleteDiscoveryConfigRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -208,8 +232,12 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // DeleteAllDiscoveryConfigs removes all DiscoveryConfig resources.
 func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoveryconfigv1.DeleteAllDiscoveryConfigsRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindDiscoveryConfig, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -101,7 +101,7 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -128,7 +128,7 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -147,7 +147,7 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -171,7 +171,7 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -195,7 +195,7 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -219,7 +219,7 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -237,7 +237,7 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -35,8 +35,12 @@ import (
 
 // GenerateAWSOIDCToken generates a token to be used when executing an AWS OIDC Integration action.
 func (s *Service) GenerateAWSOIDCToken(ctx context.Context, _ *integrationpb.GenerateAWSOIDCTokenRequest) (*integrationpb.GenerateAWSOIDCTokenResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbUse)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -40,7 +40,7 @@ func (s *Service) GenerateAWSOIDCToken(ctx context.Context, _ *integrationpb.Gen
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbUse); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -147,8 +147,12 @@ var _ integrationpb.AWSOIDCServiceServer = (*AWSOIDCService)(nil)
 
 // ListIntegrations returns a paginated list of Databases.
 func (s *AWSOIDCService) ListDatabases(ctx context.Context, req *integrationpb.ListDatabasesRequest) (*integrationpb.ListDatabasesResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbUse)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -133,7 +133,7 @@ func (s *Service) ListIntegrations(ctx context.Context, req *integrationpb.ListI
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -164,7 +164,7 @@ func (s *Service) GetIntegration(ctx context.Context, req *integrationpb.GetInte
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	integration, err := s.cache.GetIntegration(ctx, req.GetName())
@@ -187,7 +187,7 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -211,7 +211,7 @@ func (s *Service) UpdateIntegration(ctx context.Context, req *integrationpb.Upda
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -235,7 +235,7 @@ func (s *Service) DeleteIntegration(ctx context.Context, req *integrationpb.Dele
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -253,7 +253,7 @@ func (s *Service) DeleteAllIntegrations(ctx context.Context, _ *integrationpb.De
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -128,8 +128,12 @@ var _ integrationpb.IntegrationServiceServer = (*Service)(nil)
 
 // ListIntegrations returns a paginated list of all Integration resources.
 func (s *Service) ListIntegrations(ctx context.Context, req *integrationpb.ListIntegrationsRequest) (*integrationpb.ListIntegrationsResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbRead, types.VerbList)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -155,8 +159,12 @@ func (s *Service) ListIntegrations(ctx context.Context, req *integrationpb.ListI
 
 // GetIntegration returns the specified Integration resource.
 func (s *Service) GetIntegration(ctx context.Context, req *integrationpb.GetIntegrationRequest) (*types.IntegrationV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	integration, err := s.cache.GetIntegration(ctx, req.GetName())
@@ -174,8 +182,12 @@ func (s *Service) GetIntegration(ctx context.Context, req *integrationpb.GetInte
 
 // CreateIntegration creates a new Okta import rule resource.
 func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.CreateIntegrationRequest) (*types.IntegrationV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbCreate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -194,8 +206,12 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 
 // UpdateIntegration updates an existing Okta import rule resource.
 func (s *Service) UpdateIntegration(ctx context.Context, req *integrationpb.UpdateIntegrationRequest) (*types.IntegrationV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -214,8 +230,12 @@ func (s *Service) UpdateIntegration(ctx context.Context, req *integrationpb.Upda
 
 // DeleteIntegration removes the specified Integration resource.
 func (s *Service) DeleteIntegration(ctx context.Context, req *integrationpb.DeleteIntegrationRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -228,8 +248,12 @@ func (s *Service) DeleteIntegration(ctx context.Context, req *integrationpb.Dele
 
 // DeleteAllIntegrations removes all Integration resources.
 func (s *Service) DeleteAllIntegrations(ctx context.Context, _ *integrationpb.DeleteAllIntegrationsRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, true, types.KindIntegration, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -156,10 +156,12 @@ type BotService struct {
 
 // GetBot gets a bot by name. It will throw an error if the bot does not exist.
 func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bot, error) {
-	_, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbRead,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -188,10 +190,12 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 func (bs *BotService) ListBots(
 	ctx context.Context, req *pb.ListBotsRequest,
 ) (*pb.ListBotsResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbList,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -239,10 +243,11 @@ func (bs *BotService) ListBots(
 func (bs *BotService) CreateBot(
 	ctx context.Context, req *pb.CreateBotRequest,
 ) (*pb.Bot, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbCreate,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := authz.AuthorizeAdminActionAllowReusedMFA(ctx, authCtx); err != nil {
@@ -346,12 +351,15 @@ func UpsertBot(
 
 // UpsertBot creates a new bot or forcefully updates an existing bot.
 func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (*pb.Bot, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbCreate, types.VerbUpdate,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Support reused MFA for bulk tctl create requests.
 	if err := authz.AuthorizeAdminActionAllowReusedMFA(ctx, authCtx); err != nil {
 		return nil, trace.Wrap(err)
@@ -392,12 +400,15 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 func (bs *BotService) UpdateBot(
 	ctx context.Context, req *pb.UpdateBotRequest,
 ) (*pb.Bot, error) {
-	authCtx, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbUpdate,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if err := authz.AuthorizeAdminAction(ctx, authCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -517,12 +528,15 @@ func (bs *BotService) DeleteBot(
 	// seem to be any automatic deletion of locks in teleport today (other
 	// than expiration). Consistency around security controls seems important
 	// but we can revisit this if desired.
-	authCtx, err := authz.AuthorizeWithVerbs(
-		ctx, bs.logger, bs.authorizer, false, types.KindBot, types.VerbDelete,
-	)
+	authCtx, err := bs.authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if err := authz.AuthorizeAdminAction(ctx, authCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -161,7 +161,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -195,7 +195,7 @@ func (bs *BotService) ListBots(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -247,7 +247,7 @@ func (bs *BotService) CreateBot(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := authz.AuthorizeAdminActionAllowReusedMFA(ctx, authCtx); err != nil {
@@ -356,7 +356,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -405,7 +405,7 @@ func (bs *BotService) UpdateBot(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -533,7 +533,7 @@ func (bs *BotService) DeleteBot(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindBot, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/okta/service.go
+++ b/lib/auth/okta/service.go
@@ -116,7 +116,7 @@ func (s *Service) ListOktaImportRules(ctx context.Context, req *oktapb.ListOktaI
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -147,7 +147,7 @@ func (s *Service) GetOktaImportRule(ctx context.Context, req *oktapb.GetOktaImpo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	importRule, err := s.oktaImportRules.GetOktaImportRule(ctx, req.GetName())
@@ -170,7 +170,7 @@ func (s *Service) CreateOktaImportRule(ctx context.Context, req *oktapb.CreateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.CreateOktaImportRule(ctx, req.GetImportRule())
@@ -191,7 +191,7 @@ func (s *Service) UpdateOktaImportRule(ctx context.Context, req *oktapb.UpdateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.UpdateOktaImportRule(ctx, req.GetImportRule())
@@ -212,7 +212,7 @@ func (s *Service) DeleteOktaImportRule(ctx context.Context, req *oktapb.DeleteOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteOktaImportRule(ctx, req.GetName()))
@@ -225,7 +225,7 @@ func (s *Service) DeleteAllOktaImportRules(ctx context.Context, _ *oktapb.Delete
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteAllOktaImportRules(ctx))
@@ -238,7 +238,7 @@ func (s *Service) ListOktaAssignments(ctx context.Context, req *oktapb.ListOktaA
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbList, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -269,7 +269,7 @@ func (s *Service) GetOktaAssignment(ctx context.Context, req *oktapb.GetOktaAssi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	assignment, err := s.oktaAssignments.GetOktaAssignment(ctx, req.GetName())
@@ -292,7 +292,7 @@ func (s *Service) CreateOktaAssignment(ctx context.Context, req *oktapb.CreateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.CreateOktaAssignment(ctx, req.GetAssignment())
@@ -313,7 +313,7 @@ func (s *Service) UpdateOktaAssignment(ctx context.Context, req *oktapb.UpdateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.UpdateOktaAssignment(ctx, req.GetAssignment())
@@ -334,7 +334,7 @@ func (s *Service) UpdateOktaAssignmentStatus(ctx context.Context, req *oktapb.Up
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	err = s.oktaAssignments.UpdateOktaAssignmentStatus(ctx, req.GetName(), types.OktaAssignmentStatusProtoToString(req.GetStatus()),
@@ -349,7 +349,7 @@ func (s *Service) DeleteOktaAssignment(ctx context.Context, req *oktapb.DeleteOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteOktaAssignment(ctx, req.GetName()))
@@ -362,7 +362,7 @@ func (s *Service) DeleteAllOktaAssignments(ctx context.Context, _ *oktapb.Delete
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteAllOktaAssignments(ctx))

--- a/lib/auth/okta/service.go
+++ b/lib/auth/okta/service.go
@@ -111,8 +111,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 // ListOktaImportRules returns a paginated list of all Okta import rule resources.
 func (s *Service) ListOktaImportRules(ctx context.Context, req *oktapb.ListOktaImportRulesRequest) (*oktapb.ListOktaImportRulesResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbRead, types.VerbList)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -138,8 +142,12 @@ func (s *Service) ListOktaImportRules(ctx context.Context, req *oktapb.ListOktaI
 
 // GetOktaImportRule returns the specified Okta import rule resources.
 func (s *Service) GetOktaImportRule(ctx context.Context, req *oktapb.GetOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	importRule, err := s.oktaImportRules.GetOktaImportRule(ctx, req.GetName())
@@ -157,8 +165,12 @@ func (s *Service) GetOktaImportRule(ctx context.Context, req *oktapb.GetOktaImpo
 
 // CreateOktaImportRule creates a new Okta import rule resource.
 func (s *Service) CreateOktaImportRule(ctx context.Context, req *oktapb.CreateOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbCreate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.CreateOktaImportRule(ctx, req.GetImportRule())
@@ -174,8 +186,12 @@ func (s *Service) CreateOktaImportRule(ctx context.Context, req *oktapb.CreateOk
 
 // UpdateOktaImportRule updates an existing Okta import rule resource.
 func (s *Service) UpdateOktaImportRule(ctx context.Context, req *oktapb.UpdateOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.UpdateOktaImportRule(ctx, req.GetImportRule())
@@ -191,8 +207,12 @@ func (s *Service) UpdateOktaImportRule(ctx context.Context, req *oktapb.UpdateOk
 
 // DeleteOktaImportRule removes the specified Okta import rule resource.
 func (s *Service) DeleteOktaImportRule(ctx context.Context, req *oktapb.DeleteOktaImportRuleRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteOktaImportRule(ctx, req.GetName()))
@@ -200,8 +220,12 @@ func (s *Service) DeleteOktaImportRule(ctx context.Context, req *oktapb.DeleteOk
 
 // DeleteAllOktaImportRules removes all Okta import rules.
 func (s *Service) DeleteAllOktaImportRules(ctx context.Context, _ *oktapb.DeleteAllOktaImportRulesRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteAllOktaImportRules(ctx))
@@ -209,8 +233,12 @@ func (s *Service) DeleteAllOktaImportRules(ctx context.Context, _ *oktapb.Delete
 
 // ListOktaAssignments returns a paginated list of all Okta assignment resources.
 func (s *Service) ListOktaAssignments(ctx context.Context, req *oktapb.ListOktaAssignmentsRequest) (*oktapb.ListOktaAssignmentsResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbList, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -236,8 +264,12 @@ func (s *Service) ListOktaAssignments(ctx context.Context, req *oktapb.ListOktaA
 
 // GetOktaAssignment returns the specified Okta assignment resources.
 func (s *Service) GetOktaAssignment(ctx context.Context, req *oktapb.GetOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	assignment, err := s.oktaAssignments.GetOktaAssignment(ctx, req.GetName())
@@ -255,8 +287,12 @@ func (s *Service) GetOktaAssignment(ctx context.Context, req *oktapb.GetOktaAssi
 
 // CreateOktaAssignment creates a new Okta assignment resource.
 func (s *Service) CreateOktaAssignment(ctx context.Context, req *oktapb.CreateOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbCreate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.CreateOktaAssignment(ctx, req.GetAssignment())
@@ -272,8 +308,12 @@ func (s *Service) CreateOktaAssignment(ctx context.Context, req *oktapb.CreateOk
 
 // UpdateOktaAssignment updates an existing Okta assignment resource.
 func (s *Service) UpdateOktaAssignment(ctx context.Context, req *oktapb.UpdateOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.UpdateOktaAssignment(ctx, req.GetAssignment())
@@ -289,8 +329,12 @@ func (s *Service) UpdateOktaAssignment(ctx context.Context, req *oktapb.UpdateOk
 
 // UpdateOktaAssignmentStatus will update the status for an Okta assignment.
 func (s *Service) UpdateOktaAssignmentStatus(ctx context.Context, req *oktapb.UpdateOktaAssignmentStatusRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	err = s.oktaAssignments.UpdateOktaAssignmentStatus(ctx, req.GetName(), types.OktaAssignmentStatusProtoToString(req.GetStatus()),
@@ -300,8 +344,12 @@ func (s *Service) UpdateOktaAssignmentStatus(ctx context.Context, req *oktapb.Up
 
 // DeleteOktaAssignment removes the specified Okta assignment resource.
 func (s *Service) DeleteOktaAssignment(ctx context.Context, req *oktapb.DeleteOktaAssignmentRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteOktaAssignment(ctx, req.GetName()))
@@ -309,8 +357,12 @@ func (s *Service) DeleteOktaAssignment(ctx context.Context, req *oktapb.DeleteOk
 
 // DeleteAllOktaAssignments removes all Okta assignments.
 func (s *Service) DeleteAllOktaAssignments(ctx context.Context, _ *oktapb.DeleteAllOktaAssignmentsRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteAllOktaAssignments(ctx))

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -149,7 +149,7 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, verbs...); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, verbs[0], verbs[1:]...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -113,7 +113,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err = authzCtx.CheckAccessToResource(ctx, false, contextCA, readVerb); err != nil {
+	if err = authzCtx.CheckAccessToResource(false, contextCA, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -124,7 +124,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err = authzCtx.CheckAccessToResource(ctx, false, ca, readVerb); err != nil {
+	if err = authzCtx.CheckAccessToResource(false, ca, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -149,7 +149,7 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindCertAuthority, verbs...); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, verbs...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -179,7 +179,7 @@ func (s *Service) DeleteCertAuthority(ctx context.Context, req *trustpb.DeleteCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindCertAuthority, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -209,7 +209,7 @@ func (s *Service) UpsertCertAuthority(ctx context.Context, req *trustpb.UpsertCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authzCtx.CheckAccessToResource(ctx, false, req.CertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authzCtx.CheckAccessToResource(false, req.CertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -232,7 +232,7 @@ func (s *Service) RotateCertAuthority(ctx context.Context, req *trustpb.RotateCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, false, types.KindCertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -283,7 +283,7 @@ func (s *Service) RotateExternalCertAuthority(ctx context.Context, req *trustpb.
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToResource(ctx, false, req.CertAuthority, types.VerbRotate); err != nil {
+	if err := authCtx.CheckAccessToResource(false, req.CertAuthority, types.VerbRotate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -366,7 +366,6 @@ func (s *Service) GenerateHostCert(
 		},
 	}
 	if err = authCtx.CheckAccessToRule(
-		ctx,
 		false,
 		ruleCtx,
 		types.KindHostCert,

--- a/lib/auth/userloginstate/service.go
+++ b/lib/auth/userloginstate/service.go
@@ -98,7 +98,7 @@ func (s *Service) GetUserLoginStates(ctx context.Context, _ *userloginstatev1.Ge
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -124,7 +124,7 @@ func (s *Service) GetUserLoginState(ctx context.Context, req *userloginstatev1.G
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -143,7 +143,7 @@ func (s *Service) UpsertUserLoginState(ctx context.Context, req *userloginstatev
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -167,7 +167,7 @@ func (s *Service) DeleteUserLoginState(ctx context.Context, req *userloginstatev
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -186,7 +186,7 @@ func (s *Service) DeleteAllUserLoginStates(ctx context.Context, _ *userloginstat
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/userloginstate/service.go
+++ b/lib/auth/userloginstate/service.go
@@ -93,8 +93,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 // GetUserLoginStates returns a list of all user login states.
 func (s *Service) GetUserLoginStates(ctx context.Context, _ *userloginstatev1.GetUserLoginStatesRequest) (*userloginstatev1.GetUserLoginStatesResponse, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindUserLoginState, types.VerbRead, types.VerbList)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -115,8 +119,12 @@ func (s *Service) GetUserLoginStates(ctx context.Context, _ *userloginstatev1.Ge
 
 // GetUserLoginState returns the specified user login state resource.
 func (s *Service) GetUserLoginState(ctx context.Context, req *userloginstatev1.GetUserLoginStateRequest) (*userloginstatev1.UserLoginState, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindUserLoginState, types.VerbRead)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -130,8 +138,12 @@ func (s *Service) GetUserLoginState(ctx context.Context, req *userloginstatev1.G
 
 // UpsertUserLoginState creates or updates a user login state resource.
 func (s *Service) UpsertUserLoginState(ctx context.Context, req *userloginstatev1.UpsertUserLoginStateRequest) (*userloginstatev1.UserLoginState, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindUserLoginState, types.VerbCreate, types.VerbUpdate)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -150,8 +162,12 @@ func (s *Service) UpsertUserLoginState(ctx context.Context, req *userloginstatev
 
 // DeleteUserLoginState removes the specified user login state resource.
 func (s *Service) DeleteUserLoginState(ctx context.Context, req *userloginstatev1.DeleteUserLoginStateRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindUserLoginState, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -165,8 +181,12 @@ func (s *Service) DeleteUserLoginState(ctx context.Context, req *userloginstatev
 
 // DeleteAllUserLoginStates removes all user login states.
 func (s *Service) DeleteAllUserLoginStates(ctx context.Context, _ *userloginstatev1.DeleteAllUserLoginStatesRequest) (*emptypb.Empty, error) {
-	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindUserLoginState, types.VerbDelete)
+	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -192,7 +192,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 		// their own info.
 		if err := currentUserAction(*authCtx, req.Name); err != nil {
 			// not current user, perform normal permission check.
-			if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbRead); err != nil {
+			if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbRead); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
@@ -218,7 +218,7 @@ func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -290,7 +290,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *userspb.UpdateUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -377,7 +377,7 @@ func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -467,7 +467,7 @@ func (s *Service) DeleteUser(ctx context.Context, req *userspb.DeleteUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -556,7 +556,7 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 			return nil, trace.AccessDenied("this request can be only executed by an admin")
 		}
 	} else {
-		if err := authCtx.CheckAccessToKind(ctx, true, types.KindUser, types.VerbList, types.VerbRead); err != nil {
+		if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbList, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1418,32 +1418,28 @@ func AuthorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, auth
 }
 
 // CheckAccessToKind will ensure that the user has access to the given verbs for the given kind.
-func (c *Context) CheckAccessToKind(quiet bool, kind string, verbs ...string) error {
+func (c *Context) CheckAccessToKind(quiet bool, kind string, verb string, additionalVerbs ...string) error {
 	ruleCtx := &services.Context{
 		User: c.User,
 	}
 
-	return c.CheckAccessToRule(quiet, ruleCtx, kind, verbs...)
+	return c.CheckAccessToRule(quiet, ruleCtx, kind, verb, additionalVerbs...)
 }
 
 // CheckAccessToResource will ensure that the user has access to the given verbs for the given resource.
-func (c *Context) CheckAccessToResource(quiet bool, resource types.Resource, verbs ...string) error {
+func (c *Context) CheckAccessToResource(quiet bool, resource types.Resource, verb string, additionalVerbs ...string) error {
 	ruleCtx := &services.Context{
 		User:     c.User,
 		Resource: resource,
 	}
 
-	return c.CheckAccessToRule(quiet, ruleCtx, resource.GetKind(), verbs...)
+	return c.CheckAccessToRule(quiet, ruleCtx, resource.GetKind(), verb, additionalVerbs...)
 }
 
 // CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
-func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind string, verbs ...string) error {
-	if len(verbs) == 0 {
-		return trace.BadParameter("expected one or more verbs to be provided")
-	}
-
+func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind string, verb string, additionalVerbs ...string) error {
 	var errs []error
-	for _, verb := range verbs {
+	for _, verb := range append(additionalVerbs, verb) {
 		if err := c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet); err != nil {
 			errs = append(errs, err)
 		}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1418,26 +1418,26 @@ func AuthorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, auth
 }
 
 // CheckAccessToKind will ensure that the user has access to the given verbs for the given kind.
-func (c *Context) CheckAccessToKind(ctx context.Context, quiet bool, kind string, verbs ...string) error {
+func (c *Context) CheckAccessToKind(quiet bool, kind string, verbs ...string) error {
 	ruleCtx := &services.Context{
 		User: c.User,
 	}
 
-	return c.CheckAccessToRule(ctx, quiet, ruleCtx, kind, verbs...)
+	return c.CheckAccessToRule(quiet, ruleCtx, kind, verbs...)
 }
 
 // CheckAccessToResource will ensure that the user has access to the given verbs for the given resource.
-func (c *Context) CheckAccessToResource(ctx context.Context, quiet bool, resource types.Resource, verbs ...string) error {
+func (c *Context) CheckAccessToResource(quiet bool, resource types.Resource, verbs ...string) error {
 	ruleCtx := &services.Context{
 		User:     c.User,
 		Resource: resource,
 	}
 
-	return c.CheckAccessToRule(ctx, quiet, ruleCtx, resource.GetKind(), verbs...)
+	return c.CheckAccessToRule(quiet, ruleCtx, resource.GetKind(), verbs...)
 }
 
 // CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
-func (c *Context) CheckAccessToRule(ctx context.Context, quiet bool, ruleCtx *services.Context, kind string, verbs ...string) error {
+func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind string, verbs ...string) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("expected one or more verbs to be provided")
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1437,6 +1437,7 @@ func (c *Context) CheckAccessToResource(quiet bool, resource types.Resource, ver
 }
 
 // CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
+// Prefer to use [Context.CheckAccessToKind] or [Context.CheckAccessToResource] for common checks.
 func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind string, verb string, additionalVerbs ...string) error {
 	var errs []error
 	for _, verb := range append(additionalVerbs, verb) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1442,9 +1442,11 @@ func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind 
 		return trace.BadParameter("expected one or more verbs to be provided")
 	}
 
-	errs := make([]error, len(verbs))
-	for i, verb := range verbs {
-		errs[i] = c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet)
+	var errs []error
+	for _, verb := range verbs {
+		if err := c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return trace.NewAggregate(errs...)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1372,6 +1372,7 @@ func ClientUserMetadataWithUser(ctx context.Context, user string) apievents.User
 	return meta
 }
 
+// TODO(Joerger): replace with Authorize and authCtx.CheckAccessToResource
 // AuthorizeResourceWithVerbs will ensure that the user has access to the given verbs for the given kind.
 func AuthorizeResourceWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, resource types.Resource, verbs ...string) (*Context, error) {
 	authCtx, err := authorizer.Authorize(ctx)
@@ -1387,6 +1388,7 @@ func AuthorizeResourceWithVerbs(ctx context.Context, log logrus.FieldLogger, aut
 	return AuthorizeContextWithVerbs(ctx, log, authCtx, quiet, ruleCtx, resource.GetKind(), verbs...)
 }
 
+// TODO(Joerger): replace with Authorize and authCtx.CheckAccessToKind
 // AuthorizeWithVerbs will ensure that the user has access to the given verbs for the given kind.
 func AuthorizeWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, kind string, verbs ...string) (*Context, error) {
 	authCtx, err := authorizer.Authorize(ctx)
@@ -1401,6 +1403,7 @@ func AuthorizeWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer 
 	return AuthorizeContextWithVerbs(ctx, log, authCtx, quiet, ruleCtx, kind, verbs...)
 }
 
+// TODO(Joerger): replace with authCtx.CheckAccessToRule
 // AuthorizeContextWithVerbs will ensure that the user has access to the given verbs for the given services.context.
 func AuthorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, authCtx *Context, quiet bool, ruleCtx *services.Context, kind string, verbs ...string) (*Context, error) {
 	errs := make([]error, len(verbs))
@@ -1412,6 +1415,39 @@ func AuthorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, auth
 		return nil, err
 	}
 	return authCtx, nil
+}
+
+// CheckAccessToKind will ensure that the user has access to the given verbs for the given kind.
+func (c *Context) CheckAccessToKind(ctx context.Context, quiet bool, kind string, verbs ...string) error {
+	ruleCtx := &services.Context{
+		User: c.User,
+	}
+
+	return c.CheckAccessToRule(ctx, quiet, ruleCtx, kind, verbs...)
+}
+
+// CheckAccessToResource will ensure that the user has access to the given verbs for the given resource.
+func (c *Context) CheckAccessToResource(ctx context.Context, quiet bool, resource types.Resource, verbs ...string) error {
+	ruleCtx := &services.Context{
+		User:     c.User,
+		Resource: resource,
+	}
+
+	return c.CheckAccessToRule(ctx, quiet, ruleCtx, resource.GetKind(), verbs...)
+}
+
+// CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
+func (c *Context) CheckAccessToRule(ctx context.Context, quiet bool, ruleCtx *services.Context, kind string, verbs ...string) error {
+	if len(verbs) == 0 {
+		return trace.BadParameter("expected one or more verbs to be provided")
+	}
+
+	errs := make([]error, len(verbs))
+	for i, verb := range verbs {
+		errs[i] = c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet)
+	}
+
+	return trace.NewAggregate(errs...)
 }
 
 // AuthorizeAdminAction will ensure that the user is authorized to perform admin actions.


### PR DESCRIPTION
Replace authz package helper functions with `authz.Context` pointer methods:
- `AuthorizeResourceWithVerbs` -> `Authorize` + `CheckAccessToResource`
- `AuthorizeWithVerbs` -> `Authorize` + `CheckAccessToKind`
- `AuthorizeContextWithVerbs` -> `Authorize` + `CheckAccessToRule`

The goal of this change is to avoid redundant calls to `Authorize` which IMO is a bit of an anti pattern. It also [will cause failures if MFA for admin actions is necessary](https://github.com/gravitational/teleport.e/pull/3281).

The new methods may also be more intuitive by splitting up `Authorize` from `CheckAccess`.

TODO: follow up e PR