### PR TITLE
Reuse tunnel resolvers instead of creating one per connection attempt

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
@@ -53,6 +52,9 @@ type Config struct {
 	DialTimeout time.Duration
 	// Insecure turns off TLS certificate verification when enabled.
 	Insecure bool
+	// Resolver is used to identify the reverse tunnel address when connecting via
+	// the proxy.
+	Resolver reversetunnelclient.Resolver
 }
 
 // Connect creates a valid client connection to the auth service.  It may
@@ -112,25 +114,11 @@ func connectViaProxyTunnel(ctx context.Context, cfg *Config) (*auth.Client, erro
 	// If direct dial failed, we may have a proxy address in
 	// cfg.AuthServers. Try connecting to the reverse tunnel
 	// endpoint and make a client over that.
-	//
-	// TODO(nic): this logic should be implemented once and reused in IoT
-	// nodes.
-	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
-		Context:   ctx,
-		ProxyAddr: cfg.AuthServers[0].String(),
-		Insecure:  cfg.Insecure,
-		Timeout:   cfg.DialTimeout,
-	})
-
-	resolver, err := reversetunnelclient.CachingResolver(ctx, resolver, nil /* clock */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	// reversetunnel.TunnelAuthDialer will take care of creating a net.Conn
 	// within an SSH tunnel.
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
-		Resolver:              resolver,
+		Resolver:              cfg.Resolver,
 		ClientConfig:          cfg.SSH,
 		Log:                   cfg.Log,
 		InsecureSkipTLSVerify: cfg.Insecure,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib"
@@ -1122,7 +1121,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 		logger.Debug("Attempting to discover reverse tunnel address.")
 		logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-		tunnelClient, err := process.newClientThroughTunnel(authServers[0].String(), tlsConfig, sshClientConfig)
+		tunnelClient, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig)
 		if err != nil {
 			process.log.Errorf("Node failed to establish connection to Teleport Proxy. We have tried the following endpoints:")
 			process.log.Errorf("- connecting to auth server directly: %v", directErr)
@@ -1148,7 +1147,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 			logger := process.log.WithField("proxy-server", proxyServer.String())
 			logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-			tunnelClient, err := process.newClientThroughTunnel(proxyServer.String(), tlsConfig, sshClientConfig)
+			tunnelClient, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig)
 			if err != nil {
 				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
@@ -1167,21 +1166,9 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 	return nil, trace.NotImplemented("could not find connection strategy for config version %s", process.Config.Version)
 }
 
-func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
-	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
-		Context:   process.ExitContext(),
-		ProxyAddr: addr,
-		Insecure:  lib.IsInsecureDevMode(),
-		Timeout:   process.Config.Testing.ClientTimeout,
-	})
-
-	resolver, err := reversetunnelclient.CachingResolver(process.ExitContext(), resolver, process.Clock)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
-		Resolver:              resolver,
+		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
 		Log:                   process.log,
 		InsecureSkipTLSVerify: lib.IsInsecureDevMode(),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
@@ -431,6 +432,10 @@ type TeleportProcess struct {
 
 	// SSHD is used to execute commands to update or validate OpenSSH config.
 	SSHD openssh.SSHD
+
+	// resolver is used to identify the reverse tunnel address when connecting via
+	// the proxy.
+	resolver reversetunnelclient.Resolver
 }
 
 type keyPairKey struct {
@@ -982,6 +987,27 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		if err == nil {
 			process.Config.SetAuthServerAddress(utils.FromAddr(listener.Addr()))
 		}
+	}
+
+	var resolverAddr utils.NetAddr
+	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
+		resolverAddr = cfg.ProxyServer
+	} else {
+		resolverAddr = cfg.AuthServerAddresses()[0]
+	}
+
+	process.resolver, err = reversetunnelclient.CachingResolver(
+		process.ExitContext(),
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   process.ExitContext(),
+			ProxyAddr: resolverAddr.String(),
+			Insecure:  lib.IsInsecureDevMode(),
+			Timeout:   process.Config.Testing.ClientTimeout,
+		}),
+		process.Clock,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	upgraderKind := os.Getenv("TELEPORT_EXT_UPGRADER")

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -55,6 +56,7 @@ type identityService struct {
 	log               logrus.FieldLogger
 	reloadBroadcaster *channelBroadcaster
 	cfg               *config.BotConfig
+	resolver          reversetunnelclient.Resolver
 
 	mu     sync.Mutex
 	_ident *identity.Identity
@@ -158,7 +160,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 		if err := checkIdentity(s.log, loadedIdent); err != nil {
 			return trace.Wrap(err)
 		}
-		authClient, err := clientForIdentity(ctx, s.log, s.cfg, loadedIdent)
+		authClient, err := clientForIdentity(ctx, s.log, s.cfg, loadedIdent, s.resolver)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -188,7 +190,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	testClient, err := clientForIdentity(ctx, s.log, s.cfg, newIdentity)
+	testClient, err := clientForIdentity(ctx, s.log, s.cfg, newIdentity, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -290,7 +292,7 @@ func (s *identityService) renew(
 	if s.cfg.Onboarding.RenewableJoinMethod() {
 		// When using a renewable join method, we use GenerateUserCerts to
 		// request a new certificate using our current identity.
-		authClient, err := clientForIdentity(ctx, s.log, s.cfg, currentIdentity)
+		authClient, err := clientForIdentity(ctx, s.log, s.cfg, currentIdentity, s.resolver)
 		if err != nil {
 			return trace.Wrap(err, "creating auth client")
 		}

--- a/lib/tbot/service_ca_rotation.go
+++ b/lib/tbot/service_ca_rotation.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -131,6 +132,7 @@ type caRotationService struct {
 	reloadBroadcaster *channelBroadcaster
 	cfg               *config.BotConfig
 	botIdentitySrc    botIdentitySrc
+	resolver          reversetunnelclient.Resolver
 }
 
 func (s *caRotationService) String() string {
@@ -188,7 +190,7 @@ func (s *caRotationService) watchCARotations(ctx context.Context, queueReload fu
 	s.log.Debugf("Attempting to establish watch for CA events")
 
 	ident := s.botIdentitySrc.BotIdentity()
-	client, err := clientForIdentity(ctx, s.log, s.cfg, ident)
+	client, err := clientForIdentity(ctx, s.log, s.cfg, ident, s.resolver)
 	if err != nil {
 		return trace.Wrap(err, "creating client for ca watcher")
 	}

--- a/lib/tbot/service_ca_rotation_test.go
+++ b/lib/tbot/service_ca_rotation_test.go
@@ -25,12 +25,15 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
@@ -295,11 +298,21 @@ func TestBot_Run_CARotation(t *testing.T) {
 	)
 	b := New(botConfig, log)
 
+	resolver, err := reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.AuthServer,
+			Insecure:  b.cfg.Insecure,
+		}),
+		nil /* clock */)
+	require.NoError(t, err, "creating tunnel resolver")
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		err := b.Run(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	// Allow time for bot to start running and watching for CA rotations
 	// TODO: We should modify the bot to emit events that may be useful...
@@ -307,7 +320,7 @@ func TestBot_Run_CARotation(t *testing.T) {
 
 	// fetch initial host cert
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 2)
-	initialCAs := [][]byte{}
+	var initialCAs [][]byte
 	copy(initialCAs, b.BotIdentity().TLSCACertsBytes)
 
 	// Begin rotating through all of the phases, testing the client after
@@ -316,24 +329,24 @@ func TestBot_Run_CARotation(t *testing.T) {
 	// TODO: These sleeps allow the client time to rotate. They could be
 	// replaced if tbot emitted a CA rotation/renewal event.
 	time.Sleep(time.Second * 30)
-	_, err := clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateClients)
 	time.Sleep(time.Second * 30)
 	// Ensure both sets of CA certificates are now available locally
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 3)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateServers)
 	time.Sleep(time.Second * 30)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationStateStandby)
 	time.Sleep(time.Second * 30)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 2)

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -59,6 +60,7 @@ type outputsService struct {
 	reloadBroadcaster *channelBroadcaster
 	botIdentitySrc    botIdentitySrc
 	cfg               *config.BotConfig
+	resolver          reversetunnelclient.Resolver
 }
 
 func (s *outputsService) String() string {
@@ -83,7 +85,7 @@ func (s *outputsService) renewOutputs(
 	defer span.End()
 
 	botIdentity := s.botIdentitySrc.BotIdentity()
-	client, err := clientForIdentity(ctx, s.log, s.cfg, botIdentity)
+	client, err := clientForIdentity(ctx, s.log, s.cfg, botIdentity, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -548,7 +550,7 @@ func (s *outputsService) generateImpersonatedIdentity(
 
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	impersonatedClient, err = clientForIdentity(ctx, s.log, s.cfg, impersonatedIdentity)
+	impersonatedClient, err = clientForIdentity(ctx, s.log, s.cfg, impersonatedIdentity, s.resolver)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -30,10 +30,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -108,9 +110,21 @@ func (b *Bot) Run(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	resolver, err := reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.AuthServer,
+			Insecure:  b.cfg.Insecure,
+		}),
+		nil /* clock */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Create an error group to manage all the services lifetimes.
 	eg, egCtx := errgroup.WithContext(ctx)
-	services := []bot.Service{}
+	var services []bot.Service
 
 	// ReloadBroadcaster allows multiple entities to trigger a reload of
 	// all services. This allows os signals and other events such as CA
@@ -137,6 +151,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	b.botIdentitySvc = &identityService{
 		cfg:               b.cfg,
 		reloadBroadcaster: reloadBroadcaster,
+		resolver:          resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "identity"),
 		),
@@ -161,6 +176,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	services = append(services, &outputsService{
 		botIdentitySrc: b,
 		cfg:            b.cfg,
+		resolver:       resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "outputs"),
 		),
@@ -169,6 +185,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	services = append(services, &caRotationService{
 		botIdentitySrc: b,
 		cfg:            b.cfg,
+		resolver:       resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "ca-rotation"),
 		),
@@ -338,6 +355,7 @@ func clientForIdentity(
 	log logrus.FieldLogger,
 	cfg *config.BotConfig,
 	id *identity.Identity,
+	resolver reversetunnelclient.Resolver,
 ) (auth.ClientI, error) {
 	ctx, span := tracer.Start(ctx, "clientForIdentity")
 	defer span.End()
@@ -370,6 +388,7 @@ func clientForIdentity(
 		AuthServers: []utils.NetAddr{*authAddr},
 		Log:         log,
 		Insecure:    cfg.Insecure,
+		Resolver:    resolver,
 	}
 
 	c, err := authclient.Connect(ctx, authClientConfig)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -46,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
@@ -199,6 +201,20 @@ func TryRun(commands []CLICommand, args []string) error {
 	}
 
 	ctx := context.Background()
+
+	clientConfig.Resolver, err = reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: clientConfig.AuthServers[0].String(),
+			Insecure:  clientConfig.Insecure,
+			Timeout:   clientConfig.DialTimeout,
+		}),
+		nil /* clock */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	client, err := authclient.Connect(ctx, clientConfig)
 	if err != nil {
 		if utils.IsUntrustedCertErr(err) {


### PR DESCRIPTION
The `CachingResolver` is backed by a `FnCache` but does not expose a way to close the underlying cache. This leads to memory leaks as captured in #37025. Instead of modifying the resolver to allow explicit cleanup to occur, the resolvers were refactored to be created once per process instead of per connection attempt to the cluster. Since the cluster address is read from the config file, it won't be changed for the duration of the process which allows us to safely use a single resolver. The one potential downside to this approach is the cache may return possibly stale errors during an outage until the entry is TTLed.

Fixes #37025

changelog: Fix memory leak in tbot caused by never closing reverse tunnel address resolvers