### PR TITLE
Fix EKS enrolment failing because of admin MFA action.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2116,7 +2116,7 @@ func (a *ServerWithRoles) CreateToken(ctx context.Context, token types.Provision
 		return trace.Wrap(err)
 	}
 
-	if err := authz.AuthorizeAdminAction(ctx, &a.context); err != nil {
+	if err := authz.AuthorizeAdminActionAllowReusedMFA(ctx, &a.context); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -177,11 +177,18 @@ export const integrationService = {
       .then(resp => resp.clusterDashboardUrl);
   },
 
-  enrollEksClusters(
+  async enrollEksClusters(
     integrationName: string,
     req: EnrollEksClustersRequest
   ): Promise<EnrollEksClustersResponse> {
-    return api.post(cfg.getEnrollEksClusterUrl(integrationName), req);
+    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+
+    return api.post(
+      cfg.getEnrollEksClusterUrl(integrationName),
+      req,
+      null,
+      webauthnResponse
+    );
   },
 
   fetchEksClusters(


### PR DESCRIPTION
EKS enrolment was failing because we needed to have MFA admin action authorization. This PR adds MFA for the EKS enrolment and also changes CreateToken action to allow to reuse MFA.