### PR TITLE
build: Ensure pinned versions when installing wasm-pack

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install wasm-pack
         run: |
-          cargo install wasm-pack --version ${WASM_PACK_VERSION}
+          cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
 
       - name: Build
         run: make binaries

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -224,7 +224,7 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 
 ARG WASM_PACK_VERSION
 # Install wasm-pack for targeting WebAssembly from Rust.
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
 
 # Switch back to root for the remaining instructions and keep it as the default
 # user.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -259,7 +259,7 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 # Install wasm-pack for targeting WebAssembly from Rust.
 ARG WASM_PACK_VERSION
 # scl enable is required to use the newer C compiler installed above. Without it, the build fails.
-RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --version ${WASM_PACK_VERSION}"
+RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}"
 
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -81,4 +81,4 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 
 # Install wasm-pack for targeting WebAssembly from Rust.
 ARG WASM_PACK_VERSION
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "yarn build-wasm && vite",
-    "build-wasm": "wasm-pack build ./src/ironrdp --target web",
+    "build-wasm": "cargo install --locked wasm-bindgen-cli && wasm-pack build ./src/ironrdp --target web --mode no-install",
     "build": "yarn build-wasm && vite build",
     "test": "npx jest",
     "tdd": "jest . --watch"


### PR DESCRIPTION
When installing `wasm-pack` with `cargo`, use the `--locked` flag to
ensure the versions referenced in the Cargo.lock file are used and not
any newer versions. This creates a repeatable build and insulates us
from upstream breakage in new versions.

Also pre-build `wasm-bindgen-cli` first with `--locked` and tell `wasm-pack`
not to install it, as when it installs it, it does not use `--locked` and we see
the same build failure there.

In particular an upstream version change included the hoot-0.1.2
dependency on a new build which fails to build with rust 1.71.1, which
is the version we are using.

Update e ref to get matching changes from teleport.e

Link: https://github.com/rustwasm/wasm-pack/issues/1365