### PR TITLE
shink tctl by 40MB

### DIFF
--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -504,6 +504,7 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	})
 
 	if config, ok := awsKMSTestConfig(t); ok {
+		config.AWSKMS.clock = clock
 		backend, err := newAWSKMSKeystore(ctx, &config.AWSKMS, logger)
 		require.NoError(t, err)
 		backends = append(backends, &backendDesc{

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,11 +92,14 @@ func awsKMSTestConfig(t *testing.T) (Config, bool) {
 	if awsKMSAccount == "" || awsKMSRegion == "" {
 		return Config{}, false
 	}
+	cloudClients, err := cloud.NewClients()
+	require.NoError(t, err)
 	return Config{
 		AWSKMS: AWSKMSConfig{
-			Cluster:    "test-cluster",
-			AWSAccount: awsKMSAccount,
-			AWSRegion:  awsKMSRegion,
+			Cluster:      "test-cluster",
+			AWSAccount:   awsKMSAccount,
+			AWSRegion:    awsKMSRegion,
+			CloudClients: cloudClients,
 		},
 	}, true
 }

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -27,8 +27,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud"
 )
 
 func HSMTestConfig(t *testing.T) Config {


### PR DESCRIPTION
Removing a dependency on `lib/cloud.NewClients` from `lib/auth/keystore` shrinks tctl from 136MiB back down to 97MiB (local enterprise builds on ARM Mac)