### PR TITLE
[v15] build: Ensure pinned versions when installing wasm-pack

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install wasm-pack
         run: |
-          cargo install wasm-pack --version ${WASM_PACK_VERSION}
+          cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
 
       - name: Build
         run: make binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1342,9 +1342,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3001,9 +3001,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3011,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -3038,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3048,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3061,15 +3061,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -224,7 +224,7 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 
 ARG WASM_PACK_VERSION
 # Install wasm-pack for targeting WebAssembly from Rust.
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
 
 # Switch back to root for the remaining instructions and keep it as the default
 # user.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -259,7 +259,7 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 # Install wasm-pack for targeting WebAssembly from Rust.
 ARG WASM_PACK_VERSION
 # scl enable is required to use the newer C compiler installed above. Without it, the build fails.
-RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --version ${WASM_PACK_VERSION}"
+RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}"
 
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -81,4 +81,4 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 
 # Install wasm-pack for targeting WebAssembly from Rust.
 ARG WASM_PACK_VERSION
-RUN cargo install wasm-pack --version ${WASM_PACK_VERSION}
+RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "yarn build-wasm && vite",
-    "build-wasm": "wasm-pack build ./src/ironrdp --target web",
+    "build-wasm": "cargo install --locked wasm-bindgen-cli && wasm-pack build ./src/ironrdp --target web --mode no-install",
     "build": "yarn build-wasm && vite build",
     "test": "npx jest",
     "tdd": "jest . --watch"

--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -16,11 +16,11 @@ getrandom = { version = "0.2", features = ["js"] }
 ironrdp-session.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-graphics.workspace = true
-js-sys = "0.3.61"
+js-sys = "0.3.67"
 log = "0.4.20"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["time"] }
 tracing-web = "0.1.2"
 wasm-bindgen = "0.2.84"
-web-sys = { version = "0.3.61", features = ["ImageData"] }
+web-sys = { version = "0.3.67", features = ["ImageData"] }


### PR DESCRIPTION
When installing `wasm-pack` with `cargo`, use the `--locked` flag to ensure
the versions referenced in the Cargo.lock file are used and not any newer
versions. This creates a repeatable build and insulates us from upstream
breakage in new versions.

Also pre-build `wasm-bindgen-cli` first with `--locked` and tell `wasm-pack`
not to install it, as when it installs it, it does not use `--locked` and we see
the same build failure there.

Backport a rust dependency bump as that is needed for wasm-pack's view
of what version of wasm-bindgen should be built when we do it manually
to match what the latest version is. Without this, wasm-pack wants 0.2.89
but we build and install 0.2.90.

In particular an upstream version change included the hoot-0.1.2 dependency
on a new build which fails to build with rust 1.71.1, which is the version
we are using.

Update e ref to get matching changes from teleport.e

Backport: https://github.com/gravitational/teleport/pull/37568
Backport: https://github.com/gravitational/teleport/pull/36704