### PR TITLE
Adds `--locked` to all `cargo build`s and to `wasm-pack build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,9 +346,9 @@ ifeq ("$(with_rdpclient)", "yes")
 .PHONY: rdpclient
 rdpclient:
 ifneq ("$(FIPS)","")
-	cargo build -p rdp-client --features=fips --release $(CARGO_TARGET)
+	cargo build -p rdp-client --features=fips --release --locked $(CARGO_TARGET)
 else
-	cargo build -p rdp-client --release $(CARGO_TARGET)
+	cargo build -p rdp-client --release --locked $(CARGO_TARGET)
 endif
 else
 .PHONY: rdpclient

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "yarn build-wasm && vite",
-    "build-wasm": "cargo install --locked wasm-bindgen-cli && wasm-pack build ./src/ironrdp --target web --mode no-install",
+    "build-wasm": "cargo install --locked wasm-bindgen-cli && wasm-pack build ./src/ironrdp --target web --mode no-install -- --locked",
     "build": "yarn build-wasm && vite build",
     "test": "npx jest",
     "tdd": "jest . --watch"


### PR DESCRIPTION
This commit enforces that the Cargo.lock is already up-to-date (meaning semver compatible with the relevant Cargo.toml(s)) whenever we `cargo build`. This is desirable in CI, where we want to use Cargo.lock exactly, without it ever being updated unexpectedly. All updates should be explicitly handled offline.

Should not be merged until 
- [ ] https://github.com/gravitational/teleport.e/pull/3326 is merged and e-ref is updated.