### PR TITLE
Ensure yarn.lock is up to date, run workflows on relevant changes in root dir

### DIFF
--- a/.github/workflows/lint-ui-bypass.yaml
+++ b/.github/workflows/lint-ui-bypass.yaml
@@ -17,11 +17,23 @@ on:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
   merge_group:
     paths-ignore:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
 
 jobs:
   lint:

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -7,11 +7,23 @@ on:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
   merge_group:
     paths:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
 
 jobs:
   lint:

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -28,7 +28,7 @@ jobs:
           node --version
 
       - name: Install Yarn dependencies
-        run: yarn --frozen-lockfile
+        run: bash web/packages/build/scripts/yarn-install-frozen-lockfile.sh
 
       - name: Build WASM
         run: yarn build-wasm

--- a/.github/workflows/unit-tests-ui-bypass.yaml
+++ b/.github/workflows/unit-tests-ui-bypass.yaml
@@ -18,12 +18,26 @@ on:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
   merge_group:
     paths-ignore:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -8,12 +8,26 @@ on:
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
   merge_group:
     paths:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -33,7 +33,7 @@ jobs:
           node --version
 
       - name: Install Yarn dependencies
-        run: yarn --frozen-lockfile
+        run: bash web/packages/build/scripts/yarn-install-frozen-lockfile.sh
 
       - name: Build WASM
         run: yarn build-wasm

--- a/web/packages/build/scripts/yarn-install-frozen-lockfile.sh
+++ b/web/packages/build/scripts/yarn-install-frozen-lockfile.sh
@@ -6,9 +6,9 @@ set -ex
 # Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
 # https://github.com/yarnpkg/yarn/issues/4098
 
-message="yarn.lock needs an update. Run yarn install, verify that correct dependencies were \
-installed and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e \
-submodule initialized and updated first."
+message="yarn.lock needs an update. Run yarn install, verify that the correct dependencies were \
+installed and commit the updated version of yarn.lock. If you are making changes to enterprise \
+dependencies, make sure those changes are reflected in web/packages/e-imports/package.json as well."
 
 cp yarn.lock yarn-before-install.lock
 yarn install


### PR DESCRIPTION
[`yarn install --frozen-lockfile` doesn't work with workspaces](https://github.com/yarnpkg/yarn/issues/4098). This means that if someone makes changes to `package.json` but then forgets to commit the updated `yarn.lock`, our CI is going to install those new packages with no respect to what's in `yarn.lock`.

Back in the times of the webapps repo, we used to run a script to mitigate that (https://github.com/gravitational/webapps/pull/1047). However, executing the script was not carried over during the migration to a monorepo. This PR adds the execution of that script back to our CI workflows.

- [Example of a successful run](https://github.com/gravitational/teleport/actions/runs/7723998761/job/21055224948?pr=37579#step:5:46)
- [Example of an unsuccessful run](https://github.com/gravitational/teleport/actions/runs/7723844642/job/21054761487?pr=37579#step:5:69)

---

Another change introduced in this PR is running the lint and unit test workflows on relevant changes in the root dir. The workflows used to look only at `web` and `gen/proto` which meant it was possible to introduce a change in, say, `package.json` or `yarn.lock` without re-running linters and tests.