### PR TITLE
Display "UNKNOWN" for unsupported connections

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -149,12 +149,18 @@ function getKindName(connection: ExtendedTrackedConnection): string {
       if (isDatabaseUri(connection.targetUri)) {
         return 'DB';
       }
-      return '';
+      return 'UNKNOWN';
     case 'connection.server':
       return 'SSH';
     case 'connection.kube':
       return 'KUBE';
     default:
-      return '';
+      // The default branch is triggered when the state read from the disk
+      // contains a connection not supported by the given Connect version.
+      //
+      // For example, the user can open an app connection in Connect v15
+      // and then downgrade to a version that doesn't support apps.
+      // That connection should be shown as 'UNKNOWN' in the connection list.
+      return 'UNKNOWN';
   }
 }


### PR DESCRIPTION
This change was introduced in https://github.com/gravitational/teleport/pull/36730 which was merged to v14 and v13.

This PR ports it to master and v15.