### PR TITLE
Fix list all access list members/reviews pagination.

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -305,12 +305,7 @@ func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSi
 		// For listing all access list members for all access lists, we want to list members regardless of which
 		// access list they belong to. As a result, we'll use custom pagination logic here to include the appropriate
 		// prefix across pages.
-		lastItemKey := result.Items[len(out)-1].Key
-		prefixOffset := 2 + len(accessListMemberPrefix)
-		if len(lastItemKey) < prefixOffset {
-			return nil, "", trace.BadParameter("unable to calculate next page for listing all access list members")
-		}
-		nextKey = string(lastItemKey[prefixOffset:])
+		nextKey = out[pageSize].Spec.AccessList + string(backend.Separator) + out[pageSize].Metadata.Name
 		// Truncate the last item that was used to determine next row existence.
 		out = out[:pageSize]
 	}
@@ -555,15 +550,10 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 
 	var nextKey string
 	if len(out) > pageSize {
-		// For listing all access list members for all access lists, we want to list members regardless of which
+		// For listing all access list reviews for all access lists, we want to list reviews regardless of which
 		// access list they belong to. As a result, we'll use custom pagination logic here to include the appropriate
 		// prefix across pages.
-		lastItemKey := result.Items[len(out)-1].Key
-		prefixOffset := 2 + len(accessListReviewPrefix)
-		if len(lastItemKey) < prefixOffset {
-			return nil, "", trace.BadParameter("unable to calculate next page for listing all access list reviews")
-		}
-		nextKey = string(lastItemKey[prefixOffset:])
+		nextKey = out[pageSize].Spec.AccessList + string(backend.Separator) + out[pageSize].Metadata.Name
 		// Truncate the last item that was used to determine next row existence.
 		out = out[:pageSize]
 	}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -278,7 +278,7 @@ func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSi
 	}
 	var nextKey string
 	if next != nil {
-		nextKey = next.Spec.AccessList + string(backend.Separator) + next.Metadata.Name
+		nextKey = (*next).Spec.AccessList + string(backend.Separator) + (*next).Metadata.Name
 	}
 	return members, nextKey, nil
 }
@@ -498,7 +498,7 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 	}
 	var nextKey string
 	if next != nil {
-		nextKey = next.Spec.AccessList + string(backend.Separator) + next.Metadata.Name
+		nextKey = (*next).Spec.AccessList + string(backend.Separator) + (*next).Metadata.Name
 	}
 	return reviews, nextKey, nil
 }

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -956,7 +956,7 @@ func newAccessListReview(t *testing.T, accessList, name string) *accesslist.Revi
 
 	review, err := accesslist.NewReview(
 		header.Metadata{
-			Name: "test-access-list-review",
+			Name: name,
 		},
 		accesslist.ReviewSpec{
 			AccessList: accessList,
@@ -1402,6 +1402,71 @@ func TestAccessListService_ListAllAccessListMembers(t *testing.T) {
 	}
 
 	require.Empty(t, cmp.Diff(expectedMembers, allMembers, cmpopts.IgnoreFields(header.Metadata{}, "ID", "Revision")))
+}
+
+func TestAccessListService_ListAllAccessListReviews(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+
+	const numAccessLists = 10
+	const numAccessListReviewsPerAccessList = 250
+	totalReviews := numAccessLists * numAccessListReviewsPerAccessList
+
+	// Create several access lists.
+	expectedReviews := make([]*accesslist.Review, totalReviews)
+	for i := 0; i < numAccessLists; i++ {
+		alName := strconv.Itoa(i)
+		_, err := service.UpsertAccessList(ctx, newAccessList(t, alName, clock))
+		require.NoError(t, err)
+
+		for j := 0; j < numAccessListReviewsPerAccessList; j++ {
+			review, err := accesslist.NewReview(
+				header.Metadata{
+					Name: strconv.Itoa(j),
+				},
+				accesslist.ReviewSpec{
+					AccessList: alName,
+					Reviewers: []string{
+						"user1",
+					},
+					ReviewDate: time.Now(),
+				},
+			)
+			require.NoError(t, err)
+			review, _, err = service.CreateAccessListReview(ctx, review)
+			expectedReviews[i*numAccessListReviewsPerAccessList+j] = review
+			require.NoError(t, err)
+		}
+	}
+
+	allReviews := make([]*accesslist.Review, 0, totalReviews)
+	var nextToken string
+	for {
+		var reviews []*accesslist.Review
+		var err error
+		reviews, nextToken, err = service.ListAllAccessListReviews(ctx, 0, nextToken)
+		require.NoError(t, err)
+
+		allReviews = append(allReviews, reviews...)
+
+		if nextToken == "" {
+			break
+		}
+	}
+
+	require.Empty(t, cmp.Diff(expectedReviews, allReviews, cmpopts.IgnoreFields(header.Metadata{}, "ID", "Revision"), cmpopts.SortSlices(
+		func(r1, r2 *accesslist.Review) bool {
+			return r1.GetName() < r2.GetName()
+		}),
+	))
 }
 
 func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Clock, igsEnabled bool) *AccessListService {

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -274,3 +274,46 @@ func TestGenericCRUD(t *testing.T) {
 	require.Empty(t, nextToken)
 	require.Empty(t, out)
 }
+
+func TestGenericListResourcesReturnNextResource(t *testing.T) {
+	ctx := context.Background()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: "generic_prefix",
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	// Create a couple test resources.
+	r1 := newTestResource("r1")
+	r2 := newTestResource("r2")
+
+	_, err = service.WithPrefix("a-unique-prefix").UpsertResource(ctx, r1)
+	require.NoError(t, err)
+	_, err = service.WithPrefix("another-unique-prefix").UpsertResource(ctx, r2)
+	require.NoError(t, err)
+
+	page, next, err := service.ListResourcesReturnNextResource(ctx, 1, "")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*testResource{r1}, page,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
+	require.NotNil(t, next)
+
+	page, next, err = service.ListResourcesReturnNextResource(ctx, 1, "another-unique-prefix"+string(backend.Separator)+backend.GetPaginationKey(next))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*testResource{r2}, page,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
+	require.Nil(t, next)
+}

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -310,7 +310,7 @@ func TestGenericListResourcesReturnNextResource(t *testing.T) {
 	))
 	require.NotNil(t, next)
 
-	page, next, err = service.ListResourcesReturnNextResource(ctx, 1, "another-unique-prefix"+string(backend.Separator)+backend.GetPaginationKey(next))
+	page, next, err = service.ListResourcesReturnNextResource(ctx, 1, "another-unique-prefix"+string(backend.Separator)+backend.GetPaginationKey(*next))
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff([]*testResource{r2}, page,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),


### PR DESCRIPTION
Two things were happening that was preventing the cache of access list members/reviews from initializing if the number of members was greater than the default page size of 200:

1. The incorrect page token was being used in the ListAllAccessListMembers call.
2. The pagination key for listing all of these members was incorrect due to the use of sub-prefixes.

Both issues have been corrected. The ListAllAccessListMembers/Reviews calls in the access list service now uses their own custom pagination logic.

changelog: Fix cache init issue with access list members/reviews.