### PR TITLE
Make 'offline' screens not scrollable

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -183,6 +183,7 @@ function PrintState(props: {
     <Flex
       flexDirection="column"
       mx="auto"
+      mb="auto"
       alignItems="center"
       css={`
         top: 11%;

--- a/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
+++ b/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
@@ -53,6 +53,7 @@ export function OfflineGateway(props: {
     <Flex
       flexDirection="column"
       mx="auto"
+      mb="auto"
       alignItems="center"
       maxWidth="500px"
       css={`


### PR DESCRIPTION
'Offline' screens shouldn't have the scrollbar.

Before:
<img width="1030" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/49e364a9-ed17-44f0-8270-50c8a52fab23">

After:
<img width="1024" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/1aa75c3f-b64a-4ef4-85aa-3b618752fb40">
