### PR TITLE
postgres atomic write impl

### DIFF
--- a/lib/backend/pgbk/atomicwrite.go
+++ b/lib/backend/pgbk/atomicwrite.go
@@ -36,124 +36,115 @@ func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.Conditiona
 
 	newRevision := newRevision()
 
-	var includesPut bool
+	type batchItem struct {
+		query     string
+		arguments []any
+	}
+	var condBatchItems, actBatchItems []batchItem
+	var actBatchIncludesPut bool
 
-	var n int
+	for _, ca := range condacts {
+		switch ca.Condition.Kind {
+		case backend.KindWhatever:
+			// no comparison to assert
+		case backend.KindExists:
+			condBatchItems = append(condBatchItems, batchItem{
+				"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
+				[]any{nonNil(ca.Key)},
+			})
+		case backend.KindNotExists:
+			condBatchItems = append(condBatchItems, batchItem{
+				"SELECT NOT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
+				[]any{nonNil(ca.Key)},
+			})
+		case backend.KindRevision:
+			expectedRevision, ok := revisionFromString(ca.Condition.Revision)
+			if !ok {
+				return "", trace.Wrap(backend.ErrConditionFailed)
+			}
+			condBatchItems = append(condBatchItems, batchItem{
+				"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND revision = $2 AND (expires IS NULL OR expires >= now()))",
+				[]any{nonNil(ca.Key), expectedRevision},
+			})
+		default:
+			// condacts was already checked for validity
+			return "", trace.BadParameter("unexpected condition kind %v in conditional action against key %q (this is a bug)", ca.Condition.Kind, ca.Key)
+		}
 
-	_, err = pgcommon.Retry(ctx, b.log, func() (struct{}, error) {
-		n++
-		var conditionFailed bool
+		switch ca.Action.Kind {
+		case backend.KindNop:
+			// no action to be taken
+		case backend.KindPut:
+			actBatchIncludesPut = true
+			actBatchItems = append(actBatchItems, batchItem{
+				"INSERT INTO kv (key, value, expires, revision) VALUES ($1, $2, $3, $4)" +
+					" ON CONFLICT (key) DO UPDATE SET" +
+					" value = excluded.value, expires = excluded.expires, revision = excluded.revision",
+				[]any{nonNil(ca.Key), nonNil(ca.Action.Item.Value), zeronull.Timestamptz(ca.Action.Item.Expires.UTC()), newRevision},
+			})
+		case backend.KindDelete:
+			actBatchItems = append(actBatchItems, batchItem{
+				"DELETE FROM kv WHERE kv.key = $1 AND (kv.expires IS NULL OR kv.expires > now())",
+				[]any{nonNil(ca.Key)},
+			})
+		default:
+			// condacts was already checked for validity
+			return "", trace.BadParameter("unexpected action kind %v in conditional action against key %q (this is a bug)", ca.Action.Kind, ca.Key)
+		}
+	}
+
+	var success bool
+	querySuccess := func(row pgx.Row) error {
+		if !success {
+			return nil
+		}
+		return trace.Wrap(row.Scan(&success))
+	}
+
+	var tries int
+	err = pgcommon.RetryTx(ctx, b.log, b.pool, pgx.TxOptions{}, false, func(tx pgx.Tx) error {
+		tries++
+
 		var condBatch, actBatch pgx.Batch
-
-		for _, ca := range condacts {
-			switch ca.Condition.Kind {
-			case backend.KindWhatever:
-				// no comparison to assert
-			case backend.KindExists:
-				condBatch.Queue(
-					"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
-					nonNil(ca.Key),
-				).QueryRow(func(row pgx.Row) error {
-					var cond bool
-					if err := row.Scan(&cond); err != nil {
-						return trace.Wrap(err)
-					}
-					conditionFailed = conditionFailed || !cond
-					return nil
-				})
-			case backend.KindNotExists:
-				condBatch.Queue(
-					"SELECT NOT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
-					nonNil(ca.Key),
-				).QueryRow(func(row pgx.Row) error {
-					var cond bool
-					if err := row.Scan(&cond); err != nil {
-						return trace.Wrap(err)
-					}
-					conditionFailed = conditionFailed || !cond
-					return nil
-				})
-			case backend.KindRevision:
-				expectedRevision, ok := revisionFromString(ca.Condition.Revision)
-				if !ok {
-					return struct{}{}, trace.Wrap(backend.ErrConditionFailed)
-				}
-				condBatch.Queue(
-					"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND revision = $2 AND (expires IS NULL OR expires >= now()))",
-					nonNil(ca.Key), expectedRevision,
-				).QueryRow(func(row pgx.Row) error {
-					var cond bool
-					if err := row.Scan(&cond); err != nil {
-						return trace.Wrap(err)
-					}
-					conditionFailed = conditionFailed || !cond
-					return nil
-				})
-			default:
-				return struct{}{}, trace.BadParameter("unexpected condition kind %v in conditional action against key %q", ca.Condition.Kind, ca.Key)
-			}
-
-			switch ca.Action.Kind {
-			case backend.KindNop:
-				// no action to be taken
-			case backend.KindPut:
-				includesPut = true
-				actBatch.Queue(
-					"INSERT INTO kv (key, value, expires, revision) VALUES ($1, $2, $3, $4)"+
-						" ON CONFLICT (key) DO UPDATE SET"+
-						" value = excluded.value, expires = excluded.expires, revision = excluded.revision",
-					nonNil(ca.Key), nonNil(ca.Action.Item.Value), zeronull.Timestamptz(ca.Action.Item.Expires.UTC()), newRevision,
-				)
-			case backend.KindDelete:
-				actBatch.Queue(
-					"DELETE FROM kv WHERE kv.key = $1 AND (kv.expires IS NULL OR kv.expires > now())", nonNil(ca.Key),
-				)
-			default:
-				return struct{}{}, trace.BadParameter("unexpected action kind %v in conditional action against key %q", ca.Action.Kind, ca.Key)
-			}
+		for _, bi := range condBatchItems {
+			condBatch.Queue(bi.query, bi.arguments...).QueryRow(querySuccess)
+		}
+		for _, bi := range actBatchItems {
+			actBatch.Queue(bi.query, bi.arguments...)
 		}
 
-		tx, err := b.pool.Begin(ctx)
-		if err != nil {
-			return struct{}{}, trace.Wrap(err)
-		}
-
-		// Rollback is designed to be safe to defer and will have no effect if we end up
-		// committing the transaction before returning.
-		defer tx.Rollback(ctx)
-
-		if condBatch.Len() != 0 {
+		success = true
+		if condBatch.Len() > 0 {
 			if err := tx.SendBatch(ctx, &condBatch).Close(); err != nil {
-				return struct{}{}, trace.Wrap(err)
+				return trace.Wrap(err)
 			}
-		}
-
-		if conditionFailed {
-			return struct{}{}, trace.Wrap(backend.ErrConditionFailed)
+			if !success {
+				return nil
+			}
 		}
 
 		if err := tx.SendBatch(ctx, &actBatch).Close(); err != nil {
-			return struct{}{}, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
-		if err := tx.Commit(ctx); err != nil {
-			return struct{}{}, trace.Wrap(err)
-		}
-
-		return struct{}{}, nil
+		return nil
 	})
 
-	if n > 2 {
+	if tries > 2 {
 		// if we retried more than once, txn experienced non-trivial conflict and we should warn about it. Infrequent warnings of this kind
 		// are nothing to be concerned about, but high volumes may indicate that an automatic process is creating excessive conflicts.
-		b.log.Warnf("AtomicWrite retried %d times due to postgres transaction contention. Some conflict is expected, but persistent conflict warnings may indicate an unhealthy state.", n)
+		b.log.Warnf("AtomicWrite retried %d times due to postgres transaction contention. Some conflict is expected, but persistent conflict warnings may indicate an unhealthy state.", tries)
 	}
 
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 
-	if !includesPut {
+	if !success {
+		return "", trace.Wrap(backend.ErrConditionFailed)
+	}
+
+	if !actBatchIncludesPut {
 		return "", nil
 	}
 

--- a/lib/backend/pgbk/atomicwrite.go
+++ b/lib/backend/pgbk/atomicwrite.go
@@ -1,0 +1,161 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pgbk
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype/zeronull"
+
+	"github.com/gravitational/teleport/lib/backend"
+	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
+)
+
+func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.ConditionalAction) (revision string, err error) {
+	if err := backend.ValidateAtomicWrite(condacts); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	newRevision := newRevision()
+
+	var includesPut bool
+
+	var n int
+
+	_, err = pgcommon.Retry(ctx, b.log, func() (struct{}, error) {
+		n++
+		var conditionFailed bool
+		var condBatch, actBatch pgx.Batch
+
+		for _, ca := range condacts {
+			switch ca.Condition.Kind {
+			case backend.KindWhatever:
+				// no comparison to assert
+			case backend.KindExists:
+				condBatch.Queue(
+					"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
+					nonNil(ca.Key),
+				).QueryRow(func(row pgx.Row) error {
+					var cond bool
+					if err := row.Scan(&cond); err != nil {
+						return trace.Wrap(err)
+					}
+					conditionFailed = conditionFailed || !cond
+					return nil
+				})
+			case backend.KindNotExists:
+				condBatch.Queue(
+					"SELECT NOT EXISTS (SELECT FROM kv WHERE key = $1 AND (expires IS NULL OR expires >= now()))",
+					nonNil(ca.Key),
+				).QueryRow(func(row pgx.Row) error {
+					var cond bool
+					if err := row.Scan(&cond); err != nil {
+						return trace.Wrap(err)
+					}
+					conditionFailed = conditionFailed || !cond
+					return nil
+				})
+			case backend.KindRevision:
+				expectedRevision, ok := revisionFromString(ca.Condition.Revision)
+				if !ok {
+					return struct{}{}, trace.Wrap(backend.ErrConditionFailed)
+				}
+				condBatch.Queue(
+					"SELECT EXISTS (SELECT FROM kv WHERE key = $1 AND revision = $2 AND (expires IS NULL OR expires >= now()))",
+					nonNil(ca.Key), expectedRevision,
+				).QueryRow(func(row pgx.Row) error {
+					var cond bool
+					if err := row.Scan(&cond); err != nil {
+						return trace.Wrap(err)
+					}
+					conditionFailed = conditionFailed || !cond
+					return nil
+				})
+			default:
+				return struct{}{}, trace.BadParameter("unexpected condition kind %v in conditional action against key %q", ca.Condition.Kind, ca.Key)
+			}
+
+			switch ca.Action.Kind {
+			case backend.KindNop:
+				// no action to be taken
+			case backend.KindPut:
+				includesPut = true
+				actBatch.Queue(
+					"INSERT INTO kv (key, value, expires, revision) VALUES ($1, $2, $3, $4)"+
+						" ON CONFLICT (key) DO UPDATE SET"+
+						" value = excluded.value, expires = excluded.expires, revision = excluded.revision",
+					nonNil(ca.Key), nonNil(ca.Action.Item.Value), zeronull.Timestamptz(ca.Action.Item.Expires.UTC()), newRevision,
+				)
+			case backend.KindDelete:
+				actBatch.Queue(
+					"DELETE FROM kv WHERE kv.key = $1 AND (kv.expires IS NULL OR kv.expires > now())", nonNil(ca.Key),
+				)
+			default:
+				return struct{}{}, trace.BadParameter("unexpected action kind %v in conditional action against key %q", ca.Action.Kind, ca.Key)
+			}
+		}
+
+		tx, err := b.pool.Begin(ctx)
+		if err != nil {
+			return struct{}{}, trace.Wrap(err)
+		}
+
+		// Rollback is designed to be safe to defer and will have no effect if we end up
+		// committing the transaction before returning.
+		defer tx.Rollback(ctx)
+
+		if condBatch.Len() != 0 {
+			if err := tx.SendBatch(ctx, &condBatch).Close(); err != nil {
+				return struct{}{}, trace.Wrap(err)
+			}
+		}
+
+		if conditionFailed {
+			return struct{}{}, trace.Wrap(backend.ErrConditionFailed)
+		}
+
+		if err := tx.SendBatch(ctx, &actBatch).Close(); err != nil {
+			return struct{}{}, trace.Wrap(err)
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			return struct{}{}, trace.Wrap(err)
+		}
+
+		return struct{}{}, nil
+	})
+
+	if n > 2 {
+		// if we retried more than once, txn experienced non-trivial conflict and we should warn about it. Infrequent warnings of this kind
+		// are nothing to be concerned about, but high volumes may indicate that an automatic process is creating excessive conflicts.
+		b.log.Warnf("AtomicWrite retried %d times due to postgres transaction contention. Some conflict is expected, but persistent conflict warnings may indicate an unhealthy state.", n)
+	}
+
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if !includesPut {
+		return "", nil
+	}
+
+	return revisionToString(newRevision), nil
+}

--- a/lib/backend/pgbk/atomicwrite_test.go
+++ b/lib/backend/pgbk/atomicwrite_test.go
@@ -24,11 +24,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/trace"
 )
 
 // Testing requires a local psql backend to be set up, and for params to be passed via env. Ex:

--- a/lib/backend/pgbk/atomicwrite_test.go
+++ b/lib/backend/pgbk/atomicwrite_test.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pgbk
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/test"
+	"github.com/gravitational/trace"
+)
+
+// Testing requires a local psql backend to be set up, and for params to be passed via env. Ex:
+// $ docker run -it --rm --env POSTGRES_PASSWORD=insecure -p '127.0.0.1:5432:5432' debezium/postgres:14
+// $ export TELEPORT_PGBK_TEST_PARAMS_JSON='{"conn_string":"postgresql://postgres:insecure@localhost/teleport_backend","expiry_interval":"500ms","change_feed_poll_interval":"500ms"}'
+
+// newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
+// it will be integrated into the main backend interface and we can get rid of this separate helper.
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+	testCfg, err := test.ApplyOptions(options)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if testCfg.MirrorMode {
+		return nil, nil, test.ErrMirrorNotSupported
+	}
+
+	if testCfg.ConcurrentBackend != nil {
+		return nil, nil, test.ErrConcurrentAccessNotSupported
+	}
+
+	var params backend.Params
+	if err := json.Unmarshal([]byte(os.Getenv("TELEPORT_PGBK_TEST_PARAMS_JSON")), &params); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	uut, err := NewFromParams(context.Background(), params)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return uut, test.BlockingFakeClock{Clock: clockwork.NewRealClock()}, nil
+}
+
+// TestAtomicWriteSuite runs the main atomic write test suite.
+func TestAtomicWriteSuite(t *testing.T) {
+	if os.Getenv("TELEPORT_PGBK_TEST_PARAMS_JSON") == "" {
+		t.Skip("Postgres backend tests are disabled. Enable them by setting the TELEPORT_PGBK_TEST_PARAMS_JSON variable.")
+	}
+
+	test.RunAtomicWriteComplianceSuite(t, newAtomicWriteTestBackend)
+}
+
+// TestAtomicWriteShim runs the classic test suite using a shim that reimplements all single-item writes as calls
+// to AtomicWrite.
+func TestAtomicWriteShim(t *testing.T) {
+	if os.Getenv("TELEPORT_PGBK_TEST_PARAMS_JSON") == "" {
+		t.Skip("Postgres backend tests are disabled. Enable them by setting the TELEPORT_PGBK_TEST_PARAMS_JSON variable.")
+	}
+
+	test.RunBackendComplianceSuiteWithAtomicWriteShim(t, newAtomicWriteTestBackend)
+}


### PR DESCRIPTION
This PR implements the `AtomicWrite` API for postgres. Postgres testing is not currently enabled in CI, but this PR was extensively tested locally.

See https://github.com/gravitational/teleport/pull/36086 for general discussion of the `AtomicWrite` API.