### PR TITLE
[v14] Hardcode the v14 plugin version

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -344,7 +344,7 @@ Install the Helm chart for the Teleport Jira plugin:
 $ helm install teleport-plugin-jira teleport/teleport-plugin-jira \
   --namespace teleport \
   --values values.yaml \
-  --version (=teleport.plugin.version=)
+  --version 14.3.3
 ```
 
 Create a DNS record that associates the webhook's domain name with the address

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -407,7 +407,7 @@ $ teleport-msteams validate <email of your teams account>
 If everything works fine, the log output should look like this:
 
 ```text
-teleport-msteams v(=teleport.plugin.version=) go(=teleport.golang=)
+teleport-msteams v14.3.3 go(=teleport.golang=)
 
  - Checking application xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx status...
  - Application found in the team app store (internal ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
@@ -440,7 +440,7 @@ and your Teleport cluster:
 ```code
 $ teleport-msteams start -d
 DEBU   DEBUG logging enabled msteams/main.go:120
-INFO   Starting Teleport MS Teams Plugin (=teleport.plugin.version=): msteams/app.go:74
+INFO   Starting Teleport MS Teams Plugin 14.3.3: msteams/app.go:74
 DEBU   Attempting GET teleport.example.com:443/webapi/find webclient/webclient.go:129
 DEBU   Checking Teleport server version msteams/app.go:242
 INFO   MS Teams app found in org app store id:292e2881-38ab-7777-8aa7-cefed1404a63 name:TeleBot msteams/app.go:179

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -79,8 +79,8 @@ We'll reference the exported file(s) later when configuring the plugin.
 <Tabs>
 <TabItem label="Download">
   ```code
-  $ curl -L https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ curl -L https://get.gravitational.com/teleport-access-mattermost-v14.3.3-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-mattermost-v14.3.3-linux-amd64-bin.tar.gz
   $ cd teleport-access-mattermost
   $ ./install
   ```

--- a/docs/pages/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/agents/deploy-agents-terraform.mdx
@@ -214,7 +214,7 @@ In this step, you will configure the Terraform module for your environment.
    Replace the placeholder value with the latest version:
    
    ```code
-   $ sed -i "" "s/TELEPORT_VERSION/(=teleport.plugin.version=)/" provider.tf
+   $ sed -i "" "s/TELEPORT_VERSION/14.3.3/" provider.tf
    ```
 
 ## Step 4/4. Verify the deployment

--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -29,7 +29,7 @@ Service or Proxy Service:
 
 ```code
 $ TELEPORT_CLUSTER_ADDRESS=mytenant.teleport.sh:443
-$ docker run -v `pwd`:/opt/teleport-plugin -w /opt/teleport-plugin public.ecr.aws/gravitational/teleport-plugin-event-handler:(=teleport.plugin.version=) configure . ${TELEPORT_CLUSTER_ADDRESS?}
+$ docker run -v `pwd`:/opt/teleport-plugin -w /opt/teleport-plugin public.ecr.aws/gravitational/teleport-plugin-event-handler:14.3.3 configure . ${TELEPORT_CLUSTER_ADDRESS?}
 ```
 
 In order to export audit events, you'll need to have the root certificate and the

--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -2,8 +2,8 @@
 <TabItem label="Linux">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-event-handler-v14.3.3-linux-amd64-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v14.3.3-linux-amd64-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```
 
@@ -15,8 +15,8 @@ architecture, you can build from source.
 <TabItem label="macOS">
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
-$ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-event-handler-v14.3.3-darwin-amd64-bin.tar.gz
+$ tar -zxvf teleport-event-handler-v14.3.3-darwin-amd64-bin.tar.gz
 $ sudo ./teleport-event-handler/install
 ```
 
@@ -31,7 +31,7 @@ event handler plugin. You can also build from source.
 Ensure that you have Docker installed and running.
 
 ```code
-$ docker pull public.ecr.aws/gravitational/teleport-plugin-event-handler:(=teleport.plugin.version=)
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-event-handler:14.3.3
 ```
 
 </TabItem>

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -6,8 +6,8 @@ plugins from source. You can run the plugin from a remote host or your local
 development machine.
 
 ```code
-$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-{{ name }}-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-access-{{ name }}-v14.3.3-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-{{ name }}-v14.3.3-linux-amd64-bin.tar.gz
 $ cd teleport-access-{{ name }}
 $ sudo ./install
 ```
@@ -16,7 +16,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v14.3.3 git:teleport-{{ name }}-v14.3.3-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>
@@ -26,14 +26,14 @@ We currently only provide Docker images for `linux-amd64`.
 Pull the Docker image for the latest access request plugin by running the following command:
 
 ```code
-$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=)
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-{{ name }}:14.3.3
 ```
 
 Make sure the plugin is installed by running the following command:
 
 ```code
-$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=) version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-(=teleport.git=) (=teleport.golang=)
+$ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:14.3.3 version
+teleport-{{ name }} v14.3.3 git:teleport-{{ name }}-v14.3.3-(=teleport.git=) (=teleport.golang=)
 ```
 
 For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }}).
@@ -55,7 +55,7 @@ Make sure the binary is installed:
 
 ```code
 $ teleport-{{ name }} version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+teleport-{{ name }} v14.3.3 git:teleport-{{ name }}-v14.3.3-fffffffff go(=teleport.golang=)
 ```
 
 </TabItem>

--- a/docs/pages/includes/start-event-handler.mdx
+++ b/docs/pages/includes/start-event-handler.mdx
@@ -66,7 +66,7 @@ Run the following command on your workstation:
 ```code
 $ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
   --values teleport-plugin-event-handler-values.yaml \
-  --version (=teleport.plugin.version=)
+  --version 14.3.3
 ```
 
 </TabItem>

--- a/docs/pages/machine-id/deployment/spacelift.mdx
+++ b/docs/pages/machine-id/deployment/spacelift.mdx
@@ -214,7 +214,7 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = ">= (=teleport.plugin.version=)"
+      version = ">= 14.3.3"
     }
   }
 }


### PR DESCRIPTION
Since v14.3.3 is the final v14 release of `teleport-plugins`, hardcode the value.