### PR TITLE
Revert "[v15]  Read the bearer token over websocket endpoints instead of query parameter"

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -40,7 +40,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
 	"github.com/gravitational/oxy/ratelimit"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -720,10 +719,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/locks/:uuid", h.WithClusterAuth(h.deleteClusterLock))
 
 	// active sessions handlers
-	// Deprecated: The connect/ws variant should be used instead.
-	// TODO(lxea): DELETE in v16
-	h.GET("/webapi/sites/:site/connect", h.WithClusterAuthWS(false, h.siteNodeConnect))            // connect to an active session (via websocket)
-	h.GET("/webapi/sites/:site/connect/ws", h.WithClusterAuthWS(true, h.siteNodeConnect))          // connect to an active session (via websocket, with auth over websocket)
+	h.GET("/webapi/sites/:site/connect", h.WithClusterAuth(h.siteNodeConnect))                     // connect to an active session (via websocket)
 	h.GET("/webapi/sites/:site/sessions", h.WithClusterAuth(h.clusterActiveAndPendingSessionsGet)) // get list of active and pending sessions
 
 	// Audit events handlers.
@@ -831,11 +827,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/desktopservices", h.WithClusterAuth(h.clusterDesktopServicesGet))
 	h.GET("/webapi/sites/:site/desktops/:desktopName", h.WithClusterAuth(h.getDesktopHandle))
 	// GET /webapi/sites/:site/desktops/:desktopName/connect?access_token=<bearer_token>&username=<username>&width=<width>&height=<height>
-	// Deprecated: The connect/ws variant should be used instead.
-	// TODO(lxea): DELETE in v16
-	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuthWS(false, h.desktopConnectHandle))
-	// GET /webapi/sites/:site/desktops/:desktopName/connect?username=<username>&width=<width>&height=<height>
-	h.GET("/webapi/sites/:site/desktops/:desktopName/connect/ws", h.WithClusterAuthWS(true, h.desktopConnectHandle))
+	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuth(h.desktopConnectHandle))
 	// GET /webapi/sites/:site/desktopplayback/:sid?access_token=<bearer_token>
 	h.GET("/webapi/sites/:site/desktopplayback/:sid", h.WithClusterAuth(h.desktopPlaybackHandle))
 	h.GET("/webapi/sites/:site/desktops/:desktopName/active", h.WithClusterAuth(h.desktopIsActive))
@@ -896,11 +888,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/user-groups", h.WithClusterAuth(h.getUserGroups))
 
 	// WebSocket endpoint for the chat conversation
-	// Deprecated: The connect/ws variant should be used instead.
-	// TODO(lxea): DELETE in v16
-	h.GET("/webapi/sites/:site/assistant", h.WithClusterAuthWS(false, h.assistant))
-	// WebSocket endpoint for the chat conversation, websocket auth
-	h.GET("/webapi/sites/:site/assistant/ws", h.WithClusterAuthWS(true, h.assistant))
+	h.GET("/webapi/sites/:site/assistant", h.WithClusterAuth(h.assistant))
 
 	// Sets the title for the conversation.
 	h.POST("/webapi/assistant/conversations/:conversation_id/title", h.WithAuth(h.setAssistantTitle))
@@ -919,11 +907,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/assistant/conversations/:conversation_id", h.WithAuth(h.getAssistantConversationByID))
 
 	// Allows executing an arbitrary command on multiple nodes.
-	// Deprecated: The execute/ws variant should be used instead.
-	// TODO(lxea): DELETE in v16
-	h.GET("/webapi/command/:site/execute", h.WithClusterAuthWS(false, h.executeCommand))
-	// Allows executing an arbitrary command on multiple nodes, websocket auth.
-	h.GET("/webapi/command/:site/execute/ws", h.WithClusterAuthWS(true, h.executeCommand))
+	h.GET("/webapi/command/:site/execute", h.WithClusterAuth(h.executeCommand))
 
 	// Fetches the user's preferences
 	h.GET("/webapi/user/preferences", h.WithAuth(h.getUserPreferences))
@@ -2936,7 +2920,6 @@ func (h *Handler) siteNodeConnect(
 	p httprouter.Params,
 	sessionCtx *SessionContext,
 	site reversetunnelclient.RemoteSite,
-	ws *websocket.Conn,
 ) (interface{}, error) {
 	q := r.URL.Query()
 	params := q.Get("params")
@@ -3029,7 +3012,6 @@ func (h *Handler) siteNodeConnect(
 		PROXYSigner:        h.cfg.PROXYSigner,
 		Tracker:            tracker,
 		PresenceChecker:    h.cfg.PresenceChecker,
-		WebsocketConn:      ws,
 	}
 
 	term, err := NewTerminal(ctx, terminalConfig)
@@ -3728,9 +3710,6 @@ type ContextHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Pa
 // ClusterHandler is a authenticated handler that is called for some existing remote cluster
 type ClusterHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error)
 
-// ClusterWebsocketHandler is a authenticated websocket handler that is called for some existing remote cluster
-type ClusterWebsocketHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite, ws *websocket.Conn) (interface{}, error)
-
 // WithClusterAuth wraps a ClusterHandler to ensure that a request is authenticated to this proxy
 // (the same as WithAuth), as well as to grab the remoteSite (which can represent this local cluster
 // or a remote trusted cluster) as specified by the ":site" url parameter.
@@ -3745,103 +3724,12 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 	})
 }
 
-// WithClusterAuthWS wraps a ClusterWebsocketHandler to ensure that a request is authenticated
-// to this proxy via websocket if websocketAuth is true, or via query parameter if false (the same as WithAuth), as
-// well as to grab the remoteSite (which can represent this local cluster or a remote trusted cluster)
-// as specified by the ":site" url parameter.
-//
-// TODO(lxea): remove the 'websocketAuth' bool once the deprecated websocket handlers are removed
-func (h *Handler) WithClusterAuthWS(websocketAuth bool, fn ClusterWebsocketHandler) httprouter.Handle {
-	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-		if websocketAuth {
-			sctx, ws, site, err := h.authenticateWSRequestWithCluster(w, r, p)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			defer ws.Close()
-
-			if _, err := fn(w, r, p, sctx, site, ws); err != nil {
-				errEnvelope := Envelope{
-					Type:    defaults.WebsocketError,
-					Payload: err.Error(),
-				}
-				env, err := errEnvelope.Marshal()
-				if err != nil {
-					h.log.WithError(err).Error("error marshaling proto")
-					return nil, nil
-				}
-				if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
-					h.log.WithError(err).Error("error writing proto")
-					return nil, nil
-				}
-			}
-			return nil, nil
-		}
-
-		sctx, site, err := h.authenticateRequestWithCluster(w, r, p)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		upgrader := websocket.Upgrader{
-			ReadBufferSize:  1024,
-			WriteBufferSize: 1024,
-			CheckOrigin:     func(r *http.Request) bool { return true },
-		}
-		ws, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			const errMsg = "Error upgrading to websocket"
-			h.log.WithError(err).Error(errMsg)
-			http.Error(w, errMsg, http.StatusInternalServerError)
-			return nil, nil
-		}
-
-		defer ws.Close()
-		if _, err := fn(w, r, p, sctx, site, ws); err != nil {
-			errEnvelope := Envelope{
-				Type:    defaults.WebsocketError,
-				Payload: err.Error(),
-			}
-			env, err := errEnvelope.Marshal()
-			if err != nil {
-				h.log.WithError(err).Error("error marshaling proto")
-				return nil, nil
-			}
-			if err := ws.WriteMessage(websocket.BinaryMessage, env); err != nil {
-				h.log.WithError(err).Error("error writing proto")
-				return nil, nil
-			}
-		}
-		return nil, nil
-	})
-}
-
-// authenticateWSRequestWithCluster ensures that a request is
-// authenticated to this proxy via websocket, returning the
-// *SessionContext (same as AuthenticateRequest), and also grabs the
-// remoteSite (which can represent this local cluster or a remote
-// trusted cluster) as specified by the ":site" url parameter.
-func (h *Handler) authenticateWSRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, *websocket.Conn, reversetunnelclient.RemoteSite, error) {
-	sctx, ws, err := h.AuthenticateRequestWS(w, r)
-	if err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
-	site, err := h.getSiteByParams(sctx, p)
-	if err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
-	return sctx, ws, site, nil
-}
-
 // authenticateRequestWithCluster ensures that a request is authenticated
 // to this proxy, returning the *SessionContext (same as AuthenticateRequest),
 // and also grabs the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnelclient.RemoteSite, error) {
 	sctx, err := h.AuthenticateRequest(w, r, true)
-
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -4159,7 +4047,9 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 	return trace.Wrap(err)
 }
 
-func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*SessionContext, error) {
+// AuthenticateRequest authenticates request using combination of a session cookie
+// and bearer token
+func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, checkBearerToken bool) (*SessionContext, error) {
 	const missingCookieMsg = "missing session cookie"
 	cookie, err := r.Cookie(websession.CookieName)
 	if err != nil || (cookie != nil && cookie.Value == "") {
@@ -4173,17 +4063,6 @@ func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*Sessi
 	if err != nil {
 		websession.ClearCookie(w)
 		return nil, trace.AccessDenied("need auth")
-	}
-
-	return sctx, nil
-}
-
-// AuthenticateRequest authenticates request using combination of a session cookie
-// and bearer token
-func (h *Handler) AuthenticateRequest(w http.ResponseWriter, r *http.Request, checkBearerToken bool) (*SessionContext, error) {
-	sctx, err := h.validateCookie(w, r)
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 	if checkBearerToken {
 		creds, err := roundtrip.ParseAuthHeaders(r)
@@ -4235,68 +4114,6 @@ func contextWithMFAResponseFromRequestHeader(ctx context.Context, requestHeader 
 	}
 
 	return ctx, nil
-}
-
-type wsBearerToken struct {
-	Token string `json:"token"`
-}
-
-type wsStatus struct {
-	Type    string `json:"type"`
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
-}
-
-var wsIODeadline = time.Second * 4
-
-// AuthenticateRequest authenticates request using combination of a session cookie
-// and bearer token retrieved from a websocket
-func (h *Handler) AuthenticateRequestWS(w http.ResponseWriter, r *http.Request) (*SessionContext, *websocket.Conn, error) {
-	ctx, err := h.validateCookie(w, r)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	upgrader := websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
-	}
-
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return nil, nil, trace.ConnectionProblem(err, "Error upgrading to websocket: %v", err)
-	}
-	if err := ws.SetReadDeadline(deadlineForInterval(wsIODeadline)); err != nil {
-		log.WithError(err).Error("Error setting websocket read deadline")
-		return nil, nil, trace.ConnectionProblem(err, "Error setting websocket read deadline: %v", err)
-	}
-
-	var t wsBearerToken
-	if err := ws.ReadJSON(&t); err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	if err := ctx.validateBearerToken(r.Context(), t.Token); err != nil {
-		ws.WriteJSON(wsStatus{
-			Type:    "create_session_response",
-			Status:  "error",
-			Message: "invalid token",
-		})
-		return nil, nil, trace.Wrap(err)
-	}
-
-	if err := ws.WriteJSON(wsStatus{
-		Type:   "create_session_response",
-		Status: "ok",
-	}); err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	if err := ws.SetReadDeadline(time.Time{}); err != nil {
-		log.WithError(err).Error("Error setting websocket read deadline")
-		return nil, nil, trace.ConnectionProblem(err, "Error setting websocket read deadline: %v", err)
-	}
-
-	return ctx, ws, nil
 }
 
 // ProxyWithRoles returns a reverse tunnel proxy verifying the permissions

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -332,9 +332,9 @@ func (h *Handler) generateAssistantTitle(_ http.ResponseWriter, r *http.Request,
 // This handler covers the main chat conversation as well as the
 // SSH completition (SSH command generation and output explanation).
 func (h *Handler) assistant(w http.ResponseWriter, r *http.Request, _ httprouter.Params,
-	sctx *SessionContext, site reversetunnelclient.RemoteSite, ws *websocket.Conn,
+	sctx *SessionContext, site reversetunnelclient.RemoteSite,
 ) (any, error) {
-	if err := runAssistant(h, w, r, sctx, site, ws); err != nil {
+	if err := runAssistant(h, w, r, sctx, site); err != nil {
 		h.log.Warn(trace.DebugReport(err))
 		return nil, trace.Wrap(err)
 	}
@@ -420,7 +420,7 @@ func checkAssistEnabled(a auth.ClientI, ctx context.Context) error {
 
 // runAssistant upgrades the HTTP connection to a websocket and starts a chat loop.
 func runAssistant(h *Handler, w http.ResponseWriter, r *http.Request,
-	sctx *SessionContext, site reversetunnelclient.RemoteSite, ws *websocket.Conn,
+	sctx *SessionContext, site reversetunnelclient.RemoteSite,
 ) (err error) {
 	q := r.URL.Query()
 	conversationID := q.Get("conversation_id")
@@ -453,6 +453,20 @@ func runAssistant(h *Handler, w http.ResponseWriter, r *http.Request,
 	if err != nil {
 		h.log.WithError(err).Debug("Unable to fetch cluster networking config.")
 		return trace.Wrap(err)
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		errMsg := "Error upgrading to websocket"
+		h.log.WithError(err).Error(errMsg)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return nil
 	}
 
 	// Note: This time should be longer than OpenAI response time.

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -128,7 +128,6 @@ func (h *Handler) executeCommand(
 	_ httprouter.Params,
 	sessionCtx *SessionContext,
 	site reversetunnelclient.RemoteSite,
-	rawWS *websocket.Conn,
 ) (any, error) {
 	q := r.URL.Query()
 	params := q.Get("params")
@@ -171,6 +170,20 @@ func (h *Handler) executeCommand(
 	}
 
 	clusterName := site.GetName()
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+
+	rawWS, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		errMsg := "Error upgrading to websocket"
+		h.log.WithError(err).Error(errMsg)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return nil, nil
+	}
 
 	defer func() {
 		rawWS.WriteMessage(websocket.CloseMessage, nil)

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -66,7 +66,6 @@ func (h *Handler) desktopConnectHandle(
 	p httprouter.Params,
 	sctx *SessionContext,
 	site reversetunnelclient.RemoteSite,
-	ws *websocket.Conn,
 ) (interface{}, error) {
 	desktopName := p.ByName("desktopName")
 	if desktopName == "" {
@@ -76,7 +75,7 @@ func (h *Handler) desktopConnectHandle(
 	log := sctx.cfg.Log.WithField("desktop-name", desktopName).WithField("cluster-name", site.GetName())
 	log.Debug("New desktop access websocket connection")
 
-	if err := h.createDesktopConnection(w, r, desktopName, site.GetName(), log, sctx, site, ws); err != nil {
+	if err := h.createDesktopConnection(w, r, desktopName, site.GetName(), log, sctx, site); err != nil {
 		// createDesktopConnection makes a best effort attempt to send an error to the user
 		// (via websocket) before terminating the connection. We log the error here, but
 		// return nil because our HTTP middleware will try to write the returned error in JSON
@@ -95,8 +94,15 @@ func (h *Handler) createDesktopConnection(
 	log *logrus.Entry,
 	sctx *SessionContext,
 	site reversetunnelclient.RemoteSite,
-	ws *websocket.Conn,
 ) error {
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	defer ws.Close()
 
 	sendTDPError := func(err error) error {

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gorilla/websocket"
+	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -126,11 +127,12 @@ func connectToHost(ctx context.Context, cfg connectConfig) (*terminal, error) {
 	u := url.URL{
 		Host:   cfg.proxy,
 		Scheme: client.WSS,
-		Path:   "/v1/webapi/sites/-current-/connect/ws",
+		Path:   "/v1/webapi/sites/-current-/connect",
 	}
 
 	q := u.Query()
 	q.Set("params", string(data))
+	q.Set(roundtrip.AccessTokenQueryParam, cfg.pack.session.Token)
 	u.RawQuery = q.Encode()
 
 	header := http.Header{}
@@ -157,10 +159,6 @@ func connectToHost(ctx context.Context, cfg connectConfig) (*terminal, error) {
 		return nil, trace.Wrap(err, sb.String())
 	}
 	if err := resp.Body.Close(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := makeAuthReqOverWS(ws, cfg.pack.session.Token); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/web/packages/teleport/src/Console/consoleContext.tsx
+++ b/web/packages/teleport/src/Console/consoleContext.tsx
@@ -24,7 +24,7 @@ import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import webSession from 'teleport/services/websession';
 import history from 'teleport/services/history';
 import cfg, { UrlResourcesParams, UrlSshParams } from 'teleport/config';
-import { getHostName } from 'teleport/services/api';
+import { getAccessToken, getHostName } from 'teleport/services/api';
 import Tty from 'teleport/lib/term/tty';
 import TtyAddressResolver from 'teleport/lib/term/ttyAddressResolver';
 import serviceSession, {
@@ -197,6 +197,7 @@ export default class ConsoleContext {
 
     const ttyUrl = cfg.api.ttyWsAddr
       .replace(':fqdn', getHostName())
+      .replace(':token', getAccessToken())
       .replace(':clusterId', clusterId)
       .replace(':traceparent', carrier['traceparent']);
 

--- a/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -30,7 +30,7 @@ import {
   PngFrame,
   SyncKeys,
 } from 'teleport/lib/tdp/codec';
-import { getHostName } from 'teleport/services/api';
+import { getAccessToken, getHostName } from 'teleport/services/api';
 import cfg from 'teleport/config';
 import { Sha256Digest } from 'teleport/lib/util';
 
@@ -85,6 +85,7 @@ export default function useTdpClientCanvas(props: Props) {
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
       .replace(':desktopName', desktopName)
+      .replace(':token', getAccessToken())
       .replace(':username', username);
 
     setTdpClient(new TdpClient(addr));

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -23,7 +23,7 @@ import { Indicator, Box, Alert, Flex } from 'design';
 import cfg from 'teleport/config';
 import { StatusEnum, formatDisplayTime } from 'teleport/lib/player';
 import { PlayerClient, TdpClient } from 'teleport/lib/tdp';
-import { getHostName } from 'teleport/services/api';
+import { getAccessToken, getHostName } from 'teleport/services/api';
 import TdpClientCanvas from 'teleport/components/TdpClientCanvas';
 
 import ProgressBar from './ProgressBar';
@@ -157,7 +157,8 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     const url = cfg.api.desktopPlaybackWsAddr
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
-      .replace(':sid', sid);
+      .replace(':sid', sid)
+      .replace(':token', getAccessToken());
     return new PlayerClient({ url, setTime, setPlayerStatus, setStatusText });
   }, [clusterId, sid, setTime, setPlayerStatus]);
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -196,12 +196,12 @@ const cfg = {
     desktopServicesPath: `/v1/webapi/sites/:clusterId/desktopservices?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
     desktopPath: `/v1/webapi/sites/:clusterId/desktops/:desktopName`,
     desktopWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/desktops/:desktopName/connect/ws?username=:username',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/desktops/:desktopName/connect?access_token=:token&username=:username',
     desktopPlaybackWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/desktopplayback/:sid/ws',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/desktopplayback/:sid?access_token=:token',
     desktopIsActive: '/v1/webapi/sites/:clusterId/desktops/:desktopName/active',
     ttyWsAddr:
-      'wss://:fqdn/v1/webapi/sites/:clusterId/connect/ws?params=:params&traceparent=:traceparent',
+      'wss://:fqdn/v1/webapi/sites/:clusterId/connect?access_token=:token&params=:params&traceparent=:traceparent',
     ttyPlaybackWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/ttyplayback/:sid?access_token=:token', // TODO(zmb3): get token out of URL
     activeAndPendingSessionsPath: '/v1/webapi/sites/:clusterId/sessions',
@@ -310,11 +310,11 @@ const cfg = {
       '/v1/webapi/assistant/conversations/:conversationId/title',
     assistGenerateSummaryPath: '/v1/webapi/assistant/title/summary',
     assistConversationWebSocketPath:
-      'wss://:hostname/v1/webapi/sites/:clusterId/assistant/ws',
+      'wss://:hostname/v1/webapi/sites/:clusterId/assistant',
     assistConversationHistoryPath:
       '/v1/webapi/assistant/conversations/:conversationId',
     assistExecuteCommandWebSocketPath:
-      'wss://:hostname/v1/webapi/command/:clusterId/execute/ws',
+      'wss://:hostname/v1/webapi/command/:clusterId/execute',
     userPreferencesPath: '/v1/webapi/user/preferences',
     userClusterPreferencesPath: '/v1/webapi/user/preferences/:clusterId',
 
@@ -857,10 +857,12 @@ const cfg = {
   getAssistConversationWebSocketUrl(
     hostname: string,
     clusterId: string,
+    accessToken: string,
     conversationId: string
   ) {
     const searchParams = new URLSearchParams();
 
+    searchParams.set('access_token', accessToken);
     searchParams.set('conversation_id', conversationId);
 
     return (
@@ -874,10 +876,12 @@ const cfg = {
   getAssistActionWebSocketUrl(
     hostname: string,
     clusterId: string,
+    accessToken: string,
     action: string
   ) {
     const searchParams = new URLSearchParams();
 
+    searchParams.set('access_token', accessToken);
     searchParams.set('action', action);
 
     return (
@@ -897,10 +901,12 @@ const cfg = {
   getAssistExecuteCommandUrl(
     hostname: string,
     clusterId: string,
+    accessToken: string,
     params: Record<string, string>
   ) {
     const searchParams = new URLSearchParams();
 
+    searchParams.set('access_token', accessToken);
     searchParams.set('params', JSON.stringify(params));
 
     return (

--- a/web/packages/teleport/src/lib/tdp/client.ts
+++ b/web/packages/teleport/src/lib/tdp/client.ts
@@ -25,9 +25,6 @@ import init, {
 
 import { WebsocketCloseCode, TermEvent } from 'teleport/lib/term/enums';
 import { EventEmitterWebAuthnSender } from 'teleport/lib/EventEmitterWebAuthnSender';
-import { WebsocketStatus } from 'teleport/types';
-
-import { getAccessToken } from 'teleport/services/api';
 
 import Codec, {
   MessageType,
@@ -122,34 +119,13 @@ export default class Client extends EventEmitterWebAuthnSender {
 
     this.socket.onopen = () => {
       this.logger.info('websocket is open');
-      this.socket.send(JSON.stringify({ token: getAccessToken() }));
       this.emit(TdpClientEvent.WS_OPEN);
       if (spec) {
         this.sendClientScreenSpec(spec);
       }
     };
 
-    let authenticated = false;
-
     this.socket.onmessage = async (ev: MessageEvent) => {
-      if (!authenticated) {
-        const authResponse = JSON.parse(ev.data) as WebsocketStatus;
-        if (authResponse.type != 'create_session_response') {
-          this.socket.close();
-          console.log('invalid auth response type: ' + authResponse.message);
-          return;
-        }
-
-        if (authResponse.status == 'error') {
-          this.socket.close();
-          console.log(
-            'auth error connecting to websocket: ' + authResponse.message
-          );
-          return;
-        }
-        authenticated = true;
-        return;
-      }
       await this.processMessage(ev.data as ArrayBuffer);
     };
 
@@ -159,7 +135,7 @@ export default class Client extends EventEmitterWebAuthnSender {
     this.socket.onerror = null;
     this.socket.onclose = () => {
       this.logger.info('websocket is closed');
-      authenticated = false;
+
       // Clean up all of our socket's listeners and the socket itself.
       this.socket.onopen = null;
       this.socket.onmessage = null;

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -19,9 +19,7 @@
 import Logger from 'shared/libs/logger';
 
 import { EventEmitterWebAuthnSender } from 'teleport/lib/EventEmitterWebAuthnSender';
-import { getAccessToken } from 'teleport/services/api';
 import { WebauthnAssertionResponse } from 'teleport/services/auth';
-import { WebsocketStatus } from 'teleport/types';
 
 import { EventType, TermEvent, WebsocketCloseCode } from './enums';
 import { Protobuf, MessageTypeEnum } from './protobuf';
@@ -41,7 +39,6 @@ class Tty extends EventEmitterWebAuthnSender {
   _addressResolver = null;
   _proto = new Protobuf();
   _pendingUploads = {};
-  _authenticated = false;
 
   constructor(addressResolver, props = {}) {
     super();
@@ -55,7 +52,6 @@ class Tty extends EventEmitterWebAuthnSender {
     this._onOpenConnection = this._onOpenConnection.bind(this);
     this._onCloseConnection = this._onCloseConnection.bind(this);
     this._onMessage = this._onMessage.bind(this);
-    this._onAuthMessage = this._onAuthMessage.bind(this);
   }
 
   disconnect(closeCode = WebsocketCloseCode.NORMAL) {
@@ -170,7 +166,6 @@ class Tty extends EventEmitterWebAuthnSender {
   _onOpenConnection() {
     this.emit('open');
     logger.info('websocket is open');
-    this.socket.send(JSON.stringify({ token: getAccessToken() }));
   }
 
   _onCloseConnection(e) {
@@ -179,32 +174,10 @@ class Tty extends EventEmitterWebAuthnSender {
     this.socket.onclose = null;
     this.socket = null;
     this.emit(TermEvent.CONN_CLOSE, e);
-    this._authenticated = false;
     logger.info('websocket is closed');
   }
 
-  _onAuthMessage(ev) {
-    const authResponse = JSON.parse(ev.data) as WebsocketStatus;
-    if (authResponse.type != 'create_session_response') {
-      this.socket.close();
-      console.log('invalid auth response type: ' + authResponse.message);
-      return;
-    }
-    if (authResponse.status == 'error') {
-      this.socket.close();
-      console.log(
-        'auth error connecting to websocket: ' + authResponse.message
-      );
-      return;
-    }
-    this._authenticated = true;
-  }
-
   _onMessage(ev) {
-    if (!this._authenticated) {
-      this._onAuthMessage(ev);
-      return;
-    }
     try {
       const uintArray = new Uint8Array(ev.data);
       const msg = this._proto.decode(uintArray);

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -197,11 +197,3 @@ export enum RecommendationStatus {
   Notify = 'NOTIFY',
   Done = 'DONE',
 }
-
-// WebsocketStatus is used to indicate the auth status from a
-// websocket connection
-export type WebsocketStatus = {
-  type: string;
-  status: string;
-  message: string;
-};


### PR DESCRIPTION
i wasn't able to get assist working, so i think it's safer to revert for now

<img width="510" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/99dca542-3b8b-4380-a2a6-cd3200d7370b">
