### PR TITLE
Rename label `github_actions` -> `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -193,5 +193,5 @@ updates:
       - camscale
     labels:
       - "dependencies"
-      - "github_actions"
+      - "github-actions"
       - "no-changelog"


### PR DESCRIPTION
@zmb3  refactored this on all extant PRs 2 weeks ago, and now Dependabot is throwing warnings like:

```
The following labels could not be found: github_actions.
```

Example: https://github.com/gravitational/teleport/pull/37441#issuecomment-1915271653