### PR TITLE
docs: move team to cloud uninstall section instructions

### DIFF
--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -70,7 +70,7 @@ $ docker stop teleport
 ## Step 2/3. Remove Teleport binaries
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
-  <TabItem label="Teleport Community Edition/Teleport Team" scope={["oss","team"]}>
+  <TabItem label="Teleport Community Edition" scope="oss">
   <Tabs>
   <TabItem label="Debian/Ubuntu Linux (DEB)">
 
@@ -294,7 +294,7 @@ $ docker stop teleport
   </TabItem>
   </Tabs>
   </TabItem>
-  <TabItem label="Teleport Enterprise Cloud" scope="cloud">
+  <TabItem label="Teleport Team/Enterprise Cloud" scope={["team", "cloud"]}>
 
   <Tabs>
   <TabItem label="Debian/Ubuntu Linux (DEB)">
@@ -303,7 +303,7 @@ $ docker stop teleport
 
   ```code
   $ sudo apt-get -y remove teleport-ent
-  # NOTE: Older Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo apt-get -y remove teleport
   ```
 
@@ -318,7 +318,7 @@ $ docker stop teleport
 
   ```code
   $ sudo dpkg -r teleport-ent
-  # NOTE: Older Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo dpkg -r teleport
   ```
   </Admonition>
@@ -332,7 +332,7 @@ $ docker stop teleport
   $ sudo yum -y remove teleport-ent
   # Optional: Use DNF on newer distributions
   # $ sudo dnf -y remove teleport-ent
-  # NOTE: Older Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo yum -y remove teleport
   # $ sudo dnf -y remove teleport
   ```
@@ -348,7 +348,7 @@ $ docker stop teleport
 
   ```code
   $ sudo rpm -e teleport-ent
-  # NOTE: Older Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo rpm -e teleport
   ```
   </Admonition>


### PR DESCRIPTION
Team should uninstall like ent cloud, not community. This matches the install instructions.