### PR TITLE
Unmarshal and compare user objects in CompareAndSwapUser

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -31,3 +31,9 @@ func (l *globalSessionDataLimiter) Reset() {
 	l.lastReset = time.Time{}
 	l.mu.Unlock()
 }
+
+const (
+	WebPrefix    = webPrefix
+	UsersPrefix  = usersPrefix
+	ParamsPrefix = paramsPrefix
+)

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -454,12 +454,12 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 
 	newWithoutSecrets, ok := new.WithoutSecrets().(types.User)
 	if !ok {
-		return trace.BadParameter("Invalid new user type %T (this is a bug).", new)
+		return trace.BadParameter("invalid new user type %T (this is a bug)", new)
 	}
 
 	existingWithoutSecrets, ok := existing.WithoutSecrets().(types.User)
 	if !ok {
-		return trace.BadParameter("Invalid existing user type %T (this is a bug).", existing)
+		return trace.BadParameter("invalid existing user type %T (this is a bug)", existing)
 	}
 
 	item := backend.Item{

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -441,58 +441,76 @@ func (s *IdentityService) UpsertUser(ctx context.Context, user types.User) (type
 	return user, nil
 }
 
-// CompareAndSwapUser updates a user, but fails if the value (as exists in the
-// backend) differs from the provided `existing` value. If the existing value
+// CompareAndSwapUser updates a user, but fails if the user (as exists in the
+// backend) differs from the provided `existing` user. If the existing user
 // matches, returns no error, otherwise returns `trace.CompareFailed`.
 func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing types.User) error {
+	if new.GetName() != existing.GetName() {
+		return trace.BadParameter("name mismatch between new and existing user")
+	}
 	if err := services.ValidateUser(new); err != nil {
 		return trace.Wrap(err)
 	}
 
-	newRaw, ok := new.WithoutSecrets().(types.User)
+	newWithoutSecrets, ok := new.WithoutSecrets().(types.User)
 	if !ok {
-		return trace.BadParameter("Invalid user type %T", new)
+		return trace.BadParameter("Invalid new user type %T (this is a bug).", new)
 	}
-	rev := new.GetRevision()
-	newValue, err := services.MarshalUser(newRaw)
-	if err != nil {
-		return trace.Wrap(err)
+
+	existingWithoutSecrets, ok := existing.WithoutSecrets().(types.User)
+	if !ok {
+		return trace.BadParameter("Invalid existing user type %T (this is a bug).", existing)
 	}
-	newItem := backend.Item{
+
+	item := backend.Item{
 		Key:      backend.Key(webPrefix, usersPrefix, new.GetName(), paramsPrefix),
-		Value:    newValue,
+		Value:    nil, // avoid marshaling new until we pass one comparison
 		Expires:  new.Expiry(),
-		ID:       new.GetResourceID(),
-		Revision: rev,
+		Revision: "",
 	}
 
-	existingRaw, ok := existing.WithoutSecrets().(types.User)
-	if !ok {
-		return trace.BadParameter("Invalid user type %T", existing)
-	}
-	existingValue, err := services.MarshalUser(existingRaw)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	existingItem := backend.Item{
-		Key:   backend.Key(webPrefix, usersPrefix, existing.GetName(), paramsPrefix),
-		Value: existingValue,
-	}
-
-	_, err = s.CompareAndSwap(ctx, existingItem, newItem)
-	if err != nil {
-		if trace.IsCompareFailed(err) {
-			return trace.CompareFailed("user %v did not match expected existing value", new.GetName())
-		}
-		return trace.Wrap(err)
-	}
-
-	if auth := new.GetLocalAuth(); auth != nil {
-		if err = s.upsertLocalAuthSecrets(ctx, new.GetName(), *auth); err != nil {
+	const iterationLimit = 5
+	for i := 0; i < iterationLimit; i++ {
+		const notWithSecrets = false
+		currentWithoutSecrets, err := s.GetUser(ctx, new.GetName(), notWithSecrets)
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return trace.CompareFailed("user %v did not match expected existing value", new.GetName())
+			}
 			return trace.Wrap(err)
 		}
+
+		if !services.UsersEquals(existingWithoutSecrets, currentWithoutSecrets) {
+			return trace.CompareFailed("user %v did not match expected existing value", new.GetName())
+		}
+
+		if item.Value == nil {
+			v, err := services.MarshalUser(newWithoutSecrets)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			item.Value = v
+		}
+
+		item.Revision = currentWithoutSecrets.GetRevision()
+
+		_, err = s.Backend.ConditionalUpdate(ctx, item)
+		if err != nil {
+			if trace.IsCompareFailed(err) {
+				continue
+			}
+			return trace.Wrap(err)
+		}
+
+		if auth := new.GetLocalAuth(); auth != nil {
+			if err = s.upsertLocalAuthSecrets(ctx, new.GetName(), *auth); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
 	}
-	return nil
+
+	return trace.LimitExceeded("failed to update user within %v iterations", iterationLimit)
 }
 
 // GetUser returns a user by name

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"slices"
@@ -1138,4 +1139,58 @@ func TestIdentityService_ListUsers(t *testing.T) {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 	require.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")
+}
+
+func TestCompareAndSwapUser(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	ctx := context.Background()
+
+	identity := newIdentityService(t, clockwork.NewFakeClock())
+
+	bob1, err := types.NewUser("bob")
+	require.NoError(err)
+	bob1.SetLogins([]string{"bob"})
+
+	bob2, err := types.NewUser("bob")
+	require.NoError(err)
+	bob2.SetLogins([]string{"bob", "alice"})
+
+	require.False(services.UsersEquals(bob1, bob2))
+
+	currentBob, err := identity.UpsertUser(ctx, bob1)
+	require.NoError(err)
+	require.True(services.UsersEquals(currentBob, bob1))
+
+	currentBob, err = identity.GetUser(ctx, "bob", false)
+	require.NoError(err)
+	require.True(services.UsersEquals(currentBob, bob1))
+
+	err = identity.CompareAndSwapUser(ctx, bob2, bob1)
+	require.NoError(err)
+
+	currentBob, err = identity.GetUser(ctx, "bob", false)
+	require.NoError(err)
+	require.True(services.UsersEquals(currentBob, bob2))
+
+	item, err := identity.Backend.Get(ctx, backend.Key(local.WebPrefix, local.UsersPrefix, "bob", local.ParamsPrefix))
+	require.NoError(err)
+	var m map[string]any
+	require.NoError(json.Unmarshal(item.Value, &m))
+	m["deprecated_field"] = 42
+	item.Value, err = json.Marshal(m)
+	require.NoError(err)
+	_, err = identity.Backend.Put(ctx, *item)
+	require.NoError(err)
+
+	currentBob, err = identity.GetUser(ctx, "bob", false)
+	require.NoError(err)
+	require.True(services.UsersEquals(currentBob, bob2))
+
+	err = identity.CompareAndSwapUser(ctx, bob1, bob2)
+	require.NoError(err)
+
+	currentBob, err = identity.GetUser(ctx, "bob", false)
+	require.NoError(err)
+	require.True(services.UsersEquals(currentBob, bob1))
 }


### PR DESCRIPTION
This PR makes it so that `CompareAndSwapUser` does a comparison between unmarshaled user objects rather than comparing the JSON serialization through a backend `CompareAndSwap`. Seeing as this requires fetching the object anyway, the new implementation uses a `ConditionalUpdate` operation, which is generally cheaper.

This fixes the failure condition reported at https://github.com/gravitational/teleport/pull/35325#discussion_r1473524505 , but doesn't implement broader changes (to replace all the `CompareAndSwapUser` calls that almost always already get the current value anyway with calls to `UpdateUser`).

changelog: fix conditional user modifications (used by certain Teleport subsystems such as Device Trust) on users that have previously been locked out due to repeated recovery attempts