### PR TITLE
Replace kustomize dependency with fork.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -530,5 +530,6 @@ replace (
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1
 	// replace module sigs.k8s.io/kustomize/api until https://github.com/kubernetes-sigs/kustomize/issues/5524 is resolved,
 	// otherwise we get significant increase in size of the "teleport" binary.
-	sigs.k8s.io/kustomize/api => github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a
+	sigs.k8s.io/kustomize/api => github.com/gravitational/kustomize/api v0.16.0-teleport.1
+
 )

--- a/go.mod
+++ b/go.mod
@@ -507,7 +507,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.16.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
@@ -528,4 +528,7 @@ replace (
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.0.2-teleport.2
 	github.com/sijms/go-ora/v2 => github.com/gravitational/go-ora/v2 v2.0.0-20230821114616-e2a9f1131a46
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1
+	// replace module sigs.k8s.io/kustomize/api until https://github.com/kubernetes-sigs/kustomize/issues/5524 is resolved,
+	// otherwise we get significant increase in size of the "teleport" binary.
+	sigs.k8s.io/kustomize/api => github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a
 )

--- a/go.sum
+++ b/go.sum
@@ -822,8 +822,8 @@ github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8F
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33 h1:VFER/+0TfRypJhc9XeuggTtEZzhhe75DSVqMv/avHEU=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
-github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a h1:1f9Gq0tWXk3hdNh6Mr7jvf+wxQCmCqoHTqy4q/FMxVk=
-github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a/go.mod h1:E/0/egj7ED7xWEegMHlRagaZTiL6fxakmSR2pyiK2ZU=
+github.com/gravitational/kustomize/api v0.16.0-teleport.1 h1:d/aWgghHn/N6TlwGxjjbelUC7b0G0YRyUDf8XS1aScg=
+github.com/gravitational/kustomize/api v0.16.0-teleport.1/go.mod h1:E/0/egj7ED7xWEegMHlRagaZTiL6fxakmSR2pyiK2ZU=
 github.com/gravitational/license v0.0.0-20231228155916-928ed9ac0335 h1:fShrzWedyujntzzpjdDmy7r22d+6nKIokEWZRG2QoMQ=
 github.com/gravitational/license v0.0.0-20231228155916-928ed9ac0335/go.mod h1:kzMpXT7DIdeoGVSTwsZowcW6jiu3NRwg+E1XfdGvzyI=
 github.com/gravitational/oxy v0.0.0-20221029012416-9fbf4c444680 h1:acbjjEJoR2vu1cuSE15Q9YDgWZxWRFj7nr2Vsi/Pn18=

--- a/go.sum
+++ b/go.sum
@@ -822,6 +822,8 @@ github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8F
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33 h1:VFER/+0TfRypJhc9XeuggTtEZzhhe75DSVqMv/avHEU=
 github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
+github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a h1:1f9Gq0tWXk3hdNh6Mr7jvf+wxQCmCqoHTqy4q/FMxVk=
+github.com/gravitational/kustomize/api v0.0.0-20240201174225-90bb1eeead9a/go.mod h1:E/0/egj7ED7xWEegMHlRagaZTiL6fxakmSR2pyiK2ZU=
 github.com/gravitational/license v0.0.0-20231228155916-928ed9ac0335 h1:fShrzWedyujntzzpjdDmy7r22d+6nKIokEWZRG2QoMQ=
 github.com/gravitational/license v0.0.0-20231228155916-928ed9ac0335/go.mod h1:kzMpXT7DIdeoGVSTwsZowcW6jiu3NRwg+E1XfdGvzyI=
 github.com/gravitational/oxy v0.0.0-20221029012416-9fbf4c444680 h1:acbjjEJoR2vu1cuSE15Q9YDgWZxWRFj7nr2Vsi/Pn18=
@@ -2263,12 +2265,10 @@ sigs.k8s.io/controller-tools v0.14.0 h1:rnNoCC5wSXlrNoBKKzL70LNJKIQKEzT6lloG6/LF
 sigs.k8s.io/controller-tools v0.14.0/go.mod h1:TV7uOtNNnnR72SpzhStvPkoS/U5ir0nMudrkrC4M9Sc=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 h1:XX3Ajgzov2RKUdc5jW3t5jwY7Bo7dcRm+tFxT+NfgY0=
-sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3/go.mod h1:9n16EZKMhXBNSiUC5kSdFQJkdH3zbxS/JoO619G1VAY=
 sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3 h1:vq2TtoDcQomhy7OxXLUOzSbHMuMYq0Bjn93cDtJEdKw=
 sigs.k8s.io/kustomize/kustomize/v5 v5.0.4-0.20230601165947-6ce0bf390ce3/go.mod h1:/d88dHCvoy7d0AKFT0yytezSGZKjsZBVs9YTkBHSGFk=
-sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 h1:W6cLQc5pnqM7vh3b7HvGNfXrJ/xL6BDMS0v1V/HHg5U=
-sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3/go.mod h1:JWP1Fj0VWGHyw3YUPjXSQnRnrwezrZSrApfX5S0nIag=
+sigs.k8s.io/kustomize/kyaml v0.16.0 h1:6J33uKSoATlKZH16unr2XOhDI+otoe2sR3M8PDzW3K0=
+sigs.k8s.io/kustomize/kyaml v0.16.0/go.mod h1:xOK/7i+vmE14N2FdFyugIshB8eF6ALpy7jI87Q2nRh4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=


### PR DESCRIPTION
This PR replaces kustomize dependency to reduce bloated size of the our binaries. It happened because original kustomize brings "plugin" package as a dependency and it changes how go linker works, for example resulting in ~80MB overhead on Linux for "teleport" binary.

Fork changes: https://github.com/gravitational/kustomize/pull/1
Related issue: https://github.com/kubernetes-sigs/kustomize/issues/5524