### PR TITLE
Enable errorlint via golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   enable:
     - bodyclose
     - depguard
+    - errorlint
     - gci
     - goimports
     - gosimple
@@ -58,6 +59,10 @@ linters-settings:
             desc: 'experimental project, not to be confused with official Go packages'
           - pkg: golang.org/x/exp/slices
             desc: 'use "slices" instead'
+  errorlint:
+    comparison: true
+    asserts: true
+    errorf: true
   gci:
     sections:
       - standard # Standard section: captures all standard packages.

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -978,7 +978,7 @@ func (c *Client) GetCurrentUserRoles(ctx context.Context) ([]types.Role, error) 
 		return nil, trace.Wrap(err)
 	}
 	var roles []types.Role
-	for role, err := stream.Recv(); err != io.EOF; role, err = stream.Recv() {
+	for role, err := stream.Recv(); !errors.Is(err, io.EOF); role, err = stream.Recv() {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1002,7 +1002,7 @@ func (c *Client) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, 
 				return nil, trace.Wrap(err)
 			}
 			var users []types.User
-			for user, err := stream.Recv(); err != io.EOF; user, err = stream.Recv() {
+			for user, err := stream.Recv(); !errors.Is(err, io.EOF); user, err = stream.Recv() {
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -2340,7 +2340,7 @@ func (c *Client) StreamSessionEvents(ctx context.Context, sessionID string, star
 		for {
 			oneOf, err := stream.Recv()
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					e <- trace.Wrap(trace.Wrap(err))
 				} else {
 					close(ch)
@@ -2454,7 +2454,7 @@ func (c *Client) StreamUnstructuredSessionEvents(ctx context.Context, sessionID 
 		for {
 			event, err := stream.Recv()
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					// If the server does not support the unstructured events API, it will
 					// return an error with code Unimplemented. This error is received
 					// the first time the client calls Recv() on the stream.
@@ -2515,7 +2515,7 @@ func (c *Client) streamUnstructuredSessionEventsFallback(ctx context.Context, se
 		for {
 			oneOf, err := stream.Recv()
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					e <- trace.Wrap(trace.Wrap(err))
 				} else {
 					close(ch)

--- a/api/types/app_test.go
+++ b/api/types/app_test.go
@@ -38,7 +38,7 @@ func TestAppPublicAddrValidation(t *testing.T) {
 	}
 	hasErrTypeBadParameter := func() check {
 		return func(t *testing.T, err error) {
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err))
 		}
 	}
 

--- a/api/types/networking_test.go
+++ b/api/types/networking_test.go
@@ -72,7 +72,7 @@ func TestProxyListenerModeUnmarshalYAML(t *testing.T) {
 			name: "invalid value",
 			in:   "unknown value",
 			wantErr: func(t *testing.T, err error) {
-				require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+				require.True(t, trace.IsBadParameter(err))
 			},
 		},
 	}

--- a/api/utils/pingconn/pingconn_test.go
+++ b/api/utils/pingconn/pingconn_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -187,15 +188,15 @@ func TestPingConnection(t *testing.T) {
 						for {
 							n, err := r.Read(buf)
 							if err != nil {
-								switch err {
+								switch {
 								// Since we're partially reading the message, the last
 								// read will return an EOF. In this case, do nothing
 								// and send the remaining bytes.
-								case io.EOF:
+								case errors.Is(err, io.EOF):
 								// The connection will be closed only if the test is
 								// completed. The read result will be empty, so return
 								// the function to complete the goroutine.
-								case io.ErrClosedPipe:
+								case errors.Is(err, io.ErrClosedPipe):
 									return
 								// Any other error should fail the test and complete the
 								// goroutine.

--- a/api/utils/retryutils/retry.go
+++ b/api/utils/retryutils/retry.go
@@ -19,6 +19,7 @@ package retryutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -185,7 +186,8 @@ func (r *Linear) For(ctx context.Context, retryFn func() error) error {
 		if err == nil {
 			return nil
 		}
-		if _, ok := trace.Unwrap(err).(*permanentRetryError); ok {
+		var permanentRetryError *permanentRetryError
+		if errors.As(trace.Unwrap(err), &permanentRetryError) {
 			return trace.Wrap(err)
 		}
 		log.Debugf("Will retry in %v: %v.", r.Duration(), err)

--- a/api/utils/sshutils/chconn.go
+++ b/api/utils/sshutils/chconn.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sshutils
 
 import (
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -136,7 +137,7 @@ func (c *ChConn) Read(data []byte) (int, error) {
 	// A lot of code relies on "use of closed network connection" error to
 	// gracefully handle terminated connections so convert the closed pipe
 	// error to it.
-	if err != nil && err == io.ErrClosedPipe {
+	if err != nil && errors.Is(err, io.ErrClosedPipe) {
 		return n, trace.ConnectionProblem(err, constants.UseOfClosedNetworkConnection)
 	}
 	// Do not wrap the error to avoid masking the underlying error such as

--- a/dronegen/drone_cli.go
+++ b/dronegen/drone_cli.go
@@ -38,7 +38,7 @@ func signDroneConfig() error {
 	out, err := exec.Command("drone", "sign", "gravitational/teleport", "--save").CombinedOutput()
 	if err != nil {
 		if len(out) > 0 {
-			err = fmt.Errorf("drone signing failed: %v\noutput:\n%s", err, out)
+			err = fmt.Errorf("drone signing failed: %w\noutput:\n%s", err, out)
 		}
 		return err
 	}

--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -723,7 +723,7 @@ func mergeFiles(files []*os.File, outputFile *os.File) error {
 		}
 
 		nextLine, err := readLine(min.Dec)
-		if trace.Unwrap(err) == io.EOF {
+		if errors.Is(trace.Unwrap(err), io.EOF) {
 			// EOF means that file no longer has events. Continue with other files.
 			continue
 		} else if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1967,7 +1967,7 @@ type errorVerifier func(error) error
 func errorContains(text string) errorVerifier {
 	return func(err error) error {
 		if err == nil || !strings.Contains(err.Error(), text) {
-			return fmt.Errorf("Expected error to contain %q, got: %v", text, err)
+			return fmt.Errorf("Expected error to contain %q, got: %w", text, err)
 		}
 		return nil
 	}
@@ -2285,7 +2285,7 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 					asyncErrors <- badErrorErr
 				}
 			} else if err != nil && !errors.Is(err, io.EOF) && !isSSHError(err) {
-				asyncErrors <- fmt.Errorf("expected EOF, ExitError, or nil, got %v instead", err)
+				asyncErrors <- fmt.Errorf("expected EOF, ExitError, or nil, got %w instead", err)
 				return
 			}
 		}
@@ -2320,8 +2320,10 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 }
 
 func isSSHError(err error) bool {
-	switch trace.Unwrap(err).(type) {
-	case *ssh.ExitError, *ssh.ExitMissingError:
+	var exitError *ssh.ExitError
+	var exitMissingError *ssh.ExitMissingError
+	switch err := trace.Unwrap(err); {
+	case errors.As(err, &exitError), errors.As(err, &exitMissingError):
 		return true
 	default:
 		return false
@@ -4605,7 +4607,8 @@ func testExternalClient(t *testing.T, suite *integrationTestSuite) {
 			} else {
 				// ensure stderr is printed as a string rather than bytes
 				var stderr string
-				if e, ok := err.(*exec.ExitError); ok {
+				var e *exec.ExitError
+				if errors.As(err, &e) {
 					stderr = string(e.Stderr)
 				}
 				require.NoError(t, err, "stderr=%q", stderr)
@@ -4703,7 +4706,8 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 
 				// ensure stderr is printed as a string rather than bytes
 				var stderr string
-				if e, ok := err.(*exec.ExitError); ok {
+				var e *exec.ExitError
+				if errors.As(err, &e) {
 					stderr = string(e.Stderr)
 				}
 				require.NoError(t, err, "stderr=%q", stderr)

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -20,6 +20,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -280,7 +281,7 @@ func newMockTSHDEventsServiceServer(t *testing.T, tc *libclient.TeleportClient, 
 		// before grpcServer.Serve is called and grpcServer.Serve will return
 		// grpc.ErrServerStopped.
 		err := <-serveErr
-		if err != grpc.ErrServerStopped {
+		if !errors.Is(err, grpc.ErrServerStopped) {
 			assert.NoError(t, err)
 		}
 	})

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/user"
@@ -882,7 +883,7 @@ func newMockTSHDEventsServiceServer(t *testing.T) (service *mockTSHDEventsServic
 		// before grpcServer.Serve is called and grpcServer.Serve will return
 		// grpc.ErrServerStopped.
 		err := <-serveErr
-		if err != grpc.ErrServerStopped {
+		if !errors.Is(err, grpc.ErrServerStopped) {
 			assert.NoError(t, err)
 		}
 	})

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -20,6 +20,7 @@ package mattermost
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -457,7 +458,8 @@ func (b Bot) tryLookupDirectChannel(ctx context.Context, userEmail string) strin
 	log := logger.Get(ctx).WithField("mm_user_email", userEmail)
 	channel, err := b.LookupDirectChannel(ctx, userEmail)
 	if err != nil {
-		if errResult, ok := trace.Unwrap(err).(*ErrorResult); ok {
+		var errResult *ErrorResult
+		if errors.As(trace.Unwrap(err), &errResult) {
 			log.Warningf("Failed to lookup direct channel info: %q", errResult.Message)
 		} else {
 			log.WithError(err).Error("Failed to lookup direct channel info")
@@ -474,7 +476,8 @@ func (b Bot) tryLookupChannel(ctx context.Context, team, name string) string {
 	})
 	channel, err := b.LookupChannel(ctx, team, name)
 	if err != nil {
-		if errResult, ok := trace.Unwrap(err).(*ErrorResult); ok {
+		var errResult *ErrorResult
+		if errors.As(trace.Unwrap(err), &errResult) {
 			log.Warningf("Failed to lookup channel info: %q", errResult.Message)
 		} else {
 			log.WithError(err).Error("Failed to lookup channel info")

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -236,7 +236,7 @@ func (a *App) onPendingRequest(ctx context.Context, req types.AccessRequest) err
 		return nil
 	}
 	// Don't show the error if the annotation is just missing.
-	if trace.Unwrap(notifyErr) == errMissingAnnotation {
+	if errors.Is(trace.Unwrap(notifyErr), errMissingAnnotation) {
 		notifyErr = nil
 	}
 

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -255,7 +255,7 @@ func (a *App) onPendingRequest(ctx context.Context, req types.AccessRequest) err
 		return nil
 	}
 	// Don't show the error if the annotation is just missing.
-	if trace.Unwrap(notifyErr) == errSkip {
+	if errors.Is(trace.Unwrap(notifyErr), errSkip) {
 		notifyErr = nil
 	}
 

--- a/integrations/kube-agent-updater/pkg/controller/deployment.go
+++ b/integrations/kube-agent-updater/pkg/controller/deployment.go
@@ -67,8 +67,9 @@ func (r *DeploymentVersionUpdater) Reconcile(ctx context.Context, req ctrl.Reque
 	// Get the current and past version
 	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec)
 	if err != nil {
-		switch trace.Unwrap(err).(type) {
-		case *trace.BadParameterError:
+		var badParameterError *trace.BadParameterError
+		switch {
+		case errors.As(trace.Unwrap(err), &badParameterError):
 			log.Info("Teleport container found, but failed to get version from the img tag. Will continue and do a version update.")
 		default:
 			log.Error(err, "Unexpected error, not updating.")

--- a/integrations/lib/bail.go
+++ b/integrations/lib/bail.go
@@ -19,6 +19,7 @@
 package lib
 
 import (
+	"errors"
 	"os"
 
 	"github.com/gravitational/trace"
@@ -27,7 +28,8 @@ import (
 
 // Bail exits with nonzero exit code and prints an error to a log.
 func Bail(err error) {
-	if agg, ok := trace.Unwrap(err).(trace.Aggregate); ok {
+	var agg trace.Aggregate
+	if errors.As(trace.Unwrap(err), &agg) {
 		for i, err := range agg.Errors() {
 			log.WithError(err).Errorf("Terminating with fatal error [%d]...", i+1)
 		}

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -20,6 +20,7 @@ package lib
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -210,7 +211,7 @@ func ReadPassword(filename string) (string, error) {
 
 	pass := make([]byte, 2000)
 	l, err := f.Read(pass)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return "", err
 	}
 

--- a/integrations/lib/credentials/credentials_test.go
+++ b/integrations/lib/credentials/credentials_test.go
@@ -146,8 +146,8 @@ func TestCheckExpiredCredentials(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				aggregate, ok := trace.Unwrap(err).(trace.Aggregate)
-				require.True(t, ok)
+				var aggregate trace.Aggregate
+				require.ErrorAs(t, trace.Unwrap(err), &aggregate)
 				require.Len(t, aggregate.Errors(), tc.expectNumErrors, "check number of errors reported")
 			}
 		})

--- a/integrations/lib/errors.go
+++ b/integrations/lib/errors.go
@@ -34,9 +34,9 @@ func FromGRPC(err error) error {
 	switch {
 	case errors.Is(err, io.EOF):
 		fallthrough
-	case status.Code(err) == codes.Canceled, err == context.Canceled:
+	case status.Code(err) == codes.Canceled, errors.Is(err, context.Canceled):
 		fallthrough
-	case status.Code(err) == codes.DeadlineExceeded, err == context.DeadlineExceeded:
+	case status.Code(err) == codes.DeadlineExceeded, errors.Is(err, context.DeadlineExceeded):
 		return trace.Wrap(err)
 	default:
 		return trail.FromGRPC(err)
@@ -46,11 +46,11 @@ func FromGRPC(err error) error {
 // TODO: remove this when trail.FromGRPC will understand additional error codes
 func IsCanceled(err error) bool {
 	err = trace.Unwrap(err)
-	return err == context.Canceled || status.Code(err) == codes.Canceled
+	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
 }
 
 // TODO: remove this when trail.FromGRPC will understand additional error codes
 func IsDeadline(err error) bool {
 	err = trace.Unwrap(err)
-	return err == context.DeadlineExceeded || status.Code(err) == codes.DeadlineExceeded
+	return errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded
 }

--- a/integrations/lib/http.go
+++ b/integrations/lib/http.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -261,7 +262,7 @@ func (h *HTTP) ListenAndServe(ctx context.Context) error {
 		log.Debugf("Starting secure HTTPS server on %s", addr)
 		err = h.server.ServeTLS(listener, h.CertFile, h.KeyFile)
 	}
-	if err == http.ErrServerClosed {
+	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}
 	return trace.Wrap(err)

--- a/integrations/lib/testing/integration/download.go
+++ b/integrations/lib/testing/integration/download.go
@@ -21,6 +21,7 @@ package integration
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -174,7 +175,7 @@ func getBinaries(ctx context.Context, distStr, outDir string, checksum lib.SHA25
 			// Once the file is closed it will be unlocked too.
 			break
 		}
-		if err != syscall.EWOULDBLOCK {
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
 			// Advisory lock is acquired by another process.
 			return BinPaths{}, trace.NewAggregate(trace.ConvertSystemError(err), outFile.Close())
 		}

--- a/lib/ai/model/output/error.go
+++ b/lib/ai/model/output/error.go
@@ -19,6 +19,7 @@
 package output
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gravitational/trace"
@@ -34,8 +35,8 @@ func NewInvalidOutputError(coarse, detail string) error {
 
 // IsInvalidOutputError returns true if the error is an invalidOutputError.
 func IsInvalidOutputError(err error) bool {
-	_, ok := trace.Unwrap(err).(*invalidOutputError)
-	return ok
+	var invalidOutputError *invalidOutputError
+	return errors.As(trace.Unwrap(err), &invalidOutputError)
 }
 
 // invalidOutputError represents an error caused by the output of an LLM.

--- a/lib/auditd/auditd_linux.go
+++ b/lib/auditd/auditd_linux.go
@@ -147,7 +147,7 @@ func SendEvent(event EventType, result ResultType, msg Message) error {
 	}()
 
 	if err := client.SendMsg(event, result); err != nil {
-		if err == ErrAuditdDisabled || isPermissionError(err) {
+		if errors.Is(err, ErrAuditdDisabled) || isPermissionError(err) {
 			// Do not return the error to the caller if auditd is disabled,
 			// or we don't have required permissions to use it.
 			return nil

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -19,6 +19,7 @@
 package keystore
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -175,7 +176,8 @@ func softHSMTestConfig(t *testing.T) (Config, bool) {
 	cmd := exec.Command("softhsm2-util", "--init-token", "--free", "--label", tokenLabel, "--so-pin", "password", "--pin", "password")
 	t.Logf("Running command: %q", cmd)
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			require.NoError(t, exitErr, "error creating test softhsm token: %s", string(exitErr.Stderr))
 		}
 		require.NoError(t, err, "error attempting to run softhsm2-util")

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -873,7 +873,8 @@ func (a *Server) createUserWebSession(ctx context.Context, user services.UserSta
 }
 
 func getErrorByTraceField(err error) error {
-	traceErr, ok := err.(trace.Error)
+	var traceErr trace.Error
+	ok := errors.As(err, &traceErr)
 	switch {
 	case !ok:
 		log.WithError(err).Warn("Unexpected error type, wanted TraceError")

--- a/lib/automaticupgrades/cache/cache_test.go
+++ b/lib/automaticupgrades/cache/cache_test.go
@@ -60,11 +60,11 @@ func TestTimedMemoize_Get(t *testing.T) {
 	oldUpstreamError := trace.CompareFailed("comparison failed")
 
 	assertUncachedError := func(t2 require.TestingT, err error, _ ...interface{}) {
-		require.Equal(t2, err, upstreamError)
+		require.ErrorIs(t2, err, upstreamError)
 	}
 	assertCachedError := func(t2 require.TestingT, err error, _ ...interface{}) {
-		_, ok := trace.Unwrap(err).(cachedError)
-		require.True(t2, ok)
+		var cachedError cachedError
+		require.ErrorAs(t2, trace.Unwrap(err), &cachedError)
 	}
 
 	tests := []struct {

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -21,6 +21,7 @@ package dynamo
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"strconv"
@@ -1049,8 +1050,8 @@ func convertError(err error) error {
 	if err == nil {
 		return nil
 	}
-	aerr, ok := err.(awserr.Error)
-	if !ok {
+	var aerr awserr.Error
+	if !errors.As(err, &aerr) {
 		return err
 	}
 	switch aerr.Code() {

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -20,6 +20,7 @@ package dynamo
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 
@@ -163,7 +164,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 					return trace.BadParameter("empty shard ID")
 				}
 				delete(set, event.shardID)
-				if event.err != io.EOF {
+				if !errors.Is(event.err, io.EOF) {
 					b.Debugf("Shard ID %v closed with error: %v, reseting buffers.", event.shardID, event.err)
 					return trace.Wrap(event.err)
 				}

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -24,6 +24,7 @@ package bpf
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,7 +128,7 @@ func waitForContinue() error {
 	defer waitFD.Close()
 
 	buff := make([]byte, 1)
-	if _, err := waitFD.Read(buff); err != nil && err != io.EOF {
+	if _, err := waitFD.Read(buff); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -879,16 +879,15 @@ func TestFormatConnectToProxyErr(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			traceErr, isTraceErr := err.(*trace.TraceErr)
-
-			if isTraceErr {
+			var traceErr *trace.TraceErr
+			if errors.As(err, &traceErr) {
 				require.EqualError(t, traceErr.OrigError(), tt.wantError)
 			} else {
 				require.EqualError(t, err, tt.wantError)
 			}
 
 			if tt.wantUserMessage != "" {
-				require.True(t, isTraceErr)
+				require.NotNil(t, traceErr)
 				require.Contains(t, traceErr.Messages, tt.wantUserMessage)
 			}
 		})

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1403,7 +1404,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeDet
 	if err != nil {
 		// If the user pressed Ctrl-C, no need to try and read the error from
 		// the proxy, return an error right away.
-		if trace.Unwrap(err) == context.Canceled {
+		if errors.Is(trace.Unwrap(err), context.Canceled) {
 			return nil, trace.Wrap(err)
 		}
 
@@ -1588,10 +1589,12 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 	}
 
 	if err = nodeSession.runShell(ctx, mode, beforeStart, c.TC.OnShellCreated); err != nil {
-		switch e := trace.Unwrap(err).(type) {
-		case *ssh.ExitError:
-			c.TC.ExitStatus = e.ExitStatus()
-		case *ssh.ExitMissingError:
+		var exitErr *ssh.ExitError
+		var exitMissingErr *ssh.ExitMissingError
+		switch err := trace.Unwrap(err); {
+		case errors.As(err, &exitErr):
+			c.TC.ExitStatus = exitErr.ExitStatus()
+		case errors.As(err, &exitMissingErr):
 			c.TC.ExitStatus = 1
 		}
 
@@ -1731,8 +1734,8 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string, opts ...R
 	defer nodeSession.Close()
 	if err := nodeSession.runCommand(ctx, types.SessionPeerMode, command, c.TC.OnShellCreated, c.TC.Config.InteractiveCommand); err != nil {
 		originErr := trace.Unwrap(err)
-		exitErr, ok := originErr.(*ssh.ExitError)
-		if ok {
+		var exitErr *ssh.ExitError
+		if errors.As(originErr, &exitErr) {
 			c.TC.ExitStatus = exitErr.ExitStatus()
 		} else {
 			// if an error occurs, but no exit status is passed back, GoSSH returns

--- a/lib/client/conntest/database/mysql.go
+++ b/lib/client/conntest/database/mysql.go
@@ -45,8 +45,9 @@ func convertError(err error) error {
 		Cause() error
 	}
 
-	if causer, ok := err.(causer); ok {
-		return trace.Wrap(causer.Cause())
+	var c causer
+	if errors.As(err, &c) {
+		return trace.Wrap(c.Cause())
 	}
 
 	return trace.Wrap(err)

--- a/lib/client/escape/reader.go
+++ b/lib/client/escape/reader.go
@@ -211,7 +211,7 @@ func (r *Reader) setErr(err error) {
 	r.err = err
 	r.cond.Broadcast()
 	// Skip EOF, it's a normal clean exit.
-	if err != io.EOF {
+	if !errors.Is(err, io.EOF) {
 		r.onDisconnect(err)
 	}
 	r.cond.L.Unlock()

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -703,10 +703,10 @@ func handlePeerControls(term *terminal.Terminal, enableEscapeSequences bool, rem
 		stdin = escape.NewReader(stdin, term.Stderr(), func(err error) {
 			log.Debugf("escape.NewReader error: %v", err)
 
-			switch err {
-			case escape.ErrDisconnect:
+			switch {
+			case errors.Is(err, escape.ErrDisconnect):
 				fmt.Fprint(term.Stderr(), "\r\nDisconnected\r\n")
-			case escape.ErrTooMuchBufferedData:
+			case errors.Is(err, escape.ErrTooMuchBufferedData):
 				fmt.Fprint(term.Stderr(), "\r\nRemote peer may be unreachable, check your connectivity\r\n")
 			default:
 				fmt.Fprintf(term.Stderr(), "\r\nunknown error: %v\r\n", err.Error())

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -36,8 +36,8 @@ import (
 // to trace errors. If the provided error is not an `RequestFailure` it returns
 // the error without modifying it.
 func ConvertRequestFailureError(err error) error {
-	requestErr, ok := err.(awserr.RequestFailure)
-	if !ok {
+	var requestErr awserr.RequestFailure
+	if !errors.As(err, &requestErr) {
 		return err
 	}
 
@@ -66,7 +66,8 @@ func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) 
 // ConvertIAMError converts common errors from IAM clients to trace errors.
 func ConvertIAMError(err error) error {
 	// By error code.
-	if awsErr, ok := err.(awserr.Error); ok {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
 		switch awsErr.Code() {
 		case iam.ErrCodeUnmodifiableEntityException:
 			return trace.AccessDenied(awsErr.Error())
@@ -128,8 +129,9 @@ func ConvertIAMv2Error(err error) error {
 
 // ConvertLoadConfigError converts common AWS config loading errors to trace errors.
 func ConvertLoadConfigError(configErr error) error {
-	switch configErr.(type) {
-	case config.SharedConfigProfileNotExistError:
+	var sharedConfigProfileNotExistError config.SharedConfigProfileNotExistError
+	switch {
+	case errors.As(configErr, &sharedConfigProfileNotExistError):
 		return trace.NotFound(configErr.Error())
 	}
 

--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -35,20 +36,20 @@ func ConvertResponseError(err error) error {
 		return nil
 	}
 
-	switch v := err.(type) {
-	case *azcore.ResponseError:
-		switch v.StatusCode {
+	var responseErr *azcore.ResponseError
+	var authenticationFailedErr *azidentity.AuthenticationFailedError
+	switch {
+	case errors.As(err, &responseErr):
+		switch responseErr.StatusCode {
 		case http.StatusForbidden:
-			return trace.AccessDenied(v.Error())
+			return trace.AccessDenied(responseErr.Error())
 		case http.StatusConflict:
-			return trace.AlreadyExists(v.Error())
+			return trace.AlreadyExists(responseErr.Error())
 		case http.StatusNotFound:
-			return trace.NotFound(v.Error())
+			return trace.NotFound(responseErr.Error())
 		}
-
-	case *azidentity.AuthenticationFailedError:
-		return trace.AccessDenied(v.Error())
-
+	case errors.As(err, &authenticationFailedErr):
+		return trace.AccessDenied(authenticationFailedErr.Error())
 	}
 	return err // Return unmodified.
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -557,7 +557,8 @@ func (l *Log) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type logYAML Log
 	log := (*logYAML)(l)
 	if err := unmarshal(log); err != nil {
-		if _, ok := err.(*yaml.TypeError); !ok {
+		var typeError *yaml.TypeError
+		if !errors.As(err, &typeError) {
 			return err
 		}
 
@@ -1159,11 +1160,11 @@ func getCertificatePEM(certOrPath string) (string, error) {
 	data, err := os.ReadFile(certOrPath)
 	if err != nil {
 		// Don't use trace in order to keep a clean error message.
-		return "", fmt.Errorf("%q is not a valid x509 certificate (%v) and can't be read as a file (%v)", certOrPath, parseErr, err)
+		return "", fmt.Errorf("%q is not a valid x509 certificate (%w) and can't be read as a file (%w)", certOrPath, parseErr, err)
 	}
 	if _, err := tlsutils.ParseCertificatePEM(data); err != nil {
 		// Don't use trace in order to keep a clean error message.
-		return "", fmt.Errorf("file %q contains an invalid x509 certificate: %v", certOrPath, err)
+		return "", fmt.Errorf("file %q contains an invalid x509 certificate: %w", certOrPath, err)
 	}
 
 	return string(data), nil // OK, valid PEM file

--- a/lib/events/athena/consumer_test.go
+++ b/lib/events/athena/consumer_test.go
@@ -833,8 +833,8 @@ func TestDeleteMessagesFromQueue(t *testing.T) {
 			},
 			wantCheck: func(t *testing.T, err error, mock *mockSQSDeleter) {
 				require.Error(t, err)
-				agg, ok := trace.Unwrap(err).(trace.Aggregate)
-				require.True(t, ok)
+				var agg trace.Aggregate
+				require.ErrorAs(t, trace.Unwrap(err), &agg)
 				for _, errFromAgg := range agg.Errors() {
 					require.ErrorContains(t, errFromAgg, "entry failed")
 				}

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -766,7 +766,7 @@ func (l *AuditLog) unpackFile(fileName string) (readSeekCloser, error) {
 		// Unexpected EOF is returned by gzip reader
 		// when the file has not been closed yet,
 		// ignore this error
-		if err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			dest.Close()
 			return nil, trace.Wrap(err)
 		}
@@ -1011,7 +1011,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 
 			event, err := protoReader.Read(ctx)
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					e <- trace.Wrap(err)
 				} else {
 					close(c)

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -994,10 +994,11 @@ func convertError(err error) error {
 	if err == nil {
 		return nil
 	}
-	aerr, ok := err.(awserr.Error)
-	if !ok {
+	var aerr awserr.Error
+	if !errors.As(err, &aerr) {
 		return err
 	}
+
 	switch aerr.Code() {
 	case dynamodb.ErrCodeConditionalCheckFailedException:
 		return trace.AlreadyExists(aerr.Error())

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -236,7 +236,7 @@ func (u *Uploader) Serve(ctx context.Context) error {
 		case <-backoff.After():
 			var failed bool
 			if _, err := u.Scan(ctx); err != nil {
-				if trace.Unwrap(err) != errContext {
+				if !errors.Is(trace.Unwrap(err), errContext) {
 					failed = true
 					u.log.WithError(err).Warningf("Uploader scan failed.")
 				}
@@ -641,8 +641,8 @@ func (u *Uploader) emitEvent(e events.UploadEvent) {
 }
 
 func isSessionError(err error) bool {
-	_, ok := trace.Unwrap(err).(sessionError)
-	return ok
+	var sessionError sessionError
+	return errors.As(trace.Unwrap(err), &sessionError)
 }
 
 // sessionError highlights problems with session

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -55,7 +56,7 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 	h.Logger.Debugf("Creating upload at %s", uploadPath)
 	// Make sure we don't overwrite an existing upload
 	_, err := h.gcsClient.Bucket(h.Config.Bucket).Object(uploadPath).Attrs(ctx)
-	if err != storage.ErrObjectNotExist {
+	if !errors.Is(err, storage.ErrObjectNotExist) {
 		if err != nil {
 			return nil, convertGCSError(err)
 		}
@@ -110,7 +111,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	// If the session has been already created, move to cleanup
 	sessionPath := h.path(upload.SessionID)
 	_, err := h.gcsClient.Bucket(h.Config.Bucket).Object(sessionPath).Attrs(ctx)
-	if err != storage.ErrObjectNotExist {
+	if !errors.Is(err, storage.ErrObjectNotExist) {
 		if err != nil {
 			return convertGCSError(err)
 		}
@@ -171,7 +172,7 @@ func (h *Handler) cleanupUpload(ctx context.Context, upload events.StreamUpload)
 		i := bucket.Objects(ctx, &storage.Query{Prefix: prefix, Versions: false})
 		for {
 			attrs, err := i.Next()
-			if err == iterator.Done {
+			if errors.Is(err, iterator.Done) {
 				break
 			}
 			if err != nil {
@@ -234,7 +235,7 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 	var parts []events.StreamPart
 	for {
 		attrs, err := i.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
@@ -262,7 +263,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 	var uploads []events.StreamUpload
 	for {
 		attrs, err := i.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -1064,7 +1064,7 @@ func (r *ProtoReader) Read(ctx context.Context) (apievents.AuditEvent, error) {
 			// message and the message itself
 			_, err := io.ReadFull(r.gzipReader, r.sizeBytes[:Int32Size])
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					return nil, r.setError(trace.ConvertSystemError(err))
 				}
 				// reached the end of the current part, but not necessarily

--- a/lib/httplib/reverseproxy/handler.go
+++ b/lib/httplib/reverseproxy/handler.go
@@ -19,6 +19,7 @@
 package reverseproxy
 
 import (
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -39,10 +40,11 @@ type defaultHandler struct{}
 func (e *defaultHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
 	statusCode := http.StatusInternalServerError
 	switch {
-	case err == io.EOF:
+	case errors.Is(err, io.EOF):
 		statusCode = http.StatusBadGateway
 	default:
-		switch e, ok := err.(net.Error); {
+		var e net.Error
+		switch ok := errors.As(err, &e); {
 		case ok && e.Timeout():
 			statusCode = http.StatusGatewayTimeout
 		case ok:

--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -330,7 +330,7 @@ func (t *termQueue) handleResizeEvents(stream io.Reader) {
 	for {
 		size := remotecommand.TerminalSize{}
 		if err := decoder.Decode(&size); err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				log.Warningf("Failed to decode resize event: %v", err)
 			}
 			t.cancel()

--- a/lib/kube/proxy/streamproto/proto.go
+++ b/lib/kube/proxy/streamproto/proto.go
@@ -169,7 +169,7 @@ func (s *SessionStream) readTask() {
 
 		ty, data, err := s.conn.ReadMessage()
 		if err != nil {
-			if err != io.EOF && !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
+			if !errors.Is(err, io.EOF) && !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
 				log.WithError(err).Warn("Failed to read message from websocket")
 			}
 

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -484,7 +484,7 @@ func (t *termQueue) handleResizeEvents(stream io.Reader) {
 	for {
 		size := remotecommand.TerminalSize{}
 		if err := decoder.Decode(&size); err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				log.Warningf("Failed to decode resize event: %v", err)
 			}
 			t.cancel()

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"slices"
 
 	"github.com/gravitational/trace"
@@ -103,7 +104,7 @@ func GetKubeConfig(configPath string, allConfigEntries bool, clusterName string)
 	case configPath == "" && clusterName != "":
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
-			if err == rest.ErrNotInCluster {
+			if errors.Is(err, rest.ErrNotInCluster) {
 				return nil, trace.NotFound("not running inside of a Kubernetes pod")
 			}
 			return nil, trace.Wrap(err)

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -321,7 +321,7 @@ func (m *Mux) detectAndForward(conn net.Conn) {
 
 	connWrapper, err := m.detect(conn)
 	if err != nil {
-		if trace.Unwrap(err) != io.EOF {
+		if !errors.Is(trace.Unwrap(err), io.EOF) {
 			m.logLimiter.Log(m.Entry.WithFields(log.Fields{
 				"src_addr": conn.RemoteAddr(),
 				"dst_addr": conn.LocalAddr(),

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -567,7 +567,7 @@ func TestMux(t *testing.T) {
 		}
 		go func() {
 			err := httpServer.Serve(tlsLis.HTTP())
-			if err == nil || err == http.ErrServerClosed {
+			if err == nil || errors.Is(err, http.ErrServerClosed) {
 				errCh <- nil
 				return
 			}

--- a/lib/multiplexer/tls.go
+++ b/lib/multiplexer/tls.go
@@ -21,6 +21,7 @@ package multiplexer
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"time"
@@ -145,7 +146,7 @@ func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 
 	start := l.cfg.Clock.Now()
 	if err := conn.Handshake(); err != nil {
-		if trace.Unwrap(err) != io.EOF {
+		if !errors.Is(trace.Unwrap(err), io.EOF) {
 			l.log.WithFields(log.Fields{
 				"src_addr": conn.RemoteAddr(),
 				"dst_addr": conn.LocalAddr(),

--- a/lib/multiplexer/web.go
+++ b/lib/multiplexer/web.go
@@ -21,6 +21,7 @@ package multiplexer
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"time"
@@ -136,7 +137,7 @@ func (l *WebListener) detectAndForward(conn *tls.Conn) {
 	}
 
 	if err := conn.Handshake(); err != nil {
-		if trace.Unwrap(err) != io.EOF {
+		if !errors.Is(trace.Unwrap(err), io.EOF) {
 			l.log.WithFields(logrus.Fields{
 				"src_addr": conn.RemoteAddr(),
 				"dst_addr": conn.LocalAddr(),

--- a/lib/observability/metrics/prometheus.go
+++ b/lib/observability/metrics/prometheus.go
@@ -19,6 +19,7 @@
 package metrics
 
 import (
+	"errors"
 	"runtime"
 
 	"github.com/gravitational/trace"
@@ -36,7 +37,8 @@ func RegisterPrometheusCollectors(collectors ...prometheus.Collector) error {
 	var errs []error
 	for _, c := range collectors {
 		if err := prometheus.Register(c); err != nil {
-			if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			var alreadyRegisteredError prometheus.AlreadyRegisteredError
+			if errors.As(err, &alreadyRegisteredError) {
 				continue
 			}
 			errs = append(errs, err)

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -167,7 +167,7 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 				cmp.Comparer(func(a, b *AgentPool) bool {
 					aAddr, aMode, aErr := a.AgentPoolConfig.Resolver(context.Background())
 					bAddr, bMode, bErr := b.AgentPoolConfig.Resolver(context.Background())
-					if aAddr != bAddr && aMode != bMode && aErr != bErr {
+					if aAddr != bAddr && aMode != bMode && !errors.Is(bErr, aErr) {
 						return false
 					}
 

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -20,6 +20,7 @@ package service
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"strconv"
@@ -275,7 +276,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 
 		err = srv.Serve(mux.TLS())
 		if err != nil {
-			if err == http.ErrServerClosed {
+			if errors.Is(err, http.ErrServerClosed) {
 				return nil
 			}
 			return trace.Wrap(err)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -19,6 +19,7 @@
 package service
 
 import (
+	"errors"
 	"net"
 	"net/http"
 
@@ -258,7 +259,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		process.BroadcastEvent(Event{Name: KubernetesReady, Payload: nil})
 		err := kubeServer.Serve(listener)
 		if err != nil {
-			if err == http.ErrServerClosed {
+			if errors.Is(err, http.ErrServerClosed) {
 				return nil
 			}
 			return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -709,7 +709,7 @@ func Run(ctx context.Context, cfg servicecfg.Config, newTeleport NewProcess) err
 		if err != nil {
 			// This error means that was a clean shutdown
 			// and no reload is necessary.
-			if err == ErrTeleportExited {
+			if errors.Is(err, ErrTeleportExited) {
 				return nil
 			}
 			return trace.Wrap(err)
@@ -722,7 +722,7 @@ func waitAndReload(ctx context.Context, cfg servicecfg.Config, srv Process, newT
 	if err == nil {
 		return nil, ErrTeleportExited
 	}
-	if err != ErrTeleportReloading {
+	if !errors.Is(err, ErrTeleportReloading) {
 		return nil, trace.Wrap(err)
 	}
 	cfg.Log.Infof("Started in-process service reload.")
@@ -774,7 +774,7 @@ func waitAndReload(ctx context.Context, cfg servicecfg.Config, srv Process, newT
 	timeoutCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 	defer cancel()
 	srv.Shutdown(services.ProcessReloadContext(timeoutCtx))
-	if timeoutCtx.Err() == context.DeadlineExceeded {
+	if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
 		// The new service can start initiating connections to the old service
 		// keeping it from shutting down gracefully, or some external
 		// connections can keep hanging the old auth service and prevent
@@ -788,7 +788,7 @@ func waitAndReload(ctx context.Context, cfg servicecfg.Config, srv Process, newT
 		timeoutCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 		defer cancel()
 		srv.WaitWithContext(timeoutCtx)
-		if timeoutCtx.Err() == context.DeadlineExceeded {
+		if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
 			return nil, trace.BadParameter("the old service has failed to exit.")
 		}
 	} else {
@@ -4474,7 +4474,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			}
 
 			err := kubeServer.Serve(listeners.kube, mopts...)
-			if err != nil && err != http.ErrServerClosed {
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				log.Warningf("Kube TLS server exited with error: %v.", err)
 			}
 			return nil
@@ -4861,7 +4861,7 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 	process.RegisterCriticalFunc("proxy.reversetunnel.web", func() error {
 		log.Infof("Minimal web proxy service %s:%s is starting on %v.", teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 		defer minimalWebHandler.Close()
-		if err := minimalWebServer.Serve(minimalListener.Web()); err != nil && err != http.ErrServerClosed {
+		if err := minimalWebServer.Serve(minimalListener.Web()); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Warningf("Error while serving web requests: %v", err)
 		}
 		log.Info("Exited.")

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -20,6 +20,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -311,7 +312,7 @@ func (s *LocalSupervisor) serve(srv Service) {
 		l.Debug("Service has started.")
 		err := srv.Serve()
 		if err != nil {
-			if err == ErrTeleportExited {
+			if errors.Is(err, ErrTeleportExited) {
 				l.Info("Teleport process has shut down.")
 			} else {
 				if s.ExitContext().Err() == nil {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -429,7 +429,7 @@ func TestNodeCRUD(t *testing.T) {
 
 			// GetNodes should fail if namespace isn't provided
 			_, err = presence.GetNodes(ctx, "")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err))
 		})
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()
@@ -441,11 +441,11 @@ func TestNodeCRUD(t *testing.T) {
 
 			// GetNode should fail if node name isn't provided
 			_, err = presence.GetNode(ctx, apidefaults.Namespace, "")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err))
 
 			// GetNode should fail if namespace isn't provided
 			_, err = presence.GetNode(ctx, "", "node1")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.True(t, trace.IsBadParameter(err))
 		})
 	})
 

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -515,7 +515,11 @@ func (e *withUnreliability) NewWatcher(ctx context.Context, watch types.Watch) (
 
 func expectLockInForce(t *testing.T, expectedLock types.Lock, err error) {
 	require.Error(t, err)
-	errLock := err.(trace.Error).GetFields()["lock-in-force"]
+	var lockErr trace.Error
+	var errLock any
+	if errors.As(err, &lockErr) {
+		errLock = lockErr.GetFields()["lock-in-force"]
+	}
 	if expectedLock != nil {
 		require.Empty(t, resourceDiff(expectedLock, errLock.(types.Lock)))
 	} else {

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gravitational/trace"
@@ -29,11 +30,11 @@ import (
 
 // SetTeleportAPIErrorHeader saves the provided error in X-Teleport-API-Error header of response.
 func SetTeleportAPIErrorHeader(rw http.ResponseWriter, err error) {
-	obj, ok := err.(trace.DebugReporter)
-	if !ok {
-		obj = &trace.TraceErr{Err: err}
+	var debugErr trace.DebugReporter
+	if !errors.As(err, &debugErr) {
+		debugErr = &trace.TraceErr{Err: err}
 	}
-	rw.Header().Set(TeleportAPIErrorHeader, obj.DebugReport())
+	rw.Header().Set(TeleportAPIErrorHeader, debugErr.DebugReport())
 }
 
 const (

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1305,7 +1305,7 @@ func TestRedisTransaction(t *testing.T) {
 		txf := func(tx *goredis.Tx) error {
 			// Get current value or zero.
 			n, err := tx.Get(ctx, key).Int()
-			if err != nil && err != goredis.Nil {
+			if err != nil && !errors.Is(err, goredis.Nil) {
 				return err
 			}
 
@@ -1326,7 +1326,7 @@ func TestRedisTransaction(t *testing.T) {
 				// Success.
 				return nil
 			}
-			if err == goredis.TxFailedErr {
+			if errors.Is(err, goredis.TxFailedErr) {
 				// Optimistic lock lost. Retry.
 				continue
 			}

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -20,6 +20,7 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -285,7 +286,7 @@ func (c *IAM) processTask(ctx context.Context, task iamTask) error {
 	configurator, err := c.getAWSConfigurator(ctx, task.database)
 	if err != nil {
 		c.iamPolicyStatus.Store(task.database.GetName(), types.IAMPolicyStatus_IAM_POLICY_STATUS_FAILED)
-		if trace.Unwrap(err) == credentials.ErrNoValidProvidersFoundInChain {
+		if errors.Is(trace.Unwrap(err), credentials.ErrNoValidProvidersFoundInChain) {
 			c.log.Warnf("No AWS credentials provider. Skipping IAM task for database %v.", task.database.GetName())
 			return nil
 		}

--- a/lib/srv/db/mysql/autousers_test.go
+++ b/lib/srv/db/mysql/autousers_test.go
@@ -19,6 +19,7 @@
 package mysql
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -139,7 +140,7 @@ func Test_convertActivateError(t *testing.T) {
 			input: trace.Wrap(permissionError),
 			errorIs: func(err error) bool {
 				// Not converted.
-				return trace.Unwrap(err) == permissionError
+				return errors.Is(trace.Unwrap(err), permissionError)
 			},
 			errorContains: permissionError.Message,
 		},

--- a/lib/srv/db/mysql/protocol/packet_test.go
+++ b/lib/srv/db/mysql/protocol/packet_test.go
@@ -20,6 +20,7 @@ package protocol
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -471,5 +472,5 @@ func TestParsePacket(t *testing.T) {
 }
 
 func isUnexpectedEOFError(err error) bool {
-	return trace.Unwrap(err) == io.ErrUnexpectedEOF
+	return errors.Is(trace.Unwrap(err), io.ErrUnexpectedEOF)
 }

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -573,7 +573,7 @@ func (e *Engine) handleCancelRequest(ctx context.Context, sessionCtx *common.Ses
 		return trace.Wrap(err)
 	}
 	response := make([]byte, 1)
-	if _, err := tlsConn.Read(response); err != io.EOF {
+	if _, err := tlsConn.Read(response); !errors.Is(err, io.EOF) {
 		// server should close the connection after receiving cancel request.
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -21,6 +21,7 @@ package redis
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -355,7 +356,7 @@ func (c *clusterClient) Process(ctx context.Context, inCmd redis.Cmder) error {
 			}
 
 			result := c.Get(ctx, k)
-			if result.Err() == redis.Nil {
+			if errors.Is(result.Err(), redis.Nil) {
 				resultsKeys = append(resultsKeys, redis.Nil)
 				continue
 			}

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -526,14 +526,14 @@ func (e *Engine) isIAMAuthError(err error) bool {
 
 // isRedisError returns true is error comes from Redis, ex, nil, bad command, etc.
 func isRedisError(err error) bool {
-	_, ok := err.(redis.RedisError)
-	return ok
+	var redisError redis.RedisError
+	return errors.As(err, &redisError)
 }
 
 // isTeleportErr returns true if error comes from Teleport itself.
 func isTeleportErr(err error) bool {
-	_, ok := err.(trace.Error)
-	return ok
+	var error trace.Error
+	return errors.As(err, &error)
 }
 
 // driverLogger implements go-redis driver's internal logger using logrus and

--- a/lib/srv/db/secrets/aws_secrets_manager.go
+++ b/lib/srv/db/secrets/aws_secrets_manager.go
@@ -20,6 +20,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -274,8 +275,8 @@ func convertSecretsManagerError(err error) error {
 		return nil
 	}
 
-	awsError, ok := err.(awserr.Error)
-	if !ok {
+	var awsError awserr.Error
+	if !errors.As(err, &awsError) {
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -21,6 +21,7 @@ package desktop
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -61,7 +62,7 @@ func (s *WindowsService) startDesktopDiscovery() error {
 		// reconcile once before starting the ticker, so that desktops show up immediately
 		// (we still have a small delay to give the LDAP client time to initialize)
 		time.Sleep(15 * time.Second)
-		if err := reconciler.Reconcile(s.closeCtx); err != nil && err != context.Canceled {
+		if err := reconciler.Reconcile(s.closeCtx); err != nil && !errors.Is(err, context.Canceled) {
 			s.cfg.Log.Errorf("desktop reconciliation failed: %v", err)
 		}
 
@@ -74,7 +75,7 @@ func (s *WindowsService) startDesktopDiscovery() error {
 			case <-s.closeCtx.Done():
 				return
 			case <-t.Chan():
-				if err := reconciler.Reconcile(s.closeCtx); err != nil && err != context.Canceled {
+				if err := reconciler.Reconcile(s.closeCtx); err != nil && !errors.Is(err, context.Canceled) {
 					s.cfg.Log.Errorf("desktop reconciliation failed: %v", err)
 				}
 			}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -757,7 +757,8 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 	if err := s.connectRDP(ctx, log, tdpConn, desktop, authContext); err != nil {
 		log.Errorf("RDP connection failed: %v", err)
 		msg := "RDP connection failed."
-		if um, ok := err.(trace.UserMessager); ok {
+		var um trace.UserMessager
+		if errors.As(err, &um) {
 			msg = um.UserMessage()
 		}
 		sendTDPError(msg)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1409,7 +1409,7 @@ func (s *Server) Stop() {
 // Wait will block while the server is running.
 func (s *Server) Wait() error {
 	<-s.ctx.Done()
-	if err := s.ctx.Err(); err != nil && err != context.Canceled {
+	if err := s.ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -21,6 +21,7 @@ package forward
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1049,7 +1050,8 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 	if err != nil {
 		s.log.Warnf("Remote session open failed: %v", err)
 		reason, msg := ssh.ConnectionFailed, fmt.Sprintf("remote session open failed: %v", err)
-		if e, ok := trace.Unwrap(err).(*ssh.OpenChannelError); ok {
+		var e *ssh.OpenChannelError
+		if errors.As(trace.Unwrap(err), &e) {
 			reason, msg = e.Reason, e.Message
 		}
 		if err := nch.Reject(reason, msg); err != nil {

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -20,6 +20,7 @@ package forward
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -116,7 +117,7 @@ func (r *remoteSubsystem) Wait() error {
 	for i := 0; i < 3; i++ {
 		select {
 		case err := <-r.errorCh:
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				r.log.Warnf("Connection problem: %v %T", trace.DebugReport(err), err)
 				lastErr = err
 			}

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -231,7 +231,8 @@ func (t *terminal) Run(ctx context.Context) error {
 func (t *terminal) Wait() (*ExecResult, error) {
 	err := t.cmd.Wait()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			status := exitErr.Sys().(syscall.WaitStatus)
 			return &ExecResult{Code: status.ExitStatus(), Command: t.cmd.Path}, nil
 		}
@@ -594,7 +595,8 @@ func (t *remoteTerminal) Wait() (*ExecResult, error) {
 
 	err = t.session.Wait()
 	if err != nil {
-		if exitErr, ok := err.(*ssh.ExitError); ok {
+		var exitErr *ssh.ExitError
+		if errors.As(err, &exitErr) {
 			return &ExecResult{
 				Code:    exitErr.ExitStatus(),
 				Command: execRequest.GetCommand(),

--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -106,7 +106,7 @@ func (g *TermManager) writeToClients(p []byte) {
 	for key, w := range g.writers {
 		_, err := w.Write(p)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				log.Warnf("Failed to write to remote terminal: %v", err)
 			}
 			toDelete = append(

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -222,7 +222,7 @@ func (u *HostUserManagement) CreateUser(name string, ui *services.HostUsersInfo)
 	}
 
 	tempUser, err := u.backend.Lookup(name)
-	if err != nil && err != user.UnknownUserError(name) {
+	if err != nil && !errors.Is(err, user.UnknownUserError(name)) {
 		return nil, trace.Wrap(err)
 	}
 
@@ -479,7 +479,7 @@ func (u *HostUserManagement) Shutdown() {
 func (u *HostUserManagement) UserExists(username string) error {
 	_, err := u.backend.Lookup(username)
 	if err != nil {
-		if err == user.UnknownUserError(username) {
+		if errors.Is(err, user.UnknownUserError(username)) {
 			return trace.NotFound("User not found: %s", err)
 		}
 		return trace.Wrap(err)

--- a/lib/sshutils/forward.go
+++ b/lib/sshutils/forward.go
@@ -20,6 +20,7 @@ package sshutils
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -62,7 +63,7 @@ func ForwardRequests(ctx context.Context, sin <-chan *ssh.Request, sender Reques
 				continue
 			}
 		case <-ctx.Done():
-			if ctx.Err() != context.Canceled {
+			if !errors.Is(ctx.Err(), context.Canceled) {
 				return trace.Wrap(ctx.Err())
 			}
 			return nil

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -772,7 +772,7 @@ func checkTransfer(t *testing.T, preserveAttrs bool, dst string, srcs ...string)
 			dstPath := filepath.Join(dst, relPath)
 			dstInfo, err := os.Stat(dstPath)
 			if err != nil {
-				return fmt.Errorf("error getting dst file info: %v", err)
+				return fmt.Errorf("error getting dst file info: %w", err)
 			}
 			require.Equal(t, info.IsDir(), dstInfo.IsDir(), "expected %q IsDir=%t, got %t", dstPath, info.IsDir(), dstInfo.IsDir())
 

--- a/lib/sshutils/sftp/utils.go
+++ b/lib/sshutils/sftp/utils.go
@@ -20,6 +20,7 @@ package sftp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -73,7 +74,7 @@ func (r *fileStreamReader) Read(b []byte) (int, error) {
 	for _, stream := range r.streams {
 		if _, innerError := stream.Read(readBuff); innerError != nil {
 			// Ignore EOF
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				return 0, innerError
 			}
 		}

--- a/lib/tbot/service_diagnostics.go
+++ b/lib/tbot/service_diagnostics.go
@@ -20,6 +20,7 @@ package tbot
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/pprof"
 
@@ -88,7 +89,7 @@ func (s *diagnosticsService) Run(ctx context.Context) error {
 		}
 	}()
 
-	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 

--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -19,6 +19,7 @@
 package teleagent
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -164,8 +165,8 @@ func (a *AgentServer) Serve() error {
 	for {
 		conn, err := a.listener.Accept()
 		if err != nil {
-			neterr, ok := err.(net.Error)
-			if !ok {
+			var neterr net.Error
+			if !errors.As(err, &neterr) {
 				return trace.Wrap(err, "unknown error")
 			}
 			if utils.IsUseOfClosedNetworkError(neterr) {
@@ -201,7 +202,7 @@ func (a *AgentServer) Serve() error {
 		go func() {
 			defer instance.Close()
 			if err := agent.ServeAgent(instance, conn); err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					log.Error(err)
 				}
 			}

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -20,6 +20,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -611,7 +612,7 @@ func newMockTSHDEventsServiceServer(t *testing.T) (service *mockTSHDEventsServic
 		// before grpcServer.Serve is called and grpcServer.Serve will return
 		// grpc.ErrServerStopped.
 		err := <-serveErr
-		if err != grpc.ErrServerStopped {
+		if !errors.Is(err, grpc.ErrServerStopped) {
 			assert.NoError(t, err)
 		}
 	})

--- a/lib/utils/aws/s3.go
+++ b/lib/utils/aws/s3.go
@@ -41,11 +41,13 @@ func ConvertS3Error(err error, args ...interface{}) error {
 	}
 
 	// SDK v1 errors:
-	if rerr, ok := err.(awserr.RequestFailure); ok && rerr.StatusCode() == http.StatusForbidden {
+	var rerr awserr.RequestFailure
+	if errors.As(err, &rerr) && rerr.StatusCode() == http.StatusForbidden {
 		return trace.AccessDenied(rerr.Message())
 	}
 
-	if aerr, ok := err.(awserr.Error); ok {
+	var aerr awserr.Error
+	if errors.As(err, &aerr) {
 		switch aerr.Code() {
 		case s3.ErrCodeNoSuchKey, s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchUpload, "NotFound":
 			return trace.NotFound(aerr.Error(), args...)

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -55,7 +55,8 @@ func IsFailedToSendCloseNotifyError(err error) bool {
 func IsOKNetworkError(err error) bool {
 	// trace.Aggregate contains at least one error and all the errors are
 	// non-nil
-	if a, ok := trace.Unwrap(err).(trace.Aggregate); ok {
+	var a trace.Aggregate
+	if errors.As(trace.Unwrap(err), &a) {
 		for _, err := range a.Errors() {
 			if !IsOKNetworkError(err) {
 				return false
@@ -70,7 +71,7 @@ func IsOKNetworkError(err error) bool {
 func IsConnectionRefused(err error) bool {
 	var errno syscall.Errno
 	if errors.As(err, &errno) {
-		return errno == syscall.ECONNREFUSED
+		return errors.Is(errno, syscall.ECONNREFUSED)
 	}
 	return false
 }

--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -101,5 +101,5 @@ func HasBTF() error {
 		return fmt.Errorf("%v was not found. Make sure the kernel was compiled with BTF support (CONFIG_DEBUG_INFO_BTF)", btfFile)
 	}
 
-	return fmt.Errorf("failed to open %v: %v", btfFile, err)
+	return fmt.Errorf("failed to open %v: %w", btfFile, err)
 }

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"net"
@@ -301,7 +302,7 @@ func (l *LoadBalancer) forward(conn net.Conn) error {
 	for i := 0; i < 2; i++ {
 		select {
 		case err := <-messagesC:
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				logger.Warningf("connection problem: %v %T", trace.DebugReport(err), err)
 				lastErr = err
 			}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4052,7 +4052,8 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 
 	err = limiter.RegisterRequest(remote, nil /* customRate */)
 	// MaxRateError doesn't play well with errors.Is, hence the type assertion.
-	if _, ok := err.(*ratelimit.MaxRateError); ok {
+	var maxRateError *ratelimit.MaxRateError
+	if errors.As(err, &maxRateError) {
 		return trace.LimitExceeded(err.Error())
 	}
 	return trace.Wrap(err)

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -731,7 +732,7 @@ func (h *Handler) preliminaryRateLimitGuard(onMessageFn func(kind assist.Message
 
 // wsIsClosed returns true if the error is caused by a closed websocket.
 func wsIsClosed(err error) bool {
-	return err == io.EOF || websocket.IsCloseError(err, websocket.CloseAbnormalClosure,
+	return errors.Is(err, io.EOF) || websocket.IsCloseError(err, websocket.CloseAbnormalClosure,
 		websocket.CloseGoingAway, websocket.CloseNormalClosure)
 }
 

--- a/lib/web/assistant_test.go
+++ b/lib/web/assistant_test.go
@@ -266,8 +266,8 @@ func Test_runAssistError(t *testing.T) {
 
 	// Check for the close message
 	_, _, err = ws.ReadMessage()
-	closeErr, ok := err.(*websocket.CloseError)
-	require.True(t, ok, "Expected close error")
+	var closeErr *websocket.CloseError
+	require.ErrorAs(t, err, &closeErr, "Expected close error")
 	require.Equal(t, websocket.CloseInternalServerErr, closeErr.Code, "Expected abnormal closure")
 }
 

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -190,7 +191,7 @@ func mustDecodeYAMLDocuments[T any](t *testing.T, r io.Reader, out *[]T) error {
 		var entry T
 		if err := decoder.Decode(&entry); err != nil {
 			// Break when there are no more documents to decode
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				return err
 			}
 			break

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -218,7 +218,7 @@ func TestDatabaseServerResource(t *testing.T) {
 
 	_, err = runResourceCommand(t, fileConfig, []string{"get", wantServer, "--format=json"})
 	require.Error(t, err)
-	require.IsType(t, &trace.NotFoundError{}, err.(*trace.TraceErr).OrigError())
+	require.True(t, trace.IsNotFound(err))
 
 	// remove database server by discovered name.
 	_, err = runResourceCommand(t, fileConfig, []string{"rm", wantServersDiscoveredName})

--- a/tool/tctl/common/tarwriter_test.go
+++ b/tool/tctl/common/tarwriter_test.go
@@ -21,6 +21,7 @@ package common
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -110,9 +111,9 @@ func TestTarWriter(t *testing.T) {
 		reader := tar.NewReader(&tarball)
 
 		// Expect all the file content and metadata is preserved
-		for err != io.EOF {
+		for !errors.Is(err, io.EOF) {
 			header, err := reader.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 
@@ -127,7 +128,7 @@ func TestTarWriter(t *testing.T) {
 
 			actualContent := make([]byte, header.Size)
 			_, err = reader.Read(actualContent)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				require.NoError(t, err)
 			}
 			require.Equal(t, expected.content, actualContent)
@@ -153,10 +154,10 @@ func TestTarWriter(t *testing.T) {
 
 		// When I list all of the files in the resulting archive...
 		reader := tar.NewReader(&tarball)
-		archivedFiles := []string{}
-		for err != io.EOF {
+		var archivedFiles []string
+		for !errors.Is(err, io.EOF) {
 			header, err := reader.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			archivedFiles = append(archivedFiles, header.Name)

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -165,7 +165,7 @@ func (s *sftpHandler) openFile(req *sftp.Request) (*os.File, error) {
 // Filecmd handles file modification requests.
 func (s *sftpHandler) Filecmd(req *sftp.Request) (retErr error) {
 	defer func() {
-		if retErr == sftp.ErrSSHFxOpUnsupported {
+		if errors.Is(retErr, sftp.ErrSSHFxOpUnsupported) {
 			return
 		}
 		s.sendSFTPEvent(req, retErr)

--- a/tool/teleport/common/wait.go
+++ b/tool/teleport/common/wait.go
@@ -138,8 +138,8 @@ func waitNoResolve(ctx context.Context, domain string, period, timeout time.Dura
 func checkDomainNoResolve(domainName string) (exit bool, err error) {
 	endpoints, err := countEndpoints(domainName)
 	if err != nil {
-		dnsErr, ok := trace.Unwrap(err).(*net.DNSError)
-		if !ok {
+		var dnsErr *net.DNSError
+		if !errors.As(trace.Unwrap(err), &dnsErr) {
 			log.Errorf("unexpected error when resolving domain %s : %s", domainName, err)
 			return false, trace.Wrap(err)
 		}

--- a/tool/tsh/common/aliases.go
+++ b/tool/tsh/common/aliases.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"regexp"
@@ -219,7 +220,8 @@ func (ar *aliasRunner) runAliasCommand(ctx context.Context, currentExecPath, exe
 		return nil
 	}
 
-	if exitErr, ok := err.(*exec.ExitError); ok {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		return trace.Wrap(exitErr)
 	}
 


### PR DESCRIPTION
Adds the new linter and configures it to prevent direct error comparisions and type assertions in favor of errors.Is and errors.As. All current violations caught by the linter have been updated accordingly.


Depends on https://github.com/gravitational/teleport.e/pull/3348