### PR TITLE
Post-major version release activities

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -780,9 +780,9 @@ steps:
       # increment these variables when a new major/minor version is released to bump the automatic builds
       # this only needs to be done on the master branch, as that's the branch that the Drone cron is configured for
       # build major version images which are just teleport:x
-      CURRENT_VERSION_ROOT: v14
-      PREVIOUS_VERSION_ONE_ROOT: v13
-      PREVIOUS_VERSION_TWO_ROOT: v12
+      CURRENT_VERSION_ROOT: v15
+      PREVIOUS_VERSION_ONE_ROOT: v14
+      PREVIOUS_VERSION_TWO_ROOT: v13
     commands:
       - apk --update --no-cache add curl go
       - mkdir -p /go/build && cd /go/build
@@ -2468,7 +2468,7 @@ steps:
   - Assume ECR - staging AWS Role
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
-- name: Pull teleport-operator:v15-amd64 and push it to Local Registry
+- name: Pull teleport-operator:v16-amd64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -2502,7 +2502,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-operator:v15-arm and push it to Local Registry
+- name: Pull teleport-operator:v16-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -2536,7 +2536,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-operator:v15-arm64 and push it to Local Registry
+- name: Pull teleport-operator:v16-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -2570,7 +2570,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Tag and push image "teleport-operator:v15-amd64" to ECR - production
+- name: Tag and push image "teleport-operator:v16-amd64" to ECR - production
   image: docker
   commands:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
@@ -2611,8 +2611,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v15-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-operator:v15-arm" to ECR - production
+  - Pull teleport-operator:v16-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-operator:v16-arm" to ECR - production
   image: docker
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
@@ -2653,8 +2653,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v15-arm and push it to Local Registry
-- name: Tag and push image "teleport-operator:v15-arm64" to ECR - production
+  - Pull teleport-operator:v16-arm and push it to Local Registry
+- name: Tag and push image "teleport-operator:v16-arm64" to ECR - production
   image: docker
   commands:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
@@ -2695,7 +2695,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v15-arm64 and push it to Local Registry
+  - Pull teleport-operator:v16-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
   image: docker
   commands:
@@ -2725,9 +2725,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v15-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v16-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm64" to ECR - production
 - name: Create manifest and push "teleport-operator:minor" to ECR - production
   image: docker
   commands:
@@ -2757,9 +2757,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v15-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v16-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm64" to ECR - production
 - name: Create manifest and push "teleport-operator:full" to ECR - production
   image: docker
   commands:
@@ -2787,9 +2787,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v15-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm" to ECR - production
-  - Tag and push image "teleport-operator:v15-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v16-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm" to ECR - production
+  - Tag and push image "teleport-operator:v16-arm64" to ECR - production
 services:
 - name: Start Docker
   image: docker:dind
@@ -2951,6 +2951,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 47d3b4d44c75e4b7c86eba814ac8cdb16c8de36d493b2e1661cdc28d7bbe601b
+hmac: 276b194530d269773e0bbea70af4c4712bcbcb951e307701c9e22ac9140f6a5c
 
 ...

--- a/docker/teleport-lab.yml
+++ b/docker/teleport-lab.yml
@@ -3,7 +3,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: public.ecr.aws/gravitational/teleport-lab:14
+    image: public.ecr.aws/gravitational/teleport-lab:15
     container_name: teleport
     entrypoint: /bin/sh
     hostname: luna.teleport
@@ -24,7 +24,7 @@ services:
 
   # The bootstrap container generates certificates and then immediately exits.
   bootstrap:
-    image: public.ecr.aws/gravitational/teleport-lab:14
+    image: public.ecr.aws/gravitational/teleport-lab:15
     container_name: teleport-bootstrap
     entrypoint: /bin/sh
     command: -c "/etc/teleport.d/scripts/generate-certs.sh"
@@ -41,7 +41,7 @@ services:
   # openssh is a demo of openssh node
   #
   openssh:
-    image: public.ecr.aws/gravitational/teleport-lab:14
+    image: public.ecr.aws/gravitational/teleport-lab:15
     container_name: openssh
     hostname: mars.openssh.teleport
     entrypoint: /bin/sh
@@ -60,7 +60,7 @@ services:
   # term is a container with a terminal to try things out
   #
   term:
-    image: public.ecr.aws/gravitational/teleport-lab:14
+    image: public.ecr.aws/gravitational/teleport-lab:15
     hostname: term
     container_name: term
     entrypoint: /bin/sh

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -3,7 +3,7 @@ services:
   # The configure container starts, generates a config, writes it to
   # /etc/teleport/teleport.yaml and then immediately exits.
   configure:
-    image: public.ecr.aws/gravitational/teleport:14
+    image: public.ecr.aws/gravitational/teleport:15
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
@@ -14,7 +14,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: public.ecr.aws/gravitational/teleport:14
+    image: public.ecr.aws/gravitational/teleport:15
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -19,7 +19,11 @@ is published, since the PR will include an update to the plugins version as well
 
 - [ ] Update support matrix in docs FAQ page
 - [ ] Update `branchMajorVersion` const in Dronegen `/dronegen/container_images.go`, then run `make dronegen`
+- [ ] Update `CURRENT_VERSION_ROOT`, `PREVIOUS_VERSION_ONE_ROOT`, and `PREVIOUS_VERSION_TWO_ROOT` variables in `.drone.yml`, then run `make dronegen`
   - Example: https://github.com/gravitational/teleport/pull/4602
 - [ ] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml
   - Example: https://github.com/gravitational/teleport/pull/4655
 - [ ] Create PR to update default Teleport image referenced in docker/teleport-lab.yml
+- [ ] Update the list of OCI images to monitor and rebuild nightly in
+  [`monitor-teleport-oci-distroless.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/monitor-teleport-oci-distroless.yml) and
+  [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -15,5 +15,3 @@ This checklist is to be run prior to cutting the release branch.
   - [ ] Run `make dronegen` and ensure _all_ buildbox references in the resulting yaml refer to the new image
   - [ ] Commit and merge. Drone should build new buildbox images and push to
     `public.ecr.aws`
-- [ ] Update the list of OCI images to rebuild nightly in
-  [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)

--- a/dronegen/container_images.go
+++ b/dronegen/container_images.go
@@ -29,8 +29,8 @@ import (
 // *************************************************************
 // These should match up when a feature branch is cut, but should be off by
 // one on master
-const branchMajorVersion int = 15
-const latestReleaseVersion int = 14
+const branchMajorVersion int = 16
+const latestReleaseVersion int = 15
 
 func buildPipelineVersions() string {
 	branchMajorSemver := fmt.Sprintf("v%d", branchMajorVersion)


### PR DESCRIPTION
From `docs/postrelease.md`:
- [x] Update `branchMajorVersion` const in Dronegen `/dronegen/container_images.go`, then run `make dronegen`
- [x] Update `CURRENT_VERSION_ROOT`, `PREVIOUS_VERSION_ONE_ROOT`, and `PREVIOUS_VERSION_TWO_ROOT` variables in `.drone.yml`, then run `make dronegen`
  - Example: https://github.com/gravitational/teleport/pull/4602
- [x] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml
  - Example: https://github.com/gravitational/teleport/pull/4655
- [x] Create PR to update default Teleport image referenced in docker/teleport-lab.yml