### PR TITLE
[v14] Fix oversized report submission

### DIFF
--- a/lib/usagereporter/teleport/aggregating/submitter.go
+++ b/lib/usagereporter/teleport/aggregating/submitter.go
@@ -127,10 +127,13 @@ func submitOnce(ctx context.Context, c SubmitterConfig) {
 	}
 
 	freeBatchSize := submitBatchSize - len(userActivityReports)
-	resourcePresenceReports, err := svc.listResourcePresenceReports(ctx, freeBatchSize)
-	if err != nil {
-		c.Log.WithError(err).Error("Failed to load resource counts reports for submission.")
-		return
+	var resourcePresenceReports []*prehogv1.ResourcePresenceReport
+	if freeBatchSize > 0 {
+		resourcePresenceReports, err = svc.listResourcePresenceReports(ctx, freeBatchSize)
+		if err != nil {
+			c.Log.WithError(err).Error("Failed to load resource counts reports for submission.")
+			return
+		}
 	}
 
 	totalReportCount := len(userActivityReports) + len(resourcePresenceReports)

--- a/lib/usagereporter/teleport/aggregating/submitter_test.go
+++ b/lib/usagereporter/teleport/aggregating/submitter_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -48,8 +49,13 @@ func TestSubmitOnce(t *testing.T) {
 	svc := reportService{bk}
 
 	var submitted []*prehogv1.UserActivityReport
+	var submittedPresence []*prehogv1.ResourcePresenceReport
 	submitOk := func(ctx context.Context, req *prehogv1.SubmitUsageReportsRequest) (uuid.UUID, error) {
+		if l := len(req.UserActivity) + len(req.ResourcePresence); l > submitBatchSize {
+			return uuid.Nil, trace.LimitExceeded("got %v reports, expected at most %v", l, submitBatchSize)
+		}
 		submitted = append(submitted, req.UserActivity...)
+		submittedPresence = append(submittedPresence, req.ResourcePresence...)
 		return uuid.New(), nil
 	}
 	submitErr := func(ctx context.Context, req *prehogv1.SubmitUsageReportsRequest) (uuid.UUID, error) {
@@ -142,7 +148,9 @@ func TestSubmitOnce(t *testing.T) {
 	// successful submission, no remaining events but the alert stays for one more cycle
 	submitOnce(ctx, scfg)
 	require.Len(t, submitted, 1)
+	require.Len(t, submittedPresence, 1)
 	submitted = nil
+	submittedPresence = nil
 
 	alerts, err = scfg.Status.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{
 		AlertID: alertName,
@@ -159,4 +167,21 @@ func TestSubmitOnce(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, alerts)
+
+	for i := 0; i < 20; i++ {
+		require.NoError(t, svc.upsertUserActivityReport(ctx, newReport(time.Now().UTC().Add(time.Duration(i)*time.Second)), reportTTL))
+	}
+	for i := 0; i < 15; i++ {
+		require.NoError(t, svc.upsertResourcePresenceReport(ctx, newResourcePresenceReport(time.Now().UTC().Add(time.Duration(i)*time.Second)), reportTTL))
+	}
+	clk.Advance(submitLockDuration)
+	submitOnce(ctx, scfg)
+	clk.Advance(submitLockDuration)
+	submitOnce(ctx, scfg)
+	clk.Advance(submitLockDuration)
+	submitOnce(ctx, scfg)
+	clk.Advance(submitLockDuration)
+	submitOnce(ctx, scfg)
+	require.Len(t, submitted, 20)
+	require.Len(t, submittedPresence, 15)
 }


### PR DESCRIPTION
The report fetching logic in the submitter changed in #35968 with the introduction of two report types has a flaw; if there's at least 10 reports (the maximum amount) of the first type, the submitter attempts to fetch 0 reports of the second type - which, by conventional Teleport backend behavior, returns all the reports of the second type. This PR makes it so that we don't fetch all reports when we intended to fetch 0.

This issue affects Teleport Enterprise releases 12.4.33, 13.4.5, 14.3.1, 14.3.2, 14.3.3, 15.0.0

changelog: Teleport Enterprise only: fix usage data submission becoming stuck sending too many reports at once

Backports #37680