### PR TITLE
properly handle `cloud: GCP` apps without 'uri'

### DIFF
--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -128,13 +128,17 @@ Set the values in the above command as appropriate for your setup.
 These are the supported values for the `apps` map:
 
 | Key                    | Description                                                              | Example                                                    | Default | Required |
-| ---------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------- | ------- | -------- |
-| `name`                 | Name of the app to be accessed                                           | `apps[0].name=grafana`                                     |         | Yes      |
-| `uri`                  | URI of the app to be accessed                                            | `apps[0].uri=http://localhost:3000`                        |         | Yes      |
-| `public_addr`          | Public address used to access the app                                    | `apps[0].public_addr=grafana.teleport.example.com`         |         | No       |
-| `labels.[name]`        | Key-value pairs to set against the app for grouping/RBAC                 | `apps[0].labels.env=local,apps[0].labels.region=us-west-1` |         | No       |
-| `insecure_skip_verify` | Whether to skip validation of TLS certificates presented by backend apps | `apps[0].insecure_skip_verify=true`                        | `false` | No       |
-| `rewrite.redirect`     | A list of URLs to rewrite to the public address of the app service       | `apps[0].rewrite.redirect[0]=https://192.168.1.1`          |         | No       |
+| ---------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------- | ------- | ---------------------- |
+| `name`                 | Name of the app to be accessed                                           | `apps[0].name=grafana`                                     |         | Yes                    |
+| `uri`                  | URI of the app to be accessed                                            | `apps[0].uri=http://localhost:3000`                        |         | Unless `cloud` present |
+| `cloud`                | Cloud console only. Possible values: `GCP`, `AWS`, `Azure`               | `apps[0].cloud=GCP`                                        |         | No                     |
+| `aws.external_id`      | AWS External ID used when assuming roles in an AWS cloud app.            | `apps[0].aws.external_id="example-external-id"`            |         | No                     |
+| `public_addr`          | Public address used to access the app                                    | `apps[0].public_addr=grafana.teleport.example.com`         |         | No                     |
+| `labels.[name]`        | Key-value pairs to set against the app for grouping/RBAC                 | `apps[0].labels.env=local,apps[0].labels.region=us-west-1` |         | No                     |
+| `insecure_skip_verify` | Whether to skip validation of TLS certificates presented by backend apps | `apps[0].insecure_skip_verify=true`                        | `false` | No                     |
+| `rewrite.redirect`     | A list of URLs to rewrite to the public address of the app service       | `apps[0].rewrite.redirect[0]=https://192.168.1.1`          |         | No                     |
+
+Note that the `apps` map is passed verbatim to the rendered `teleport.yaml`. Refer to the [Application Access Reference](https://goteleport.com/docs/application-access/reference/) for a more complete `apps` reference.
 
 You can add multiple apps using `apps[1].name`, `apps[1].uri`, `apps[2].name`, `apps[2].uri` etc.
 

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -54,8 +54,8 @@ app_service:
       {{- if not (hasKey $app "name") }}
         {{- fail "'name' is required for all 'apps' in chart values when app role is enabled, see README" }}
       {{- end }}
-      {{- if not (hasKey $app "uri") }}
-        {{- fail "'uri' is required for all 'apps' in chart values when app role is enabled, see README" }}
+      {{- if (and (not (hasKey $app "uri")) (not (hasKey $app "cloud"))) }}
+        {{- fail "'uri' or 'cloud' is required for all 'apps' in chart values when app role is enabled, see README" }}
       {{- end }}
     {{- end }}
   apps:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -93,22 +93,39 @@
             "$id": "#/properties/apps",
             "type": "array",
             "default": [],
-            "required": [
-                "name",
-                "uri"
-            ],
-            "properties": {
-                "name": {
-                    "$id": "#/properties/apps/name",
-                    "type": "string",
-                    "default": ""
-                },
-                "uri": {
-                    "$id": "#/properties/apps/uri",
-                    "type": "string",
-                    "default": ""
-                },
-                "additionalProperties": true
+            "items": {
+                "type": "object",
+                "default": {},
+                "required": [
+                    "name"
+                ],
+                "anyOf": [
+                    {
+                        "required": ["uri"]
+                    },
+                    {
+                        "required": ["cloud"]
+                    }
+                ],
+                "properties": {
+                    "name": {
+                        "$id": "#/properties/apps/name",
+                        "type": "string",
+                        "default": ""
+                    },
+                    "uri": {
+                        "$id": "#/properties/apps/uri",
+                        "type": "string",
+                        "default": ""
+                    },
+                    "cloud": {
+                        "$id": "#/properties/apps/cloud",
+                        "type": "string",
+                        "enum": ["GCP", "AWS", "Aure"],
+                        "default": ""
+                    },
+                    "additionalProperties": true
+                }
             }
         },
         "appResources": {

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -121,10 +121,9 @@
                     "cloud": {
                         "$id": "#/properties/apps/cloud",
                         "type": "string",
-                        "enum": ["GCP", "AWS", "Aure"],
+                        "enum": ["GCP", "AWS", "Azure"],
                         "default": ""
-                    },
-                    "additionalProperties": true
+                    }
                 }
             }
         },


### PR DESCRIPTION
When trying to set up GCP console in app access in the `teleport-kube-agent` chart, the lack of a `uri` throws an error.

```
% helm template gcpapp teleport/teleport-kube-agent --version 14.3.3 --set proxyAddr=p --set roles=app --set 'apps[0].cloud=GCP' --set 'apps[0].name=GCP'
Error: execution error at (teleport-kube-agent/templates/statefulset.yaml:26:28): 'uri' is required for all 'apps' in chart values when app role is enabled, see README
```

When using GCP, `uri` is not required: https://goteleport.com/docs/application-access/cloud-apis/google-cloud/

I updated the config file template logic, README, and JSON schema to reflect that at least `uri` or `cloud` are required. There are still valid cases where one would set both.