### PR TITLE
[v14] Reuse tunnel resolvers instead of creating one per connection attempt

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
@@ -55,6 +54,9 @@ type Config struct {
 	PromptAdminRequestMFA func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
 	// Insecure turns off TLS certificate verification when enabled.
 	Insecure bool
+	// Resolver is used to identify the reverse tunnel address when connecting via
+	// the proxy.
+	Resolver reversetunnelclient.Resolver
 }
 
 // Connect creates a valid client connection to the auth service.  It may
@@ -115,25 +117,11 @@ func connectViaProxyTunnel(ctx context.Context, cfg *Config) (auth.ClientI, erro
 	// If direct dial failed, we may have a proxy address in
 	// cfg.AuthServers. Try connecting to the reverse tunnel
 	// endpoint and make a client over that.
-	//
-	// TODO(nic): this logic should be implemented once and reused in IoT
-	// nodes.
-	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
-		Context:   ctx,
-		ProxyAddr: cfg.AuthServers[0].String(),
-		Insecure:  cfg.Insecure,
-		Timeout:   cfg.DialTimeout,
-	})
-
-	resolver, err := reversetunnelclient.CachingResolver(ctx, resolver, nil /* clock */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	// reversetunnel.TunnelAuthDialer will take care of creating a net.Conn
 	// within an SSH tunnel.
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
-		Resolver:              resolver,
+		Resolver:              cfg.Resolver,
 		ClientConfig:          cfg.SSH,
 		Log:                   cfg.Log,
 		InsecureSkipTLSVerify: cfg.Insecure,

--- a/lib/tbot/service_ca_rotation.go
+++ b/lib/tbot/service_ca_rotation.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -129,6 +130,7 @@ type caRotationService struct {
 	reloadBroadcaster *channelBroadcaster
 	cfg               *config.BotConfig
 	botIdentitySrc    botIdentitySrc
+	resolver          reversetunnelclient.Resolver
 }
 
 func (s *caRotationService) String() string {
@@ -186,7 +188,7 @@ func (s *caRotationService) watchCARotations(ctx context.Context, queueReload fu
 	s.log.Debugf("Attempting to establish watch for CA events")
 
 	ident := s.botIdentitySrc.BotIdentity()
-	client, err := clientForIdentity(ctx, s.log, s.cfg, ident)
+	client, err := clientForIdentity(ctx, s.log, s.cfg, ident, s.resolver)
 	if err != nil {
 		return trace.Wrap(err, "creating client for ca watcher")
 	}

--- a/lib/tbot/service_ca_rotation_test.go
+++ b/lib/tbot/service_ca_rotation_test.go
@@ -23,12 +23,15 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
@@ -293,11 +296,21 @@ func TestBot_Run_CARotation(t *testing.T) {
 	)
 	b := New(botConfig, log)
 
+	resolver, err := reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.AuthServer,
+			Insecure:  b.cfg.Insecure,
+		}),
+		nil /* clock */)
+	require.NoError(t, err, "creating tunnel resolver")
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		err := b.Run(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	// Allow time for bot to start running and watching for CA rotations
 	// TODO: We should modify the bot to emit events that may be useful...
@@ -305,7 +318,7 @@ func TestBot_Run_CARotation(t *testing.T) {
 
 	// fetch initial host cert
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 2)
-	initialCAs := [][]byte{}
+	var initialCAs [][]byte
 	copy(initialCAs, b.BotIdentity().TLSCACertsBytes)
 
 	// Begin rotating through all of the phases, testing the client after
@@ -314,24 +327,24 @@ func TestBot_Run_CARotation(t *testing.T) {
 	// TODO: These sleeps allow the client time to rotate. They could be
 	// replaced if tbot emitted a CA rotation/renewal event.
 	time.Sleep(time.Second * 30)
-	_, err := clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateClients)
 	time.Sleep(time.Second * 30)
 	// Ensure both sets of CA certificates are now available locally
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 3)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateServers)
 	time.Sleep(time.Second * 30)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	rotate(ctx, t, log, teleportProcess(), types.RotationStateStandby)
 	time.Sleep(time.Second * 30)
-	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity())
+	_, err = clientForIdentity(ctx, log, botConfig, b.BotIdentity(), resolver)
 	require.NoError(t, err)
 
 	require.Len(t, b.BotIdentity().TLSCACertsBytes, 2)

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -57,6 +58,7 @@ type outputsService struct {
 	reloadBroadcaster *channelBroadcaster
 	botIdentitySrc    botIdentitySrc
 	cfg               *config.BotConfig
+	resolver          reversetunnelclient.Resolver
 }
 
 func (s *outputsService) String() string {
@@ -81,7 +83,7 @@ func (s *outputsService) renewOutputs(
 	defer span.End()
 
 	botIdentity := s.botIdentitySrc.BotIdentity()
-	client, err := clientForIdentity(ctx, s.log, s.cfg, botIdentity)
+	client, err := clientForIdentity(ctx, s.log, s.cfg, botIdentity, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -546,7 +548,7 @@ func (s *outputsService) generateImpersonatedIdentity(
 
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	impersonatedClient, err = clientForIdentity(ctx, s.log, s.cfg, impersonatedIdentity)
+	impersonatedClient, err = clientForIdentity(ctx, s.log, s.cfg, impersonatedIdentity, s.resolver)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -28,10 +28,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -106,9 +108,21 @@ func (b *Bot) Run(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	resolver, err := reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.AuthServer,
+			Insecure:  b.cfg.Insecure,
+		}),
+		nil /* clock */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Create an error group to manage all the services lifetimes.
 	eg, egCtx := errgroup.WithContext(ctx)
-	services := []bot.Service{}
+	var services []bot.Service
 
 	// ReloadBroadcaster allows multiple entities to trigger a reload of
 	// all services. This allows os signals and other events such as CA
@@ -135,6 +149,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	b.botIdentitySvc = &identityService{
 		cfg:               b.cfg,
 		reloadBroadcaster: reloadBroadcaster,
+		resolver:          resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "identity"),
 		),
@@ -159,6 +174,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	services = append(services, &outputsService{
 		botIdentitySrc: b,
 		cfg:            b.cfg,
+		resolver:       resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "outputs"),
 		),
@@ -167,6 +183,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	services = append(services, &caRotationService{
 		botIdentitySrc: b,
 		cfg:            b.cfg,
+		resolver:       resolver,
 		log: b.log.WithField(
 			trace.Component, teleport.Component(componentTBot, "ca-rotation"),
 		),
@@ -336,6 +353,7 @@ func clientForIdentity(
 	log logrus.FieldLogger,
 	cfg *config.BotConfig,
 	id *identity.Identity,
+	resolver reversetunnelclient.Resolver,
 ) (auth.ClientI, error) {
 	ctx, span := tracer.Start(ctx, "clientForIdentity")
 	defer span.End()
@@ -368,6 +386,7 @@ func clientForIdentity(
 		AuthServers: []utils.NetAddr{*authAddr},
 		Log:         log,
 		Insecure:    cfg.Insecure,
+		Resolver:    resolver,
 	}
 
 	c, err := authclient.Connect(ctx, authClientConfig)


### PR DESCRIPTION
Backport #37566 to branch/v14

changelog: Fix memory leak in tbot caused by never closing reverse tunnel address resolvers