### PR TITLE
[v13] Reuse tunnel resolvers instead of creating one per connection attempt

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib"
@@ -1222,7 +1221,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 		logger.Debug("Attempting to discover reverse tunnel address.")
 		logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-		tunnelClient, err := process.newClientThroughTunnel(authServers[0].String(), tlsConfig, sshClientConfig)
+		tunnelClient, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig)
 		if err != nil {
 			process.log.Errorf("Node failed to establish connection to Teleport Proxy. We have tried the following endpoints:")
 			process.log.Errorf("- connecting to auth server directly: %v", directErr)
@@ -1248,7 +1247,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 			logger := process.log.WithField("proxy-server", proxyServer.String())
 			logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-			tunnelClient, err := process.newClientThroughTunnel(proxyServer.String(), tlsConfig, sshClientConfig)
+			tunnelClient, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig)
 			if err != nil {
 				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
@@ -1267,21 +1266,9 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 	return nil, trace.NotImplemented("could not find connection strategy for config version %s", process.Config.Version)
 }
 
-func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
-	resolver := reversetunnelclient.WebClientResolver(&webclient.Config{
-		Context:   process.ExitContext(),
-		ProxyAddr: addr,
-		Insecure:  lib.IsInsecureDevMode(),
-		Timeout:   process.Config.Testing.ClientTimeout,
-	})
-
-	resolver, err := reversetunnelclient.CachingResolver(process.ExitContext(), resolver, process.Clock)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
-		Resolver:              resolver,
+		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
 		Log:                   process.log,
 		InsecureSkipTLSVerify: lib.IsInsecureDevMode(),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
@@ -411,6 +412,10 @@ type TeleportProcess struct {
 
 	// SSHD is used to execute commands to update or validate OpenSSH config.
 	SSHD openssh.SSHD
+
+	// resolver is used to identify the reverse tunnel address when connecting via
+	// the proxy.
+	resolver reversetunnelclient.Resolver
 }
 
 type keyPairKey struct {
@@ -966,6 +971,27 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		if err == nil {
 			process.Config.SetAuthServerAddress(utils.FromAddr(listener.Addr()))
 		}
+	}
+
+	var resolverAddr utils.NetAddr
+	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
+		resolverAddr = cfg.ProxyServer
+	} else {
+		resolverAddr = cfg.AuthServerAddresses()[0]
+	}
+
+	process.resolver, err = reversetunnelclient.CachingResolver(
+		process.ExitContext(),
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   process.ExitContext(),
+			ProxyAddr: resolverAddr.String(),
+			Insecure:  lib.IsInsecureDevMode(),
+			Timeout:   process.Config.Testing.ClientTimeout,
+		}),
+		process.Clock,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	upgraderKind := os.Getenv("TELEPORT_EXT_UPGRADER")

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -97,6 +97,7 @@ func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *ident
 		SSH:         sshConfig,
 		AuthServers: []utils.NetAddr{*authAddr},
 		Log:         b.log,
+		Resolver:    b.resolver,
 	}
 
 	c, err := authclient.Connect(ctx, authClientConfig)

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/utils"
@@ -47,6 +48,7 @@ type Bot struct {
 	log        logrus.FieldLogger
 	reloadChan chan struct{}
 	modules    modules.Modules
+	resolver   reversetunnelclient.Resolver
 
 	// These are protected by getter/setters with mutex locks
 	mu         sync.Mutex
@@ -341,6 +343,17 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 	}
 
 	var authClient auth.ClientI
+
+	b.resolver, err = reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.AuthServer,
+		}),
+		nil /* clock */)
+	if err != nil {
+		return unlock, trace.Wrap(err)
+	}
 
 	fetchNewIdentity := true
 	// First, attempt to load an identity from storage.


### PR DESCRIPTION
Backport #37566 to branch/v13


changelog: Fixed memory leak in tbot caused by never closing reverse tunnel address resolvers