### PR TITLE
Don't submit add device form through the browser if validation fails

### DIFF
--- a/web/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
@@ -34,7 +34,7 @@ import Dialog, {
 } from 'design/Dialog';
 import { Danger } from 'design/Alert';
 import FieldInput from 'shared/components/FieldInput';
-import Validation from 'shared/components/Validation';
+import Validation, { Validator } from 'shared/components/Validation';
 import {
   requiredToken,
   requiredField,
@@ -100,8 +100,15 @@ export function AddDevice({
     setMfaOption(option);
   }
 
-  function onSubmit(e: React.MouseEvent<HTMLButtonElement>) {
+  function onSubmit(
+    validator: Validator,
+    e: React.MouseEvent<HTMLButtonElement>
+  ) {
+    // Call preventDefault() before validate() to make sure the form doesn't get
+    // submitted by the browser if validation fails.
     e.preventDefault();
+
+    if (!validator.validate()) return;
 
     if (mfaOption.value === 'webauthn') {
       addWebauthnDevice(deviceName, resolvedDeviceUsage);
@@ -264,7 +271,7 @@ export function AddDevice({
                 size="large"
                 width="45%"
                 type="submit"
-                onClick={e => validator.validate() && onSubmit(e)}
+                onClick={e => onSubmit(validator, e)}
                 disabled={addDeviceAttempt.status === 'processing'}
                 mr={3}
               >


### PR DESCRIPTION
Fixes #31350 

Note: I'm not adding any unit test for 2 reasons:
1. This component will soon be replaced.
2. It's surprisingly hard to verify that a form has _not_ been automatically submitted. I tried mucking around `HTMLFormElement.prototype`, but no luck. The jsdom code goes straight to some internals that are not easily accessible.

Tested manually instead using a passkey, a MFA token, and an authenticator app.

Demo: https://www.loom.com/share/3fa1983639a341d1b36be0a03bbc678c