### PR TITLE
Remove use of `CanonicalizeHostname` in Machine ID Ansible guide

### DIFF
--- a/docs/pages/machine-id/access-guides/ansible.mdx
+++ b/docs/pages/machine-id/access-guides/ansible.mdx
@@ -131,15 +131,23 @@ remote_tmp=/tmp
 
 [ssh_connection]
 scp_if_ssh = True
-# Replace ".example.com" below with the name of your cluster.
-ssh_args = -F /opt/machine-id/ssh_config -o CanonicalizeHostname=yes -o CanonicalDomains=example.com
+ssh_args = -F /opt/machine-id/ssh_config
 ```
 
-You can create an inventory file called `hosts` manually or use a script like the one
-below to generate it from your environment.
+You can then create an inventory file called `hosts`. This should refer to the
+hosts using their hostname as registered in Teleport and the name of your
+Teleport cluster should be appended to this. For example, if your cluster is
+called `teleport.example.com` and your host is called `node1`, the entry in
+`hosts` would be `node1.teleport.example.com`.
+
+You can generate an inventory file for all your nodes that meets this
+requirement with a script like the following:
 
 ```code
-$ tsh ls --format=json | jq -r '.[].spec.hostname' > hosts
+# Source tsh env to get the name of the current Teleport cluster.
+$ eval "$( tsh env )"
+# You can modify the `tsh ls` command to filter nodes based ont he label.
+$ tsh ls --format=json | jq --arg cluster $TELEPORT_CLUSTER -r '.[].spec.hostname + "." + $cluster' > hosts
 ```
 
 <Details title="Not seeing Nodes?">


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/37713

Remove use of `CanonicalizeHostname` - this does not function when using a hostname with multiple dots or when using an IP. I've also tried to better explain that your inventory file needs to include the full hostname including the Teleport cluster name.