### PR TITLE
Temporarily disable AWS Database E2E tests

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   TEST_KUBE: true
-  TEST_AWS_DB: true
+  TEST_AWS_DB: false # Set to true to enable AWS RDS tests once the postgres issue is resolved
   AWS_REGION: us-west-2
   GHA_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role
   KUBERNETES_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role


### PR DESCRIPTION
This commit temporarily disables the AWS Database E2E tests because the infrastructure isn't available at the moment.

This will unblock any merges to [`master`, `branch/v15`, `branch/v14`] since this is a required step.