### PR TITLE
Run check-devbox on dependabot PRs

### DIFF
--- a/.github/workflows/check-devbox.yaml
+++ b/.github/workflows/check-devbox.yaml
@@ -33,7 +33,7 @@ jobs:
   check-devbox:
     name: Check Devbox
     needs: changes
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.changed == 'true' }}
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This workflow is already narrowly scoped to only the relevant files.  We *want* to check that dependabot doesn't break anything if it updates these files.

Contributes to https://github.com/gravitational/teleport/pull/37761