### PR TITLE
Always convert authorizer error

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -187,7 +187,7 @@ func (s *APIServer) WithAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 		// HTTPS server expects auth context to be set by the auth middleware
 		authContext, err := s.Authorizer.Authorize(r.Context())
 		if err != nil {
-			return nil, authz.ConvertAuthorizerError(r.Context(), log, err)
+			return nil, trace.Wrap(err)
 		}
 		auth := &ServerWithRoles{
 			authServer: s.AuthServer,

--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -108,7 +108,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.CreateAssistantConversationRequest) (*assist.CreateAssistantConversationResponse, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbCreate)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -123,7 +123,7 @@ func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.C
 func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assist.UpdateAssistantConversationInfoRequest) (*emptypb.Empty, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbUpdate)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -142,7 +142,7 @@ func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assi
 func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.GetAssistantConversationsRequest) (*assist.GetAssistantConversationsResponse, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbList)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -157,7 +157,7 @@ func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.Get
 func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.DeleteAssistantConversationRequest) (*emptypb.Empty, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbDelete)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -171,7 +171,7 @@ func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.D
 func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssistantMessagesRequest) (*assist.GetAssistantMessagesResponse, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbRead)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -186,7 +186,7 @@ func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssis
 func (a *Service) CreateAssistantMessage(ctx context.Context, req *assist.CreateAssistantMessageRequest) (*emptypb.Empty, error) {
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, types.KindAssistant, types.VerbCreate)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if userHasAccess(authCtx, req) {
@@ -210,7 +210,7 @@ func (a *Service) IsAssistEnabled(ctx context.Context, _ *assist.IsAssistEnabled
 
 	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Check if this endpoint is called by a user or Proxy.
@@ -221,7 +221,7 @@ func (a *Service) IsAssistEnabled(ctx context.Context, _ *assist.IsAssistEnabled
 			false, /* silent */
 		)
 		if checkErr != nil {
-			return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+			return nil, trace.Wrap(err)
 		}
 	} else {
 		// This endpoint is called from Proxy to check if the assist is enabled.
@@ -245,7 +245,7 @@ func (a *Service) GetAssistantEmbeddings(ctx context.Context, msg *assist.GetAss
 
 	authCtx, err := authz.AuthorizeWithVerbs(ctx, a.log, a.authorizer, true, msg.Kind, types.VerbRead, types.VerbList)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	if a.embedder == nil {
@@ -285,7 +285,7 @@ func (a *Service) SearchUnifiedResources(ctx context.Context, msg *assist.Search
 
 	authCtx, err := a.authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, a.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Use default values for the id and content, as we only care about the embeddings.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5376,7 +5376,7 @@ func (g *GRPCServer) authenticate(ctx context.Context) (*grpcContext, error) {
 	// HTTPS server expects auth context to be set by the auth middleware
 	authContext, err := g.Authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, g.Logger, err)
+		return nil, trace.Wrap(err)
 	}
 	return &grpcContext{
 		Context: authContext,

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -329,7 +329,7 @@ func (s *Service) GenerateHostCert(
 	// resource type.
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, s.logger, err)
+		return nil, trace.Wrap(err)
 	}
 	ruleCtx := &services.Context{
 		User: authCtx.User,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -324,7 +324,13 @@ func (c *Context) GetAccessState(authPref types.AuthPreference) services.AccessS
 }
 
 // Authorize authorizes user based on identity supplied via context
-func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
+func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error) {
+	defer func() {
+		if err != nil {
+			err = ConvertAuthorizerError(ctx, a.logger, err)
+		}
+	}()
+
 	if ctx == nil {
 		return nil, trace.AccessDenied("missing authentication context")
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1376,7 +1376,7 @@ func ConvertAuthorizerError(ctx context.Context, log logrus.FieldLogger, err err
 func AuthorizeResourceWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, resource types.Resource, verbs ...string) (*Context, error) {
 	authCtx, err := authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, ConvertAuthorizerError(ctx, log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	ruleCtx := &services.Context{
@@ -1391,7 +1391,7 @@ func AuthorizeResourceWithVerbs(ctx context.Context, log logrus.FieldLogger, aut
 func AuthorizeWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, kind string, verbs ...string) (*Context, error) {
 	authCtx, err := authorizer.Authorize(ctx)
 	if err != nil {
-		return nil, ConvertAuthorizerError(ctx, log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	ruleCtx := &services.Context{

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -977,7 +977,7 @@ func TestAuthorizeWithVerbs(t *testing.T) {
 			ctx := context.Background()
 			log := logrus.New()
 			_, err = AuthorizeWithVerbs(ctx, log, test.delegate, true, test.kind, test.verbs...)
-			test.errAssertion(t, ConvertAuthorizerError(ctx, log, err))
+			test.errAssertion(t, err)
 		})
 	}
 }

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -20,7 +20,6 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -30,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -881,104 +879,6 @@ func TestCheckIPPinning(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-	}
-}
-
-func TestAuthorizeWithVerbs(t *testing.T) {
-	backend, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	accessService := local.NewAccessService(backend)
-
-	role, err := types.NewRole("test", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			Rules: []types.Rule{
-				{
-					Resources: []string{types.KindUser},
-					Verbs:     []string{types.ActionRead},
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	_, err = accessService.CreateRole(context.Background(), role)
-	require.NoError(t, err)
-
-	tests := []struct {
-		name         string
-		delegate     Authorizer
-		kind         string
-		verbs        []string
-		errAssertion require.ErrorAssertionFunc
-	}{
-		{
-			name: "regular auth",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				return &Context{}, nil
-			}),
-			errAssertion: require.NoError,
-		},
-		{
-			name: "regular auth with verbs",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				accessChecker, err := services.NewAccessChecker(&services.AccessInfo{
-					Roles: []string{"test"},
-				}, "test-cluster", accessService)
-				require.NoError(t, err)
-				return &Context{
-					Checker: accessChecker,
-				}, nil
-			}),
-			kind:         types.KindUser,
-			verbs:        []string{types.VerbRead},
-			errAssertion: require.NoError,
-		},
-		{
-			name: "connection problem",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				return nil, trace.ConnectionProblem(errors.New("err msg"), "err msg")
-			}),
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.True(t, trace.IsConnectionProblem(err))
-				require.Equal(t, "failed to connect to the database", err.Error())
-			},
-		},
-		{
-			name: "not found",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				return nil, trace.NotFound("err msg")
-			}),
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.True(t, trace.IsNotFound(err))
-				require.Equal(t, "access denied\n\taccess denied\n\t\terr msg", trace.UserMessage(err))
-			},
-		},
-		{
-			name: "access denied",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				return nil, trace.AccessDenied("access denied")
-			}),
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.ErrorIs(t, err, trace.AccessDenied("access denied"))
-			},
-		},
-		{
-			name: "private key policy error",
-			delegate: AuthorizerFunc(func(ctx context.Context) (*Context, error) {
-				return nil, keys.NewPrivateKeyPolicyError("error")
-			}),
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.ErrorIs(t, err, keys.NewPrivateKeyPolicyError("error"))
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			log := logrus.New()
-			_, err = AuthorizeWithVerbs(ctx, log, test.delegate, true, test.kind, test.verbs...)
-			test.errAssertion(t, err)
-		})
 	}
 }
 

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -331,7 +331,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			name:       "nok: user without extensions and mode=required",
 			deviceMode: constants.DeviceTrustModeRequired,
 			user:       userWithoutExtensions,
-			wantErr:    "trusted device",
+			wantErr:    "access denied",
 		},
 		{
 			name:       "global mode disabled only",
@@ -580,7 +580,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				},
 			},
 			withMFA:                   invalidMFA,
-			wantErrContains:           "invalid MFA",
+			wantErrContains:           "access denied",
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "NOK local user reused mfa with reuse not allowed",

--- a/lib/kube/grpc/grpc.go
+++ b/lib/kube/grpc/grpc.go
@@ -173,7 +173,7 @@ func (s *Server) ListKubernetesResources(ctx context.Context, req *proto.ListKub
 func (s *Server) authorize(ctx context.Context) (*authz.Context, error) {
 	authCtx, err := s.cfg.Authz.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, s.cfg.Log, err)
+		return nil, trace.Wrap(err)
 	}
 	return authCtx, nil
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -520,7 +520,7 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 
 	userContext, err := f.cfg.Authz.Authorize(ctx)
 	if err != nil {
-		return nil, authz.ConvertAuthorizerError(ctx, f.log, err)
+		return nil, trace.Wrap(err)
 	}
 
 	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser)


### PR DESCRIPTION
Refactor authorizer to always call `convertAuthorizerError` before returning. This way callers do not need to convert errors themselves. Many callers did not convert the error at all.

Note: It looks like the prior direction was chosen to allow custom loggers to be used for the error logging in `ConvertAuthorizerError`. With the new approach, the Authorizer should be passed the correct logger upfront during `NewAuthorizer` if necessary.

This PR was made in response to a separate PR comment - https://github.com/gravitational/teleport/pull/37564#discussion_r1472959406