### PR TITLE
Improve Teleport reload behavior

### DIFF
--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -11,6 +11,6 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-auth.service
+++ b/assets/aws/files/system/teleport-auth.service
@@ -11,7 +11,7 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-node.service
+++ b/assets/aws/files/system/teleport-node.service
@@ -12,7 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-proxy-acm.service
+++ b/assets/aws/files/system/teleport-proxy-acm.service
@@ -13,7 +13,7 @@ RuntimeDirectory=teleport
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-proxy.service
+++ b/assets/aws/files/system/teleport-proxy.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStartPre=/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -12,7 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-all-pre-start
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport.pid
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=auth --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport.pid
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport.pid
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=proxy --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport.pid
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F /run/teleport.pid
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/go-tpm-tools v0.4.2
+	github.com/google/renameio/v2 v2.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.0
@@ -340,7 +341,6 @@ require (
 	github.com/google/go-tpm v0.9.0 // indirect
 	github.com/google/go-tspi v0.3.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -47,12 +47,13 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --config {{ .TeleportConfigPath }} --pid-file={{ .PIDFile }}
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F "{{ .PIDFile }}"
 PIDFile={{ .PIDFile }}
 LimitNOFILE={{ .FileDescriptorLimit }}
 
 [Install]
-WantedBy=multi-user.target`))
+WantedBy=multi-user.target
+`))
 
 // SystemdFlags specifies configuration parameters for a systemd unit file.
 type SystemdFlags struct {

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --config /etc/teleport.yaml --pid-file=/custom/pid/dir/teleport.pid
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=pkill -HUP -L -F "/custom/pid/dir/teleport.pid"
 PIDFile=/custom/pid/dir/teleport.pid
 LimitNOFILE=16384
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -315,10 +315,6 @@ const (
 	// LowResPollingPeriod is a default low resolution polling period
 	LowResPollingPeriod = 600 * time.Second
 
-	// HighResReportingPeriod is a high resolution polling reporting
-	// period used in services
-	HighResReportingPeriod = 10 * time.Second
-
 	// SessionControlTimeout is the maximum amount of time a controlled session
 	// may persist after contact with the auth server is lost (sessctl semaphore
 	// leases are refreshed at a rate of ~1/2 this duration).

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -58,6 +58,7 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -1255,8 +1256,8 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	// create the new pid file only after started successfully
 	if cfg.PIDFile != "" {
-		if err := renameio.WriteFile(cfg.PIDFile, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
-			return nil, trace.ConvertSystemError(err)
+		if err := createLockedPIDFile(cfg.PIDFile); err != nil {
+			return nil, trace.Wrap(err, "creating pidfile")
 		}
 	}
 
@@ -6098,4 +6099,36 @@ func (process *TeleportProcess) newExternalAuditStorageConfigurator() (*external
 	}
 	statusService := local.NewStatusService(process.backend)
 	return externalauditstorage.NewConfigurator(process.ExitContext(), ecaSvc, integrationSvc, statusService)
+}
+
+// createLockedPIDFile creates a PID file in the path specified by pidFile
+// containing the current PID, atomically swapping it in the final place and
+// leaving it with an exclusive advisory lock that will get released when the
+// process ends, for the benefit of "pkill -L".
+func createLockedPIDFile(pidFile string) error {
+	pending, err := renameio.NewPendingFile(pidFile, renameio.WithPermissions(0o644))
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	defer pending.Cleanup()
+	if _, err := fmt.Fprintf(pending, "%v\n", os.Getpid()); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	const minimumDupFD = 3 // skip stdio
+	locker, err := unix.FcntlInt(pending.Fd(), unix.F_DUPFD_CLOEXEC, minimumDupFD)
+	runtime.KeepAlive(pending)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	if err := unix.Flock(locker, unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = unix.Close(locker)
+		return trace.ConvertSystemError(err)
+	}
+	// deliberately leak the fd to hold the lock until the process dies
+
+	if err := pending.CloseAtomicallyReplace(); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	return nil
 }

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -41,13 +41,16 @@ import (
 
 // printShutdownStatus prints running services until shut down
 func (process *TeleportProcess) printShutdownStatus(ctx context.Context) {
-	t := time.NewTicker(defaults.HighResReportingPeriod)
+	statusInterval := defaults.HighResPollingPeriod
+	t := time.NewTimer(statusInterval)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			statusInterval = min(statusInterval*2, defaults.LowResPollingPeriod)
+			t.Reset(statusInterval)
 			process.log.Infof("Waiting for services: %v to finish.", process.Supervisor.Services())
 		}
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -374,20 +374,30 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if activeConnections == 0 {
 		return err
 	}
+	minReportInterval := 10 * s.shutdownPollPeriod
+	maxReportInterval := 600 * s.shutdownPollPeriod
 	s.log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
-	lastReport := time.Time{}
+	reportedConnections := activeConnections
+	lastReport := time.Now()
+	reportInterval := minReportInterval
 	ticker := time.NewTicker(s.shutdownPollPeriod)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ticker.C:
+		case now := <-ticker.C:
 			activeConnections = s.trackUserConnections(0)
 			if activeConnections == 0 {
 				return err
 			}
-			if time.Since(lastReport) > 10*s.shutdownPollPeriod {
+			if activeConnections != reportedConnections || now.Sub(lastReport) > reportInterval {
 				s.log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
-				lastReport = time.Now()
+				lastReport = now
+				if activeConnections == reportedConnections {
+					reportInterval = min(reportInterval*2, maxReportInterval)
+				} else {
+					reportInterval = minReportInterval
+					reportedConnections = activeConnections
+				}
 			}
 		case <-ctx.Done():
 			s.log.Infof("Context canceled wait, returning.")


### PR DESCRIPTION
This PR tweaks some of the Teleport behavior around SIGHUP reloads and forking:
- the PID file (if any) is not recreated after a host CA rotation (which spins up a new `TeleportProcess` in the same process)
- the PID file (if any) is created atomically, and the process that creates it holds an exclusive advisory lock on it that only unlocks at process end (so that we can `pkill -L -F <pidfile>` and greatly reduce the chance that we accidentally send a signal to an unintended process
- systemd unit files are configured to use `pkill -L -F` on the pidfile rather than relying on the `$MAINPID` as detected by systemd: this is needed because the way Teleport forks a new subprocess on HUP to upgrade itself leaves systemd with no way to accurately keep track of what the "main" Teleport process should be, with the end result being that a second `systemctl reload` while the first Teleport process hasn't exited yet is likely to not get directed at the new Teleport process (weirdly enough, after the second SIGHUP systemd seems to reload the `PIDFile` configured in the unit 🤷)
- child Teleport processes are actively reaped on death even after exiting the `WaitForSignals` loop; this prevents the accumulation of zombies while Teleport is gracefully shutting down (possible when reloading more than once, which is plausible with a combination of very long lived sessions and frequent updates)
- failing to start a new child process doesn't leave the parent process hanging for two minutes while not responding (but buffering) signals
- exponential backoff is added to the logging of "Waiting for services: [...] to finish." and "Shutdown: waiting for N connections to finish.", so that slow graceful shutdowns don't fill the log too much

Changelog: improved the stability of Teleport during graceful upgrades