### PR TITLE
Update access graph documentation

### DIFF
--- a/docs/pages/access-controls/access-graph.mdx
+++ b/docs/pages/access-controls/access-graph.mdx
@@ -5,7 +5,7 @@ description: A reference for Teleport Access Graph.
 
 <Admonition type="tip" title="Preview">
   Teleport Access Graph is currently in Preview. Currently, it is only available
-  to Teleport Team users, and only visualizes access to SSH servers enrolled with your Teleport clusters.
+  to Teleport Team users, and only visualizes access to resources enrolled with your Teleport clusters.
 </Admonition>
 
 Teleport Access Graph visualizes and helps you understand access to your
@@ -231,4 +231,4 @@ Resource Groups are created from Teleport roles.
 #### Resources
 
 Resources are created from Teleport resources like nodes, databases, and
-Kubernetes clusters. Currently, only SSH nodes are supported.
+Kubernetes clusters.


### PR DESCRIPTION
The documentation for the Access Graph has been updated to better reflect its functionalities. It now states that the tool visualizes access to all resources, instead of merely SSH servers, enrolled with your Teleport clusters. It also removes the limitation of only supporting SSH nodes.