### PR TITLE
Fix image name for Kubernetes/Machine ID guide

### DIFF
--- a/docs/pages/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-id/deployment/kubernetes.mdx
@@ -240,7 +240,7 @@ spec:
     spec:
       containers:
         - name: tbot
-          image: public.ecr.aws/gravitational/teleport:(=teleport.version=)
+          image: public.ecr.aws/gravitational/teleport-distroless:(=teleport.version=)
           command:
             - tbot
           args:

--- a/docs/pages/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-id/deployment/kubernetes.mdx
@@ -338,7 +338,7 @@ metadata:
 spec:
   containers:
     - name: tsh
-      image: public.ecr.aws/gravitational/teleport:(=teleport.version=)
+      image: public.ecr.aws/gravitational/teleport-distroless:(=teleport.version=)
       command:
         - tsh
       args:


### PR DESCRIPTION
It looks like in v15 we stopped publishing the `teleport` image and now only publish `teleport-distroless`- this guide needs updating to reflect this.