### PR TITLE
[v14] Remove unused const in `auth` - TokenLenBytes

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6169,12 +6169,6 @@ func (k *authKeepAliver) Close() error {
 	return nil
 }
 
-const (
-	// TokenLenBytes is len in bytes of the invite token
-	// TODO(marco): remove const block when e/ code is no longer using it.
-	TokenLenBytes = 16
-)
-
 // githubClient is internal structure that stores Github OAuth 2client and its config
 type githubClient struct {
 	client *oauth2.Client

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -314,7 +314,7 @@ func (a *Server) checkOrCreateBotToken(ctx context.Context, req *proto.CreateBot
 	}
 
 	// create a new random dynamic token
-	tokenName, err := utils.CryptoRandomHex(TokenLenBytes)
+	tokenName, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #37316 to branch/v14