### PR TITLE
[v15] Remove unused const in `auth` - TokenLenBytes

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6430,12 +6430,6 @@ func (k *authKeepAliver) Close() error {
 	return nil
 }
 
-const (
-	// TokenLenBytes is len in bytes of the invite token
-	// TODO(marco): remove const block when e/ code is no longer using it.
-	TokenLenBytes = 16
-)
-
 // githubClient is internal structure that stores Github OAuth 2client and its config
 type githubClient struct {
 	client *oauth2.Client


### PR DESCRIPTION
Backport #37316 to branch/v15