### PR TITLE
Subnet misaligned

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -135,7 +135,7 @@ networks:
     ipam:
       driver: default
       config:
-      - subnet: 172.10.1.0/16
+      - subnet: 172.10.0.0/16
         ip_range: 172.10.1.0/24
         gateway: 172.10.1.254
 


### PR DESCRIPTION
There are too many bits in the CIDR notation, so I replaced the excess 1 with a 0 to dismiss a relevant docker-compose error.