### PR TITLE
docs: update docker installation for distroless info

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -174,7 +174,9 @@ Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 #### Interacting with Distroless Images
 
 Since version 15, Teleport images are based on Google's [Distroless](https://github.com/GoogleContainerTools/distroless) images.
-Those images don't contain any shell. Here are some on how to invoke commands in shell-less images if you are unfamiliar:
+Those images don't contain any shell. 
+
+To execute Teleport commands on containers based on these images, run commands similar to the following:
 
 ```code
 # in docker

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -197,7 +197,7 @@ total 24
 -rw-------  1 trent  staff  1679 Jul 24 15:52 admin.key
 ```
 
-Alternatively, you can use the debug variant of the image, which contains [busybox](https://www.busybox.net/about.html) and a minimal shell invocable via busybox sh:
+Alternatively, you can use the debug variant of the image, which contains [busybox](https://www.busybox.net/about.html) and a minimal shell invocable via `busybox sh`:
 
 ```code
 $ docker run -it --entrypoint="" public.ecr.aws/gravitational/teleport-distroless -debug:(=teleport.latest_oss_docker_image=) busybox sh

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -171,6 +171,37 @@ Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 </TabItem>
 </Tabs>
 
+#### Interacting with Distroless Images
+
+Since version 15, Teleport images are based on Google's [Distroless](https://github.com/GoogleContainerTools/distroless) images.
+Those images don't contain any shell. Here are some on how to invoke commands in shell-less images if you are unfamiliar:
+
+```code
+# in docker
+$ docker run -i my-container tctl status
+
+# in Kubernetes
+$ kubectl exec -i my-pod -- tctl status
+
+# sending local files via stdin
+$ kubectl exec -i my-pod -- tctl create -f < my-local-file.yaml
+
+# retrieving output via stdout and tar
+$ kubectl exec -i my-pod -- tctl auth sign --user admin --format tls --ttl 10m --tar -o admin| tar xv -C local
+$ ls -l local
+total 24
+-rw-------  1 trent  staff  1318 Jul 24 15:52 admin.cas
+-rw-------  1 trent  staff  1895 Jul 24 15:52 admin.crt
+-rw-------  1 trent  staff  1679 Jul 24 15:52 admin.key
+```
+
+Alternatively, you can use the debug variant of the image, which contains [busybox](https://www.busybox.net/about.html) and a minimal shell invocable via busybox sh:
+
+```code
+$ docker run -it --entrypoint="" public.ecr.aws/gravitational/teleport-distroless -debug:(=teleport.latest_oss_docker_image=) busybox sh
+```
+
+
 ### Running Teleport on Docker
 
 When running a container from one of the images listed above, consider the

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -108,9 +108,6 @@ describes the available Docker images.
 These images are hosted on [Amazon ECR
 Public](https://gallery.ecr.aws/gravitational).
 
-Starting from Teleport `15.0` only distroless images are provided to increase
-default security.
-
 #### Image suffixes
 
 For each of the image names listed in this section, you can specify attributes

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -108,6 +108,9 @@ describes the available Docker images.
 These images are hosted on [Amazon ECR
 Public](https://gallery.ecr.aws/gravitational).
 
+Starting from Teleport `15.0` only distroless images are provided to increase
+default security.
+
 #### Image suffixes
 
 For each of the image names listed in this section, you can specify attributes
@@ -122,12 +125,6 @@ Images with the `*-distroless-debug` suffix within the repository name include a
 Busybox shell and tool suite in addition to Teleport, and are intended for
 troubleshooting deployments only. They are not intended for production use. An
 example is `public.ecr.aws/gravitational/teleport-distroless-debug`.
-
-You can specify the architecture of an image by appending a suffix to its tag.
-We support the following architecture suffixes: `amd64`, `arm`, and `arm64`. For
-example, if you want to pull the ARM64 image for
-`public.ecr.aws/gravitational/teleport`, you can use
-`public.ecr.aws/gravitational/teleport:(=teleport.version=)-arm64`.
 
 `*-distroless` and `*-distroless-debug` images support multiple architectures
 natively, and do not require (or support) image suffixes. You can specify an
@@ -156,11 +153,6 @@ either:
 For testing, we always recommend that you use the latest released version of
 Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
-[Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)-based images are available from
-our [Legacy Amazon ECR Public
-repository](https://gallery.ecr.aws/gravitational/teleport-ent).  Their use is
-considered deprecated, and they may be removed in future releases.
-
 </TabItem>
 <TabItem label="Teleport Enterprise Cloud/Enterprise" scope={["cloud", "enterprise"]}>
 
@@ -178,9 +170,6 @@ We also provide the following images for FIPS builds of Teleport Enterprise:
 
 For testing, we always recommend that you use the latest release version of
 Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
-
-[Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)-based images for non-FIPS
-Teleport are available from our [Legacy Amazon ECR Public repository](https://gallery.ecr.aws/gravitational/teleport-ent).
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Related to https://github.com/gravitational/teleport/pull/37786 update to indicate only distroless is available starting in v15.