### PR TITLE
 Implement granular db permissions for Postgres (RFD 151)

### DIFF
--- a/api/utils/slices.go
+++ b/api/utils/slices.go
@@ -99,3 +99,33 @@ func ContainSameUniqueElements[S ~[]E, E comparable](s1, s2 S) bool {
 	}
 	return true
 }
+
+// Any checks if any element of slice satisfy given predicate. If the slice is empty, it returns false.
+func Any[S ~[]E, E any](s S, predicate func(E) bool) bool {
+	for _, e := range s {
+		if predicate(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// All checks if all elements of slice satisfy given predicate. If the slice is empty, it returns true.
+func All[S ~[]E, E any](s S, predicate func(E) bool) bool {
+	for _, e := range s {
+		if !predicate(e) {
+			return false
+		}
+	}
+	return true
+}
+
+// CountBy counts the occurrences of each element in a slice based on a given mapper function.
+func CountBy[S ~[]E, E any](elements S, mapper func(E) string) map[string]int {
+	out := make(map[string]int)
+	for _, elem := range elements {
+		key := mapper(elem)
+		out[key] += 1
+	}
+	return out
+}

--- a/api/utils/slices_test.go
+++ b/api/utils/slices_test.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"bytes"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -103,6 +104,122 @@ func TestContainSameUniqueElements(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			test.check(t, ContainSameUniqueElements(test.s1, test.s2))
+		})
+	}
+}
+
+func TestAny(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputSlice []int
+		predicate  func(e int) bool
+		expected   bool
+	}{
+		{
+			name:       "empty slice",
+			inputSlice: []int{},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   false,
+		},
+		{
+			name:       "non-empty slice with matching element",
+			inputSlice: []int{1, 2, 3},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   true,
+		},
+		{
+			name:       "non-empty slice with no matching element",
+			inputSlice: []int{-1, -2, -3},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, Any(tt.inputSlice, tt.predicate))
+		})
+	}
+}
+
+func TestAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputSlice []int
+		predicate  func(e int) bool
+		expected   bool
+	}{
+		{
+			name:       "empty slice",
+			inputSlice: []int{},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   true,
+		},
+		{
+			name:       "non-empty slice with all matching elements",
+			inputSlice: []int{1, 2, 3},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   true,
+		},
+		{
+			name:       "non-empty slice with at least one non-matching element",
+			inputSlice: []int{1, 2, -3},
+			predicate:  func(e int) bool { return e > 0 },
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, All(tt.inputSlice, tt.predicate))
+		})
+	}
+}
+
+func TestCountBy(t *testing.T) {
+	type testCase struct {
+		name     string
+		elements []int
+		mapper   func(int) string
+		want     map[string]int
+	}
+	tests := []testCase{
+		{
+			name:     "empty slice",
+			elements: nil,
+			mapper:   nil,
+			want:     make(map[string]int),
+		},
+		{
+			name:     "identity",
+			elements: []int{1, 2, 3, 4},
+			mapper:   strconv.Itoa,
+			want: map[string]int{
+				"1": 1,
+				"2": 1,
+				"3": 1,
+				"4": 1,
+			},
+		},
+		{
+			name:     "even-odd",
+			elements: []int{1, 2, 3, 4},
+			mapper: func(i int) string {
+				if i%2 == 0 {
+					return "even"
+				}
+				return "odd"
+			},
+			want: map[string]int{
+				"odd":  2,
+				"even": 2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CountBy(tt.elements, tt.mapper)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0 // replaced
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 // replaced
+	github.com/lib/pq v1.10.9
 	github.com/mailgun/holster/v3 v3.16.2
 	github.com/mailgun/lemma v0.0.0-20170619173223-4214099fb348
 	github.com/mailgun/mailgun-go/v4 v4.12.0
@@ -392,7 +393,6 @@ require (
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20231026200631-000cd05d5491 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
@@ -522,6 +523,13 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 			return trace.Wrap(err)
 		}
 		span.AddEvent("completed creating preset users")
+
+		span.AddEvent("creating preset database object import rules")
+		if err := createPresetDatabaseObjectImportRule(ctx, asrv); err != nil {
+			// merely raise a warning; this is not a fatal error.
+			log.WithError(err).Warn("error creating preset database object import rules")
+		}
+		span.AddEvent("completed creating database object import rules")
 	} else {
 		log.Info("skipping preset role and user creation")
 	}
@@ -916,6 +924,29 @@ func createPresetUsers(ctx context.Context, um PresetUsers) error {
 		if user, err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err, "failed creating preset user %s", user.GetName())
 		}
+	}
+
+	return nil
+}
+
+// createPresetDatabaseObjectImportRule will create a sample database object import rule if there are none.
+func createPresetDatabaseObjectImportRule(ctx context.Context, rules services.DatabaseObjectImportRules) error {
+	importRules, _, err := rules.ListDatabaseObjectImportRules(ctx, 100, "")
+	if err != nil {
+		return trace.Wrap(err, "failed listing available database object import rules")
+	}
+	if len(importRules) > 0 {
+		return nil
+	}
+
+	rule := permissions.NewPresetImportAllObjectsRule()
+	if rule == nil {
+		return nil
+	}
+
+	_, err = rules.CreateDatabaseObjectImportRule(ctx, rule)
+	if err != nil {
+		return trace.Wrap(err, "failed to create default database object import rule")
 	}
 
 	return nil

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -155,7 +155,7 @@ type AccessChecker interface {
 	CheckDatabaseRoles(database types.Database, userRequestedRoles []string) (roles []string, err error)
 
 	// GetDatabasePermissions returns a set of database permissions applicable for the user.
-	GetDatabasePermissions() (allow types.DatabasePermissions, deny types.DatabasePermissions)
+	GetDatabasePermissions(database types.Database) (allow types.DatabasePermissions, deny types.DatabasePermissions, err error)
 
 	// CheckImpersonate checks whether current user is allowed to impersonate
 	// users and roles
@@ -534,27 +534,27 @@ func (a *accessChecker) Traits() wrappers.Traits {
 // DatabaseAutoUserMode returns whether a user should be auto-created in
 // the database.
 func (a *accessChecker) DatabaseAutoUserMode(database types.Database) (types.CreateDatabaseUserMode, error) {
-	mode, _, err := a.checkDatabaseRoles(database)
-	return mode, trace.Wrap(err)
+	result, err := a.checkDatabaseRoles(database)
+	return result.createDatabaseUserMode(), trace.Wrap(err)
 }
 
 // CheckDatabaseRoles returns whether a user should be auto-created in the
 // database and a list of database roles to assign.
 func (a *accessChecker) CheckDatabaseRoles(database types.Database, userRequestedRoles []string) ([]string, error) {
-	mode, allowedRoles, err := a.checkDatabaseRoles(database)
+	result, err := a.checkDatabaseRoles(database)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	switch {
-	case !mode.IsEnabled():
+	case !result.createDatabaseUserMode().IsEnabled():
 		return []string{}, nil
 
 	// If user requested a list of roles, make sure all requested roles are
 	// allowed.
 	case len(userRequestedRoles) > 0:
 		for _, requestedRole := range userRequestedRoles {
-			if !slices.Contains(allowedRoles, requestedRole) {
+			if !slices.Contains(result.allowedRoles(), requestedRole) {
 				return nil, trace.AccessDenied("access to database role %q denied", requestedRole)
 			}
 		}
@@ -562,11 +562,42 @@ func (a *accessChecker) CheckDatabaseRoles(database types.Database, userRequeste
 
 	// If user does not provide any roles, use all allowed roles from roleset.
 	default:
-		return allowedRoles, nil
+		return result.allowedRoles(), nil
 	}
 }
 
-func (a *accessChecker) checkDatabaseRoles(database types.Database) (types.CreateDatabaseUserMode, []string, error) {
+type checkDatabaseRolesResult struct {
+	allowedRoleSet RoleSet
+	deniedRoleSet  RoleSet
+}
+
+func (result *checkDatabaseRolesResult) createDatabaseUserMode() types.CreateDatabaseUserMode {
+	if result == nil {
+		return types.CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED
+	}
+	return result.allowedRoleSet.GetCreateDatabaseUserMode()
+}
+
+func (result *checkDatabaseRolesResult) allowedRoles() []string {
+	if result == nil {
+		return nil
+	}
+
+	rolesMap := make(map[string]struct{})
+	for _, role := range result.allowedRoleSet {
+		for _, dbRole := range role.GetDatabaseRoles(types.Allow) {
+			rolesMap[dbRole] = struct{}{}
+		}
+	}
+	for _, role := range result.deniedRoleSet {
+		for _, dbRole := range role.GetDatabaseRoles(types.Deny) {
+			delete(rolesMap, dbRole)
+		}
+	}
+	return utils.StringsSliceFromSet(rolesMap)
+}
+
+func (a *accessChecker) checkDatabaseRoles(database types.Database) (*checkDatabaseRolesResult, error) {
 	// First, collect roles from this roleset that have create database user mode set.
 	var autoCreateRoles RoleSet
 	for _, role := range a.RoleSet {
@@ -576,53 +607,62 @@ func (a *accessChecker) checkDatabaseRoles(database types.Database) (types.Creat
 	}
 	// If there are no "auto-create user" roles, nothing to do.
 	if len(autoCreateRoles) == 0 {
-		return types.CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, nil, nil
+		return nil, nil
 	}
 	// Otherwise, iterate over auto-create roles matching the database user
 	// is connecting to and compile a list of roles database user should be
 	// assigned.
 	var allowedRoleSet RoleSet
-	rolesMap := make(map[string]struct{})
 	for _, role := range autoCreateRoles {
 		match, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, database, false)
 		if err != nil {
-			return types.CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, nil, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		if !match {
 			continue
 		}
 		allowedRoleSet = append(allowedRoleSet, role)
-		for _, dbRole := range role.GetDatabaseRoles(types.Allow) {
-			rolesMap[dbRole] = struct{}{}
-		}
+
 	}
+	var deniedRoleSet RoleSet
 	for _, role := range autoCreateRoles {
 		match, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, database, false)
 		if err != nil {
-			return types.CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, nil, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		if !match {
 			continue
 		}
-		for _, dbRole := range role.GetDatabaseRoles(types.Deny) {
-			delete(rolesMap, dbRole)
-		}
+		deniedRoleSet = append(deniedRoleSet, role)
+
 	}
 	// The collected role list can be empty and that should be ok, we want to
 	// leave the behavior of what happens when a user is created with default
 	// "no roles" configuration up to the target database.
-	return allowedRoleSet.GetCreateDatabaseUserMode(), utils.StringsSliceFromSet(rolesMap), nil
+	result := checkDatabaseRolesResult{
+		allowedRoleSet: allowedRoleSet,
+		deniedRoleSet:  deniedRoleSet,
+	}
+	return &result, nil
 }
 
-// GetDatabasePermissions returns a set of database permissions applicable for the user.
-func (a *accessChecker) GetDatabasePermissions() (allow types.DatabasePermissions, deny types.DatabasePermissions) {
-	for _, role := range a.RoleSet {
+// GetDatabasePermissions returns a set of database permissions applicable for the user in the context of particular database.
+func (a *accessChecker) GetDatabasePermissions(database types.Database) (allow types.DatabasePermissions, deny types.DatabasePermissions, err error) {
+	result, err := a.checkDatabaseRoles(database)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if !result.createDatabaseUserMode().IsEnabled() {
+		return nil, nil, nil
+	}
+
+	for _, role := range result.allowedRoleSet {
 		allow = append(allow, role.GetDatabasePermissions(types.Allow)...)
 	}
-	for _, role := range a.RoleSet {
+	for _, role := range result.deniedRoleSet {
 		deny = append(deny, role.GetDatabasePermissions(types.Deny)...)
 	}
-	return allow, deny
+	return allow, deny, nil
 }
 
 // EnumerateDatabaseUsers specializes EnumerateEntities to enumerate db_users.

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -4331,7 +4331,7 @@ func TestCheckDatabaseRoles(t *testing.T) {
 		Metadata: types.Metadata{Name: "roleB", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Options: types.RoleOptions{
-				CreateDatabaseUser: types.NewBoolOption(true),
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			},
 			Allow: types.RoleConditions{
 				DatabaseLabelsExpression: `labels["env"] == "prod"`,
@@ -4350,7 +4350,7 @@ func TestCheckDatabaseRoles(t *testing.T) {
 		Metadata: types.Metadata{Name: "roleC", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Options: types.RoleOptions{
-				CreateDatabaseUser: types.NewBoolOption(true),
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			},
 			Allow: types.RoleConditions{
 				DatabaseLabels: types.Labels{"app": []string{"metrics"}},
@@ -4364,7 +4364,7 @@ func TestCheckDatabaseRoles(t *testing.T) {
 		Metadata: types.Metadata{Name: "roleD", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Options: types.RoleOptions{
-				CreateDatabaseUser: types.NewBoolOption(true),
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			},
 			Allow: types.RoleConditions{
 				DatabaseLabelsExpression: `a bad expression`,
@@ -4373,15 +4373,67 @@ func TestCheckDatabaseRoles(t *testing.T) {
 		},
 	}
 
+	// roleE is like roleB, allows auto-user provisioning for production database,
+	// but uses database permissions instead of roles.
+	roleE := &types.RoleV6{
+		Metadata: types.Metadata{Name: "roleB", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Options: types.RoleOptions{
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
+			},
+			Allow: types.RoleConditions{
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabasePermissions: []types.DatabasePermission{
+					{
+						Permissions: []string{"SELECT"},
+						Match:       map[string]apiutils.Strings{"*": []string{"*"}},
+					},
+				},
+			},
+			Deny: types.RoleConditions{
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabasePermissions: []types.DatabasePermission{
+					{
+						Permissions: []string{"UPDATE", "INSERT", "DELETE"},
+						Match:       map[string]apiutils.Strings{"*": []string{"*"}},
+					},
+				},
+			},
+		},
+	}
+
+	// roleF is like roleC, allows auto-user provisioning for metrics database,
+	// but uses database permissions instead of roles.
+	roleF := &types.RoleV6{
+		Metadata: types.Metadata{Name: "roleC", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Options: types.RoleOptions{
+				CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
+			},
+			Allow: types.RoleConditions{
+				DatabaseLabels: types.Labels{"app": []string{"metrics"}},
+				DatabasePermissions: []types.DatabasePermission{
+					{
+						Permissions: []string{"SELECT", "UPDATE", "INSERT", "DELETE"},
+						Match:       map[string]apiutils.Strings{"*": []string{"*"}},
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
-		name             string
-		roleSet          RoleSet
-		inDatabaseLabels map[string]string
-		inRequestedRoles []string
-		outModeError     bool
-		outRolesError    bool
-		outCreateUser    bool
-		outRoles         []string
+		name                string
+		roleSet             RoleSet
+		inDatabaseLabels    map[string]string
+		inRequestedRoles    []string
+		outModeError        bool
+		outRolesError       bool
+		outCreateUser       bool
+		outRoles            []string
+		outPermissionsError bool
+		outAllowPermissions types.DatabasePermissions
+		outDenyPermissions  types.DatabasePermissions
 	}{
 		{
 			name:             "no auto-provision roles assigned",
@@ -4412,11 +4464,37 @@ func TestCheckDatabaseRoles(t *testing.T) {
 			outRoles:         []string{"reader", "writer"},
 		},
 		{
+			name:             "connect to metrics database, get reader/writer permissions",
+			roleSet:          RoleSet{roleA, roleE, roleF},
+			inDatabaseLabels: map[string]string{"app": "metrics"},
+			outCreateUser:    true,
+			outRoles:         []string{},
+			outAllowPermissions: types.DatabasePermissions{
+				types.DatabasePermission{Permissions: []string{"SELECT", "UPDATE", "INSERT", "DELETE"}, Match: types.Labels{"*": apiutils.Strings{"*"}}},
+			},
+		},
+		{
 			name:             "connect to prod database, get reader role",
 			roleSet:          RoleSet{roleA, roleB, roleC},
 			inDatabaseLabels: map[string]string{"app": "metrics", "env": "prod"},
 			outCreateUser:    true,
 			outRoles:         []string{"reader"},
+		},
+		{
+			name:             "connect to prod database, get reader permissions",
+			roleSet:          RoleSet{roleA, roleE, roleF},
+			inDatabaseLabels: map[string]string{"app": "metrics", "env": "prod"},
+			outCreateUser:    true,
+			outRoles:         []string{},
+			// the overlap between outAllowPermissions and outDenyPermissions is expected.
+			// the permission arithmetic (e.g. removing denied permissions) will be done ba a downstream function.
+			outAllowPermissions: types.DatabasePermissions{
+				types.DatabasePermission{Permissions: []string{"SELECT"}, Match: types.Labels{"*": apiutils.Strings{"*"}}},
+				types.DatabasePermission{Permissions: []string{"SELECT", "UPDATE", "INSERT", "DELETE"}, Match: types.Labels{"*": apiutils.Strings{"*"}}},
+			},
+			outDenyPermissions: types.DatabasePermissions{
+				types.DatabasePermission{Permissions: []string{"UPDATE", "INSERT", "DELETE"}, Match: types.Labels{"*": apiutils.Strings{"*"}}},
+			},
 		},
 		{
 			name:             "connect to metrics database, requested writer role",
@@ -4435,11 +4513,12 @@ func TestCheckDatabaseRoles(t *testing.T) {
 			outRolesError:    true,
 		},
 		{
-			name:             "check fails",
-			roleSet:          RoleSet{roleD},
-			inDatabaseLabels: map[string]string{"app": "metrics"},
-			outModeError:     true,
-			outRolesError:    true,
+			name:                "check fails",
+			roleSet:             RoleSet{roleD},
+			inDatabaseLabels:    map[string]string{"app": "metrics"},
+			outModeError:        true,
+			outRolesError:       true,
+			outPermissionsError: true,
 		},
 	}
 
@@ -4469,6 +4548,17 @@ func TestCheckDatabaseRoles(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, test.outRoles, roles)
+			}
+
+			allow, deny, err := accessChecker.GetDatabasePermissions(database)
+			if test.outPermissionsError {
+				require.Error(t, err)
+				require.Empty(t, allow)
+				require.Empty(t, deny)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.outAllowPermissions, allow)
+				require.Equal(t, test.outDenyPermissions, deny)
 			}
 		})
 	}

--- a/lib/srv/db/autousers_test.go
+++ b/lib/srv/db/autousers_test.go
@@ -26,47 +26,105 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/databaseobjectimportrule"
+	"github.com/gravitational/teleport/api/types/label"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/srv/db/mongodb"
+	"github.com/gravitational/teleport/lib/srv/db/postgres"
 )
 
 // TestAutoUsersPostgres verifies automatic database user creation for Postgres.
 func TestAutoUsersPostgres(t *testing.T) {
 	ctx := context.Background()
 	for name, tc := range map[string]struct {
-		mode                 types.CreateDatabaseUserMode
-		databaseRoles        []string
-		adminDefaultDatabase string
-		expectConnectionErr  bool
-		expectAdminDatabase  string
+		mode          types.CreateDatabaseUserMode
+		databaseRoles []string
+
+		databasePermissions types.DatabasePermissions
+		expectedPermissions postgres.Permissions
+		importRuleSpec      *dbobjectimportrulev1.DatabaseObjectImportRuleSpec
+
+		adminDefaultDatabase   string
+		connectionErrorMessage string
+		expectAdminDatabase    string
 	}{
 		"activate/deactivate users": {
 			mode:                types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			databaseRoles:       []string{"reader", "writer"},
-			expectConnectionErr: false,
 			expectAdminDatabase: "user-db",
 		},
 		"activate/delete users": {
 			mode:                types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
 			databaseRoles:       []string{"reader", "writer"},
-			expectConnectionErr: false,
 			expectAdminDatabase: "user-db",
 		},
 		"disabled": {
 			mode:          types.CreateDatabaseUserMode_DB_USER_MODE_OFF,
 			databaseRoles: []string{"reader", "writer"},
 			// Given the "alice" user is not present on the database and
-			// Teleport won't create it, this should fail with an access denied
+			// Teleport won't create it, this should fail with access denied
 			// error.
-			expectConnectionErr: true,
+			connectionErrorMessage: "access to db denied. User does not have permissions. Confirm database user and name.",
 		},
 		"admin user default database": {
 			mode:                 types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 			databaseRoles:        []string{"reader", "writer"},
 			adminDefaultDatabase: "admin-db",
-			expectConnectionErr:  false,
 			expectAdminDatabase:  "admin-db",
+		},
+		"roles and permissions are mutually exclusive": {
+			mode:          types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+			databaseRoles: []string{"reader", "writer"},
+			databasePermissions: types.DatabasePermissions{
+				{
+					Permissions: []string{"SELECT"},
+					Match: map[string]apiutils.Strings{
+						"can_select": []string{"true"},
+					},
+				},
+			},
+			connectionErrorMessage: "fine-grained database permissions and database roles are mutually exclusive, yet both were provided",
+			expectAdminDatabase:    "user-db",
+		},
+		"database permissions are granted": {
+			mode: types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+			databasePermissions: types.DatabasePermissions{
+				{
+					Permissions: []string{"SELECT"},
+					Match: map[string]apiutils.Strings{
+						"can_select": []string{"true"},
+					},
+				},
+			},
+			importRuleSpec: &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
+				Priority:       0,
+				DatabaseLabels: label.FromMap(map[string][]string{"*": {"*"}}),
+				Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{
+					{
+						// select three tables out of five in the public schema.
+						// see handleSchemaInfo() for the effective schema.
+						Match: &dbobjectimportrulev1.DatabaseObjectImportMatch{
+							TableNames: []string{"orders", "departments", "projects"},
+						},
+						// select public schema, skipping the hr schema.
+						Scope: &dbobjectimportrulev1.DatabaseObjectImportScope{
+							SchemaNames: []string{"public"},
+						},
+						AddLabels: map[string]string{"can_select": "true"},
+					},
+				},
+			},
+			expectedPermissions: postgres.Permissions{
+				Tables: []postgres.TablePermission{
+					{Privilege: "SELECT", Schema: "public", Table: "orders"},
+					{Privilege: "SELECT", Schema: "public", Table: "departments"},
+					{Privilege: "SELECT", Schema: "public", Table: "projects"},
+				},
+			},
+			expectAdminDatabase: "user-db",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -82,6 +140,14 @@ func TestAutoUsersPostgres(t *testing.T) {
 			}))
 			go testCtx.startHandlingConnections()
 
+			// Populate the global database object import rule, if provided.
+			if tc.importRuleSpec != nil {
+				rule, err := databaseobjectimportrule.NewDatabaseObjectImportRule("dummy", tc.importRuleSpec)
+				require.NoError(t, err)
+				_, err = testCtx.tlsServer.Auth().CreateDatabaseObjectImportRule(ctx, rule)
+				require.NoError(t, err)
+			}
+
 			// Create user with role that allows user provisioning.
 			_, role, err := auth.CreateUserAndRole(testCtx.tlsServer.Auth(), "alice", []string{"auto"}, nil)
 			require.NoError(t, err)
@@ -89,30 +155,51 @@ func TestAutoUsersPostgres(t *testing.T) {
 			options.CreateDatabaseUserMode = tc.mode
 			role.SetOptions(options)
 			role.SetDatabaseRoles(types.Allow, tc.databaseRoles)
+			role.SetDatabasePermissions(types.Allow, tc.databasePermissions)
 			role.SetDatabaseNames(types.Allow, []string{"*"})
 			_, err = testCtx.tlsServer.Auth().UpsertRole(ctx, role)
 			require.NoError(t, err)
 
 			// Try to connect to the database as this user.
 			pgConn, err := testCtx.postgresClient(ctx, "alice", "postgres", "alice", "user-db")
-			if tc.expectConnectionErr {
+			if tc.connectionErrorMessage != "" {
 				require.Error(t, err)
+				require.ErrorContains(t, err, tc.connectionErrorMessage)
 				return
 			}
 			require.NoError(t, err)
 
-			// Verify there are two connections.
+			// Verify incoming connections.
+			// 1. Admin connecting to admin database
 			requirePostgresConnection(t, testCtx.postgres["postgres"].db.ParametersCh(), "postgres", tc.expectAdminDatabase)
+
+			// 2. If there are any database permissions: admin connecting to session database.
+			if len(tc.databasePermissions) > 0 {
+				requirePostgresConnection(t, testCtx.postgres["postgres"].db.ParametersCh(), "postgres", "user-db")
+			}
+
+			// 3. User connecting to session database.
 			requirePostgresConnection(t, testCtx.postgres["postgres"].db.ParametersCh(), "alice", "user-db")
 
 			// Verify user was activated.
 			select {
 			case e := <-testCtx.postgres["postgres"].db.UserEventsCh():
 				require.Equal(t, "alice", e.Name)
-				require.Equal(t, []string{"reader", "writer"}, e.Roles)
+				require.Equal(t, tc.databaseRoles, e.Roles)
 				require.True(t, e.Active)
 			case <-time.After(5 * time.Second):
 				t.Fatal("user not activated after 5s")
+			}
+
+			// Verify proper permissions were granted
+			if len(tc.databasePermissions) > 0 {
+				select {
+				case e := <-testCtx.postgres["postgres"].db.UserPermissionsCh():
+					require.Equal(t, "alice", e.Name)
+					require.Equal(t, tc.expectedPermissions, e.Permissions)
+				case <-time.After(5 * time.Second):
+					t.Fatal("user permissions not updated after 5s")
+				}
 			}
 
 			// Disconnect.

--- a/lib/srv/db/common/permissions/calculation.go
+++ b/lib/srv/db/common/permissions/calculation.go
@@ -1,0 +1,144 @@
+// Teleport
+// Copyright (C) 2023  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/maps"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// PermissionSet represents calculated database permissions.
+// Each permission is a key in the map, whereas the objects it applies to are elements in the value slice.
+type PermissionSet map[string][]*dbobjectv1.DatabaseObject
+
+type GetDatabasePermissions interface {
+	GetDatabasePermissions(database types.Database) (allow types.DatabasePermissions, deny types.DatabasePermissions, err error)
+}
+
+func databasePermissionMatch(perm types.DatabasePermission, obj *dbobjectv1.DatabaseObject) bool {
+	ok, _, _ := services.MatchLabels(perm.Match, obj.Metadata.Labels)
+	return ok
+}
+
+// CountObjectKinds counts the number of different database object kinds. It returns a map and a string representation of it.
+func CountObjectKinds(objs []*dbobjectv1.DatabaseObject) (string, map[string]int) {
+	var fragments []string
+
+	counts := utils.CountBy(objs, func(obj *dbobjectv1.DatabaseObject) string {
+		return obj.GetSpec().ObjectKind
+	})
+	kinds := maps.Keys(counts)
+	slices.Sort(kinds)
+	for _, kind := range kinds {
+		fragments = append(fragments, fmt.Sprintf("%v:%v", kind, counts[kind]))
+	}
+
+	if len(fragments) == 0 {
+		return "none", counts
+	}
+	return strings.Join(fragments, ", "), counts
+}
+
+// SummarizePermissions summarizes permissions for logging.
+func SummarizePermissions(perms PermissionSet) (string, []events.DatabasePermissionEntry) {
+	eventData := map[string]map[string]int{}
+	var fragments []string
+
+	permNames := maps.Keys(perms)
+	slices.Sort(permNames)
+	for _, perm := range permNames {
+		objects := perms[perm]
+		countText, countMap := CountObjectKinds(objects)
+		fragments = append(fragments, fmt.Sprintf("%q: %v objects (%v)", perm, len(objects), countText))
+		eventData[perm] = countMap
+	}
+
+	var entries []events.DatabasePermissionEntry
+	for perm, counts := range eventData {
+		countsConv := map[string]int32{}
+		for k, cnt := range counts {
+			countsConv[k] = int32(cnt)
+		}
+		entries = append(entries, events.DatabasePermissionEntry{
+			Permission: perm,
+			Counts:     countsConv,
+		})
+	}
+
+	if len(fragments) == 0 {
+		return "(none)", entries
+	}
+
+	return strings.Join(fragments, ", "), entries
+}
+
+// CalculatePermissions calculates the effective permissions for a set of database objects based on the provided allow and deny permissions.
+func CalculatePermissions(getter GetDatabasePermissions, database types.Database, objs []*dbobjectv1.DatabaseObject) (PermissionSet, error) {
+	allow, deny, err := getter.GetDatabasePermissions(database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	out := map[string][]*dbobjectv1.DatabaseObject{}
+
+	for _, obj := range objs {
+		permsToAdd := map[string]string{}
+
+		// add allowed permissions
+		for _, perm := range allow {
+			if databasePermissionMatch(perm, obj) {
+				for _, permission := range perm.Permissions {
+					permsToAdd[strings.TrimSpace(strings.ToUpper(permission))] = permission
+				}
+			}
+		}
+
+		// remove denied permissions
+		for _, perm := range deny {
+			// check if there is any work left to do
+			if len(permsToAdd) == 0 {
+				break
+			}
+			if databasePermissionMatch(perm, obj) {
+				for _, permission := range perm.Permissions {
+					// wildcard clears the permissions
+					if permission == types.Wildcard {
+						clear(permsToAdd)
+						break
+					}
+
+					delete(permsToAdd, strings.TrimSpace(strings.ToUpper(permission)))
+				}
+			}
+		}
+
+		for _, perm := range permsToAdd {
+			out[perm] = append(out[perm], obj)
+		}
+	}
+
+	return out, nil
+}

--- a/lib/srv/db/common/permissions/calculation_test.go
+++ b/lib/srv/db/common/permissions/calculation_test.go
@@ -1,0 +1,237 @@
+// Teleport
+// Copyright (C) 2023  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/databaseobject"
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+type mockGetter struct {
+	allow []types.DatabasePermission
+	deny  []types.DatabasePermission
+}
+
+func (m mockGetter) GetDatabasePermissions(_ types.Database) (allow types.DatabasePermissions, deny types.DatabasePermissions, err error) {
+	return m.allow, m.deny, nil
+}
+
+func TestCalculatePermissions(t *testing.T) {
+	mkDatabaseObject := func(name string, labels map[string]string) *dbobjectv1.DatabaseObject {
+		out, err := databaseobject.NewDatabaseObjectWithLabels(name, maps.Clone(labels), &dbobjectv1.DatabaseObjectSpec{
+			Protocol:            types.DatabaseProtocolPostgreSQL,
+			DatabaseServiceName: "dummy",
+			ObjectKind:          ObjectKindTable,
+			Database:            "dummy",
+			Schema:              "public",
+			Name:                name,
+		})
+
+		require.NoError(t, err)
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		getter  GetDatabasePermissions
+		objs    []*dbobjectv1.DatabaseObject
+		want    PermissionSet
+		summary string
+		details []events.DatabasePermissionEntry
+	}{
+		{
+			name: "some permissions for some objects",
+			getter: &mockGetter{
+				allow: []types.DatabasePermission{
+					{
+						Permissions: []string{"SELECT"},
+						Match:       map[string]utils.Strings{"kind": []string{"table"}},
+					},
+					{
+						Permissions: []string{"DELETE"},
+						Match:       map[string]utils.Strings{"kind": []string{"schema"}},
+					},
+				},
+				deny: nil,
+			},
+			objs: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", map[string]string{"kind": "table"}),
+				mkDatabaseObject("bar", map[string]string{"kind": "schema"}),
+				mkDatabaseObject("myproc", map[string]string{"kind": "procedure"}),
+				mkDatabaseObject("myunknown", map[string]string{"kind": "unknown"}),
+			},
+			want: PermissionSet{
+				"SELECT": {
+					mkDatabaseObject("foo", map[string]string{"kind": "table"}),
+				},
+				"DELETE": {
+					mkDatabaseObject("bar", map[string]string{"kind": "schema"}),
+				},
+			},
+			summary: "\"DELETE\": 1 objects (table:1), \"SELECT\": 1 objects (table:1)",
+			details: []events.DatabasePermissionEntry{
+				{
+					Permission: "DELETE",
+					Counts:     map[string]int32{"table": 1},
+				},
+				{
+					Permission: "SELECT",
+					Counts:     map[string]int32{"table": 1},
+				},
+			},
+		},
+		{
+			name: "deny removes permissions",
+			getter: &mockGetter{
+				allow: []types.DatabasePermission{
+					{
+						Permissions: []string{"SELECT", "INSERT"},
+						Match:       map[string]utils.Strings{"kind": []string{"table"}},
+					},
+					{
+						Permissions: []string{"SELECT", "DELETE"},
+						Match:       map[string]utils.Strings{"kind": []string{"schema"}},
+					},
+				},
+				deny: []types.DatabasePermission{
+					{
+						Permissions: []string{"*"},
+						Match:       map[string]utils.Strings{"kind": []string{"table"}},
+					},
+					{
+						Permissions: []string{"DELETE"},
+						Match:       map[string]utils.Strings{"kind": []string{"schema"}},
+					},
+				},
+			},
+			objs: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", map[string]string{"kind": "table"}),
+				mkDatabaseObject("bar", map[string]string{"kind": "schema"}),
+			},
+			want: PermissionSet{
+				"SELECT": {
+					mkDatabaseObject("bar", map[string]string{"kind": "schema"}),
+				},
+			},
+			summary: "\"SELECT\": 1 objects (table:1)",
+			details: []events.DatabasePermissionEntry{
+				{
+					Permission: "SELECT",
+					Counts:     map[string]int32{"table": 1},
+				},
+			},
+		},
+		{
+			name:   "no permissions",
+			getter: &mockGetter{},
+			objs: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", map[string]string{"kind": "table"}),
+				mkDatabaseObject("bar", map[string]string{"kind": "schema"}),
+			},
+			want:    PermissionSet{},
+			summary: "(none)",
+			details: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := types.NewDatabaseV3(types.Metadata{Name: "dummy"}, types.DatabaseSpecV3{Protocol: "postgres", URI: "dummy"})
+			require.NoError(t, err)
+			perms, err := CalculatePermissions(tt.getter, db, tt.objs)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, perms)
+
+			summary, details := SummarizePermissions(perms)
+			require.Equal(t, tt.summary, summary)
+			require.ElementsMatch(t, tt.details, details)
+		})
+	}
+}
+
+func TestDatabasePermissionMatch(t *testing.T) {
+	mkDatabaseObject := func(labels map[string]string) *dbobjectv1.DatabaseObject {
+		out, err := databaseobject.NewDatabaseObjectWithLabels("foo", maps.Clone(labels), &dbobjectv1.DatabaseObjectSpec{
+			Protocol:            types.DatabaseProtocolPostgreSQL,
+			DatabaseServiceName: "dummy",
+			ObjectKind:          ObjectKindTable,
+			Database:            "dummy",
+			Schema:              "public",
+			Name:                "foo",
+		})
+
+		require.NoError(t, err)
+		return out
+	}
+
+	tests := []struct {
+		name      string
+		obj       *dbobjectv1.DatabaseObject
+		labels    types.Labels
+		wantMatch bool
+	}{
+		{
+			name: "object with some labels",
+			obj:  mkDatabaseObject(map[string]string{"owner": "scrooge", "env": "dev"}),
+			labels: types.Labels{
+				"env":   {"production", "dev"},
+				"owner": {"john_doe", "scrooge"},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "labels and glob patterns",
+			obj:  mkDatabaseObject(map[string]string{"owner": "scrooge", "env": "dev"}),
+			labels: types.Labels{
+				"env":   {"*"},
+				"owner": {"john_doe", "scrooge"},
+			},
+			wantMatch: true,
+		},
+
+		{
+			name: "mismatch: object without labels",
+			obj:  mkDatabaseObject(nil),
+			labels: types.Labels{
+				"env":   {"production", "dev"},
+				"owner": {"john_doe", "scrooge"},
+			},
+			wantMatch: false,
+		},
+		{
+			name:      "mismatch: no labels",
+			obj:       mkDatabaseObject(map[string]string{"env": "dev"}),
+			labels:    types.Labels{},
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := databasePermissionMatch(types.DatabasePermission{Permissions: []string{"SELECT"}, Match: tt.labels}, tt.obj)
+			require.Equal(t, tt.wantMatch, matched)
+		})
+	}
+}

--- a/lib/srv/db/common/permissions/import_rules.go
+++ b/lib/srv/db/common/permissions/import_rules.go
@@ -1,0 +1,141 @@
+// Teleport
+// Copyright (C) 2023  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	"sort"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/label"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+	libutils "github.com/gravitational/teleport/lib/utils"
+)
+
+// ApplyDatabaseObjectImportRules applies the given set of rules onto a set of objects coming from a same database.
+// Returns a fresh copy of a subset of supplied objects, filtered and modified.
+// For the object to be returned, it must match at least one rule.
+// The modification consists of application of extra labels, per matching mappings.
+func ApplyDatabaseObjectImportRules(rules []*dbobjectimportrulev1.DatabaseObjectImportRule, database types.Database, objs []*dbobjectv1.DatabaseObject) []*dbobjectv1.DatabaseObject {
+	// sort: rules with higher priorities are applied last.
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].Spec.Priority < rules[j].Spec.Priority
+	})
+
+	// filter rules: keep those with matching labels
+	// we only need mappings from the rules, so extract those.
+	var mappings []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping
+	for _, rule := range rules {
+		dbLabels := make(types.Labels)
+		mapLabel := label.ToMap(rule.Spec.GetDatabaseLabels())
+		for k, v := range mapLabel {
+			dbLabels[k] = v
+		}
+		if ok, _, _ := services.MatchLabels(dbLabels, database.GetAllLabels()); ok {
+			mappings = append(mappings, rule.Spec.Mappings...)
+		}
+	}
+
+	// anything to do?
+	if len(mappings) == 0 {
+		return nil
+	}
+
+	var out []*dbobjectv1.DatabaseObject
+
+	// find all objects that match any of the rules
+	for _, obj := range objs {
+		var objClone *dbobjectv1.DatabaseObject
+
+		// apply each mapping in order.
+		for _, mapping := range mappings {
+			// the matching is applied to the object spec; existing object labels does not matter
+			if !databaseObjectScopeMatch(mapping.GetScope(), obj.GetSpec()) {
+				continue
+			}
+			if databaseObjectImportMatch(mapping.GetMatch(), obj.GetSpec()) {
+				if objClone == nil {
+					objClone = utils.CloneProtoMsg(obj)
+				}
+
+				// mapping applies additional labels
+				labels := objClone.Metadata.Labels
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				for k, v := range mapping.AddLabels {
+					labels[k] = v
+				}
+				objClone.Metadata.Labels = labels
+			}
+		}
+
+		if objClone != nil {
+			out = append(out, objClone)
+		}
+	}
+
+	return out
+}
+
+func matchPattern(pattern, value string) bool {
+	re, err := libutils.CompileExpression(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(value)
+}
+
+func matchAny(patterns []string, value string) bool {
+	return utils.Any(patterns, func(pattern string) bool {
+		return matchPattern(pattern, value)
+	})
+}
+
+func databaseObjectScopeMatch(scope *dbobjectimportrulev1.DatabaseObjectImportScope, spec *dbobjectv1.DatabaseObjectSpec) bool {
+	// require at least one match if there are any names to match against.
+	if len(scope.GetDatabaseNames()) > 0 && !matchAny(scope.GetDatabaseNames(), spec.GetDatabase()) {
+		return false
+	}
+	if len(scope.GetSchemaNames()) > 0 && !matchAny(scope.GetSchemaNames(), spec.GetSchema()) {
+		return false
+	}
+	return true
+}
+
+func databaseObjectImportMatch(match *dbobjectimportrulev1.DatabaseObjectImportMatch, spec *dbobjectv1.DatabaseObjectSpec) bool {
+	switch spec.GetObjectKind() {
+	case ObjectKindTable:
+		return matchAny(match.GetTableNames(), spec.GetName())
+	case ObjectKindView:
+		return matchAny(match.GetViewNames(), spec.GetName())
+	case ObjectKindProcedure:
+		return matchAny(match.GetProcedureNames(), spec.GetName())
+	default:
+		// unknown object kind
+		return false
+	}
+
+}
+
+const (
+	ObjectKindTable     = "table"
+	ObjectKindView      = "view"
+	ObjectKindProcedure = "procedure"
+)

--- a/lib/srv/db/common/permissions/import_rules_test.go
+++ b/lib/srv/db/common/permissions/import_rules_test.go
@@ -1,0 +1,406 @@
+// Teleport
+// Copyright (C) 2023  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	databaseobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/databaseobject"
+	"github.com/gravitational/teleport/api/types/databaseobjectimportrule"
+	"github.com/gravitational/teleport/api/types/label"
+)
+
+func TestApplyDatabaseObjectImportRules(t *testing.T) {
+	mkDatabase := func(name string, labels map[string]string) *types.DatabaseV3 {
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name:   name,
+			Labels: labels,
+		}, types.DatabaseSpecV3{
+			Protocol: "postgres",
+			URI:      "localhost:5252",
+		})
+		require.NoError(t, err)
+		return db
+	}
+
+	type option func(db *dbobjectv1.DatabaseObject) error
+
+	mkDatabaseObject := func(name string, spec *dbobjectv1.DatabaseObjectSpec, options ...option) *dbobjectv1.DatabaseObject {
+		spec.Name = name
+		out, err := databaseobject.NewDatabaseObject(name, spec)
+		require.NoError(t, err)
+		for _, opt := range options {
+			require.NoError(t, opt(out))
+		}
+
+		return out
+	}
+
+	mkImportRule := func(name string, spec *databaseobjectimportrulev1.DatabaseObjectImportRuleSpec) *databaseobjectimportrulev1.DatabaseObjectImportRule {
+		out, err := databaseobjectimportrule.NewDatabaseObjectImportRule(name, spec)
+		require.NoError(t, err)
+		return out
+	}
+	tests := []struct {
+		name     string
+		rules    []*databaseobjectimportrulev1.DatabaseObjectImportRule
+		database types.Database
+		objs     []*dbobjectv1.DatabaseObject
+		want     []*dbobjectv1.DatabaseObject
+	}{
+		{
+			name:     "empty inputs",
+			rules:    []*databaseobjectimportrulev1.DatabaseObjectImportRule{},
+			database: mkDatabase("dummy", map[string]string{"env": "prod"}),
+			objs:     nil,
+			want:     nil,
+		},
+		{
+			name: "database labels are matched by the rules",
+			rules: []*databaseobjectimportrulev1.DatabaseObjectImportRule{
+				mkImportRule("foo", &databaseobjectimportrulev1.DatabaseObjectImportRuleSpec{
+					Priority:       10,
+					DatabaseLabels: label.FromMap(map[string][]string{"env": {"dev"}}),
+					Mappings: []*databaseobjectimportrulev1.DatabaseObjectImportRuleMapping{
+						{
+							Match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+								TableNames: []string{"*"},
+							},
+							AddLabels: map[string]string{
+								"dev_access":    "rw",
+								"flag_from_dev": "dummy",
+							},
+						},
+					},
+				}),
+				mkImportRule("bar", &databaseobjectimportrulev1.DatabaseObjectImportRuleSpec{
+					Priority:       20,
+					DatabaseLabels: label.FromMap(map[string][]string{"env": {"prod"}}),
+					Mappings: []*databaseobjectimportrulev1.DatabaseObjectImportRuleMapping{
+						{
+							Match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+								TableNames: []string{"*"},
+							},
+							AddLabels: map[string]string{
+								"dev_access":     "ro",
+								"flag_from_prod": "dummy",
+							},
+						},
+					},
+				}),
+			},
+			database: mkDatabase("dummy", map[string]string{"env": "prod"}),
+			objs: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", &dbobjectv1.DatabaseObjectSpec{ObjectKind: ObjectKindTable, Protocol: "postgres"}),
+			},
+			want: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", &dbobjectv1.DatabaseObjectSpec{ObjectKind: ObjectKindTable, Protocol: "postgres"},
+					func(db *dbobjectv1.DatabaseObject) error {
+						db.Metadata.Labels = map[string]string{
+							"dev_access":     "ro",
+							"flag_from_prod": "dummy",
+						}
+						return nil
+					}),
+			},
+		},
+		{
+			name: "rule priorities are applied",
+			rules: []*databaseobjectimportrulev1.DatabaseObjectImportRule{
+				mkImportRule("foo", &databaseobjectimportrulev1.DatabaseObjectImportRuleSpec{
+					Priority:       10,
+					DatabaseLabels: label.FromMap(map[string][]string{"*": {"*"}}),
+					Mappings: []*databaseobjectimportrulev1.DatabaseObjectImportRuleMapping{
+						{
+							Match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+								TableNames: []string{"*"},
+							},
+							AddLabels: map[string]string{
+								"dev_access":    "rw",
+								"flag_from_dev": "dummy",
+							},
+						},
+					},
+				}),
+
+				mkImportRule("bar", &databaseobjectimportrulev1.DatabaseObjectImportRuleSpec{
+					Priority:       20,
+					DatabaseLabels: label.FromMap(map[string][]string{"*": {"*"}}),
+					Mappings: []*databaseobjectimportrulev1.DatabaseObjectImportRuleMapping{
+						{
+							Match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+								TableNames: []string{"*"},
+							},
+							AddLabels: map[string]string{
+								"dev_access":     "ro",
+								"flag_from_prod": "dummy",
+							},
+						},
+					},
+				}),
+			},
+			database: mkDatabase("dummy", map[string]string{}),
+			objs: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", &dbobjectv1.DatabaseObjectSpec{ObjectKind: ObjectKindTable, Protocol: "postgres"}),
+			},
+			want: []*dbobjectv1.DatabaseObject{
+				mkDatabaseObject("foo", &dbobjectv1.DatabaseObjectSpec{ObjectKind: ObjectKindTable, Protocol: "postgres"}, func(db *dbobjectv1.DatabaseObject) error {
+					db.Metadata.Labels = map[string]string{
+						"dev_access":     "ro",
+						"flag_from_dev":  "dummy",
+						"flag_from_prod": "dummy",
+					}
+					return nil
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ApplyDatabaseObjectImportRules(tt.rules, tt.database, tt.objs)
+			require.Len(t, out, len(tt.want))
+			for i, obj := range out {
+				require.Equal(t, tt.want[i].String(), obj.String())
+			}
+		})
+	}
+}
+
+func TestMatchPattern(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pattern  string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "plain text match",
+			pattern:  "exactMatch",
+			value:    "exactMatch",
+			expected: true,
+		},
+		{
+			name:     "substring mismatch",
+			pattern:  "exact",
+			value:    "exactMatch",
+			expected: false,
+		},
+		{
+			name:     "plain text mismatch",
+			pattern:  "exactMatch",
+			value:    "noMatch",
+			expected: false,
+		},
+		{
+			name:     "glob match",
+			pattern:  "gl*b*",
+			value:    "globMatch",
+			expected: true,
+		},
+		{
+			name:     "glob mismatch",
+			pattern:  "glob*",
+			value:    "noMatch",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := matchPattern(tc.pattern, tc.value)
+			require.Equal(t, tc.expected, result, "Mismatch in test case: %s", tc.name)
+		})
+	}
+}
+
+func TestDatabaseObjectImportMatch(t *testing.T) {
+	testCases := []struct {
+		name      string
+		match     *databaseobjectimportrulev1.DatabaseObjectImportMatch
+		spec      *dbobjectv1.DatabaseObjectSpec
+		wantMatch bool
+	}{
+		{
+			name:      "empty",
+			match:     &databaseobjectimportrulev1.DatabaseObjectImportMatch{},
+			spec:      &dbobjectv1.DatabaseObjectSpec{},
+			wantMatch: false,
+		},
+		{
+			name: "match table name",
+			match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+				TableNames: []string{"object1", "object2"},
+			},
+			spec: &dbobjectv1.DatabaseObjectSpec{
+				Database:            "db1",
+				DatabaseServiceName: "service1",
+				Protocol:            "postgres",
+				ObjectKind:          ObjectKindTable,
+				Name:                "object1",
+				Schema:              "schema1",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "glob",
+			match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+				TableNames: []string{"*"},
+			},
+			spec: &dbobjectv1.DatabaseObjectSpec{
+				Database:            "db1",
+				DatabaseServiceName: "service1",
+				Protocol:            "postgres",
+				ObjectKind:          ObjectKindTable,
+				Name:                "object1",
+				Schema:              "schema1",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "mismatch",
+			match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+				ViewNames: []string{"object1", "object2"},
+			},
+			spec: &dbobjectv1.DatabaseObjectSpec{
+				Database:            "db3",
+				DatabaseServiceName: "service3",
+				Protocol:            "postgres",
+				ObjectKind:          ObjectKindView,
+				Name:                "object3",
+				Schema:              "schema3",
+			},
+			wantMatch: false,
+		},
+		{
+			name: "empty name matches no objects",
+			match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{
+				TableNames: []string{""},
+			},
+			spec: &dbobjectv1.DatabaseObjectSpec{
+				Database:            "db1",
+				DatabaseServiceName: "service1",
+				Protocol:            "postgres",
+				ObjectKind:          ObjectKindTable,
+				Name:                "object1",
+				Schema:              "schema1",
+			},
+			wantMatch: false,
+		},
+		{
+			name:  "empty clause matches no objects",
+			match: &databaseobjectimportrulev1.DatabaseObjectImportMatch{},
+			spec: &dbobjectv1.DatabaseObjectSpec{
+				Database:            "db1",
+				DatabaseServiceName: "service1",
+				Protocol:            "postgres",
+				ObjectKind:          ObjectKindTable,
+				Name:                "object1",
+				Schema:              "schema1",
+			},
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMatch := databaseObjectImportMatch(tc.match, tc.spec)
+			require.Equal(t, tc.wantMatch, gotMatch)
+		})
+	}
+}
+
+func Test_databaseObjectScopeMatch(t *testing.T) {
+	spec := &dbobjectv1.DatabaseObjectSpec{
+		Database: "foo",
+		Schema:   "public",
+
+		DatabaseServiceName: "service1",
+		Protocol:            "postgres",
+		ObjectKind:          ObjectKindTable,
+		Name:                "object1",
+	}
+
+	tests := []struct {
+		name  string
+		scope *databaseobjectimportrulev1.DatabaseObjectImportScope
+		want  bool
+	}{
+		{
+			name: "empty db name and schema",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				DatabaseNames: nil,
+				SchemaNames:   nil,
+			},
+			want: true,
+		},
+		{
+			name: "just db name",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				DatabaseNames: []string{"foo", "bar", "baz"},
+			},
+			want: true,
+		},
+		{
+			name: "db name glob match",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				DatabaseNames: []string{"f*o"},
+			},
+			want: true,
+		},
+		{
+			name: "just schema",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				SchemaNames: []string{"public", "private"},
+			},
+			want: true,
+		},
+		{
+			name: "schema name glob match",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				SchemaNames: []string{"pub*"},
+			},
+			want: true,
+		},
+		{
+			name: "match db name and schema",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				DatabaseNames: []string{"foo", "bar", "baz"},
+				SchemaNames:   []string{"public", "private"},
+			},
+			want: true,
+		},
+		{
+			name: "mismatch db name and schema",
+			scope: &databaseobjectimportrulev1.DatabaseObjectImportScope{
+				DatabaseNames: []string{"dummy"},
+				SchemaNames:   []string{"dummy"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, databaseObjectScopeMatch(tt.scope, spec))
+		})
+	}
+}

--- a/lib/srv/db/common/permissions/presets.go
+++ b/lib/srv/db/common/permissions/presets.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	dbobjectimportrulev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	"github.com/gravitational/teleport/api/types/databaseobjectimportrule"
+	"github.com/gravitational/teleport/api/types/label"
+)
+
+// NewPresetImportAllObjectsRule creates new "import_all_objects" database object import rule, which applies `kind: <object kind>` label to all database objects.
+// This is a convenience rule and users are free to modify it to suit their needs.
+func NewPresetImportAllObjectsRule() *dbobjectimportrulev1pb.DatabaseObjectImportRule {
+	rule, err := databaseobjectimportrule.NewDatabaseObjectImportRule("import_all_objects", &dbobjectimportrulev1pb.DatabaseObjectImportRuleSpec{
+		Priority:       0,
+		DatabaseLabels: label.FromMap(map[string][]string{"*": {"*"}}),
+		Mappings: []*dbobjectimportrulev1pb.DatabaseObjectImportRuleMapping{
+			{
+				Match:     &dbobjectimportrulev1pb.DatabaseObjectImportMatch{TableNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": ObjectKindTable},
+			},
+			{
+				Match:     &dbobjectimportrulev1pb.DatabaseObjectImportMatch{ViewNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": ObjectKindView},
+			},
+			{
+				Match:     &dbobjectimportrulev1pb.DatabaseObjectImportMatch{ProcedureNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": ObjectKindProcedure},
+			},
+		},
+	})
+
+	if err != nil {
+		log.WithError(err).Warn("failed to create import_all_objects database object import rule")
+		return nil
+	}
+	return rule
+}

--- a/lib/srv/db/common/permissions/presets_test.go
+++ b/lib/srv/db/common/permissions/presets_test.go
@@ -1,0 +1,28 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPresetImportAllObjectsRule(t *testing.T) {
+	rule := NewPresetImportAllObjectsRule()
+	require.NotNil(t, rule)
+}

--- a/lib/srv/db/common/state.go
+++ b/lib/srv/db/common/state.go
@@ -33,7 +33,7 @@ const (
 	// attributes.
 	SQLStateUsernameDoesNotMatch = "TP001"
 	// SQLStateRolesChanged is the SQLSTATE raised by activation procedure when
-	// the user has active connections but roles has changed.
+	// the user has active connections but roles have changed.
 	SQLStateRolesChanged = "TP002"
 	// SQLStateUserDropped is the SQLSTATE returned by the delete procedure
 	// indicating the user was dropped.
@@ -41,4 +41,7 @@ const (
 	// SQLStateUserDeactivated is the SQLSTATE returned by the delete procedure
 	// indicating was deactivated.
 	SQLStateUserDeactivated = "TP004"
+	// SQLStatePermissionsChanged is the SQLSTATE raised by permissions update procedure when
+	// the user has active connections for current database but permissions have changed.
+	SQLStatePermissionsChanged = "TP005"
 )

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -401,6 +402,11 @@ func (e *Engine) auditFuncCallMessage(session *common.Session, msg *pgproto3.Fun
 	}
 	e.Audit.EmitEvent(e.Context, makeFuncCallEvent(session, msg.Function,
 		formatParameters(msg.Arguments, formatCodes)))
+}
+
+// auditUserPermissions calls OnPermissionsUpdate() with appropriate context.
+func (e *Engine) auditUserPermissions(session *common.Session, entries []events.DatabasePermissionEntry) {
+	e.Audit.OnPermissionsUpdate(e.Context, session, entries)
 }
 
 // receiveFromServer receives messages from the provided frontend (which

--- a/lib/srv/db/postgres/schema.go
+++ b/lib/srv/db/postgres/schema.go
@@ -21,9 +21,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgx/v4"
 
-	"github.com/gravitational/teleport/api/types/databaseobject"
-
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/api/types/databaseobject"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
 )

--- a/lib/srv/db/postgres/schema.go
+++ b/lib/srv/db/postgres/schema.go
@@ -21,8 +21,9 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgx/v4"
 
-	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/api/types/databaseobject"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
 )
@@ -90,6 +91,7 @@ func getSchemaInfo(ctx context.Context, conn *pgx.Conn) (schemaInfo, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer schemaRows.Close()
 
 	var tables []row
 

--- a/lib/srv/db/postgres/schema.go
+++ b/lib/srv/db/postgres/schema.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgx/v4"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/api/types/databaseobject"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
+)
+
+// schemaInfo represents information about all schemas in a database.
+type schemaInfo map[string]schema
+
+// schema represents single schema.
+type schema struct {
+	tables []string
+}
+
+// schemaInfoQuery is a query to return the schema info.
+// TODO(Tener): for very large schemas adding a filtering right into this query could improve performance.
+// It doesn't appear necessary right now.
+const schemaInfoQuery = "SELECT schemaname, tablename FROM pg_catalog.pg_tables"
+
+func fetchDatabaseObjects(ctx context.Context, session *common.Session, conn *pgx.Conn) ([]*dbobjectv1.DatabaseObject, error) {
+	s, err := getSchemaInfo(ctx, conn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var out []*dbobjectv1.DatabaseObject
+
+	for schemaName, schemaVal := range s {
+		for _, table := range schemaVal.tables {
+			name := strings.Join([]string{
+				session.Database.GetProtocol(),
+				session.Database.GetType(),
+				session.Database.GetName(),
+				permissions.ObjectKindTable,
+				session.DatabaseName,
+				schemaName,
+				table,
+			}, "/")
+
+			obj, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
+				ObjectKind:          permissions.ObjectKindTable,
+				DatabaseServiceName: session.Database.GetName(),
+				Protocol:            session.Database.GetProtocol(),
+				Database:            session.DatabaseName,
+				Schema:              schemaName,
+				Name:                table,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out = append(out, obj)
+		}
+	}
+
+	return out, nil
+}
+
+// getSchemaInfo returns SchemaInfo for given database.
+func getSchemaInfo(ctx context.Context, conn *pgx.Conn) (schemaInfo, error) {
+	type row struct {
+		SchemaName string
+		TableName  string
+	}
+
+	schemaRows, err := conn.Query(ctx, schemaInfoQuery)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var tables []row
+
+	for schemaRows.Next() {
+		var r row
+		if err := schemaRows.Scan(&r.SchemaName, &r.TableName); err != nil {
+			return nil, err
+		}
+		tables = append(tables, r)
+	}
+
+	if err := schemaRows.Err(); err != nil {
+		return nil, err
+	}
+
+	schemas := map[string]schema{}
+	for _, table := range tables {
+		sch := schemas[table.SchemaName]
+		sch.tables = append(sch.tables, table.TableName)
+
+		schemas[table.SchemaName] = sch
+	}
+
+	return schemas, nil
+}

--- a/lib/srv/db/postgres/sql/remove-permissions.sql
+++ b/lib/srv/db/postgres/sql/remove-permissions.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE PROCEDURE pg_temp.teleport_remove_permissions(username VARCHAR)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    row_data RECORD;
+BEGIN
+    -- Check active connections.
+    IF EXISTS (SELECT usename FROM pg_stat_activity WHERE usename = username AND datname = current_database()) THEN
+       RAISE NOTICE 'User has active connections to current database';
+    ELSE
+        -- Loop through table permissions
+        FOR row_data IN (SELECT DISTINCT table_schema, table_name FROM information_schema.table_privileges WHERE grantee = username)
+        LOOP
+            EXECUTE 'REVOKE ALL PRIVILEGES ON ' || quote_ident(row_data.table_schema) || '.' || quote_ident(row_data.table_name) || ' FROM ' || quote_ident(username);
+        END LOOP;
+    END IF;
+END;
+$$;

--- a/lib/srv/db/postgres/sql/update-permissions.sql
+++ b/lib/srv/db/postgres/sql/update-permissions.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE pg_temp.teleport_update_permissions(username VARCHAR, permissions_ JSONB)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    grant_data JSONB;
+    grant_item JSONB;
+    diff_count_1 INTEGER;
+    diff_count_2 INTEGER;
+BEGIN
+
+    grant_data = COALESCE(permissions_->'tables', '[]'::JSONB);
+
+    -- If the user has active connections to current database, verify that permissions haven't changed.
+    IF EXISTS (SELECT usename FROM pg_stat_activity WHERE usename = username AND datname = current_database()) THEN
+        CREATE TEMPORARY TABLE cur_perms AS SELECT table_schema, table_name, privilege_type FROM information_schema.table_privileges WHERE grantee = username;
+        CREATE TEMPORARY TABLE new_perms AS SELECT item->>'schema' as table_schema, item->>'table' as table_name, item->>'privilege' as privilege_type FROM jsonb_array_elements(grant_data) as item;
+
+        SELECT COUNT(*) INTO diff_count_1 FROM (SELECT * FROM cur_perms EXCEPT SELECT * FROM new_perms) q1;
+        SELECT COUNT(*) INTO diff_count_2 FROM (SELECT * FROM new_perms EXCEPT SELECT * FROM cur_perms) q2;
+
+        IF (diff_count_1 > 0) OR (diff_count_2 > 0) THEN
+            RAISE WARNING 'Permission changes: removed=%, added=%', diff_count_1, diff_count_2;
+            RAISE EXCEPTION SQLSTATE 'TP005' USING MESSAGE = 'TP005: User has active connections and permissions have changed';
+        END IF;
+    ELSE
+        CALL pg_temp.teleport_remove_permissions(username);
+
+        -- Assign all roles to the created/activated user if grants are provided.
+        IF grant_data <> 'null'::JSONB THEN
+            FOR grant_item IN SELECT * FROM jsonb_array_elements(grant_data)
+            LOOP
+                EXECUTE 'GRANT ' || text(grant_item->>'privilege') || ' ON TABLE ' || QUOTE_IDENT(grant_item->>'schema') || '.' || QUOTE_IDENT(grant_item->>'table') || ' TO ' || QUOTE_IDENT(username);
+            END LOOP;
+        END IF;
+    END IF;
+END;
+$$;

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -85,6 +85,8 @@ type TestServer struct {
 	storedProcedures map[string]string
 	// userEventsCh receives user activate/deactivate events.
 	userEventsCh chan UserEvent
+	// userPermissionEventsCh receives user permission change events.
+	userPermissionEventsCh chan UserPermissionEvent
 	// mu protects test server's shared state.
 	mu sync.Mutex
 	// allowedUsers list of users that can be used to connect to the server.
@@ -122,6 +124,14 @@ type UserEvent struct {
 	Active bool
 }
 
+// UserPermissionEvent represents a user permission change event.
+type UserPermissionEvent struct {
+	// Name is the name of the user.
+	Name string
+	// Permissions are the user permissions.
+	Permissions Permissions
+}
+
 // NewTestServer returns a new instance of a test Postgres server.
 func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) {
 	err = config.CheckAndSetDefaults()
@@ -153,12 +163,13 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 			trace.Component: defaults.ProtocolPostgres,
 			"name":          config.Name,
 		}),
-		parametersCh:     make(chan map[string]string, 100),
-		pids:             make(map[uint32]*pidHandle),
-		storedProcedures: make(map[string]string),
-		userEventsCh:     make(chan UserEvent, 100),
-		allowedUsers:     &allowedUsers,
-		mmCache:          make(map[string]*multiMessage),
+		parametersCh:           make(chan map[string]string, 100),
+		pids:                   make(map[uint32]*pidHandle),
+		storedProcedures:       make(map[string]string),
+		userEventsCh:           make(chan UserEvent, 100),
+		userPermissionEventsCh: make(chan UserPermissionEvent, 100),
+		allowedUsers:           &allowedUsers,
+		mmCache:                make(map[string]*multiMessage),
 	}, nil
 }
 
@@ -295,6 +306,16 @@ func (s *TestServer) handleStartup(client *pgproto3.Backend, startupMessage *pgp
 				if err := s.handleDeactivateUser(client); err != nil {
 					s.log.WithError(err).Error("Failed to handle user deactivation.")
 				}
+			case updatePermissionsQuery:
+				if err := s.handleUpdatePermissions(client); err != nil {
+					s.log.WithError(err).Error("Failed to handle user permissions update.")
+				}
+			case schemaInfoQuery:
+				if err := s.handleSchemaInfo(client); err != nil {
+					s.log.WithError(err).Error("Failed to handle schema info query.")
+				}
+			default:
+				s.log.Warnf("Ignoring PARSE message for query %q", msg.Query)
 			}
 		case *pgproto3.Bind:
 		case *pgproto3.Describe:
@@ -351,7 +372,7 @@ func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uin
 	if query == TestLongRunningQuery {
 		return trace.Wrap(s.fakeLongRunningQuery(client, pid))
 	}
-	if strings.Contains(query, "create or replace procedure") {
+	if strings.Contains(strings.ToUpper(query), "CREATE OR REPLACE PROCEDURE") {
 		if err := s.handleCreateStoredProcedure(query); err != nil {
 			return trace.Wrap(err)
 		}
@@ -381,12 +402,14 @@ func (s *TestServer) handleCreateStoredProcedure(query string) error {
 	if len(match) != 2 {
 		return trace.BadParameter("failed to extract stored procedure name from query")
 	}
-	switch match[1] {
-	case activateProcName, deactivateProcName, deleteProcName:
-		s.log.Debugf("Created stored procedure %q.", match[1])
-	default:
-		return trace.BadParameter("test server doesn't support stored procedure %q", match[1])
+
+	if _, ok := ephemeralProcs[match[1]]; !ok {
+		if _, ok := procs[match[1]]; !ok {
+			return trace.BadParameter("test server doesn't support stored procedure %q", match[1])
+		}
 	}
+
+	s.log.Debugf("Created stored procedure %q.", match[1])
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.storedProcedures[match[1]] = query
@@ -621,6 +644,145 @@ func (s *TestServer) handleDeactivateUser(client *pgproto3.Backend) error {
 	return nil
 }
 
+func (s *TestServer) handleUpdatePermissions(client *pgproto3.Backend) error {
+	// Expect Describe message.
+	_, err := s.receiveDescribeMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Sync message.
+	_, err = s.receiveSyncMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Respond to Parse message.
+	err = s.sendMessages(client,
+		&pgproto3.ParseComplete{},
+		&pgproto3.ParameterDescription{ParameterOIDs: []uint32{pgtype.VarcharOID, pgtype.JSONBOID}},
+		&pgproto3.NoData{},
+		&pgproto3.ReadyForQuery{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Bind message.
+	bind, err := s.receiveBindMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Extract user name.
+	name, err := getVarchar(bind.ParameterFormatCodes[0], bind.Parameters[0])
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Extract role names.
+	perms, err := getJSONB[Permissions](bind.ParameterFormatCodes[1], bind.Parameters[1])
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Describe message.
+	_, err = s.receiveDescribeMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Execute message.
+	_, err = s.receiveExecuteMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Sync message.
+	_, err = s.receiveSyncMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Respond to Bind message.
+	err = s.sendMessages(client,
+		&pgproto3.BindComplete{},
+		&pgproto3.NoData{},
+		&pgproto3.CommandComplete{},
+		&pgproto3.ReadyForQuery{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Mark the user as active.
+	s.log.Debugf("Updated permissions for user %q with permissions %#v.", name, perms)
+	s.userPermissionEventsCh <- UserPermissionEvent{Name: name, Permissions: perms}
+	return nil
+}
+
+func (s *TestServer) handleSchemaInfo(client *pgproto3.Backend) error {
+	// Expect Describe message.
+	_, err := s.receiveDescribeMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Sync message.
+	_, err = s.receiveSyncMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Respond to Parse message.
+	err = s.sendMessages(client,
+		&pgproto3.ParseComplete{},
+		&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+		&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{{Name: []byte("schemaname")}, {Name: []byte("tablename")}}},
+		&pgproto3.ReadyForQuery{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Bind message.
+	_, err = s.receiveBindMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Describe message.
+	_, err = s.receiveDescribeMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Execute message.
+	_, err = s.receiveExecuteMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Expect Sync message.
+	_, err = s.receiveSyncMessage(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Respond to Bind message.
+	err = s.sendMessages(client,
+		&pgproto3.BindComplete{},
+		&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{{Name: []byte("schemaname")}, {Name: []byte("tablename")}}},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Send over results
+	fixedSchema := map[string][]string{
+		"public": {"employees", "orders", "departments", "projects", "customers"},
+		"hr":     {"salaries"},
+	}
+	for schemaName, tables := range fixedSchema {
+		for _, tableName := range tables {
+			err = s.sendMessages(client, &pgproto3.DataRow{Values: [][]byte{[]byte(schemaName), []byte(tableName)}})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	// Notify the client we are finished.
+	err = s.sendMessages(client,
+		&pgproto3.CommandComplete{},
+		&pgproto3.ReadyForQuery{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 func (s *TestServer) receiveDescribeMessage(client *pgproto3.Backend) (*pgproto3.Describe, error) {
 	message, err := s.receiveFrontendMessage(client)
 	if err != nil {
@@ -708,6 +870,16 @@ func getVarcharArray(formatCode int16, src []byte) ([]string, error) {
 	return strs, nil
 }
 
+// getJSONB parses the incoming JSONB data into target type. To get raw data, pass pgtype.JSONB as T.
+func getJSONB[T any](formatCode int16, src []byte) (T, error) {
+	var dst T
+	err := pgtype.NewConnInfo().Scan(pgtype.JSONBOID, formatCode, src, &dst)
+	if err != nil {
+		return dst, trace.Wrap(err)
+	}
+	return dst, nil
+}
+
 func (s *TestServer) sendMessages(client *pgproto3.Backend, messages ...pgproto3.BackendMessage) error {
 	for _, message := range messages {
 		s.log.Debugf("Sending %#v.", message)
@@ -771,6 +943,11 @@ func (s *TestServer) ParametersCh() chan map[string]string {
 // UserEventsCh returns channel that receives user activate/deactivate events.
 func (s *TestServer) UserEventsCh() <-chan UserEvent {
 	return s.userEventsCh
+}
+
+// UserPermissionsCh returns channel that receives user permission events.
+func (s *TestServer) UserPermissionsCh() <-chan UserPermissionEvent {
+	return s.userPermissionEventsCh
 }
 
 // Close closes the server listener.
@@ -844,7 +1021,7 @@ const userParameterName = "user"
 
 // storedProcedureRe is the regex for capturing stored procedure name from its
 // creation query.
-var storedProcedureRe = regexp.MustCompile(`create or replace procedure (.+)\(`)
+var storedProcedureRe = regexp.MustCompile(`(?i)create or replace procedure (.+)\(`)
 
 // selectBenchmarkRe is the regex for capturing the parameters from the select query used for read benchmark.
 var selectBenchmarkRe = regexp.MustCompile(`SELECT \* FROM bench\_(\d+) LIMIT (\d+)`)

--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -44,7 +44,6 @@ func (e *Engine) connectAsAdmin(ctx context.Context, sessionCtx *common.Session,
 		loginDatabase = sessionCtx.Database.GetAdminUser().DefaultDatabase
 	} else {
 		e.Log.WithField("database", loginDatabase).Info("Connecting to session database")
-
 	}
 	conn, err := e.pgxConnect(ctx, sessionCtx.WithUserAndDatabase(sessionCtx.Database.GetAdminUser().Name, loginDatabase))
 	return conn, trace.Wrap(err)
@@ -103,6 +102,7 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 	return nil
 }
 
+// TablePermission is the represents a permission for particular database table.
 type TablePermission struct {
 	Privilege string `json:"privilege"`
 	Schema    string `json:"schema"`

--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -22,23 +22,29 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgx/v4"
+	"github.com/lib/pq"
 
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
 )
 
-func (e *Engine) connectAsAdmin(ctx context.Context, sessionCtx *common.Session) (*pgx.Conn, error) {
-	// Log into GetAdminUser().DefaultDatabase if specified, otherwise use
-	// database name from db route.
+// connectAsAdmin connect to the database from db route as admin user.
+// If useDefaultDatabase is true and a default database is configured for the admin user, it will be used instead.
+func (e *Engine) connectAsAdmin(ctx context.Context, sessionCtx *common.Session, useDefaultDatabase bool) (*pgx.Conn, error) {
 	loginDatabase := sessionCtx.DatabaseName
-	if sessionCtx.Database.GetAdminUser().DefaultDatabase != "" {
+	if useDefaultDatabase && sessionCtx.Database.GetAdminUser().DefaultDatabase != "" {
 		loginDatabase = sessionCtx.Database.GetAdminUser().DefaultDatabase
+	} else {
+		e.Log.WithField("database", loginDatabase).Info("Connecting to session database")
+
 	}
 	conn, err := e.pgxConnect(ctx, sessionCtx.WithUserAndDatabase(sessionCtx.Database.GetAdminUser().Name, loginDatabase))
 	return conn, trace.Wrap(err)
@@ -55,7 +61,7 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 		return trace.BadParameter("auto-user provisioning is not supported for RDS reader endpoints")
 	}
 
-	conn, err := e.connectAsAdmin(ctx, sessionCtx)
+	conn, err := e.connectAsAdmin(ctx, sessionCtx, true)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -74,15 +80,208 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 		return trace.Wrap(err)
 	}
 
-	e.Log.Infof("Activating PostgreSQL user %q with roles %v.", sessionCtx.DatabaseUser, roles)
+	e.Log.WithField("user", sessionCtx.DatabaseUser).WithField("roles", roles).Info("Activating PostgreSQL user")
 
 	_, err = conn.Exec(ctx, activateQuery, sessionCtx.DatabaseUser, roles)
 	if err != nil {
-		e.Log.Debugf("Call teleport_activate_user failed: %v", err)
+		e.Log.WithError(err).Debug("Call teleport_activate_user failed.")
 		return trace.Wrap(convertActivateError(sessionCtx, err))
 	}
-	return nil
 
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return trace.AlreadyExists("user %q already exists in this PostgreSQL database and is not managed by Teleport", sessionCtx.DatabaseUser)
+		}
+		return trace.Wrap(err)
+	}
+
+	err = e.applyPermissions(ctx, sessionCtx)
+	if err != nil {
+		e.Log.WithError(err).Warn("Failed to apply permissions.")
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+type TablePermission struct {
+	Privilege string `json:"privilege"`
+	Schema    string `json:"schema"`
+	Table     string `json:"table"`
+}
+
+type Permissions struct {
+	Tables []TablePermission `json:"tables"`
+}
+
+var pgTablePerms = map[string]struct{}{
+	"SELECT":     {},
+	"INSERT":     {},
+	"UPDATE":     {},
+	"DELETE":     {},
+	"TRUNCATE":   {},
+	"REFERENCES": {},
+	"TRIGGER":    {},
+}
+
+func checkPgPermission(objKind, perm string) error {
+	// for now, only tables are supported. ignore other kinds of objects.
+	if objKind != permissions.ObjectKindTable {
+		return nil
+	}
+
+	normalized := strings.ToUpper(strings.TrimSpace(perm))
+	_, found := pgTablePerms[normalized]
+	if !found {
+		return trace.BadParameter("unrecognized %q Postgres permission: %q", objKind, perm)
+	}
+	return nil
+}
+
+// convertPermissions converts the permissions into a stable format expected by the stored procedure. It also filters out any unsupported objects.
+func convertPermissions(perms permissions.PermissionSet) (*Permissions, error) {
+	var out Permissions
+	var errors []error
+	for permission, objects := range perms {
+		for _, obj := range objects {
+			if err := checkPgPermission(obj.GetSpec().ObjectKind, permission); err != nil {
+				errors = append(errors, err)
+				continue
+			}
+			if obj.GetSpec().ObjectKind == permissions.ObjectKindTable {
+				out.Tables = append(out.Tables, TablePermission{
+					Privilege: permission,
+					Schema:    obj.GetSpec().Schema,
+					Table:     obj.GetSpec().Name,
+				})
+			}
+		}
+	}
+	if len(errors) > 0 {
+		return nil, trace.NewAggregate(errors...)
+	}
+	return &out, nil
+}
+
+func (e *Engine) granularPermissionsEnabled(sessionCtx *common.Session) bool {
+	allow, _, _ := sessionCtx.Checker.GetDatabasePermissions(sessionCtx.Database)
+	if len(allow) == 0 {
+		return false
+	}
+
+	if len(sessionCtx.DatabaseRoles) > 0 {
+		return false
+	}
+
+	return true
+}
+
+func (e *Engine) applyPermissions(ctx context.Context, sessionCtx *common.Session) error {
+	allow, _, err := sessionCtx.Checker.GetDatabasePermissions(sessionCtx.Database)
+	if err != nil {
+		e.Log.WithError(err).Error("Failed to calculate effective database permissions.")
+		return trace.Wrap(err)
+	}
+	if len(allow) == 0 {
+		e.Log.Info("Skipping applying fine-grained permissions: none to apply.")
+		return nil
+	}
+
+	if len(sessionCtx.DatabaseRoles) > 0 {
+		e.Log.WithField("roles", sessionCtx.DatabaseRoles).Error("Cannot apply fine-grained permissions: non-empty list of database roles.")
+		return trace.BadParameter("fine-grained database permissions and database roles are mutually exclusive, yet both were provided.")
+	}
+
+	rules, err := e.AuthClient.GetDatabaseObjectImportRules(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	conn, err := e.connectAsAdmin(ctx, sessionCtx, false)
+	if err != nil {
+		e.Log.WithError(err).Error("Failed to connect to the database.")
+		return trace.Wrap(err)
+	}
+	defer conn.Close(ctx)
+
+	objsFetched, err := fetchDatabaseObjects(ctx, sessionCtx, conn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	counts, countMap := permissions.CountObjectKinds(objsFetched)
+	e.Log.WithField("kind_counts", countMap).WithField("total", len(objsFetched)).Infof("Fetched %v objects from the database (%v).", len(objsFetched), counts)
+
+	objsTagged := permissions.ApplyDatabaseObjectImportRules(rules, sessionCtx.Database, objsFetched)
+	counts, countMap = permissions.CountObjectKinds(objsTagged)
+	e.Log.WithField("kind_counts", countMap).WithField("total", len(objsFetched)).Infof("Tagged %v database objects (%v).", len(objsTagged), counts)
+
+	permissionSet, err := permissions.CalculatePermissions(sessionCtx.Checker, sessionCtx.Database, objsTagged)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	summary, eventData := permissions.SummarizePermissions(permissionSet)
+	e.Log.WithField("user", sessionCtx.DatabaseUser).Infof("Calculated database permissions: %v.", summary)
+	e.auditUserPermissions(sessionCtx, eventData)
+
+	perms, err := convertPermissions(permissionSet)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// teleport_remove_permissions and teleport_update_permissions are created in pg_temp table of the session database.
+	// teleport_remove_permissions gets called by teleport_update_permissions as needed.
+	_, err = conn.Exec(ctx, removePermissionsProc)
+	if err != nil {
+		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", removePermissionsProcName)
+		return trace.Wrap(err)
+	}
+
+	_, err = conn.Exec(ctx, updatePermissionsProc)
+	if err != nil {
+		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", updatePermissionsProcName)
+		return trace.Wrap(err)
+	}
+
+	_, err = conn.Exec(ctx, updatePermissionsQuery, sessionCtx.DatabaseUser, perms)
+	if err != nil {
+		var pgErr *pq.Error
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == common.SQLStatePermissionsChanged {
+				e.Log.WithError(err).WithField("user", sessionCtx.DatabaseUser).Error("Permissions have changed, rejecting connection.")
+			}
+		} else {
+			e.Log.WithError(err).WithField("user", sessionCtx.DatabaseUser).Error("Failed to update permissions.")
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (e *Engine) removePermissions(ctx context.Context, sessionCtx *common.Session) error {
+	if !e.granularPermissionsEnabled(sessionCtx) {
+		e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Granular database permissions not enabled, skipping removal step.")
+		return nil
+	}
+
+	e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Removing permissions from PostgreSQL user")
+	conn, err := e.connectAsAdmin(ctx, sessionCtx, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer conn.Close(ctx)
+
+	// teleport_remove_permissions is created in pg_temp table of the session database.
+	_, err = conn.Exec(ctx, removePermissionsProc)
+	if err != nil {
+		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", removePermissionsProcName)
+		return trace.Wrap(err)
+	}
+
+	_, err = conn.Exec(ctx, removePermissionsQuery, sessionCtx.DatabaseUser)
+	if err != nil {
+		e.Log.WithError(err).WithField("user", sessionCtx.DatabaseUser).Error("Removing permissions from user failed.")
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // DeactivateUser disables the database user.
@@ -91,20 +290,23 @@ func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session)
 		return trace.BadParameter("Teleport does not have admin user configured for this database")
 	}
 
-	conn, err := e.connectAsAdmin(ctx, sessionCtx)
+	// removal may yield errors, but we will still attempt to deactivate the user.
+	errRemove := trace.Wrap(e.removePermissions(ctx, sessionCtx))
+
+	conn, err := e.connectAsAdmin(ctx, sessionCtx, true)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.NewAggregate(errRemove, trace.Wrap(err))
 	}
 	defer conn.Close(ctx)
 
-	e.Log.Infof("Deactivating PostgreSQL user %q.", sessionCtx.DatabaseUser)
+	e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Deactivating PostgreSQL user.")
 
 	_, err = conn.Exec(ctx, deactivateQuery, sessionCtx.DatabaseUser)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.NewAggregate(errRemove, trace.Wrap(err))
 	}
 
-	return nil
+	return errRemove
 }
 
 // DeleteUser deletes the database user.
@@ -113,13 +315,16 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 		return trace.BadParameter("Teleport does not have admin user configured for this database")
 	}
 
-	conn, err := e.connectAsAdmin(ctx, sessionCtx)
+	// removal may yield errors, but we will still attempt to delete the user.
+	errRemove := trace.Wrap(e.removePermissions(ctx, sessionCtx))
+
+	conn, err := e.connectAsAdmin(ctx, sessionCtx, true)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.NewAggregate(errRemove, trace.Wrap(err))
 	}
 	defer conn.Close(ctx)
 
-	e.Log.Infof("Deleting PostgreSQL user %q.", sessionCtx.DatabaseUser)
+	e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Deleting PostgreSQL user.")
 
 	var state string
 	switch {
@@ -129,19 +334,19 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 		err = conn.QueryRow(ctx, deleteQuery, sessionCtx.DatabaseUser).Scan(&state)
 	}
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.NewAggregate(errRemove, trace.Wrap(err))
 	}
 
 	switch state {
 	case common.SQLStateUserDropped:
-		e.Log.Debugf("User %q deleted successfully.", sessionCtx.DatabaseUser)
+		e.Log.WithField("user", sessionCtx.DatabaseUser).Debug("User deleted successfully.")
 	case common.SQLStateUserDeactivated:
-		e.Log.Infof("Unable to delete user %q, it was disabled instead.", sessionCtx.DatabaseUser)
+		e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Unable to delete user, it was disabled instead.")
 	default:
-		e.Log.Warnf("Unable to determine user %q deletion state.", sessionCtx.DatabaseUser)
+		e.Log.WithField("user", sessionCtx.DatabaseUser).Warn("Unable to determine user deletion state.")
 	}
 
-	return nil
+	return errRemove
 }
 
 // deleteUserRedshift deletes the Redshift database user.
@@ -256,7 +461,12 @@ const (
 	// deleteProcName is the name of the stored procedure Teleport will use to
 	// automatically delete database users after session ends.
 	deleteProcName = "teleport_delete_user"
-
+	// updatePermissionsProcName is the name of the stored procedure Teleport will use
+	// to automatically update database permissions.
+	updatePermissionsProcName = "pg_temp.teleport_update_permissions"
+	// removePermissionsProcName is the name of the stored procedure Teleport will use
+	// to automatically remove all database permissions.
+	removePermissionsProcName = "pg_temp.teleport_remove_permissions"
 	// teleportAutoUserRole is the name of a PostgreSQL role that all Teleport
 	// managed users will be a part of.
 	teleportAutoUserRole = "teleport-auto-user"
@@ -285,14 +495,32 @@ var (
 	//go:embed sql/redshift-delete-user.sql
 	redshiftDeleteProc string
 
+	//go:embed sql/update-permissions.sql
+	updatePermissionsProc string
+	// updatePermissionsQuery is the query for calling update permissions procedure.
+	// the procedure is created on demand in the pg_temp table in the session database.
+	updatePermissionsQuery = fmt.Sprintf(`call %v($1, $2::jsonb)`, updatePermissionsProcName)
+
+	//go:embed sql/remove-permissions.sql
+	removePermissionsProc string
+	// removePermissionsQuery is the query for calling update permissions procedure.
+	// the procedure is created on demand in the pg_temp table in the session database.
+	removePermissionsQuery = fmt.Sprintf(`call %v($1)`, removePermissionsProcName)
+
 	procs = map[string]string{
 		activateProcName:   activateProc,
 		deactivateProcName: deactivateProc,
 		deleteProcName:     deleteProc,
 	}
+
 	redshiftProcs = map[string]string{
 		activateProcName:   redshiftActivateProc,
 		deactivateProcName: redshiftDeactivateProc,
 		deleteProcName:     redshiftDeleteProc,
+	}
+
+	ephemeralProcs = map[string]string{
+		updatePermissionsProcName: updatePermissionsProc,
+		removePermissionsProcName: removePermissionsProc,
 	}
 )

--- a/lib/srv/db/postgres/users_test.go
+++ b/lib/srv/db/postgres/users_test.go
@@ -21,11 +21,16 @@ package postgres
 import (
 	"testing"
 
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/databaseobject"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/common/permissions"
 )
 
 func Test_prepareRoles(t *testing.T) {
@@ -81,6 +86,126 @@ func Test_prepareRoles(t *testing.T) {
 			actualRoles, err := prepareRoles(sessionCtx)
 			require.NoError(t, err)
 			require.Equal(t, test.expectRoles, actualRoles)
+		})
+	}
+}
+
+func TestCheckPgPermission(t *testing.T) {
+	tests := []struct {
+		name     string
+		perm     string
+		objKind  string
+		checkErr require.ErrorAssertionFunc
+	}{
+		{
+			name:     "valid permission",
+			perm:     "SELECT",
+			objKind:  permissions.ObjectKindTable,
+			checkErr: require.NoError,
+		},
+		{
+			name:     "whitespace trimmed",
+			perm:     "  SELECT   ",
+			objKind:  permissions.ObjectKindTable,
+			checkErr: require.NoError,
+		},
+		{
+			name:     "case-insensitive",
+			perm:     "seLEct",
+			objKind:  permissions.ObjectKindTable,
+			checkErr: require.NoError,
+		},
+		{
+			name:    "invalid permission",
+			perm:    "INVALID",
+			objKind: permissions.ObjectKindTable,
+			checkErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "unrecognized \"table\" Postgres permission: \"INVALID\"")
+			},
+		},
+		{
+			name:    "multiple permissions not allowed",
+			perm:    "SELECT, UPDATE",
+			objKind: permissions.ObjectKindTable,
+			checkErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "unrecognized \"table\" Postgres permission: \"SELECT, UPDATE\"")
+			},
+		},
+		{
+			name:     "permissions for unknown object kinds are ignored",
+			perm:     "invalid",
+			objKind:  "unknown object kind",
+			checkErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.checkErr(t, checkPgPermission(tt.objKind, tt.perm))
+		})
+	}
+}
+
+func TestConvertPermissions(t *testing.T) {
+	mkObject := func(name, schema, kind string) *dbobjectv1.DatabaseObject {
+		obj, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
+			ObjectKind: kind,
+			Schema:     schema,
+			Name:       name,
+			Protocol:   "postgres",
+		})
+		require.NoError(t, err)
+		return obj
+	}
+
+	// Define test cases
+	tests := []struct {
+		name          string
+		input         permissions.PermissionSet
+		expected      *Permissions
+		expectedError error
+	}{
+		{
+			name: "valid table permissions, ignoring procedure",
+			input: permissions.PermissionSet{
+				"SELECT":  {mkObject("my_table", "public", permissions.ObjectKindTable)},
+				"INSERT":  {mkObject("other_table", "secret", permissions.ObjectKindTable)},
+				"EXECUTE": {mkObject("my_proc", "public", permissions.ObjectKindProcedure)},
+			},
+			expected: &Permissions{
+				Tables: []TablePermission{
+					{
+						Privilege: "SELECT",
+						Schema:    "public",
+						Table:     "my_table",
+					},
+					{
+						Privilege: "INSERT",
+						Schema:    "secret",
+						Table:     "other_table",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid table permissions lead to an error",
+			input: permissions.PermissionSet{
+				"invalid": {mkObject("my_table", "public", permissions.ObjectKindTable)},
+			},
+			expectedError: trace.BadParameter("unrecognized \"table\" Postgres permission: \"invalid\""),
+		},
+	}
+
+	// Run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := convertPermissions(tt.input)
+			if tt.expectedError != nil {
+				require.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				require.ElementsMatch(t, tt.expected.Tables, result.Tables)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This is a capstone PR in a series of PRs implementing [RFD 151](https://github.com/gravitational/teleport/blob/master/rfd/0151-database-permission-management.md).

changelog: Implement granular db permissions for Postgres (RFD 151).