### PR TITLE
[v14] Ensure yarn.lock is up to date, run workflows on relevant changes in root dir

### DIFF
--- a/.github/workflows/lint-ui-bypass.yaml
+++ b/.github/workflows/lint-ui-bypass.yaml
@@ -16,10 +16,18 @@ on:
     paths-ignore:
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
   merge_group:
     paths-ignore:
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
 
 jobs:
   lint:

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Yarn dependencies
-        run: yarn --frozen-lockfile
+        run: bash web/packages/build/scripts/yarn-install-frozen-lockfile.sh
 
       - name: Run Type Check
         run: yarn type-check

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -6,10 +6,18 @@ on:
     paths:
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
   merge_group:
     paths:
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests-ui-bypass.yaml
+++ b/.github/workflows/unit-tests-ui-bypass.yaml
@@ -17,11 +17,21 @@ on:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
   merge_group:
     paths-ignore:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Yarn dependencies
-        run: yarn --frozen-lockfile
+        run: bash web/packages/build/scripts/yarn-install-frozen-lockfile.sh
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -7,11 +7,21 @@ on:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
   merge_group:
     paths:
       - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - 'tsconfig.node.json'
+      - 'jest.config.js'
 
 jobs:
   test:

--- a/web/packages/build/scripts/yarn-install-frozen-lockfile.sh
+++ b/web/packages/build/scripts/yarn-install-frozen-lockfile.sh
@@ -6,9 +6,9 @@ set -ex
 # Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
 # https://github.com/yarnpkg/yarn/issues/4098
 
-message="yarn.lock needs an update. Run yarn install, verify that correct dependencies were \
-installed and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e \
-submodule initialized and updated first."
+message="yarn.lock needs an update. Run yarn install, verify that the correct dependencies were \
+installed and commit the updated version of yarn.lock. If you are making changes to enterprise \
+dependencies, make sure those changes are reflected in web/packages/e-imports/package.json as well."
 
 cp yarn.lock yarn-before-install.lock
 yarn install


### PR DESCRIPTION
Backport #37579.

Manual backport because v14 doesn't have `gen/proto/ts` and it doesn't have `ironrdp` in `Cargo.toml`.