### PR TITLE
charts/kube-agent: support restricted PSS by default

### DIFF
--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -1589,12 +1589,14 @@ for more details.
 
 | Type | Default |
 |------|---------|
-| `object` | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":9807}` |
+| `object` | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":9807,"seccompProfile":{"type":"RuntimeDefault"}}` |
 
 `initSecurityContext` sets the init container security context for any
 pods created by the chart.
 See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
 for more details.
+
+The default value is compatible with [the restricted PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
 To unset the security context, set it to `null` or `~`.
 
@@ -1602,11 +1604,13 @@ To unset the security context, set it to `null` or `~`.
 
 | Type | Default |
 |------|---------|
-| `object` | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":9807}` |
+| `object` | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":9807,"seccompProfile":{"type":"RuntimeDefault"}}` |
 
 `securityContext` sets the container security context for any pods created by the chart.
 See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
 for more details.
+
+The default value is compatible with [the restricted PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
 To unset the security context, set it to `null` or `~`.
 

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/clusterrole_test.yaml.snap
@@ -1,4 +1,64 @@
+adds services listing permission if discovery is enabled:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - users
+      - groups
+      - serviceaccounts
+      verbs:
+      - impersonate
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - selfsubjectaccessreviews
+      verbs:
+      - create
 creates a ClusterRole:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - users
+      - groups
+      - serviceaccounts
+      verbs:
+      - impersonate
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - selfsubjectaccessreviews
+      verbs:
+      - create
+does not add services listing permission if discovery is disabled:
   1: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -33,66 +93,6 @@ sets ClusterRole labels when specified:
       labels:
         app.kubernetes.io/name: teleport-kube-agent
         resource: clusterrole
-      name: RELEASE-NAME
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - users
-      - groups
-      - serviceaccounts
-      verbs:
-      - impersonate
-    - apiGroups:
-      - ""
-      resources:
-      - pods
-      verbs:
-      - get
-    - apiGroups:
-      - authorization.k8s.io
-      resources:
-      - selfsubjectaccessreviews
-      verbs:
-      - create
-adds services listing permission if discovery is enabled:
-  1: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: RELEASE-NAME
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - users
-      - groups
-      - serviceaccounts
-      verbs:
-      - impersonate
-    - apiGroups:
-      - ""
-      resources:
-      - services
-      verbs:
-      - list
-    - apiGroups:
-      - ""
-      resources:
-      - pods
-      verbs:
-      - get
-    - apiGroups:
-      - authorization.k8s.io
-      resources:
-      - selfsubjectaccessreviews
-      verbs:
-      - create
-does not add services listing permission if discovery is disabled:
-  1: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
       name: RELEASE-NAME
     rules:
     - apiGroups:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -57,10 +57,12 @@ sets Deployment annotations when specified if action is Upgrade:
               allowPrivilegeEscalation: false
               capabilities:
                 drop:
-                - all
+                - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 9807
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
             - mountPath: /etc/teleport
               name: config
@@ -130,10 +132,12 @@ sets Deployment labels when specified if action is Upgrade:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - all
+              - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 9807
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
           - mountPath: /etc/teleport
             name: config
@@ -190,10 +194,12 @@ sets Pod annotations when specified if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -250,10 +256,12 @@ sets Pod labels when specified if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -280,18 +288,22 @@ sets by default a container security context if action is Upgrade:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 9807
+    seccompProfile:
+      type: RuntimeDefault
   2: |
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 9807
+    seccompProfile:
+      type: RuntimeDefault
 should add emptyDir for data when existingDataVolume is not set if action is Upgrade:
   1: |
     containers:
@@ -327,10 +339,12 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -388,10 +402,12 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -448,10 +464,12 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -506,10 +524,12 @@ should expose diag port if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -578,10 +598,12 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -650,10 +672,12 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -710,10 +734,12 @@ should have one replica when replicaCount is not set if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -770,10 +796,12 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -837,10 +865,12 @@ should mount tls.existingCASecretName and set environment when set in values if 
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -907,10 +937,12 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -980,10 +1012,12 @@ should provision initContainer correctly when set in values if action is Upgrade
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1009,70 +1043,12 @@ should provision initContainer correctly when set in values if action is Upgrade
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
-      volumeMounts:
-      - mountPath: /etc/teleport
-        name: config
-        readOnly: true
-      - mountPath: /etc/teleport-secrets
-        name: auth-token
-        readOnly: true
-      - mountPath: /var/lib/teleport
-        name: data
-    securityContext:
-      fsGroup: 9807
-    serviceAccountName: RELEASE-NAME
-    volumes:
-    - configMap:
-        name: RELEASE-NAME
-      name: config
-    - name: auth-token
-      secret:
-        secretName: teleport-kube-agent-join-token
-    - emptyDir: {}
-      name: data
-should set SecurityContext if action is Upgrade:
-  1: |
-    containers:
-    - args:
-      - --diag-addr=0.0.0.0:3000
-      env:
-      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-        value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /healthz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      name: teleport
-      ports:
-      - containerPort: 3000
-        name: diag
-        protocol: TCP
-      readinessProbe:
-        failureThreshold: 12
-        httpGet:
-          path: /readyz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - all
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1149,10 +1125,12 @@ should set affinity when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1209,10 +1187,12 @@ should set default serviceAccountName when not set in values if action is Upgrad
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1282,10 +1262,12 @@ should set environment when extraEnv set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1342,10 +1324,12 @@ should set image and tag correctly if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1402,10 +1386,12 @@ should set imagePullPolicy when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1462,10 +1448,12 @@ should set nodeSelector if set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1524,10 +1512,12 @@ should set not set priorityClassName when not set in values if action is Upgrade
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1596,10 +1586,12 @@ should set preferred affinity when more than one replica is used if action is Up
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1656,10 +1648,12 @@ should set priorityClassName when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1717,10 +1711,12 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1787,10 +1783,12 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1854,10 +1852,12 @@ should set resources when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1914,10 +1914,12 @@ should set serviceAccountName when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1974,10 +1976,12 @@ should set tolerations when set in values if action is Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -32,10 +32,12 @@ should create ServiceAccount for post-delete hook by default:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
     restartPolicy: OnFailure
     serviceAccountName: lint-serviceaccount
 should not create ServiceAccount for post-delete hook if serviceAccount.create is false:
@@ -111,10 +113,12 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
               allowPrivilegeEscalation: false
               capabilities:
                 drop:
-                - all
+                - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 9807
+              seccompProfile:
+                type: RuntimeDefault
           restartPolicy: OnFailure
           serviceAccountName: lint-serviceaccount
 should not create ServiceAccount, Role or RoleBinding for post-delete hook if serviceAccount.create and rbac.create are false:
@@ -139,10 +143,12 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
     restartPolicy: OnFailure
     serviceAccountName: lint-serviceaccount
 should set nodeSelector in post-delete hook:
@@ -167,39 +173,13 @@ should set nodeSelector in post-delete hook:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
     nodeSelector:
       gravitational.io/k8s-role: node
-    restartPolicy: OnFailure
-    serviceAccountName: RELEASE-NAME-delete-hook
-should set securityContext in post-delete hook:
-  1: |
-    containers:
-    - args:
-      - kube-state
-      - delete
-      command:
-      - teleport
-      env:
-      - name: KUBE_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: RELEASE_NAME
-        value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
-      imagePullPolicy: IfNotPresent
-      name: post-delete-job
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - all
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 9807
     restartPolicy: OnFailure
     serviceAccountName: RELEASE-NAME-delete-hook

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -43,10 +43,12 @@ sets Pod annotations when specified:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -111,10 +113,12 @@ sets Pod labels when specified:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -203,10 +207,12 @@ sets StatefulSet labels when specified:
               allowPrivilegeEscalation: false
               capabilities:
                 drop:
-                - all
+                - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 9807
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
             - mountPath: /etc/teleport
               name: config
@@ -241,18 +247,22 @@ sets by default a container security context:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 9807
+    seccompProfile:
+      type: RuntimeDefault
   2: |
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 9807
+    seccompProfile:
+      type: RuntimeDefault
 should add insecureSkipProxyTLSVerify to args when set in values:
   1: |
     containers:
@@ -299,10 +309,12 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -367,10 +379,12 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -455,10 +469,12 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               allowPrivilegeEscalation: false
               capabilities:
                 drop:
-                - all
+                - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 9807
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
             - mountPath: /etc/teleport
               name: config
@@ -533,10 +549,12 @@ should add volumeMount for data volume when using StatefulSet:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -601,10 +619,12 @@ should expose diag port:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -669,10 +689,12 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -751,10 +773,12 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -831,10 +855,12 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -899,10 +925,12 @@ should have one replica when replicaCount is not set:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -967,10 +995,12 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1037,10 +1067,12 @@ should mount extraVolumes and extraVolumeMounts:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1112,10 +1144,12 @@ should mount tls.existingCASecretName and set environment when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1192,10 +1226,12 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1268,10 +1304,12 @@ should not add emptyDir for data when using StatefulSet:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1343,10 +1381,12 @@ should provision initContainer correctly when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1372,78 +1412,12 @@ should provision initContainer correctly when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
-      volumeMounts:
-      - mountPath: /etc/teleport
-        name: config
-        readOnly: true
-      - mountPath: /etc/teleport-secrets
-        name: auth-token
-        readOnly: true
-      - mountPath: /var/lib/teleport
-        name: RELEASE-NAME-teleport-data
-    securityContext:
-      fsGroup: 9807
-    serviceAccountName: RELEASE-NAME
-    volumes:
-    - configMap:
-        name: RELEASE-NAME
-      name: config
-    - name: auth-token
-      secret:
-        secretName: teleport-kube-agent-join-token
-should set SecurityContext:
-  1: |
-    containers:
-    - args:
-      - --diag-addr=0.0.0.0:3000
-      env:
-      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-        value: "true"
-      - name: TELEPORT_REPLICA_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: KUBE_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: RELEASE_NAME
-        value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /healthz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      name: teleport
-      ports:
-      - containerPort: 3000
-        name: diag
-        protocol: TCP
-      readinessProbe:
-        failureThreshold: 12
-        httpGet:
-          path: /readyz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - all
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1528,10 +1502,12 @@ should set affinity when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1596,10 +1572,12 @@ should set default serviceAccountName when not set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1677,10 +1655,12 @@ should set environment when extraEnv set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1745,10 +1725,12 @@ should set image and tag correctly:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1813,10 +1795,12 @@ should set imagePullPolicy when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1881,10 +1865,12 @@ should set nodeSelector if set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -1963,10 +1949,12 @@ should set preferred affinity when more than one replica is used:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2031,10 +2019,12 @@ should set probeTimeoutSeconds when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2109,10 +2099,12 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2184,10 +2176,12 @@ should set resources when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2252,10 +2246,12 @@ should set serviceAccountName when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2320,10 +2316,12 @@ should set storage.requests when set in values and action is an Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2388,10 +2386,12 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config
@@ -2456,10 +2456,12 @@ should set tolerations when set in values:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
       - mountPath: /etc/teleport
         name: config

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -57,10 +57,12 @@ sets the affinity:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
     serviceAccountName: RELEASE-NAME-updater
 sets the tolerations:
   1: |
@@ -101,10 +103,12 @@ sets the tolerations:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
-          - all
+          - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
     serviceAccountName: RELEASE-NAME-updater
     tolerations:
     - effect: NoExecute

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -247,24 +247,17 @@ tests:
       - ../.lint/backwards-compatibility.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.capabilities
+          path: spec.template.spec.containers[0].securityContext
           value:
-            drop:
-              - all
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 9807
-      - matchSnapshot:
-          path: spec.template.spec
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 9807
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: should set image and tag correctly if action is Upgrade
     template: deployment.yaml

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -31,24 +31,17 @@ tests:
       - ../.lint/backwards-compatibility.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.capabilities
+          path: spec.template.spec.containers[0].securityContext
           value:
-            drop:
-              - all
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 9807
-      - matchSnapshot:
-          path: spec.template.spec
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 9807
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: should set nodeSelector in post-delete hook
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -179,30 +179,36 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
-  - it: should set SecurityContext
+  - it: should set a restricted-friendly SecurityContext by default
     template: statefulset.yaml
     values:
       - ../.lint/stateful.yaml
+      - ../.lint/initcontainers.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.capabilities
+          path: spec.template.spec.containers[0].securityContext
           value:
-            drop:
-              - all
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 9807
+            seccompProfile:
+              type: RuntimeDefault
       - equal:
-          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
-          value: true
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 9807
-      - matchSnapshot:
-          path: spec.template.spec
+          path: spec.template.spec.initContainers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 9807
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: should set image and tag correctly
     template: statefulset.yaml

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1163,29 +1163,37 @@ resources: {}
 # See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
 # for more details.
 #
+# The default value is compatible with [the restricted PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+#
 # To unset the security context, set it to `null` or `~`.
 initSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-      - all
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 9807
+  seccompProfile:
+    type: RuntimeDefault
 
 # securityContext(object) -- sets the container security context for any pods created by the chart.
 # See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
 # for more details.
+#
+# The default value is compatible with [the restricted PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 #
 # To unset the security context, set it to `null` or `~`.
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-      - all
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 9807
+  seccompProfile:
+    type: RuntimeDefault
 
 # podSecurityContext(object) -- sets the pod security context for any pods created by the chart.
 # See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)


### PR DESCRIPTION
Fixes part of https://github.com/gravitational/teleport/issues/30687

changelog: Default setting for the teleport-kube-agent chart now complies with the Restricted Pod Security Standard.

DO NOT BACKPORT, this might be incompatible with (very) old Kube versions not supporting the DefaultRuntime seccomp profile. Those versions are out of support since a couple years so we can afford to drop them.

Nore for reviewers: I regenerated all the snapshots; it caused a bit of noise. I isolated this in a separate commit to make review easier. Sorry  🙃 