### PR TITLE
AWS OIDC: remove dependency on servicecfg

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/pam"
@@ -225,7 +226,7 @@ type CommandLineFlags struct {
 
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
-	IntegrationConfExternalAuditStorageArguments ExternalAuditStorageConfiguration
+	IntegrationConfExternalAuditStorageArguments easconfig.ExternalAuditStorageConfiguration
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -282,33 +283,6 @@ type IntegrationConfListDatabasesIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
-}
-
-// ExternalAuditStorageConfiguration contains the arguments to configure the
-// External Audit Storage.
-type ExternalAuditStorageConfiguration struct {
-	// Bootstrap is whether to bootstrap infrastructure (default: false).
-	Bootstrap bool
-	// Region is the AWS Region used.
-	Region string
-	// Role is the AWS IAM Role associated with the OIDC integration.
-	Role string
-	// Policy is the name to use for the IAM policy.
-	Policy string
-	// SessionRecordingsURI is the S3 URI where session recordings are stored.
-	SessionRecordingsURI string
-	// AuditEventsURI is the S3 URI where audit events are stored.
-	AuditEventsURI string
-	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
-	AthenaResultsURI string
-	// AthenaWorkgroup is the name of the Athena workgroup used.
-	AthenaWorkgroup string
-	// GlueDatabase is the name of the Glue database used.
-	GlueDatabase string
-	// GlueTable is the name of the Glue table used.
-	GlueTable string
-	// Partition is the AWS partition to use (default: aws).
-	Partition string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -225,7 +225,7 @@ type CommandLineFlags struct {
 
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
-	IntegrationConfExternalAuditStorageArguments servicecfg.ExternalAuditStorageConfiguration
+	IntegrationConfExternalAuditStorageArguments ExternalAuditStorageConfiguration
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -282,6 +282,33 @@ type IntegrationConfListDatabasesIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+}
+
+// ExternalAuditStorageConfiguration contains the arguments to configure the
+// External Audit Storage.
+type ExternalAuditStorageConfiguration struct {
+	// Bootstrap is whether to bootstrap infrastructure (default: false).
+	Bootstrap bool
+	// Region is the AWS Region used.
+	Region string
+	// Role is the AWS IAM Role associated with the OIDC integration.
+	Role string
+	// Policy is the name to use for the IAM policy.
+	Policy string
+	// SessionRecordingsURI is the S3 URI where session recordings are stored.
+	SessionRecordingsURI string
+	// AuditEventsURI is the S3 URI where audit events are stored.
+	AuditEventsURI string
+	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
+	AthenaResultsURI string
+	// AthenaWorkgroup is the name of the Athena workgroup used.
+	AthenaWorkgroup string
+	// GlueDatabase is the name of the Glue database used.
+	GlueDatabase string
+	// GlueTable is the name of the Glue table used.
+	GlueTable string
+	// Partition is the AWS partition to use (default: aws).
+	Partition string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 )
 
 // ConfigureExternalAuditStorageClient is an interface for the AWS client methods
@@ -60,38 +61,13 @@ func (d *DefaultConfigureExternalAuditStorageClient) GetCallerIdentity(ctx conte
 	return d.Sts.GetCallerIdentity(ctx, input, opts...)
 }
 
-// ExternalAuditStorageConfiguration contains the arguments to configure the
-// External Audit Storage.
-type ExternalAuditStorageConfiguration struct {
-	// Region is the AWS Region used.
-	Region string
-	// Role is the AWS IAM Role associated with the OIDC integration.
-	Role string
-	// Policy is the name to use for the IAM policy.
-	Policy string
-	// SessionRecordingsURI is the S3 URI where session recordings are stored.
-	SessionRecordingsURI string
-	// AuditEventsURI is the S3 URI where audit events are stored.
-	AuditEventsURI string
-	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
-	AthenaResultsURI string
-	// AthenaWorkgroup is the name of the Athena workgroup used.
-	AthenaWorkgroup string
-	// GlueDatabase is the name of the Glue database used.
-	GlueDatabase string
-	// GlueTable is the name of the Glue table used.
-	GlueTable string
-	// Partition is the AWS partition to use (default: aws).
-	Partition string
-}
-
 // ConfigureExternalAuditStorage attaches an IAM policy with necessary permissions
 // for the ExternalAuditStorage feature to an existing IAM role associated with an
 // AWS OIDC integration.
 func ConfigureExternalAuditStorage(
 	ctx context.Context,
 	clt ConfigureExternalAuditStorageClient,
-	params ExternalAuditStorageConfiguration,
+	params *easconfig.ExternalAuditStorageConfiguration,
 ) error {
 	fmt.Println("\nConfiguring necessary IAM permissions for External Audit Storage")
 

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 // ConfigureExternalAuditStorageClient is an interface for the AWS client methods
@@ -61,13 +60,38 @@ func (d *DefaultConfigureExternalAuditStorageClient) GetCallerIdentity(ctx conte
 	return d.Sts.GetCallerIdentity(ctx, input, opts...)
 }
 
+// ExternalAuditStorageConfiguration contains the arguments to configure the
+// External Audit Storage.
+type ExternalAuditStorageConfiguration struct {
+	// Region is the AWS Region used.
+	Region string
+	// Role is the AWS IAM Role associated with the OIDC integration.
+	Role string
+	// Policy is the name to use for the IAM policy.
+	Policy string
+	// SessionRecordingsURI is the S3 URI where session recordings are stored.
+	SessionRecordingsURI string
+	// AuditEventsURI is the S3 URI where audit events are stored.
+	AuditEventsURI string
+	// AthenaResultsURI is the S3 URI where temporary Athena results are stored.
+	AthenaResultsURI string
+	// AthenaWorkgroup is the name of the Athena workgroup used.
+	AthenaWorkgroup string
+	// GlueDatabase is the name of the Glue database used.
+	GlueDatabase string
+	// GlueTable is the name of the Glue table used.
+	GlueTable string
+	// Partition is the AWS partition to use (default: aws).
+	Partition string
+}
+
 // ConfigureExternalAuditStorage attaches an IAM policy with necessary permissions
 // for the ExternalAuditStorage feature to an existing IAM role associated with an
 // AWS OIDC integration.
 func ConfigureExternalAuditStorage(
 	ctx context.Context,
 	clt ConfigureExternalAuditStorageClient,
-	params *servicecfg.ExternalAuditStorageConfiguration,
+	params ExternalAuditStorageConfiguration,
 ) error {
 	fmt.Println("\nConfiguring necessary IAM permissions for External Audit Storage")
 

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 )
 
 // TestConfigureExternalAuditStorage tests that ConfigureExternalAuditStorage
@@ -40,7 +42,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc                 string
-		params               ExternalAuditStorageConfiguration
+		params               *easconfig.ExternalAuditStorageConfiguration
 		stsAccount           string
 		existingRolePolicies map[string]map[string]string
 		expectedRolePolicies map[string]map[string]string
@@ -49,7 +51,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		{
 			// A passing case with the account from sts:GetCallerIdentity
 			desc: "passing",
-			params: ExternalAuditStorageConfiguration{
+			params: &easconfig.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -129,7 +131,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "alternate partition and region",
-			params: ExternalAuditStorageConfiguration{
+			params: &easconfig.ExternalAuditStorageConfiguration{
 				Partition:            "aws-cn",
 				Region:               "cn-north-1",
 				Role:                 "test-role",
@@ -209,7 +211,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "bad uri",
-			params: ExternalAuditStorageConfiguration{
+			params: &easconfig.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -231,7 +233,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "role not found",
-			params: ExternalAuditStorageConfiguration{
+			params: &easconfig.ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "bad-role",

--- a/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
+++ b/lib/integrations/awsoidc/externalauditstorage_iam_config_test.go
@@ -30,8 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 // TestConfigureExternalAuditStorage tests that ConfigureExternalAuditStorage
@@ -42,7 +40,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc                 string
-		params               *servicecfg.ExternalAuditStorageConfiguration
+		params               ExternalAuditStorageConfiguration
 		stsAccount           string
 		existingRolePolicies map[string]map[string]string
 		expectedRolePolicies map[string]map[string]string
@@ -51,7 +49,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		{
 			// A passing case with the account from sts:GetCallerIdentity
 			desc: "passing",
-			params: &servicecfg.ExternalAuditStorageConfiguration{
+			params: ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -131,7 +129,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "alternate partition and region",
-			params: &servicecfg.ExternalAuditStorageConfiguration{
+			params: ExternalAuditStorageConfiguration{
 				Partition:            "aws-cn",
 				Region:               "cn-north-1",
 				Role:                 "test-role",
@@ -211,7 +209,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "bad uri",
-			params: &servicecfg.ExternalAuditStorageConfiguration{
+			params: ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "test-role",
@@ -233,7 +231,7 @@ func TestConfigureExternalAuditStorage(t *testing.T) {
 		},
 		{
 			desc: "role not found",
-			params: &servicecfg.ExternalAuditStorageConfiguration{
+			params: ExternalAuditStorageConfiguration{
 				Partition:            "aws",
 				Region:               "us-west-2",
 				Role:                 "bad-role",

--- a/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
+++ b/lib/integrations/externalauditstorage/easconfig/externalauditstroageconfig.go
@@ -1,20 +1,22 @@
 /*
-Copyright 2024 Gravitational, Inc.
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package servicecfg
+package easconfig
 
 // ExternalAuditStorageConfiguration contains the arguments to configure the
 // External Audit Storage.

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
+	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/openssh"
 	"github.com/gravitational/teleport/lib/service"
@@ -1058,7 +1059,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params config.ExternalAuditStorageConfiguration) error {
+func onIntegrationConfExternalAuditCmd(params easconfig.ExternalAuditStorageConfiguration) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {
@@ -1088,17 +1089,5 @@ func onIntegrationConfExternalAuditCmd(params config.ExternalAuditStorageConfigu
 		Iam: iam.NewFromConfig(cfg),
 		Sts: sts.NewFromConfig(cfg),
 	}
-	confExternalAuditStorageParams := awsoidc.ExternalAuditStorageConfiguration{
-		Region:               params.Region,
-		Role:                 params.Role,
-		Policy:               params.Policy,
-		SessionRecordingsURI: params.SessionRecordingsURI,
-		AuditEventsURI:       params.AuditEventsURI,
-		AthenaResultsURI:     params.AthenaResultsURI,
-		AthenaWorkgroup:      params.AthenaWorkgroup,
-		GlueDatabase:         params.GlueDatabase,
-		GlueTable:            params.GlueTable,
-		Partition:            params.Partition,
-	}
-	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, confExternalAuditStorageParams))
+	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, &params))
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1058,7 +1058,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 	return nil
 }
 
-func onIntegrationConfExternalAuditCmd(params servicecfg.ExternalAuditStorageConfiguration) error {
+func onIntegrationConfExternalAuditCmd(params config.ExternalAuditStorageConfiguration) error {
 	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {
@@ -1088,5 +1088,17 @@ func onIntegrationConfExternalAuditCmd(params servicecfg.ExternalAuditStorageCon
 		Iam: iam.NewFromConfig(cfg),
 		Sts: sts.NewFromConfig(cfg),
 	}
-	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, &params))
+	confExternalAuditStorageParams := awsoidc.ExternalAuditStorageConfiguration{
+		Region:               params.Region,
+		Role:                 params.Role,
+		Policy:               params.Policy,
+		SessionRecordingsURI: params.SessionRecordingsURI,
+		AuditEventsURI:       params.AuditEventsURI,
+		AthenaResultsURI:     params.AthenaResultsURI,
+		AthenaWorkgroup:      params.AthenaWorkgroup,
+		GlueDatabase:         params.GlueDatabase,
+		GlueTable:            params.GlueTable,
+		Partition:            params.Partition,
+	}
+	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, confExternalAuditStorageParams))
 }


### PR DESCRIPTION
Currently the ExternalAuditStorage methods require the `servicecfg` package to re-use the configuration struct used in `teleport integration configure`.

We are refactoring the AWS OIDC actions to use a gRPC Service. Importing the `sevicecfg` package makes this refactoring a bit difficult because of a cycling dependency: `awsoidc` requires `servicecfg` which requires `auth` which will require the `awsoidc service` which requires the `awsoidc` package.

This PR removes the usage of the `servicecfg` package in `awsoidc` package.

Context: https://github.com/gravitational/teleport/issues/37245