### PR TITLE
Update `cert-manager` instructions in Teleport cluster guides

### DIFF
--- a/assets/loadtest/control-plane/dns/init-cert-manager.sh
+++ b/assets/loadtest/control-plane/dns/init-cert-manager.sh
@@ -35,6 +35,7 @@ helm install cert-manager jetstack/cert-manager \
     --create-namespace \
     --namespace cert-manager \
     --set installCRDs=true \
+    --set global.leaderElection.namespace=cert-manager \
     --set extraArgs="{--issuer-ambient-credentials}" # required to automount ambient AWS credentials when using an Issuer
 
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -184,6 +184,7 @@ $ helm install cert-manager jetstack/cert-manager \
 --create-namespace \
 --namespace cert-manager \
 --set installCRDs=true \
+--set global.leaderElection.namespace=cert-manager \
 --set extraArgs="{--issuer-ambient-credentials}" # required to automount ambient AWS credentials when using an Issuer
 ```
 
@@ -338,11 +339,11 @@ podSecurityPolicy:
   enabled: false
 ```
 <Admonition type="note">
-If using an AWS PCA with cert-manager, you will need to 
+If using an AWS PCA with cert-manager, you will need to
 [ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
 `highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
-certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
-upload the full certificate chain to a secret, and 
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`),
+upload the full certificate chain to a secret, and
 [reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
 with `tls.existingCASecretName` in the values file.
 </Admonition>
@@ -428,11 +429,11 @@ podSecurityPolicy:
   enabled: false
 ```
 <Admonition type="note">
-If using an AWS PCA with cert-manager, you will need to 
+If using an AWS PCA with cert-manager, you will need to
 [ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
 `highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
-certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
-upload the full certificate chain to a secret, and 
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`),
+upload the full certificate chain to a secret, and
 [reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
 with `tls.existingCASecretName` in the values file.
 </Admonition>
@@ -449,7 +450,7 @@ aws:
   backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
   auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
   auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings 
+  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
   backups: true                                   # Whether or not to turn on DynamoDB backups
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -220,6 +220,7 @@ $ helm repo update
 $ helm install cert-manager jetstack/cert-manager \
 --create-namespace \
 --namespace cert-manager \
+--set global.leaderElection.namespace=cert-manager \
 --set installCRDs=true
 ```
 
@@ -318,7 +319,7 @@ highAvailability:
   certManager:
     enabled: true                                 # Enable cert-manager support to get TLS certificates
     issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
-    
+
 # If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
 podSecurityPolicy:
   enabled: false


### PR DESCRIPTION
This commit updates the `cert-manager` installation instructions to configure the `cert-manager` leader election to use `cert-manager` namespace instead of `kube-system`.

This is required because in GCP Autopilot clusters lock down access to `kube-system` and helm installation can't be successful.

By default, `cert-manager` uses `kube-system` as leader election to prevent multiple parallel installations of `cert-manager` in the same cluster, but if it's already running in the target cluster, the installation will fail with a non clear error. Given the above, it's preferred to use a separate namespace for leader election to prevent races.

Fixes #25312