### PR TITLE
chore: Bump Go toolchain to 1.22.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.21.6
+GOLANG_VERSION ?= go1.22.0
 
 NODE_VERSION ?= 18.18.2
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -1844,7 +1844,7 @@
       "major_version": "16",
       "version": "16.0.0-dev",
       "url": "teleport.example.com",
-      "golang": "1.21",
+      "golang": "1.22",
       "plugin": {
         "version": "13.3.7"
       },

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.21.6
+toolchain go1.22.0
 
 require (
 	cloud.google.com/go/compute v1.23.4

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -886,7 +886,11 @@ func newFakeIdentity(user string, devices ...*types.MFADevice) *fakeIdentity {
 }
 
 func (f *fakeIdentity) GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
-	return f.User.GetLocalAuth().MFA, nil
+	// Return a defensive copy, caller might modify the slice.
+	devices := f.User.GetLocalAuth().MFA
+	devicesCopy := make([]*types.MFADevice, len(devices))
+	copy(devicesCopy, devices)
+	return devicesCopy, nil
 }
 
 func (f *fakeIdentity) UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error {


### PR DESCRIPTION
Update the Go toolchain to the latest release.

* https://go.dev/doc/go1.22

Changelog: Updated Go to 1.22.0