### PR TITLE
[v12] chore: Bump Go to v1.20.14

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,7 +1,7 @@
 # Keep all tool versions in one place.
 # This file can be included in other Makefiles to avoid duplication.
 
-GOLANG_VERSION ?= go1.20.13
+GOLANG_VERSION ?= go1.20.14
 
 NODE_VERSION ?= 18.18.2
 


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.20.14

Changelog: Updated Go to 1.20.14