### PR TITLE
[v13] chore: Bump golangci-lint to v1.56.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport13
 
     env:
-      GOLANGCI_LINT_VERSION: v1.55.2
+      GOLANGCI_LINT_VERSION: v1.56.0
 
     steps:
       - name: Checkout

--- a/api/types/cluster_alert_test.go
+++ b/api/types/cluster_alert_test.go
@@ -122,14 +122,14 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 	expires := time.Now().Add(5 * time.Minute)
 
 	testcases := []struct {
-		desc        string
-		ack         *AlertAcknowledgement
-		expectedErr error
+		desc    string
+		ack     *AlertAcknowledgement
+		wantErr bool
 	}{
 		{
-			desc:        "empty",
-			ack:         &AlertAcknowledgement{},
-			expectedErr: &trace.BadParameterError{},
+			desc:    "empty",
+			ack:     &AlertAcknowledgement{},
+			wantErr: true,
 		},
 		{
 			desc: "missing reason",
@@ -137,7 +137,7 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 				AlertID: "alert-id",
 				Expires: expires,
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "missing alert ID",
@@ -145,7 +145,7 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 				Expires: expires,
 				Reason:  "some reason",
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "missing expiry",
@@ -153,7 +153,7 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 				AlertID: "alert-id",
 				Reason:  "some reason",
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "success",
@@ -162,7 +162,6 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 				Expires: expires,
 				Reason:  "some reason",
 			},
-			expectedErr: nil,
 		},
 	}
 
@@ -170,12 +169,15 @@ func TestAlertAcknowledgement_Check(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := tc.ack.Check()
 
-			if tc.expectedErr == nil {
-				require.Equal(t, err, nil)
+			if !tc.wantErr {
+				require.NoError(t, err)
 				return
 			}
 
-			require.ErrorAs(t, err, &tc.expectedErr)
+			require.Error(t, err)
+			require.True(t,
+				trace.IsBadParameter(err),
+				"want BadParameter, got %v (%T)", err, trace.Unwrap(err))
 		})
 	}
 }

--- a/api/types/integration_test.go
+++ b/api/types/integration_test.go
@@ -43,7 +43,7 @@ func TestIntegrationJSONMarshalCycle(t *testing.T) {
 	err = json.Unmarshal(bs, &ig2)
 	require.NoError(t, err)
 
-	require.Equal(t, ig, &ig2)
+	require.Equal(t, &ig2, ig)
 }
 
 func TestIntegrationCheckAndSetDefaults(t *testing.T) {

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -28,15 +28,15 @@ import (
 
 func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 	testcases := []struct {
-		desc        string
-		token       *ProvisionTokenV2
-		expected    *ProvisionTokenV2
-		expectedErr error
+		desc     string
+		token    *ProvisionTokenV2
+		expected *ProvisionTokenV2
+		wantErr  bool
 	}{
 		{
-			desc:        "empty",
-			token:       &ProvisionTokenV2{},
-			expectedErr: &trace.BadParameterError{},
+			desc:    "empty",
+			token:   &ProvisionTokenV2{},
+			wantErr: true,
 		},
 		{
 			desc: "missing roles",
@@ -45,7 +45,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					Name: "test",
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "invalid role",
@@ -57,7 +57,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					Roles: []SystemRole{RoleNode, "not a role"},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "simple token",
@@ -158,7 +158,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					JoinMethod: "ec2",
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "ec2 method with aws_arn",
@@ -177,7 +177,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "ec2 method empty rule",
@@ -191,7 +191,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					Allow:      []*TokenRule{{}},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "iam method",
@@ -237,7 +237,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "iam method with aws_regions",
@@ -256,7 +256,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "github valid",
@@ -316,7 +316,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "circleci valid",
@@ -353,7 +353,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "circleci and no org id",
@@ -373,7 +373,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "circleci allow rule blank",
@@ -391,7 +391,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "kubernetes: in_cluster defaults",
@@ -494,7 +494,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "kubernetes: missing static_jwks.jwks",
@@ -516,7 +516,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "kubernetes: wrong service account name",
@@ -536,7 +536,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "kubernetes: allow rule blank",
@@ -554,7 +554,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "gitlab empty allow rules",
@@ -570,7 +570,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "gitlab missing config",
@@ -584,7 +584,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					GitLab:     nil,
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "gitlab empty allow rule",
@@ -602,7 +602,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "gitlab defaults",
@@ -702,7 +702,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "spacelift",
@@ -759,7 +759,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "spacelift rule missing fields",
@@ -776,7 +776,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "spacelift missing hostname",
@@ -796,7 +796,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "spacelift incorrect hostname",
@@ -817,7 +817,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 		{
 			desc: "gcp method",
@@ -877,18 +877,22 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: &trace.BadParameterError{},
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := tc.token.CheckAndSetDefaults()
-			if tc.expectedErr != nil {
-				require.ErrorAs(t, err, &tc.expectedErr)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.True(t,
+					trace.IsBadParameter(err),
+					"want BadParameter, got %v (%T)", err, trace.Unwrap(err))
 				return
 			}
 			require.NoError(t, err)
+
 			if tc.expected != nil {
 				require.Equal(t, tc.expected, tc.token)
 			}

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -285,7 +285,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.12.1
 
 # Install golangci-lint.
-RUN VERSION='v1.55.2'; \
+RUN VERSION='v1.56.0'; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -2279,7 +2279,7 @@ func TestGetAndList_ApplicationServers(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err := clt.GetApplicationServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, len(servers))
+	require.Len(t, servers, 1)
 	require.Empty(t, cmp.Diff(testServers[0:1], servers))
 	resp, err := clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
@@ -2346,7 +2346,7 @@ func TestGetAndList_ApplicationServers(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err = clt.GetApplicationServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 0, len(servers))
+	require.Empty(t, servers)
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
 	require.Empty(t, resp.Resources)
@@ -2441,7 +2441,7 @@ func TestGetAndList_AppServersAndSAMLIdPServiceProviders(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err := clt.GetApplicationServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, len(servers))
+	require.Len(t, servers, 1)
 	require.Empty(t, cmp.Diff(testAppServers[0:1], servers))
 	resp, err := clt.ListResources(ctx, listRequestAppsOnly)
 	require.NoError(t, err)
@@ -2520,7 +2520,7 @@ func TestGetAndList_AppServersAndSAMLIdPServiceProviders(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err = clt.GetApplicationServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 0, len(servers))
+	require.Empty(t, servers)
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
 	require.Empty(t, resp.Resources)
@@ -3445,7 +3445,7 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 
 	desktops, err := clt.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
-	require.EqualValues(t, 1, len(desktops))
+	require.Len(t, desktops, 1)
 	require.Empty(t, cmp.Diff(testDesktops[0:1], desktops))
 
 	resp, err := clt.ListResources(ctx, listRequest)
@@ -3528,7 +3528,7 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 
 	desktops, err = clt.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
-	require.EqualValues(t, 0, len(desktops))
+	require.Empty(t, desktops)
 	require.Empty(t, cmp.Diff([]types.WindowsDesktop{}, desktops))
 
 	resp, err = clt.ListResources(ctx, listRequest)

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
@@ -67,10 +67,10 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 		require.Equal(t, "t", iamToken.GetName())
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
 		require.Len(t, iamToken.GetAllowRules(), 1)
-		require.Equal(t, iamToken.GetAllowRules()[0], &types.TokenRule{
+		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		})
+		}, iamToken.GetAllowRules()[0])
 	})
 
 	t.Run("when token exist but is missing the required allow rule and system role, it is updated", func(t *testing.T) {
@@ -102,10 +102,10 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 		require.Equal(t, "t", iamToken.GetName())
 		require.Len(t, iamToken.GetAllowRules(), 1)
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
-		require.Equal(t, iamToken.GetAllowRules()[0], &types.TokenRule{
+		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		})
+		}, iamToken.GetAllowRules()[0])
 	})
 
 	t.Run("when token exist but has an invalid join method, it returns an error", func(t *testing.T) {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -483,10 +483,12 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	// Verify changes to access list.
 	accessList1Updated, err := service.GetAccessList(ctx, accessList1.GetName())
 	require.NoError(t, err)
-	require.Equal(t, accessList1Updated.Spec.Audit.NextAuditDate,
+	require.Equal(t,
 		time.Date(accessList1OrigDate.Year(),
 			accessList1OrigDate.Month()+time.Month(accessList1Updated.Spec.Audit.Recurrence.Frequency),
-			int(accessList1Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC))
+			int(accessList1Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC),
+		accessList1Updated.Spec.Audit.NextAuditDate,
+	)
 	require.Empty(t, cmp.Diff(*(accessList1Review1.Spec.Changes.MembershipRequirementsChanged), accessList1Updated.Spec.MembershipRequires))
 	require.Equal(t, accessList1Review1.Spec.Changes.ReviewFrequencyChanged, accessList1Updated.Spec.Audit.Recurrence.Frequency)
 	require.Equal(t, accessList1Review1.Spec.Changes.ReviewDayOfMonthChanged, accessList1Updated.Spec.Audit.Recurrence.DayOfMonth)
@@ -505,10 +507,12 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	// Verify changes to the access list again.
 	accessList1Updated, err = service.GetAccessList(ctx, accessList1.GetName())
 	require.NoError(t, err)
-	require.Equal(t, accessList1Updated.Spec.Audit.NextAuditDate,
+	require.Equal(t,
 		time.Date(accessList1OrigDate.Year(),
 			accessList1OrigDate.Month()+time.Month(accessList1Updated.Spec.Audit.Recurrence.Frequency)*2,
-			int(accessList1Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC))
+			int(accessList1Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC),
+		accessList1Updated.Spec.Audit.NextAuditDate,
+	)
 
 	// Attempting to apply changes already reflected in the access list should modify the original review.
 	require.Nil(t, accessList1Review2.Spec.Changes.MembershipRequirementsChanged)
@@ -527,10 +531,12 @@ func TestAccessListReviewCRUD(t *testing.T) {
 
 	accessList2Updated, err := service.GetAccessList(ctx, accessList2.GetName())
 	require.NoError(t, err)
-	require.Equal(t, accessList2Updated.Spec.Audit.NextAuditDate,
+	require.Equal(t,
 		time.Date(accessList2OrigDate.Year(),
 			accessList2OrigDate.Month()+time.Month(accessList2Updated.Spec.Audit.Recurrence.Frequency),
-			int(accessList2Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC))
+			int(accessList2Updated.Spec.Audit.Recurrence.DayOfMonth), 0, 0, 0, 0, time.UTC),
+		accessList2Updated.Spec.Audit.NextAuditDate,
+	)
 	require.Empty(t, cmp.Diff(accessList2.Spec.MembershipRequires, accessList2Updated.Spec.MembershipRequires))
 	require.Equal(t, accessList2.Spec.Audit.Recurrence.Frequency, accessList2Updated.Spec.Audit.Recurrence.Frequency)
 	require.Equal(t, accessList2.Spec.Audit.Recurrence.DayOfMonth, accessList2Updated.Spec.Audit.Recurrence.DayOfMonth)

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -409,7 +409,7 @@ func TestNodeCRUD(t *testing.T) {
 			// Get all nodes, transparently handle limit exceeded errors
 			nodes, err := presence.GetNodes(ctx, apidefaults.Namespace)
 			require.NoError(t, err)
-			require.EqualValues(t, len(nodes), 2)
+			require.Len(t, nodes, 2)
 			require.Empty(t, cmp.Diff([]types.Server{node1, node2}, nodes,
 				cmpopts.IgnoreFields(types.Metadata{}, "ID")))
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -750,7 +750,7 @@ func TestRoleParse(t *testing.T) {
 
 				role2, err := UnmarshalRole(out)
 				require.NoError(t, err)
-				require.Equal(t, role2, &tc.role)
+				require.Equal(t, &tc.role, role2)
 			}
 		})
 	}

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -154,7 +154,7 @@ func TestServerDeepCopy(t *testing.T) {
 
 	// verify
 	require.Empty(t, cmp.Diff(srv, srv2))
-	require.IsType(t, srv2, &types.ServerV2{})
+	require.IsType(t, &types.ServerV2{}, srv2)
 
 	// Mutate the second value but expect the original to be unaffected
 	srv2.(*types.ServerV2).Metadata.Labels["foo"] = "bar"

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -218,7 +218,7 @@ func TestDiscoveryServer(t *testing.T) {
 			emitter: &mockEmitter{
 				eventHandler: func(t *testing.T, ae events.AuditEvent, server *Server) {
 					t.Helper()
-					require.Equal(t, ae, &events.SSMRun{
+					require.Equal(t, &events.SSMRun{
 						Metadata: events.Metadata{
 							Type: libevents.SSMRunEvent,
 							Code: libevents.SSMRunSuccessCode,
@@ -229,7 +229,7 @@ func TestDiscoveryServer(t *testing.T) {
 						Region:     "eu-central-1",
 						ExitCode:   0,
 						Status:     ssm.CommandStatusSuccess,
-					})
+					}, ae)
 				},
 			},
 			wantInstalledInstances: []string{"instance-id-1"},

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -30,7 +30,9 @@ func TestRejectsInvalidPEMData(t *testing.T) {
 	t.Parallel()
 
 	_, err := ReadCertificates([]byte("no data"))
-	require.IsType(t, trace.Unwrap(err), &trace.NotFoundError{})
+	require.True(t,
+		trace.IsNotFound(err),
+		"want trace.NotFoundError, got %v (%T)", err, trace.Unwrap(err))
 }
 
 func TestRejectsSelfSignedCertificate(t *testing.T) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6711,9 +6711,9 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 					}
 
 					foundTrace = true
-					require.Equal(t, returnedTrace.Status, expectedTrace.Status.String())
-					require.Equal(t, returnedTrace.Details, expectedTrace.Details)
-					require.Contains(t, returnedTrace.Error, expectedTrace.Error)
+					require.Equal(t, expectedTrace.Status.String(), returnedTrace.Status)
+					require.Equal(t, expectedTrace.Details, returnedTrace.Details)
+					require.Contains(t, expectedTrace.Error, returnedTrace.Error)
 				}
 
 				require.True(t, foundTrace, expectedTrace)

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -393,7 +393,7 @@ func TestHandleDatabaseServicesGet(t *testing.T) {
 	require.Len(t, respDBService.ResourceMatchers, 1)
 	respResourceMatcher := respDBService.ResourceMatchers[0]
 
-	require.Equal(t, respResourceMatcher.Labels, &types.Labels{"env": []string{"prod"}})
+	require.Equal(t, &types.Labels{"env": []string{"prod"}}, respResourceMatcher.Labels)
 }
 
 func mustCreateDatabaseServer(t *testing.T, db *types.DatabaseV3) types.DatabaseServer {

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -279,13 +279,13 @@ version: v2
 	require.Nil(t, err)
 
 	item, err := ui.NewResourceItem(cluster)
-	require.Nil(t, err)
-	require.Equal(t, item, &ui.ResourceItem{
+	require.NoError(t, err)
+	require.Equal(t, &ui.ResourceItem{
 		ID:      "trusted_cluster:tcName",
 		Kind:    types.KindTrustedCluster,
 		Name:    "tcName",
 		Content: contents,
-	})
+	}, item)
 }
 
 func TestGetRoles(t *testing.T) {

--- a/lib/web/servers_test.go
+++ b/lib/web/servers_test.go
@@ -154,15 +154,15 @@ func TestCreateNode(t *testing.T) {
 			node, err := env.proxies[0].client.GetNode(ctx, "default", tt.req.Name)
 			require.NoError(t, err)
 
-			require.Equal(t, node.GetName(), tt.req.Name)
-			require.Equal(t, node.GetAWSInfo(), &types.AWSInfo{
+			require.Equal(t, tt.req.Name, node.GetName())
+			require.Equal(t, &types.AWSInfo{
 				AccountID:   tt.req.AWSInfo.AccountID,
 				InstanceID:  tt.req.AWSInfo.InstanceID,
 				Region:      tt.req.AWSInfo.Region,
 				VPCID:       tt.req.AWSInfo.VPCID,
 				Integration: tt.req.AWSInfo.Integration,
 				SubnetID:    tt.req.AWSInfo.SubnetID,
-			})
+			}, node.GetAWSInfo())
 		}
 	})
 


### PR DESCRIPTION
Backport #37854 to branch/v13.

Update golangci-lint to the latest version.

* https://github.com/golangci/golangci-lint/releases/tag/v1.56.0