### PR TITLE
Fix data race in lib/client tests

### DIFF
--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -259,7 +259,6 @@ func newTestListener(t *testing.T, handle func(net.Conn)) net.Listener {
 		for {
 			con, err := l.Accept()
 			if err != nil {
-				t.Logf("listener error: %v", err)
 				return
 			}
 			go handle(con)


### PR DESCRIPTION
newTestListener would call (*testing.T).Log when the Accept call fails. This resulted in racy behavior due to the log sometimes happening after the test completes (it's normal for accept to return an error after the listener is closed, which we do on test cleanup).