### PR TITLE
Fix panic when `TLSServer.Close()` is invoked before `TLSServer.Serve()`

### DIFF
--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 func TestServeConfigureError(t *testing.T) {
-	srv := &TLSServer{Server: &http.Server{TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12, CipherSuites: []uint16{}}}}
+	srv := &TLSServer{Server: &http.Server{TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12, CipherSuites: []uint16{}}}, closeContext: context.Background()}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()


### PR DESCRIPTION
This PR prevents a panic when the `TLSServer` is closed before the `Serve` function is called. This happens in special situations during tests when something else failed causing the test to fail which triggers the cleanup function.
If the cleanup function executes before `Serve` goroutine is executed, the listener is nil which triggers the panic.

Part of #37884