### PR TITLE
Use the correct timestamp for the last resource presence report

### DIFF
--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -379,7 +379,7 @@ Ingest:
 	}
 
 	if len(resourcePresences) > 0 {
-		r.persistResourcePresence(ctx, userActivityStartTime, resourcePresences)
+		r.persistResourcePresence(ctx, resourceUsageStartTime, resourcePresences)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
We're currently using the user activity timestamp instead of the resource presence timestamp when persisting data before the auth server shutdown; this PR fixes that.

This issue manifests as a small amount of resource presence events with a timestamp aligned to the quarter hour (like user activity reports). Thankfully, truncating the timestamp to the start of the hour when processing the data is correct.