### PR TITLE
TAG: Poll AWS Users, Roles, and Groups

### DIFF
--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -1,0 +1,198 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+	"github.com/gravitational/teleport/lib/cloud"
+)
+
+// pageSize is the default page size to use when fetching AWS resources
+// from the AWS API for endpoints that support pagination.
+const pageSize int64 = 500
+
+// Config is the configuration for the AWS fetcher.
+type Config struct {
+	// CloudClients is the cloud clients to use when fetching AWS resources.
+	CloudClients cloud.Clients
+	// AccountID is the AWS account ID to use when fetching resources.
+	AccountID string
+	// Regions is the list of AWS regions to fetch resources from.
+	Regions []string
+	// AssumeRole is the configuration for assuming an AWS role.
+	AssumeRole *AssumeRole
+	// Integration is the name of the AWS integration to use when fetching resources.
+	Integration string
+}
+
+// AssumeRole is the configuration for assuming an AWS role.
+type AssumeRole struct {
+	// RoleARN is the ARN of the role to assume.
+	RoleARN string
+	// ExternalID is the external ID to use when assuming the role.
+	ExternalID string
+}
+
+// awsFetcher is a fetcher that fetches AWS resources.
+type awsFetcher struct {
+	Config
+}
+
+// AWSSync is the interface for fetching AWS resources.
+type AWSSync interface {
+	// Poll polls all AWS resources and returns the result.
+	Poll(ctx context.Context) (*Resources, error)
+}
+
+// Resources is a collection of polled AWS resources.
+type Resources struct {
+	// Users is the list of AWS users.
+	Users []*accessgraphv1alpha.AWSUserV1
+	// UserInlinePolicies is the list of inline policies configured for AWS users.
+	UserInlinePolicies []*accessgraphv1alpha.AWSUserInlinePolicyV1
+	// UserAttachedPolicies is the list of attached policies configured for AWS users.
+	// This is a User ARN -> Policy ARN mapping and the policy document is included
+	// in Policies.
+	UserAttachedPolicies []*accessgraphv1alpha.AWSUserAttachedPolicies
+	// UserGroups is the list of groups that AWS users are members of.
+	UserGroups []*accessgraphv1alpha.AWSUserGroupsV1
+	// Groups is the list of AWS groups.
+	Groups []*accessgraphv1alpha.AWSGroupV1
+	// GroupInlinePolicies is the list of inline policies configured for AWS groups.
+	GroupInlinePolicies []*accessgraphv1alpha.AWSGroupInlinePolicyV1
+	// GroupAttachedPolicies is the list of attached policies configured for AWS groups.
+	// This is a Group ARN -> Policy ARN mapping and the policy document is included
+	GroupAttachedPolicies []*accessgraphv1alpha.AWSGroupAttachedPolicies
+	// Instances is the list of AWS EC2 instances.
+	Instances []*accessgraphv1alpha.AWSInstanceV1
+	// Policies is the list of AWS IAM policies and their policy documents.
+	Policies []*accessgraphv1alpha.AWSPolicyV1
+	// S3Buckets is the list of AWS S3 buckets.
+	S3Buckets []*accessgraphv1alpha.AWSS3BucketV1
+	// Roles is the list of AWS IAM roles.
+	Roles []*accessgraphv1alpha.AWSRoleV1
+	// RoleInlinePolicies is the list of inline policies configured for AWS roles.
+	RoleInlinePolicies []*accessgraphv1alpha.AWSRoleInlinePolicyV1
+	// RoleAttachedPolicies is the list of attached policies configured for AWS roles.
+	// This is a Role ARN -> Policy ARN mapping and the policy document is included
+	RoleAttachedPolicies []*accessgraphv1alpha.AWSRoleAttachedPolicies
+	// InstanceProfiles is the list of AWS IAM instance profiles.
+	InstanceProfiles []*accessgraphv1alpha.AWSInstanceProfileV1
+}
+
+// NewAWSFetcher creates a new AWS fetcher.
+func NewAWSFetcher(ctx context.Context, cfg Config) (AWSSync, error) {
+	a := &awsFetcher{
+		Config: cfg,
+	}
+	accountID, err := a.getAccountId(context.Background())
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to get AWS account ID")
+	}
+	a.AccountID = accountID
+	return a, nil
+}
+
+// Poll retrieves all AWS resources and returns the result.
+// Poll is a blocking call and will return when all resources have been fetched.
+// It's possible that the call returns Resources and an error at the same time
+// if some resources were fetched successfully and some were not.
+func (a *awsFetcher) Poll(ctx context.Context) (*Resources, error) {
+	result, err := a.poll(ctx)
+	return result, trace.Wrap(err)
+}
+
+func (a *awsFetcher) poll(ctx context.Context) (*Resources, error) {
+	eGroup, ctx := errgroup.WithContext(ctx)
+	eGroup.SetLimit(5)
+	var (
+		errs   []error
+		errMu  sync.Mutex
+		result = &Resources{}
+	)
+	// collectErr collects an error and adds it to the list of errors.
+	// errors are collected in parallel and are not returned until all
+	// resources have been fetched.
+	collectErr := func(err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		errs = append(errs, err)
+	}
+
+	// fetch AWS users and their associated resources.
+	// - inline policies
+	// - attached policies
+	// - user groups they are members of
+	eGroup.Go(a.pollAWSUsers(ctx, result, collectErr))
+
+	// fetch AWS groups and their associated resources.
+	// - inline policies
+	// - attached policies
+	eGroup.Go(a.pollAWSRoles(ctx, result, collectErr))
+
+	// fetch AWS groups and their associated resources.
+	// - inline policies
+	// - attached policies
+	eGroup.Go(a.pollAWSGroups(ctx, result, collectErr))
+
+	if err := eGroup.Wait(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return result, trace.NewAggregate(errs...)
+}
+
+// getAWSOptions returns a list of AWSAssumeRoleOptionFn to be used when
+// creating AWS clients.
+func (a *awsFetcher) getAWSOptions() []cloud.AWSAssumeRoleOptionFn {
+	opts := []cloud.AWSAssumeRoleOptionFn{
+		cloud.WithCredentialsMaybeIntegration(a.Config.Integration),
+	}
+
+	if a.Config.AssumeRole != nil {
+		opts = append(opts, cloud.WithAssumeRole(a.Config.AssumeRole.RoleARN, a.Config.AssumeRole.ExternalID))
+	}
+	return opts
+}
+
+func (a *awsFetcher) getAccountId(ctx context.Context) (string, error) {
+	stsClient, err := a.CloudClients.GetAWSSTSClient(
+		ctx,
+		"", /* region is empty because groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	input := &sts.GetCallerIdentityInput{}
+	req, err := stsClient.GetCallerIdentityWithContext(ctx, input)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return aws.StringValue(req.Account), nil
+}

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -128,6 +128,9 @@ func (a *awsFetcher) Poll(ctx context.Context) (*Resources, error) {
 
 func (a *awsFetcher) poll(ctx context.Context) (*Resources, error) {
 	eGroup, ctx := errgroup.WithContext(ctx)
+	// Set the limit for the number of concurrent pollers running in parallel.
+	// This is to prevent the number of concurrent pollers from growing too large
+	// and causing the AWS API to throttle requests.
 	eGroup.SetLimit(5)
 	var (
 		errs   []error

--- a/lib/srv/discovery/fetchers/aws-sync/groups.go
+++ b/lib/srv/discovery/fetchers/aws-sync/groups.go
@@ -42,6 +42,10 @@ func (a *awsFetcher) pollAWSGroups(ctx context.Context, result *Resources, colle
 		}
 
 		eG, ctx := errgroup.WithContext(ctx)
+		// Limit the number of concurrent goroutines to avoid overwhelming the AWS API.
+		// These goroutines are fetching inline and attached policies for each group.
+		// We also have other goroutines fetching inline and attached policies for users
+		// and roles.
 		eG.SetLimit(10)
 		groupsMu := sync.Mutex{}
 		for _, group := range result.Groups {

--- a/lib/srv/discovery/fetchers/aws-sync/groups.go
+++ b/lib/srv/discovery/fetchers/aws-sync/groups.go
@@ -1,0 +1,205 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSGroups is a function that returns a function that fetches
+// AWS groups and their inline and attached policies.
+func (a *awsFetcher) pollAWSGroups(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+		result.Groups, err = a.fetchGroups(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch groups"))
+			return nil
+		}
+
+		eG, ctx := errgroup.WithContext(ctx)
+		eG.SetLimit(10)
+		groupsMu := sync.Mutex{}
+		for _, group := range result.Groups {
+			group := group
+			eG.Go(func() error {
+				groupInlinePolicies, err := a.fetchGroupInlinePolicies(ctx, group)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch group %q inline policies", group.Name))
+				}
+
+				groupAttachedPolicies, err := a.fetchGroupAttachedPolicies(ctx, group)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch group %q attached policies", group.Name))
+				}
+
+				groupsMu.Lock()
+				if groupAttachedPolicies != nil {
+					result.GroupAttachedPolicies = append(result.GroupAttachedPolicies, groupAttachedPolicies)
+				}
+				result.GroupInlinePolicies = append(result.GroupInlinePolicies, groupInlinePolicies...)
+				groupsMu.Unlock()
+				return nil
+			})
+		}
+
+		_ = eG.Wait()
+
+		return nil
+	}
+}
+
+// fetchGroups fetches AWS groups and returns them as a slice of accessgraphv1alpha.AWSGroupV1.
+// It uses ListGroupsPagesWithContext to iterate over all groups.
+func (a *awsFetcher) fetchGroups(ctx context.Context) ([]*accessgraphv1alpha.AWSGroupV1, error) {
+	var groups []*accessgraphv1alpha.AWSGroupV1
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListGroupsPagesWithContext(ctx, &iam.ListGroupsInput{
+		MaxItems: aws.Int64(pageSize),
+	},
+		func(page *iam.ListGroupsOutput, lastPage bool) bool {
+			for _, group := range page.Groups {
+				groups = append(groups, awsGroupToProtoGroup(group, a.AccountID))
+			}
+			return !lastPage
+		},
+	)
+
+	return groups, trace.Wrap(err)
+}
+
+// awsGroupToProtoGroup converts an AWS IAM group to a proto group.
+func awsGroupToProtoGroup(group *iam.Group, accountID string) *accessgraphv1alpha.AWSGroupV1 {
+	return &accessgraphv1alpha.AWSGroupV1{
+		Name:      aws.ToString(group.GroupName),
+		Arn:       aws.ToString(group.Arn),
+		Path:      aws.ToString(group.Path),
+		GroupId:   aws.ToString(group.GroupId),
+		CreatedAt: awsTimeToProtoTime(group.CreateDate),
+		AccountId: accountID,
+	}
+}
+
+// fetchGroupInlinePolicies fetches inline policies for a group and returns them
+// as a slice of accessgraphv1alpha.AWSGroupInlinePolicyV1.
+// It uses ListGroupPoliciesPagesWithContext to iterate over all inline policies
+// associated with the group.
+func (a *awsFetcher) fetchGroupInlinePolicies(ctx context.Context, group *accessgraphv1alpha.AWSGroupV1) ([]*accessgraphv1alpha.AWSGroupInlinePolicyV1, error) {
+	var policies []*accessgraphv1alpha.AWSGroupInlinePolicyV1
+	var errs []error
+	errCollect := func(err error) {
+		errs = append(errs, err)
+	}
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = iamClient.ListGroupPoliciesPagesWithContext(
+		ctx,
+		&iam.ListGroupPoliciesInput{
+			GroupName: aws.String(group.Name),
+			MaxItems:  aws.Int64(pageSize),
+		},
+		func(page *iam.ListGroupPoliciesOutput, lastPage bool) bool {
+			for _, policyName := range page.PolicyNames {
+				policy, err := iamClient.GetGroupPolicyWithContext(ctx, &iam.GetGroupPolicyInput{
+					GroupName:  aws.String(group.Name),
+					PolicyName: policyName,
+				})
+				if err != nil {
+					errCollect(trace.Wrap(err, "failed to fetch group %q inline policy %q", group.Name, *policyName))
+					continue
+				}
+				policies = append(policies, awsGroupPolicyToProtoGroupPolicy(policy, a.AccountID, group))
+			}
+			return !lastPage
+		},
+	)
+
+	return policies, trace.Wrap(err)
+}
+
+func awsGroupPolicyToProtoGroupPolicy(policy *iam.GetGroupPolicyOutput, accountID string, group *accessgraphv1alpha.AWSGroupV1) *accessgraphv1alpha.AWSGroupInlinePolicyV1 {
+	return &accessgraphv1alpha.AWSGroupInlinePolicyV1{
+		PolicyName:     aws.ToString(policy.PolicyName),
+		PolicyDocument: []byte(aws.ToString(policy.PolicyDocument)),
+		Group:          group,
+		AccountId:      accountID,
+	}
+}
+
+// fetchGroupAttachedPolicies fetches attached policies for a group.
+func (a *awsFetcher) fetchGroupAttachedPolicies(ctx context.Context, group *accessgraphv1alpha.AWSGroupV1) (*accessgraphv1alpha.AWSGroupAttachedPolicies, error) {
+	rsp := &accessgraphv1alpha.AWSGroupAttachedPolicies{
+		Group:     group,
+		AccountId: a.AccountID,
+	}
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListAttachedGroupPoliciesPagesWithContext(
+		ctx,
+		&iam.ListAttachedGroupPoliciesInput{
+			GroupName: aws.String(group.Name),
+			MaxItems:  aws.Int64(pageSize),
+		},
+		func(page *iam.ListAttachedGroupPoliciesOutput, lastPage bool) bool {
+			for _, policy := range page.AttachedPolicies {
+				rsp.Policies = append(
+					rsp.Policies,
+					&accessgraphv1alpha.AttachedPolicyV1{
+						Arn:        aws.ToString(policy.PolicyArn),
+						PolicyName: aws.ToString(policy.PolicyName),
+					},
+				)
+			}
+			return !lastPage
+		},
+	)
+
+	return rsp, trace.Wrap(err)
+}

--- a/lib/srv/discovery/fetchers/aws-sync/roles.go
+++ b/lib/srv/discovery/fetchers/aws-sync/roles.go
@@ -1,0 +1,236 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSRoles is a function that returns a function that fetches
+// AWS roles and their inline and attached policies.
+func (a *awsFetcher) pollAWSRoles(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+
+		result.Roles, err = a.fetchRoles(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch roles"))
+			return nil
+		}
+
+		eG, ctx := errgroup.WithContext(ctx)
+		eG.SetLimit(10)
+		roleMu := sync.Mutex{}
+		for _, role := range result.Roles {
+			role := role
+			eG.Go(func() error {
+				roleInlinePolicies, err := a.fetchRoleInlinePolicies(ctx, role)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch role %q inline policies", role.Name))
+				}
+
+				roleAttachedPolicies, err := a.fetchRoleAttachedPolicies(ctx, role)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch role %q attached policies", role.Name))
+				}
+
+				roleMu.Lock()
+				result.RoleInlinePolicies = append(result.RoleInlinePolicies, roleInlinePolicies...)
+				if roleAttachedPolicies != nil {
+					result.RoleAttachedPolicies = append(result.RoleAttachedPolicies, roleAttachedPolicies)
+				}
+				roleMu.Unlock()
+				return nil
+			})
+		}
+		_ = eG.Wait()
+		return nil
+	}
+}
+
+// fetchRoles fetches AWS roles and returns them as a slice of accessgraphv1alpha.AWSRoleV1.
+func (a *awsFetcher) fetchRoles(ctx context.Context) ([]*accessgraphv1alpha.AWSRoleV1, error) {
+	var roles []*accessgraphv1alpha.AWSRoleV1
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because roles are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListRolesPagesWithContext(ctx, &iam.ListRolesInput{
+		MaxItems: aws.Int64(pageSize),
+	},
+		func(page *iam.ListRolesOutput, lastPage bool) bool {
+			for _, role := range page.Roles {
+				roles = append(roles, awsRoleToProtoRole(role, a.AccountID))
+			}
+			return !lastPage
+		},
+	)
+
+	return roles, trace.Wrap(err)
+}
+
+// fetchRoleInlinePolicies fetches inline policies for an AWS role and returns
+// them as a slice of accessgraphv1alpha.AWSRoleInlinePolicyV1.
+// It uses iam.ListRolePoliciesPagesWithContext to iterate over all inline policies
+// and iam.GetRolePolicyWithContext to fetch policy documents.
+func (a *awsFetcher) fetchRoleInlinePolicies(ctx context.Context, role *accessgraphv1alpha.AWSRoleV1) ([]*accessgraphv1alpha.AWSRoleInlinePolicyV1, error) {
+	var policies []*accessgraphv1alpha.AWSRoleInlinePolicyV1
+	var errs []error
+	errCollect := func(err error) {
+		errs = append(errs, err)
+	}
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = iamClient.ListRolePoliciesPagesWithContext(
+		ctx,
+		&iam.ListRolePoliciesInput{
+			RoleName: aws.String(role.Name),
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListRolePoliciesOutput, lastPage bool) bool {
+			for _, policyName := range page.PolicyNames {
+				policy, err := iamClient.GetRolePolicyWithContext(ctx, &iam.GetRolePolicyInput{
+					RoleName:   aws.String(role.Name),
+					PolicyName: policyName,
+				})
+				if err != nil {
+					errCollect(trace.Wrap(err, "failed to fetch user %q inline policy %q", role.Name, *policyName))
+					continue
+				}
+
+				policies = append(policies, awsRolePolicyToProtoUserPolicy(policy, role, a.AccountID))
+			}
+			return !lastPage
+		})
+
+	return policies, trace.NewAggregate(append(errs, err)...)
+}
+
+// fetchRoleAttachedPolicies fetches attached policies for an AWS role.
+func (a *awsFetcher) fetchRoleAttachedPolicies(ctx context.Context, role *accessgraphv1alpha.AWSRoleV1) (*accessgraphv1alpha.AWSRoleAttachedPolicies, error) {
+	rsp := &accessgraphv1alpha.AWSRoleAttachedPolicies{
+		AwsRole:   role,
+		AccountId: a.AccountID,
+	}
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListAttachedRolePoliciesPagesWithContext(
+		ctx,
+		&iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(role.Name),
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
+			for _, policy := range page.AttachedPolicies {
+				rsp.Policies = append(
+					rsp.Policies,
+					&accessgraphv1alpha.AttachedPolicyV1{
+						Arn:        aws.ToString(policy.PolicyArn),
+						PolicyName: aws.ToString(policy.PolicyName),
+					},
+				)
+			}
+			return !lastPage
+		},
+	)
+
+	return rsp, trace.Wrap(err)
+}
+
+// awsRoleToProtoRole converts an AWS IAM Role to a proto Role.
+func awsRoleToProtoRole(role *iam.Role, accountID string) *accessgraphv1alpha.AWSRoleV1 {
+	tags := make([]*accessgraphv1alpha.AWSTag, 0, len(role.Tags))
+	for _, tag := range role.Tags {
+		tags = append(tags, &accessgraphv1alpha.AWSTag{
+			Key:   aws.ToString(tag.Key),
+			Value: strPtrToWrapper(tag.Value),
+		})
+	}
+
+	var permissionsBoundary *accessgraphv1alpha.RolePermissionsBoundaryV1
+
+	if role.PermissionsBoundary != nil {
+		permissionsBoundary = &accessgraphv1alpha.RolePermissionsBoundaryV1{
+			PermissionsBoundaryArn:  aws.ToString(role.PermissionsBoundary.PermissionsBoundaryArn),
+			PermissionsBoundaryType: accessgraphv1alpha.RolePermissionsBoundaryType_ROLE_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY,
+		}
+	}
+
+	var lastTimeUsed *accessgraphv1alpha.RoleLastUsedV1
+	if role.RoleLastUsed != nil {
+		lastTimeUsed = &accessgraphv1alpha.RoleLastUsedV1{
+			LastUsedDate: awsTimeToProtoTime(role.RoleLastUsed.LastUsedDate),
+			Region:       aws.ToString(role.RoleLastUsed.Region),
+		}
+	}
+
+	return &accessgraphv1alpha.AWSRoleV1{
+		Name:                     aws.ToString(role.RoleName),
+		Arn:                      aws.ToString(role.Arn),
+		AssumeRolePolicyDocument: strPtrToByteSlice(role.AssumeRolePolicyDocument),
+		Path:                     aws.ToString(role.Path),
+		Description:              aws.ToString(role.Description),
+		MaxSessionDuration:       durationpb.New(time.Duration(aws.ToInt64(role.MaxSessionDuration)) * time.Second),
+		RoleId:                   aws.ToString(role.RoleId),
+		CreatedAt:                awsTimeToProtoTime(role.CreateDate),
+		AccountId:                accountID,
+		RoleLastUsed:             lastTimeUsed,
+		Tags:                     tags,
+		PermissionsBoundary:      permissionsBoundary,
+	}
+}
+
+func awsRolePolicyToProtoUserPolicy(policy *iam.GetRolePolicyOutput, role *accessgraphv1alpha.AWSRoleV1, accountID string) *accessgraphv1alpha.AWSRoleInlinePolicyV1 {
+	return &accessgraphv1alpha.AWSRoleInlinePolicyV1{
+		PolicyName:     aws.ToString(policy.PolicyName),
+		PolicyDocument: []byte(aws.ToString(policy.PolicyDocument)),
+		AwsRole:        role,
+		AccountId:      accountID,
+	}
+}

--- a/lib/srv/discovery/fetchers/aws-sync/roles.go
+++ b/lib/srv/discovery/fetchers/aws-sync/roles.go
@@ -45,6 +45,10 @@ func (a *awsFetcher) pollAWSRoles(ctx context.Context, result *Resources, collec
 		}
 
 		eG, ctx := errgroup.WithContext(ctx)
+		// Limit the number of concurrent goroutines to avoid overwhelming the AWS API.
+		// These goroutines are fetching inline and attached policies for each group.
+		// We also have other goroutines fetching inline and attached policies for users
+		// and roles.
 		eG.SetLimit(10)
 		roleMu := sync.Mutex{}
 		for _, role := range result.Roles {

--- a/lib/srv/discovery/fetchers/aws-sync/users.go
+++ b/lib/srv/discovery/fetchers/aws-sync/users.go
@@ -43,6 +43,10 @@ func (a *awsFetcher) pollAWSUsers(ctx context.Context, result *Resources, collec
 		}
 
 		eG, ctx := errgroup.WithContext(ctx)
+		// Limit the number of concurrent goroutines to avoid overwhelming the AWS API.
+		// These goroutines are fetching inline and attached policies for each group.
+		// We also have other goroutines fetching inline and attached policies for users
+		// and roles.
 		eG.SetLimit(10)
 		usersMu := sync.Mutex{}
 		// fetch user inline policies, attached policies, and groups in parallel

--- a/lib/srv/discovery/fetchers/aws-sync/users.go
+++ b/lib/srv/discovery/fetchers/aws-sync/users.go
@@ -1,0 +1,265 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSUsers is a function that returns a function that fetches
+// AWS users and their inline and attached policies, and groups.
+func (a *awsFetcher) pollAWSUsers(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+
+		result.Users, err = a.fetchUsers(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch users"))
+			return nil
+		}
+
+		eG, ctx := errgroup.WithContext(ctx)
+		eG.SetLimit(10)
+		usersMu := sync.Mutex{}
+		// fetch user inline policies, attached policies, and groups in parallel
+		// and collect the results.
+		for _, user := range result.Users {
+			user := user
+			eG.Go(func() error {
+				userInlinePolicies, err := a.fetchUserInlinePolicies(ctx, user)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch user %q inline policies", user.UserName))
+				}
+
+				userAttachedPolicies, err := a.fetchUserAttachedPolicies(ctx, user)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch user %q attached policies", user.UserName))
+				}
+
+				userGroups, err := a.fetchGroupsForUser(ctx, user)
+				if err != nil {
+					collectErr(trace.Wrap(err, "failed to fetch user %q groups", user.UserName))
+				}
+
+				usersMu.Lock()
+				result.UserInlinePolicies = append(result.UserInlinePolicies, userInlinePolicies...)
+				if userAttachedPolicies != nil {
+					result.UserAttachedPolicies = append(result.UserAttachedPolicies, userAttachedPolicies)
+				}
+				if userGroups != nil {
+					result.UserGroups = append(result.UserGroups, userGroups)
+				}
+				usersMu.Unlock()
+				return nil
+			})
+		}
+		// always discard the error
+		_ = eG.Wait()
+		return nil
+	}
+}
+
+// fetchUsers fetches AWS users and returns them as a slice of accessgraphv1alpha.AWSUserV1.
+// It uses iam.ListUsersPagesWithContext to iterate over all users.
+func (a *awsFetcher) fetchUsers(ctx context.Context) ([]*accessgraphv1alpha.AWSUserV1, error) {
+	var users []*accessgraphv1alpha.AWSUserV1
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListUsersPagesWithContext(ctx, &iam.ListUsersInput{
+		MaxItems: aws.Int64(pageSize),
+	},
+		func(page *iam.ListUsersOutput, lastPage bool) bool {
+			for _, user := range page.Users {
+				users = append(users, awsUserToProtoUser(user, a.AccountID))
+			}
+			return !lastPage
+		},
+	)
+
+	return users, trace.Wrap(err)
+}
+
+// awsUserToProtoUser converts an AWS IAM user to a proto user.
+func awsUserToProtoUser(user *iam.User, accountID string) *accessgraphv1alpha.AWSUserV1 {
+	tags := make([]*accessgraphv1alpha.AWSTag, 0, len(user.Tags))
+	for _, tag := range user.Tags {
+		tags = append(tags, &accessgraphv1alpha.AWSTag{
+			Key:   aws.ToString(tag.Key),
+			Value: strPtrToWrapper(tag.Value),
+		})
+	}
+
+	var permissionsBoundary *accessgraphv1alpha.UsersPermissionsBoundaryV1
+
+	if user.PermissionsBoundary != nil {
+		permissionsBoundary = &accessgraphv1alpha.UsersPermissionsBoundaryV1{
+			PermissionsBoundaryArn:  aws.ToString(user.PermissionsBoundary.PermissionsBoundaryArn),
+			PermissionsBoundaryType: accessgraphv1alpha.UsersPermissionsBoundaryType_USERS_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY,
+		}
+	}
+
+	return &accessgraphv1alpha.AWSUserV1{
+		UserName:            aws.ToString(user.UserName),
+		Arn:                 aws.ToString(user.Arn),
+		Path:                aws.ToString(user.Path),
+		UserId:              aws.ToString(user.UserId),
+		CreatedAt:           awsTimeToProtoTime(user.CreateDate),
+		AccountId:           accountID,
+		PasswordLastUsed:    awsTimeToProtoTime(user.PasswordLastUsed),
+		Tags:                tags,
+		PermissionsBoundary: permissionsBoundary,
+	}
+}
+
+func (a *awsFetcher) fetchUserInlinePolicies(ctx context.Context, user *accessgraphv1alpha.AWSUserV1) ([]*accessgraphv1alpha.AWSUserInlinePolicyV1, error) {
+	var policies []*accessgraphv1alpha.AWSUserInlinePolicyV1
+	var errs []error
+	errCollect := func(err error) {
+		errs = append(errs, err)
+	}
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = iamClient.ListUserPoliciesPagesWithContext(
+		ctx,
+		&iam.ListUserPoliciesInput{
+			UserName: aws.String(user.UserName),
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListUserPoliciesOutput, lastPage bool) bool {
+			for _, policyName := range page.PolicyNames {
+				policy, err := iamClient.GetUserPolicyWithContext(ctx, &iam.GetUserPolicyInput{
+					UserName:   aws.String(user.UserName),
+					PolicyName: policyName,
+				})
+				if err != nil {
+					errCollect(trace.Wrap(err, "failed to fetch user %q inline policy %q", user.UserName, *policyName))
+					continue
+				}
+
+				policies = append(policies, awsUserPolicyToProtoUserPolicy(policy, user, a.AccountID))
+			}
+			return !lastPage
+		})
+
+	return policies, trace.NewAggregate(append(errs, err)...)
+}
+
+func awsUserPolicyToProtoUserPolicy(policy *iam.GetUserPolicyOutput, user *accessgraphv1alpha.AWSUserV1, accountID string) *accessgraphv1alpha.AWSUserInlinePolicyV1 {
+	return &accessgraphv1alpha.AWSUserInlinePolicyV1{
+		PolicyName:     aws.ToString(policy.PolicyName),
+		PolicyDocument: []byte(aws.ToString(policy.PolicyDocument)),
+		User:           user,
+		AccountId:      accountID,
+	}
+}
+
+func (a *awsFetcher) fetchUserAttachedPolicies(ctx context.Context, user *accessgraphv1alpha.AWSUserV1) (*accessgraphv1alpha.AWSUserAttachedPolicies, error) {
+	rsp := &accessgraphv1alpha.AWSUserAttachedPolicies{
+		User:      user,
+		AccountId: a.AccountID,
+	}
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListAttachedUserPoliciesPagesWithContext(
+		ctx,
+		&iam.ListAttachedUserPoliciesInput{
+			UserName: aws.String(user.UserName),
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
+			for _, policy := range page.AttachedPolicies {
+				rsp.Policies = append(
+					rsp.Policies,
+					&accessgraphv1alpha.AttachedPolicyV1{
+						Arn:        aws.ToString(policy.PolicyArn),
+						PolicyName: aws.ToString(policy.PolicyName),
+					},
+				)
+			}
+			return !lastPage
+		},
+	)
+
+	return rsp, trace.Wrap(err)
+}
+
+func (a *awsFetcher) fetchGroupsForUser(ctx context.Context, user *accessgraphv1alpha.AWSUserV1) (*accessgraphv1alpha.AWSUserGroupsV1, error) {
+	userGroups := &accessgraphv1alpha.AWSUserGroupsV1{
+		User: user,
+	}
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListGroupsForUserPagesWithContext(
+		ctx,
+		&iam.ListGroupsForUserInput{
+			UserName: aws.String(user.UserName),
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(lgfuo *iam.ListGroupsForUserOutput, b bool) bool {
+			for _, group := range lgfuo.Groups {
+				userGroups.Groups = append(userGroups.Groups, awsGroupToProtoGroup(group, a.AccountID))
+			}
+			return !b
+		},
+	)
+
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return userGroups, nil
+}

--- a/lib/srv/discovery/fetchers/aws-sync/utils.go
+++ b/lib/srv/discovery/fetchers/aws-sync/utils.go
@@ -1,0 +1,47 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func awsTimeToProtoTime(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}
+
+func strPtrToWrapper(s *string) *wrapperspb.StringValue {
+	if s == nil {
+		return nil
+	}
+	return &wrapperspb.StringValue{Value: *s}
+}
+
+func strPtrToByteSlice(s *string) []byte {
+	if s == nil {
+		return nil
+	}
+	return []byte(*s)
+}


### PR DESCRIPTION
This PR adds the code required for Teleport Discovery Service to be able to poll AWS resources in preparation to send them to TAG.

It only retrieves the resources and doesn't push them yet to TAG.

Part of https://github.com/gravitational/access-graph/issues/458