### PR TITLE
TAG: Poll AWS EC2, S3 and Policies

### DIFF
--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -57,6 +57,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -134,6 +136,8 @@ type AWSClients interface {
 	GetAWSEKSClient(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (eksiface.EKSAPI, error)
 	// GetAWSKMSClient returns AWS KMS client for the specified region.
 	GetAWSKMSClient(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (kmsiface.KMSAPI, error)
+	// GetAWSS3Client returns AWS S3 client.
+	GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error)
 }
 
 // AzureClients is an interface for Azure-specific API clients
@@ -542,6 +546,15 @@ func (c *cloudClients) GetAWSIAMClient(ctx context.Context, region string, opts 
 		return nil, trace.Wrap(err)
 	}
 	return iam.New(session), nil
+}
+
+// GetAWSS3Client returns AWS S3 client.
+func (c *cloudClients) GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
+	session, err := c.GetAWSSession(ctx, "", opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s3.New(session), nil
 }
 
 // GetAWSSTSClient returns AWS STS client for the specified region.
@@ -960,6 +973,7 @@ type TestCloudClients struct {
 	InstanceMetadata        InstanceMetadata
 	EKS                     eksiface.EKSAPI
 	KMS                     kmsiface.KMSAPI
+	S3                      s3iface.S3API
 	AzureMySQL              azure.DBServersClient
 	AzureMySQLPerSub        map[string]azure.DBServersClient
 	AzurePostgres           azure.DBServersClient
@@ -1088,6 +1102,15 @@ func (c *TestCloudClients) GetAWSIAMClient(ctx context.Context, region string, o
 		return nil, trace.Wrap(err)
 	}
 	return c.IAM, nil
+}
+
+// GetAWSS3Client returns AWS S3 client.
+func (c *TestCloudClients) GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
+	_, err := c.GetAWSSession(ctx, "", opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return c.S3, nil
 }
 
 // GetAWSSTSClient returns AWS STS client for the specified region.

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -162,6 +162,16 @@ func (a *awsFetcher) poll(ctx context.Context) (*Resources, error) {
 	// - attached policies
 	eGroup.Go(a.pollAWSGroups(ctx, result, collectErr))
 
+	// fetch AWS EC2 instances and their associated resources.
+	// - instance profiles
+	eGroup.Go(a.pollAWSEC2Instances(ctx, result, collectErr))
+
+	// fetch AWS IAM policies and their policy documents.
+	eGroup.Go(a.pollAWSPolicies(ctx, result, collectErr))
+
+	// fetch AWS S3 buckets.
+	eGroup.Go(a.pollAWSS3Buckets(ctx, result, collectErr))
+
 	if err := eGroup.Wait(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/aws-sync/ec2.go
+++ b/lib/srv/discovery/fetchers/aws-sync/ec2.go
@@ -1,0 +1,196 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSEC2Instances is a function that returns a function that fetches
+// ec2 instances and instance profiles and returns an error if any.
+func (a *awsFetcher) pollAWSEC2Instances(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+		result.Instances, err = a.fetchAWSEC2Instances(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch instances"))
+		}
+		result.InstanceProfiles, err = a.fetchInstanceProfiles(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch instance profiles"))
+		}
+		return nil
+	}
+}
+
+// fetchAWSEC2Instances fetches ec2 instances from all regions and returns them
+// as a slice of accessgraphv1alpha.AWSInstanceV1.
+// It uses ec2.DescribeInstancesPagesWithContext to iterate over all instances
+// in all regions.
+func (a *awsFetcher) fetchAWSEC2Instances(ctx context.Context) ([]*accessgraphv1alpha.AWSInstanceV1, error) {
+	var (
+		hosts   []*accessgraphv1alpha.AWSInstanceV1
+		hostsMu sync.Mutex
+		errs    []error
+	)
+	eG, ctx := errgroup.WithContext(ctx)
+	// Set the limit to 10 to avoid too many concurrent requests.
+	// This is a temporary solution until we have a better way to limit the
+	// number of concurrent requests.
+	eG.SetLimit(10)
+	collectHosts := func(lHosts []*accessgraphv1alpha.AWSInstanceV1, err error) {
+		hostsMu.Lock()
+		defer hostsMu.Unlock()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		hosts = append(hosts, lHosts...)
+	}
+
+	for _, region := range a.Regions {
+		region := region
+		eG.Go(func() error {
+			ec2Client, err := a.CloudClients.GetAWSEC2Client(ctx, region, a.getAWSOptions()...)
+			if err != nil {
+				collectHosts(nil, trace.Wrap(err))
+				return nil
+			}
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			err = ec2Client.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{
+				MaxResults: aws.Int64(pageSize),
+			}, func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
+				lHosts := make([]*accessgraphv1alpha.AWSInstanceV1, 0, len(page.Reservations))
+				for _, reservation := range page.Reservations {
+					for _, instance := range reservation.Instances {
+						hosts = append(hosts, awsInstanceToProtoInstance(instance, a.AccountID))
+					}
+				}
+				collectHosts(lHosts, nil)
+				return !lastPage
+			})
+
+			if err != nil {
+				collectHosts(hosts, trace.Wrap(err))
+			}
+			return nil
+		})
+	}
+
+	err := eG.Wait()
+	return hosts, trace.NewAggregate(append(errs, err)...)
+}
+
+// awsInstanceToProtoInstance converts an ec2.Instance to accessgraphv1alpha.AWSInstanceV1
+// representation.
+func awsInstanceToProtoInstance(instance *ec2.Instance, accountID string) *accessgraphv1alpha.AWSInstanceV1 {
+	var tags []*accessgraphv1alpha.AWSTag
+	for _, tag := range instance.Tags {
+		tags = append(tags, &accessgraphv1alpha.AWSTag{
+			Key:   aws.ToString(tag.Key),
+			Value: strPtrToWrapper(tag.Value),
+		})
+	}
+
+	var instanceProfileMetadata *wrapperspb.StringValue
+	if instance.IamInstanceProfile != nil {
+		instanceProfileMetadata = strPtrToWrapper(instance.IamInstanceProfile.Arn)
+	}
+	return &accessgraphv1alpha.AWSInstanceV1{
+		InstanceId:            aws.ToString(instance.InstanceId),
+		Region:                aws.ToString(instance.Placement.AvailabilityZone),
+		PublicDnsName:         aws.ToString(instance.PublicDnsName),
+		LaunchKeyName:         strPtrToWrapper(instance.KeyName),
+		IamInstanceProfileArn: instanceProfileMetadata,
+		AccountId:             accountID,
+		Tags:                  tags,
+		LaunchTime:            awsTimeToProtoTime(instance.LaunchTime),
+	}
+}
+
+// fetchInstanceProfiles fetches instance profiles from all regions and returns them
+// as a slice of accessgraphv1alpha.AWSInstanceProfileV1.
+func (a *awsFetcher) fetchInstanceProfiles(ctx context.Context) ([]*accessgraphv1alpha.AWSInstanceProfileV1, error) {
+	var profiles []*accessgraphv1alpha.AWSInstanceProfileV1
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = iamClient.ListInstanceProfilesPagesWithContext(
+		ctx,
+		&iam.ListInstanceProfilesInput{
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListInstanceProfilesOutput, lastPage bool) bool {
+			for _, profile := range page.InstanceProfiles {
+				profiles = append(
+					profiles,
+					awsInstanceProfileToProtoInstanceProfile(profile, a.AccountID),
+				)
+			}
+			return !lastPage
+		},
+	)
+
+	return profiles, trace.Wrap(err)
+}
+
+// awsInstanceProfileToProtoInstanceProfile converts an iam.InstanceProfile to accessgraphv1alpha.AWSInstanceProfileV1
+func awsInstanceProfileToProtoInstanceProfile(profile *iam.InstanceProfile, accountID string) *accessgraphv1alpha.AWSInstanceProfileV1 {
+	tags := make([]*accessgraphv1alpha.AWSTag, 0, len(profile.Tags))
+	for _, tag := range profile.Tags {
+		tags = append(tags, &accessgraphv1alpha.AWSTag{
+			Key:   aws.ToString(tag.Key),
+			Value: strPtrToWrapper(tag.Value),
+		})
+	}
+
+	out := &accessgraphv1alpha.AWSInstanceProfileV1{
+		InstanceProfileId:   aws.ToString(profile.InstanceProfileId),
+		InstanceProfileName: aws.ToString(profile.InstanceProfileName),
+		Arn:                 aws.ToString(profile.Arn),
+		Path:                aws.ToString(profile.Path),
+		AccountId:           accountID,
+		Tags:                tags,
+		CreatedAt:           awsTimeToProtoTime(profile.CreateDate),
+	}
+	for _, role := range profile.Roles {
+		if role == nil {
+			continue
+		}
+		out.Roles = append(out.Roles, awsRoleToProtoRole(role, accountID))
+	}
+	return out
+}

--- a/lib/srv/discovery/fetchers/aws-sync/groups.go
+++ b/lib/srv/discovery/fetchers/aws-sync/groups.go
@@ -71,6 +71,7 @@ func (a *awsFetcher) pollAWSGroups(ctx context.Context, result *Resources, colle
 			})
 		}
 
+		// always discard the error
 		_ = eG.Wait()
 
 		return nil

--- a/lib/srv/discovery/fetchers/aws-sync/policies.go
+++ b/lib/srv/discovery/fetchers/aws-sync/policies.go
@@ -1,0 +1,133 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSPolicies is a function that returns a function that fetches
+// AWS policies and returns an error if any.
+func (a *awsFetcher) pollAWSPolicies(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+		result.Policies, err = a.fetchPolicies(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch policies"))
+		}
+		return nil
+	}
+}
+
+// fetchPolicies fetches AWS policies and returns them as a slice of
+// accessgraphv1alpha.AWSPolicyV1.
+// It uses iam.ListPoliciesPagesWithContext to iterate over all policies
+// and iam.GetPolicyVersionWithContext to fetch policy documents.
+func (a *awsFetcher) fetchPolicies(ctx context.Context) ([]*accessgraphv1alpha.AWSPolicyV1, error) {
+	var policies []*accessgraphv1alpha.AWSPolicyV1
+	var errs []error
+	var mu sync.Mutex
+	collect := func(policy *accessgraphv1alpha.AWSPolicyV1, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if policy != nil {
+			policies = append(policies, policy)
+		}
+	}
+
+	iamClient, err := a.CloudClients.GetAWSIAMClient(
+		ctx,
+		"", /* region is empty because users and groups are global */
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	eGroup, ctx := errgroup.WithContext(ctx)
+	eGroup.SetLimit(10)
+	pageSize := int64(20)
+	err = iamClient.ListPoliciesPagesWithContext(
+		ctx,
+		&iam.ListPoliciesInput{
+			MaxItems: aws.Int64(pageSize),
+		},
+		func(page *iam.ListPoliciesOutput, lastPage bool) bool {
+			pp := page.Policies
+			eGroup.Go(func() error {
+				for _, policy := range pp {
+					out, err := iamClient.GetPolicyVersionWithContext(ctx, &iam.GetPolicyVersionInput{
+						PolicyArn: policy.Arn,
+						VersionId: policy.DefaultVersionId,
+					})
+					if err != nil {
+						collect(nil, trace.Wrap(err, "failed to fetch policy %q", *policy.Arn))
+						continue
+					}
+					collect(
+						awsPolicyToProtoPolicy(
+							policy,
+							[]byte(aws.ToString(out.PolicyVersion.Document)),
+							a.AccountID,
+						),
+						nil,
+					)
+				}
+				return nil
+			})
+			return !lastPage
+		},
+	)
+	_ = eGroup.Wait()
+	return policies, trace.NewAggregate(append(errs, err)...)
+}
+
+func awsPolicyToProtoPolicy(policy *iam.Policy, policyDoc []byte, accountID string) *accessgraphv1alpha.AWSPolicyV1 {
+	tags := make([]*accessgraphv1alpha.AWSTag, 0, len(policy.Tags))
+	for _, tag := range policy.Tags {
+		tags = append(tags, &accessgraphv1alpha.AWSTag{
+			Key:   aws.ToString(tag.Key),
+			Value: strPtrToWrapper(tag.Value),
+		})
+	}
+	return &accessgraphv1alpha.AWSPolicyV1{
+		PolicyName:       aws.ToString(policy.PolicyName),
+		Arn:              aws.ToString(policy.Arn),
+		CreatedAt:        awsTimeToProtoTime(policy.CreateDate),
+		DefaultVersionId: aws.ToString(policy.DefaultVersionId),
+		Description:      aws.ToString(policy.Description),
+		IsAttachable:     aws.ToBool(policy.IsAttachable),
+		Path:             aws.ToString(policy.Path),
+		UpdatedAt:        awsTimeToProtoTime(policy.UpdateDate),
+		PolicyId:         aws.ToString(policy.PolicyId),
+		Tags:             tags,
+		PolicyDocument:   policyDoc,
+		AccountId:        accountID,
+	}
+}

--- a/lib/srv/discovery/fetchers/aws-sync/roles.go
+++ b/lib/srv/discovery/fetchers/aws-sync/roles.go
@@ -73,6 +73,7 @@ func (a *awsFetcher) pollAWSRoles(ctx context.Context, result *Resources, collec
 				return nil
 			})
 		}
+		// always discard the error
 		_ = eG.Wait()
 		return nil
 	}

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -1,0 +1,147 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// pollAWSS3Buckets is a function that returns a function that fetches
+// AWS s3 buckets and their inline and attached policies.
+func (a *awsFetcher) pollAWSS3Buckets(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+		result.S3Buckets, err = a.fetchS3Buckets(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch s3 buckets"))
+		}
+		return nil
+	}
+}
+
+// fetchS3Buckets fetches AWS s3 buckets and returns them as a slice of
+// accessgraphv1alpha.AWSS3BucketV1.
+func (a *awsFetcher) fetchS3Buckets(ctx context.Context) ([]*accessgraphv1alpha.AWSS3BucketV1, error) {
+	var s3s []*accessgraphv1alpha.AWSS3BucketV1
+	var errs []error
+	var mu sync.Mutex
+	eG, ctx := errgroup.WithContext(ctx)
+	// Set the limit to 10 to avoid too many concurrent requests.
+	// This is a temporary solution until we have a better way to limit the
+	// number of concurrent requests.
+	eG.SetLimit(10)
+	collect := func(s3 *accessgraphv1alpha.AWSS3BucketV1, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if s3 != nil {
+			s3s = append(s3s, s3)
+		}
+	}
+
+	s3Client, err := a.CloudClients.GetAWSS3Client(
+		ctx,
+		a.getAWSOptions()...,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rsp, err := s3Client.ListBucketsWithContext(
+		ctx,
+		&s3.ListBucketsInput{},
+	)
+
+	for _, bucket := range rsp.Buckets {
+		bucket := bucket
+		eG.Go(func() error {
+			policy, err := s3Client.GetBucketPolicyWithContext(ctx, &s3.GetBucketPolicyInput{
+				Bucket: bucket.Name,
+			})
+			if err != nil {
+				collect(nil, trace.Wrap(err, "failed to fetch bucket %q inline policy", aws.ToString(bucket.Name)))
+			}
+
+			policyStatus, err := s3Client.GetBucketPolicyStatusWithContext(ctx, &s3.GetBucketPolicyStatusInput{
+				Bucket: bucket.Name,
+			})
+			if err != nil {
+				collect(nil, trace.Wrap(err, "failed to fetch bucket %q policy status", aws.ToString(bucket.Name)))
+			}
+
+			acls, err := s3Client.GetBucketAclWithContext(ctx, &s3.GetBucketAclInput{
+				Bucket: bucket.Name,
+			})
+			if err != nil {
+				collect(nil, trace.Wrap(err, "failed to fetch bucket %q acls policies", aws.ToString(bucket.Name)))
+			}
+			collect(
+				awsS3Bucket(aws.ToString(bucket.Name), policy, policyStatus, acls, a.AccountID),
+				nil)
+			return nil
+		})
+	}
+	// always discard the error
+	_ = eG.Wait()
+
+	return s3s, trace.Wrap(err)
+}
+
+func awsS3Bucket(name string, policy *s3.GetBucketPolicyOutput, policyStatus *s3.GetBucketPolicyStatusOutput, acls *s3.GetBucketAclOutput, accountID string) *accessgraphv1alpha.AWSS3BucketV1 {
+	s3 := &accessgraphv1alpha.AWSS3BucketV1{
+		Name:      name,
+		AccountId: accountID,
+	}
+	if policy != nil {
+		s3.PolicyDocument = []byte(aws.ToString(policy.Policy))
+	}
+	if policyStatus != nil && policyStatus.PolicyStatus != nil {
+		s3.IsPublic = aws.ToBool(policyStatus.PolicyStatus.IsPublic)
+	}
+	if acls != nil {
+		s3.Acls = awsACLsToProtoACLs(acls.Grants)
+	}
+	return s3
+}
+
+func awsACLsToProtoACLs(grants []*s3.Grant) []*accessgraphv1alpha.AWSS3BucketACL {
+	var acls []*accessgraphv1alpha.AWSS3BucketACL
+	for _, grant := range grants {
+		acls = append(acls, &accessgraphv1alpha.AWSS3BucketACL{
+			Grantee: &accessgraphv1alpha.AWSS3BucketACLGrantee{
+				Id:           aws.ToString(grant.Grantee.ID),
+				DisplayName:  aws.ToString(grant.Grantee.DisplayName),
+				Type:         aws.ToString(grant.Grantee.Type),
+				Uri:          aws.ToString(grant.Grantee.URI),
+				EmailAddress: aws.ToString(grant.Grantee.EmailAddress),
+			},
+			Permission: aws.ToString(grant.Permission),
+		})
+	}
+	return acls
+}


### PR DESCRIPTION
This PR adds the code required for Teleport Discovery Service to be able to poll AWS resources in preparation to send them to TAG.

It only retrieves the resources and doesn't push them yet to TAG.

Part of https://github.com/gravitational/access-graph/issues/458 
Depends on #37899
