### PR TITLE
TAG: Add `Merge` and `Reconcile` functions

### DIFF
--- a/lib/srv/discovery/fetchers/aws-sync/merge.go
+++ b/lib/srv/discovery/fetchers/aws-sync/merge.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+// MergeResources merges multiple resources into a single Resources object.
+// This is used to merge resources from multiple accounts and regions
+// into a single object.
+// It does not check for duplicates, so it is possible to have duplicates.
+func MergeResources(results ...*Resources) *Resources {
+	if len(results) == 0 {
+		return &Resources{}
+	}
+	if len(results) == 1 {
+		return results[0]
+	}
+	result := &Resources{}
+	for _, r := range results {
+		result.Users = append(result.Users, r.Users...)
+		result.UserInlinePolicies = append(result.UserInlinePolicies, r.UserInlinePolicies...)
+		result.UserAttachedPolicies = append(result.UserAttachedPolicies, r.UserAttachedPolicies...)
+		result.UserGroups = append(result.UserGroups, r.UserGroups...)
+		result.Groups = append(result.Groups, r.Groups...)
+		result.GroupInlinePolicies = append(result.GroupInlinePolicies, r.GroupInlinePolicies...)
+		result.GroupAttachedPolicies = append(result.GroupAttachedPolicies, r.GroupAttachedPolicies...)
+		result.Instances = append(result.Instances, r.Instances...)
+		result.Policies = append(result.Policies, r.Policies...)
+		result.S3Buckets = append(result.S3Buckets, r.S3Buckets...)
+		result.Roles = append(result.Roles, r.Roles...)
+		result.RoleInlinePolicies = append(result.RoleInlinePolicies, r.RoleInlinePolicies...)
+		result.RoleAttachedPolicies = append(result.RoleAttachedPolicies, r.RoleAttachedPolicies...)
+		result.InstanceProfiles = append(result.InstanceProfiles, r.InstanceProfiles...)
+	}
+	return result
+}

--- a/lib/srv/discovery/fetchers/aws-sync/merge_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/merge_test.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeResources(t *testing.T) {
+	oldUsers, newUsers := generateUsers()
+	oldRoles, newRoles := generateRoles()
+	oldEC2, newEC2 := generateEC2()
+
+	oldResults := Resources{
+		Users:     oldUsers,
+		Roles:     oldRoles,
+		Instances: oldEC2,
+	}
+	newResults := Resources{
+		Users:     newUsers,
+		Roles:     newRoles,
+		Instances: newEC2,
+	}
+
+	result := MergeResources(&oldResults, &newResults)
+	expected := Resources{
+		Users:     append(oldUsers, newUsers...),
+		Roles:     append(oldRoles, newRoles...),
+		Instances: append(oldEC2, newEC2...),
+	}
+	require.Equal(t, &expected, result)
+}

--- a/lib/srv/discovery/fetchers/aws-sync/reconcile.go
+++ b/lib/srv/discovery/fetchers/aws-sync/reconcile.go
@@ -1,0 +1,449 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+// ReconcileResults reconciles two Resources objects and returns the operations
+// required to reconcile them into the new state.
+// It returns two AWSResourceList objects, one for resources to upsert and one
+// for resources to delete.
+func ReconcileResults(old *Resources, new *Resources) (upsert, delete *accessgraphv1alpha.AWSResourceList) {
+	upsert, delete = &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	for _, results := range []*reconcileIntermeditateResult{
+		reconcileUsers(old.Users, new.Users),
+		reconcileUserInlinePolicies(old.UserInlinePolicies, new.UserInlinePolicies),
+		reconcileUserAttachedPolicies(old.UserAttachedPolicies, new.UserAttachedPolicies),
+		reconcileUserGroups(old.UserGroups, new.UserGroups),
+		reconcileGroups(old.Groups, new.Groups),
+		reconcileGroupInlinePolicies(old.GroupInlinePolicies, new.GroupInlinePolicies),
+		reconcileGroupAttachedPolicies(old.GroupAttachedPolicies, new.GroupAttachedPolicies),
+		reconcilePolicies(old.Policies, new.Policies),
+		reconcileInstances(old.Instances, new.Instances),
+		reconcileS3(old.S3Buckets, new.S3Buckets),
+		reconcileRoles(old.Roles, new.Roles),
+		reconcileRoleInlinePolicies(old.RoleInlinePolicies, new.RoleInlinePolicies),
+		reconcileRoleAttachedPolicies(old.RoleAttachedPolicies, new.RoleAttachedPolicies),
+		reconcileInstanceProfiles(old.InstanceProfiles, new.InstanceProfiles),
+	} {
+		upsert.Resources = append(upsert.Resources, results.upsert.Resources...)
+		delete.Resources = append(delete.Resources, results.delete.Resources...)
+	}
+
+	return upsert, delete
+}
+
+type reconcileIntermeditateResult struct {
+	upsert, delete *accessgraphv1alpha.AWSResourceList
+}
+
+func reconcileInstances(old []*accessgraphv1alpha.AWSInstanceV1, new []*accessgraphv1alpha.AWSInstanceV1) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(instance *accessgraphv1alpha.AWSInstanceV1) string {
+		return fmt.Sprintf("%s;%s", instance.InstanceId, instance.Region)
+	})
+
+	for _, instance := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Instance{
+				Instance: instance,
+			},
+		})
+	}
+	for _, instance := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Instance{
+				Instance: instance,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileUsers(
+	old []*accessgraphv1alpha.AWSUserV1,
+	new []*accessgraphv1alpha.AWSUserV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(user *accessgraphv1alpha.AWSUserV1) string {
+		return fmt.Sprintf("%s;%s", user.AccountId, user.Arn)
+	})
+	for _, user := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_User{
+				User: user,
+			},
+		})
+	}
+	for _, user := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_User{
+				User: user,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileUserInlinePolicies(
+	old []*accessgraphv1alpha.AWSUserInlinePolicyV1,
+	new []*accessgraphv1alpha.AWSUserInlinePolicyV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSUserInlinePolicyV1) string {
+		return fmt.Sprintf("%s;%s;%s", policy.AccountId, policy.GetUser().GetUserName(), policy.PolicyName)
+	})
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserInlinePolicy{
+				UserInlinePolicy: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserInlinePolicy{
+				UserInlinePolicy: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileUserAttachedPolicies(
+	old []*accessgraphv1alpha.AWSUserAttachedPolicies,
+	new []*accessgraphv1alpha.AWSUserAttachedPolicies,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSUserAttachedPolicies) string {
+		return fmt.Sprintf("%s;%s", policy.AccountId, policy.User.Arn)
+	})
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserAttachedPolicies{
+				UserAttachedPolicies: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserAttachedPolicies{
+				UserAttachedPolicies: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileUserGroups(
+	old []*accessgraphv1alpha.AWSUserGroupsV1,
+	new []*accessgraphv1alpha.AWSUserGroupsV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(group *accessgraphv1alpha.AWSUserGroupsV1) string {
+		return fmt.Sprintf("%s;%s", group.User.AccountId, group.User.Arn)
+	})
+	for _, group := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserGroups{
+				UserGroups: group,
+			},
+		})
+	}
+	for _, group := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_UserGroups{
+				UserGroups: group,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileGroups(
+	old []*accessgraphv1alpha.AWSGroupV1,
+	new []*accessgraphv1alpha.AWSGroupV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(group *accessgraphv1alpha.AWSGroupV1) string {
+		return fmt.Sprintf("%s;%s", group.AccountId, group.Arn)
+	})
+	for _, group := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Group{
+				Group: group,
+			},
+		})
+	}
+	for _, group := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Group{
+				Group: group,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileGroupInlinePolicies(
+	old []*accessgraphv1alpha.AWSGroupInlinePolicyV1,
+	new []*accessgraphv1alpha.AWSGroupInlinePolicyV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSGroupInlinePolicyV1) string {
+		return fmt.Sprintf("%s;%s;%s", policy.Group.Name, policy.PolicyName, policy.AccountId)
+	})
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_GroupInlinePolicy{
+				GroupInlinePolicy: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_GroupInlinePolicy{
+				GroupInlinePolicy: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileGroupAttachedPolicies(
+	old []*accessgraphv1alpha.AWSGroupAttachedPolicies,
+	new []*accessgraphv1alpha.AWSGroupAttachedPolicies,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSGroupAttachedPolicies) string {
+		return fmt.Sprintf("%s;%s", policy.Group.GetAccountId(), policy.Group.Arn)
+	})
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_GroupAttachedPolicies{
+				GroupAttachedPolicies: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_GroupAttachedPolicies{
+				GroupAttachedPolicies: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcilePolicies(
+	old []*accessgraphv1alpha.AWSPolicyV1,
+	new []*accessgraphv1alpha.AWSPolicyV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSPolicyV1) string {
+		return fmt.Sprintf("%s;%s", policy.AccountId, policy.Arn)
+	})
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Policy{
+				Policy: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Policy{
+				Policy: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcile[T protoreflect.ProtoMessage](old []T, new []T, key func(T) string) (upsert, delete []T) {
+	if len(old) == 0 {
+		return new, nil
+	}
+	if len(new) == 0 {
+		return nil, old
+	}
+
+	oldMap := make(map[string]T, len(old))
+	for _, item := range old {
+		oldMap[key(item)] = item
+	}
+
+	newMap := make(map[string]T, len(new))
+	for _, item := range new {
+		newMap[key(item)] = item
+	}
+
+	for _, item := range new {
+		if oldItem, ok := oldMap[key(item)]; !ok || !proto.Equal(oldItem, item) {
+			upsert = append(upsert, item)
+		}
+	}
+	for _, item := range old {
+		if _, ok := newMap[key(item)]; !ok {
+			delete = append(delete, item)
+		}
+	}
+	return upsert, delete
+}
+
+func reconcileS3(old []*accessgraphv1alpha.AWSS3BucketV1, new []*accessgraphv1alpha.AWSS3BucketV1) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+
+	toAdd, toRemove := reconcile(old, new, func(s3 *accessgraphv1alpha.AWSS3BucketV1) string {
+		return fmt.Sprintf("%s;%s", s3.AccountId, s3.Name)
+	})
+
+	for _, s3 := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_S3Bucket{
+				S3Bucket: s3,
+			},
+		})
+	}
+	for _, s3 := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_S3Bucket{
+				S3Bucket: s3,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileRoles(old []*accessgraphv1alpha.AWSRoleV1, new []*accessgraphv1alpha.AWSRoleV1) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+	toAdd, toRemove := reconcile(old, new, func(role *accessgraphv1alpha.AWSRoleV1) string {
+		return fmt.Sprintf("%s;%s", role.AccountId, role.Arn)
+	})
+
+	for _, role := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Role{
+				Role: role,
+			},
+		})
+	}
+	for _, role := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_Role{
+				Role: role,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileRoleInlinePolicies(
+	old []*accessgraphv1alpha.AWSRoleInlinePolicyV1,
+	new []*accessgraphv1alpha.AWSRoleInlinePolicyV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSRoleInlinePolicyV1) string {
+		return fmt.Sprintf("%s;%s;%s", policy.AccountId, policy.GetAwsRole().Arn, policy.PolicyName)
+	})
+
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_RoleInlinePolicy{
+				RoleInlinePolicy: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_RoleInlinePolicy{
+				RoleInlinePolicy: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileRoleAttachedPolicies(
+	old []*accessgraphv1alpha.AWSRoleAttachedPolicies,
+	new []*accessgraphv1alpha.AWSRoleAttachedPolicies,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+	toAdd, toRemove := reconcile(old, new, func(policy *accessgraphv1alpha.AWSRoleAttachedPolicies) string {
+		return fmt.Sprintf("%s;%s", policy.GetAwsRole().GetArn(), policy.AccountId)
+	})
+
+	for _, policy := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_RoleAttachedPolicies{
+				RoleAttachedPolicies: policy,
+			},
+		})
+	}
+	for _, policy := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_RoleAttachedPolicies{
+				RoleAttachedPolicies: policy,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}
+
+func reconcileInstanceProfiles(
+	old []*accessgraphv1alpha.AWSInstanceProfileV1,
+	new []*accessgraphv1alpha.AWSInstanceProfileV1,
+) *reconcileIntermeditateResult {
+	upsert, delete := &accessgraphv1alpha.AWSResourceList{}, &accessgraphv1alpha.AWSResourceList{}
+	toAdd, toRemove := reconcile(old, new, func(profile *accessgraphv1alpha.AWSInstanceProfileV1) string {
+		return fmt.Sprintf("%s;%s", profile.AccountId, profile.InstanceProfileId)
+	})
+
+	for _, profile := range toAdd {
+		upsert.Resources = append(upsert.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_InstanceProfile{
+				InstanceProfile: profile,
+			},
+		})
+	}
+	for _, profile := range toRemove {
+		delete.Resources = append(delete.Resources, &accessgraphv1alpha.AWSResource{
+			Resource: &accessgraphv1alpha.AWSResource_InstanceProfile{
+				InstanceProfile: profile,
+			},
+		})
+	}
+	return &reconcileIntermeditateResult{upsert, delete}
+}

--- a/lib/srv/discovery/fetchers/aws-sync/reconcile_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/reconcile_test.go
@@ -1,0 +1,160 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+func TestReconcileResults(t *testing.T) {
+	oldUsers, newUsers := generateUsers()
+	oldRoles, newRoles := generateRoles()
+	oldEC2, newEC2 := generateEC2()
+
+	oldResults := Resources{
+		Users:     oldUsers,
+		Roles:     oldRoles,
+		Instances: oldEC2,
+	}
+	newResults := Resources{
+		Users:     newUsers,
+		Roles:     newRoles,
+		Instances: newEC2,
+	}
+
+	upsert, delete := ReconcileResults(&oldResults, &newResults)
+
+	wantDelete := []*accessgraphv1alpha.AWSResource{
+		{
+			Resource: &accessgraphv1alpha.AWSResource_Role{
+				Role: oldRoles[0],
+			},
+		},
+	}
+
+	wantUpsert := []*accessgraphv1alpha.AWSResource{
+		{
+			Resource: &accessgraphv1alpha.AWSResource_Role{
+				Role: newRoles[0],
+			},
+		},
+		{
+			Resource: &accessgraphv1alpha.AWSResource_Role{
+				Role: newRoles[1],
+			},
+		},
+		{
+			Resource: &accessgraphv1alpha.AWSResource_User{
+				User: newUsers[1],
+			},
+		},
+		{
+			Resource: &accessgraphv1alpha.AWSResource_User{
+				User: newUsers[2],
+			},
+		},
+		{
+			Resource: &accessgraphv1alpha.AWSResource_Instance{
+				Instance: newEC2[2],
+			},
+		},
+	}
+
+	require.ElementsMatch(t, wantDelete, delete.Resources)
+	require.ElementsMatch(t, wantUpsert, upsert.Resources)
+}
+
+func generateUsers() (old, new []*accessgraphv1alpha.AWSUserV1) {
+	userA := &accessgraphv1alpha.AWSUserV1{
+		UserName: "userA",
+		Arn:      "arn:userA",
+		Tags:     []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	userBOld := &accessgraphv1alpha.AWSUserV1{
+		UserName: "userB",
+		Arn:      "arn:userB",
+		Tags:     []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	userBNew := &accessgraphv1alpha.AWSUserV1{
+		UserName: "userB",
+		Arn:      "arn:userB",
+		Tags:     []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value2")}},
+	}
+	userC := &accessgraphv1alpha.AWSUserV1{
+		UserName: "userC",
+		Arn:      "arn:userC",
+		Tags:     []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	old = []*accessgraphv1alpha.AWSUserV1{userA, userBOld}
+	new = []*accessgraphv1alpha.AWSUserV1{userA, userC, userBNew}
+	return
+}
+
+func generateRoles() (old, new []*accessgraphv1alpha.AWSRoleV1) {
+	roleA := &accessgraphv1alpha.AWSRoleV1{
+		Name: "roleA",
+		Arn:  "arn:roleA",
+		Tags: []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	roleBOld := &accessgraphv1alpha.AWSRoleV1{
+		Name: "roleB",
+		Arn:  "arn:roleB",
+		Tags: []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	roleBNew := &accessgraphv1alpha.AWSRoleV1{
+		Name: "roleB",
+		Arn:  "arn:roleB",
+		Tags: []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value2")}},
+	}
+	roleC := &accessgraphv1alpha.AWSRoleV1{
+		Name: "roleC",
+		Arn:  "arn:roleC",
+		Tags: []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	old = []*accessgraphv1alpha.AWSRoleV1{roleA, roleBOld}
+	new = []*accessgraphv1alpha.AWSRoleV1{roleC, roleBNew}
+	return
+}
+
+func generateEC2() (old, new []*accessgraphv1alpha.AWSInstanceV1) {
+	instanceA := &accessgraphv1alpha.AWSInstanceV1{
+		InstanceId: "instanceA",
+		Tags:       []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	instanceBOld := &accessgraphv1alpha.AWSInstanceV1{
+		InstanceId: "instanceB",
+		Tags:       []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	instanceBNew := &accessgraphv1alpha.AWSInstanceV1{
+		InstanceId: "instanceB",
+		Tags:       []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value2")}},
+	}
+	instanceC := &accessgraphv1alpha.AWSInstanceV1{
+		InstanceId: "instanceC",
+		Tags:       []*accessgraphv1alpha.AWSTag{{Key: "key1", Value: wrapperspb.String("value1")}},
+	}
+	old = []*accessgraphv1alpha.AWSInstanceV1{instanceA, instanceBOld, instanceC}
+	new = []*accessgraphv1alpha.AWSInstanceV1{instanceA, instanceC, instanceBNew}
+	return
+}


### PR DESCRIPTION
These functions are used to merge results polled from multiple accounts and to compute the required operations to move from old state into the new state.

Part of https://github.com/gravitational/access-graph/issues/458 
Depends on #37899 and #37900