### PR TITLE
Make resource helpers strict

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -680,84 +680,82 @@ func FriendlyName(resource ResourceWithLabels) string {
 // If the label is missing, an empty string is returned.
 //
 // Works for both [ResourceWithOrigin] and [ResourceMetadata] instances.
-func GetOrigin(v any) string {
+func GetOrigin(v any) (string, error) {
 	switch r := v.(type) {
 	case ResourceWithOrigin:
-		return r.Origin()
+		return r.Origin(), nil
 	case ResourceMetadata:
 		meta := r.GetMetadata()
 		if meta.Labels == nil {
-			return ""
+			return "", nil
 		}
-		return meta.Labels[OriginLabel]
+		return meta.Labels[OriginLabel], nil
 	}
-
-	return ""
+	return "", trace.BadParameter("unable to determine origin from resource of type %T", v)
 }
 
 // GetKind returns the kind, if one can be obtained, otherwise
 // an empty string is returned.
 //
 // Works for both [Resource] and [ResourceMetadata] instances.
-func GetKind(v any) string {
+func GetKind(v any) (string, error) {
 	type kinder interface {
 		GetKind() string
 	}
-
 	if k, ok := v.(kinder); ok {
-		return k.GetKind()
+		return k.GetKind(), nil
 	}
-
-	return ""
+	return "", trace.BadParameter("unable to determine kind from resource of type %T", v)
 }
 
 // GetRevision returns the revision, if one can be obtained, otherwise
 // an empty string is returned.
 //
 // Works for both [Resource] and [ResourceMetadata] instances.
-func GetRevision(v any) string {
+func GetRevision(v any) (string, error) {
 	switch r := v.(type) {
 	case Resource:
-		return r.GetRevision()
+		return r.GetRevision(), nil
 	case ResourceMetadata:
-		return r.GetMetadata().Revision
+		return r.GetMetadata().Revision, nil
 	}
-
-	return ""
+	return "", trace.BadParameter("unable to determine revision from resource of type %T", v)
 }
 
 // SetRevision updates the revision if v supports the concept of revisions.
 //
 // Works for both [Resource] and [ResourceMetadata] instances.
-func SetRevision(v any, revision string) {
+func SetRevision(v any, revision string) error {
 	switch r := v.(type) {
 	case Resource:
 		r.SetRevision(revision)
+		return nil
 	case ResourceMetadata:
 		r.GetMetadata().Revision = revision
+		return nil
 	}
+	return trace.BadParameter("unable to set revision on resource of type %T", v)
 }
 
 // GetExpiry returns the expiration, if one can be obtained, otherwise returns
 // an empty time `time.Time{}`, which is equivalent to no expiry.
 //
 // Works for both [Resource] and [ResourceMetadata] instances.
-func GetExpiry(v any) time.Time {
+func GetExpiry(v any) (time.Time, error) {
 	switch r := v.(type) {
 	case Resource:
-		return r.Expiry()
+		return r.Expiry(), nil
 	case ResourceMetadata:
 		// ResourceMetadata uses *timestamppb.Timestamp instead of time.Time. The zero value for this type is 01/01/1970.
 		// This is a problem for resources without explicit expiry set: they'd become obsolete on creation.
 		// For this reason, we check for nil expiry explicitly, and default it to time.Time{}.
 		exp := r.GetMetadata().GetExpires()
 		if exp == nil {
-			return time.Time{}
+			return time.Time{}, nil
 		}
-		return exp.AsTime()
+		return exp.AsTime(), nil
 	}
-
-	return time.Time{}
+	return time.Time{}, trace.BadParameter("unable to determine expiry from resource of type %T", v)
 }
 
 // GetResourceID returns the id, if one can be obtained, otherwise returns
@@ -766,15 +764,14 @@ func GetExpiry(v any) time.Time {
 // Works for both [Resource] and [ResourceMetadata] instances.
 //
 // Deprecated: GetRevision should be used instead.
-func GetResourceID(v any) int64 {
+func GetResourceID(v any) (int64, error) {
 	switch r := v.(type) {
 	case Resource:
 		//nolint:staticcheck // SA1019. Added for backward compatibility.
-		return r.GetResourceID()
+		return r.GetResourceID(), nil
 	case ResourceMetadata:
 		//nolint:staticcheck // SA1019. Added for backward compatibility.
-		return r.GetMetadata().Id
+		return r.GetMetadata().Id, nil
 	}
-
-	return 0
+	return 0, trace.BadParameter("unable to determine resource ID from resource of type %T", v)
 }

--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -144,45 +144,97 @@ func TestResourceMethods(t *testing.T) {
 	}
 
 	t.Run("GetExpiry", func(t *testing.T) {
-		require.Equal(t, expiry, types.GetExpiry(user))
-		require.Equal(t, expiry, types.GetExpiry(bot))
+		_, err := types.GetExpiry("invalid type")
+		require.Error(t, err)
+
+		objExpiry, err := types.GetExpiry(user)
+		require.NoError(t, err)
+		require.Equal(t, expiry, objExpiry)
+
+		objExpiry, err = types.GetExpiry(bot)
+		require.NoError(t, err)
+		require.Equal(t, expiry, objExpiry)
 
 		// check the nil expiry special case.
 		user.Metadata.Expires = nil
-		require.Equal(t, time.Time{}, types.GetExpiry(user))
+		objExpiry, err = types.GetExpiry(user)
+		require.NoError(t, err)
+		require.Equal(t, time.Time{}, objExpiry)
 
 		bot.Metadata.Expires = nil
-		require.Equal(t, time.Time{}, types.GetExpiry(bot))
+		objExpiry, err = types.GetExpiry(bot)
+		require.NoError(t, err)
+		require.Equal(t, time.Time{}, objExpiry)
 	})
 
 	t.Run("GetResourceID", func(t *testing.T) {
-		//nolint:staticcheck // SA1019. Added for backward compatibility.
-		require.Equal(t, user.GetResourceID(), types.GetResourceID(user))
-		//nolint:staticcheck // SA1019. Added for backward compatibility.
-		require.Equal(t, bot.GetMetadata().Id, types.GetResourceID(bot))
+		//nolint:staticcheck // SA1019. Deprecated, but still needed.
+		_, err := types.GetResourceID("invalid type")
+		require.Error(t, err)
+
+		//nolint:staticcheck // SA1019. Deprecated, but still needed.
+		id, err := types.GetResourceID(user)
+		require.NoError(t, err)
+		require.Equal(t, user.GetResourceID(), id)
+
+		//nolint:staticcheck // SA1019. Deprecated, but still needed.
+		id, err = types.GetResourceID(bot)
+		require.NoError(t, err)
+		//nolint:staticcheck // SA1019. Deprecated, but still needed.
+		require.Equal(t, bot.GetMetadata().Id, id)
 	})
 
 	t.Run("GetRevision", func(t *testing.T) {
-		require.Equal(t, user.GetRevision(), types.GetRevision(user))
-		require.Equal(t, bot.GetMetadata().Revision, types.GetRevision(bot))
+		_, err := types.GetRevision("invalid type")
+		require.Error(t, err)
+
+		revision, err := types.GetRevision(user)
+		require.Equal(t, user.GetRevision(), revision)
+		require.NoError(t, err)
+
+		revision, err = types.GetRevision(bot)
+		require.NoError(t, err)
+		require.Equal(t, bot.GetMetadata().Revision, revision)
 	})
 
 	t.Run("SetRevision", func(t *testing.T) {
 		rev := uuid.NewString()
-		types.SetRevision(bot, rev)
-		types.SetRevision(user, rev)
+		require.NoError(t, types.SetRevision(bot, rev))
+		require.NoError(t, types.SetRevision(user, rev))
+		require.Error(t, types.SetRevision("invalid type", "dummy"))
 
-		require.Equal(t, rev, types.GetRevision(user))
-		require.Equal(t, rev, types.GetRevision(bot))
+		revision, err := types.GetRevision(user)
+		require.NoError(t, err)
+		require.Equal(t, rev, revision)
+
+		revision, err = types.GetRevision(bot)
+		require.NoError(t, err)
+		require.Equal(t, rev, revision)
 	})
 
 	t.Run("GetKind", func(t *testing.T) {
-		require.Equal(t, types.KindUser, types.GetKind(user))
-		require.Equal(t, types.KindBot, types.GetKind(bot))
+		_, err := types.GetKind("invalid type")
+		require.Error(t, err)
+
+		kind, err := types.GetKind(user)
+		require.NoError(t, err)
+		require.Equal(t, types.KindUser, kind)
+
+		kind, err = types.GetKind(bot)
+		require.NoError(t, err)
+		require.Equal(t, types.KindBot, kind)
 	})
 
 	t.Run("GetOrigin", func(t *testing.T) {
-		require.Equal(t, user.Origin(), types.GetOrigin(user))
-		require.Equal(t, "mars", types.GetOrigin(bot))
+		_, err := types.GetOrigin("invalid type")
+		require.Error(t, err)
+
+		origin, err := types.GetOrigin(user)
+		require.NoError(t, err)
+		require.Equal(t, user.Origin(), origin)
+
+		origin, err = types.GetOrigin(bot)
+		require.NoError(t, err)
+		require.Equal(t, "mars", origin)
 	})
 }

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -323,18 +323,30 @@ func (s *Service[T]) MakeBackendItem(resource T, name string) (backend.Item, err
 		return backend.Item{}, trace.Wrap(err)
 	}
 
-	rev := types.GetRevision(resource)
+	rev, err := types.GetRevision(resource)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
 	value, err := s.marshalFunc(resource)
 	if err != nil {
 		return backend.Item{}, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:     s.MakeKey(name),
-		Value:   value,
-		Expires: types.GetExpiry(resource),
-		//nolint:staticcheck // SA1019. Added for backward compatibility.
-		ID:       types.GetResourceID(resource),
+		Key:      s.MakeKey(name),
+		Value:    value,
 		Revision: rev,
+	}
+
+	item.Expires, err = types.GetExpiry(resource)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
+	//nolint:staticcheck // SA1019. Added for backward compatibility.
+	item.ID, err = types.GetResourceID(resource)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
 	}
 
 	return item, nil

--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -142,7 +142,10 @@ func (r *Reconciler[T]) processRegisteredResource(ctx context.Context, newResour
 		return nil
 	}
 
-	kind := types.GetKind(registered)
+	kind, err := types.GetKind(registered)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	r.log.Infof("%v %v removed, deleting.", kind, name)
 	if err := r.cfg.OnDelete(ctx, registered); err != nil {
 		return trace.Wrap(err, "failed to delete  %v %v", kind, name)
@@ -159,7 +162,10 @@ func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources
 	// matches the selector labels and should be registered.
 	registered, ok := currentResources[name]
 	if !ok {
-		kind := types.GetKind(newT)
+		kind, err := types.GetKind(newT)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		if r.cfg.Matcher(newT) {
 			r.log.Infof("%v %v matches, creating.", kind, name)
 			if err := r.cfg.OnCreate(ctx, newT); err != nil {
@@ -172,8 +178,14 @@ func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources
 	}
 
 	// Don't overwrite resource of a different origin (e.g., keep static resource from config and ignore dynamic resource)
-	registeredOrigin := types.GetOrigin(registered)
-	newOrigin := types.GetOrigin(newT)
+	registeredOrigin, err := types.GetOrigin(registered)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	newOrigin, err := types.GetOrigin(newT)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	if registeredOrigin != newOrigin {
 		r.log.Warnf("%v has different origin (%v vs %v), not updating.", name, newOrigin, registeredOrigin)
 		return nil
@@ -181,7 +193,10 @@ func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources
 
 	// If the resource is already registered but was updated, see if its
 	// labels still match.
-	kind := types.GetKind(registered)
+	kind, err := types.GetKind(registered)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	if CompareResources(newT, registered) != Equal {
 		if r.cfg.Matcher(newT) {
 			r.log.Infof("%v %v updated, updating.", kind, name)

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -229,3 +229,7 @@ func (r testResource) GetMetadata() *headerv1.Metadata {
 func (r testResource) GetName() string {
 	return r.Metadata.GetName()
 }
+
+func (r testResource) GetKind() string {
+	return "testResource"
+}


### PR DESCRIPTION
The helpers will now return an error if their argument has unexpected type.

This change makes it harder to accidentally misuse these helpers, which would manifest as silent corruption of data as well as other issues.