### PR TITLE
Fix default expiry for timestamp-based RFD 153-style resources

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -747,7 +747,14 @@ func GetExpiry(v any) time.Time {
 	case Resource:
 		return r.Expiry()
 	case ResourceMetadata:
-		return r.GetMetadata().Expires.AsTime()
+		// ResourceMetadata uses *timestamppb.Timestamp instead of time.Time. The zero value for this type is 01/01/1970.
+		// This is a problem for resources without explicit expiry set: they'd become obsolete on creation.
+		// For this reason, we check for nil expiry explicitly, and default it to time.Time{}.
+		exp := r.GetMetadata().GetExpires()
+		if exp == nil {
+			return time.Time{}
+		}
+		return exp.AsTime()
 	}
 
 	return time.Time{}

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -739,7 +739,7 @@ func SetRevision(v any, revision string) {
 }
 
 // GetExpiry returns the expiration, if one can be obtained, otherwise returns
-// an empty time.
+// an empty time `time.Time{}`, which is equivalent to no expiry.
 //
 // Works for both [Resource] and [ResourceMetadata] instances.
 func GetExpiry(v any) time.Time {

--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -17,6 +17,7 @@ package types_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -145,6 +146,13 @@ func TestResourceMethods(t *testing.T) {
 	t.Run("GetExpiry", func(t *testing.T) {
 		require.Equal(t, expiry, types.GetExpiry(user))
 		require.Equal(t, expiry, types.GetExpiry(bot))
+
+		// check the nil expiry special case.
+		user.Metadata.Expires = nil
+		require.Equal(t, time.Time{}, types.GetExpiry(user))
+
+		bot.Metadata.Expires = nil
+		require.Equal(t, time.Time{}, types.GetExpiry(bot))
 	})
 
 	t.Run("GetResourceID", func(t *testing.T) {


### PR DESCRIPTION
RFD 153-style resources are using `timestamppb.Timestamp` instead of `time.Time` for expiry. The zero value for this type is 01/01/1970. This is a problem for resources without explicit expiry set: they become instantly obsolete on creation. To avoid this problem, we will now check for nil expiry explicitly, and default it to `time.Time{}`.