### PR TITLE
Add missing error checks for against backend operations

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -218,6 +218,9 @@ func (s *Service[T]) CreateResource(ctx context.Context, resource T) (T, error) 
 	if trace.IsAlreadyExists(err) {
 		return t, trace.AlreadyExists("%s %q already exists", s.resourceKind, resource.GetName())
 	}
+	if err != nil {
+		return t, trace.Wrap(err)
+	}
 
 	types.SetRevision(resource, lease.Revision)
 	return resource, trace.Wrap(err)
@@ -234,6 +237,9 @@ func (s *Service[T]) UpdateResource(ctx context.Context, resource T) (T, error) 
 	lease, err := s.backend.Update(ctx, item)
 	if trace.IsNotFound(err) {
 		return t, trace.NotFound("%s %q doesn't exist", s.resourceKind, resource.GetName())
+	}
+	if err != nil {
+		return t, trace.Wrap(err)
 	}
 
 	types.SetRevision(resource, lease.Revision)


### PR DESCRIPTION
In generic service implementation, methods `CreateResource` and `UpdateResource` were liable to ignore non-specific errors, which might potentially lead to a panic. This is now fixed.