### PR TITLE
Recommend on-demand mode and continuous backups in DynamoDB docs

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -715,13 +715,13 @@ To make changes to your Teleport cluster after deployment, you can use `helm upg
 Helm defaults to using the latest version of the chart available in the repo, which will also correspond to the latest
 version of Teleport. You can make sure that the repo is up to date by running `helm repo update`.
 
-Here's an example where we set the chart to use 3 replicas:
+Here's an example where we set the chart to use 2 replicas:
 
 Edit your `aws-values.yaml` file from above and make the appropriate changes:
 
 ```yaml
 highAvailability:
-  replicaCount: 3
+  replicaCount: 2
 ```
 
 Upgrade the deployment with the values from your `aws-values.yaml` file using this command:
@@ -735,33 +735,6 @@ $ helm upgrade <Var name="release-name" /> teleport/teleport-cluster \
 <Admonition type="note">
   To change `chartMode`, `clusterName`, or any `aws` settings, you must first uninstall the existing chart and then install a new version with the appropriate values.
 </Admonition>
-
-### Autoscaling
-
-In order to reduce DynamoDB costs you might want to enable DynamoDB autoscaling.
-This step is usually done after a successful Teleport deployment, once you have gathered some data
-about Teleport's DynamoDB usage and know what regular usage looks like and how autoscaling should be tuned.
-You must know the desired read/write minimum, maximum and target capacity for your DynamoDB instance in order to enable autoscaling.
-
-You can delegate your autoscaling configuration to Teleport or manage it by creating an AWS Application Auto Scaling policy.
-The following steps will set up Teleport-configured DynamoDB autoscaling.
-
-You must grant autoscaling configuration rights to Teleport, as documented in
-[the DynamoDB autoscaling section](../../reference/backends.mdx#dynamodb-autoscaling).
-
-Set the following fields in your existing `aws-values.yaml` file and replace the numeric values with yours:
-
-```yaml
-aws:
-  # [...] already present values under `aws`
-  dynamoAutoScaling: true
-  readMinCapacity: 5     # integer
-  readMaxCapacity: 100   # integer
-  readTargetValue: 50.0  # float
-  writeMinCapacity: 5    # integer
-  writeMaxCapacity: 100  # integer
-  writeTargetValue: 50.0 # float
-```
 
 Then perform a cluster upgrade with the new values:
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -85,7 +85,7 @@ machines running Teleport. This endpoint must be enabled by using the
 reply `{"status":"ok"}` if the Teleport service is running without problems.
 
 We'll cover how to use `etcd`, PostgreSQL, DynamoDB, and Firestore storage
-back-ends to make Teleport highly available below.
+backends to make Teleport highly available below.
 
 ## Etcd
 
@@ -185,7 +185,7 @@ Teleport `13.3`.
   in Teleport Architecture documentation.
 </Admonition>
 
-Teleport can use [PostgreSQL](https://www.postgresql.org/) as a storage back-end
+Teleport can use [PostgreSQL](https://www.postgresql.org/) as a storage backend
 to achieve high availability. You must take steps to protect access to
 PostgreSQL in this configuration because that is where Teleport secrets like
 keys and user records will be stored. The PostgreSQL backend supports two types
@@ -261,9 +261,9 @@ their API; this should only be leveraged if the entire PostgreSQL cluster is
 dedicated to Teleport.
 
 To configure Teleport to use PostgreSQL:
-- Configure all Teleport Auth Service instances to use the PostgreSQL back-end in the
+- Configure all Teleport Auth Service instances to use the PostgreSQL backend in the
   `storage` section of `teleport.yaml` as shown below.
-- Deploy several Auth Service instances connected to the PostgreSQL storage back-end.
+- Deploy several Auth Service instances connected to the PostgreSQL storage backend.
 - Deploy several Proxy Service nodes.
 - Make sure that the Proxy Service instances and all Teleport agent services that
   connect directly to the the Auth Service have the `auth_server` configuration
@@ -749,14 +749,14 @@ For more information, see the [AWS Documentation](https://docs.aws.amazon.com/Am
 </Admonition>
 
 If you are running Teleport on AWS, you can use
-[DynamoDB](https://aws.amazon.com/dynamodb/) as a storage back-end to achieve
+[DynamoDB](https://aws.amazon.com/dynamodb/) as a storage backend to achieve
 High Availability. DynamoDB backend supports two types of Teleport data:
 
 - Cluster state
 - Audit log events
 
 Teleport uses DynamoDB and DynamoDB Streams endpoints for its storage
-back-end management.
+backend management.
 
 DynamoDB cannot store the recorded sessions. You are advised to use AWS S3 for
 that as shown above.
@@ -782,13 +782,23 @@ access to DynamoDB.
 
 To configure Teleport to use DynamoDB:
 
-- Configure all Teleport Auth servers to use DynamoDB back-end in the "storage"
+- Configure all Teleport Auth servers to use DynamoDB backend in the "storage"
   section of `teleport.yaml` as shown below.
 - Auth servers must be able to reach DynamoDB and DynamoDB Streams endpoints.
-- Deploy several auth servers connected to DynamoDB storage back-end.
+- Deploy up to two auth servers connected to DynamoDB storage backend.
 - Deploy several proxy nodes.
 - Make sure that all Teleport resource services have the `auth_servers` configuration setting
   populated with the addresses of your cluster's Auth Service instances.
+
+<Notice type="danger">
+
+AWS can throttle DynamoDB if more than two processes are reading from the same
+stream's shard simultaneously, so you must not deploy more than two Auth Service
+instances that read from a DynamoDB backend. For details on DynamoDB Streams,
+read the [AWS
+documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html).
+
+</Notice>
 
 ```yaml
 teleport:
@@ -819,6 +829,10 @@ teleport:
     # Possible values: "pay_per_request" and "provisioned"
     # default: "pay_per_request"
     billing_mode: "pay_per_request"
+
+    # continuous_backups is used to optionally enable continuous backups.
+    # default: false
+    continuous_backups: true
 ```
 
 - Replace `us-east-1` and `Example_TELEPORT_DYNAMO_TABLE_NAME`
@@ -839,96 +853,20 @@ The optional `GET` parameters shown below control how Teleport interacts with a 
 - `endpoint=dynamo.example.com` - connect to a custom S3 endpoint.
 - `use_fips_endpoint=true` -  [Configure DynamoDB FIPS endpoints](#configuring-aws-fips-endpoints).
 
-### DynamoDB autoscaling
-
-When setting up DynamoDB it's important to set up backups. Autoscaling is
-optional with Teleport, and it is advised to collect some production usage data
-before enabling autoscaling.
-
-Autoscaling and backup can be configured on DynamoDB directly. We also make
-setup simpler by allowing AWS DynamoDB settings to be set automatically during
-Teleport startup. The configuration is described below.
 
 **DynamoDB Continuous Backups**
 
+When setting up DynamoDB it's important to enable backups so that cluster state can be restored
+if needed from a snapshot in the past.
+
 - [AWS Blog Post - Amazon DynamoDB Continuous Backup](https://aws.amazon.com/blogs/aws/new-amazon-dynamodb-continuous-backups-and-point-in-time-recovery-pitr/)
 
-**DynamoDB Autoscaling Options**
+**DynamoDB On-Demand**
 
-- [AWS Docs - Managing Throughput Capacity Automatically with DynamoDB Auto Scaling](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AutoScaling.html)
+For best performance it is recommended to use On-Demand mode instead of configuring capacity manually via Provisioned
+mode. This helps prevent any DynamoDB throttling due to underestimated usage or increased usage from impacting Teleport.
 
-<Notice type="danger">
-
-AWS can throttle DynamoDB if more than two processes are reading from the same
-stream's shard simultaneously, so you must not deploy more than two Auth Service
-instances that read from a DynamoDB backend. For details on DynamoDB Streams,
-read the [AWS
-documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html).
-
-</Notice>
-
-```yaml
-# ...
-teleport:
-  storage:
-    type: "dynamodb"
-    [...]
-
-    # continuous_backups is used to optionally enable continuous backups.
-    # default: false
-    continuous_backups: true
-
-    # auto_scaling is used to optionally enable (and define settings for) auto scaling.
-    # default: false
-    auto_scaling: true
-    # Enables either Pay-Per-Request or Provisioned billing for the DynamoDB table. Set when Teleport creates the table.
-    # If billing_mode is set to "pay_per_request", read/write capacity and auto_scaling settings will be ignored.
-    # Possible values: "pay_per_request" and "provisioned"
-    # default: "pay_per_request"
-    billing_mode: ["pay_per_request"|"provisioned"]
-    # Minimum/maximum read capacity in units
-    read_min_capacity: int
-    read_max_capacity: int
-    read_target_value: float
-    # Minimum/maximum write capacity in units
-    write_min_capacity: int
-    write_max_capacity: int
-    write_target_value: float
-```
-
-To enable these options you will need to update the IAM Policy for Teleport.
-
-```json
-{
-    "Action": [
-        "application-autoscaling:PutScalingPolicy",
-        "application-autoscaling:RegisterScalableTarget"
-    ],
-    "Effect": "Allow",
-    "Resource": "*"
-},
-{
-    "Action": [
-        "iam:CreateServiceLinkedRole"
-    ],
-    "Condition": {
-        "StringEquals": {
-            "iam:AWSServiceName": [
-                "dynamodb.application-autoscaling.amazonaws.com"
-            ]
-        }
-    },
-    "Effect": "Allow",
-    "Resource": "*"
-}
-```
-
-<Admonition
-  type="warning"
-  title="pay_per_request with autoscaling"
->
-  If billing mode is set to `pay_per_request`, the settings for read/write capacity and auto scaling will be ignored.
-</Admonition>
+- [AWS Docs - Amazon DynamoDB On-Demand and Pay-Per-Request](https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/)
 
 ### Configuring AWS FIPS endpoints
 
@@ -954,16 +892,16 @@ Config option priority is applied in the following order:
 
 ## Athena
 
-The Athena audit log back-end is available starting from Teleport v14.0.
+The Athena audit log backend is available starting from Teleport v14.0.
 
 If you are running Teleport on AWS, you can use an
 [Athena](https://aws.amazon.com/athena/)-based audit log system that manages
 [Parquet files](https://parquet.apache.org/) stored on
-[S3](https://aws.amazon.com/s3/) as a storage back-end to achieve high
-availability. The Athena back-end supports only one type of Teleport data, audit
+[S3](https://aws.amazon.com/s3/) as a storage backend to achieve high
+availability. The Athena backend supports only one type of Teleport data, audit
 events.
 
-The Athena audit back-end is better at scale and search than DynamoDB.
+The Athena audit backend is better at scale and search than DynamoDB.
 
 The Athena audit logs are eventually consistent. It may take up to one minute
 (depending on the `batchMaxInterval` setting and event load) until you can view
@@ -1295,7 +1233,7 @@ Replace the following variables in the above example with your own values:
 </Admonition>
 
 If you are running Teleport on GCP, you can use
-[Firestore](https://cloud.google.com/firestore/) as a storage back-end to achieve
+[Firestore](https://cloud.google.com/firestore/) as a storage backend to achieve
 high availability. Firestore backend supports two types of Teleport data:
 
 - Cluster state
@@ -1305,9 +1243,9 @@ Firestore cannot store the recorded sessions. You are advised to use Google
 Cloud Storage (GCS) for that as shown above. To configure Teleport to use
 Firestore:
 
-- Configure all Teleport Auth servers to use Firestore back-end in the "storage"
+- Configure all Teleport Auth servers to use Firestore backend in the "storage"
   section of `teleport.yaml` as shown below.
-- Deploy several auth servers connected to Firestore storage back-end.
+- Deploy several auth servers connected to Firestore storage backend.
 - Deploy several proxy nodes.
 - Make sure that all Teleport resource services have the `auth_servers`
   configuration setting populated with the addresses of your cluster's Auth


### PR DESCRIPTION
Removes mention to provisioned mode and manually setting capacity in favor of using on-demand mode. Enabling continuous backups was also elevated into the main configuration reference since they are strongly encouraged.

Additionally all occurrences of `back-end` were replaced with `backend` to be consistent with all other usages.