### PR TITLE
Set noEmit in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tdd": "jest --watch",
     "lint": "yarn prettier-check && yarn eslint",
     "eslint": "eslint --quiet '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
-    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc --noEmit",
+    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc",
     "prettier-check": "yarn prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "prettier-write": "yarn prettier --write --loglevel silent '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "process-icons": "node web/packages/design/src/Icon/script/script.js & yarn prettier --loglevel silent --write 'web/packages/design/src/Icon/Icons/*.tsx'",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
     "noEmitHelpers": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
@@ -34,8 +35,7 @@
       "gen-proto-js/*": ["gen/proto/js/*"],
       "gen-proto-ts/*": ["gen/proto/ts/*"],
       "access-graph": ["e/web/teleport/src/AccessGraph/Loader.tsx"],
-    },
-    "outDir": "dist"
+    }
   },
   "include": [
     "e/web/**/*.ts",


### PR DESCRIPTION
We use Vite to compile TS files, so tsc is used merely for type-checking. Setting noEmit to true makes sure that other tools which use tsc (like editor plugins) do not make tsc compile code.

outDir is removed as it's not needed if we do not use tsc to compile code.