### PR TITLE
Reduce the warning about host user management to debug level

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2056,9 +2056,9 @@ func (process *TeleportProcess) initAuthService() error {
 		log.Info("Starting Auth service with external PROXY protocol support.")
 	}
 	if cfg.Auth.PROXYProtocolMode == multiplexer.PROXYProtocolUnspecified {
-		log.Warn("'proxy_protocol' unspecified." +
+		log.Warn("'proxy_protocol' unspecified. " +
 			"Starting Auth service with external PROXY protocol support, " +
-			"but IP pinned connection affected by PROXY headers will not be allowed." +
+			"but IP pinned connection affected by PROXY headers will not be allowed. " +
 			"Set 'proxy_protocol: on' in 'auth_service' config if Auth service runs behind L4 load balancer with enabled " +
 			"PROXY protocol, or set 'proxy_protocol: off' otherwise")
 	}

--- a/lib/srv/db/mongodb/autousers_admin.go
+++ b/lib/srv/db/mongodb/autousers_admin.go
@@ -31,7 +31,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
 	mongoauth "go.mongodb.org/mongo-driver/x/mongo/driver/auth"
 
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -201,7 +200,7 @@ func makeBasicAdminClient(ctx context.Context, sessionCtx *common.Session, e *En
 		return nil, trace.Wrap(err)
 	}
 	clientCfg.SetTLSConfig(tlsConfig)
-	clientCfg.SetAuth(mongooptions.Credential{
+	clientCfg.SetAuth(options.Credential{
 		AuthMechanism: mongoauth.MongoDBX509,
 		Username:      x509Username(sessionCtx),
 	})

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -40,10 +40,12 @@ import (
 
 // NewHostUsers initialize a new HostUsers object
 func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid string) HostUsers {
-	// newHostUsersBackend statically returns a valid backend or an error,
-	// resulting in a staticcheck linter error on darwin
-	backend, err := newHostUsersBackend() //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-	if err != nil {                       //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+	backend, err := newHostUsersBackend()
+	switch {
+	case trace.IsNotImplemented(err):
+		log.Debugf("Skipping host user management: %v", err)
+		return nil
+	case err != nil: //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
 		log.Warnf("Error making new HostUsersBackend: %s", err)
 		return nil
 	}
@@ -58,11 +60,13 @@ func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid stri
 }
 
 func NewHostSudoers(uuid string) HostSudoers {
-	// newHostSudoersBackend statically returns a valid backend or an error,
-	// resulting in a staticcheck linter error on darwin
-	backend, err := newHostSudoersBackend(uuid) //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-	if err != nil {                             //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-		log.Warnf("Error making new HostUsersBackend: %s", err)
+	backend, err := newHostSudoersBackend(uuid)
+	switch {
+	case trace.IsNotImplemented(err):
+		log.Debugf("Skipping host sudoers management: %v", err)
+		return nil
+	case err != nil: //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+		log.Warnf("Error making new HostSudoersBackend: %s", err)
 		return nil
 	}
 	return &HostSudoersManagement{


### PR DESCRIPTION
On non-Linux platforms, the warning draws attention and makes it look like something is wrong. Disabling host user management here is expected behavior and not an exceptional circumstance, so it doesn't need to be a warning.

Also fix a duplicate import in lib/srv/db