### PR TITLE
Add bot permissions and turn on feature

### DIFF
--- a/web/packages/teleport/src/Bots/List/ActionCell.tsx
+++ b/web/packages/teleport/src/Bots/List/ActionCell.tsx
@@ -28,6 +28,7 @@ export function BotOptionsCell({
   onClickView,
   bot,
   disabledEdit,
+  disabledDelete,
   onClickEdit,
 }: BotOptionsCellProps) {
   return (
@@ -36,7 +37,9 @@ export function BotOptionsCell({
         <MenuItem onClick={onClickEdit} disabled={disabledEdit}>
           Edit...
         </MenuItem>
-        <MenuItem onClick={onClickDelete}>Delete...</MenuItem>
+        <MenuItem onClick={onClickDelete} disabled={disabledDelete}>
+          Delete...
+        </MenuItem>
         {bot.type === BotUiFlow.GitHubActionsSsh && (
           <MenuItem onClick={onClickView}>View...</MenuItem>
         )}

--- a/web/packages/teleport/src/Bots/List/BotList.test.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.test.tsx
@@ -27,6 +27,7 @@ const makeProps = (): BotListProps => ({
   attempt: { status: '' },
   bots: botsFixture,
   disabledEdit: false,
+  disabledDelete: false,
   onClose: () => {},
   onDelete: () => {},
   onEdit: () => {},

--- a/web/packages/teleport/src/Bots/List/BotList.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.tsx
@@ -39,6 +39,7 @@ export function BotList({
   attempt,
   bots,
   disabledEdit,
+  disabledDelete,
   roles,
   onClose,
   onDelete,
@@ -78,6 +79,7 @@ export function BotList({
                   setInteraction(Interaction.VIEW);
                 }}
                 disabledEdit={disabledEdit}
+                disabledDelete={disabledDelete}
                 onClickEdit={() => {
                   setSelectedBot(bot);
                   setSelectedRoles(bot.roles);

--- a/web/packages/teleport/src/Bots/List/Bots.story.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.story.tsx
@@ -31,6 +31,7 @@ export const List = () => {
       attempt={{ status: '' }}
       bots={botsFixture}
       disabledEdit={false}
+      disabledDelete={false}
       onClose={() => {}}
       onDelete={() => {}}
       onEdit={() => {}}

--- a/web/packages/teleport/src/Bots/List/Bots.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.tsx
@@ -146,7 +146,8 @@ export function Bots() {
         <BotList
           attempt={crudAttempt}
           bots={bots}
-          disabledEdit={!flags.roles}
+          disabledEdit={!flags.roles || !flags.editBots}
+          disabledDelete={!flags.removeBots}
           roles={roles}
           onClose={onClose}
           onDelete={onDelete}

--- a/web/packages/teleport/src/Bots/types.ts
+++ b/web/packages/teleport/src/Bots/types.ts
@@ -23,6 +23,7 @@ import { FlatBot } from 'teleport/services/bot/types';
 export type BotOptionsCellProps = {
   bot: FlatBot;
   disabledEdit: boolean;
+  disabledDelete: boolean;
   onClickEdit: (bot: FlatBot) => void;
   onClickDelete: (bot: FlatBot) => void;
   onClickView: (bot: FlatBot) => void;
@@ -32,6 +33,7 @@ export type BotListProps = {
   attempt: Attempt;
   bots: FlatBot[];
   disabledEdit: boolean;
+  disabledDelete: boolean;
   roles: string[];
   onClose: () => void;
   onDelete: () => void;

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -222,9 +222,8 @@ export class FeatureBots implements TeleportFeature {
     component: Bots,
   };
 
-  // todo (michellescripts) return flags.Users once integrated with mcbattirola and feature is ready
-  hasAccess() {
-    return false;
+  hasAccess(flags: FeatureFlags) {
+    return flags.listBots;
   }
 
   navigationItem = {

--- a/web/packages/teleport/src/services/bot/bot.ts
+++ b/web/packages/teleport/src/services/bot/bot.ts
@@ -61,7 +61,7 @@ export function fetchBots(
   signal: AbortSignal,
   flags: FeatureFlags
 ): Promise<BotList> {
-  if (!flags.users) {
+  if (!flags.listBots) {
     return;
   }
 
@@ -89,7 +89,7 @@ export function editBot(
   name: string,
   req: EditBotRequest
 ): Promise<FlatBot> {
-  if (!flags.users || !flags.roles) {
+  if (!flags.editBots || !flags.roles) {
     return;
   }
 
@@ -99,7 +99,7 @@ export function editBot(
 }
 
 export function deleteBot(flags: FeatureFlags, name: string) {
-  if (!flags.users) {
+  if (!flags.removeBots) {
     return;
   }
 

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -216,6 +216,8 @@ class TeleportContext implements types.Context {
       externalAuditStorage: userContext.getExternalAuditStorageAccess().list,
       listBots: userContext.getBotsAccess().list,
       addBots: userContext.getBotsAccess().create,
+      editBots: userContext.getBotsAccess().edit,
+      removeBots: userContext.getBotsAccess().remove,
     };
   }
 }
@@ -253,6 +255,8 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   externalAuditStorage: false,
   addBots: false,
   listBots: false,
+  editBots: false,
+  removeBots: false,
 };
 
 export default TeleportContext;

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -179,6 +179,8 @@ export interface FeatureFlags {
   externalAuditStorage: boolean;
   listBots: boolean;
   addBots: boolean;
+  editBots: boolean;
+  removeBots: boolean;
 }
 
 // LockedFeatures are used for determining which features are disabled in the user's cluster.


### PR DESCRIPTION
This PR adds the remaining bot permission checks (list, write, delete) and turns on the bot list feature.

changelog: Add the ability to view and manage Machine ID bots from the UI

closes https://github.com/gravitational/teleport/issues/34260