### PR TITLE
Deflake TestWriteMovieCanBeCanceled

### DIFF
--- a/tool/tsh/common/recording_export.go
+++ b/tool/tsh/common/recording_export.go
@@ -240,7 +240,7 @@ loop:
 	// if we received a session start event but the context is canceled
 	// before we received the screen dimensions, then there's no movie to close
 	if movie == nil {
-		return 0, trace.BadParameter("operation canceled")
+		return 0, ctx.Err()
 	}
 
 	err = movie.Close()

--- a/tool/tsh/common/recording_export_test.go
+++ b/tool/tsh/common/recording_export_test.go
@@ -60,7 +60,7 @@ func TestWriteMovieCanBeCanceled(t *testing.T) {
 	cancel()
 
 	frames, _, err := writeMovieWrapper(t, ctx, fs, "test", "test", nil)
-	require.ErrorIs(t, context.Canceled, err)
+	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, 0, frames)
 }
 


### PR DESCRIPTION
Ensure we're returning context.Canceled in all cases. Also fix the order of the ErrorIs assertion.

Fixes errors like the one seen here: https://github.com/gravitational/teleport/actions/runs/7804158020/job/21285521166

```
        	Error Trace:	/__w/teleport/teleport/tool/tsh/common/recording_export_test.go:63
        	Error:      	Target error should be in err chain:
        	            	expected: "operation canceled"
        	            	in chain: "context canceled"
        	Test:       	TestWriteMovieCanBeCanceled
```