### PR TITLE
Add notes on upgrading Teleport on Docker

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -182,7 +182,7 @@ Teleport Enterprise, which is currently `public.ecr.aws/gravitational/teleport-e
 </TabItem>
 </Tabs>
 
-#### Interacting with Distroless Images
+#### Interacting with distroless images
 
 Since version 15, Teleport images are based on Google's [Distroless](https://github.com/GoogleContainerTools/distroless) images.
 Those images don't contain any shell.
@@ -213,7 +213,6 @@ Alternatively, you can use the debug variant of the image, which contains [busyb
 ```code
 $ docker run -it --entrypoint="" public.ecr.aws/gravitational/teleport-distroless -debug:(=teleport.latest_oss_docker_image=) busybox sh
 ```
-
 
 ### Running Teleport on Docker
 
@@ -287,7 +286,7 @@ to a local file for later use.
 For example:
 
 ```code
-docker exec ${TELEPORT_CONTAINER} \
+$ docker exec ${TELEPORT_CONTAINER} \
   tctl auth sign --user alice --format tls -o alice.local --tar | tar xv
 x alice.local.crt
 x alice.local.key
@@ -296,8 +295,8 @@ x alice.local.cas
 
 ### Example of running a Teleport container
 
-In this example, we will show you how to run the Teleport Auth and Proxy
-Services on a local Docker container using Teleport Community Edition.
+In this example, we will show you how to run the Teleport Auth Service and Proxy
+Service on a local Docker container using Teleport Community Edition.
 
 Since this container uses a self-signed certificate, we do not recommend using
 this configuration to protect any infrastructure outside your workstation. You
@@ -379,6 +378,17 @@ You should see JSON output similar to the following:
 We are using the `--insecure` flag to trust Teleport's self-signed certificate.
 In production, you will want to provision TLS credentials to the Proxy Service
 from a trusted CA, e.g., Let's Encrypt.
+
+### Upgrading Teleport on Docker
+
+To upgrade a Teleport container running on Docker:
+
+1. Leave the container's data directory in place.
+1. Stop the container.
+1. Run a new container with an image based on a newer Teleport version, mounting
+   the data directory as you did while running the container initially. As long
+   as the data directory contains the same content as before the upgrade, the
+   Teleport container does not need to re-join the cluster.
 
 ## Amazon EC2
 


### PR DESCRIPTION
Closes #17421

Expand the "Docker" section of the Installation guide. The required instructions are fairly straightforawrd, so this note is mainly to assure users that this is possible.