### PR TITLE
Switch errata-ai/vale-action to a tag (v2.1.0) instead of a branch

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -109,7 +109,7 @@ jobs:
           repository: "gravitational/teleport"
 
       - name: Run the linter
-        uses: errata-ai/vale-action@3f7188c866bcb3259339a09f517d7c4a8838303c # reviewdog
+        uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018 # v2.1.0
         with:
           version: 2.30.0
           separator: ","


### PR DESCRIPTION
The upstream recently started publishing tags again 🙌. All we had to do was [ask](https://github.com/errata-ai/vale-action/issues/115).

Referencing a tag is the GHA standard, and it also gives us changelogs when we need to review updates.

https://github.com/errata-ai/vale-action/releases/tag/v2.1.0 for the immediate changes.  Though in our case https://github.com/errata-ai/vale-action/compare/3f7188c866bcb3259339a09f517d7c4a8838303c...v2.1.0 is a better view.

None of these changes look dangerous, though https://github.com/errata-ai/vale-action/commit/92d66125c35defdd7e911b6f1ffcb1df78aa7949 may affect how findings are surfaced.
 