### PR TITLE
[v14] Use the correct timestamp for the last resource presence report

### DIFF
--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -375,7 +375,7 @@ Ingest:
 	}
 
 	if len(resourcePresences) > 0 {
-		r.persistResourcePresence(ctx, userActivityStartTime, resourcePresences)
+		r.persistResourcePresence(ctx, resourceUsageStartTime, resourcePresences)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Backport #37897 to branch/v14