### PR TITLE
[v15] chore: Bump golangci-lint to v1.56.1

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport15
 
     env:
-      GOLANGCI_LINT_VERSION: v1.56.0
+      GOLANGCI_LINT_VERSION: v1.56.1
 
     steps:
       - name: Checkout

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -319,7 +319,7 @@ RUN go install github.com/daixiang0/gci@v0.12.1
 RUN go install gotest.tools/gotestsum@v1.10.1
 
 # Install golangci-lint.
-RUN VERSION='v1.56.0'; \
+RUN VERSION='v1.56.1'; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 


### PR DESCRIPTION
Backport #37964 to branch/v15