### PR TITLE
[v13] chore: Bump golangci-lint to v1.56.1

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport13
 
     env:
-      GOLANGCI_LINT_VERSION: v1.56.0
+      GOLANGCI_LINT_VERSION: v1.56.1
 
     steps:
       - name: Checkout

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -285,7 +285,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.12.1
 
 # Install golangci-lint.
-RUN VERSION='v1.56.0'; \
+RUN VERSION='v1.56.1'; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 


### PR DESCRIPTION
Backport #37964 to branch/v13.

Update to the latest patch.

* https://github.com/golangci/golangci-lint/releases/tag/v1.56.1