### PR TITLE
[v13] Set noEmit in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tdd": "jest --watch",
     "lint": "yarn prettier-check && yarn eslint",
     "eslint": "eslint --quiet '+(e|web)/**/*.{ts,tsx,js,jsx}'",
-    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc --noEmit",
+    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc",
     "prettier-check": "yarn prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx}'",
     "prettier-write": "yarn prettier --write --loglevel silent '+(e|web)/**/*.{ts,tsx,js,jsx}'",
     "nop": "exit 0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
     "noEmitHelpers": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Backport #37928

v13 doesn't have `outDir`, so I didn't have to remove it.