### PR TITLE
[v12] Prevent leaking gRPC clients when connecting to the cluster fails

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -666,21 +666,19 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		Type:       types.HostCA,
 	}, false)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.NewAggregate(err, connector.Close())
 	}
 
-	err = process.storage.WriteIdentity(auth.IdentityCurrent, *identity)
-	if err != nil {
+	if err := process.storage.WriteIdentity(auth.IdentityCurrent, *identity); err != nil {
 		process.log.Warningf("Failed to write %v identity: %v.", role, err)
 	}
 
-	err = process.storage.WriteState(role, auth.StateV2{
+	if err := process.storage.WriteState(role, auth.StateV2{
 		Spec: auth.StateSpecV2{
 			Rotation: ca.GetRotation(),
 		},
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	}); err != nil {
+		return nil, trace.NewAggregate(err, connector.Close())
 	}
 	process.log.Infof("The process successfully wrote the credentials and state of %v to the disk.", role)
 	return connector, nil


### PR DESCRIPTION
Backport #37944 to branch/v12

changelog: Force agents to terminate Auth connections if joining fails
