### PR TITLE
[Web] Replace all instances of the brain icon for Assist

### DIFF
--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/ActionBar.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/ActionBar.tsx
@@ -19,8 +19,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Copy, Cross } from 'design/Icon';
-import { BrainIcon } from 'design/SVGIcon';
+import { ChatCircleSparkle, Copy, Cross } from 'design/Icon';
 
 interface Position {
   top: number;
@@ -94,7 +93,7 @@ export function ActionBar(props: ActionBarProps) {
       </Button>
 
       <Button onClick={handleAskAssist}>
-        <BrainIcon size={14} />
+        <ChatCircleSparkle size={14} />
         Ask Assist
       </Button>
 

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
@@ -19,7 +19,8 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
-import { BrainIcon, CloseIcon } from 'design/SVGIcon';
+import { CloseIcon } from 'design/SVGIcon';
+import { ChatCircleSparkle } from 'design/Icon';
 
 import { HeaderIcon, Tooltip } from 'teleport/Assist/shared';
 import {
@@ -196,7 +197,7 @@ export function TerminalAssist(props: TerminalAssistProps) {
         }}
         onClick={() => open()}
       >
-        <BrainIcon size={22} />
+        <ChatCircleSparkle size={22} />
       </Button>
 
       <KeyShortcut style={{ opacity: visible ? 0 : 0.5 }}>


### PR DESCRIPTION
`e` counterpart: https://github.com/gravitational/teleport.e/pull/3407