### PR TITLE
[v13] Fix test after Go 1.21 upgrade

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -727,6 +727,10 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 
+	// Go 1.21 changed the default behavior of TLS servers.
+	// See https://go.dev/doc/go1.21#crypto/tls.
+	tlsConfig.SessionTicketsDisabled = true
+
 	accessPoint, err := NewAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.AuditLog)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Fully backport #30201 to branch/v13, in the process fixing the flaky rotation and rollback tests.

I wrongly left this line out of #37561, believing it was not necessary (as it was removed from master).