### PR TITLE
docs: Use different versions of Teleport Windows auth package for Team/Cloud

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -46,7 +46,7 @@ To prepare a Windows computer:
    ```
 
 <Tabs>
-<TabItem scope={["oss"]} label="Teleport Community Edition">
+<TabItem scope={["oss", "enterprise"]} label="Teleport Community Edition/Teleport Enterprise">
 
 3. Download the Teleport Windows Auth setup program:
 
@@ -55,25 +55,7 @@ $ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cd
 ```
 
 </TabItem>
-<TabItem scope="team" label="Teleport Team">
-
-3. Download the Teleport Windows Auth setup program:
-
-```code
-$ curl -o teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
-```
-
-</TabItem>
-<TabItem scope={["enterprise"]} label="Teleport Enterprise">
-
-3. Download the Teleport Windows Auth setup program:
-
-```code
-$ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
-```
-
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+<TabItem scope={["team", "cloud"]} label="Teleport Team/Teleport Enterprise Cloud">
 
 3. Download the Teleport Windows Auth setup program:
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -39,6 +39,7 @@ To prepare a Windows computer:
 
 1. Open a Command Prompt (`cmd.exe`) window on the Windows computer you want to enroll.
 
+{/*lint ignore ordered-list-marker-value*/}
 2. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
 
    ```code
@@ -76,6 +77,7 @@ interactively and select the Teleport certificate that you exported when prompte
    - Disables Network Level Authentication (NLA) for remote desktop services.
    - Enables RemoteFX compression, if using Teleport version 15 or newer.
 
+{/*lint ignore ordered-list-marker-value*/}
 5. Restart the computer.
 
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -21,17 +21,17 @@ To complete the steps in this guide, verify your environment meets the following
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A Linux server to run the Teleport Windows Desktop Service.
-  You can reuse an existing server running any other Teleport instance. 
+  You can reuse an existing server running any other Teleport instance.
   However, you must generate a new invitation token to add the Windows Desktop Service
   to an existing Teleport instance.
-- A physical or virtual machine running Microsoft Windows with Remote Desktop enabled 
+- A physical or virtual machine running Microsoft Windows with Remote Desktop enabled
   and the RDP port (typically port 3389) open for inbound connections from the Linux server.
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Prepare Windows
 
 Before you can enroll a Microsoft Windows desktop as a resource to be protected by Teleport,
-you need to prepare the Microsoft Windows environment with a certificate from the Teleport 
+you need to prepare the Microsoft Windows environment with a certificate from the Teleport
 certificate authority (CA) and modify the default authentication service for remote desktop
 access.
 
@@ -39,27 +39,65 @@ To prepare a Windows computer:
 
 1. Open a Command Prompt (`cmd.exe`) window on the Windows computer you want to enroll.
 
-1. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
+2. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
 
    ```code
    $ curl -o teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
-1. Download the Teleport Windows Auth [setup program](https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe).
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
-1. Double-click the executable you downloaded to run the Teleport Windows Auth Setup program 
+3. Download the Teleport Windows Auth setup program:
+
+```code
+$ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
+```
+
+</TabItem>
+<TabItem scope="team" label="Teleport Team">
+
+3. Download the Teleport Windows Auth setup program:
+
+```code
+$ curl -o teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
+```
+
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
+
+3. Download the Teleport Windows Auth setup program:
+
+```code
+$ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+
+3. Download the Teleport Windows Auth setup program:
+
+```code
+$ curl -o teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe https://cdn.teleport.dev/teleport-windows-auth-setup-v(=cloud.version=)-amd64.exe
+```
+
+</TabItem>
+</Tabs>
+
+4. Double-click the executable you downloaded to run the Teleport Windows Auth Setup program
 interactively and select the Teleport certificate that you exported when prompted.
 
    The setup program:
 
    - Enables Windows to trust the Teleport certificate authority.
    - Installs the required dynamic link library (DLL) for Teleport to use.
-   - Disables Network Level Authentication (NLA) for remote desktop services. 
+   - Disables Network Level Authentication (NLA) for remote desktop services.
+   - Enables RemoteFX compression, if using Teleport version 15 or newer.
 
-1. Restart the computer.
+5. Restart the computer.
 
 
-If you want to automate the installation process, you can run the setup program from 
+If you want to automate the installation process, you can run the setup program from
 an administrative Command Prompt or PowerShell console with the following command:
 
 ```code
@@ -91,13 +129,13 @@ To configure the Windows Desktop Service:
    This token will expire in 60 minutes.
    ```
 
-1. Copy the token from your administrative workstation and paste it into a file on the 
+1. Copy the token from your administrative workstation and paste it into a file on the
 Linux server where you want to run the Windows Desktop Service.
 
    For example, create a file named `/tmp/token` on the Linux server and paste the token
    into the file.
 
-1. Check whether Teleport is installed on the Linux server where you want to run the 
+1. Check whether Teleport is installed on the Linux server where you want to run the
 Windows Desktop Service by running the following command:
 
    ```code
@@ -107,8 +145,8 @@ Windows Desktop Service by running the following command:
    If Teleport isn't installed on the Linux server, follow the appropriate [Installation
 instructions](../installation.mdx#installation-instructions) for your environment.
 
-1. Configure the `/etc/teleport.yaml` file on the Linux server with settings similar to the 
-following for the Windows Desktop Service: 
+1. Configure the `/etc/teleport.yaml` file on the Linux server with settings similar to the
+following for the Windows Desktop Service:
 
 
    ```yml
@@ -123,7 +161,7 @@ following for the Windows Desktop Service:
      - name: host1
        ad: false
        addr: 192.0.2.156
-   
+
    auth_service:
      enabled: no
    proxy_service:
@@ -137,12 +175,12 @@ following for the Windows Desktop Service:
    - Set the `proxy_server` to the address of your Teleport cluster.
    - List the Windows desktops under `static_hosts`.
 
-   Teleport can't automatically discover Windows desktops without Active Directory. 
-   Therefore, you must specify the Windows IP addresses or host names that you want to 
-   enroll using the Teleport configuration file or use the Teleport API to build your own 
-   integration. 
-   
-   You can find an example of API integration on 
+   Teleport can't automatically discover Windows desktops without Active Directory.
+   Therefore, you must specify the Windows IP addresses or host names that you want to
+   enroll using the Teleport configuration file or use the Teleport API to build your own
+   integration.
+
+   You can find an example of API integration on
   [GitHub](https://github.com/gravitational/teleport/tree/master/examples/desktop-registration).
 
 1. (Optional) Add labels for the Windows Desktop Service to the configuration file.
@@ -167,7 +205,7 @@ following for the Windows Desktop Service:
    ```
 
    Alternatively, you can attach labels to Windows computers by matching to their hostnames.
-   For example, the following adds the `cloud: ec2` label to computers that have 
+   For example, the following adds the `cloud: ec2` label to computers that have
    host names ending with `.us-east-2.compute.internal`:
 
    ```diff
@@ -188,7 +226,7 @@ following for the Windows Desktop Service:
    +        cloud: ec2
    ```
 
-   For more information about using labels and roles, see [Configure Windows-specific 
+   For more information about using labels and roles, see [Configure Windows-specific
    role permissions](./rbac.mdx).
 
 1. (!docs/pages/includes/start-teleport.mdx service="the Teleport Windows Desktop Service"!)
@@ -222,7 +260,7 @@ To configure a role for desktop access:
    - Set `windows_desktop_logins` to specify the Windows logins that Teleport users assigned to the role
    can use to access Windows desktops.
 
-   Depending on how you configure role-based access controls for Windows, Teleport can create local user logins 
+   Depending on how you configure role-based access controls for Windows, Teleport can create local user logins
    automatically from the `windows_desktop_logins` you specify. For more information about enabling Teleport
    to create local Windows logins, see [Logins](./rbac.mdx#logins).
 
@@ -238,19 +276,19 @@ To configure a role for desktop access:
 
 Now that you have configured a Linux server to run the Windows Desktop Service and
 created a role to allow a Teleport user to connect to Microsoft Windows with a local
-Windows login, you can use the Teleport user assigned the `windows-desktop-admins` role 
+Windows login, you can use the Teleport user assigned the `windows-desktop-admins` role
 to connect to Windows desktops from the Teleport Web UI.
 
 To connect to a Windows desktop:
 
-1. Sign in to the Teleport cluster using an account that's assigned the 
+1. Sign in to the Teleport cluster using an account that's assigned the
 `windows-desktop-admins` role.
 
 1. Select **Resources**.
 
 1. Click **Type**, then select **Desktops**.
 
-1. Click **Connect** for the Windows desktop you want to access, then select the 
+1. Click **Connect** for the Windows desktop you want to access, then select the
 Windows login to use for the connection.
 
    ![Connect to a Windows desktop from the Teleport Web UI](../../img/desktop-access/passwordless-desktop.png)
@@ -260,12 +298,12 @@ Windows login to use for the connection.
 
    ![Disconnect from a Windows desktop ](../../img/desktop-access/desktop-disconnect.png)
 
-   To view the recording, select **Management** in the Teleport Web UI, then click **Session Recordings** 
+   To view the recording, select **Management** in the Teleport Web UI, then click **Session Recordings**
    in the Activity section.
 
 ## Next steps
 
-For more general information about how to create, assign, and update roles, see [Access Controls 
+For more general information about how to create, assign, and update roles, see [Access Controls
 Getting Started](../access-controls/getting-started.mdx#step-13-add-local-users-with-preset-roles).
-For more specific information about configuring Windows-specific role permissions, see 
+For more specific information about configuring Windows-specific role permissions, see
 [Role-Based Access Control for Desktops](./rbac.mdx).


### PR DESCRIPTION
Previously, we always told the user to install the latest version of the auth package rather than attempting to match it to their Teleport version. This doesn't currently do any harm, but this might not always be the case and this is good practice.

This PR:
- adds specific auth package versions for each Teleport edition
- adds instructions for downloading the package at the command line using `curl`, rather than leaving this as an exercise for the reader
- adds a note that the installer will enable RemoteFX when using v15+

All other changes are my editor trimming whitespace.
