### PR TITLE
Improve handling of unrecognized documents in Connect

### DIFF
--- a/web/packages/shared/utils/assertUnreachable.ts
+++ b/web/packages/shared/utils/assertUnreachable.ts
@@ -17,5 +17,11 @@
  */
 
 export function assertUnreachable(x: never): never {
-  throw new Error(`Unhandled case: ${x}`);
+  throw new UnhandledCaseError(x);
+}
+
+export class UnhandledCaseError extends Error {
+  constructor(public unhandledCase: unknown) {
+    super(`Unhandled case: ${unhandledCase}`);
+  }
 }

--- a/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
+++ b/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
@@ -18,11 +18,13 @@
 
 import React from 'react';
 
+import { UnhandledCaseError } from 'shared/utils/assertUnreachable';
+
 import { FailedApp } from 'teleterm/ui/components/App';
 import Logger from 'teleterm/logger';
 
 export class CatchError extends React.Component {
-  logger = new Logger('components/CatchError');
+  logger = new Logger('CatchError');
 
   static getDerivedStateFromError(error) {
     return { error };
@@ -33,7 +35,17 @@ export class CatchError extends React.Component {
   };
 
   componentDidCatch(err) {
-    this.logger.error('render', err);
+    if (err instanceof UnhandledCaseError) {
+      try {
+        // Log this message only to console to avoid storing it on disk. unhandledCase might be an
+        // object which holds sensitive data.
+        console.error('Unhandled case', JSON.stringify(err.unhandledCase));
+      } catch (error) {
+        console.error('Cannot stringify unhandled case', error);
+      }
+    }
+
+    this.logger.error('Caught', err.stack || err);
   }
 
   render() {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -17,7 +17,6 @@
  */
 
 import { ClusterOrResourceUri, routing } from 'teleterm/ui/uri';
-import { assertUnreachable } from 'teleterm/ui/utils';
 
 import { Document, isDocumentTshNodeWithServerId } from './types';
 
@@ -57,6 +56,7 @@ export function getResourceUri(
     case 'doc.blank':
       return undefined;
     default:
-      assertUnreachable(document);
+      document satisfies never;
+      return undefined;
   }
 }


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/36730 made it so that Connect doesn't throw when it encounters an unknown document kind. This can typically happen when downgrading the app while your app_state.json contains documents from a newer version.

However, `getResourceUri` was still throwing and with "Unhandled case: [object Object]". This PR makes it so that we serialize the unhandled case to console and prevents `getResourceUri` from throwing.