### PR TITLE
Fix TestReadEnvironmentFile on macOS

### DIFF
--- a/lib/utils/envutils/environment.go
+++ b/lib/utils/envutils/environment.go
@@ -71,7 +71,7 @@ func readEnvironment(r io.Reader) ([]string, error) {
 		// split on first =, if not found, log it and continue
 		idx := strings.Index(line, "=")
 		if idx == -1 {
-			log.Debugf("Bad line %v while reading environment: no = separator found", lineno)
+			log.Debugf("Bad line %v while reading environment file: no = separator found", lineno)
 			continue
 		}
 

--- a/lib/utils/envutils/environment.go
+++ b/lib/utils/envutils/environment.go
@@ -21,6 +21,7 @@ package envutils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -43,10 +44,14 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 	}
 	defer file.Close()
 
+	return readEnvironment(file)
+}
+
+func readEnvironment(r io.Reader) ([]string, error) {
 	var lineno int
 	env := &SafeEnv{}
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
@@ -54,7 +59,7 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 		// https://github.com/openssh/openssh-portable/blob/master/session.c#L873-L874
 		lineno = lineno + 1
 		if lineno > teleport.MaxEnvironmentFileLines {
-			log.Warnf("Too many lines in environment file %v, returning first %v lines", filename, teleport.MaxEnvironmentFileLines)
+			log.Warnf("Too many lines in environment file, returning first %v lines", teleport.MaxEnvironmentFileLines)
 			return *env, nil
 		}
 
@@ -66,7 +71,7 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 		// split on first =, if not found, log it and continue
 		idx := strings.Index(line, "=")
 		if idx == -1 {
-			log.Debugf("Bad line %v while reading %v: no = separator found", lineno, filename)
+			log.Debugf("Bad line %v while reading environment: no = separator found", lineno)
 			continue
 		}
 
@@ -74,7 +79,7 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 		key := line[:idx]
 		value := line[idx+1:]
 		if strings.TrimSpace(key) == "" {
-			log.Debugf("Bad line %v while reading %v: key without name", lineno, filename)
+			log.Debugf("Bad line %v while reading environment file: key without name", lineno)
 			continue
 		}
 
@@ -82,9 +87,8 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 		env.AddTrusted(key, value)
 	}
 
-	err = scanner.Err()
-	if err != nil {
-		log.Warnf("Unable to read environment file %v: %v, skipping", filename, err)
+	if err := scanner.Err(); err != nil {
+		log.Warnf("Unable to read environment file: %v", err)
 		return []string{}, nil
 	}
 

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -19,14 +19,13 @@
 package envutils
 
 import (
-	"os"
+	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadEnvironmentFile(t *testing.T) {
+func TestReadEnvironment(t *testing.T) {
 	t.Parallel()
 
 	// contents of environment file
@@ -43,21 +42,11 @@ bar=foo
 LD_PRELOAD=attack
 `)
 
-	// create a temp file with an environment in it
-	f, err := os.CreateTemp(t.TempDir(), "teleport-environment-")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-	_, err = f.Write(rawenv)
-	require.NoError(t, err)
-	err = f.Close()
-	require.NoError(t, err)
-
-	// read in the temp file
-	env, err := ReadEnvironmentFile(f.Name())
+	env, err := readEnvironment(bytes.NewReader(rawenv))
 	require.NoError(t, err)
 
 	// check we parsed it correctly
-	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "foo=bar=baz", "foo=", "bar=foo"}))
+	require.Equal(t, []string{"foo=bar", "foo=bar=baz", "foo=", "bar=foo"}, env)
 }
 
 func TestSafeEnvAdd(t *testing.T) {


### PR DESCRIPTION
This test writes sample data to a temporary file and then tries to parse it. In #34177 we disallowed reading the environment file from a symlink, but the Go utilities we use to create temp files end up using symlinks on macOS.

Fix this by breaking out the core functionality such that it only requires an io.Reader instead of an os.File.