### PR TITLE
chore: Update various devbox packages

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -17,13 +17,13 @@
     "wasm-pack@latest",
     "wasm-bindgen-cli@latest",
 
-    "buf@1.26.1",
-    "go@1.21.4",
-    "gci@0.11.2",
+    "buf@1.29.0",
+    "go@1.22.0",
+    "gci@0.12.1",
     "golangci-lint@1.55.2",
-    "libfido2@1.13.0",
+    "libfido2@1.14.0",
     "llvmPackages_14.clangUseLLVM@14.0.6",
-    "nodejs@18.16.1",
+    "nodejs@18.18.2",
     "protobuf3_20@3.20.3",
     "yarn@1.22.19",
 


### PR DESCRIPTION
Update various packages to the currently-used versions.

A notable exception is golangci-lint, which should be v1.56.1, but that version isn't yet available.