### PR TITLE
Sort okta apps by friendlyName in unified cache

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -392,7 +392,12 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 	case types.AppServer:
 		app := r.GetApp()
 		if app != nil {
-			name = app.GetName()
+			friendlyName := types.FriendlyName(app)
+			if friendlyName != "" {
+				name = friendlyName
+			} else {
+				name = app.GetName()
+			}
 			kind = types.KindApp
 		}
 	case types.SAMLIdPServiceProvider:


### PR DESCRIPTION
Recently, we added a PR to sort[ user_groups by their friendly name](https://github.com/gravitational/teleport/pull/35696) to help sort the user_groups when creating an Access Request in a more predictable manner. This PR does nearly the same thing for Okta apps in the unified resources cache. 