### PR TITLE
Add Dependabot config for .github/actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -180,7 +180,24 @@ updates:
       - "no-changelog"
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: "/.github/workflows"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    reviewers:
+      - wadells
+      - jentfoo
+      - fheinecke
+      - camscale
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "no-changelog"
+
+  - package-ecosystem: github-actions
+    directory: "/.github/actions"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
We're not currently getting dependabot updates for the `.github/actions` directory, as it isn't included in the recommended `/` config. We need to keep dependencies in there up to date too.

## Related Discussions

* https://github.com/dependabot/dependabot-core/pull/6189 (which discusses what is going on with `/` and `/.github/workflows`)
* https://github.com/gravitational/teleport.e/pull/3402#pullrequestreview-1872782942 (where we noticed `.github/actions` was missed)
* https://github.com/gravitational/teleport.e/pull/3410 (the `e` version of this PR)
* https://gravitational.slack.com/archives/C0351AUPJ8K/p1707505260781949
