### PR TITLE
Add LoadAndDelete and Range to utils.SyncMap

### DIFF
--- a/lib/utils/sync_map_test.go
+++ b/lib/utils/sync_map_test.go
@@ -21,7 +21,7 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSyncMap(t *testing.T) {
@@ -31,8 +31,8 @@ func TestSyncMap(t *testing.T) {
 
 	// Nothing stored yet.
 	v, ok := m.Load("key1")
-	require.Nil(t, v)
-	require.False(t, ok)
+	assert.Nil(t, v)
+	assert.False(t, ok)
 
 	// Store some values.
 	value1 := NewRealUID()
@@ -42,20 +42,39 @@ func TestSyncMap(t *testing.T) {
 
 	// Check stored values.
 	v, ok = m.Load("key1")
-	require.Equal(t, value1, v)
-	require.True(t, ok)
+	assert.Equal(t, value1, v)
+	assert.True(t, ok)
 
 	v, ok = m.Load("key2")
-	require.Equal(t, value2, v)
-	require.True(t, ok)
+	assert.Equal(t, value2, v)
+	assert.True(t, ok)
+
+	// Iterate stored values with Range.
+	var keys []string
+	var values []UID
+	m.Range(func(key string, value UID) bool {
+		keys = append(keys, key)
+		values = append(values, value)
+		return true
+	})
+	assert.ElementsMatch(t, []string{"key1", "key2"}, keys)
+	assert.ElementsMatch(t, []UID{value1, value2}, values)
 
 	// Delete one.
 	m.Delete("key1")
 	v, ok = m.Load("key1")
-	require.Nil(t, v)
-	require.False(t, ok)
+	assert.Nil(t, v)
+	assert.False(t, ok)
 
 	v, ok = m.Load("key2")
-	require.Equal(t, value2, v)
-	require.True(t, ok)
+	assert.Equal(t, value2, v)
+	assert.True(t, ok)
+
+	// Load and delete.
+	v, ok = m.LoadAndDelete("key2")
+	assert.Equal(t, value2, v)
+	assert.True(t, ok)
+	v, ok = m.LoadAndDelete("key2")
+	assert.Nil(t, v)
+	assert.False(t, ok)
 }


### PR DESCRIPTION
This change adds the `LoadAndDelete` and `Range` methods to `utils.SyncMap`, which function the same as their [`sync.Map`](https://pkg.go.dev/sync#Map) counterparts.

Prerequisite for #37117.