### PR TITLE
Add remote port forwarding for OpenSSH nodes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -723,6 +723,14 @@ const (
 	// TerminalSizeRequest is a request for the terminal size of the session.
 	TerminalSizeRequest = "x-teleport-terminal-size"
 
+	// TCPIPForwardRequest is an SSH request for the server to open a listener
+	// for port forwarding.
+	TCPIPForwardRequest = "tcpip-forward"
+
+	// CancelTCPIPForwardRequest is an SSHRequest to cancel a previous
+	// TCPIPForwardRequest.
+	CancelTCPIPForwardRequest = "cancel-tcpip-forward"
+
 	// MFAPresenceRequest is an SSH request to notify clients that MFA presence is required for a session.
 	MFAPresenceRequest = "x-teleport-mfa-presence"
 
@@ -834,10 +842,13 @@ const (
 )
 
 const (
-	// ChanDirectTCPIP is a SSH channel of type "direct-tcpip".
+	// ChanDirectTCPIP is an SSH channel of type "direct-tcpip".
 	ChanDirectTCPIP = "direct-tcpip"
 
-	// ChanSession is a SSH channel of type "session".
+	// ChanForwardedTCPIP is an SSH channel of type "forwarded-tcpip".
+	ChanForwardedTCPIP = "forwarded-tcpip"
+
+	// ChanSession is an SSH channel of type "session".
 	ChanSession = "session"
 )
 

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -412,18 +412,18 @@ type ServerContext struct {
 	// recordNonInteractiveSession enables non-interactive session recording. Used by Assist.
 	recordNonInteractiveSession bool
 
-	// ChannelType holds the type of the channel. For example "session" or
+	// ExecType holds the type of the channel or request. For example "session" or
 	// "direct-tcpip". Used to create correct subcommand during re-exec.
-	ChannelType string
+	ExecType string
 
 	// SrcAddr is the source address of the request. This the originator IP
-	// address and port in an SSH "direct-tcpip" request. This value is only
-	// populated for port forwarding requests.
+	// address and port in an SSH "direct-tcpip" or "tcpip-forward" request. This
+	// value is only populated for port forwarding requests.
 	SrcAddr string
 
 	// DstAddr is the destination address of the request. This is the host and
-	// port to connect to in a "direct-tcpip" request. This value is only
-	// populated for port forwarding requests.
+	// port to connect to in a "direct-tcpip" or "tcpip-forward" request. This
+	// value is only populated for port forwarding requests.
 	DstAddr string
 
 	// allowFileCopying controls if remote file operations via SCP/SFTP are allowed
@@ -1378,5 +1378,24 @@ func (c *ServerContext) GetSessionMetadata() apievents.SessionMetadata {
 		SessionID:        string(c.SessionID()),
 		WithMFA:          c.Identity.Certificate.Extensions[teleport.CertExtensionMFAVerified],
 		PrivateKeyPolicy: c.Identity.Certificate.Extensions[teleport.CertExtensionPrivateKeyPolicy],
+	}
+}
+
+func (c *ServerContext) GetPortForwardEvent() apievents.PortForward {
+	sconn := c.ConnectionContext.ServerConn
+	return apievents.PortForward{
+		Metadata: apievents.Metadata{
+			Type: events.PortForwardEvent,
+			Code: events.PortForwardCode,
+		},
+		UserMetadata: c.Identity.GetUserMetadata(),
+		ConnectionMetadata: apievents.ConnectionMetadata{
+			LocalAddr:  sconn.LocalAddr().String(),
+			RemoteAddr: sconn.RemoteAddr().String(),
+		},
+		Addr: c.DstAddr,
+		Status: apievents.Status{
+			Success: true,
+		},
 	}
 }

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -25,9 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -640,6 +638,9 @@ func (s *Server) Serve() {
 
 	succeeded = true
 
+	// Add channel handlers immediately to avoid rejecting a channel.
+	forwardedTCPIP := s.remoteClient.HandleChannelOpen(teleport.ChanForwardedTCPIP)
+
 	// The keep-alive loop will keep pinging the remote server and after it has
 	// missed a certain number of keep-alive requests it will cancel the
 	// closeContext which signals the server to shutdown.
@@ -654,6 +655,7 @@ func (s *Server) Serve() {
 		CloseCancel:  func() { s.connectionContext.Close() },
 	})
 
+	go s.handleClientChannels(ctx, forwardedTCPIP)
 	go s.handleConnection(ctx, chans, reqs)
 }
 
@@ -851,6 +853,82 @@ func (s *Server) handleConnection(ctx context.Context, chans <-chan ssh.NewChann
 	}
 }
 
+// handleClientChannels handles channel open requests from the remote server.
+func (s *Server) handleClientChannels(ctx context.Context, forwardedTCPIP <-chan ssh.NewChannel) {
+	for nch := range forwardedTCPIP {
+		chanCtx, nch := tracessh.ContextFromNewChannel(nch)
+		ctx, span := s.tracerProvider.Tracer("ssh").Start(
+			oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(chanCtx)),
+			fmt.Sprintf("ssh.Forward.OpenChannel/%s", nch.ChannelType()),
+			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+			oteltrace.WithAttributes(
+				semconv.RPCServiceKey.String("ssh.ForwardServer"),
+				semconv.RPCMethodKey.String("OpenChannel"),
+				semconv.RPCSystemKey.String("ssh"),
+			),
+		)
+
+		go func() {
+			defer span.End()
+			if err := s.handleForwardedTCPIPRequest(ctx, nch); err != nil && !utils.IsOKNetworkError(err) {
+				s.log.WithError(err).Errorf("Error handling %s request.", teleport.ChanForwardedTCPIP)
+			}
+		}()
+	}
+}
+
+// handleForwardedTCPIPRequest handles remote port forwarding requests.
+func (s *Server) handleForwardedTCPIPRequest(ctx context.Context, nch ssh.NewChannel) error {
+	req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
+	if err != nil {
+		if err := nch.Reject(ssh.ConnectionFailed, "failed to parse forwarded-tcpip request"); err != nil {
+			s.log.WithError(err).Errorf("Error rejecting %s channel.", teleport.ChanForwardedTCPIP)
+		}
+		return trace.Wrap(err)
+	}
+
+	// Create context for this channel. This context will be closed when
+	// forwarding is complete.
+	ctx, scx, err := srv.NewServerContext(ctx, s.connectionContext, s, s.identityContext)
+	if err != nil {
+		if err := nch.Reject(ssh.ConnectionFailed, "failed to open server context"); err != nil {
+			s.log.WithError(err).Errorf("Error rejecting %s channel.", teleport.ChanForwardedTCPIP)
+		}
+		return trace.Wrap(err)
+	}
+	scx.RemoteClient = s.remoteClient
+	scx.ExecType = teleport.ChanDirectTCPIP
+	scx.SrcAddr = sshutils.JoinHostPort(req.Orig, req.OrigPort)
+	scx.DstAddr = sshutils.JoinHostPort(req.Host, req.Port)
+	defer scx.Close()
+
+	// Open a forwarding channel on the client.
+	outCh, outRequests, err := scx.ServerConn.OpenChannel(nch.ChannelType(), nch.ExtraData())
+	if err != nil {
+		if err := nch.Reject(ssh.ConnectionFailed, "failed to open remote client channel"); err != nil {
+			s.log.WithError(err).Errorf("Error rejecting %s channel.", teleport.ChanForwardedTCPIP)
+		}
+		return trace.Wrap(err)
+	}
+	go ssh.DiscardRequests(outRequests)
+	go io.Copy(io.Discard, outCh.Stderr())
+
+	ch, requests, err := nch.Accept()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	go ssh.DiscardRequests(requests)
+	go io.Copy(io.Discard, ch.Stderr())
+	ch = scx.TrackActivity(ch)
+
+	event := scx.GetPortForwardEvent()
+	if err := s.EmitAuditEvent(ctx, &event); err != nil {
+		s.log.WithError(err).Error("Failed to emit audit event.")
+	}
+
+	return trace.Wrap(utils.ProxyConn(ctx, ch, outCh))
+}
+
 func (s *Server) rejectChannel(chans <-chan ssh.NewChannel, errMessage string) {
 	newChannel, ok := <-chans
 	if !ok {
@@ -862,13 +940,29 @@ func (s *Server) rejectChannel(chans <-chan ssh.NewChannel, errMessage string) {
 }
 
 func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
-	// Version requests are internal Teleport requests, they should not be
-	// forwarded to the remote server.
-	if req.Type == teleport.VersionRequest {
+	switch req.Type {
+	case teleport.VersionRequest:
+		// Version requests are internal Teleport requests, they should not be
+		// forwarded to the remote server.
 		err := req.Reply(true, []byte(teleport.Version))
 		if err != nil {
 			s.log.Debugf("Failed to reply to version request: %v.", err)
 		}
+		return
+	case teleport.TCPIPForwardRequest, teleport.CancelTCPIPForwardRequest:
+		// Forwarding requests need to be authorized first.
+		if err := s.checkTCPIPForwardRequest(req); err != nil {
+			s.log.WithError(err).Warnf("Failed to check tcpip forward request")
+			if err := req.Reply(false, nil); err != nil {
+				s.log.Warnf("Failed to reply to global request: %v: %v", req.Type, err)
+			}
+			return
+		}
+		// Pass request on unchanged.
+	case teleport.KeepAliveReqType:
+	default:
+		s.log.Debugf("Rejecting unknown global request %q.", req.Type)
+		_ = req.Reply(false, nil)
 		return
 	}
 
@@ -877,13 +971,26 @@ func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 		s.log.Warnf("Failed to forward global request %v: %v", req.Type, err)
 		return
 	}
-
-	if req.WantReply {
-		err = req.Reply(ok, payload)
-		if err != nil {
-			s.log.Warnf("Failed to reply to global request: %v: %v", req.Type, err)
-		}
+	if err := req.Reply(ok, payload); err != nil {
+		s.log.Warnf("Failed to reply to global request: %v: %v", req.Type, err)
 	}
+}
+
+// checkTCPIPForwardRequest handles remote port forwarding requests.
+func (s *Server) checkTCPIPForwardRequest(r *ssh.Request) error {
+	// On forward server in "tcpip-forward" requests from SessionJoinPrincipal
+	//  should be rejected, otherwise it's possible to use the
+	// "-teleport-internal-join" user to bypass RBAC.
+	if s.identityContext.Login == teleport.SSHSessionJoinPrincipal {
+		s.log.Error("Request rejected, tcpip-forward with SessionJoinPrincipal in forward node must be blocked")
+		err := trace.AccessDenied("attempted tcpip-forward request in join-only mode")
+		if replyErr := r.Reply(false, []byte(utils.FormatErrorWithNewline(err))); replyErr != nil {
+			s.log.Errorf("sending error reply to SSH global request: %v", replyErr)
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
@@ -932,7 +1039,7 @@ func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
 	}
 }
 
-// handleDirectTCPIPRequest handles port forwarding requests.
+// handleDirectTCPIPRequest handles local port forwarding requests.
 func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when
 	// forwarding is complete.
@@ -943,9 +1050,9 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 		return
 	}
 	scx.RemoteClient = s.remoteClient
-	scx.ChannelType = teleport.ChanDirectTCPIP
-	scx.SrcAddr = net.JoinHostPort(req.Orig, strconv.Itoa(int(req.OrigPort)))
-	scx.DstAddr = net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
+	scx.ExecType = teleport.ChanDirectTCPIP
+	scx.SrcAddr = sshutils.JoinHostPort(req.Orig, req.OrigPort)
+	scx.DstAddr = sshutils.JoinHostPort(req.Host, req.Port)
 	defer scx.Close()
 
 	ch = scx.TrackActivity(ch)
@@ -968,51 +1075,13 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	}
 	defer conn.Close()
 
-	if err := s.EmitAuditEvent(s.closeContext, &apievents.PortForward{
-		Metadata: apievents.Metadata{
-			Type: events.PortForwardEvent,
-			Code: events.PortForwardCode,
-		},
-		UserMetadata: s.identityContext.GetUserMetadata(),
-		ConnectionMetadata: apievents.ConnectionMetadata{
-			LocalAddr:  s.sconn.LocalAddr().String(),
-			RemoteAddr: s.sconn.RemoteAddr().String(),
-		},
-		Addr: scx.DstAddr,
-		Status: apievents.Status{
-			Success: true,
-		},
-	}); err != nil {
+	event := scx.GetPortForwardEvent()
+	if err := s.EmitAuditEvent(s.closeContext, &event); err != nil {
 		scx.WithError(err).Warn("Failed to emit port forward event.")
 	}
 
-	var wg sync.WaitGroup
-	wch := make(chan struct{})
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if _, err := io.Copy(ch, conn); err != nil {
-			scx.Warningf("failed proxying data for port forwarding connection: %v", err)
-		}
-		ch.Close()
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if _, err := io.Copy(conn, ch); err != nil {
-			scx.Warningf("failed proxying data for port forwarding connection: %v", err)
-		}
-		conn.Close()
-	}()
-	// block on wg in separate goroutine so that we
-	// can select on wg and context cancellation.
-	go func() {
-		defer close(wch)
-		wg.Wait()
-	}()
-	select {
-	case <-wch:
-	case <-ctx.Done():
+	if err := utils.ProxyConn(ctx, ch, conn); err != nil {
+		s.log.WithError(err).Warn("Pailed proxying data for port forwarding connection.")
 	}
 }
 
@@ -1035,7 +1104,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 	}
 
 	scx.RemoteClient = s.remoteClient
-	scx.ChannelType = teleport.ChanSession
+	scx.ExecType = teleport.ChanSession
 	// Allow file copying at the server level as controlling node-wide
 	// file copying isn't supported for OpenSSH nodes. Users not allowed
 	// to copy files will still get checked and denied properly.

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -985,7 +985,7 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 	// The channel type determines the subcommand to execute (execution or
 	// port forwarding).
 	subCommand := teleport.ExecSubCommand
-	if ctx.ChannelType == teleport.ChanDirectTCPIP {
+	if ctx.ExecType == teleport.ChanDirectTCPIP {
 		subCommand = teleport.ForwardSubCommand
 	}
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1244,7 +1244,7 @@ func (s *Server) serveAgent(ctx *srv.ServerContext) error {
 // req.Reply(false, nil).
 //
 // For more details: https://tools.ietf.org/html/rfc4254.html#page-4
-func (s *Server) HandleRequest(ctx context.Context, r *ssh.Request) {
+func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) {
 	switch r.Type {
 	case teleport.KeepAliveReqType:
 		s.handleKeepAlive(r)
@@ -1455,7 +1455,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	}
 	scx.IsTestStub = s.isTestStub
 	scx.AddCloser(channel)
-	scx.ChannelType = teleport.ChanDirectTCPIP
+	scx.ExecType = teleport.ChanDirectTCPIP
 	scx.SrcAddr = net.JoinHostPort(req.Orig, strconv.Itoa(int(req.OrigPort)))
 	scx.DstAddr = net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
 	scx.SetAllowFileCopying(s.allowFileCopying)
@@ -1545,7 +1545,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 	}
 	scx.IsTestStub = s.isTestStub
 	scx.AddCloser(ch)
-	scx.ChannelType = teleport.ChanSession
+	scx.ExecType = teleport.ChanSession
 	scx.SetAllowFileCopying(s.allowFileCopying)
 	defer scx.Close()
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -635,7 +635,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 			if s.reqHandler != nil {
 				go func(span oteltrace.Span) {
 					defer span.End()
-					s.reqHandler.HandleRequest(ctx, req)
+					s.reqHandler.HandleRequest(ctx, ccx, req)
 				}(span)
 			} else {
 				span.End()
@@ -678,7 +678,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 }
 
 type RequestHandler interface {
-	HandleRequest(ctx context.Context, r *ssh.Request)
+	HandleRequest(ctx context.Context, ccx *ConnectionContext, r *ssh.Request)
 }
 
 type NewChanHandler interface {

--- a/lib/sshutils/tcpip.go
+++ b/lib/sshutils/tcpip.go
@@ -19,23 +19,39 @@
 package sshutils
 
 import (
+	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
+// DirectTCPIPReq represents the payload of an SSH "direct-tcpip" or
+// "forwarded-tcpip" request.
 type DirectTCPIPReq struct {
+	// Host is the receiver-side address to forward to.
 	Host string
+	// Port is the receiver-side port to forward to.
 	Port uint32
-
-	Orig     string
+	// Orig is the sender-side address to forward from.
+	Orig string
+	// OrigPort is the sender-side port to forward from.
 	OrigPort uint32
 }
 
+// ParseDirectTCPIPReq parses an SSH request's payload into a DirectTCPIPReq.
 func ParseDirectTCPIPReq(data []byte) (*DirectTCPIPReq, error) {
 	var r DirectTCPIPReq
 	if err := ssh.Unmarshal(data, &r); err != nil {
 		log.Infof("failed to parse Direct TCP IP request: %v", err)
-		return nil, err
+		return nil, trace.Wrap(err)
 	}
 	return &r, nil
+}
+
+// TCPIPForwardReq represents the payload of an SSH "tcpip-forward" or
+// "cancel-tcpip-forward" request.
+type TCPIPForwardReq struct {
+	// Addr is the address to listen on.
+	Addr string
+	// Port is the port to listen on.
+	Port uint32
 }

--- a/lib/sshutils/utils.go
+++ b/lib/sshutils/utils.go
@@ -1,0 +1,29 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sshutils
+
+import (
+	"net"
+	"strconv"
+)
+
+// JoinHostPort is a wrapper for net.JoinHostPort that takes a uint32 port..
+func JoinHostPort(host string, port uint32) string {
+	return net.JoinHostPort(host, strconv.Itoa(int(port)))
+}

--- a/lib/sshutils/utils_test.go
+++ b/lib/sshutils/utils_test.go
@@ -1,0 +1,29 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package sshutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinHostPort(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "example.com:1234", JoinHostPort("example.com", 1234))
+}


### PR DESCRIPTION
This change adds server-side support for remote port forwarding (`ssh -R`) for OpenSSH nodes.

Merge after #38046.

Changelog: Added remote port forwarding for OpenSSH nodes