### PR TITLE
Fix closed channel panic in headless subscriber logic

### DIFF
--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -382,6 +382,13 @@ func (s *headlessAuthenticationSubscriber) update(ha *types.HeadlessAuthenticati
 	s.updatesMu.Lock()
 	defer s.updatesMu.Unlock()
 
+	select {
+	case <-s.closed:
+		// subscriber is closing, ignore updates.
+		return
+	default:
+	}
+
 	// Drain stale update if there is one.
 	if overwrite {
 		select {


### PR DESCRIPTION
Previously it was possible for a subscriber to get closed during an update, resulting in the update channel getting closed before the update goes through - [discovered in this test](https://pipelinesghubeus4.actions.githubusercontent.com/VVrb3tw6aEXEmt5xOEyxCzdtHOEBwL2kXDxWgcjzlvxw3Xh6fI/_apis/pipelines/1/runs/1742029/signedlogcontent/2?urlExpires=2024-02-09T21%3A44%3A13.7455022Z&urlSigningMethod=HMACV1&urlSignature=8wtd%2FGjlp3XOlcKA2KwpIIRWM4YnRyXGl2n7t7fBfE0%3D).

This PR fixes this by checking if the subscriber is closing before completing an update.