### PR TITLE
Add remote port forwarding subcommand

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -818,9 +818,13 @@ const (
 	// command execution (exec and shells).
 	ExecSubCommand = "exec"
 
-	// ForwardSubCommand is the sub-command Teleport uses to re-exec itself
-	// for port forwarding.
-	ForwardSubCommand = "forwardv2"
+	// LocalForwardSubCommand is the sub-command Teleport uses to re-exec itself
+	// for local port forwarding.
+	LocalForwardSubCommand = "forwardv2"
+
+	// RemoteForwardSubCommand is the sub-command Teleport uses to re-exec itself
+	// for remote port forwarding.
+	RemoteForwardSubCommand = "remoteforward"
 
 	// CheckHomeDirSubCommand is the sub-command Teleport uses to re-exec itself
 	// to check if the user's home directory exists.

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -612,9 +612,77 @@ func (o *osWrapper) startNewParker(ctx context.Context, credential *syscall.Cred
 	return nil
 }
 
-// RunForward reads in the command to run from the parent process (over a
+type forwardHandler func(ctx context.Context, addr string, file *os.File) error
+
+func handleLocalPortForward(ctx context.Context, addr string, file *os.File) error {
+	conn, err := uds.FromFile(file)
+	_ = file.Close()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	defer conn.Close()
+	var d net.Dialer
+	remote, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer remote.Close()
+	if err := utils.ProxyConn(ctx, conn, remote); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func createRemotePortForwardingListener(ctx context.Context, addr string) (*os.File, error) {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer listener.Close()
+
+	tcpListener, _ := listener.(*net.TCPListener)
+	if tcpListener == nil {
+		return nil, trace.Errorf("expected listener to be of type *net.TCPListener, but was %T", listener)
+	}
+
+	listenerFD, err := tcpListener.File()
+	return listenerFD, trace.Wrap(err)
+}
+
+func handleRemotePortForward(ctx context.Context, addr string, file *os.File) error {
+	controlConn, err := uds.FromFile(file)
+	_ = file.Close()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	// unblock the final write
+	context.AfterFunc(ctx, func() { _ = controlConn.Close() })
+	go func() {
+		defer cancel()
+		_, _ = controlConn.Read(make([]byte, 1))
+	}()
+
+	var payload []byte
+	var files []*os.File
+	listenerFD, err := createRemotePortForwardingListener(ctx, addr)
+	if err == nil {
+		files = []*os.File{listenerFD}
+	} else {
+		payload = []byte(err.Error())
+	}
+	_, _, err2 := controlConn.WriteWithFDs(payload, files)
+	return trace.NewAggregate(err, err2)
+}
+
+// runForward reads in the command to run from the parent process (over a
 // pipe) then port forwards.
-func RunForward() (errw io.Writer, code int, err error) {
+func runForward(handler forwardHandler) (errw io.Writer, code int, err error) {
 	// errorWriter is used to return any error message back to the client.
 	// Use stderr so that it's not forwarded to the remote client.
 	errorWriter := os.Stderr
@@ -682,37 +750,42 @@ func RunForward() (errw io.Writer, code int, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var buf [1024]byte
-	var fbuf [1]*os.File
 	for {
-		n, fn, err := conn.ReadWithFDs(buf[:], fbuf[:])
+		buf := make([]byte, 1024)
+		fbuf := make([]*os.File, 1)
+		n, fn, err := conn.ReadWithFDs(buf, fbuf)
 		if err != nil {
 			if utils.IsOKNetworkError(err) {
 				return errorWriter, teleport.RemoteCommandSuccess, nil
 			}
 			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 		}
-
+		addr := string(buf[:n])
 		if fn == 0 {
+			log.Errorf("Parent did not send a file descriptor for address %q.", addr)
 			continue
 		}
 
-		conn, err := uds.FromFile(fbuf[0])
-		fbuf[0].Close()
-		if err != nil {
-			continue
-		}
-
-		go func(addr string, conn net.Conn) {
-			defer conn.Close()
-			remote, err := net.Dial("tcp", addr)
-			if err != nil {
-				return
+		go func() {
+			if err := handler(ctx, addr, fbuf[0]); err != nil {
+				log.WithError(err).Errorf("Error handling forwarding request for address %q.", addr)
 			}
-			defer remote.Close()
-			utils.ProxyConn(ctx, conn, remote)
-		}(string(buf[:n]), conn)
+		}()
 	}
+}
+
+// RunLocalForward reads in the command to run from the parent process (over a
+// pipe) then port forwards.
+func RunLocalForward() (errw io.Writer, code int, err error) {
+	errw, code, err = runForward(handleLocalPortForward)
+	return errw, code, trace.Wrap(err)
+}
+
+// RunRemoteForward reads in the command to run from the parent process (over a
+// pipe) then listens for port forwarding.
+func RunRemoteForward() (errw io.Writer, code int, err error) {
+	errw, code, err = runForward(handleRemotePortForward)
+	return errw, code, trace.Wrap(err)
 }
 
 // runCheckHomeDir check's if the active user's $HOME dir exists.
@@ -747,8 +820,10 @@ func RunAndExit(commandType string) {
 	switch commandType {
 	case teleport.ExecSubCommand:
 		w, code, err = RunCommand()
-	case teleport.ForwardSubCommand:
-		w, code, err = RunForward()
+	case teleport.LocalForwardSubCommand:
+		w, code, err = RunLocalForward()
+	case teleport.RemoteForwardSubCommand:
+		w, code, err = RunRemoteForward()
 	case teleport.CheckHomeDirSubCommand:
 		w, code, err = runCheckHomeDir()
 	case teleport.ParkSubCommand:
@@ -768,8 +843,8 @@ func RunAndExit(commandType string) {
 func IsReexec() bool {
 	if len(os.Args) == 2 {
 		switch os.Args[1] {
-		case teleport.ExecSubCommand, teleport.ForwardSubCommand, teleport.CheckHomeDirSubCommand,
-			teleport.ParkSubCommand, teleport.SFTPSubCommand:
+		case teleport.ExecSubCommand, teleport.LocalForwardSubCommand, teleport.RemoteForwardSubCommand,
+			teleport.CheckHomeDirSubCommand, teleport.ParkSubCommand, teleport.SFTPSubCommand:
 			return true
 		}
 	}
@@ -982,11 +1057,16 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 	}
 	executableDir, _ := filepath.Split(executable)
 
-	// The channel type determines the subcommand to execute (execution or
+	// The channel/request type determines the subcommand to execute (execution or
 	// port forwarding).
-	subCommand := teleport.ExecSubCommand
-	if ctx.ExecType == teleport.ChanDirectTCPIP {
-		subCommand = teleport.ForwardSubCommand
+	var subCommand string
+	switch ctx.ExecType {
+	case teleport.ChanDirectTCPIP:
+		subCommand = teleport.LocalForwardSubCommand
+	case teleport.TCPIPForwardRequest:
+		subCommand = teleport.RemoteForwardSubCommand
+	default:
+		subCommand = teleport.ExecSubCommand
 	}
 
 	// Build the list of arguments to have Teleport re-exec itself. The "-d" flag

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -111,7 +111,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	scpc := app.Command("scp", "Server-side implementation of SCP.").Hidden()
 	sftp := app.Command(teleport.SFTPSubCommand, "Server-side implementation of SFTP.").Hidden()
 	exec := app.Command(teleport.ExecSubCommand, "Used internally by Teleport to re-exec itself to run a command.").Hidden()
-	forward := app.Command(teleport.ForwardSubCommand, "Used internally by Teleport to re-exec itself to port forward.").Hidden()
+	forward := app.Command(teleport.LocalForwardSubCommand, "Used internally by Teleport to re-exec itself to port forward.").Hidden()
+	remoteForward := app.Command(teleport.RemoteForwardSubCommand, "Used internally by Teleport to re-exec itself to remote port forward.").Hidden()
 	checkHomeDir := app.Command(teleport.CheckHomeDirSubCommand, "Used internally by Teleport to re-exec itself to check access to a directory.").Hidden()
 	park := app.Command(teleport.ParkSubCommand, "Used internally by Teleport to re-exec itself to do nothing.").Hidden()
 	app.HelpFlag.Short('h')
@@ -564,7 +565,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	case exec.FullCommand():
 		srv.RunAndExit(teleport.ExecSubCommand)
 	case forward.FullCommand():
-		srv.RunAndExit(teleport.ForwardSubCommand)
+		srv.RunAndExit(teleport.LocalForwardSubCommand)
+	case remoteForward.FullCommand():
+		srv.RunAndExit(teleport.RemoteForwardSubCommand)
 	case checkHomeDir.FullCommand():
 		srv.RunAndExit(teleport.CheckHomeDirSubCommand)
 	case park.FullCommand():


### PR DESCRIPTION
This change adds the `remoteforward` subcommand to Teleport that handles remote port forwarding, similar to how `forwardv2` handles local port forwarding.

This is the flow for `remoteforward`:
- `remoteforward` is launched by the parent Teleport node with a Unix socket (labeled `A`) for inter-process commands (note: this part is not implemented in this PR).
- `remoteforward` reads from `A` an address and the file descriptor for a new socket `B`. `remoteforward` calls `net.Listen` with the given address and writes the listen address back to the parent over `B` (the address will have changed if the caller did not request a particular port, so the caller needs to know the port chosen).
- For each accepted connection on the listener, `remoteforward` creates a new socket `C` and writes `C`'s file descriptor over `B` to the parent. `remoteforward` proxies between the accepted connection and `C`.

```mermaid
sequenceDiagram
    participant Parent
    participant Forwarder
    Parent->>Forwarder: A: { "127.0.0.1:0", [ fd(B) ] }
    Note right of Forwarder: l, err := net.Listen("tcp", "127.0.0.1:0")
    Forwarder-->>Parent: B: { "127.0.0.1:12345", [ ] }
    Note left of Parent: Parent replies to tcpip-forward<br>SSH request with chosen port<br>(not in this PR)
    Note right of Forwarder: conn, err := l.Accept()
    Forwarder-->>Parent: B: { "", [ fd(C) ] }
    Parent->Forwarder: C: (Proxy connection over C)
```

Part of #37117.