### PR TITLE
Discovery: Allow configuring AWS TAG IAM integration

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -25,9 +25,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-var (
-	allResources = []string{"*"}
-)
+var allResources = []string{"*"}
 
 // StatementForIAMEditRolePolicy returns a IAM Policy Statement which allows editting Role Policy
 // of the resources.
@@ -240,7 +238,7 @@ func PolicyDocumentForExternalAuditStorage(cfg *ExternalAuditStoragePolicyConfig
 	return &PolicyDocument{
 		Version: PolicyVersion,
 		Statements: []*Statement{
-			&Statement{
+			{
 				StatementID: "ReadWriteSessionsAndEvents",
 				Effect:      EffectAllow,
 				Actions: []string{
@@ -260,7 +258,7 @@ func PolicyDocumentForExternalAuditStorage(cfg *ExternalAuditStoragePolicyConfig
 				},
 				Resources: cfg.S3ARNs,
 			},
-			&Statement{
+			{
 				StatementID: "AllowAthenaQuery",
 				Effect:      EffectAllow,
 				Actions: []string{
@@ -278,7 +276,7 @@ func PolicyDocumentForExternalAuditStorage(cfg *ExternalAuditStoragePolicyConfig
 					}.String(),
 				},
 			},
-			&Statement{
+			{
 				StatementID: "FullAccessOnGlueTable",
 				Effect:      EffectAllow,
 				Actions: []string{
@@ -313,4 +311,59 @@ func PolicyDocumentForExternalAuditStorage(cfg *ExternalAuditStoragePolicyConfig
 			},
 		},
 	}, nil
+}
+
+// StatementAccessGraphAWSSync returns the statement that allows configuring the AWS Sync feature.
+func StatementAccessGraphAWSSync() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			// EC2 IAM
+			"ec2:DescribeInstances",
+			"ec2:DescribeImages",
+			"ec2:DescribeTags",
+			"ec2:DescribeSnapshots",
+			"ec2:DescribeKeyPairs",
+			// EKS IAM
+			"eks:ListClusters",
+			"eks:DescribeCluster",
+			"eks:ListAccessEntries",
+			"eks:ListAccessPolicies",
+			"eks:ListAssociatedAccessPolicies",
+
+			// RDS IAM
+			"rds:DescribeDBInstances",
+			"rds:DescribeDBClusters",
+			"rds:ListTagsForResource",
+			"rds:List*",
+			// DynamoDB IAM
+			"dynamodb:ListTables",
+			"dynamodb:DescribeTable",
+			// Redshift IAM
+			"redshift:DescribeClusters",
+			"redshift:Describe*",
+			// S3 IAM
+			"s3:ListAllMyBuckets",
+			"s3:GetBucketPolicy",
+			"s3:ListBucket",
+			"s3:GetBucketLocation",
+			// IAM IAM
+			"iam:ListUsers",
+			"iam:GetUser",
+			"iam:ListRoles",
+			"iam:ListGroups",
+			"iam:ListPolicies",
+			"iam:ListGroupsForUser",
+			"iam:ListInstanceProfiles",
+			"iam:ListUserPolicies",
+			"iam:GetUserPolicy",
+			"iam:ListAttachedUserPolicies",
+			"iam:ListGroupPolicies",
+			"iam:GetGroupPolicy",
+			"iam:ListAttachedGroupPolicies",
+			"iam:GetPolicy",
+			"iam:GetPolicyVersion",
+		},
+		Resources: allResources,
+	}
 }

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -335,7 +335,8 @@ func StatementAccessGraphAWSSync() *Statement {
 			"rds:DescribeDBInstances",
 			"rds:DescribeDBClusters",
 			"rds:ListTagsForResource",
-			"rds:List*",
+			"rds:DescribeDBProxies",
+
 			// DynamoDB IAM
 			"dynamodb:ListTables",
 			"dynamodb:DescribeTable",

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -227,6 +227,17 @@ type CommandLineFlags struct {
 	// IntegrationConfExternalAuditStorageArguments contains the arguments of the
 	// `teleport integration configure externalauditstorage` command
 	IntegrationConfExternalAuditStorageArguments easconfig.ExternalAuditStorageConfiguration
+
+	// IntegrationConfAccessGraphAWSSyncArguments contains the arguments of
+	// `teleport integration configure access-graph aws-iam` command
+	IntegrationConfAccessGraphAWSSyncArguments IntegrationConfAccessGraphAWSSync
+}
+
+// IntegrationConfAccessGraphAWSSync contains the arguments of
+// `teleport integration configure access-graph aws-iam` command.
+type IntegrationConfAccessGraphAWSSync struct {
+	// Role is the AWS Role associated with the Integration
+	Role string
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of

--- a/lib/integrations/awsoidc/access_graph_aws_sync.go
+++ b/lib/integrations/awsoidc/access_graph_aws_sync.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// defaultPolicyNameForTAGSync is the default name for the Inline TAG Policy added to the IntegrationRole.
-	defaultPolicyNameForTAGSync = "AccessGraphAWSSyncAccess"
+	defaultPolicyNameForTAGSync = "AccessGraphSyncAccess"
 )
 
 // AccessGraphAWSIAMConfigureRequest is a request to configure the required Policies to use the TAG AWS Sync.
@@ -40,7 +40,7 @@ type AccessGraphAWSIAMConfigureRequest struct {
 	IntegrationRole string
 
 	// IntegrationRoleTAGPolicy is the Policy Name that is created to allow access to call AWS APIs.
-	// Defaults to "AccessGraphAWSSyncAccess"
+	// Defaults to "AccessGraphSyncAccess"
 	IntegrationRoleTAGPolicy string
 }
 

--- a/lib/integrations/awsoidc/access_graph_aws_sync.go
+++ b/lib/integrations/awsoidc/access_graph_aws_sync.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	// defaultPolicyNameForTAGSync is the default name for the Inline TAG Policy added to the IntegrationRole.
+	defaultPolicyNameForTAGSync = "AccessGraphAWSSyncAccess"
+)
+
+// AccessGraphAWSIAMConfigureRequest is a request to configure the required Policies to use the TAG AWS Sync.
+type AccessGraphAWSIAMConfigureRequest struct {
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+
+	// IntegrationRoleTAGPolicy is the Policy Name that is created to allow access to call AWS APIs.
+	// Defaults to "AccessGraphAWSSyncAccess"
+	IntegrationRoleTAGPolicy string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *AccessGraphAWSIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.IntegrationRoleTAGPolicy == "" {
+		r.IntegrationRoleTAGPolicy = defaultPolicyNameForTAGSync
+	}
+
+	return nil
+}
+
+// AccessGraphIAMConfigureClient describes the required methods to create the IAM Policies
+// required for enrolling Access Graph AWS Sync into Teleport.
+type AccessGraphIAMConfigureClient interface {
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultTAGIAMConfigureClient struct {
+	*iam.Client
+}
+
+// NewAccessGraphIAMConfigureClient creates a new TAGIAMConfigureClient.
+func NewAccessGraphIAMConfigureClient(ctx context.Context) (AccessGraphIAMConfigureClient, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("" /* region */))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultTAGIAMConfigureClient{
+		Client: iam.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureAccessGraphSyncIAM sets up the roles required for Teleport to be able to pool
+// AWS resources into Teleport.
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - iam:PutRolePolicy
+func ConfigureAccessGraphSyncIAM(ctx context.Context, clt AccessGraphIAMConfigureClient, req AccessGraphAWSIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	policyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementAccessGraphAWSSync(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.IntegrationRoleTAGPolicy,
+		RoleName:       &req.IntegrationRole,
+		PolicyDocument: &policyDocument,
+	})
+	if err != nil {
+		if trace.IsNotFound(awslib.ConvertIAMv2Error(err)) {
+			return trace.NotFound("role %q not found.", req.IntegrationRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleTAGPolicy, req.IntegrationRole)
+	return nil
+}

--- a/lib/integrations/awsoidc/access_graph_aws_sync_test.go
+++ b/lib/integrations/awsoidc/access_graph_aws_sync_test.go
@@ -48,7 +48,7 @@ func TestAccessGraphIAMConfigReqDefaults(t *testing.T) {
 			errCheck: require.NoError,
 			expected: AccessGraphAWSIAMConfigureRequest{
 				IntegrationRole:          "integrationrole",
-				IntegrationRoleTAGPolicy: "AccessGraphAWSSyncAccess",
+				IntegrationRoleTAGPolicy: "AccessGraphSyncAccess",
 			},
 		},
 

--- a/lib/integrations/awsoidc/access_graph_aws_sync_test.go
+++ b/lib/integrations/awsoidc/access_graph_aws_sync_test.go
@@ -1,0 +1,128 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessGraphIAMConfigReqDefaults(t *testing.T) {
+	baseReq := func() AccessGraphAWSIAMConfigureRequest {
+		return AccessGraphAWSIAMConfigureRequest{
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() AccessGraphAWSIAMConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected AccessGraphAWSIAMConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseReq,
+			errCheck: require.NoError,
+			expected: AccessGraphAWSIAMConfigureRequest{
+				IntegrationRole:          "integrationrole",
+				IntegrationRoleTAGPolicy: "AccessGraphAWSSyncAccess",
+			},
+		},
+
+		{
+			name: "missing integration role",
+			req: func() AccessGraphAWSIAMConfigureRequest {
+				req := baseReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestAccessGraphAWSIAMConfig(t *testing.T) {
+	ctx := context.Background()
+	baseReq := func() AccessGraphAWSIAMConfigureRequest {
+		return AccessGraphAWSIAMConfigureRequest{
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name              string
+		mockExistingRoles []string
+		req               func() AccessGraphAWSIAMConfigureRequest
+		errCheck          require.ErrorAssertionFunc
+	}{
+		{
+			name:              "valid",
+			req:               baseReq,
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          require.NoError,
+		},
+		{
+			name:              "integration role does not exist",
+			mockExistingRoles: []string{},
+			req:               baseReq,
+			errCheck:          notFoundCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockAccessGraphAWSAMConfigClient{
+				existingRoles: tt.mockExistingRoles,
+			}
+
+			err := ConfigureAccessGraphSyncIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockAccessGraphAWSAMConfigClient struct {
+	existingRoles []string
+}
+
+func (m *mockAccessGraphAWSAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
+		return nil, &iamTypes.NoSuchEntityException{
+			Message: &noSuchEntityMessage,
+		}
+	}
+	return nil, nil
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -886,6 +886,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/requireddatabasesvpcs", h.WithClusterAuth(h.awsOIDCRequiredDatabasesVPCS))
 	h.GET("/webapi/scripts/integrations/configure/eice-iam.sh", h.WithLimiter(h.awsOIDCConfigureEICEIAM))
 	h.GET("/webapi/scripts/integrations/configure/eks-iam.sh", h.WithLimiter(h.awsOIDCConfigureEKSIAM))
+	h.GET("/webapi/scripts/integrations/configure/access-graph-cloud-sync-iam.sh", h.WithLimiter(h.accessGraphCloudSyncOIDC))
 
 	// AWS OIDC Integration specific endpoints:
 	// Unauthenticated access to OpenID Configuration - used for AWS OIDC IdP integration
@@ -3890,7 +3891,6 @@ func (h *Handler) authenticateWSRequestWithClusterDeprecated(w http.ResponseWrit
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnelclient.RemoteSite, error) {
 	sctx, err := h.AuthenticateRequest(w, r, true)
-
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -890,7 +890,7 @@ func (h *Handler) accessGraphCloudSyncOIDC(w http.ResponseWriter, r *http.Reques
 	case "aws-iam":
 		return h.awsAccessGraphOIDCSync(w, r, p)
 	default:
-		return nil, trace.BadParameter("unsuported kind provided %q", kind)
+		return nil, trace.BadParameter("unsupported kind provided %q", kind)
 	}
 }
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -886,12 +886,11 @@ func (h *Handler) awsOIDCConfigureListDatabasesIAM(w http.ResponseWriter, r *htt
 func (h *Handler) accessGraphCloudSyncOIDC(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	queryParams := r.URL.Query()
 
-	cloud := queryParams.Get("provider")
-	switch cloud {
-	case "aws":
+	switch kind := queryParams.Get("kind"); kind {
+	case "aws-iam":
 		return h.awsAccessGraphOIDCSync(w, r, p)
 	default:
-		return nil, trace.BadParameter("invalid cloud provider %q", cloud)
+		return nil, trace.BadParameter("unsuported kind provided %q", kind)
 	}
 }
 
@@ -903,7 +902,7 @@ func (h *Handler) awsAccessGraphOIDCSync(w http.ResponseWriter, r *http.Request,
 	}
 
 	// The script must execute the following command:
-	// "teleport integration configure  access-graph aws-iam"
+	// "teleport integration configure access-graph aws-iam"
 	argsList := []string{
 		"integration", "configure", "access-graph", "aws-iam",
 		fmt.Sprintf("--role=%s", role),

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -477,6 +477,10 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEKSCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Region)
 	integrationConfEKSCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEKSIAMArguments.Role)
 
+	integrationConfAccessGraphCmd := integrationConfigureCmd.Command("access-graph", "Manages Access Graph configuration.")
+	integrationConfTAGSyncCmd := integrationConfAccessGraphCmd.Command("aws-iam", "Adds required IAM permissions for syncing data into Access Graph service.")
+	integrationConfTAGSyncCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.Role)
+
 	integrationConfAWSOIDCIdPCmd := integrationConfigureCmd.Command("awsoidc-idp", "Creates an IAM IdP (OIDC) in your AWS account to allow the AWS OIDC Integration to access AWS APIs.")
 	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster name.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Cluster)
@@ -608,6 +612,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onIntegrationConfListDatabasesIAM(ccf.IntegrationConfListDatabasesIAMArguments)
 	case integrationConfExternalAuditCmd.FullCommand():
 		err = onIntegrationConfExternalAuditCmd(ccf.IntegrationConfExternalAuditStorageArguments)
+	case integrationConfTAGSyncCmd.FullCommand():
+		err = onIntegrationConfAccessGraphAWSSync(ccf.IntegrationConfAccessGraphAWSSyncArguments)
 	}
 	if err != nil {
 		utils.FatalError(err)
@@ -1090,4 +1096,22 @@ func onIntegrationConfExternalAuditCmd(params easconfig.ExternalAuditStorageConf
 		Sts: sts.NewFromConfig(cfg),
 	}
 	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, &params))
+}
+
+func onIntegrationConfAccessGraphAWSSync(params config.IntegrationConfAccessGraphAWSSync) error {
+	ctx := context.Background()
+
+	iamClient, err := awsoidc.NewAccessGraphIAMConfigureClient(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = awsoidc.ConfigureAccessGraphSyncIAM(ctx, iamClient, awsoidc.AccessGraphAWSIAMConfigureRequest{
+		IntegrationRole: params.Role,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR allows the configuration of IAM permissions required for Access Graph AWS Sync using Teleport OIDC integration.

Part of https://github.com/gravitational/access-graph/issues/458