### PR TITLE
WebAPI: Allow creating `discovery_config` with Access Graph settings

### DIFF
--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -276,30 +276,11 @@ func grpcCredentials(config servicecfg.AccessGraphConfig, certs []tls.Certificat
 }
 
 func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error {
-	if cfg.Matchers.AccessGraph != nil && len(cfg.Matchers.AccessGraph.AWS) > 0 {
-		for _, awsFetcher := range cfg.Matchers.AccessGraph.AWS {
-			var assumeRole *aws_sync.AssumeRole
-			if awsFetcher.AssumeRole != nil {
-				assumeRole = &aws_sync.AssumeRole{
-					RoleARN:    awsFetcher.AssumeRole.RoleARN,
-					ExternalID: awsFetcher.AssumeRole.ExternalID,
-				}
-			}
-			fetcher, err := aws_sync.NewAWSFetcher(
-				ctx,
-				aws_sync.Config{
-					CloudClients: s.CloudClients,
-					AssumeRole:   assumeRole,
-					Regions:      awsFetcher.Regions,
-					Integration:  awsFetcher.Integration,
-				},
-			)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			s.staticTAGSyncFetchers = append(s.staticTAGSyncFetchers, fetcher)
-		}
+	fetchers, err := s.accessGraphFetchersFromMatchers(ctx, cfg.Matchers)
+	if err != nil {
+		s.Log.WithError(err).Error("Error initializing access graph fetchers")
 	}
+	s.staticTAGSyncFetchers = fetchers
 
 	if cfg.AccessGraphConfig.Enabled {
 		go func() {
@@ -319,4 +300,36 @@ func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error
 		}()
 	}
 	return nil
+}
+
+// accessGraphFetchersFromMatchers converts Matchers into a set of AWS Sync Fetchers.
+func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers Matchers) ([]aws_sync.AWSSync, error) {
+	var fetchers []aws_sync.AWSSync
+	var errs []error
+	if matchers.AccessGraph != nil && len(matchers.AccessGraph.AWS) > 0 {
+		for _, awsFetcher := range matchers.AccessGraph.AWS {
+			var assumeRole *aws_sync.AssumeRole
+			if awsFetcher.AssumeRole != nil {
+				assumeRole = &aws_sync.AssumeRole{
+					RoleARN:    awsFetcher.AssumeRole.RoleARN,
+					ExternalID: awsFetcher.AssumeRole.ExternalID,
+				}
+			}
+			fetcher, err := aws_sync.NewAWSFetcher(
+				ctx,
+				aws_sync.Config{
+					CloudClients: s.CloudClients,
+					AssumeRole:   assumeRole,
+					Regions:      awsFetcher.Regions,
+					Integration:  awsFetcher.Integration,
+				},
+			)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			fetchers = append(fetchers, fetcher)
+		}
+	}
+	return fetchers, trace.NewAggregate(errs...)
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1241,7 +1241,7 @@ func (s *Server) startDynamicWatcherUpdater() {
 				continue
 			}
 
-			if err := s.upsertDynamicMatchers(dc); err != nil {
+			if err := s.upsertDynamicMatchers(s.ctx, dc); err != nil {
 				s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
 				continue
 			}
@@ -1273,7 +1273,7 @@ func (s *Server) startDynamicWatcherUpdater() {
 					continue
 				}
 
-				if err := s.upsertDynamicMatchers(dc); err != nil {
+				if err := s.upsertDynamicMatchers(s.ctx, dc); err != nil {
 					s.Log.WithError(err).Warnf("failed to update dynamic matchers for discovery config %q", dc.GetName())
 					continue
 				}
@@ -1332,15 +1332,20 @@ func (s *Server) deleteDynamicFetchers(name string) {
 	s.muDynamicServerGCPFetchers.Lock()
 	delete(s.dynamicServerGCPFetchers, name)
 	s.muDynamicServerGCPFetchers.Unlock()
+
+	s.muDynamicTAGSyncFetchers.Lock()
+	delete(s.dynamicTAGSyncFetchers, name)
+	s.muDynamicTAGSyncFetchers.Unlock()
 }
 
 // upsertDynamicMatchers upserts the internal set of dynamic matchers given a particular discovery config.
-func (s *Server) upsertDynamicMatchers(dc *discoveryconfig.DiscoveryConfig) error {
+func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) error {
 	matchers := Matchers{
-		AWS:        dc.Spec.AWS,
-		Azure:      dc.Spec.Azure,
-		GCP:        dc.Spec.GCP,
-		Kubernetes: dc.Spec.Kube,
+		AWS:         dc.Spec.AWS,
+		Azure:       dc.Spec.Azure,
+		GCP:         dc.Spec.GCP,
+		Kubernetes:  dc.Spec.Kube,
+		AccessGraph: dc.Spec.AccessGraph,
 	}
 	s.discardUnsupportedMatchers(&matchers)
 
@@ -1373,6 +1378,16 @@ func (s *Server) upsertDynamicMatchers(dc *discoveryconfig.DiscoveryConfig) erro
 	s.muDynamicDatabaseFetchers.Lock()
 	s.dynamicDatabaseFetchers[dc.GetName()] = databaseFetchers
 	s.muDynamicDatabaseFetchers.Unlock()
+
+	awsSyncMatchers, err := s.accessGraphFetchersFromMatchers(
+		ctx, matchers,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	s.muDynamicTAGSyncFetchers.Lock()
+	s.dynamicTAGSyncFetchers[dc.GetName()] = awsSyncMatchers
+	s.muDynamicTAGSyncFetchers.Unlock()
 
 	// TODO(marco): add other fetchers: Kube Clusters and Kube Resources (Apps)
 	return nil

--- a/lib/web/discoveryconfig.go
+++ b/lib/web/discoveryconfig.go
@@ -53,6 +53,7 @@ func (h *Handler) discoveryconfigCreate(w http.ResponseWriter, r *http.Request, 
 			Azure:          req.Azure,
 			GCP:            req.GCP,
 			Kube:           req.Kube,
+			AccessGraph:    req.AccessGraph,
 		},
 	)
 	if err != nil {
@@ -106,6 +107,7 @@ func (h *Handler) discoveryconfigUpdate(w http.ResponseWriter, r *http.Request, 
 	dc.Spec.Azure = req.Azure
 	dc.Spec.GCP = req.GCP
 	dc.Spec.Kube = req.Kube
+	dc.Spec.AccessGraph = req.AccessGraph
 
 	if _, err := clt.DiscoveryConfigClient().UpdateDiscoveryConfig(r.Context(), dc); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/discoveryconfig_test.go
+++ b/lib/web/discoveryconfig_test.go
@@ -261,14 +261,15 @@ func TestDiscoveryConfig(t *testing.T) {
 			require.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
 			require.Equal(t, "dc01", discoveryConfigResp.Name)
 			require.NotNil(t, discoveryConfigResp.AccessGraph)
-			require.Equal(t, discoveryConfigResp.AccessGraph, &types.AccessGraphSync{
+			expected := &types.AccessGraphSync{
 				AWS: []*types.AccessGraphAWSSync{
 					{
 						Regions:     []string{"us-west-2"},
 						Integration: "integrationrole",
 					},
 				},
-			})
+			}
+			require.Equal(t, expected, discoveryConfigResp.AccessGraph)
 		})
 	})
 }

--- a/lib/web/discoveryconfig_test.go
+++ b/lib/web/discoveryconfig_test.go
@@ -215,4 +215,60 @@ func TestDiscoveryConfig(t *testing.T) {
 		require.Len(t, uniqDC, listTestCount)
 		require.Zero(t, iterationsCount, "invalid number of iterations")
 	})
+
+	t.Run("Create valid access graph", func(t *testing.T) {
+		resp, err := pack.clt.PostJSON(ctx, createEndpoint, ui.DiscoveryConfig{
+			Name:           "dc01",
+			DiscoveryGroup: "dg01",
+			AccessGraph: &types.AccessGraphSync{
+				AWS: []*types.AccessGraphAWSSync{
+					{
+						Regions:     []string{"us-west-2"},
+						Integration: "integrationrole",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Code())
+
+		t.Run("Create fails when name already exists", func(t *testing.T) {
+			resp, err := pack.clt.PostJSON(ctx, createEndpoint, ui.DiscoveryConfig{
+				Name:           "dc01",
+				DiscoveryGroup: "dg01",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Regions:     []string{"us-west-2"},
+							Integration: "integrationrole",
+						},
+					},
+				},
+			})
+			require.ErrorContains(t, err, "already exists")
+			require.Equal(t, http.StatusConflict, resp.Code())
+		})
+
+		getDC01Endpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "discoveryconfig", "dc01")
+		t.Run("Get one", func(t *testing.T) {
+			resp, err := pack.clt.Get(ctx, getDC01Endpoint, nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.Code())
+
+			var discoveryConfigResp ui.DiscoveryConfig
+			err = json.Unmarshal(resp.Bytes(), &discoveryConfigResp)
+			require.NoError(t, err)
+			require.Equal(t, "dg01", discoveryConfigResp.DiscoveryGroup)
+			require.Equal(t, "dc01", discoveryConfigResp.Name)
+			require.NotNil(t, discoveryConfigResp.AccessGraph)
+			require.Equal(t, discoveryConfigResp.AccessGraph, &types.AccessGraphSync{
+				AWS: []*types.AccessGraphAWSSync{
+					{
+						Regions:     []string{"us-west-2"},
+						Integration: "integrationrole",
+					},
+				},
+			})
+		})
+	})
 }

--- a/lib/web/ui/discoveryconfig.go
+++ b/lib/web/ui/discoveryconfig.go
@@ -39,6 +39,8 @@ type DiscoveryConfig struct {
 	GCP []types.GCPMatcher `json:"gcpMatchers,omitempty"`
 	// Kube is a list of matchers for AWS resources.
 	Kube []types.KubernetesMatcher `json:"kube,omitempty"`
+	// AccessGraph is the configuration for the Access Graph Cloud sync.
+	AccessGraph *types.AccessGraphSync `json:"accessGraph,omitempty"`
 }
 
 // CheckAndSetDefaults for the create request.
@@ -67,6 +69,8 @@ type UpdateDiscoveryConfigRequest struct {
 	GCP []types.GCPMatcher `json:"gcpMatchers,omitempty"`
 	// Kube is a list of matchers for AWS resources.
 	Kube []types.KubernetesMatcher `json:"kube,omitempty"`
+	// AccessGraph is the configuration for the Access Graph Cloud sync.
+	AccessGraph *types.AccessGraphSync `json:"accessGraph,omitempty"`
 }
 
 // CheckAndSetDefaults checks if the provided values are valid.
@@ -108,5 +112,6 @@ func MakeDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig) DiscoveryConfig {
 		Azure:          dc.Spec.Azure,
 		GCP:            dc.Spec.GCP,
 		Kube:           dc.Spec.Kube,
+		AccessGraph:    dc.Spec.AccessGraph,
 	}
 }


### PR DESCRIPTION
This PR allows the configuration of `discovery_config` resources with the `access_graph` section.
These configs will later be loaded by `discovery_services` whose discovery group match with the ones provided and will be used to sync cloud data into Access Graph service.

```yaml
name: dc01
discoveryGroup: dg01
accessGraph:
  aws:
  - regions:
    - us-west-2
    integration: integrationrole
```

Part of https://github.com/gravitational/access-graph/issues/458