### PR TITLE
Attempts to stabilize lib/srv/regular tests

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -254,7 +254,8 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		sshSrv.Wait()
 	})
 
-	require.NoError(t, sshSrv.heartbeat.ForceSend(time.Second))
+	_, err = testServer.Auth().UpsertNode(ctx, sshSrv.getServerInfo())
+	require.NoError(t, err)
 
 	sshSrvAddress := sshSrv.Addr()
 	_, sshSrvPort, err := net.SplitHostPort(sshSrvAddress)


### PR DESCRIPTION
All tests that use the common fixture suffer from periodic failures due to `timeout waiting for announce to be sent`. This stems from the fixture forcing a heartbeat for the node being created in the test timing out. Instead of using the heartbeat interface to fire an early heartbeat, the server is upserted directly into the test auth instance.