### PR TITLE
Web: Add a shared LabelsInput component

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
@@ -33,10 +33,10 @@ import { getBot } from 'teleport/services/bot';
 
 import useTeleport from 'teleport/useTeleport';
 
+import { LabelsInput } from 'teleport/components/LabelsInput';
+
 import { FlowStepProps } from '../Shared/GuidedFlow';
 import { FlowButtons } from '../Shared/FlowButtons';
-
-import { LabelsInput } from '../Shared/LabelsInput';
 
 import { useGitHubFlow } from './useGitHubFlow';
 
@@ -152,6 +152,12 @@ export function ConfigureBot({ nextStep, prevStep }: FlowStepProps) {
                   setCreateBotRequest({ ...createBotRequest, labels: labels })
                 }
                 disableBtns={isLoading}
+                inputWidth={350}
+                areLabelsRequired={true}
+                labelKey={{
+                  fieldName: 'Label for Resources the User Can Access',
+                  placeholder: 'label key',
+                }}
               />
             </Box>
             <FormItem>

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2024 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import Validation from 'shared/components/Validation';
+import { ButtonSecondary } from 'design/Button';
+
+import { LabelsInput, Label } from './LabelsInput';
+
+export default {
+  title: 'Teleport/LabelsInput',
+};
+
+export const Default = () => {
+  const [labels, setLables] = useState<Label[]>([]);
+
+  return (
+    <Validation>
+      {({ validator }) => (
+        <div>
+          <div>
+            <LabelsInput labels={labels} setLabels={setLables} />
+          </div>
+          <ButtonSecondary
+            mt={6}
+            onClick={() => {
+              if (!validator.validate()) {
+                return;
+              }
+            }}
+          >
+            Test Validation For Empty Inputs
+          </ButtonSecondary>
+        </div>
+      )}
+    </Validation>
+  );
+};
+
+export const Custom = () => {
+  const [labels, setLables] = useState<Label[]>([]);
+  return (
+    <Validation>
+      <LabelsInput
+        labels={labels}
+        setLabels={setLables}
+        labelKey={{
+          fieldName: 'Custom Key Name',
+          placeholder: 'custom key placeholder',
+        }}
+        labelVal={{
+          fieldName: 'Custom Value',
+          placeholder: 'custom value placeholder',
+        }}
+        adjective="Custom Adjective"
+        inputWidth={350}
+      />
+    </Validation>
+  );
+};
+
+export const Disabled = () => {
+  const [labels, setLables] = useState<Label[]>([
+    { name: 'some-name', value: 'some-value' },
+  ]);
+  return (
+    <Validation>
+      <LabelsInput labels={labels} setLabels={setLables} disableBtns={true} />
+    </Validation>
+  );
+};
+
+export const AutoFocus = () => {
+  const [labels, setLables] = useState<Label[]>([{ name: '', value: '' }]);
+  return (
+    <Validation>
+      <LabelsInput labels={labels} setLabels={setLables} autoFocus={true} />
+    </Validation>
+  );
+};
+
+export const AtLeastOneRequired = () => {
+  const [labels, setLables] = useState<Label[]>([{ name: '', value: '' }]);
+  return (
+    <Validation>
+      <LabelsInput
+        labels={labels}
+        setLabels={setLables}
+        areLabelsRequired={true}
+      />
+    </Validation>
+  );
+};

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, fireEvent, screen } from 'design/utils/testing';
+
+import {
+  Default,
+  Custom,
+  Disabled,
+  AtLeastOneRequired,
+} from './LabelsInput.story';
+
+test('defaults, with empty labels', async () => {
+  render(<Default />);
+
+  expect(screen.queryByText(/key/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/value/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/required field/i)).not.toBeInTheDocument();
+  expect(screen.queryByPlaceholderText('label key')).not.toBeInTheDocument();
+  expect(screen.queryByPlaceholderText('label value')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(/add a label/i));
+
+  expect(screen.getByText(/key/i)).toBeInTheDocument();
+  expect(screen.getByText(/value/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/required field/i)).toHaveLength(2);
+  expect(screen.getByPlaceholderText('label key')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('label value')).toBeInTheDocument();
+  expect(screen.getByTitle(/remove label/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(/add another label/i));
+
+  expect(screen.getAllByPlaceholderText('label key')).toHaveLength(2);
+  expect(screen.getAllByPlaceholderText('label value')).toHaveLength(2);
+  expect(screen.getAllByTitle(/remove label/i)).toHaveLength(2);
+});
+
+test('with custom texts', async () => {
+  render(<Custom />);
+
+  fireEvent.click(screen.getByText(/add a custom adjective/i));
+
+  expect(screen.getByText(/custom key name/i)).toBeInTheDocument();
+  expect(screen.getByText(/custom value/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/required field/i)).toHaveLength(2);
+  expect(
+    screen.getByPlaceholderText('custom key placeholder')
+  ).toBeInTheDocument();
+  expect(
+    screen.getByPlaceholderText('custom value placeholder')
+  ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole('button', { name: 'Add another Custom Adjective' })
+  ).toBeInTheDocument();
+
+  // Delete the only row.
+  fireEvent.click(screen.getByTitle(/remove custom adjective/i));
+  expect(
+    screen.getByRole('button', { name: 'Add a Custom Adjective' })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByPlaceholderText('custom key placeholder')
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByPlaceholderText('custom value placeholder')
+  ).not.toBeInTheDocument();
+});
+
+test('disabled buttons', async () => {
+  render(<Disabled />);
+
+  expect(screen.getByTitle(/remove label/i)).toBeDisabled();
+  expect(
+    screen.getByRole('button', { name: 'Add another Label' })
+  ).toBeDisabled();
+});
+
+test('removing last label is not possible due to requiring labels', async () => {
+  render(<AtLeastOneRequired />);
+
+  expect(screen.getByPlaceholderText('label key')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('label value')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByTitle(/remove label/i));
+
+  expect(screen.getByPlaceholderText('label key')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('label value')).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,25 +16,46 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import { Box, Flex, ButtonIcon, ButtonSecondary } from 'design';
-import * as Icons from 'design/Icon';
+import styled from 'styled-components';
+import { Flex, Box, ButtonSecondary, ButtonIcon } from 'design';
 import FieldInput from 'shared/components/FieldInput';
-import { useValidation, Validator } from 'shared/components/Validation';
+import { Validator, useValidation } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
+import * as Icons from 'design/Icon';
 
-import { ResourceLabel } from 'teleport/services/agents';
+export type Label = {
+  name: string;
+  value: string;
+};
+
+export type LabelInputTexts = {
+  fieldName: string;
+  placeholder: string;
+};
 
 export function LabelsInput({
   labels = [],
   setLabels,
   disableBtns = false,
   autoFocus = false,
+  areLabelsRequired = false,
+  adjective = 'Label',
+  labelKey = { fieldName: 'Key', placeholder: 'label key' },
+  labelVal = { fieldName: 'Value', placeholder: 'label value' },
+  inputWidth = 200,
 }: {
-  labels: ResourceLabel[];
-  setLabels(l: ResourceLabel[]): void;
+  labels: Label[];
+  setLabels(l: Label[]): void;
   disableBtns?: boolean;
   autoFocus?: boolean;
+  adjective?: string;
+  labelKey?: LabelInputTexts;
+  labelVal?: LabelInputTexts;
+  inputWidth?: number;
+  /**
+   * Makes it so at least one label is required
+   */
+  areLabelsRequired?: boolean;
 }) {
   const validator = useValidation() as Validator;
 
@@ -43,7 +64,7 @@ export function LabelsInput({
   }
 
   function removeLabel(index: number) {
-    if (labels.length === 1) {
+    if (areLabelsRequired && labels.length === 1) {
       // Since at least one label is required
       // instead of removing the last row, clear
       // the input and turn on error.
@@ -62,7 +83,7 @@ export function LabelsInput({
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement>,
     index: number,
-    labelField: keyof ResourceLabel
+    labelField: keyof Label
   ) => {
     const { value } = event.target;
     const newList = [...labels];
@@ -80,21 +101,16 @@ export function LabelsInput({
     };
   };
 
+  const width = `${inputWidth}px`;
   return (
     <>
       {labels.length > 0 && (
         <Flex mt={2}>
-          <Box width="350px" mr="3">
-            Label for Resources the User Can Access{' '}
-            <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
-              (required field)
-            </span>
+          <Box width={width} mr="3">
+            {labelKey.fieldName} <SmallText>(required field)</SmallText>
           </Box>
           <Box>
-            Label Value{' '}
-            <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
-              (required field)
-            </span>
+            {labelVal.fieldName} <SmallText>(required field)</SmallText>
           </Box>
         </Flex>
       )}
@@ -108,8 +124,8 @@ export function LabelsInput({
                   rule={requiredUniqueKey}
                   autoFocus={autoFocus}
                   value={label.name}
-                  placeholder="label key"
-                  width="350px"
+                  placeholder={labelKey.placeholder}
+                  width={width}
                   mr={3}
                   mb={0}
                   onChange={e => handleChange(e, index, 'name')}
@@ -118,8 +134,8 @@ export function LabelsInput({
                 <FieldInput
                   rule={requiredField('required')}
                   value={label.value}
-                  placeholder="label value"
-                  width="350px"
+                  placeholder={labelVal.placeholder}
+                  width={width}
                   mb={0}
                   mr={2}
                   onChange={e => handleChange(e, index, 'value')}
@@ -127,7 +143,7 @@ export function LabelsInput({
                 />
                 <ButtonIcon
                   size={1}
-                  title="Remove Label"
+                  title={`Remove ${adjective}`}
                   onClick={() => removeLabel(index)}
                   css={`
                     &:disabled {
@@ -162,18 +178,16 @@ export function LabelsInput({
           }
         `}
         disabled={disableBtns}
+        gap={1}
       >
-        <Icons.Add
-          className="icon-add"
-          disabled={disableBtns}
-          size="small"
-          css={`
-            margin-top: -2px;
-            margin-right: 3px;
-          `}
-        />
-        Add Another Label
+        <Icons.Add className="icon-add" disabled={disableBtns} size="small" />
+        {labels.length > 0 ? `Add another ${adjective}` : `Add a ${adjective}`}
       </ButtonSecondary>
     </>
   );
 }
+
+const SmallText = styled.span`
+  font-size: ${p => p.theme.fontSizes[1]}px;
+  font-weight: lighter;
+`;

--- a/web/packages/teleport/src/components/LabelsInput/index.ts
+++ b/web/packages/teleport/src/components/LabelsInput/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export {LabelsInput} from './LabelsInput'
+export { LabelsInput } from './LabelsInput';

--- a/web/packages/teleport/src/components/LabelsInput/index.ts
+++ b/web/packages/teleport/src/components/LabelsInput/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export {LabelsInput} from './LabelsInput'


### PR DESCRIPTION
This component was used in few places, pulled it out for shared use

default:

<img width="487" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/0d7b811d-22a5-4c9f-91ca-a475a9970b24">

custom example:

<img width="680" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/cf96929c-8692-4fac-bb3c-97dcbc2dad2a">

<img width="802" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/e45a563d-7115-4ef1-8e8b-052cd3c48291">

