### PR TITLE
[v14] docs: Recommend correct versions of Docker images for Teleport Team/Teleport Cloud

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -146,14 +146,14 @@ either:
   `(=teleport.version=)`.
 
 <Tabs>
-<TabItem label="Teleport Team/Community Edition" scope={["oss", "team"]}>
+<TabItem label="Teleport Community Edition" scope={["oss"]}>
 
 |Image name|Troubleshooting Tools?|Image base|
 |-|-|-|
 |`(=teleport.latest_oss_docker_image=)`|No|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
 |`(=teleport.latest_oss_debug_docker_image=)`|Yes|[Distroless Debian 12](https://github.com/GoogleContainerTools/distroless)|
 
-For testing, we always recommend that you use the latest released version of
+For testing, we always recommend that you use the latest release version of
 Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
 [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)-based images are available from
@@ -162,7 +162,7 @@ repository](https://gallery.ecr.aws/gravitational/teleport-ent).  Their use is
 considered deprecated, and they may be removed in future releases.
 
 </TabItem>
-<TabItem label="Teleport Enterprise Cloud/Enterprise" scope={["cloud", "enterprise"]}>
+<TabItem label="Teleport Enterprise" scope={["enterprise"]}>
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
@@ -181,6 +181,17 @@ Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 
 [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)-based images for non-FIPS
 Teleport are available from our [Legacy Amazon ECR Public repository](https://gallery.ecr.aws/gravitational/teleport-ent).
+
+</TabItem>
+<TabItem label="Teleport Team/Teleport Enterprise Cloud" scope={["team", "cloud"]}>
+
+| Image name | Includes troubleshooting tools | Image base |
+| - | - | - |
+| `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)` | No | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+| `public.ecr.aws/gravitational/teleport-ent-distroless-debug:(=cloud.version=)` | Yes | [Distroless Debian 12](https://github.com/GoogleContainerTools/distroless) |
+
+For testing, we always recommend that you use the latest Cloud release version of
+Teleport Enterprise, which is currently `public.ecr.aws/gravitational/teleport-ent-distroless:(=cloud.version=)`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Backports #38033 to `branch/v14`