### PR TITLE
Fix json tag for hardware key serial number validation config

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1236,7 +1236,7 @@ type HardwareKey struct {
 
 	// SerialNumberValidation contains optional settings for hardware key
 	// serial number validation, including whether it is enabled.
-	SerialNumberValidation *HardwareKeySerialNumberValidation `yaml:"require_known_serial_number,omitempty"`
+	SerialNumberValidation *HardwareKeySerialNumberValidation `yaml:"serial_number_validation,omitempty"`
 }
 
 func (h *HardwareKey) Parse() (*types.HardwareKey, error) {


### PR DESCRIPTION
As the title indicates, there was a typo in https://github.com/gravitational/teleport/pull/37727 for the json tag.