### PR TITLE
Start Vite server for teleterm on localhost only

### DIFF
--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -107,7 +107,7 @@ const config = defineConfig(env => {
         },
       },
       server: {
-        host: '0.0.0.0',
+        host: 'localhost',
         port: 8080,
         fs: {
           allow: [rootDirectory, '.'],


### PR DESCRIPTION
The Electron app in dev mode uses localhost. Opening the teleterm frontend app over local IP wouldn't work anyway as:

1) The frontend app needs to be opened from within Electron.
2) The main process of the Electron app in dev mode has multiple checks that limit loading resources to `localhost:8080`.