### PR TITLE
Reuse `BotTiles` component on `Enroll New Integration` page

### DIFF
--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.story.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.story.tsx
@@ -19,6 +19,10 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
+import { ContextProvider } from 'teleport';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+
 import { AddBotsPicker } from './AddBotsPicker';
 
 export default {
@@ -26,9 +30,13 @@ export default {
 };
 
 export const Picker = () => {
+  const ctx = createTeleportContext();
+
   return (
     <MemoryRouter>
-      <AddBotsPicker />
+      <ContextProvider ctx={ctx}>
+        <AddBotsPicker />
+      </ContextProvider>
     </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -45,6 +45,9 @@ import {
 import { IntegrationTile } from 'teleport/Integrations';
 import { FeatureHeader, FeatureHeaderTitle } from 'teleport/components/Layout';
 
+import useTeleport from 'teleport/useTeleport';
+import { ToolTipNoPermBadge } from 'teleport/components/ToolTipNoPermBadge';
+
 import { BotFlowType } from '../types';
 
 type BotIntegration = {
@@ -136,6 +139,7 @@ const integrations: BotIntegration[] = [
 ];
 
 export function AddBotsPicker() {
+  const ctx = useTeleport();
   return (
     <>
       <FeatureHeader>
@@ -147,18 +151,25 @@ export function AddBotsPicker() {
         to access resources protected by Teleport.
       </Text>
 
-      <BotTiles />
+      <BotTiles hasCreateBotPermission={ctx.getFeatureFlags().addBots} />
     </>
   );
 }
 
-export function BotTiles() {
+export function BotTiles({
+  hasCreateBotPermission,
+}: {
+  hasCreateBotPermission: boolean;
+}) {
   return (
     <Flex gap={3} flexWrap="wrap">
       {integrations.map(i => (
         <Box key={i.title}>
           {i.guided ? (
-            <GuidedTile integration={i} />
+            <GuidedTile
+              integration={i}
+              hasCreateBotPermission={hasCreateBotPermission}
+            />
           ) : (
             <ExternalLinkTile integration={i} />
           )}
@@ -189,12 +200,21 @@ function ExternalLinkTile({ integration }: { integration: BotIntegration }) {
   );
 }
 
-function GuidedTile({ integration }: { integration: BotIntegration }) {
+function GuidedTile({
+  integration,
+  hasCreateBotPermission,
+}: {
+  integration: BotIntegration;
+  hasCreateBotPermission: boolean;
+}) {
   return (
     <IntegrationTile
       as={Link}
-      to={integration.link}
+      to={hasCreateBotPermission ? integration.link : null}
       onClick={() => {
+        if (!hasCreateBotPermission) {
+          return;
+        }
         userEventService.captureIntegrationEnrollEvent({
           event: IntegrationEnrollEvent.Started,
           eventData: {
@@ -204,7 +224,16 @@ function GuidedTile({ integration }: { integration: BotIntegration }) {
         });
       }}
     >
-      <BadgeGuided>Guided</BadgeGuided>
+      {hasCreateBotPermission ? (
+        <BadgeGuided>Guided</BadgeGuided>
+      ) : (
+        <ToolTipNoPermBadge>
+          <div>
+            You don’t have sufficient permissions to create bots. Reach out to
+            your Teleport administrator to request additional permissions.
+          </div>
+        </ToolTipNoPermBadge>
+      )}
       <TileContent icon={integration.icon} title={integration.title} />
     </IntegrationTile>
   );

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -142,7 +142,7 @@ export function AddBotsPicker() {
         <FeatureHeaderTitle>Select Bot Type</FeatureHeaderTitle>
       </FeatureHeader>
 
-      <Text typography="body1">
+      <Text typography="body1" mb="5">
         Set up Teleport Machine ID to allow CI/CD workflows and other machines
         to access resources protected by Teleport.
       </Text>
@@ -154,7 +154,7 @@ export function AddBotsPicker() {
 
 export function BotTiles() {
   return (
-    <Flex mt={5} gap={3} flexWrap="wrap">
+    <Flex gap={3} flexWrap="wrap">
       {integrations.map(i => (
         <Box key={i.title}>
           {i.guided ? (

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.story.tsx
@@ -19,6 +19,10 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
+import { ContextProvider } from 'teleport';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+
 import cfg from 'teleport/config';
 
 import { IntegrationEnroll } from './IntegrationEnroll';
@@ -27,8 +31,14 @@ export default {
   title: 'Teleport/Integrations/Enroll',
 };
 
-export const Picker = () => (
-  <MemoryRouter initialEntries={[cfg.routes.integrationEnroll]}>
-    <IntegrationEnroll />
-  </MemoryRouter>
-);
+export const Picker = () => {
+  const ctx = createTeleportContext();
+
+  return (
+    <MemoryRouter initialEntries={[cfg.routes.integrationEnroll]}>
+      <ContextProvider ctx={ctx}>
+        <IntegrationEnroll />
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
@@ -21,8 +21,10 @@ import React from 'react';
 import { Box, Text } from 'design';
 
 import { BotTiles } from 'teleport/Bots/Add/AddBotsPicker';
+import useTeleport from 'teleport/useTeleport';
 
 export const MachineIDIntegrationSection = () => {
+  const ctx = useTeleport();
   return (
     <>
       <Box mb={3}>
@@ -34,7 +36,7 @@ export const MachineIDIntegrationSection = () => {
           to access resources protected by Teleport.
         </Text>
       </Box>
-      <BotTiles />
+      <BotTiles hasCreateBotPermission={ctx.getFeatureFlags().addBots} />
     </>
   );
 };

--- a/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
@@ -16,105 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  AnsibleIcon,
-  AWSIcon,
-  AzureIcon,
-  CircleCIIcon,
-  GCPIcon,
-  GitHubIcon,
-  GitLabIcon,
-  JenkinsIcon,
-  KubernetesIcon,
-  ServersIcon,
-  SpaceliftIcon,
-} from 'design/SVGIcon';
-import { Box, Flex, Link as ExternalLink, Text } from 'design';
 import React from 'react';
 
-import {
-  IntegrationEnrollEvent,
-  IntegrationEnrollKind,
-  userEventService,
-} from 'teleport/services/userEvent';
+import { Box, Text } from 'design';
 
-import { IntegrationTile } from './common';
-
-interface Integration {
-  title: string;
-  link: string;
-  icon: JSX.Element;
-  kind: IntegrationEnrollKind;
-}
-
-const integrations: Integration[] = [
-  {
-    title: 'GitHub Actions',
-    link: 'https://goteleport.com/docs/machine-id/deployment/github-actions/',
-    icon: <GitHubIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDGitHubActions,
-  },
-  {
-    title: 'CircleCI',
-    link: 'https://goteleport.com/docs/machine-id/deployment/circleci/',
-    icon: <CircleCIIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDCircleCI,
-  },
-  {
-    title: 'GitLab CI/CD',
-    link: 'https://goteleport.com/docs/machine-id/deployment/gitlab/',
-    icon: <GitLabIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDGitLab,
-  },
-  {
-    title: 'Jenkins',
-    link: 'https://goteleport.com/docs/machine-id/deployment/jenkins/',
-    icon: <JenkinsIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDJenkins,
-  },
-  {
-    title: 'Ansible',
-    link: 'https://goteleport.com/docs/machine-id/access-guides/ansible/',
-    icon: <AnsibleIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDAnsible,
-  },
-  {
-    title: 'Spacelift',
-    link: 'https://goteleport.com/docs/machine-id/deployment/spacelift/',
-    icon: <SpaceliftIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDSpacelift,
-  },
-  {
-    title: 'AWS',
-    link: 'https://goteleport.com/docs/machine-id/deployment/aws/',
-    icon: <AWSIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDAWS,
-  },
-  {
-    title: 'GCP',
-    link: 'https://goteleport.com/docs/machine-id/deployment/gcp/',
-    icon: <GCPIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDGCP,
-  },
-  {
-    title: 'Azure',
-    link: 'https://goteleport.com/docs/machine-id/deployment/azure/',
-    icon: <AzureIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDAzure,
-  },
-  {
-    title: 'Kubernetes',
-    link: 'https://goteleport.com/docs/machine-id/deployment/kubernetes/',
-    icon: <KubernetesIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineIDKubernetes,
-  },
-  {
-    title: 'Generic',
-    link: 'https://goteleport.com/docs/machine-id/getting-started/',
-    icon: <ServersIcon size={80} />,
-    kind: IntegrationEnrollKind.MachineID,
-  },
-];
+import { BotTiles } from 'teleport/Bots/Add/AddBotsPicker';
 
 export const MachineIDIntegrationSection = () => {
   return (
@@ -128,33 +34,7 @@ export const MachineIDIntegrationSection = () => {
           to access resources protected by Teleport.
         </Text>
       </Box>
-      {/* TODO(mcbattirola): replace this section with BotTiles and remove Integrations */}
-      <Flex mb={2} gap={3} flexWrap="wrap">
-        {integrations.map(i => {
-          return (
-            <IntegrationTile
-              key={i.title}
-              as={ExternalLink}
-              href={i.link}
-              target="_blank"
-              onClick={() => {
-                userEventService.captureIntegrationEnrollEvent({
-                  event: IntegrationEnrollEvent.Started,
-                  eventData: {
-                    id: crypto.randomUUID(),
-                    kind: i.kind,
-                  },
-                });
-              }}
-            >
-              <Box mt={3} mb={2}>
-                {i.icon}
-              </Box>
-              <Text>{i.title}</Text>
-            </IntegrationTile>
-          );
-        })}
-      </Flex>
+      <BotTiles />
     </>
   );
 };


### PR DESCRIPTION
When https://github.com/gravitational/teleport/pull/37443 introduced the `BotTiles` component I copied the content of `MachineIDIntegrationSection.tsx`, but since it changes one of the tiles to a page that wasn't available, I didn't reuse it in the integrations page.

Once https://github.com/gravitational/teleport/pull/37943 is merged, we can reuse `BotTiles` in the integrations enroll page.


With permission:
![Screenshot from 2024-02-13 10-41-15](https://github.com/gravitational/teleport/assets/8400114/ce5f3ca5-d3b1-44be-a235-6857513506f5)

Without permission:
![Screenshot from 2024-02-13 10-40-56](https://github.com/gravitational/teleport/assets/8400114/1a1f62c7-efb3-4d22-9acd-5f12aa6b355d)


Blocked by https://github.com/gravitational/teleport/pull/37943