### PR TITLE
Fix Assist z-index so it doesn't hide the user dropdown when docked

### DIFF
--- a/web/packages/teleport/src/Assist/Assist.tsx
+++ b/web/packages/teleport/src/Assist/Assist.tsx
@@ -201,7 +201,7 @@ const Container = styled.div<{ docked: boolean }>`
   opacity: 0;
   animation: forwards ${fadeIn} 0.3s ease-in-out;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 1000;
+  z-index: ${p => (p.docked ? 2 : 100)};
   display: flex;
   justify-content: flex-end;
 `;


### PR DESCRIPTION
When Assist is docked, it obstructs the user dropdown

Before:
<img width="366" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/943c6f8e-a6bc-4415-87c4-754be7b44fce">

After:
<img width="556" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/9ab3bb44-5138-4f58-b149-d9dd3e379365">

This changes the z-index to just 2 when docked, and 100 when not docked

changelog: Fix Assist obstructing the user dropdown menu when in docked mode