### PR TITLE
[v15] Fix Assist z-index so it doesn't hide the user dropdown when docked

### DIFF
--- a/web/packages/teleport/src/Assist/Assist.tsx
+++ b/web/packages/teleport/src/Assist/Assist.tsx
@@ -201,7 +201,7 @@ const Container = styled.div<{ docked: boolean }>`
   opacity: 0;
   animation: forwards ${fadeIn} 0.3s ease-in-out;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 1000;
+  z-index: ${p => (p.docked ? 2 : 100)};
   display: flex;
   justify-content: flex-end;
 `;


### PR DESCRIPTION
Backport #38148 to branch/v15

changelog: Fix Assist obstructing the user dropdown menu when in docked mode
