### PR TITLE
Keep topbar font size to 16px

### DIFF
--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -399,7 +399,6 @@ const MainNavItem = ({
   const { currentWidth } = useLayout();
   const theme: Theme = useTheme();
   const mediumAndUp = currentWidth >= theme.breakpoints.medium;
-  const largeAndUp = currentWidth >= theme.breakpoints.large;
   return (
     <NavigationButton
       selected={isSelected}
@@ -409,7 +408,7 @@ const MainNavItem = ({
       <Icon color={isSelected ? 'text.main' : 'text.muted'} size={size} />
       <Text
         ml={3}
-        fontSize={largeAndUp ? 4 : 3}
+        fontSize={3}
         fontWeight={500}
         color={isSelected ? 'text.main' : 'text.muted'}
         css={`


### PR DESCRIPTION
The design team have requested that we no longer scale the fontsize up,  and instead, keep the font at a consistent 16px while visible at any size.