### PR TITLE
add atomicwrite to backend interface

### DIFF
--- a/lib/backend/atomicwrite.go
+++ b/lib/backend/atomicwrite.go
@@ -19,8 +19,6 @@
 package backend
 
 import (
-	"context"
-
 	"github.com/gravitational/trace"
 )
 
@@ -223,24 +221,9 @@ const (
 	MaxAtomicWriteSize = 64
 )
 
-// AtomicWriter is a standalone interface for the AtomicWrite method. This interface will be deprecated
-// once all backends implement AtomicWrite.
-type AtomicWriter interface {
-	// AtomicWrite executes a batch of conditional actions atomically s.t. all actions happen if all
-	// conditions are met, but no actions happen if any condition fails to hold. If one or more conditions
-	// failed to hold, [ErrConditionFailed] is returned. The number of conditional actions must not
-	// exceed [MaxAtomicWriteSize] and no two conditional actions may point to the same key. If successful,
-	// the returned revision is the new revision associated with all [Put] actions that were part of the
-	// operation (the revision value has no meaning outside of the context of puts).
-	AtomicWrite(ctx context.Context, condacts []ConditionalAction) (revision string, err error)
-}
-
-// AtomicWriterBackend joins the AtomicWrite interface with the standard backend interface. This interface
-// will be deprecated once all backends implement AtomicWrite.
-type AtomicWriterBackend interface {
-	Backend
-	AtomicWriter
-}
+// AtomicWriterBackend was used to extend the backend interface with the AtomicWrite method prior to all backends
+// implementing AtomicWrite. This alias can be safely deleted once it is no longer referenced by enterprise backend logic.
+type AtomicWriterBackend = Backend
 
 // ValidateAtomicWrite verifies that the supplied group of conditional actions are a valid input for atomic
 // application. This means both verifying that each individual conditional action is well-formed, and also

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -92,6 +92,14 @@ type Backend interface {
 	// ConditionalDelete deletes the item by key if the revision matches the stored revision.
 	ConditionalDelete(ctx context.Context, key []byte, revision string) error
 
+	// AtomicWrite executes a batch of conditional actions atomically s.t. all actions happen if all
+	// conditions are met, but no actions happen if any condition fails to hold. If one or more conditions
+	// failed to hold, [ErrConditionFailed] is returned. The number of conditional actions must not
+	// exceed [MaxAtomicWriteSize] and no two conditional actions may point to the same key. If successful,
+	// the returned revision is the new revision associated with all [Put] actions that were part of the
+	// operation (the revision value has no meaning outside of the context of puts).
+	AtomicWrite(ctx context.Context, condacts []ConditionalAction) (revision string, err error)
+
 	// NewWatcher returns a new event watcher
 	NewWatcher(ctx context.Context, watch Watch) (Watcher, error)
 

--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/utils"
@@ -245,6 +246,10 @@ TxnLoop:
 			codes = slices.Compact(codes)
 
 			return "", trace.Errorf("unexpected error during atomic write: %v (reason(s): %s)", err, strings.Join(codes, ","))
+		}
+
+		if i > 0 {
+			backend.AtomicWriteContention.WithLabelValues(teleport.ComponentDynamoDB).Add(float64(i))
 		}
 
 		if n := i + 1; n > 2 {

--- a/lib/backend/dynamo/atomicwrite_test.go
+++ b/lib/backend/dynamo/atomicwrite_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/test"
 )
 
-func newAtomicWriteBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteBackend(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 	dynamoCfg := map[string]interface{}{
 		"table_name":         dynamoDBTestTable(),
 		"poll_stream_period": 300 * time.Millisecond,

--- a/lib/backend/etcdbk/atomicwrite_test.go
+++ b/lib/backend/etcdbk/atomicwrite_test.go
@@ -31,7 +31,7 @@ import (
 
 // newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
 // it will be integrated into the main backend interface and we can get rid of this separate helper.
-func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 	opts, err := test.ApplyOptions(options)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/backend/firestore/atomicwrite.go
+++ b/lib/backend/firestore/atomicwrite.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 )
 
@@ -143,6 +144,10 @@ func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.Conditiona
 		}
 
 		return "", trace.Wrap(ConvertGRPCError(err))
+	}
+
+	if n > 1 {
+		backend.AtomicWriteContention.WithLabelValues(teleport.ComponentFirestore).Add(float64(n - 1))
 	}
 
 	if n > 2 {

--- a/lib/backend/firestore/atomicwrite_test.go
+++ b/lib/backend/firestore/atomicwrite_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/test"
 )
 
-func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 	cfg := firestoreParams()
 
 	testCfg, err := test.ApplyOptions(options)

--- a/lib/backend/lite/atomicwrite_test.go
+++ b/lib/backend/lite/atomicwrite_test.go
@@ -32,8 +32,8 @@ import (
 
 // newAtomicWriteTestBackendBuilder builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
 // it will be integrated into the main backend interface and we can get rid of this separate helper.
-func newAtomicWriteTestBackendBuilder(t *testing.T) func(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
-	return func(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteTestBackendBuilder(t *testing.T) func(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
+	return func(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 		clock := clockwork.NewFakeClock()
 
 		cfg, err := test.ApplyOptions(options)

--- a/lib/backend/memory/atomicwrite_test.go
+++ b/lib/backend/memory/atomicwrite_test.go
@@ -30,7 +30,7 @@ import (
 
 // newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
 // it will be integrated into the main backend interface and we can get rid of this separate helper.
-func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 	cfg, err := test.ApplyOptions(options)
 
 	if err != nil {
@@ -47,7 +47,7 @@ func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.Atom
 		case *Memory:
 			return bk, nil, nil
 		case test.AtomicWriteShim:
-			if _, ok := bk.AtomicWriterBackend.(*Memory); !ok {
+			if _, ok := bk.Backend.(*Memory); !ok {
 				return nil, nil, trace.BadParameter("target is not a Memory backend (%T)", cfg.ConcurrentBackend)
 			}
 			return bk, nil, nil

--- a/lib/backend/pgbk/atomicwrite.go
+++ b/lib/backend/pgbk/atomicwrite.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype/zeronull"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 )

--- a/lib/backend/pgbk/atomicwrite.go
+++ b/lib/backend/pgbk/atomicwrite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype/zeronull"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 )
@@ -129,6 +130,10 @@ func (b *Backend) AtomicWrite(ctx context.Context, condacts []backend.Conditiona
 
 		return nil
 	})
+
+	if tries > 1 {
+		backend.AtomicWriteContention.WithLabelValues(b.GetName()).Add(float64(tries - 1))
+	}
 
 	if tries > 2 {
 		// if we retried more than once, txn experienced non-trivial conflict and we should warn about it. Infrequent warnings of this kind

--- a/lib/backend/pgbk/atomicwrite_test.go
+++ b/lib/backend/pgbk/atomicwrite_test.go
@@ -37,7 +37,7 @@ import (
 
 // newAtomicWriteTestBackend builds a backend suitable for the atomic write test suite. Once all backends implement AtomicWrite,
 // it will be integrated into the main backend interface and we can get rid of this separate helper.
-func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error) {
+func newAtomicWriteTestBackend(options ...test.ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 	testCfg, err := test.ApplyOptions(options)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -20,6 +20,8 @@ package backend
 
 import (
 	"context"
+	"errors"
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -70,6 +72,8 @@ func (r *ReporterConfig) CheckAndSetDefaults() error {
 	}
 	return nil
 }
+
+var _ Backend = (*Reporter)(nil)
 
 // Reporter wraps a Backend implementation and reports
 // statistics about the backend operations
@@ -134,6 +138,8 @@ func (s *Reporter) GetRange(ctx context.Context, startKey []byte, endKey []byte,
 	batchReadRequests.WithLabelValues(s.Component).Inc()
 	if err != nil {
 		batchReadRequestsFailed.WithLabelValues(s.Component).Inc()
+	} else {
+		reads.WithLabelValues(s.Component).Add(float64(len(res.Items)))
 	}
 	s.trackRequest(types.OpGet, startKey, endKey)
 	return res, err
@@ -157,6 +163,11 @@ func (s *Reporter) Create(ctx context.Context, i Item) (*Lease, error) {
 	writeRequests.WithLabelValues(s.Component).Inc()
 	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsAlreadyExists(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, i.Key, nil)
 	return lease, err
@@ -181,6 +192,8 @@ func (s *Reporter) Put(ctx context.Context, i Item) (*Lease, error) {
 	writeRequests.WithLabelValues(s.Component).Inc()
 	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, i.Key, nil)
 	return lease, err
@@ -204,6 +217,11 @@ func (s *Reporter) Update(ctx context.Context, i Item) (*Lease, error) {
 	writeRequests.WithLabelValues(s.Component).Inc()
 	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsNotFound(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, i.Key, nil)
 	return lease, err
@@ -227,6 +245,11 @@ func (s *Reporter) ConditionalUpdate(ctx context.Context, i Item) (*Lease, error
 	writeRequests.WithLabelValues(s.Component).Inc()
 	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if errors.Is(err, ErrIncorrectRevision) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, i.Key, nil)
 	return lease, err
@@ -247,6 +270,7 @@ func (s *Reporter) Get(ctx context.Context, key []byte) (*Item, error) {
 	item, err := s.Backend.Get(ctx, key)
 	readLatencies.WithLabelValues(s.Component).Observe(s.Clock().Since(start).Seconds())
 	readRequests.WithLabelValues(s.Component).Inc()
+	reads.WithLabelValues(s.Component).Inc()
 	if err != nil && !trace.IsNotFound(err) {
 		readRequestsFailed.WithLabelValues(s.Component).Inc()
 	}
@@ -270,8 +294,13 @@ func (s *Reporter) CompareAndSwap(ctx context.Context, expected Item, replaceWit
 	lease, err := s.Backend.CompareAndSwap(ctx, expected, replaceWith)
 	writeLatencies.WithLabelValues(s.Component).Observe(s.Clock().Since(start).Seconds())
 	writeRequests.WithLabelValues(s.Component).Inc()
-	if err != nil && !trace.IsNotFound(err) && !trace.IsCompareFailed(err) {
+	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsNotFound(err) || trace.IsCompareFailed(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, expected.Key, nil)
 	return lease, err
@@ -292,8 +321,13 @@ func (s *Reporter) Delete(ctx context.Context, key []byte) error {
 	err := s.Backend.Delete(ctx, key)
 	writeLatencies.WithLabelValues(s.Component).Observe(s.Clock().Since(start).Seconds())
 	writeRequests.WithLabelValues(s.Component).Inc()
-	if err != nil && !trace.IsNotFound(err) {
+	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsNotFound(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpDelete, key, nil)
 	return err
@@ -315,11 +349,69 @@ func (s *Reporter) ConditionalDelete(ctx context.Context, key []byte, revision s
 	err := s.Backend.ConditionalDelete(ctx, key, revision)
 	writeLatencies.WithLabelValues(s.Component).Observe(s.Clock().Since(start).Seconds())
 	writeRequests.WithLabelValues(s.Component).Inc()
-	if err != nil && !trace.IsNotFound(err) {
+	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsNotFound(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpDelete, key, nil)
 	return err
+}
+
+// AtomicWrite implements batch conditional updates s.t. no writes occur unless all
+// conditions hold.
+func (s *Reporter) AtomicWrite(ctx context.Context, condacts []ConditionalAction) (revision string, err error) {
+	// note: the atomic write method's metrics are counted toward both the general 'write'
+	// metrics as well as equivalent metrics specific to atomic write.
+	ctx, span := s.Tracer.Start(
+		ctx,
+		"backend/AtomicWrite",
+		oteltrace.WithAttributes(
+			attribute.Int("condacts", len(condacts)),
+		),
+	)
+	defer span.End()
+
+	start := s.Clock().Now()
+	revision, err = s.Backend.AtomicWrite(ctx, condacts)
+
+	elapsed := s.Clock().Since(start).Seconds()
+	writeLatencies.WithLabelValues(s.Component).Observe(elapsed)
+	atomicWriteLatencies.WithLabelValues(s.Component).Observe(elapsed)
+
+	writeRequests.WithLabelValues(s.Component).Inc()
+	atomicWriteRequests.WithLabelValues(s.Component).Inc()
+	atomicWriteSize.WithLabelValues(s.Component).Observe(float64(len(condacts)))
+	if err != nil {
+		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		atomicWriteRequestsFailed.WithLabelValues(s.Component).Inc()
+		if errors.Is(err, ErrConditionFailed) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+			atomicWriteConditionFailed.WithLabelValues(s.Component).Inc()
+		}
+	}
+
+	var writeTotal int
+	for _, ca := range condacts {
+		switch ca.Action.Kind {
+		case KindPut:
+			writeTotal++
+			s.trackRequest(types.OpPut, ca.Key, nil)
+		case KindDelete:
+			writeTotal++
+			s.trackRequest(types.OpDelete, ca.Key, nil)
+		default:
+			// ignore other variants
+		}
+	}
+
+	if err == nil {
+		writes.WithLabelValues(s.Component).Add(float64(writeTotal))
+	}
+	return
 }
 
 // DeleteRange deletes range of items
@@ -365,8 +457,13 @@ func (s *Reporter) KeepAlive(ctx context.Context, lease Lease, expires time.Time
 	err := s.Backend.KeepAlive(ctx, lease, expires)
 	writeLatencies.WithLabelValues(s.Component).Observe(s.Clock().Since(start).Seconds())
 	writeRequests.WithLabelValues(s.Component).Inc()
-	if err != nil && !trace.IsNotFound(err) {
+	if err != nil {
 		writeRequestsFailed.WithLabelValues(s.Component).Inc()
+		if trace.IsNotFound(err) {
+			writeRequestsFailedPrecondition.WithLabelValues(s.Component).Inc()
+		}
+	} else {
+		writes.WithLabelValues(s.Component).Inc()
 	}
 	s.trackRequest(types.OpPut, lease.Key, nil)
 	return err
@@ -563,10 +660,79 @@ var (
 		},
 		[]string{teleport.ComponentLabel},
 	)
+	writes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendWrites,
+			Help:      "Number of individual items written to the backend",
+		},
+		[]string{teleport.ComponentLabel},
+	)
 	writeRequestsFailed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: teleport.MetricBackendWriteFailedRequests,
 			Help: "Number of failed write requests to the backend",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	writeRequestsFailedPrecondition = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendWriteFailedPreconditionRequests,
+			Help:      "Number of write requests that failed due to a precondition (existence, revision, value, etc)",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	atomicWriteRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteRequests,
+			Help:      "Number of atomic write requests to the backend",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	atomicWriteRequestsFailed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteFailedRequests,
+			Help:      "Number of failed atomic write requests to the backend",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	atomicWriteConditionFailed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteConditionFailed,
+			Help:      "Number of times an atomic write request results in condition failure",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	atomicWriteLatencies = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteHistogram,
+			Help:      "Latency for backend atomic write operations",
+			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
+			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	atomicWriteSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteSize,
+			Help:      "Atomic write batch size",
+			// buckets of the form 1, 2, 4, 8, 16, etc...
+			Buckets: prometheus.ExponentialBuckets(1, 2, int(math.Sqrt(MaxAtomicWriteSize))),
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	AtomicWriteContention = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendAtomicWriteContention,
+			Help:      "Number of times atomic write requests experience contention",
 		},
 		[]string{teleport.ComponentLabel},
 	)
@@ -588,6 +754,14 @@ var (
 		prometheus.CounterOpts{
 			Name: teleport.MetricBackendReadRequests,
 			Help: "Number of read requests to the backend",
+		},
+		[]string{teleport.ComponentLabel},
+	)
+	reads = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBackendReads,
+			Help:      "Number of individual items read from the backend",
 		},
 		[]string{teleport.ComponentLabel},
 	)
@@ -657,6 +831,9 @@ var (
 		watchers, watcherQueues, requests, writeRequests,
 		writeRequestsFailed, batchWriteRequests, batchWriteRequestsFailed, readRequests,
 		readRequestsFailed, batchReadRequests, batchReadRequestsFailed, writeLatencies,
+		writeRequestsFailedPrecondition,
+		atomicWriteRequests, atomicWriteRequestsFailed, atomicWriteConditionFailed, atomicWriteLatencies,
+		AtomicWriteContention, atomicWriteSize, reads, writes,
 		batchWriteLatencies, batchReadLatencies, readLatencies,
 	}
 )

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -192,6 +192,10 @@ func (n *nopBackend) KeepAlive(_ context.Context, _ Lease, _ time.Time) error {
 	return nil
 }
 
+func (n *nopBackend) AtomicWrite(_ context.Context, _ []ConditionalAction) (revision string, err error) {
+	return "", nil
+}
+
 func (n *nopBackend) Close() error {
 	return nil
 }

--- a/lib/backend/test/atomicwrite.go
+++ b/lib/backend/test/atomicwrite.go
@@ -27,18 +27,13 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/lib/backend"
 )
 
-// AtomicWriteConstructor is equivalent to [Constructor], except that it includes the new AtomicWrite method. This type
-// will be deprecated once all backends implement AtomicWrite.
-type AtomicWriteConstructor func(options ...ConstructionOption) (backend.AtomicWriterBackend, clockwork.FakeClock, error)
-
-func RunAtomicWriteComplianceSuite(t *testing.T, newBackend AtomicWriteConstructor) {
+func RunAtomicWriteComplianceSuite(t *testing.T, newBackend Constructor) {
 	t.Run("Move", func(t *testing.T) {
 		testAtomicWriteMove(t, newBackend)
 	})
@@ -65,7 +60,7 @@ func RunAtomicWriteComplianceSuite(t *testing.T, newBackend AtomicWriteConstruct
 }
 
 // testAtomicWriteMove verifies the correct behavior of "move" operations.
-func testAtomicWriteMove(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteMove(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
 
@@ -127,7 +122,7 @@ func testAtomicWriteMove(t *testing.T, newBackend AtomicWriteConstructor) {
 
 // testAtomicWriteLock verifies correct behavior of various "lock" patterns (i.e. where some update on key X is conditional on
 // the state of key Y).
-func testAtomicWriteLock(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteLock(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
 
@@ -281,7 +276,7 @@ func testAtomicWriteLock(t *testing.T, newBackend AtomicWriteConstructor) {
 }
 
 // testAtomicWriteMax verifies correct behavior of very large atomic writes.
-func testAtomicWriteMax(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteMax(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
 
@@ -367,7 +362,7 @@ func testAtomicWriteMax(t *testing.T, newBackend AtomicWriteConstructor) {
 }
 
 // testAtomicWriteConcurrent is a sanity-check intended to verify the correctness of AtomicWrite under high concurrency.
-func testAtomicWriteConcurrent(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteConcurrent(t *testing.T, newBackend Constructor) {
 	const (
 		increments = 200
 		workers    = 20
@@ -460,7 +455,7 @@ func testAtomicWriteConcurrent(t *testing.T, newBackend AtomicWriteConstructor) 
 // testAtomicWriteNonConflicting verifies that non-conflicting but overlapping transactions all succeed
 // on the first attempt when running concurrently, meaning that backends that treat overlap as conflict (e.g. dynamo)
 // handle such conflicts internally.
-func testAtomicWriteNonConflicting(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteNonConflicting(t *testing.T, newBackend Constructor) {
 	const workers = 60
 
 	bk, _, err := newBackend()
@@ -527,7 +522,7 @@ func testAtomicWriteNonConflicting(t *testing.T, newBackend AtomicWriteConstruct
 // testAtomicWriteOther verifies some minor edge-cases that may not be covered by other tests. Specifically,
 // it verifies that Item.Key has no effect on writes or subsequent reads, and that ineffectual writes still
 // update the value of revision.
-func testAtomicWriteOther(t *testing.T, newBackend AtomicWriteConstructor) {
+func testAtomicWriteOther(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
 

--- a/lib/backend/test/atomicwrite_shim.go
+++ b/lib/backend/test/atomicwrite_shim.go
@@ -35,7 +35,7 @@ import (
 // with a shim that converts all calls to single-write methods (all write methods but DeleteRange) into calls to
 // AtomicWrite. This is done to ensure that the relationship between the conditional actions of AtomicWrite and the
 // single-write methods is well defined, and to improve overall coverage of AtomicWrite implementations via reuse.
-func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend AtomicWriteConstructor) {
+func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Constructor) {
 	RunBackendComplianceSuite(t, func(options ...ConstructionOption) (backend.Backend, clockwork.FakeClock, error) {
 		bk, clock, err := newBackend(options...)
 		if err != nil {
@@ -43,15 +43,15 @@ func RunBackendComplianceSuiteWithAtomicWriteShim(t *testing.T, newBackend Atomi
 		}
 
 		return AtomicWriteShim{
-			AtomicWriterBackend: bk,
-			sentinel:            []byte(uuid.New().String()),
+			Backend:  bk,
+			sentinel: []byte(uuid.New().String()),
 		}, clock, nil
 	})
 }
 
 // atomciWriteShim reimplements all single-write backend methods as calls to AtomicWrite.
 type AtomicWriteShim struct {
-	backend.AtomicWriterBackend
+	backend.Backend
 	sentinel []byte
 }
 

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -27,6 +27,8 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+var _ Backend = (*Wrapper)(nil)
+
 // Wrapper wraps a Backend implementation that can fail
 // on demand.
 type Wrapper struct {
@@ -119,6 +121,10 @@ func (s *Wrapper) ConditionalDelete(ctx context.Context, key []byte, revision st
 // DeleteRange deletes range of items
 func (s *Wrapper) DeleteRange(ctx context.Context, startKey []byte, endKey []byte) error {
 	return s.backend.DeleteRange(ctx, startKey, endKey)
+}
+
+func (s *Wrapper) AtomicWrite(ctx context.Context, condacts []ConditionalAction) (revision string, err error) {
+	return s.backend.AtomicWrite(ctx, condacts)
 }
 
 // KeepAlive keeps object from expiring, updates lease on the existing object,

--- a/metrics.go
+++ b/metrics.go
@@ -179,8 +179,34 @@ const (
 	// MetricBackendWriteRequests measures backend write requests count
 	MetricBackendWriteRequests = "backend_write_requests_total"
 
+	// MetricBackendWrites tallies all individual backend writes (this is distinct from backend write
+	// requests in that bulk writes count as multiple writes).
+	MetricBackendWrites = "backend_writes_total"
+
 	// MetricBackendWriteFailedRequests measures failed backend write requests count
 	MetricBackendWriteFailedRequests = "backend_write_requests_failed_total"
+
+	// MetricBackendWriteFailedPreconditionRequests measures the portion of failed backend write requests
+	// that failed due to a custom precondition (existence, revision, value, etc).
+	MetricBackendWriteFailedPreconditionRequests = "backend_write_requests_failed_precondition_total"
+
+	// MetricBackendAtomicWriteRequests measures backend atomic write requests count
+	MetricBackendAtomicWriteRequests = "backend_atomic_write_requests_total"
+
+	// MetricBackendAtomicWriteFailedRequests measures failed backend atomic write requests count
+	MetricBackendAtomicWriteFailedRequests = "backend_atomic_write_requests_failed_total"
+
+	// MetricBackendAtomicWriteConditionFailed measures the amount of atomic write requests that result in condition failure.
+	MetricBackendAtomicWriteConditionFailed = "backend_atomic_write_condition_failed_total"
+
+	// MetricBackendAtomicWriteHistogram measures histogram of backend write latencies
+	MetricBackendAtomicWriteHistogram = "backend_atomic_write_seconds"
+
+	// MetricBackendAtomicWriteSize measures the histogram of atomic write batch sizes
+	MetricBackendAtomicWriteSize = "backend_atomic_write_size"
+
+	// MetricBackendAtomicWriteContention counts the amount of times atomic writes experience internal retries due to contention.
+	MetricBackendAtomicWriteContention = "backend_atomic_write_contention"
 
 	// MetricBackendBatchWriteRequests measures batch backend writes count
 	MetricBackendBatchWriteRequests = "backend_batch_write_requests_total"
@@ -190,6 +216,10 @@ const (
 
 	// MetricBackendReadRequests measures backend read requests count
 	MetricBackendReadRequests = "backend_read_requests_total"
+
+	// MetricBackendReads tallies all individual backend reads (this is distinct from backend read
+	// requests in that bulk reads count as multiple reads).
+	MetricBackendReads = "backend_reads_total"
 
 	// MetricBackendFailedReadRequests measures failed backend read requests count
 	MetricBackendFailedReadRequests = "backend_read_requests_failed_total"


### PR DESCRIPTION
Adds the `AtomicWrite` method to the standard `backend.Backend` interface, and adds related metrics.

See https://github.com/gravitational/teleport/pull/36086 for general discussion of the `AtomicWrite` API.