### PR TITLE
tsh: fix panic when loading profile

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -359,10 +359,15 @@ func profileFromFile(filePath string) (*Profile, error) {
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	var p *Profile
+	var p Profile
 	if err := yaml.Unmarshal(bytes, &p); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if p.Name() == "" {
+		return nil, trace.NotFound("invalid or empty profile at %q", filePath)
+	}
+
 	p.Dir = filepath.Dir(filePath)
 
 	// Older versions of tsh did not always store the cluster name in the
@@ -371,7 +376,7 @@ func profileFromFile(filePath string) (*Profile, error) {
 	if p.SiteName == "" {
 		p.SiteName = p.Name()
 	}
-	return p, nil
+	return &p, nil
 }
 
 // SaveToDir saves this profile to the specified directory.


### PR DESCRIPTION
When unmarshaling the profile YAML, it's possible for the unmarshal to complete without error while not populating the profile struct, which leads to a panic.

Fix the nil pointer dereference by unmarshaling into a Profile instead of a *Profile, and further improve the error message when this happens.

Fixes #38188

Changelog: fix a potential panic in the `tsh status` command.