### PR TITLE
Use cached remote clients in Connect

### DIFF
--- a/lib/teleterm/apiserver/handler/handler_apps.go
+++ b/lib/teleterm/apiserver/handler/handler_apps.go
@@ -34,7 +34,12 @@ func (s *Handler) GetApps(ctx context.Context, req *api.GetAppsRequest) (*api.Ge
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := cluster.GetApps(ctx, req)
+	proxyClient, err := s.DaemonService.GetCachedClient(ctx, cluster.URI)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := cluster.GetApps(ctx, proxyClient.CurrentCluster(), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -37,8 +37,7 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 	// added by daemon.Service.ResolveClusterURI.
 	clusterClient.MFAPromptConstructor = nil
 
-	err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI)
-	if err != nil {
+	if err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -37,6 +37,11 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 	// added by daemon.Service.ResolveClusterURI.
 	clusterClient.MFAPromptConstructor = nil
 
+	err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if req.Params == nil {
 		return nil, trace.BadParameter("missing login parameters")
 	}

--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -88,6 +88,10 @@ func (s *Handler) LoginPasswordless(stream api.TerminalService_LoginPasswordless
 	// daemon.Service.ResolveClusterURI.
 	clusterClient.MFAPromptConstructor = nil
 
+	if err := s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Start the prompt flow.
 	if err := cluster.PasswordlessLogin(stream.Context(), stream); err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/apiserver/middleware.go
+++ b/lib/teleterm/apiserver/middleware.go
@@ -20,11 +20,15 @@ package apiserver
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 )
 
 // withErrorHandling is gRPC middleware that maps internal errors to proper gRPC error codes
@@ -38,6 +42,15 @@ func withErrorHandling(log logrus.FieldLogger) grpc.UnaryServerInterceptor {
 		resp, err := handler(ctx, req)
 		if err != nil {
 			log.WithError(err).Error("Request failed.")
+			// A stop gap solution that allows us to show a relogin modal when we
+			// receive an error from the server saying that the cert is expired.
+			// Read more: https://github.com/gravitational/teleport/pull/38202#discussion_r1497181659
+			// TODO(gzdunek): fix when addressing https://github.com/gravitational/teleport/issues/32550
+			var remoteErr *interceptors.RemoteError
+			if errors.As(err, &remoteErr) && strings.Contains(trace.Unwrap(err).Error(), "client credentials have expired") {
+				return resp, trail.ToGRPC(err)
+			}
+
 			// do not return a full error stack on access denied errors
 			if trace.IsAccessDenied(err) {
 				return resp, trail.ToGRPC(trace.AccessDenied("access denied"))

--- a/lib/teleterm/apiserver/middleware.go
+++ b/lib/teleterm/apiserver/middleware.go
@@ -47,7 +47,7 @@ func withErrorHandling(log logrus.FieldLogger) grpc.UnaryServerInterceptor {
 			// Read more: https://github.com/gravitational/teleport/pull/38202#discussion_r1497181659
 			// TODO(gzdunek): fix when addressing https://github.com/gravitational/teleport/issues/32550
 			var remoteErr *interceptors.RemoteError
-			if errors.As(err, &remoteErr) && strings.Contains(trace.Unwrap(err).Error(), "client credentials have expired") {
+			if errors.As(err, &remoteErr) && strings.Contains(remoteErr.Error(), "client credentials have expired") {
 				return resp, trail.ToGRPC(err)
 			}
 

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -65,7 +65,7 @@ type AppOrSAMLIdPServiceProvider struct {
 }
 
 // GetApps returns a paginated apps list
-func (c *Cluster) GetApps(ctx context.Context, clt auth.ClientI, r *api.GetAppsRequest) (*GetAppsResponse, error) {
+func (c *Cluster) GetApps(ctx context.Context, authClient auth.ClientI, r *api.GetAppsRequest) (*GetAppsResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.AppServerOrSAMLIdPServiceProvider]
 		err  error
@@ -83,7 +83,7 @@ func (c *Cluster) GetApps(ctx context.Context, clt auth.ClientI, r *api.GetAppsR
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
-		page, err = apiclient.GetResourcePage[types.AppServerOrSAMLIdPServiceProvider](ctx, clt, req)
+		page, err = apiclient.GetResourcePage[types.AppServerOrSAMLIdPServiceProvider](ctx, authClient, req)
 		return trace.Wrap(err)
 	})
 	if err != nil {
@@ -124,10 +124,10 @@ type GetAppsResponse struct {
 	TotalCount int
 }
 
-func (c *Cluster) getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Application, error) {
+func (c *Cluster) getApp(ctx context.Context, authClient auth.ClientI, appName string) (types.Application, error) {
 	var app types.Application
 	err := AddMetadataToRetryableError(ctx, func() error {
-		apps, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
+		apps, err := apiclient.GetAllResources[types.AppServer](ctx, authClient, &proto.ListResourcesRequest{
 			Namespace:           c.clusterClient.Namespace,
 			ResourceType:        types.KindAppServer,
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -65,12 +65,10 @@ type AppOrSAMLIdPServiceProvider struct {
 }
 
 // GetApps returns a paginated apps list
-func (c *Cluster) GetApps(ctx context.Context, r *api.GetAppsRequest) (*GetAppsResponse, error) {
+func (c *Cluster) GetApps(ctx context.Context, clt auth.ClientI, r *api.GetAppsRequest) (*GetAppsResponse, error) {
 	var (
-		page        apiclient.ResourcePage[types.AppServerOrSAMLIdPServiceProvider]
-		authClient  auth.ClientI
-		proxyClient *client.ProxyClient
-		err         error
+		page apiclient.ResourcePage[types.AppServerOrSAMLIdPServiceProvider]
+		err  error
 	)
 
 	req := &proto.ListResourcesRequest{
@@ -85,25 +83,8 @@ func (c *Cluster) GetApps(ctx context.Context, r *api.GetAppsRequest) (*GetAppsR
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
-		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer proxyClient.Close()
-
-		authClient, err = proxyClient.ConnectToCluster(ctx, c.clusterClient.SiteName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer authClient.Close()
-
-		page, err = apiclient.GetResourcePage[types.AppServerOrSAMLIdPServiceProvider](ctx, authClient, req)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		return nil
+		page, err = apiclient.GetResourcePage[types.AppServerOrSAMLIdPServiceProvider](ctx, clt, req)
+		return trace.Wrap(err)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -143,10 +124,10 @@ type GetAppsResponse struct {
 	TotalCount int
 }
 
-func (c *Cluster) getApp(ctx context.Context, appName string) (types.Application, error) {
+func (c *Cluster) getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Application, error) {
 	var app types.Application
 	err := AddMetadataToRetryableError(ctx, func() error {
-		apps, err := c.clusterClient.ListApps(ctx, &proto.ListResourcesRequest{
+		apps, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
 			Namespace:           c.clusterClient.Namespace,
 			ResourceType:        types.KindAppServer,
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),
@@ -159,7 +140,7 @@ func (c *Cluster) getApp(ctx context.Context, appName string) (types.Application
 			return trace.NotFound("app %q not found", appName)
 		}
 
-		app = apps[0]
+		app = apps[0].GetApp()
 		return nil
 	})
 

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -117,7 +117,7 @@ func (c *Cluster) GetDatabases(ctx context.Context, clt auth.ClientI, r *api.Get
 }
 
 // reissueDBCerts issues new certificates for specific DB access and saves them to disk.
-func (c *Cluster) reissueDBCerts(ctx context.Context, routeToDatabase tlsca.RouteToDatabase) error {
+func (c *Cluster) reissueDBCerts(ctx context.Context, proxyClient *client.ProxyClient, routeToDatabase tlsca.RouteToDatabase) error {
 	// When generating certificate for MongoDB access, database username must
 	// be encoded into it. This is required to be able to tell which database
 	// user to authenticate the connection as.
@@ -126,7 +126,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, routeToDatabase tlsca.Rout
 	}
 
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
-	err := c.clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
+	err := proxyClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		AccessRequests: c.status.ActiveRequests.AccessRequests,
 	})
@@ -135,7 +135,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, routeToDatabase tlsca.Rout
 	}
 
 	// Fetch the certs for the database.
-	err = c.clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
+	err = proxyClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		RouteToDatabase: proto.RouteToDatabase{
 			ServiceName: routeToDatabase.ServiceName,

--- a/lib/teleterm/clusters/cluster_headless.go
+++ b/lib/teleterm/clusters/cluster_headless.go
@@ -26,52 +26,25 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 )
 
 // WatchPendingHeadlessAuthentications watches the backend for pending headless authentication requests for the user.
-func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context) (watcher types.Watcher, close func(), err error) {
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
+func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context, clt auth.ClientI) (watcher types.Watcher, close func(), err error) {
+	watcher, err = clt.WatchPendingHeadlessAuthentications(ctx)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	rootClient, err := proxyClient.ConnectToRootCluster(ctx)
-	if err != nil {
-		proxyClient.Close()
-		return nil, nil, trace.Wrap(err)
-	}
-
-	watcher, err = rootClient.WatchPendingHeadlessAuthentications(ctx)
-	if err != nil {
-		proxyClient.Close()
-		rootClient.Close()
 		return nil, nil, trace.Wrap(err)
 	}
 
 	close = func() {
 		watcher.Close()
-		proxyClient.Close()
-		rootClient.Close()
 	}
 
 	return watcher, close, trace.Wrap(err)
 }
 
 // WatchHeadlessAuthentications watches the backend for headless authentication events for the user.
-func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context) (watcher types.Watcher, close func(), err error) {
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	rootClient, err := proxyClient.ConnectToRootCluster(ctx)
-	if err != nil {
-		proxyClient.Close()
-		return nil, nil, trace.Wrap(err)
-	}
-
+func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context, clt auth.ClientI) (watcher types.Watcher, close func(), err error) {
 	watch := types.Watch{
 		Kinds: []types.WatchKind{{
 			Kind: types.KindHeadlessAuthentication,
@@ -81,17 +54,13 @@ func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context) (watcher typ
 		}},
 	}
 
-	watcher, err = rootClient.NewWatcher(ctx, watch)
+	watcher, err = clt.NewWatcher(ctx, watch)
 	if err != nil {
-		proxyClient.Close()
-		rootClient.Close()
 		return nil, nil, trace.Wrap(err)
 	}
 
 	close = func() {
 		watcher.Close()
-		proxyClient.Close()
-		rootClient.Close()
 	}
 
 	return watcher, close, trace.Wrap(err)
@@ -99,25 +68,12 @@ func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context) (watcher typ
 
 // UpdateHeadlessAuthenticationState updates the headless authentication matching the given id to the given state.
 // MFA will be prompted when updating to the approve state.
-func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, headlessID string, state types.HeadlessAuthenticationState) error {
+func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, rootClt auth.ClientI, headlessID string, state types.HeadlessAuthenticationState) error {
 	err := AddMetadataToRetryableError(ctx, func() error {
-		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer proxyClient.Close()
-
-		rootClient, err := proxyClient.ConnectToRootCluster(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer rootClient.Close()
-
 		// If changing state to approved, create an MFA challenge and prompt for MFA.
 		var mfaResponse *proto.MFAAuthenticateResponse
 		if state == types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED {
-			chall, err := rootClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+			chall, err := rootClt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 				Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 					ContextUser: &proto.ContextUser{},
 				},
@@ -135,7 +91,7 @@ func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, headles
 			}
 		}
 
-		err = rootClient.UpdateHeadlessAuthenticationState(ctx, headlessID, state, mfaResponse)
+		err := rootClt.UpdateHeadlessAuthenticationState(ctx, headlessID, state, mfaResponse)
 		return trace.Wrap(err)
 	})
 	return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -48,7 +48,7 @@ type Kube struct {
 }
 
 // GetKubes returns a paginated kubes list
-func (c *Cluster) GetKubes(ctx context.Context, clt auth.ClientI, r *api.GetKubesRequest) (*GetKubesResponse, error) {
+func (c *Cluster) GetKubes(ctx context.Context, authClient auth.ClientI, r *api.GetKubesRequest) (*GetKubesResponse, error) {
 	var (
 		page apiclient.ResourcePage[types.KubeCluster]
 		err  error
@@ -66,7 +66,7 @@ func (c *Cluster) GetKubes(ctx context.Context, clt auth.ClientI, r *api.GetKube
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
-		page, err = apiclient.GetResourcePage[types.KubeCluster](ctx, clt, req)
+		page, err = apiclient.GetResourcePage[types.KubeCluster](ctx, authClient, req)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -154,11 +154,11 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, proxyClient *client.Proxy
 	return cert, nil
 }
 
-func (c *Cluster) getKube(ctx context.Context, clt auth.ClientI, kubeCluster string) (types.KubeCluster, error) {
+func (c *Cluster) getKube(ctx context.Context, authClient auth.ClientI, kubeCluster string) (types.KubeCluster, error) {
 	var kubeClusters []types.KubeCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
 		var err error
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clt, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, authClient, proto.ListResourcesRequest{
 			PredicateExpression: fmt.Sprintf("name == %q", kubeCluster),
 		})
 

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -101,22 +101,15 @@ type GetKubesResponse struct {
 }
 
 // reissueKubeCert issue new certificates for kube cluster and saves them to disk.
-func (c *Cluster) reissueKubeCert(ctx context.Context, kubeCluster string) (tls.Certificate, error) {
+func (c *Cluster) reissueKubeCert(ctx context.Context, proxyClient *client.ProxyClient, kubeCluster string) (tls.Certificate, error) {
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
-	err := c.clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
+	err := proxyClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		AccessRequests: c.status.ActiveRequests.AccessRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
-
-	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-	defer proxyClient.Close()
 
 	key, err := proxyClient.IssueUserCertsWithMFA(
 		ctx, client.ReissueParams{
@@ -135,7 +128,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, kubeCluster string) (tls.
 	// via the RBAC rules, but we also need to make sure that the user has
 	// access to the cluster with at least one kubernetes_user or kubernetes_group
 	// defined.
-	rootClusterName, err := c.clusterClient.RootClusterName(ctx)
+	rootClusterName, err := proxyClient.RootClusterName(ctx)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}

--- a/lib/teleterm/clusters/cluster_leaves.go
+++ b/lib/teleterm/clusters/cluster_leaves.go
@@ -42,13 +42,13 @@ type LeafCluster struct {
 }
 
 // GetLeafClusters returns leaf clusters
-func (c *Cluster) GetLeafClusters(ctx context.Context, proxyClient *client.ProxyClient) ([]LeafCluster, error) {
+func (c *Cluster) GetLeafClusters(ctx context.Context, rootProxyClient *client.ProxyClient) ([]LeafCluster, error) {
 	var (
 		remoteClusters []types.RemoteCluster
 		err            error
 	)
 	err = AddMetadataToRetryableError(ctx, func() error {
-		remoteClusters, err = proxyClient.GetLeafClusters(ctx)
+		remoteClusters, err = rootProxyClient.GetLeafClusters(ctx)
 		return trace.Wrap(err)
 	})
 	if err != nil {

--- a/lib/teleterm/clusters/cluster_leaves.go
+++ b/lib/teleterm/clusters/cluster_leaves.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 )
 
@@ -41,22 +42,14 @@ type LeafCluster struct {
 }
 
 // GetLeafClusters returns leaf clusters
-func (c *Cluster) GetLeafClusters(ctx context.Context) ([]LeafCluster, error) {
-	var remoteClusters []types.RemoteCluster
-	err := AddMetadataToRetryableError(ctx, func() error {
-		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer proxyClient.Close()
-
+func (c *Cluster) GetLeafClusters(ctx context.Context, proxyClient *client.ProxyClient) ([]LeafCluster, error) {
+	var (
+		remoteClusters []types.RemoteCluster
+		err            error
+	)
+	err = AddMetadataToRetryableError(ctx, func() error {
 		remoteClusters, err = proxyClient.GetLeafClusters(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		return nil
+		return trace.Wrap(err)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_servers.go
+++ b/lib/teleterm/clusters/cluster_servers.go
@@ -42,12 +42,10 @@ type Server struct {
 }
 
 // GetServers returns a paginated list of servers.
-func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest) (*GetServersResponse, error) {
+func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest, authClient auth.ClientI) (*GetServersResponse, error) {
 	var (
-		page        apiclient.ResourcePage[types.Server]
-		authClient  auth.ClientI
-		proxyClient *client.ProxyClient
-		err         error
+		page apiclient.ResourcePage[types.Server]
+		err  error
 	)
 
 	req := &proto.ListResourcesRequest{
@@ -62,19 +60,6 @@ func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest) (*Ge
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
-		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
-		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer proxyClient.Close()
-
-		authClient, err = proxyClient.ConnectToCluster(ctx, c.clusterClient.SiteName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer authClient.Close()
-
 		page, err = apiclient.GetResourcePage[types.Server](ctx, authClient, req)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/gateway_creator.go
+++ b/lib/teleterm/clusters/gateway_creator.go
@@ -38,13 +38,13 @@ func NewGatewayCreator(resolver Resolver) GatewayCreator {
 	}
 }
 
-func (g GatewayCreator) CreateGateway(ctx context.Context, proxyClient *client.ProxyClient, params CreateGatewayParams) (gateway.Gateway, error) {
+func (g GatewayCreator) CreateGateway(ctx context.Context, params CreateGatewayParams) (gateway.Gateway, error) {
 	cluster, _, err := g.resolver.ResolveCluster(params.TargetURI)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	gateway, err := cluster.CreateGateway(ctx, proxyClient, params)
+	gateway, err := cluster.CreateGateway(ctx, params)
 	return gateway, trace.Wrap(err)
 }
 

--- a/lib/teleterm/clusters/gateway_creator.go
+++ b/lib/teleterm/clusters/gateway_creator.go
@@ -38,13 +38,13 @@ func NewGatewayCreator(resolver Resolver) GatewayCreator {
 	}
 }
 
-func (g GatewayCreator) CreateGateway(ctx context.Context, params CreateGatewayParams) (gateway.Gateway, error) {
+func (g GatewayCreator) CreateGateway(ctx context.Context, proxyClient *client.ProxyClient, params CreateGatewayParams) (gateway.Gateway, error) {
 	cluster, _, err := g.resolver.ResolveCluster(params.TargetURI)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	gateway, err := cluster.CreateGateway(ctx, params)
+	gateway, err := cluster.CreateGateway(ctx, proxyClient, params)
 	return gateway, trace.Wrap(err)
 }
 

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -276,6 +276,10 @@ func (s *Service) ClusterLogout(ctx context.Context, uri string) error {
 		return trace.Wrap(err)
 	}
 
+	if err := s.ClearCachedClientsForRoot(cluster.URI); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -276,11 +276,7 @@ func (s *Service) ClusterLogout(ctx context.Context, uri string) error {
 		return trace.Wrap(err)
 	}
 
-	if err := s.ClearCachedClientsForRoot(cluster.URI); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(s.ClearCachedClientsForRoot(cluster.URI))
 }
 
 // CreateGateway creates a gateway to given targetURI
@@ -741,12 +737,7 @@ func (s *Service) DeleteAccessRequest(ctx context.Context, req *api.DeleteAccess
 		return trace.Wrap(err)
 	}
 
-	err = cluster.DeleteAccessRequest(ctx, proxyClient.CurrentCluster(), req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(cluster.DeleteAccessRequest(ctx, proxyClient.CurrentCluster(), req))
 }
 
 func (s *Service) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) error {
@@ -760,14 +751,12 @@ func (s *Service) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) er
 		return trace.Wrap(err)
 	}
 
-	err = cluster.AssumeRole(ctx, proxyClient, req)
-	if err != nil {
+	if err := cluster.AssumeRole(ctx, proxyClient, req); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// We have to reconnect using the updated cert.
-	err = s.ClearCachedClientsForRoot(cluster.URI)
-	return trace.Wrap(err)
+	return trace.Wrap(s.ClearCachedClientsForRoot(cluster.URI))
 }
 
 // GetKubes accepts parameterized input to enable searching, sorting, and pagination.

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -34,34 +34,34 @@ import (
 )
 
 // UpdateHeadlessAuthenticationState updates a headless authentication state.
-func (s *Service) UpdateHeadlessAuthenticationState(ctx context.Context, clusterURI, headlessID string, state api.HeadlessAuthenticationState) error {
-	cluster, _, err := s.ResolveCluster(clusterURI)
+func (s *Service) UpdateHeadlessAuthenticationState(ctx context.Context, rootClusterURI, headlessID string, state api.HeadlessAuthenticationState) error {
+	cluster, _, err := s.ResolveCluster(rootClusterURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	rootProxyClient, err := s.GetCachedClient(ctx, cluster.URI.GetRootClusterURI())
+	proxyClient, err := s.GetCachedClient(ctx, cluster.URI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := cluster.UpdateHeadlessAuthenticationState(ctx, rootProxyClient.CurrentCluster(), headlessID, types.HeadlessAuthenticationState(state)); err != nil {
+	if err := cluster.UpdateHeadlessAuthenticationState(ctx, proxyClient.CurrentCluster(), headlessID, types.HeadlessAuthenticationState(state)); err != nil {
 		return trace.Wrap(err)
 	}
 
 	return nil
 }
 
-// StartHeadlessHandlers starts a headless watcher for the given cluster URI.
+// StartHeadlessWatcher starts a headless watcher for the given cluster URI.
 //
 // If waitInit is true, this method will wait for the watcher to connect to the
 // Auth Server and receive an OpInit event to indicate that the watcher is fully
 // initialized and ready to catch headless events.
-func (s *Service) StartHeadlessWatcher(uri string, waitInit bool) error {
+func (s *Service) StartHeadlessWatcher(rootClusterURI string, waitInit bool) error {
 	s.headlessWatcherClosersMu.Lock()
 	defer s.headlessWatcherClosersMu.Unlock()
 
-	cluster, _, err := s.ResolveCluster(uri)
+	cluster, _, err := s.ResolveCluster(rootClusterURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -97,10 +97,10 @@ func (s *Service) StartHeadlessWatchers() error {
 // If waitInit is true, this method will wait for the watcher to connect to the
 // Auth Server and receive an OpInit event to indicate that the watcher is fully
 // initialized and ready to catch headless events.
-func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool) error {
+func (s *Service) startHeadlessWatcher(rootCluster *clusters.Cluster, waitInit bool) error {
 	// If there is already a watcher for this cluster, close and replace it.
 	// This may occur after relogin, for example.
-	if err := s.stopHeadlessWatcher(cluster.URI.String()); err != nil && !trace.IsNotFound(err) {
+	if err := s.stopHeadlessWatcher(rootCluster.URI.String()); err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
 
@@ -117,9 +117,9 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 	}
 
 	watchCtx, watchCancel := context.WithCancel(s.closeContext)
-	s.headlessWatcherClosers[cluster.URI.String()] = watchCancel
+	s.headlessWatcherClosers[rootCluster.URI.String()] = watchCancel
 
-	log := s.cfg.Log.WithField("cluster", cluster.URI.String())
+	log := s.cfg.Log.WithField("cluster", rootCluster.URI.String())
 
 	pendingRequests := make(map[string]context.CancelFunc)
 	pendingRequestsMu := sync.Mutex{}
@@ -142,19 +142,19 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 	pendingWatcherInitializedOnce := sync.Once{}
 
 	watch := func() error {
-		rootProxyClient, err := s.GetCachedClient(watchCtx, cluster.URI.GetRootClusterURI())
+		proxyClient, err := s.GetCachedClient(watchCtx, rootCluster.URI)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		rootClt := rootProxyClient.CurrentCluster()
+		clt := proxyClient.CurrentCluster()
 
-		pendingWatcher, closePendingWatcher, err := cluster.WatchPendingHeadlessAuthentications(watchCtx, rootClt)
+		pendingWatcher, closePendingWatcher, err := rootCluster.WatchPendingHeadlessAuthentications(watchCtx, clt)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		defer closePendingWatcher()
 
-		resolutionWatcher, closeResolutionWatcher, err := cluster.WatchHeadlessAuthentications(watchCtx, rootClt)
+		resolutionWatcher, closeResolutionWatcher, err := rootCluster.WatchHeadlessAuthentications(watchCtx, clt)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -201,7 +201,7 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 				// We do this in a goroutine so the watch loop can continue and cancel resolved requests.
 				go func() {
 					defer cancelSend()
-					if err := s.sendPendingHeadlessAuthentication(sendCtx, ha, cluster.URI.String()); err != nil {
+					if err := s.sendPendingHeadlessAuthentication(sendCtx, ha, rootCluster.URI.String()); err != nil {
 						if !strings.Contains(err.Error(), context.Canceled.Error()) && !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
 							log.WithError(err).Debug("sendPendingHeadlessAuthentication resulted in unexpected error.")
 						}
@@ -244,14 +244,14 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 				// watcher was canceled by an outside call to stopHeadlessWatcher.
 			default:
 				// watcher closed due to error or cluster disconnect.
-				if err := s.stopHeadlessWatcher(cluster.URI.String()); err != nil {
+				if err := s.stopHeadlessWatcher(rootCluster.URI.String()); err != nil {
 					log.WithError(err).Debug("Failed to remove headless watcher.")
 				}
 			}
 		}()
 
 		for {
-			if !cluster.Connected() {
+			if !rootCluster.Connected() {
 				log.Debugf("Not connected to cluster. Returning from headless watch loop.")
 				return
 			}
@@ -287,9 +287,9 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 }
 
 // sendPendingHeadlessAuthentication notifies the Electron App of a pending headless authentication.
-func (s *Service) sendPendingHeadlessAuthentication(ctx context.Context, ha *types.HeadlessAuthentication, clusterURI string) error {
+func (s *Service) sendPendingHeadlessAuthentication(ctx context.Context, ha *types.HeadlessAuthentication, rootClusterURI string) error {
 	req := &api.SendPendingHeadlessAuthenticationRequest{
-		RootClusterUri:                 clusterURI,
+		RootClusterUri:                 rootClusterURI,
 		HeadlessAuthenticationId:       ha.GetName(),
 		HeadlessAuthenticationClientIp: ha.ClientIpAddress,
 	}

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -146,15 +146,15 @@ func (s *Service) startHeadlessWatcher(rootCluster *clusters.Cluster, waitInit b
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		clt := proxyClient.CurrentCluster()
+		authClient := proxyClient.CurrentCluster()
 
-		pendingWatcher, closePendingWatcher, err := rootCluster.WatchPendingHeadlessAuthentications(watchCtx, clt)
+		pendingWatcher, closePendingWatcher, err := rootCluster.WatchPendingHeadlessAuthentications(watchCtx, authClient)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		defer closePendingWatcher()
 
-		resolutionWatcher, closeResolutionWatcher, err := rootCluster.WatchHeadlessAuthentications(watchCtx, clt)
+		resolutionWatcher, closeResolutionWatcher, err := rootCluster.WatchHeadlessAuthentications(watchCtx, authClient)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -55,7 +55,7 @@ type mockGatewayCreator struct {
 	tcpPortAllocator gateway.TCPPortAllocator
 }
 
-func (m *mockGatewayCreator) CreateGateway(ctx context.Context, proxyClient *client.ProxyClient, params clusters.CreateGatewayParams) (gateway.Gateway, error) {
+func (m *mockGatewayCreator) CreateGateway(ctx context.Context, params clusters.CreateGatewayParams) (gateway.Gateway, error) {
 	m.callCount++
 
 	hs := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {}))

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/teleterm/gatewaytest"
-	"github.com/gravitational/teleport/lib/teleterm/services/clientcache"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -273,7 +272,7 @@ func TestGatewayCRUD(t *testing.T) {
 				GatewayCreator: mockGatewayCreator,
 				KubeconfigsDir: t.TempDir(),
 				AgentsDir:      t.TempDir(),
-				ClientCache:    &fakeClientCache{},
+				ClientCache:    fakeClientCache{},
 			})
 			require.NoError(t, err)
 
@@ -452,7 +451,7 @@ func TestRetryWithRelogin(t *testing.T) {
 				},
 				KubeconfigsDir: t.TempDir(),
 				AgentsDir:      t.TempDir(),
-				ClientCache:    &fakeClientCache{},
+				ClientCache:    fakeClientCache{},
 			})
 			require.NoError(t, err)
 
@@ -503,7 +502,7 @@ func TestImportantModalSemaphore(t *testing.T) {
 		},
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),
-		ClientCache:    &fakeClientCache{},
+		ClientCache:    fakeClientCache{},
 	})
 	require.NoError(t, err)
 
@@ -652,7 +651,7 @@ func TestGetGatewayCLICommand(t *testing.T) {
 		},
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),
-		ClientCache:    &fakeClientCache{},
+		ClientCache:    fakeClientCache{},
 	})
 	require.NoError(t, err)
 
@@ -731,9 +730,9 @@ func (f fakeStorage) GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cl
 }
 
 type fakeClientCache struct {
-	clientcache.Cache
+	ClientCache
 }
 
-func (f *fakeClientCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ProxyClient, error) {
+func (f fakeClientCache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.ProxyClient, error) {
 	return &client.ProxyClient{}, nil
 }

--- a/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
+++ b/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
@@ -97,7 +97,9 @@ export function isRetryable(error: unknown): boolean {
   return (
     error instanceof Error &&
     (error.message.includes('ssh: handshake failed') ||
-      error.message.includes('ssh: cert has expired'))
+      error.message.includes('ssh: cert has expired') ||
+      error.message.includes('tls: expired certificate') ||
+      error.message.includes('client credentials have expired'))
   );
 }
 


### PR DESCRIPTION
2/2 of https://github.com/gravitational/teleport/issues/15603

This PR replaces calls to `clusterClient.ConnectToProxy()` with `daemon.GetRemoteClient()`. 
Most of the callsites now receive `auth.ClientI` that they can use to make remote calls. 
This also aligns with [the idea of refactoring `clusters.Cluster`](https://github.com/gravitational/teleport/issues/13278). Most of its methods now no longer need `clusterClient` and can be easily extracted to smaller packages like [`unifiedresources`](https://github.com/gravitational/teleport/blob/e4fc2f9b186f74791c82a7f2440e81c92ab15ef9/lib/teleterm/services/unifiedresources/unifiedresources.go).

Changelog: Improve performance of remote calls in Teleport Connect.