### PR TITLE
Always verify the old password when changing it

### DIFF
--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -371,6 +371,11 @@ func (a *Server) authenticateUserInternal(ctx context.Context, req AuthenticateU
 		authErr = authenticateHeadlessError
 	case req.Webauthn != nil:
 		authenticateFn = func() (*types.MFADevice, error) {
+			if req.Pass != nil {
+				if err = a.checkPasswordWOToken(user, req.Pass.Password); err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
 			mfaResponse := &proto.MFAAuthenticateResponse{
 				Response: &proto.MFAAuthenticateResponse_Webauthn{
 					Webauthn: wantypes.CredentialAssertionResponseToProto(req.Webauthn),

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -129,10 +129,8 @@ func (a *Server) ChangePassword(ctx context.Context, req *proto.ChangePasswordRe
 		Username: user,
 		Webauthn: wantypes.CredentialAssertionResponseFromProto(req.Webauthn),
 	}
-	if len(req.OldPassword) > 0 {
-		authReq.Pass = &PassCreds{
-			Password: req.OldPassword,
-		}
+	authReq.Pass = &PassCreds{
+		Password: req.OldPassword,
 	}
 	if req.SecondFactorToken != "" {
 		authReq.OTP = &OTPCreds{

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
@@ -303,19 +304,20 @@ func TestServer_ChangePassword(t *testing.T) {
 func TestServer_ChangePassword_FailsWithoutOldPassword(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestTLSServer(t)
-	mfa := configureForMFA(t, srv)
-	authServer := srv.Auth()
+	server := newTestTLSServer(t)
+	mfa := configureForMFA(t, server)
+	authServer := server.Auth()
 	ctx := context.Background()
 
 	username := mfa.User
 	newPass := []byte("capybarasarecool123")
 
-	clt, err := srv.NewClient(TestUser(username))
+	userClient, err := server.NewClient(TestUser(username))
 	require.NoError(t, err)
+	defer userClient.Close()
 
 	// Acquire and solve an MFA challenge.
-	mfaChallenge, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+	mfaChallenge, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 			ContextUser: &proto.ContextUser{},
 		},
@@ -333,10 +335,14 @@ func TestServer_ChangePassword_FailsWithoutOldPassword(t *testing.T) {
 		NewPassword: newPass,
 		Webauthn:    mfaResp.GetWebauthn(),
 	}
-	require.Error(t, authServer.ChangePassword(ctx, req), "changing password")
+	err = authServer.ChangePassword(ctx, req)
+	assert.True(t,
+		trace.IsAccessDenied(err),
+		"ChangePassword error mismatch, want=AccessDenied, got=%v (%T)",
+		err, trace.Unwrap(err))
 
 	// Did the password change take effect?
-	require.Error(t, authServer.checkPasswordWOToken(username, newPass), "password was changed")
+	assert.Error(t, authServer.checkPasswordWOToken(username, newPass), "password was changed")
 }
 
 func TestChangeUserAuthentication(t *testing.T) {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
@@ -292,6 +293,50 @@ func TestServer_ChangePassword(t *testing.T) {
 			oldPass = newPass // Set for next iteration.
 		})
 	}
+}
+
+// This test asserts that an attacker is unable to change password without
+// providing the old one if they take over a user's web session and use a
+// different type of WebAuthn challenge that would be normally requested by the
+// Web UI. This is a regression test for
+// https://github.com/gravitational/teleport-private/issues/1369.
+func TestServer_ChangePassword_FailsWithoutOldPassword(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestTLSServer(t)
+	mfa := configureForMFA(t, srv)
+	authServer := srv.Auth()
+	ctx := context.Background()
+
+	username := mfa.User
+	newPass := []byte("capybarasarecool123")
+
+	clt, err := srv.NewClient(TestUser(username))
+	require.NoError(t, err)
+
+	// Acquire and solve an MFA challenge.
+	mfaChallenge, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
+			ContextUser: &proto.ContextUser{},
+		},
+		ChallengeExtensions: &mfav1.ChallengeExtensions{
+			AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO,
+		},
+	})
+	require.NoError(t, err, "creating challenge")
+	mfaResp, err := mfa.WebDev.SolveAuthn(mfaChallenge)
+	require.NoError(t, err, "solving challenge with device")
+
+	// Change password.
+	req := &proto.ChangePasswordRequest{
+		User:        username,
+		NewPassword: newPass,
+		Webauthn:    mfaResp.GetWebauthn(),
+	}
+	require.Error(t, authServer.ChangePassword(ctx, req), "changing password")
+
+	// Did the password change take effect?
+	require.Error(t, authServer.checkPasswordWOToken(username, newPass), "password was changed")
 }
 
 func TestChangeUserAuthentication(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/1369

Approved for fixing directly on OSS by @jentfoo.

Note that the logic here will be further amended by the upcoming implementation of RFD 0159; this change is a trimmed down subset of it that will need to be privately backported to all of the supported branches.

Tested locally; the following cases were covered:

Changing password with MFA, through the exploit mentioned in the attached issue.
Changing password without MFA (success, wrong password).
Changing password with an authenticator app (success, wrong old password, wrong app token).
Changing password with an MFA device (success, wrong password).
Changing password with an passwordless device (success, wrong password).
The behavior was verified both by looking at success/error messages, as well as an attempt to sign in using the new password.

Changelog: Fixed an issue where it was possible to skip providing old password when setting a new one.