### PR TITLE
Prevent data race in lib/srv/session

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1243,7 +1243,11 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 	}
 
 	inReader, inWriter := io.Pipe()
+
+	s.mu.Lock()
 	s.inWriter = inWriter
+	s.mu.Unlock()
+
 	s.io.AddReader("reader", inReader)
 	s.io.AddWriter(sessionRecorderID, utils.WriteCloserWithContext(scx.srv.Context(), s.Recorder()))
 	s.BroadcastMessage("Creating session with ID: %v", s.id)


### PR DESCRIPTION
Fixes the race identified in #38192 by protecting the inWriter assignment with the session mutex.

Closes https://github.com/gravitational/teleport/issues/38192.