### PR TITLE
Deprecate `(TeleportClient) ConnectToProxy`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1553,6 +1553,7 @@ func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
 		tc.Stdout = person
 		tc.Stdin = person
 
+		//nolint:staticcheck // SA1019. This test is meant to exercise the SSH connection path as long as it exists.
 		clt, err := tc.ConnectToProxy(ctx)
 		require.NoError(t, err)
 		defer clt.Close()
@@ -1676,6 +1677,7 @@ func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
 		})
 		require.NoError(t, err)
 
+		//nolint:staticcheck // SA1019. This test is meant to exercise the SSH connection path as long as it exists.
 		clt, err := tc.ConnectToProxy(ctx)
 		require.NoError(t, err)
 		defer clt.Close()
@@ -8433,6 +8435,7 @@ func TestProxySSHPortMultiplexing(t *testing.T) {
 			// connect via SSH
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
+			//nolint:staticcheck // SA1019. This test is meant to exercise the SSH connection path as long as it exists.
 			pc, err := tc.ConnectToProxy(ctx)
 			require.NoError(t, err)
 			require.NoError(t, pc.Close())

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -1307,12 +1307,16 @@ func TestALPNProxyRootLeafAuthDial(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	proxyClient, err := client.ConnectToProxy(context.Background())
+
+	clusterClient, err := client.ConnectToCluster(ctx)
 	require.NoError(t, err)
+	defer clusterClient.Close()
 
 	// Dial root auth service.
-	rootAuthClient, err := proxyClient.ConnectToAuthServiceThroughALPNSNIProxy(ctx, "root.example.com", "")
+	rootAuthClient, err := clusterClient.ConnectToCluster(ctx, "root.example.com")
 	require.NoError(t, err)
+	defer rootAuthClient.Close()
+
 	pr, err := rootAuthClient.Ping(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "root.example.com", pr.ClusterName)
@@ -1320,8 +1324,10 @@ func TestALPNProxyRootLeafAuthDial(t *testing.T) {
 	require.NoError(t, err)
 
 	// Dial leaf auth service.
-	leafAuthClient, err := proxyClient.ConnectToAuthServiceThroughALPNSNIProxy(ctx, "leaf.example.com", "")
+	leafAuthClient, err := clusterClient.ConnectToCluster(ctx, "leaf.example.com")
 	require.NoError(t, err)
+	defer leafAuthClient.Close()
+
 	pr, err = leafAuthClient.Ping(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "leaf.example.com", pr.ClusterName)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -450,11 +450,11 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 			}, nil
 		})
 
-		proxyClient, err := teleportClient.ConnectToProxy(ctx)
+		clusterClient, err := teleportClient.ConnectToCluster(ctx)
 		require.NoError(t, err)
-		defer proxyClient.Close()
+		defer clusterClient.Close()
 
-		rootAuthClient, err := proxyClient.ConnectToRootCluster(ctx)
+		rootAuthClient, err := clusterClient.ConnectToRootCluster(ctx)
 		require.NoError(t, err)
 		defer rootAuthClient.Close()
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1210,7 +1210,7 @@ func TestConnectToProxyCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	proxy, err := clt.ConnectToProxy(ctx)
-	require.Nil(t, proxy)
+	clusterClient, err := clt.ConnectToCluster(ctx)
+	require.Nil(t, clusterClient)
 	require.Error(t, err)
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -540,6 +540,7 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 			// In case of MFA connect to root teleport proxy instead of JumpHost to request
 			// MFA certificates.
 			proxy.teleportClient.JumpHosts = nil
+			//nolint:staticcheck // SA1019. TODO(tross) remove once ProxyClient is no longer used.
 			rootClusterProxy, err = proxy.teleportClient.ConnectToProxy(ctx)
 			proxy.teleportClient.JumpHosts = jumpHost
 			if err != nil {

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -54,6 +54,15 @@ func (c *ClusterClient) ClusterName() string {
 	return c.cluster
 }
 
+// RootClusterName returns the name of the root cluster. If the
+// client is connected directly to the root cluster, then this
+// returns the same value as [ClusterClient.ClusterName]. If
+// the client is connected to a leaf cluster, this returns the
+// root cluster associated with the leaf.
+func (c *ClusterClient) RootClusterName() string {
+	return c.root
+}
+
 // CurrentCluster returns an authenticated auth server client for the local cluster.
 // The returned auth server client does not need to be closed, it will be closed
 // when the ClusterClient is closed.

--- a/lib/client/kubesession.go
+++ b/lib/client/kubesession.go
@@ -187,6 +187,7 @@ func handleIncomingResizeEvents(stream *streamproto.SessionStream, term *termina
 
 func (s *KubeSession) handleMFA(ctx context.Context, tc *TeleportClient, mode types.SessionParticipantMode, stdout io.Writer) error {
 	if s.stream.MFARequired && mode == types.SessionModeratorMode {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxy, err := tc.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -98,6 +98,7 @@ func (c *Cluster) GetWithDetails(ctx context.Context) (*ClusterWithDetails, erro
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -192,6 +193,7 @@ func convertToAPIResourceAccess(access services.ResourceAccess) *api.ResourceAcc
 func (c *Cluster) GetRoles(ctx context.Context) ([]*types.Role, error) {
 	var roles []*types.Role
 	err := AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -235,6 +237,7 @@ func (c *Cluster) GetRequestableRoles(ctx context.Context, req *api.GetRequestab
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -56,6 +56,7 @@ func (c *Cluster) GetAccessRequest(ctx context.Context, req types.AccessRequestF
 	)
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -179,6 +180,7 @@ func (c *Cluster) ReviewAccessRequest(ctx context.Context, req *api.ReviewAccess
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -223,6 +225,7 @@ func (c *Cluster) DeleteAccessRequest(ctx context.Context, req *api.DeleteAccess
 	)
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -85,6 +85,7 @@ func (c *Cluster) GetApps(ctx context.Context, r *api.GetAppsRequest) (*GetAppsR
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -179,6 +180,7 @@ func (c *Cluster) reissueAppCert(ctx context.Context, app types.Application) (tl
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
+	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -69,6 +69,7 @@ func (c *Cluster) GetDatabase(ctx context.Context, dbURI uri.ResourceURI) (*Data
 func (c *Cluster) getAllDatabases(ctx context.Context) ([]Database, error) {
 	var dbs []types.Database
 	err := AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -120,6 +121,7 @@ func (c *Cluster) GetDatabases(ctx context.Context, r *api.GetDatabasesRequest) 
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -205,6 +207,7 @@ func (c *Cluster) GetAllowedDatabaseUsers(ctx context.Context, dbURI string) ([]
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_headless.go
+++ b/lib/teleterm/clusters/cluster_headless.go
@@ -30,6 +30,7 @@ import (
 
 // WatchPendingHeadlessAuthentications watches the backend for pending headless authentication requests for the user.
 func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context) (watcher types.Watcher, close func(), err error) {
+	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -59,6 +60,7 @@ func (c *Cluster) WatchPendingHeadlessAuthentications(ctx context.Context) (watc
 
 // WatchHeadlessAuthentications watches the backend for headless authentication events for the user.
 func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context) (watcher types.Watcher, close func(), err error) {
+	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -99,6 +101,7 @@ func (c *Cluster) WatchHeadlessAuthentications(ctx context.Context) (watcher typ
 // MFA will be prompted when updating to the approve state.
 func (c *Cluster) UpdateHeadlessAuthenticationState(ctx context.Context, headlessID string, state types.HeadlessAuthenticationState) error {
 	err := AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -68,6 +68,7 @@ func (c *Cluster) GetKubes(ctx context.Context, r *api.GetKubesRequest) (*GetKub
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -125,6 +126,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, kubeCluster string) (tls.
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
+	//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 	proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -177,6 +179,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, kubeCluster string) (tls.
 func (c *Cluster) getKube(ctx context.Context, kubeCluster string) (types.KubeCluster, error) {
 	var kubeClusters []types.KubeCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_leaves.go
+++ b/lib/teleterm/clusters/cluster_leaves.go
@@ -44,6 +44,7 @@ type LeafCluster struct {
 func (c *Cluster) GetLeafClusters(ctx context.Context) ([]LeafCluster, error) {
 	var remoteClusters []types.RemoteCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_servers.go
+++ b/lib/teleterm/clusters/cluster_servers.go
@@ -62,6 +62,7 @@ func (c *Cluster) GetServers(ctx context.Context, r *api.GetServersRequest) (*Ge
 	}
 
 	err = AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -566,6 +566,7 @@ func (s *Service) PromoteAccessRequest(ctx context.Context, rootClusterURI uri.R
 
 	var response *clusters.AccessRequest
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -602,6 +603,7 @@ func (s *Service) GetSuggestedAccessLists(ctx context.Context, rootClusterURI ur
 
 	var response []*accesslist.AccessList
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -830,6 +832,7 @@ func (s *Service) CreateConnectMyComputerRole(ctx context.Context, req *api.Crea
 	}
 	response := &api.CreateConnectMyComputerRoleResponse{}
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -861,6 +864,7 @@ func (s *Service) CreateConnectMyComputerNodeToken(ctx context.Context, rootClus
 	}
 	var nodeToken string
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -887,6 +891,7 @@ func (s *Service) DeleteConnectMyComputerNode(ctx context.Context, req *api.Dele
 		return &api.DeleteConnectMyComputerNodeResponse{}, trace.Wrap(err)
 	}
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -927,6 +932,7 @@ func (s *Service) WaitForConnectMyComputerNodeJoin(ctx context.Context, rootClus
 
 	var server clusters.Server
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -960,6 +966,7 @@ func (s *Service) ListUnifiedResources(ctx context.Context, clusterURI uri.Resou
 	var resources *unifiedresources.ListResponse
 
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := clusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -994,6 +1001,7 @@ func (s *Service) GetUserPreferences(ctx context.Context, clusterURI uri.Resourc
 	var preferences *api.UserPreferences
 
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := rootClusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)
@@ -1037,6 +1045,7 @@ func (s *Service) UpdateUserPreferences(ctx context.Context, clusterURI uri.Reso
 	var preferences *api.UserPreferences
 
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxyClient, err := rootClusterClient.ConnectToProxy(ctx)
 		if err != nil {
 			return trace.Wrap(err)

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -452,13 +452,11 @@ func onRequestSearch(cf *CLIConf) error {
 		tableColumns = []string{"Name", "Namespace", "Labels", "Resource ID"}
 	default:
 		// For all other resources, we need to connect to the auth server.
-		proxyClient, err := tc.ConnectToProxy(cf.Context)
+		clusterClient, err := tc.ConnectToCluster(cf.Context)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer proxyClient.Close()
-
-		authClient := proxyClient.CurrentCluster()
+		defer clusterClient.Close()
 
 		req := proto.ListResourcesRequest{
 			Labels:              tc.Labels,
@@ -467,7 +465,7 @@ func onRequestSearch(cf *CLIConf) error {
 			UseSearchAsRoles:    true,
 		}
 
-		resources, err = accessrequest.GetResourcesByKind(cf.Context, authClient, req, cf.ResourceKind)
+		resources, err = accessrequest.GetResourcesByKind(cf.Context, clusterClient.AuthClient, req, cf.ResourceKind)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/common/config.go
+++ b/tool/tsh/common/config.go
@@ -61,15 +61,20 @@ func onConfig(cf *CLIConf) error {
 	// destination (possibly their ssh config file) may get polluted with
 	// invalid output. Instead, rely on the normal error messages (which are
 	// sent to stderr) and expect the user to log in manually.
-	proxyClient, err := tc.ConnectToProxy(cf.Context)
+	clusterClient, err := tc.ConnectToCluster(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clusterClient.Close()
 
-	rootClusterName, rootErr := proxyClient.RootClusterName(cf.Context)
-	leafClusters, leafErr := proxyClient.GetLeafClusters(cf.Context)
-	if err := trace.NewAggregate(rootErr, leafErr); err != nil {
+	rootAuthClient, err := clusterClient.ConnectToRootCluster(cf.Context)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rootAuthClient.Close()
+
+	leafClusters, err := rootAuthClient.GetRemoteClusters()
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -84,17 +89,16 @@ func onConfig(cf *CLIConf) error {
 
 	var sb strings.Builder
 	if err := writeSSHConfig(&sb, &openssh.SSHConfigParameters{
-		AppName:          openssh.TshApp,
-		ClusterNames:     append([]string{rootClusterName}, leafClustersNames...),
-		KnownHostsPath:   knownHostsPath,
-		IdentityFilePath: identityFilePath,
-		CertificateFilePath: keypaths.SSHCertPath(keysDir, proxyHost,
-			tc.Config.Username, rootClusterName),
-		ProxyHost:      proxyHost,
-		ProxyPort:      proxyPort,
-		ExecutablePath: cf.executablePath,
-		Username:       cf.NodeLogin,
-		Port:           int(cf.NodePort),
+		AppName:             openssh.TshApp,
+		ClusterNames:        append([]string{clusterClient.RootClusterName()}, leafClustersNames...),
+		KnownHostsPath:      knownHostsPath,
+		IdentityFilePath:    identityFilePath,
+		CertificateFilePath: keypaths.SSHCertPath(keysDir, proxyHost, tc.Config.Username, clusterClient.RootClusterName()),
+		ProxyHost:           proxyHost,
+		ProxyPort:           proxyPort,
+		ExecutablePath:      cf.executablePath,
+		Username:            cf.NodeLogin,
+		Port:                int(cf.NodePort),
 	}, nil); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/device.go
+++ b/tool/tsh/common/device.go
@@ -116,13 +116,13 @@ func (c *deviceEnrollCommand) run(cf *CLIConf) error {
 
 	ctx := cf.Context
 	return trace.Wrap(client.RetryWithRelogin(ctx, teleportClient, func() error {
-		proxyClient, err := teleportClient.ConnectToProxy(ctx)
+		clusterClient, err := teleportClient.ConnectToCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer proxyClient.Close()
+		defer clusterClient.Close()
 
-		authClient, err := proxyClient.ConnectToRootCluster(ctx)
+		authClient, err := clusterClient.ConnectToRootCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -115,14 +115,13 @@ func newKubeJoinCommand(parent *kingpin.CmdClause) *kubeJoinCommand {
 }
 
 func (c *kubeJoinCommand) getSessionMeta(ctx context.Context, tc *client.TeleportClient) (types.SessionTracker, error) {
-	proxy, err := tc.ConnectToProxy(ctx)
+	clusterClient, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	site := proxy.CurrentCluster()
-
-	return site.GetSessionTracker(ctx, c.session)
+	tracker, err := clusterClient.AuthClient.GetSessionTracker(ctx, c.session)
+	return tracker, trace.Wrap(err)
 }
 
 func (c *kubeJoinCommand) run(cf *CLIConf) error {
@@ -528,13 +527,13 @@ func (c *kubeSessionsCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	proxy, err := tc.ConnectToProxy(cf.Context)
+	clusterClient, err := tc.ConnectToCluster(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer clusterClient.Close()
 
-	site := proxy.CurrentCluster()
-	sessions, err := site.GetActiveSessionTrackers(cf.Context)
+	sessions, err := clusterClient.AuthClient.GetActiveSessionTrackers(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1356,17 +1355,14 @@ Learn more at https://goteleport.com/docs/architecture/tls-routing/#working-with
 
 func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleportCluster string, kubeClusters []types.KubeCluster, err error) {
 	err = client.RetryWithRelogin(ctx, tc, func() error {
-		pc, err := tc.ConnectToProxy(ctx)
+		clusterClient, err := tc.ConnectToCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer pc.Close()
+		defer clusterClient.Close()
 
-		ac := pc.CurrentCluster()
-		defer ac.Close()
-
-		teleportCluster = pc.ClusterName()
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, ac, proto.ListResourcesRequest{
+		teleportCluster = clusterClient.ClusterName()
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clusterClient.AuthClient, proto.ListResourcesRequest{
 			SearchKeywords:      tc.SearchKeywords,
 			PredicateExpression: tc.PredicateExpression,
 			Labels:              tc.Labels,

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -458,6 +458,7 @@ func loadKubeUserCerts(ctx context.Context, tc *client.TeleportClient, clusters 
 	var proxy *client.ProxyClient
 	err := client.RetryWithRelogin(ctx, tc, func() error {
 		var err error
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxy, err = tc.ConnectToProxy(ctx)
 		return trace.Wrap(err)
 	})
@@ -544,6 +545,7 @@ func (k *kubeLocalProxy) getCertReissuer(tc *client.TeleportClient) func(ctx con
 			defer cancel()
 
 			var err error
+			//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 			proxy, err = tc.ConnectToProxy(ctx)
 			return trace.Wrap(err)
 		})

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -114,18 +114,18 @@ func (c *mfaLSCommand) run(cf *CLIConf) error {
 
 	var devs []*types.MFADevice
 	if err := client.RetryWithRelogin(cf.Context, tc, func() error {
-		pc, err := tc.ConnectToProxy(cf.Context)
+		clusterClient, err := tc.ConnectToCluster(cf.Context)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer pc.Close()
-		aci, err := pc.ConnectToRootCluster(cf.Context)
+		defer clusterClient.Close()
+		rootAuthClient, err := clusterClient.ConnectToRootCluster(cf.Context)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer aci.Close()
+		defer rootAuthClient.Close()
 
-		resp, err := aci.GetMFADevices(cf.Context, &proto.GetMFADevicesRequest{})
+		resp, err := rootAuthClient.GetMFADevices(cf.Context, &proto.GetMFADevicesRequest{})
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -314,16 +314,16 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 
 	var dev *types.MFADevice
 	if err := client.RetryWithRelogin(ctx, tc, func() error {
-		pc, err := tc.ConnectToProxy(ctx)
+		clusterClient, err := tc.ConnectToCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer pc.Close()
-		aci, err := pc.ConnectToRootCluster(ctx)
+		defer clusterClient.Close()
+		rootAuthClient, err := clusterClient.ConnectToRootCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer aci.Close()
+		defer rootAuthClient.Close()
 
 		// TODO(awly): mfa: move this logic somewhere under /lib/auth/, closer
 		// to the server logic. The CLI layer should ideally be thin.
@@ -335,7 +335,7 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 
 		// Issue the authn challenge.
 		// Required for the registration challenge.
-		authChallenge, err := aci.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+		authChallenge, err := rootAuthClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			ChallengeExtensions: &mfav1.ChallengeExtensions{
 				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_MANAGE_DEVICES,
 			},
@@ -361,7 +361,7 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 		}
 
 		// Issue the registration challenge.
-		registerChallenge, err := aci.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+		registerChallenge, err := rootAuthClient.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
 			ExistingMFAResponse: authnResp,
 			DeviceType:          devTypePB,
 			DeviceUsage:         usage,
@@ -378,7 +378,7 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 		}
 
 		// Complete registration and confirm new key.
-		addResp, err := aci.AddMFADeviceSync(ctx, &proto.AddMFADeviceSyncRequest{
+		addResp, err := rootAuthClient.AddMFADeviceSync(ctx, &proto.AddMFADeviceSyncRequest{
 			NewDeviceName:  c.devName,
 			NewMFAResponse: registerResp,
 			DeviceUsage:    usage,
@@ -567,21 +567,21 @@ func (c *mfaRemoveCommand) run(cf *CLIConf) error {
 
 	ctx := cf.Context
 	if err := client.RetryWithRelogin(ctx, tc, func() error {
-		pc, err := tc.ConnectToProxy(ctx)
+		clusterClient, err := tc.ConnectToCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer pc.Close()
-		aci, err := pc.ConnectToRootCluster(ctx)
+		defer clusterClient.Close()
+		rootAuthClient, err := clusterClient.ConnectToRootCluster(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer aci.Close()
+		defer rootAuthClient.Close()
 
 		// Lookup device to delete.
 		// This lets us exit early if the device doesn't exist and enables the
 		// Touch ID cleanup at the end.
-		devicesResp, err := aci.GetMFADevices(ctx, &proto.GetMFADevicesRequest{})
+		devicesResp, err := rootAuthClient.GetMFADevices(ctx, &proto.GetMFADevicesRequest{})
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -597,7 +597,7 @@ func (c *mfaRemoveCommand) run(cf *CLIConf) error {
 		}
 
 		// Issue and solve authn challenge.
-		authnChal, err := aci.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+		authnChal, err := rootAuthClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 				ContextUser: &proto.ContextUser{},
 			},
@@ -614,7 +614,7 @@ func (c *mfaRemoveCommand) run(cf *CLIConf) error {
 		}
 
 		// Delete device.
-		if err := aci.DeleteMFADeviceSync(ctx, &proto.DeleteMFADeviceSyncRequest{
+		if err := rootAuthClient.DeleteMFADeviceSync(ctx, &proto.DeleteMFADeviceSyncRequest{
 			DeviceName:          c.name,
 			ExistingMFAResponse: authnSolved,
 		}); err != nil {

--- a/tool/tsh/common/putty_config_windows.go
+++ b/tool/tsh/common/putty_config_windows.go
@@ -287,11 +287,11 @@ func onPuttyConfig(cf *CLIConf) error {
 	}
 
 	// connect to proxy to fetch cluster info
-	proxyClient, err := tc.ConnectToProxy(cf.Context)
+	clusterClient, err := tc.ConnectToCluster(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clusterClient.Close()
 
 	// parse out proxy details
 	proxyHost, _, err := net.SplitHostPort(tc.Config.SSHProxyAddr)
@@ -300,10 +300,7 @@ func onPuttyConfig(cf *CLIConf) error {
 	}
 
 	// get root cluster name and set keypaths
-	rootClusterName, err := proxyClient.RootClusterName(cf.Context)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	rootClusterName := clusterClient.RootClusterName()
 	keysDir := profile.FullProfilePath(tc.Config.KeysDir)
 	ppkFilePath := keypaths.PPKFilePath(keysDir, proxyHost, tc.Config.Username)
 	certificateFilePath := keypaths.SSHCertPath(keysDir, proxyHost, tc.Config.Username, rootClusterName)

--- a/tool/tsh/common/recording_export.go
+++ b/tool/tsh/common/recording_export.go
@@ -50,14 +50,11 @@ func onExportRecording(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	proxyClient, err := tc.ConnectToProxy(cf.Context)
+	clusterClient, err := tc.ConnectToCluster(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer proxyClient.Close()
-
-	authClient := proxyClient.CurrentCluster()
-	defer authClient.Close()
+	defer clusterClient.Close()
 
 	filenamePrefix := cf.SessionID
 	if cf.OutFile != "" {
@@ -66,7 +63,7 @@ func onExportRecording(cf *CLIConf) error {
 			strings.TrimSuffix(cf.OutFile, ".avi"), ".AVI")
 	}
 
-	_, err = writeMovie(cf.Context, authClient, session.ID(cf.SessionID), filenamePrefix, fmt.Printf, tc.Config.WebProxyAddr)
+	_, err = writeMovie(cf.Context, clusterClient.AuthClient, session.ID(cf.SessionID), filenamePrefix, fmt.Printf, tc.Config.WebProxyAddr)
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2209,6 +2209,7 @@ func getClusterClients(cf *CLIConf, resource string) ([]*clusterClient, error) {
 		logger := log.WithField("cluster", profile.Cluster)
 
 		logger.Debug("Creating client...")
+		//nolint:staticcheck // SA1019. TODO(tross) update to use ClusterClient
 		proxy, err := tc.ConnectToProxy(ctx)
 		if err != nil {
 			// log error and return nil so that results may still be retrieved
@@ -2978,16 +2979,22 @@ func onListClusters(cf *CLIConf) error {
 	var rootClusterName string
 	var leafClusters []types.RemoteCluster
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		proxyClient, err := tc.ConnectToProxy(cf.Context)
+		clusterClient, err := tc.ConnectToCluster(cf.Context)
 		if err != nil {
 			return err
 		}
-		defer proxyClient.Close()
+		defer clusterClient.Close()
 
-		var rootErr, leafErr error
-		rootClusterName, rootErr = proxyClient.RootClusterName(cf.Context)
-		leafClusters, leafErr = proxyClient.GetLeafClusters(cf.Context)
-		return trace.NewAggregate(rootErr, leafErr)
+		rootClusterName = clusterClient.RootClusterName()
+
+		rootAuthClient, err := clusterClient.ConnectToRootCluster(cf.Context)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootAuthClient.Close()
+
+		leafClusters, err = rootAuthClient.GetRemoteClusters()
+		return trace.Wrap(err)
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This legacy connection mechanism uses SSH to connect to the Proxy and tunnel the Auth connection. It was replaced by
`(TeleportClient) ConnectToCluster` in v13 which uses gRPC to reduce latency when connecting to the cluster. When initially added only `tsh ssh` and `tsh ls` were converted to use ConnectToCluster since those were the two commands we were targeting to reduce latency on. 

Step one of https://github.com/gravitational/teleport/issues/38239