### PR TITLE
Fix `TestResumption/no_roaming`

### DIFF
--- a/lib/resumption/resumption_test.go
+++ b/lib/resumption/resumption_test.go
@@ -119,7 +119,7 @@ func TestResumption(t *testing.T) {
 			}
 
 			// the original connection is on localhost, which is distincly not 127.0.0.42
-			go resumableServer.sshServer(
+			go resumableServer.HandleConnection(
 				utils.NewConnWithSrcAddr(p1, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 42), Port: 55555}),
 			)
 


### PR DESCRIPTION
This makes it so that we actually test the correct thing, while avoiding a potential hang caused by the first reconnection attempt not correctly realizing that the connection is no longer resumable (see https://github.com/gravitational/teleport/actions/runs/7903648085/job/21572037956?pr=38210).