### PR TITLE
Introduce `tbot-distroless` image

### DIFF
--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -1,0 +1,26 @@
+ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
+
+FROM debian:12 AS teleport
+# Install the teleport binary from an architecture-specific debian package. Note
+# that we cannot simply pass a ready-made package filename in as a build-arg, as
+# this dockerfile is used for a multiarch build and any build-args will be
+# re-used for multiple ${TARGETARCH}es. In order to get around this we pass
+# various components of the architecture-specific debian package filename in as
+# individual build args and re-assemble it *inside* the build.
+
+# NOTE that TELEPORT_RELEASE_INFIX *must* include the leading dash if set.
+ARG TELEPORT_RELEASE_INFIX
+ARG TELEPORT_VERSION
+# TARGETARCH is supplied by the `buildx` mechanics
+ARG TARGETARCH
+ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}_${TARGETARCH}.deb
+COPY $TELEPORT_DEB_FILE_NAME ./$TELEPORT_DEB_FILE_NAME
+RUN dpkg-deb -R $TELEPORT_DEB_FILE_NAME /opt/staging && \
+    mkdir -p /opt/staging/etc/teleport && \
+    mkdir -p /opt/staging/var/lib/dpkg/status.d/ && \
+    mv /opt/staging/DEBIAN/control /opt/staging/var/lib/dpkg/status.d/teleport && \
+    rm -rf /opt/staging/DEBIAN
+
+FROM $BASE_IMAGE
+COPY --from=teleport /opt/staging/usr/local/bin/tbot /usr/local/bin/tbot
+ENTRYPOINT ["/usr/local/bin/tbot"]

--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -14,8 +14,7 @@ ARG TELEPORT_VERSION
 # TARGETARCH is supplied by the `buildx` mechanics
 ARG TARGETARCH
 ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}_${TARGETARCH}.deb
-COPY $TELEPORT_DEB_FILE_NAME ./$TELEPORT_DEB_FILE_NAME
-RUN dpkg-deb -R $TELEPORT_DEB_FILE_NAME /opt/staging && \
+RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/staging && \
     mkdir -p /opt/staging/etc/teleport && \
     mkdir -p /opt/staging/var/lib/dpkg/status.d/ && \
     mv /opt/staging/DEBIAN/control /opt/staging/var/lib/dpkg/status.d/teleport && \

--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -14,11 +14,7 @@ ARG TELEPORT_VERSION
 # TARGETARCH is supplied by the `buildx` mechanics
 ARG TARGETARCH
 ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}_${TARGETARCH}.deb
-RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/staging && \
-    mkdir -p /opt/staging/etc/teleport && \
-    mkdir -p /opt/staging/var/lib/dpkg/status.d/ && \
-    mv /opt/staging/DEBIAN/control /opt/staging/var/lib/dpkg/status.d/teleport && \
-    rm -rf /opt/staging/DEBIAN
+RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/staging
 
 FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging/usr/local/bin/tbot /usr/local/bin/tbot


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/21280

Paired with https://github.com/gravitational/teleport.e/pull/3465

changelog: tbot-distroless image is now published. This contains just the tbot binary and therefore has a smaller image size.

Successful build: https://drone.platform.teleport.sh/gravitational/teleport/34023
Image: public.ecr.aws/gravitational/tbot-distroless:16.0.0-dev.noah.tbr.1

Working `docker run`:
````
docker run public.ecr.aws/gravitational/tbot-distroless:16.0.0-dev.noah.tbr.1                                                                   
Unable to find image 'public.ecr.aws/gravitational/tbot-distroless:16.0.0-dev.noah.tbr.1' locally
16.0.0-dev.noah.tbr.1: Pulling from gravitational/tbot-distroless
8398841c8311: Pull complete 
2b776ada0341: Pull complete 
2a977872b36c: Pull complete 
fcb6f6d2c998: Pull complete 
e8c73c638ae9: Pull complete 
1e3d9b7d1452: Pull complete 
4aa0ea1413d3: Pull complete 
2fa82a9c76b2: Pull complete 
672354a91bfa: Pull complete 
acd581f1e199: Pull complete 
972a9f56458f: Pull complete 
810b5cc4682a: Pull complete 
45c2519a3853: Pull complete 
2b9c28259b9a: Pull complete 
0d7c3f6d6dc4: Pull complete 
Digest: sha256:1d2d377a93cbff0c66953670c19eef2e793d3c630f361758fec802fe0565078a
Status: Downloaded newer image for public.ecr.aws/gravitational/tbot-distroless:16.0.0-dev.noah.tbr.1
Usage: tbot [<flags>] <command> [<args> ...]

Teleport Machine ID

Machine ID issues and renews short-lived certificates so your machines can
access Teleport protected resources in the same way your engineers do!

Find out more at https://goteleport.com/docs/machine-id/introduction/

Flags:
  -d, --[no-]debug  Verbose logging to stdout.
  -c, --config      Path to a configuration file.
      --[no-]fips   Runs tbot in FIPS compliance mode. This requires the FIPS
                    binary is in use.

Commands:
  help         Show help.
  version      Print the version of your tbot binary.
  start        Starts the renewal bot, writing certificates to the data dir at a set interval.
  init         Initialize a certificate destination directory for writes from a separate bot user.
  configure    Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).
  migrate      Migrates a config file from an older version to the newest version. Outputs to stdout by default.
  db           Execute database commands through tsh.
  proxy        Start a local TLS proxy via tsh to connect to Teleport in single-port mode.

Try 'tbot help [command]' to get help for a given command.
````