### PR TITLE
Enforce "automatic update"

### DIFF
--- a/.github/vale-styles/messaging/consistent-terms.yml
+++ b/.github/vale-styles/messaging/consistent-terms.yml
@@ -19,3 +19,4 @@ swap:
   'Auth Services': Auth Service instances
   'Teleport open source|open source Teleport': Teleport Community Edition
   'OSS Teleport|Teleport OSS': Teleport Community Edition
+  'automatic upgrade': automatic update

--- a/docs/pages/architecture/agent-update-management.mdx
+++ b/docs/pages/architecture/agent-update-management.mdx
@@ -90,5 +90,5 @@ ensure every agent is healthy and running the correct version.
 Self-hosted users must first [set up self-hosted automatic agent upgrades
 ](../upgrading/self-hosted-automatic-agent-updates.mdx).
 
-After that, you can set enroll agents in automatic upgrades as part of the
+After that, you can set enroll agents in automatic updates as part of the
 [upgrading procedure](../upgrading.mdx).

--- a/docs/pages/includes/server-access/custom-installer.mdx
+++ b/docs/pages/includes/server-access/custom-installer.mdx
@@ -45,7 +45,7 @@ The `installer` resource has the following templating options:
 connect to.
 - `{{ .RepoChannel }}`: Optional package repository (apt/yum) channel name.
 Has format `<channel>/<version>` e.g. stable/v(=teleport.major_version=). See [installation](../../installation.mdx#linux) for more details.
-- `{{ .AutomaticUpgrades }}`: indicates whether Automatic Upgrades are enabled or disabled.
+- `{{ .AutomaticUpgrades }}`: indicates whether Automatic Updates are enabled or disabled.
   Its value is either `true` or `false`. See
   [self-hosted automatic agent updates](../../upgrading/self-hosted-automatic-agent-updates.mdx)
   for more information.

--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -973,7 +973,7 @@ You can override this to use your own Teleport image rather than a Teleport-publ
   to pull the image.
 
   For this reason, it is strongly discouraged to set a custom image when
-  using automatic updates. Teleport Cloud uses automatic upgrades by default.
+  using automatic updates. Teleport Cloud uses automatic updates by default.
 </Admonition>
 
 Since version 13, hardened distroless images are used by default.
@@ -1003,7 +1003,7 @@ Teleport-published image.
   to pull the image.
 
   For this reason, it is strongly discouraged to set a custom image when
-  using automatic updates. Teleport Cloud uses automatic upgrades by default.
+  using automatic updates. Teleport Cloud uses automatic updates by default.
 </Admonition>
 
 Since version 13, hardened distroless images are used by default.

--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -37,7 +37,7 @@ compatibility. [#22748](https://github.com/gravitational/teleport/issues/22748)
 | 13.0.0-alpha.1 | April 17th, 2023 |
 | 13.0.0         | May 8th, 2023    |
 
-####  Automatic upgrades
+####  Automatic updates
 
 Users will be able to configure Teleport agents to upgrade automatically.
 

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -5,7 +5,7 @@ description: Provides instructions for upgrading Teleport Cloud agents that run 
 
 This guide explains how to upgrade Teleport Cloud agents running on Kubernetes.
 On Teleport Cloud, Auth Service and Proxy Service upgrades are managed for you.
-To keep agents up to date, you can either enroll them in automatic upgrades or
+To keep agents up to date, you can either enroll them in automatic updates or
 upgrade them manually using the method you used to install Teleport.
 
 ## Prerequisites
@@ -27,8 +27,8 @@ chart. The [Automatic Update Architecture
 ](../architecture/agent-update-management.mdx) guide describes how agent
 updating works. Automatic agent upgrades require:
 
-- A Teleport Cloud account that supports automatic upgrades. To determine if
-  your account supports automatic upgrades, run the following command, replacing
+- A Teleport Cloud account that supports automatic updates. To determine if
+  your account supports automatic updates, run the following command, replacing
   `mytenant.teleport.sh` with the address of your Teleport Cloud account:
 
   ```code
@@ -38,7 +38,7 @@ updating works. Automatic agent upgrades require:
 - At least one Teleport Enterprise agent deployed via the `teleport-kube-agent`
   Helm chart.
 
-## Step 1/2. Determine whether any agents require automatic upgrades
+## Step 1/2. Determine whether any agents require automatic updates
 
 To determine if any agents in your cluster are not configured for automatic
 upgrades, run the following command. This prints a list of all Teleport services
@@ -54,9 +54,9 @@ Server ID                            Hostname                        Services Ve
 00000000-0000-0000-0000-000000000000 teleport-agent-0                Kube     v13.4.3 none
 ```
 
-If the list is nonempty, proceed to the next step to enable automatic upgrades.
+If the list is nonempty, proceed to the next step to enable automatic updates.
 
-## Step 2/2. Enroll agents in automatic upgrades
+## Step 2/2. Enroll agents in automatic updates
 
 This section assumes that the name of your `teleport-kube-agent` release is
 `teleport-agent`, and that you have installed it in the `teleport` namespace.
@@ -115,7 +115,7 @@ will send an event, so the updater can be triggered by annotating the resource:
 $ kubectl -n <Var name="teleport" /> annotate statefulset/<Var name="teleport-agent" /> 'debug.teleport.dev/trigger-event=1'
 ```
 
-To suspend automatic upgrades for an agent, annotate the agent deployment with
+To suspend automatic updates for an agent, annotate the agent deployment with
 `teleport.dev/skipreconcile: "true"`, either by setting the
 `annotations.deployment` value in Helm, or by patching the deployment directly
 with `kubectl`.

--- a/docs/pages/upgrading/cloud-linux.mdx
+++ b/docs/pages/upgrading/cloud-linux.mdx
@@ -28,8 +28,8 @@ using `apt`, `yum`, and `zypper` package managers. The [Automatic Update
 Architecture](../architecture/agent-update-management.mdx) guide describes
 how agent updating works. Automatic agent upgrades require:
 
-- A Teleport Cloud account that supports automatic upgrades. To determine if
-  your account supports automatic upgrades, run the following command, replacing
+- A Teleport Cloud account that supports automatic updates. To determine if
+  your account supports automatic updates, run the following command, replacing
   `mytenant.teleport.sh` with the address of your Teleport Cloud account:
 
   ```code
@@ -46,7 +46,7 @@ how agent updating works. Automatic agent upgrades require:
 
 ## Step 1/2. Find agents to upgrade
 
-To list agents that are not enrolled in automatic upgrades, use the `tctl
+To list agents that are not enrolled in automatic updates, use the `tctl
 inventory ls` command with the `--upgrader=none` flag. This command also uses
 the `--services` flag to constrain the search to Teleport processes running
 agent services:
@@ -71,7 +71,7 @@ Server ID                            Hostname        Services Version Upgrader
 ...
 ```
 
-When you enroll each agent in automatic upgrades in the next section, you can
+When you enroll each agent in automatic updates in the next section, you can
 run the following commands to fetch the hostname for each agent and access it
 via Teleport. 
 
@@ -85,12 +85,12 @@ $ tsh ssh "${USER?}@${HOST?}"
 ```
 
 You can then follow the steps in the next section on each agent to enroll it in
-automatic upgrades.
+automatic updates.
 
-## Step 2/2. Enroll agents in automatic upgrades
+## Step 2/2. Enroll agents in automatic updates
 
 Complete the following instructions on each agent you would like to enroll into
-automatic upgrades:
+automatic updates:
 
 1. Ensure the Teleport repository is added and Teleport Enterprise is installed.
 
@@ -107,7 +107,7 @@ automatic upgrades:
    it is up to date.
 
 1. If the repository was added, make sure the Teleport binary installed on the
-   agent can run the automatic upgrader:
+   agent can run the automatic updater:
 
    ```code
    $ which teleport-upgrade || echo "Install the upgrader"
@@ -164,7 +164,7 @@ and look at its logs:
 $ sudo teleport-upgrade run
 ```
 
-To suspend automatic upgrades, disable the systemd timer:
+To suspend automatic updates, disable the systemd timer:
 
 ```code
 $ sudo systemctl disable --now teleport-upgrade.timer

--- a/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
@@ -9,7 +9,7 @@ clusters.
 
 Teleport agents run an **upgrader** that queries a **version server** to
 determine whether they are out of date. This guide describes how to set up your
-infrastructure to support automatic upgrades. If you are a Teleport Cloud user
+infrastructure to support automatic updates. If you are a Teleport Cloud user
 or run a version server already, return to the [Upgrading](../upgrading.mdx)
 menu for the appropriate next steps to upgrade Teleport.
 
@@ -17,7 +17,7 @@ The [Automatic Update Architecture](../architecture/agent-update-management.mdx)
 guide explains how automatic agent upgrades work in more detail.
 
 <Admonition type="warning">
-Systemd agents enrolled into automatic upgrades can only install versions
+Systemd agents enrolled into automatic updates can only install versions
 present in their package repositories. As Teleport 14 won't be published to
 `stable/v13`, those agents will require manual intervention to be upgraded to
 the next major version (adding a new APT/YUM/zypper repo for `stable/v14`).
@@ -279,12 +279,12 @@ $ tctl create cmc.yaml
 maintenance window has been updated
 ```
 
-## Step 4/5. Enroll Kubernetes agents in automatic upgrades
+## Step 4/5. Enroll Kubernetes agents in automatic updates
 
 Now that you have deployed a version server, you can enroll agents in automatic
 upgrades. This guide begins with agents deployed on Kubernetes. If all of your
 agents run on Linux servers, you can skip to [Step
-5](#step-55-enroll-linux-agents-in-automatic-upgrades).
+5](#step-55-enroll-linux-agents-in-automatic-updates).
 
 ### Install the agent upgrader Helm chart
 
@@ -357,15 +357,15 @@ until the next reconciliation, you can trigger an event.
    $ kubectl -n <Var name="teleport" /> annotate statefulset/<Var name="teleport-agent" /> 'debug.teleport.dev/trigger-event=1'
    ```
 
-1. To suspend automatic upgrades for an agent, annotate the agent deployment
+1. To suspend automatic updates for an agent, annotate the agent deployment
    with `teleport.dev/skipreconcile: "true"`, either by setting the
    `annotations.deployment` value in Helm, or by patching the deployment
    directly with `kubectl`.
 
-## Step 5/5. Enroll Linux agents in automatic upgrades
+## Step 5/5. Enroll Linux agents in automatic updates
 
 This section shows you how to enroll Teleport agents running on Linux virtual or
-bare-metal machines into automatic upgrades.
+bare-metal machines into automatic updates.
 
 Follow these instructions on each of your Teleport agents.
 
@@ -385,7 +385,7 @@ Follow these instructions on each of your Teleport agents.
    it is up to date.
    
 1. If the repository was added, make sure the Teleport binary installed on the
-   agent can run the automatic upgrader:
+   agent can run the automatic updater:
 
    ```code
    $ which teleport-upgrade || echo "Install the upgrader"
@@ -454,7 +454,7 @@ Follow these instructions on each of your Teleport agents.
    $ sudo teleport-upgrade run
    ```
 
-1. To suspend automatic upgrades, disable the systemd timer:
+1. To suspend automatic updates, disable the systemd timer:
 
    ```code
    $ sudo systemctl disable --now teleport-upgrade.timer

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -783,7 +783,7 @@ adminClusterRoleBinding:
 #   to pull the image.
 #
 #   For this reason, it is strongly discouraged to set a custom image when
-#   using automatic updates. Teleport Cloud uses automatic upgrades by default.
+#   using automatic updates. Teleport Cloud uses automatic updates by default.
 # </Admonition>
 #
 # Since version 13, hardened distroless images are used by default.
@@ -808,7 +808,7 @@ image: public.ecr.aws/gravitational/teleport-distroless
 #   to pull the image.
 #
 #   For this reason, it is strongly discouraged to set a custom image when
-#   using automatic updates. Teleport Cloud uses automatic upgrades by default.
+#   using automatic updates. Teleport Cloud uses automatic updates by default.
 # </Admonition>
 #
 # Since version 13, hardened distroless images are used by default.


### PR DESCRIPTION
See #36816

The docs are inconsistent in using "automatic updates" vs. "automatic upgrades". Prefer the former to be consistent with the `teleport-ent-updater` script.

- Replace "automatic upgrade" with "automatic update" in docs pages.
- Replace "automatic upgrade" uses in the `teleport-kube-agent` chart and regenerate the docs.
- Catch uses of "automatic upgrade" in the `consistent-terms` Vale rule