### PR TITLE
[v14] Unblock SSO user with auto discover on setup access screen

### DIFF
--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.tsx
@@ -130,6 +130,7 @@ export function SetupAccessWrapper({
       break;
   }
 
+  const ssoUserWithAutoDiscover = wantAutoDiscover && isSsoUser;
   return (
     <Box maxWidth="700px">
       <Header>Set Up Access</Header>
@@ -143,7 +144,14 @@ export function SetupAccessWrapper({
         disableProceed={
           attempt.status === 'failed' ||
           attempt.status === 'processing' ||
-          !hasTraits
+          // Only block on no traits, if the user is not a SSO user
+          // and did not enable auto discover.
+          // SSO user's cannot currently add traits and the SSO user
+          // may already have set upped traits in their roles, but we
+          // currently don't have a way to retrieve all the traits from
+          // users roles - in which the user can end up blocked on this step
+          // with "no traits".
+          (!ssoUserWithAutoDiscover && !hasTraits)
         }
       />
     </Box>


### PR DESCRIPTION
Backport #38132 to branch/v14

changelog: Fix locking SSO user in the setup access step of the RDS auto discover flow in the web UI
