### PR TITLE
Update license generation instructions

### DIFF
--- a/docs/pages/includes/enterprise/obtainlicense.mdx
+++ b/docs/pages/includes/enterprise/obtainlicense.mdx
@@ -1,10 +1,10 @@
 The Teleport Auth Service reads a license file to authenticate your Teleport
 Enterprise account.
 
-To obtain your license file, navigate to your [Teleport
-account](https://teleport.sh) and enter your
-account name (e.g., `my-license`). After logging in, click
-the "DOWNLOAD LICENSE KEY" button to download your
-license file.
+To obtain your license file, navigate to your Teleport account dashboard and log
+in. You can start at [teleport.sh](https://teleport.sh) and enter your Teleport
+account name (e.g. my-company). After logging in you will see a "GENERATE
+LICENSE KEY" button, which will generate a new license file and allow you to
+download it.
 
 ![License File Download](../../../img/enterprise/license.png)


### PR DESCRIPTION
Closes #37174

Update the `obtainlicense` partial to be consistent with the changes introduced in #36673.