### PR TITLE
Avoid busting the layer cache when installing `osslsigncode` in buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -187,9 +187,9 @@ RUN apt-get -y update && \
 # Code Signing Certificate needs us to use osslsigncode >= 2.6, which
 # allows the use of legacy OpenSSL algorithms. This is not yet provided
 # by Ubuntu, so we will have to fetch it ourselves.
-RUN --mount=type=bind,target=/context \
+RUN --mount=type=bind,source=download-hashes/osslsigncode.sha256,target=/context/osslsigncode.sha256 \
     curl -L https://github.com/mtrojnar/osslsigncode/releases/download/2.6/osslsigncode-2.6-ubuntu-22.04.zip -o osslsigncode.zip \
-    && sha256sum --strict -c /context/download-hashes/osslsigncode.sha256 \
+    && sha256sum --strict -c /context/osslsigncode.sha256 \
     && unzip -d /tmp/osslsigncode osslsigncode.zip \
     && install -m 0755 /tmp/osslsigncode/bin/osslsigncode /usr/bin \
     && rm -rf /tmp/osslsigncode \


### PR DESCRIPTION
By binding without a `source` we bind the entire `build.assets` directory (as it defaults to the build context). This causes the layer cache to bust any time any file within `build.assets` changes - but - we only need it to bust if `osslsigncode.sha256` changes.

This should speed up running something like `make fix-imports` which ends up rebuilding the container basically from scratch if anything in `build.assets` changed.

As this occurs so early within the build, it prevents any layers after this from using the cache.

See https://github.com/gravitational/teleport/actions/runs/7899691481/job/21559671401 for an example build where the cache stops being used after this step is hit.

Sources:
- https://github.com/moby/buildkit/issues/1903
- https://docs.docker.com/build/guide/mounts/#add-bind-mounts

