### PR TITLE
[v13] tsh: fix panic when loading profile

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -356,10 +356,15 @@ func profileFromFile(filePath string) (*Profile, error) {
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	var p *Profile
+	var p Profile
 	if err := yaml.Unmarshal(bytes, &p); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if p.Name() == "" {
+		return nil, trace.NotFound("invalid or empty profile at %q", filePath)
+	}
+
 	p.Dir = filepath.Dir(filePath)
 
 	// Older versions of tsh did not always store the cluster name in the
@@ -368,7 +373,7 @@ func profileFromFile(filePath string) (*Profile, error) {
 	if p.SiteName == "" {
 		p.SiteName = p.Name()
 	}
-	return p, nil
+	return &p, nil
 }
 
 // SaveToDir saves this profile to the specified directory.


### PR DESCRIPTION
Backport #38197 to branch/v13

changelog: Fixed a potential panic in the `tsh status` command.
