### PR TITLE
[v13] Relax CA Rotation test assertions

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -506,7 +506,9 @@ func TestAutoRotation(t *testing.T) {
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "certificate")
+	// TODO(rosstimothy, espadolini, jakule): figure out how to consistently
+	// match a certificate error and not other errors
+	require.Error(t, err)
 
 	// new clients work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -678,7 +680,7 @@ func TestManualRotation(t *testing.T) {
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "certificate")
+	require.Error(t, err)
 
 	// new clients work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
@@ -773,7 +775,7 @@ func TestRollback(t *testing.T) {
 
 	// clients with new creds will no longer work
 	_, err = tt.server.CloneClient(newProxy).GetNodes(ctx, apidefaults.Namespace)
-	require.ErrorContains(t, err, "certificate")
+	require.Error(t, err)
 
 	// clients with old creds will still work
 	_, err = tt.server.CloneClient(proxy).GetNodes(ctx, apidefaults.Namespace)


### PR DESCRIPTION
Backport #31098 to branch/v13


This wasn't done prior because branch/v13 wasn't using go 1.21. Now that we've updated branch/v13 this should resolve any flaky tests. 