### PR TITLE
Update Electron to 28.2.3 and Node.js to 18.19.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -5,7 +5,7 @@
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.0
 
-NODE_VERSION ?= 18.18.2
+NODE_VERSION ?= 18.19.1
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -48,7 +48,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.10",
     "@types/jsdom": "^21.1.6",
-    "@types/node": "^18.18.5",
+    "@types/node": "^18.19.17",
     "@types/react": "^18.2.39",
     "@types/react-dom": "^18.2.17",
     "@types/react-router-dom": "^5.1.1",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
     "clean-webpack-plugin": "4.0.0",
-    "electron": "28.1.1",
+    "electron": "28.2.3",
     "electron-notarize": "^1.2.1",
     "electron-vite": "^2.0.0",
     "eslint-import-resolver-webpack": "0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7496,10 +7496,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.1.1.tgz#37254967e32a4a69e18378f3b1aba1475522d08d"
-  integrity sha512-HJSbGHpRl46jWCp5G4OH57KSm2F5u15tB10ixD8iFiz9dhwojqlSQTRAcjSwvga+Vqs1jv7iqwQRrolXP4DgOA==
+electron@28.2.3:
+  version "28.2.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.3.tgz#d26821bcfda7ee445b4b75231da4b057a7ce6e7b"
+  integrity sha512-he9nGphZo03ejDjYBXpmFVw0KBKogXvR2tYxE4dyYvnfw42uaFIBFrwGeenvqoEOfheJfcI0u4rFG6h3QxDwnA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,10 +4127,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.11.18", "@types/node@^18.18.5":
-  version "18.18.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.5.tgz#afc0fd975df946d6e1add5bbf98264225b212244"
-  integrity sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.11.18", "@types/node@^18.19.17":
+  version "18.19.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.17.tgz#a581a9fb4b2cfdbc61f008804f4436b2d5c40354"
+  integrity sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.18.16"
@@ -15289,6 +15291,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Electron changelog https://releases.electronjs.org/release/compare/v28.1.1/v28.2.3

I also bumped Node version to 18.19.1 which includes some security fixes https://gravitational.slack.com/archives/C01US9V97RS/p1708025138096649.

Tested on macOS, Windows (VM) and Ubuntu (test build 15.0.0-dev.gzdunek.8).
Resolving shell env and starting CMC works fine.