### PR TITLE
tsh: skip invalid profiles instead of failing

### DIFF
--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -230,7 +230,8 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 		}
 		status, err := s.ReadProfileStatus(profileName)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			s.log.WithError(err).Warnf("skipping profile %q due to error", profileName)
+			continue
 		}
 		profiles = append(profiles, status)
 	}


### PR DESCRIPTION
The tsh status command attempts to decode one profile per YAML file in $TSH_HOME. If an error is encountered along the way, the entire command fails and tsh does not display information about any profiles.

An especially confusing corner case is when a user mistakenly places tsh's configuration at $TSH_HOME/config.yaml instead of $TSH_HOME/config/config.yaml. In this case, the config file is assumed to be a profile and the user is presentedc with a confusing error message.

Fix this by skipping over profiles that fail to load but continuing to report on the ones that load successfully.

Closes #38302

changelog: Ensure that tsh continues to function if one of its profiles is invalid.