### PR TITLE
Revert "Fix opsgenie plugin to use correct annotation to determine whether or not to create alerts"

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -75,10 +75,10 @@ spec:
         - approve: 1
           deny: 1
       annotations:
-        teleport.dev/notify-services: ['teleport-access-request-notifications']
+        teleport.dev/schedules: ['teleport-access-request-notifications']
 ```
 
-The `teleport.dev/notify-services` annotation specifies the schedules the alert will be be created for.
+The `teleport.dev/schedules` annotation specifies the schedule the alert will be be created for.
 
 ### Create a user who will request access
 
@@ -121,7 +121,7 @@ As the Teleport user `myuser`, create an Access Request for the `editor` role:
 
 In Opsgenie, you will see a new alert containing information about the
 Access Request in either the default schedule specified when enrolling the plugin,
-or in the schedules specified by `teleport.dev/notify-services` annotation in the requester's role.
+or in the schedules specified by `teleport.dev/schedules` annotation in the requester's role.
 
 ### Resolve the request
 

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -352,7 +352,7 @@ func (a *App) getMessageRecipients(ctx context.Context, req types.AccessRequest)
 		recipientSet.Add(common.Recipient{})
 		return recipientSet.ToSlice()
 	case types.PluginTypeOpsgenie:
-		if recipients, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationNotifyServicesLabel]; ok {
+		if recipients, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationSchedulesLabel]; ok {
 			for _, recipient := range recipients {
 				rec, err := a.bot.FetchRecipient(ctx, recipient)
 				if err != nil {

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -61,15 +61,11 @@ func (b Bot) SendReviewReminders(ctx context.Context, recipients []common.Recipi
 
 // BroadcastAccessRequestMessage creates an alert for the provided recipients (schedules)
 func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []common.Recipient, reqID string, reqData pd.AccessRequestData) (data accessrequest.SentMessages, err error) {
-	rawRecipients := []string{}
-	for _, recipient := range recipients {
-		rawRecipients = append(rawRecipients, recipient.Name)
-	}
 	schedules := []string{}
-	if annSchedules, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationSchedulesLabel]; ok {
-		schedules = annSchedules
+	for _, recipient := range recipients {
+		schedules = append(schedules, recipient.Name)
 	}
-	if len(schedules) == 0 {
+	if len(recipients) == 0 {
 		schedules = append(schedules, b.client.DefaultSchedules...)
 	}
 	opsgenieReqData := RequestData{
@@ -83,8 +79,7 @@ func (b *Bot) BroadcastAccessRequestMessage(ctx context.Context, recipients []co
 			Reason: reqData.ResolutionReason,
 		},
 		SystemAnnotations: types.Labels{
-			types.TeleportNamespace + types.ReqAnnotationSchedulesLabel:      schedules,
-			types.TeleportNamespace + types.ReqAnnotationNotifyServicesLabel: rawRecipients,
+			types.TeleportNamespace + types.ReqAnnotationSchedulesLabel: schedules,
 		},
 	}
 	opsgenieData, err := b.client.CreateAlert(ctx, reqID, opsgenieReqData)

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -160,7 +160,7 @@ func (og Client) CreateAlert(ctx context.Context, reqID string, reqData RequestD
 
 func (og Client) getResponders(reqData RequestData) []Responder {
 	schedules := og.DefaultSchedules
-	if reqSchedules, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationNotifyServicesLabel]; ok {
+	if reqSchedules, ok := reqData.SystemAnnotations[types.TeleportNamespace+types.ReqAnnotationSchedulesLabel]; ok {
 		schedules = reqSchedules
 	}
 	responders := make([]Responder, 0, len(schedules))

--- a/integrations/access/opsgenie/client_test.go
+++ b/integrations/access/opsgenie/client_test.go
@@ -56,7 +56,7 @@ func TestCreateAlert(t *testing.T) {
 		Roles:         []string{"role1", "role2"},
 		RequestReason: "someReason",
 		SystemAnnotations: types.Labels{
-			types.TeleportNamespace + types.ReqAnnotationNotifyServicesLabel: {"responder@teleport.com"},
+			types.TeleportNamespace + types.ReqAnnotationSchedulesLabel: {"responder@teleport.com"},
 		},
 	})
 	assert.NoError(t, err)

--- a/rfd/0109-opsgenie-plugin.md
+++ b/rfd/0109-opsgenie-plugin.md
@@ -108,8 +108,8 @@ spec:
     request:
       roles: [someOtherRole]
       annotations:
-        teleport.dev/notify-services: ["service1", "service2"] # These are the Opsgenie schedules alerts will be created under
-        teleport.dev/schedules: ["service1", "service2"] # These are the Opsgenie schedules checked during auto approval
+        opsgenie_notify_services: ["service1", "service2"] # These are the Opsgenie services alerts will be created under
+        opsgenie_oncall_schedules: ["service1", "service2"] # These are the Opsgenie schedules checked during auto approval
 ```
 
 ## Implementation details


### PR DESCRIPTION
Reverts gravitational/teleport#37929

Fix was not backwards compatible. Separate PR will address issue in a  way that wont cause breaking changes.