### PR TITLE
[v13] Update Electron to 28.2.3 and Node.js to 18.19.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 
 GOLANG_VERSION ?= go1.21.7
 
-NODE_VERSION ?= 18.18.2
+NODE_VERSION ?= 18.19.1
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -49,7 +49,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.6",
     "@types/jsdom": "^21.1.0",
-    "@types/node": "^18.18.5",
+    "@types/node": "^18.19.17",
     "@types/react": "^16.8.19",
     "@types/react-router-dom": "^5.1.1",
     "@types/react-transition-group": "^4.4.5",

--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
@@ -31,7 +31,7 @@ export const ProgressBarDesktop = (props: {
   id?: string;
 }) => {
   const { playerClient, durationMs } = props;
-  const intervalRef = useRef<NodeJS.Timer>();
+  const intervalRef = useRef<number>();
   let playSpeed = 1.0;
 
   const toHuman = (currentMs: number) => {
@@ -71,7 +71,7 @@ export const ProgressBarDesktop = (props: {
       const smoothOutProgress = (speed: number) => {
         const smoothingInterval = 25;
 
-        intervalRef.current = setInterval(() => {
+        intervalRef.current = window.setInterval(() => {
           setState(prevState => {
             const nextTimeMs = prevState.current + smoothingInterval * speed;
             if (nextTimeMs <= durationMs) {
@@ -91,7 +91,7 @@ export const ProgressBarDesktop = (props: {
       // should be called when the playback is paused or ended.
       const stopProgress = () => {
         throttledUpdateCurrentTime.cancel();
-        clearInterval(intervalRef.current);
+        window.clearInterval(intervalRef.current);
       };
 
       const throttledUpdateCurrentTime = throttle(

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -40,7 +40,7 @@
     "@types/node-forge": "^1.0.4",
     "clean-webpack-plugin": "4.0.0",
     "cross-env": "5.0.5",
-    "electron": "28.0.0",
+    "electron": "28.2.3",
     "electron-notarize": "^1.2.1",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-loader": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,25 +3543,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "16.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
-  integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
-
-"@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "18.14.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
-  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.11.18", "@types/node@^18.19.17":
+  version "18.19.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.17.tgz#a581a9fb4b2cfdbc61f008804f4436b2d5c40354"
+  integrity sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.18.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.16.tgz#09ff98b144abae2d7cce3e9fe9040ab2bf73222c"
   integrity sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==
-
-"@types/node@^18.11.18", "@types/node@^18.18.5":
-  version "18.18.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.5.tgz#afc0fd975df946d6e1add5bbf98264225b212244"
-  integrity sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6610,10 +6602,10 @@ electron-to-chromium@^1.4.535:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.551.tgz#14db6660a88f66ce095ea2657abe5653bc7f42ed"
   integrity sha512-/Ng/W/kFv7wdEHYzxdK7Cv0BHEGSkSB3M0Ssl8Ndr1eMiYeas/+Mv4cNaDqamqWx6nd2uQZfPz6g25z25M/sdw==
 
-electron@28.0.0:
-  version "28.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.0.0.tgz#21e5590c967125a3c1ec6b0d8d923baf9eb6fd72"
-  integrity sha512-eDhnCFBvG0PGFVEpNIEdBvyuGUBsFdlokd+CtuCe2ER3P+17qxaRfWRxMmksCOKgDHb5Wif5UxqOkZSlA4snlw==
+electron@28.2.3:
+  version "28.2.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.3.tgz#d26821bcfda7ee445b4b75231da4b057a7ce6e7b"
+  integrity sha512-he9nGphZo03ejDjYBXpmFVw0KBKogXvR2tYxE4dyYvnfw42uaFIBFrwGeenvqoEOfheJfcI0u4rFG6h3QxDwnA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
@@ -14623,6 +14615,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Manual backport of #38328 due to `package.json` an `yarn.lock` conflicts.

I also had to fix a TS error, `setInterval` should use `number` since we are in `window` context, not `Node.JS`. 