### PR TITLE
Update cluster configuration backend service APIs

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -153,6 +153,54 @@ func (c *Client) Close() error {
 	return c.APIClient.Close()
 }
 
+func (c *Client) CreateAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateClusterNetworkingConfig(context.Context, types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateClusterNetworkingConfig(ctx context.Context, preference types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertClusterNetworkingConfig(ctx context.Context, preference types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
 // CreateCertAuthority not implemented: can only be called locally.
 func (c *Client) CreateCertAuthority(ctx context.Context, ca types.CertAuthority) error {
 	return trace.NotImplemented(notImplementedMessage)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1221,10 +1221,23 @@ func TestAuthPreferenceSettings(t *testing.T) {
 	clt, err := testSrv.NewClient(TestAdmin())
 	require.NoError(t, err)
 
-	suite := &suite.ServicesTestSuite{
-		ConfigS: clt,
-	}
-	suite.AuthPreference(t)
+	ctx := context.Background()
+	ap, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
+		Type:                  "local",
+		SecondFactor:          "otp",
+		DisconnectExpiredCert: types.NewBoolOption(true),
+	})
+	require.NoError(t, err)
+
+	err = clt.SetAuthPreference(ctx, ap)
+	require.NoError(t, err)
+
+	gotAP, err := clt.GetAuthPreference(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "local", gotAP.GetType())
+	require.Equal(t, constants.SecondFactorOTP, gotAP.GetSecondFactor())
+	require.True(t, gotAP.GetDisconnectExpiredCert())
 }
 
 func TestTunnelConnectionsCRUD(t *testing.T) {

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -28,7 +28,7 @@ import (
 // the resources modified by this interface can only have a single instance
 // in the backend.
 type ClusterConfiguration interface {
-	// SetClusterName gets services.ClusterName from the backend.
+	// GetClusterName gets types.ClusterName from the backend.
 	GetClusterName(opts ...MarshalOption) (types.ClusterName, error)
 	// SetClusterName sets services.ClusterName on the backend.
 	SetClusterName(types.ClusterName) error
@@ -54,28 +54,56 @@ type ClusterConfiguration interface {
 
 	// GetAuthPreference gets types.AuthPreference from the backend.
 	GetAuthPreference(context.Context) (types.AuthPreference, error)
+	// CreateAuthPreference creates an auth preference if once does not already exist.
+	CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	// UpdateAuthPreference updates an existing auth preference.
+	UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+	UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
 	// SetAuthPreference sets types.AuthPreference from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetAuthPreference(context.Context, types.AuthPreference) error
 	// DeleteAuthPreference deletes types.AuthPreference from the backend.
 	DeleteAuthPreference(ctx context.Context) error
 
 	// GetSessionRecordingConfig gets SessionRecordingConfig from the backend.
 	GetSessionRecordingConfig(context.Context, ...MarshalOption) (types.SessionRecordingConfig, error)
+	// CreateSessionRecordingConfig creates a session recording config if once does not already exist.
+	CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
+	// UpdateSessionRecordingConfig updates an existing session recording config.
+	UpdateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
+	// UpsertSessionRecordingConfig creates a new session recording config or overwrites the existing session recording.
+	UpsertSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
 	// SetSessionRecordingConfig sets SessionRecordingConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetSessionRecordingConfig(context.Context, types.SessionRecordingConfig) error
 	// DeleteSessionRecordingConfig deletes SessionRecordingConfig from the backend.
 	DeleteSessionRecordingConfig(ctx context.Context) error
 
 	// GetClusterAuditConfig gets ClusterAuditConfig from the backend.
 	GetClusterAuditConfig(context.Context, ...MarshalOption) (types.ClusterAuditConfig, error)
+	// CreateClusterAuditConfig creates a cluster audit config if once does not already exist.
+	CreateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
+	// UpdateClusterAuditConfig updates an existing cluster audit config.
+	UpdateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
+	// UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
+	UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
 	// SetClusterAuditConfig sets ClusterAuditConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetClusterAuditConfig(context.Context, types.ClusterAuditConfig) error
 	// DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
 	DeleteClusterAuditConfig(ctx context.Context) error
 
 	// GetClusterNetworkingConfig gets ClusterNetworkingConfig from the backend.
 	GetClusterNetworkingConfig(context.Context, ...MarshalOption) (types.ClusterNetworkingConfig, error)
+	// CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.
+	CreateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
+	// UpdateClusterNetworkingConfig updates an existing cluster networking config.
+	UpdateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
+	// UpsertClusterNetworkingConfig creates a new cluster networking config or overwrites the existing cluster networking config.
+	UpsertClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
 	// SetClusterNetworkingConfig sets ClusterNetworkingConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetClusterNetworkingConfig(context.Context, types.ClusterNetworkingConfig) error
 	// DeleteClusterNetworkingConfig deletes ClusterNetworkingConfig from the backend.
 	DeleteClusterNetworkingConfig(ctx context.Context) error

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -191,31 +191,90 @@ func (s *ClusterConfigurationService) GetAuthPreference(ctx context.Context) (ty
 
 // SetAuthPreference sets the cluster authentication preferences
 // on the backend.
-func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, preferences types.AuthPreference) error {
+func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, preference types.AuthPreference) error {
+	_, err := s.UpsertAuthPreference(ctx, preference)
+	return trace.Wrap(err)
+}
+
+// CreateAuthPreference creates an auth preference if once does not already exist.
+func (s *ClusterConfigurationService) CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
 	// Perform the modules-provided checks.
-	rev := preferences.GetRevision()
-	if err := modules.ValidateResource(preferences); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	value, err := services.MarshalAuthPreference(preferences)
+	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	preference.SetRevision(lease.Revision)
+	return preference, nil
+}
+
+// UpdateAuthPreference updates an existing auth preference.
+func (s *ClusterConfigurationService) UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
+	// Perform the modules-provided checks.
+	rev := preference.GetRevision()
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalAuthPreference(preference)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
 		Value:    value,
-		ID:       preferences.GetResourceID(),
+		ID:       preference.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return nil
+	preference.SetRevision(lease.Revision)
+	return preference, nil
+}
+
+// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalAuthPreference(preference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	preference.SetRevision(lease.Revision)
+	return preference, nil
 }
 
 // DeleteAuthPreference deletes types.AuthPreference from the backend.
@@ -243,25 +302,73 @@ func (s *ClusterConfigurationService) GetClusterAuditConfig(ctx context.Context,
 }
 
 // SetClusterAuditConfig sets the cluster audit config on the backend.
-func (s *ClusterConfigurationService) SetClusterAuditConfig(ctx context.Context, auditConfig types.ClusterAuditConfig) error {
-	rev := auditConfig.GetRevision()
-	value, err := services.MarshalClusterAuditConfig(auditConfig)
+func (s *ClusterConfigurationService) SetClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) error {
+	_, err := s.UpsertClusterAuditConfig(ctx, cfg)
+	return trace.Wrap(err)
+}
+
+// CreateClusterAuditConfig creates a cluster audit config if once does not already exist.
+func (s *ClusterConfigurationService) CreateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	value, err := services.MarshalClusterAuditConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateClusterAuditConfig updates an existing cluster audit config.
+func (s *ClusterConfigurationService) UpdateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	rev := cfg.GetRevision()
+	value, err := services.MarshalClusterAuditConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, auditPrefix),
 		Value:    value,
-		ID:       auditConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
+func (s *ClusterConfigurationService) UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	value, err := services.MarshalClusterAuditConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
 }
 
 // DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
@@ -288,32 +395,90 @@ func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Con
 	return services.UnmarshalClusterNetworkingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
 }
 
-// SetClusterNetworkingConfig sets the cluster networking config
-// on the backend.
-func (s *ClusterConfigurationService) SetClusterNetworkingConfig(ctx context.Context, netConfig types.ClusterNetworkingConfig) error {
+// CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.
+func (s *ClusterConfigurationService) CreateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
 	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(netConfig); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	rev := netConfig.GetRevision()
-	value, err := services.MarshalClusterNetworkingConfig(netConfig)
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateClusterNetworkingConfig updates an existing cluster networking config.
+func (s *ClusterConfigurationService) UpdateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rev := cfg.GetRevision()
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
 		Value:    value,
-		ID:       netConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertClusterNetworkingConfig creates a new cluster networking config or overwrites the existing cluster networking config.
+func (s *ClusterConfigurationService) UpsertClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// SetClusterNetworkingConfig sets the cluster networking config
+// on the backend.
+func (s *ClusterConfigurationService) SetClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) error {
+	_, err := s.UpsertClusterNetworkingConfig(ctx, cfg)
+	return trace.Wrap(err)
 }
 
 // DeleteClusterNetworkingConfig deletes ClusterNetworkingConfig from the backend.
@@ -340,31 +505,90 @@ func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Cont
 	return services.UnmarshalSessionRecordingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
 }
 
-// SetSessionRecordingConfig sets session recording config on the backend.
-func (s *ClusterConfigurationService) SetSessionRecordingConfig(ctx context.Context, recConfig types.SessionRecordingConfig) error {
+// CreateSessionRecordingConfig creates a session recording config if once does not already exist.
+func (s *ClusterConfigurationService) CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
 	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(recConfig); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	rev := recConfig.GetRevision()
-	value, err := services.MarshalSessionRecordingConfig(recConfig)
+	value, err := services.MarshalSessionRecordingConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateSessionRecordingConfig updates an existing session recording config.
+func (s *ClusterConfigurationService) UpdateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rev := cfg.GetRevision()
+	value, err := services.MarshalSessionRecordingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
 		Value:    value,
-		ID:       recConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertSessionRecordingConfig creates a new session recording or overwrites the existing session recording.
+func (s *ClusterConfigurationService) UpsertSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalSessionRecordingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// SetSessionRecordingConfig sets session recording config on the backend.
+func (s *ClusterConfigurationService) SetSessionRecordingConfig(ctx context.Context, recConfig types.SessionRecordingConfig) error {
+	_, err := s.UpsertSessionRecordingConfig(ctx, recConfig)
+	return trace.Wrap(err)
 }
 
 // DeleteSessionRecordingConfig deletes SessionRecordingConfig from the backend.

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -94,6 +94,18 @@ func TestClusterNetworkingConfig(t *testing.T) {
 	suite.ClusterNetworkingConfig(t)
 }
 
+func TestClusterAuditConfig(t *testing.T) {
+	tt := setupConfigContext(context.Background(), t)
+
+	clusterConfig, err := NewClusterConfigurationService(tt.bk)
+	require.NoError(t, err)
+
+	suite := &suite.ServicesTestSuite{
+		ConfigS: clusterConfig,
+	}
+	suite.ClusterNetworkingConfig(t)
+}
+
 func TestSessionRecordingConfig(t *testing.T) {
 	tt := setupConfigContext(context.Background(), t)
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1124,21 +1124,36 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 func (s *ServicesTestSuite) AuthPreference(t *testing.T) {
 	ctx := context.Background()
 	ap, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
-		Type:                  "local",
-		SecondFactor:          "otp",
+		Type:                  constants.Local,
+		SecondFactor:          constants.SecondFactorOTP,
 		DisconnectExpiredCert: types.NewBoolOption(true),
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetAuthPreference(ctx, ap)
+	// Create a preference when one does not exist.
+	created, err := s.ConfigS.CreateAuthPreference(ctx, ap)
 	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
 
+	// Validate the created preference matches the retrieve preference.
 	gotAP, err := s.ConfigS.GetAuthPreference(ctx)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(ap, gotAP), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"))
 
-	require.Equal(t, "local", gotAP.GetType())
-	require.Equal(t, constants.SecondFactorOTP, gotAP.GetSecondFactor())
-	require.True(t, gotAP.GetDisconnectExpiredCert())
+	// Validate that update only works if the revision matches.
+	gotAP.SetRevision("123")
+	_, err = s.ConfigS.UpdateAuthPreference(ctx, gotAP)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetSecondFactor(constants.SecondFactorOff)
+	updated, err := s.ConfigS.UpdateAuthPreference(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, constants.SecondFactorOff, updated.GetSecondFactor())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertAuthPreference(ctx, gotAP)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotAP), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"))
 }
 
 // SessionRecordingConfig tests session recording configuration.
@@ -1149,13 +1164,36 @@ func (s *ServicesTestSuite) SessionRecordingConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetSessionRecordingConfig(ctx, recConfig)
-	require.NoError(t, err)
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateSessionRecordingConfig(ctx, recConfig)
+	require.True(t, trace.IsCompareFailed(err))
 
-	gotrecConfig, err := s.ConfigS.GetSessionRecordingConfig(ctx)
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateSessionRecordingConfig(ctx, recConfig)
 	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
 
-	require.Equal(t, types.RecordAtProxy, gotrecConfig.GetMode())
+	// Validate the created config matches the retrieve config.
+	gotRecConfig, err := s.ConfigS.GetSessionRecordingConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(recConfig, gotRecConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Validate that update only works if the revision matches.
+	gotRecConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateSessionRecordingConfig(ctx, gotRecConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetMode(types.RecordAtNode)
+
+	updated, err := s.ConfigS.UpdateSessionRecordingConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, types.RecordAtNode, updated.GetMode())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertSessionRecordingConfig(ctx, gotRecConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotRecConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
 }
 
 func (s *ServicesTestSuite) StaticTokens(t *testing.T) {
@@ -1247,14 +1285,75 @@ func (s *ServicesTestSuite) ClusterNetworkingConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetClusterNetworkingConfig(ctx, netConfig)
-	require.NoError(t, err)
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateClusterNetworkingConfig(ctx, netConfig)
+	require.True(t, trace.IsCompareFailed(err))
 
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateClusterNetworkingConfig(ctx, netConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
+
+	// Validate the created config matches the retrieve config.
 	gotNetConfig, err := s.ConfigS.GetClusterNetworkingConfig(ctx)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(netConfig, gotNetConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
-	require.Equal(t, 17*time.Second, gotNetConfig.GetClientIdleTimeout())
-	require.Equal(t, int64(3000), gotNetConfig.GetKeepAliveCountMax())
+	// Validate that update only works if the revision matches.
+	gotNetConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateClusterNetworkingConfig(ctx, gotNetConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetKeepAliveCountMax(10)
+
+	updated, err := s.ConfigS.UpdateClusterNetworkingConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), updated.GetKeepAliveCountMax())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertClusterNetworkingConfig(ctx, gotNetConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotNetConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+}
+
+// ClusterAuditConfig tests cluster audit configuration.
+func (s *ServicesTestSuite) ClusterAuditConfig(t *testing.T) {
+	ctx := context.Background()
+	auditConfig, err := types.NewClusterAuditConfig(types.ClusterAuditConfigSpecV2{
+		Region:                  "us-east-1",
+		EnableContinuousBackups: true,
+	})
+	require.NoError(t, err)
+
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateClusterAuditConfig(ctx, auditConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateClusterAuditConfig(ctx, auditConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
+
+	// Validate the created config matches the retrieve config.
+	gotAuditConfig, err := s.ConfigS.GetClusterAuditConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(auditConfig, gotAuditConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Validate that update only works if the revision matches.
+	gotAuditConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateClusterAuditConfig(ctx, gotAuditConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetRegion("us-west-2")
+
+	updated, err := s.ConfigS.UpdateClusterAuditConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, "us-west-2", updated.Region())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertClusterAuditConfig(ctx, gotAuditConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotAuditConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 }
 
 // sem wrapper is a helper for overriding the keepalive


### PR DESCRIPTION
Extends the storage layer of ClusterAuthPreference, ClusterNetworkingConfig, ClusterAuditConfig, and
SessionRecordingConfig to support Create, Update and Upsert. This will allow consumers of this layer to chose the appropriate write operation instead of only having a single Set operation.