### PR TITLE
fix indention in helm code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,9 +157,10 @@ throughout the remainder of these releases' lifecycle.
 The teleport-cluster chart no longer uses versionOverride and extraArgs to set FIPS mode. 
 
 Instead, you should use the following values file configuration:
+```
 enterpriseImage: public.ecr.aws/gravitational/teleport-ent-fips-distroless
-localAuth: false
-
+authentication:
+  localAuth: false
 ```
 
 ##### Multi-architecture Teleport Operator images
@@ -249,7 +250,8 @@ Instead, you should use the following values file configuration:
 
 ```
 enterpriseImage: public.ecr.aws/gravitational/teleport-ent-fips-distroless
-localAuth: false
+authentication:
+  localAuth: false
 
 ```
 

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -169,7 +169,8 @@ Set the following values in your cluster-values.yaml configuration:
 
 ```
 enterpriseImage: public.ecr.aws/gravitational/teleport-ent-fips-distroless
-localAuth: false
+authentication:
+  localAuth: false
 
 ```
 


### PR DESCRIPTION
localAuth: false must be nested under authentication whereas the example appears it can be at the same indention as enterpriseImage