### PR TITLE
Limit the scope docs linting

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -27,7 +27,6 @@ jobs:
           filters: |
             changed:
               - '.github/workflows/doc-tests.yaml'
-              - 'CHANGELOG.md'
               - 'docs/**'
               - 'examples/**'
 
@@ -116,10 +115,8 @@ jobs:
           # relevant changes" job.
           separator: ","
           files: ${{ needs.changes.outputs.changed_files }}
-          # Report all results in a file modified in the PR, even if it wasn't
-          # touched by the diff. This way, we can gradually implement a style
-          # guide across the docs: docs authors do a little bit of extra work,
-          # but aren't responsible for entire docs site.
-          filter_mode: file
+          # Restrict the linter to lines modified/added by a PR, not entire
+          # changed files.
+          filter_mode: added
           fail_on_error: true
 


### PR DESCRIPTION
- **Don't run vale linters on the changelog:** The changelog has different requirements than other docs pages. For example, we can publish releases after changing product language, meaning that language that applied at one release doesn't apply at another release. This causes friction when, say, using the vale linter to check product language.
- **Restrict the vale linter to changed lines, not whole files:** This makes following vale style rules less onerous for docs authors.