### PR TITLE
Revert "[v14] Use buildx `docker` driver, add `--cache-to type=inline` (#38133)"

### DIFF
--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
@@ -63,8 +61,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "e"]
+	path = e
+	url = git@github.com:gravitational/teleport.e.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "e"]
-	path = e
-	url = git@github.com:gravitational/teleport.e.git

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -82,17 +82,6 @@ REQUIRE_HOST_ARCH = $(if $(filter-out $(ARCH),$(RUNTIME_ARCH)),$(error Cannot cr
 # needed on CI as they start with a fresh state each time.
 PULL_ON_CI = $(if $(filter $(CI),true),docker inspect --type=image $(1) >/dev/null 2>&1 || docker pull $(1) || true)
 
-# DOCKER_BUILDER_NAME extracts the name of the buildx builder that uses the "docker" driver.
-#
-# The awk command looks for the first line that has "docker" in the second (DRIVER) column.
-# -F '[ *]+': there may be an asterisk between the first and second column if that record is the default,
-# so just subsume the asterisk into the field separator.
-DOCKER_BUILDER_NAME = $(shell docker buildx ls 2>/dev/null | awk -F '[ *]+' '$$2 == "docker" {print $$1}')
-
-.PHONY:print-docker-builder-name
-print-docker-builder-name:
-	@echo $(DOCKER_BUILDER_NAME)
-
 #
 # Build 'teleport' release inside a docker container
 #
@@ -137,7 +126,6 @@ build-binaries-fips: buildbox-centos7-fips webassets
 buildbox:
 	$(call PULL_ON_CI,$(BUILDBOX))
 	DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -151,7 +139,6 @@ buildbox:
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
 		--tag $(BUILDBOX) .
 
@@ -170,7 +157,6 @@ buildbox-centos7:
 	$(REQUIRE_HOST_ARCH)
 	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7))
 	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -181,7 +167,6 @@ buildbox-centos7:
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
 
@@ -191,8 +176,7 @@ buildbox-centos7:
 .PHONY:buildbox-centos7-fips
 buildbox-centos7-fips:
 	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS))
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -202,7 +186,6 @@ buildbox-centos7-fips:
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
@@ -214,10 +197,8 @@ buildbox-centos7-fips:
 .PHONY:buildbox-arm
 buildbox-arm:
 	$(call PULL_ON_CI,$(BUILDBOX_ARM))
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
 		--build-arg UID=$(UID) \
@@ -239,9 +220,7 @@ endif
 buildbox-connect:
 	if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CONNECT) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CONNECT) || true; fi; \
 	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CONNECT) \
 		--tag $(BUILDBOX_CONNECT) -f Dockerfile-connect .
 
@@ -570,12 +549,9 @@ print-buildbox-version:
 #
 .PHONY:build-centos7-assets
 build-centos7-assets:
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg TARGETARCH=$(HOST_ARCH) \
-		--cache-to type=inline \
-		--cache-from $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .
 


### PR DESCRIPTION
This reverts commit 3b7f2a92a3b815e2dff1e6f2dbdde2479eb6db79. This is being reverted due to a build failure in combination with https://github.com/gravitational/teleport/pull/34950 not being backported.