### PR TITLE
[v13] Revert "Use buildx `docker` driver, add `--cache-to type=inline` (#38134)"

### DIFF
--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
@@ -61,8 +59,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-        with:
-          driver: docker
 
       - name: Login to registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -82,17 +82,6 @@ REQUIRE_HOST_ARCH = $(if $(filter-out $(ARCH),$(RUNTIME_ARCH)),$(error Cannot cr
 # needed on CI as they start with a fresh state each time.
 PULL_ON_CI = $(if $(filter $(CI),true),docker inspect --type=image $(1) >/dev/null 2>&1 || docker pull $(1) || true)
 
-# DOCKER_BUILDER_NAME extracts the name of the buildx builder that uses the "docker" driver.
-#
-# The awk command looks for the first line that has "docker" in the second (DRIVER) column.
-# -F '[ *]+': there may be an asterisk between the first and second column if that record is the default,
-# so just subsume the asterisk into the field separator.
-DOCKER_BUILDER_NAME = $(shell docker buildx ls 2>/dev/null | awk -F '[ *]+' '$$2 == "docker" {print $$1}')
-
-.PHONY:print-docker-builder-name
-print-docker-builder-name:
-	@echo $(DOCKER_BUILDER_NAME)
-
 #
 # Build 'teleport' release inside a docker container
 #
@@ -134,11 +123,9 @@ build-binaries-fips: buildbox-centos7-fips webassets
 # BUILDARCH is set explicitly, so it's set with and without BuildKit enabled.
 #
 .PHONY:buildbox
-.PHONY:buildbox
 buildbox:
 	$(call PULL_ON_CI,$(BUILDBOX))
 	DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -150,8 +137,7 @@ buildbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
-		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
-		--cache-to type=inline \
+		--build-arg PROTOC_VER=$(PROTOC_VER) \
 		--cache-from $(BUILDBOX) \
 		--tag $(BUILDBOX) .
 
@@ -170,7 +156,6 @@ buildbox-centos7:
 	$(REQUIRE_HOST_ARCH)
 	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7))
 	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -180,24 +165,16 @@ buildbox-centos7:
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
 
 #
 # Builds a Docker buildbox for CentOS 7 FIPS builds
 #
-# Because this target uses the image built by the buildbox-centos7 target, it is
-# expected to be run with a buildx builder that uses the "docker" driver. If another
-# driver is used, the --build-arg BUILDBOX_CENTOS7=$(BUILDBOX_CENTOS7)-$(RUNTIME_ARCH)
-# will not know about the local image that was just built, and will pull the image from
-# the Docker repository instead, which will be out of date.
-#
 .PHONY:buildbox-centos7-fips
 buildbox-centos7-fips:
 	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS))
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -206,7 +183,6 @@ buildbox-centos7-fips:
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
@@ -218,10 +194,8 @@ buildbox-centos7-fips:
 .PHONY:buildbox-arm
 buildbox-arm: buildbox
 	$(call PULL_ON_CI,$(BUILDBOX_ARM))
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
@@ -238,9 +212,7 @@ endif
 buildbox-connect:
 	if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CONNECT) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CONNECT) || true; fi; \
 	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
-		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CONNECT) \
 		--tag $(BUILDBOX_CONNECT) -f Dockerfile-connect .
 
@@ -614,11 +586,8 @@ print-buildbox-version:
 #
 .PHONY:build-centos7-assets
 build-centos7-assets:
-	DOCKER_BUILDKIT=1 docker build \
-		--builder $(DOCKER_BUILDER_NAME) \
+	docker build \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg TARGETARCH=$(HOST_ARCH) \
-		--cache-to type=inline \
-		--cache-from $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .


### PR DESCRIPTION
This reverts commit 4fdd60558a7e9cad217c7689de377e74aa0a8f31.

That commit needs to be reverted as it breaks the build on branch/v13 for two reasons:
* Changing a docker build-arg parameter from `PROTOC_VER` to `PROTOC_VERSION`
  which should not have changed. The PR that updated `PROTOC_VER` to `PROTOC_VERSION`
  was not backported to branch/v13
* branch/v13 still uses `docker build` (with `DOCKER_BUILDKIT=1`) and not `docker buildx`
  so the `--builder` arg introduced in the backported PR does not work.

Testing manually in: https://drone.platform.teleport.sh/gravitational/teleport/34120