### PR TITLE
Adds a `Windows Desktop Service` section to scaling

### DIFF
--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -9,4 +9,4 @@ layout: tocless-doc
 - [Clipboard](./reference/clipboard.mdx): Share your clipboard with a remote desktop.
 - [Session Recording](./reference/sessions.mdx): Desktop session recording and playback
 - [CLI](./reference/cli.mdx): Relevant `tctl` commands
-- [Scaling](../management/operations/scaling.mdx): Tips on scaling to many concurrent users
+- [Scaling](../management/operations/scaling.mdx#windows-desktop-service): Tips on scaling to many concurrent users.

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -8,3 +8,5 @@ layout: tocless-doc
 - [Audit](./reference/audit.mdx): Desktop access audit events.
 - [Clipboard](./reference/clipboard.mdx): Share your clipboard with a remote desktop.
 - [Session Recording](./reference/sessions.mdx): Desktop session recording and playback
+- [CLI](./reference/cli.mdx): Relevant `tctl` commands
+- [Scaling](../management/operations/scaling.mdx): Tips on scaling to many concurrent users

--- a/docs/pages/management/operations/scaling.mdx
+++ b/docs/pages/management/operations/scaling.mdx
@@ -125,3 +125,36 @@ has default limits of 4CPU and 4Gi memory.
 | Application   | 2500     | Proxy CPU Limits exceeded |
 | Database      | 40       | Proxy CPU Limits exceeded |
 | Kubernetes    | 50       | Proxy CPU Limits exceeded |
+
+## Windows Desktop Service
+
+Windows Desktop sessions can vary greatly in resource usage depending on the applications being used. The primary
+factor affecting resource usage per session is how often the screen is updated. For example, a session playing a video
+in full screen mode will consume significantly more resources than a session where the user is typing in a text editor.
+
+We measured the resource usage of sessions playing fullscreen videos to get the worst-case estimate for resource requirements.
+We then inferred resource requirements for more standard use cases on the basis of those measurements.
+
+**Worst Case:**
+- 1/12 vCPU per concurrent session
+- 42 MB RAM per concurrent session
+
+**Typical Case:**
+- 1/240 vCPU per concurrent session
+- 2 MB RAM per concurrent session
+
+From these estimates we calculated the following table of recommendations based on the expected maximum number of concurrent
+sessions:
+
+| Concurrent users | CPU (vCPU, low to high) | Memory (GB, low to high) |
+|------------------|-------------------------|--------------------------|
+| 1                | 1                       | 0.5                      |
+| 10               | 1                       | 0.5 to 1                 |
+| 100              | 1 to 8                  | 1 to 8                   |
+| 1000             | 4 to 96                 | 4 to 64                  |
+
+To avoid service interruptions, we recommend leaning towards the higher end of the recommendations to start while monitoring
+your resource usage, and then scaling resources based on measured outcomes.
+
+Note that you are not limited to a single `windows_desktop_service`, and can connect multiple to your cluster in order to
+spread resources out over multiple logical machines.


### PR DESCRIPTION
Also adds a link in the windows desktop reference page, as well as including the CLI in the reference page bullet list.

Based on the reasoning [documented here](https://docs.google.com/document/d/1HsPgN2K6HU1X9iFZ_c9g1glrj4lMh1pXZsS_U1yo2iQ/edit?usp=sharing).

Closes #14957