### PR TITLE
Migrate to `connectrpc.com/connect`

### DIFF
--- a/buf-connect-go.gen.yaml
+++ b/buf-connect-go.gen.yaml
@@ -17,6 +17,6 @@ plugins:
     path:
       - go
       - run
-      - github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go
+      - connectrpc.com/connect/cmd/protoc-gen-connect-go
     out: .
     opt: module=github.com/gravitational/teleport

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -45,6 +45,6 @@ RUN VERSION="$BUF_VERSION"; \
 # branch.
 COPY go.mod go.sum /teleport-module/
 RUN cd /teleport-module; \
-  go install github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go && \
+  go install connectrpc.com/connect/cmd/protoc-gen-connect-go && \
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
   go install google.golang.org/protobuf/cmd/protoc-gen-go

--- a/e_imports.go
+++ b/e_imports.go
@@ -47,6 +47,7 @@ xargs go list -find -f '{{if (and
 */
 
 import (
+	_ "connectrpc.com/connect"
 	_ "github.com/alecthomas/kingpin/v2"
 	_ "github.com/aws/aws-sdk-go-v2/aws"
 	_ "github.com/aws/aws-sdk-go-v2/config"
@@ -58,7 +59,6 @@ import (
 	_ "github.com/aws/aws-sdk-go-v2/service/sts"
 	_ "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	_ "github.com/beevik/etree"
-	_ "github.com/bufbuild/connect-go"
 	_ "github.com/coreos/go-oidc/jose"
 	_ "github.com/coreos/go-oidc/oauth2"
 	_ "github.com/coreos/go-oidc/oidc"

--- a/gen/proto/go/prehog/v1/prehogv1connect/teleport.connect.go
+++ b/gen/proto/go/prehog/v1/prehogv1connect/teleport.connect.go
@@ -22,9 +22,9 @@
 package prehogv1connect
 
 import (
+	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	connect_go "github.com/bufbuild/connect-go"
 	v1 "github.com/gravitational/teleport/gen/proto/go/prehog/v1"
 	http "net/http"
 	strings "strings"
@@ -35,7 +35,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// TeleportReportingServiceName is the fully-qualified name of the TeleportReportingService service.
@@ -55,6 +55,12 @@ const (
 	TeleportReportingServiceSubmitUsageReportsProcedure = "/prehog.v1.TeleportReportingService/SubmitUsageReports"
 )
 
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
+var (
+	teleportReportingServiceServiceDescriptor                  = v1.File_prehog_v1_teleport_proto.Services().ByName("TeleportReportingService")
+	teleportReportingServiceSubmitUsageReportsMethodDescriptor = teleportReportingServiceServiceDescriptor.Methods().ByName("SubmitUsageReports")
+)
+
 // TeleportReportingServiceClient is a client for the prehog.v1.TeleportReportingService service.
 type TeleportReportingServiceClient interface {
 	// encodes and forwards usage reports to the PostHog event database; each
@@ -66,7 +72,7 @@ type TeleportReportingServiceClient interface {
 	//   - tp.license_authority (name of the authority that signed the license file
 	//     used for authentication)
 	//   - tp.is_cloud (boolean)
-	SubmitUsageReports(context.Context, *connect_go.Request[v1.SubmitUsageReportsRequest]) (*connect_go.Response[v1.SubmitUsageReportsResponse], error)
+	SubmitUsageReports(context.Context, *connect.Request[v1.SubmitUsageReportsRequest]) (*connect.Response[v1.SubmitUsageReportsResponse], error)
 }
 
 // NewTeleportReportingServiceClient constructs a client for the prehog.v1.TeleportReportingService
@@ -76,24 +82,25 @@ type TeleportReportingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewTeleportReportingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) TeleportReportingServiceClient {
+func NewTeleportReportingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) TeleportReportingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &teleportReportingServiceClient{
-		submitUsageReports: connect_go.NewClient[v1.SubmitUsageReportsRequest, v1.SubmitUsageReportsResponse](
+		submitUsageReports: connect.NewClient[v1.SubmitUsageReportsRequest, v1.SubmitUsageReportsResponse](
 			httpClient,
 			baseURL+TeleportReportingServiceSubmitUsageReportsProcedure,
-			opts...,
+			connect.WithSchema(teleportReportingServiceSubmitUsageReportsMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
 
 // teleportReportingServiceClient implements TeleportReportingServiceClient.
 type teleportReportingServiceClient struct {
-	submitUsageReports *connect_go.Client[v1.SubmitUsageReportsRequest, v1.SubmitUsageReportsResponse]
+	submitUsageReports *connect.Client[v1.SubmitUsageReportsRequest, v1.SubmitUsageReportsResponse]
 }
 
 // SubmitUsageReports calls prehog.v1.TeleportReportingService.SubmitUsageReports.
-func (c *teleportReportingServiceClient) SubmitUsageReports(ctx context.Context, req *connect_go.Request[v1.SubmitUsageReportsRequest]) (*connect_go.Response[v1.SubmitUsageReportsResponse], error) {
+func (c *teleportReportingServiceClient) SubmitUsageReports(ctx context.Context, req *connect.Request[v1.SubmitUsageReportsRequest]) (*connect.Response[v1.SubmitUsageReportsResponse], error) {
 	return c.submitUsageReports.CallUnary(ctx, req)
 }
 
@@ -109,7 +116,7 @@ type TeleportReportingServiceHandler interface {
 	//   - tp.license_authority (name of the authority that signed the license file
 	//     used for authentication)
 	//   - tp.is_cloud (boolean)
-	SubmitUsageReports(context.Context, *connect_go.Request[v1.SubmitUsageReportsRequest]) (*connect_go.Response[v1.SubmitUsageReportsResponse], error)
+	SubmitUsageReports(context.Context, *connect.Request[v1.SubmitUsageReportsRequest]) (*connect.Response[v1.SubmitUsageReportsResponse], error)
 }
 
 // NewTeleportReportingServiceHandler builds an HTTP handler from the service implementation. It
@@ -117,11 +124,12 @@ type TeleportReportingServiceHandler interface {
 //
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
-func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opts ...connect_go.HandlerOption) (string, http.Handler) {
-	teleportReportingServiceSubmitUsageReportsHandler := connect_go.NewUnaryHandler(
+func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	teleportReportingServiceSubmitUsageReportsHandler := connect.NewUnaryHandler(
 		TeleportReportingServiceSubmitUsageReportsProcedure,
 		svc.SubmitUsageReports,
-		opts...,
+		connect.WithSchema(teleportReportingServiceSubmitUsageReportsMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/prehog.v1.TeleportReportingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -136,6 +144,6 @@ func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opt
 // UnimplementedTeleportReportingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTeleportReportingServiceHandler struct{}
 
-func (UnimplementedTeleportReportingServiceHandler) SubmitUsageReports(context.Context, *connect_go.Request[v1.SubmitUsageReportsRequest]) (*connect_go.Response[v1.SubmitUsageReportsResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1.TeleportReportingService.SubmitUsageReports is not implemented"))
+func (UnimplementedTeleportReportingServiceHandler) SubmitUsageReports(context.Context, *connect.Request[v1.SubmitUsageReportsRequest]) (*connect.Response[v1.SubmitUsageReportsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1.TeleportReportingService.SubmitUsageReports is not implemented"))
 }

--- a/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/connect.connect.go
+++ b/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/connect.connect.go
@@ -22,9 +22,9 @@
 package prehogv1alphaconnect
 
 import (
+	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	connect_go "github.com/bufbuild/connect-go"
 	v1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	http "net/http"
 	strings "strings"
@@ -35,7 +35,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// ConnectReportingServiceName is the fully-qualified name of the ConnectReportingService service.
@@ -55,9 +55,15 @@ const (
 	ConnectReportingServiceSubmitConnectEventProcedure = "/prehog.v1alpha.ConnectReportingService/SubmitConnectEvent"
 )
 
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
+var (
+	connectReportingServiceServiceDescriptor                  = v1alpha.File_prehog_v1alpha_connect_proto.Services().ByName("ConnectReportingService")
+	connectReportingServiceSubmitConnectEventMethodDescriptor = connectReportingServiceServiceDescriptor.Methods().ByName("SubmitConnectEvent")
+)
+
 // ConnectReportingServiceClient is a client for the prehog.v1alpha.ConnectReportingService service.
 type ConnectReportingServiceClient interface {
-	SubmitConnectEvent(context.Context, *connect_go.Request[v1alpha.SubmitConnectEventRequest]) (*connect_go.Response[v1alpha.SubmitConnectEventResponse], error)
+	SubmitConnectEvent(context.Context, *connect.Request[v1alpha.SubmitConnectEventRequest]) (*connect.Response[v1alpha.SubmitConnectEventResponse], error)
 }
 
 // NewConnectReportingServiceClient constructs a client for the
@@ -67,31 +73,32 @@ type ConnectReportingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewConnectReportingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) ConnectReportingServiceClient {
+func NewConnectReportingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConnectReportingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &connectReportingServiceClient{
-		submitConnectEvent: connect_go.NewClient[v1alpha.SubmitConnectEventRequest, v1alpha.SubmitConnectEventResponse](
+		submitConnectEvent: connect.NewClient[v1alpha.SubmitConnectEventRequest, v1alpha.SubmitConnectEventResponse](
 			httpClient,
 			baseURL+ConnectReportingServiceSubmitConnectEventProcedure,
-			opts...,
+			connect.WithSchema(connectReportingServiceSubmitConnectEventMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
 
 // connectReportingServiceClient implements ConnectReportingServiceClient.
 type connectReportingServiceClient struct {
-	submitConnectEvent *connect_go.Client[v1alpha.SubmitConnectEventRequest, v1alpha.SubmitConnectEventResponse]
+	submitConnectEvent *connect.Client[v1alpha.SubmitConnectEventRequest, v1alpha.SubmitConnectEventResponse]
 }
 
 // SubmitConnectEvent calls prehog.v1alpha.ConnectReportingService.SubmitConnectEvent.
-func (c *connectReportingServiceClient) SubmitConnectEvent(ctx context.Context, req *connect_go.Request[v1alpha.SubmitConnectEventRequest]) (*connect_go.Response[v1alpha.SubmitConnectEventResponse], error) {
+func (c *connectReportingServiceClient) SubmitConnectEvent(ctx context.Context, req *connect.Request[v1alpha.SubmitConnectEventRequest]) (*connect.Response[v1alpha.SubmitConnectEventResponse], error) {
 	return c.submitConnectEvent.CallUnary(ctx, req)
 }
 
 // ConnectReportingServiceHandler is an implementation of the prehog.v1alpha.ConnectReportingService
 // service.
 type ConnectReportingServiceHandler interface {
-	SubmitConnectEvent(context.Context, *connect_go.Request[v1alpha.SubmitConnectEventRequest]) (*connect_go.Response[v1alpha.SubmitConnectEventResponse], error)
+	SubmitConnectEvent(context.Context, *connect.Request[v1alpha.SubmitConnectEventRequest]) (*connect.Response[v1alpha.SubmitConnectEventResponse], error)
 }
 
 // NewConnectReportingServiceHandler builds an HTTP handler from the service implementation. It
@@ -99,11 +106,12 @@ type ConnectReportingServiceHandler interface {
 //
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
-func NewConnectReportingServiceHandler(svc ConnectReportingServiceHandler, opts ...connect_go.HandlerOption) (string, http.Handler) {
-	connectReportingServiceSubmitConnectEventHandler := connect_go.NewUnaryHandler(
+func NewConnectReportingServiceHandler(svc ConnectReportingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	connectReportingServiceSubmitConnectEventHandler := connect.NewUnaryHandler(
 		ConnectReportingServiceSubmitConnectEventProcedure,
 		svc.SubmitConnectEvent,
-		opts...,
+		connect.WithSchema(connectReportingServiceSubmitConnectEventMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/prehog.v1alpha.ConnectReportingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -118,6 +126,6 @@ func NewConnectReportingServiceHandler(svc ConnectReportingServiceHandler, opts 
 // UnimplementedConnectReportingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedConnectReportingServiceHandler struct{}
 
-func (UnimplementedConnectReportingServiceHandler) SubmitConnectEvent(context.Context, *connect_go.Request[v1alpha.SubmitConnectEventRequest]) (*connect_go.Response[v1alpha.SubmitConnectEventResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1alpha.ConnectReportingService.SubmitConnectEvent is not implemented"))
+func (UnimplementedConnectReportingServiceHandler) SubmitConnectEvent(context.Context, *connect.Request[v1alpha.SubmitConnectEventRequest]) (*connect.Response[v1alpha.SubmitConnectEventResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1alpha.ConnectReportingService.SubmitConnectEvent is not implemented"))
 }

--- a/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/tbot.connect.go
+++ b/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/tbot.connect.go
@@ -22,9 +22,9 @@
 package prehogv1alphaconnect
 
 import (
+	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	connect_go "github.com/bufbuild/connect-go"
 	v1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	http "net/http"
 	strings "strings"
@@ -35,7 +35,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// TbotReportingServiceName is the fully-qualified name of the TbotReportingService service.
@@ -55,9 +55,15 @@ const (
 	TbotReportingServiceSubmitTbotEventProcedure = "/prehog.v1alpha.TbotReportingService/SubmitTbotEvent"
 )
 
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
+var (
+	tbotReportingServiceServiceDescriptor               = v1alpha.File_prehog_v1alpha_tbot_proto.Services().ByName("TbotReportingService")
+	tbotReportingServiceSubmitTbotEventMethodDescriptor = tbotReportingServiceServiceDescriptor.Methods().ByName("SubmitTbotEvent")
+)
+
 // TbotReportingServiceClient is a client for the prehog.v1alpha.TbotReportingService service.
 type TbotReportingServiceClient interface {
-	SubmitTbotEvent(context.Context, *connect_go.Request[v1alpha.SubmitTbotEventRequest]) (*connect_go.Response[v1alpha.SubmitTbotEventResponse], error)
+	SubmitTbotEvent(context.Context, *connect.Request[v1alpha.SubmitTbotEventRequest]) (*connect.Response[v1alpha.SubmitTbotEventResponse], error)
 }
 
 // NewTbotReportingServiceClient constructs a client for the prehog.v1alpha.TbotReportingService
@@ -67,31 +73,32 @@ type TbotReportingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewTbotReportingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) TbotReportingServiceClient {
+func NewTbotReportingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) TbotReportingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &tbotReportingServiceClient{
-		submitTbotEvent: connect_go.NewClient[v1alpha.SubmitTbotEventRequest, v1alpha.SubmitTbotEventResponse](
+		submitTbotEvent: connect.NewClient[v1alpha.SubmitTbotEventRequest, v1alpha.SubmitTbotEventResponse](
 			httpClient,
 			baseURL+TbotReportingServiceSubmitTbotEventProcedure,
-			opts...,
+			connect.WithSchema(tbotReportingServiceSubmitTbotEventMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
 
 // tbotReportingServiceClient implements TbotReportingServiceClient.
 type tbotReportingServiceClient struct {
-	submitTbotEvent *connect_go.Client[v1alpha.SubmitTbotEventRequest, v1alpha.SubmitTbotEventResponse]
+	submitTbotEvent *connect.Client[v1alpha.SubmitTbotEventRequest, v1alpha.SubmitTbotEventResponse]
 }
 
 // SubmitTbotEvent calls prehog.v1alpha.TbotReportingService.SubmitTbotEvent.
-func (c *tbotReportingServiceClient) SubmitTbotEvent(ctx context.Context, req *connect_go.Request[v1alpha.SubmitTbotEventRequest]) (*connect_go.Response[v1alpha.SubmitTbotEventResponse], error) {
+func (c *tbotReportingServiceClient) SubmitTbotEvent(ctx context.Context, req *connect.Request[v1alpha.SubmitTbotEventRequest]) (*connect.Response[v1alpha.SubmitTbotEventResponse], error) {
 	return c.submitTbotEvent.CallUnary(ctx, req)
 }
 
 // TbotReportingServiceHandler is an implementation of the prehog.v1alpha.TbotReportingService
 // service.
 type TbotReportingServiceHandler interface {
-	SubmitTbotEvent(context.Context, *connect_go.Request[v1alpha.SubmitTbotEventRequest]) (*connect_go.Response[v1alpha.SubmitTbotEventResponse], error)
+	SubmitTbotEvent(context.Context, *connect.Request[v1alpha.SubmitTbotEventRequest]) (*connect.Response[v1alpha.SubmitTbotEventResponse], error)
 }
 
 // NewTbotReportingServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -99,11 +106,12 @@ type TbotReportingServiceHandler interface {
 //
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
-func NewTbotReportingServiceHandler(svc TbotReportingServiceHandler, opts ...connect_go.HandlerOption) (string, http.Handler) {
-	tbotReportingServiceSubmitTbotEventHandler := connect_go.NewUnaryHandler(
+func NewTbotReportingServiceHandler(svc TbotReportingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	tbotReportingServiceSubmitTbotEventHandler := connect.NewUnaryHandler(
 		TbotReportingServiceSubmitTbotEventProcedure,
 		svc.SubmitTbotEvent,
-		opts...,
+		connect.WithSchema(tbotReportingServiceSubmitTbotEventMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/prehog.v1alpha.TbotReportingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -118,6 +126,6 @@ func NewTbotReportingServiceHandler(svc TbotReportingServiceHandler, opts ...con
 // UnimplementedTbotReportingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTbotReportingServiceHandler struct{}
 
-func (UnimplementedTbotReportingServiceHandler) SubmitTbotEvent(context.Context, *connect_go.Request[v1alpha.SubmitTbotEventRequest]) (*connect_go.Response[v1alpha.SubmitTbotEventResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1alpha.TbotReportingService.SubmitTbotEvent is not implemented"))
+func (UnimplementedTbotReportingServiceHandler) SubmitTbotEvent(context.Context, *connect.Request[v1alpha.SubmitTbotEventRequest]) (*connect.Response[v1alpha.SubmitTbotEventResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1alpha.TbotReportingService.SubmitTbotEvent is not implemented"))
 }

--- a/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/teleport.connect.go
+++ b/gen/proto/go/prehog/v1alpha/prehogv1alphaconnect/teleport.connect.go
@@ -22,9 +22,9 @@
 package prehogv1alphaconnect
 
 import (
+	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	connect_go "github.com/bufbuild/connect-go"
 	v1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	http "net/http"
 	strings "strings"
@@ -35,7 +35,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// TeleportReportingServiceName is the fully-qualified name of the TeleportReportingService service.
@@ -61,13 +61,21 @@ const (
 	TeleportReportingServiceHelloTeleportProcedure = "/prehog.v1alpha.TeleportReportingService/HelloTeleport"
 )
 
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
+var (
+	teleportReportingServiceServiceDescriptor             = v1alpha.File_prehog_v1alpha_teleport_proto.Services().ByName("TeleportReportingService")
+	teleportReportingServiceSubmitEventMethodDescriptor   = teleportReportingServiceServiceDescriptor.Methods().ByName("SubmitEvent")
+	teleportReportingServiceSubmitEventsMethodDescriptor  = teleportReportingServiceServiceDescriptor.Methods().ByName("SubmitEvents")
+	teleportReportingServiceHelloTeleportMethodDescriptor = teleportReportingServiceServiceDescriptor.Methods().ByName("HelloTeleport")
+)
+
 // TeleportReportingServiceClient is a client for the prehog.v1alpha.TeleportReportingService
 // service.
 type TeleportReportingServiceClient interface {
 	// equivalent to SubmitEvents with a single event, should be unused by now
 	//
 	// Deprecated: do not use.
-	SubmitEvent(context.Context, *connect_go.Request[v1alpha.SubmitEventRequest]) (*connect_go.Response[v1alpha.SubmitEventResponse], error)
+	SubmitEvent(context.Context, *connect.Request[v1alpha.SubmitEventRequest]) (*connect.Response[v1alpha.SubmitEventResponse], error)
 	// encodes and forwards usage events to the PostHog event database; each
 	// event is annotated with some properties that depend on the identity of the
 	// caller:
@@ -77,8 +85,8 @@ type TeleportReportingServiceClient interface {
 	//   - tp.license_authority (name of the authority that signed the license file
 	//     used for authentication)
 	//   - tp.is_cloud (boolean)
-	SubmitEvents(context.Context, *connect_go.Request[v1alpha.SubmitEventsRequest]) (*connect_go.Response[v1alpha.SubmitEventsResponse], error)
-	HelloTeleport(context.Context, *connect_go.Request[v1alpha.HelloTeleportRequest]) (*connect_go.Response[v1alpha.HelloTeleportResponse], error)
+	SubmitEvents(context.Context, *connect.Request[v1alpha.SubmitEventsRequest]) (*connect.Response[v1alpha.SubmitEventsResponse], error)
+	HelloTeleport(context.Context, *connect.Request[v1alpha.HelloTeleportRequest]) (*connect.Response[v1alpha.HelloTeleportResponse], error)
 }
 
 // NewTeleportReportingServiceClient constructs a client for the
@@ -88,48 +96,51 @@ type TeleportReportingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewTeleportReportingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) TeleportReportingServiceClient {
+func NewTeleportReportingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) TeleportReportingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &teleportReportingServiceClient{
-		submitEvent: connect_go.NewClient[v1alpha.SubmitEventRequest, v1alpha.SubmitEventResponse](
+		submitEvent: connect.NewClient[v1alpha.SubmitEventRequest, v1alpha.SubmitEventResponse](
 			httpClient,
 			baseURL+TeleportReportingServiceSubmitEventProcedure,
-			opts...,
+			connect.WithSchema(teleportReportingServiceSubmitEventMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
-		submitEvents: connect_go.NewClient[v1alpha.SubmitEventsRequest, v1alpha.SubmitEventsResponse](
+		submitEvents: connect.NewClient[v1alpha.SubmitEventsRequest, v1alpha.SubmitEventsResponse](
 			httpClient,
 			baseURL+TeleportReportingServiceSubmitEventsProcedure,
-			opts...,
+			connect.WithSchema(teleportReportingServiceSubmitEventsMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
-		helloTeleport: connect_go.NewClient[v1alpha.HelloTeleportRequest, v1alpha.HelloTeleportResponse](
+		helloTeleport: connect.NewClient[v1alpha.HelloTeleportRequest, v1alpha.HelloTeleportResponse](
 			httpClient,
 			baseURL+TeleportReportingServiceHelloTeleportProcedure,
-			opts...,
+			connect.WithSchema(teleportReportingServiceHelloTeleportMethodDescriptor),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
 
 // teleportReportingServiceClient implements TeleportReportingServiceClient.
 type teleportReportingServiceClient struct {
-	submitEvent   *connect_go.Client[v1alpha.SubmitEventRequest, v1alpha.SubmitEventResponse]
-	submitEvents  *connect_go.Client[v1alpha.SubmitEventsRequest, v1alpha.SubmitEventsResponse]
-	helloTeleport *connect_go.Client[v1alpha.HelloTeleportRequest, v1alpha.HelloTeleportResponse]
+	submitEvent   *connect.Client[v1alpha.SubmitEventRequest, v1alpha.SubmitEventResponse]
+	submitEvents  *connect.Client[v1alpha.SubmitEventsRequest, v1alpha.SubmitEventsResponse]
+	helloTeleport *connect.Client[v1alpha.HelloTeleportRequest, v1alpha.HelloTeleportResponse]
 }
 
 // SubmitEvent calls prehog.v1alpha.TeleportReportingService.SubmitEvent.
 //
 // Deprecated: do not use.
-func (c *teleportReportingServiceClient) SubmitEvent(ctx context.Context, req *connect_go.Request[v1alpha.SubmitEventRequest]) (*connect_go.Response[v1alpha.SubmitEventResponse], error) {
+func (c *teleportReportingServiceClient) SubmitEvent(ctx context.Context, req *connect.Request[v1alpha.SubmitEventRequest]) (*connect.Response[v1alpha.SubmitEventResponse], error) {
 	return c.submitEvent.CallUnary(ctx, req)
 }
 
 // SubmitEvents calls prehog.v1alpha.TeleportReportingService.SubmitEvents.
-func (c *teleportReportingServiceClient) SubmitEvents(ctx context.Context, req *connect_go.Request[v1alpha.SubmitEventsRequest]) (*connect_go.Response[v1alpha.SubmitEventsResponse], error) {
+func (c *teleportReportingServiceClient) SubmitEvents(ctx context.Context, req *connect.Request[v1alpha.SubmitEventsRequest]) (*connect.Response[v1alpha.SubmitEventsResponse], error) {
 	return c.submitEvents.CallUnary(ctx, req)
 }
 
 // HelloTeleport calls prehog.v1alpha.TeleportReportingService.HelloTeleport.
-func (c *teleportReportingServiceClient) HelloTeleport(ctx context.Context, req *connect_go.Request[v1alpha.HelloTeleportRequest]) (*connect_go.Response[v1alpha.HelloTeleportResponse], error) {
+func (c *teleportReportingServiceClient) HelloTeleport(ctx context.Context, req *connect.Request[v1alpha.HelloTeleportRequest]) (*connect.Response[v1alpha.HelloTeleportResponse], error) {
 	return c.helloTeleport.CallUnary(ctx, req)
 }
 
@@ -139,7 +150,7 @@ type TeleportReportingServiceHandler interface {
 	// equivalent to SubmitEvents with a single event, should be unused by now
 	//
 	// Deprecated: do not use.
-	SubmitEvent(context.Context, *connect_go.Request[v1alpha.SubmitEventRequest]) (*connect_go.Response[v1alpha.SubmitEventResponse], error)
+	SubmitEvent(context.Context, *connect.Request[v1alpha.SubmitEventRequest]) (*connect.Response[v1alpha.SubmitEventResponse], error)
 	// encodes and forwards usage events to the PostHog event database; each
 	// event is annotated with some properties that depend on the identity of the
 	// caller:
@@ -149,8 +160,8 @@ type TeleportReportingServiceHandler interface {
 	//   - tp.license_authority (name of the authority that signed the license file
 	//     used for authentication)
 	//   - tp.is_cloud (boolean)
-	SubmitEvents(context.Context, *connect_go.Request[v1alpha.SubmitEventsRequest]) (*connect_go.Response[v1alpha.SubmitEventsResponse], error)
-	HelloTeleport(context.Context, *connect_go.Request[v1alpha.HelloTeleportRequest]) (*connect_go.Response[v1alpha.HelloTeleportResponse], error)
+	SubmitEvents(context.Context, *connect.Request[v1alpha.SubmitEventsRequest]) (*connect.Response[v1alpha.SubmitEventsResponse], error)
+	HelloTeleport(context.Context, *connect.Request[v1alpha.HelloTeleportRequest]) (*connect.Response[v1alpha.HelloTeleportResponse], error)
 }
 
 // NewTeleportReportingServiceHandler builds an HTTP handler from the service implementation. It
@@ -158,21 +169,24 @@ type TeleportReportingServiceHandler interface {
 //
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
-func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opts ...connect_go.HandlerOption) (string, http.Handler) {
-	teleportReportingServiceSubmitEventHandler := connect_go.NewUnaryHandler(
+func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	teleportReportingServiceSubmitEventHandler := connect.NewUnaryHandler(
 		TeleportReportingServiceSubmitEventProcedure,
 		svc.SubmitEvent,
-		opts...,
+		connect.WithSchema(teleportReportingServiceSubmitEventMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
-	teleportReportingServiceSubmitEventsHandler := connect_go.NewUnaryHandler(
+	teleportReportingServiceSubmitEventsHandler := connect.NewUnaryHandler(
 		TeleportReportingServiceSubmitEventsProcedure,
 		svc.SubmitEvents,
-		opts...,
+		connect.WithSchema(teleportReportingServiceSubmitEventsMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
-	teleportReportingServiceHelloTeleportHandler := connect_go.NewUnaryHandler(
+	teleportReportingServiceHelloTeleportHandler := connect.NewUnaryHandler(
 		TeleportReportingServiceHelloTeleportProcedure,
 		svc.HelloTeleport,
-		opts...,
+		connect.WithSchema(teleportReportingServiceHelloTeleportMethodDescriptor),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/prehog.v1alpha.TeleportReportingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -191,14 +205,14 @@ func NewTeleportReportingServiceHandler(svc TeleportReportingServiceHandler, opt
 // UnimplementedTeleportReportingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedTeleportReportingServiceHandler struct{}
 
-func (UnimplementedTeleportReportingServiceHandler) SubmitEvent(context.Context, *connect_go.Request[v1alpha.SubmitEventRequest]) (*connect_go.Response[v1alpha.SubmitEventResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.SubmitEvent is not implemented"))
+func (UnimplementedTeleportReportingServiceHandler) SubmitEvent(context.Context, *connect.Request[v1alpha.SubmitEventRequest]) (*connect.Response[v1alpha.SubmitEventResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.SubmitEvent is not implemented"))
 }
 
-func (UnimplementedTeleportReportingServiceHandler) SubmitEvents(context.Context, *connect_go.Request[v1alpha.SubmitEventsRequest]) (*connect_go.Response[v1alpha.SubmitEventsResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.SubmitEvents is not implemented"))
+func (UnimplementedTeleportReportingServiceHandler) SubmitEvents(context.Context, *connect.Request[v1alpha.SubmitEventsRequest]) (*connect.Response[v1alpha.SubmitEventsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.SubmitEvents is not implemented"))
 }
 
-func (UnimplementedTeleportReportingServiceHandler) HelloTeleport(context.Context, *connect_go.Request[v1alpha.HelloTeleportRequest]) (*connect_go.Response[v1alpha.HelloTeleportResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.HelloTeleport is not implemented"))
+func (UnimplementedTeleportReportingServiceHandler) HelloTeleport(context.Context, *connect.Request[v1alpha.HelloTeleportRequest]) (*connect.Response[v1alpha.HelloTeleportResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("prehog.v1alpha.TeleportReportingService.HelloTeleport is not implemented"))
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	cloud.google.com/go/iam v1.1.6
 	cloud.google.com/go/kms v1.15.7
 	cloud.google.com/go/storage v1.38.0
+	connectrpc.com/connect v1.15.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1
@@ -61,7 +62,6 @@ require (
 	github.com/aws/smithy-go v1.19.0
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8
 	github.com/beevik/etree v1.3.0
-	github.com/bufbuild/connect-go v1.10.0
 	github.com/buildkite/bintest/v3 v3.2.0
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ cloud.google.com/go/pubsub v1.36.1 h1:dfEPuGCHGbWUhaMCTHUFjfroILEkx55iUmKBZTP5f+
 cloud.google.com/go/pubsub v1.36.1/go.mod h1:iYjCa9EzWOoBiTdd4ps7QoMtMln5NwaZQpK1hbRfBDE=
 cloud.google.com/go/storage v1.38.0 h1:Az68ZRGlnNTpIBbLjSMIV2BDcwwXYlRlQzis0llkpJg=
 cloud.google.com/go/storage v1.38.0/go.mod h1:tlUADB0mAb9BgYls9lq+8MGkfzOXuLrnHXlpHmvFJoY=
+connectrpc.com/connect v1.15.0 h1:lFdeCbZrVVDydAqwr4xGV2y+ULn+0Z73s5JBj2LikWo=
+connectrpc.com/connect v1.15.0/go.mod h1:bQmjpDY8xItMnttnurVgOkHUBMRT9cpsNi2O4AjKhmA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
@@ -280,8 +282,6 @@ github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
 github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
 github.com/bsm/gomega v1.20.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
-github.com/bufbuild/connect-go v1.10.0 h1:QAJ3G9A1OYQW2Jbk3DeoJbkCxuKArrvZgDt47mjdTbg=
-github.com/bufbuild/connect-go v1.10.0/go.mod h1:CAIePUgkDR5pAFaylSMtNK45ANQjp9JvpluG20rhpV8=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=

--- a/lib/usagereporter/daemon/usagereporter.go
+++ b/lib/usagereporter/daemon/usagereporter.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 

--- a/lib/usagereporter/teleport/usagereporter.go
+++ b/lib/usagereporter/teleport/usagereporter.go
@@ -26,7 +26,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"

--- a/protogen.go
+++ b/protogen.go
@@ -26,7 +26,7 @@ package teleport
 // "naturally")
 
 import (
-	_ "github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go"
+	_ "connectrpc.com/connect/cmd/protoc-gen-connect-go"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/tool/tbot/anonymous_telemetry.go
+++ b/tool/tbot/anonymous_telemetry.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"

--- a/tool/tbot/anonymous_telemetry_test.go
+++ b/tool/tbot/anonymous_telemetry_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"


### PR DESCRIPTION
The ConnectRPC module migrated from `github.com/bufbuild/connect-go` to `connectrpc.com/connect`; version 1.15.0 includes connectrpc/connect-go#649, which saves us some explicit retries (and subsequent log spam) in Teleport Cloud (`unavailable: http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error`, occurring between 700 and 3500 times per hour, depending on load).

Will break the enterprise build, which will be fixed by gravitational/teleport.e#3478 
