### PR TITLE
docs: document location of SQLite in Teleport data directory

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1420,5 +1420,5 @@ the location set the `data_dir` value within the Teleport configuration file.
 
 ```yaml
 teleport:
-  data_dir: /var/lib/teleport_datadir
+  data_dir: /var/lib/teleport_data
 ```

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1413,3 +1413,12 @@ teleport:
     sync: NORMAL
     journal: WAL
 ```
+
+The SQLite backend and other required data will be written to the Teleport data directory.
+The data directory location for Teleport by default is `/var/lib/teleport`. To modify
+the location set the `data_dir` value within the Teleport configuration file.
+
+```yaml
+teleport:
+  data_dir: /var/lib/teleport_datadir
+```

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -36,7 +36,7 @@ run in a highly available fashion.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
-## Auth Server State
+## Auth Service State
 
 To run multiple instances of the Teleport Auth Service, you must switch to one of
 the high-availability secrets backend listed below first.
@@ -57,7 +57,7 @@ be paid to keeping their configuration identical. Settings like `cluster_name`,
 `tokens`, `storage`, etc. must be the same.
 </Admonition>
 
-## Proxy Server State
+## Proxy Service State
 
 The Teleport Proxy is stateless which makes running multiple instances trivial.
 
@@ -123,8 +123,8 @@ To configure Teleport for using etcd as a storage backend:
   - You can use [this script provided by
     etcd](https://github.com/etcd-io/etcd/tree/master/hack/tls-setup) if you
     don't already have a TLS setup.
-- Configure all Teleport Auth servers to use etcd in the "storage" section of the config file as shown below.
-- Deploy several auth servers connected to etcd backend.
+- Configure all Teleport Auth Service instances to use etcd in the "storage" section of the config file as shown below.
+- Deploy several Auth Service instances connected to etcd backend.
 - Deploy several Proxy Service instances that have `auth_server` pointed to the auth server to connect to.
 
 ```yaml
@@ -851,7 +851,7 @@ teleport:
   audit log in DynamoDB and the session recordings **must** be stored in an S3
   bucket, i.e. both `audit_xxx` settings must be present. If they are not set,
   Teleport will default to a local file system for the audit log, i.e.
-  `/var/lib/teleport/log` on an auth server.
+  `/var/lib/teleport/log` on an Auth Service instance.
 
 The optional `GET` parameters shown below control how Teleport interacts with a DynamoDB endpoint.
 
@@ -1200,7 +1200,7 @@ To disable writing to DynamoDB, remove the DynamoDB URL from the
 
 Google Cloud Storage (GCS) can be used as storage for recorded
 sessions. GCS cannot store the audit log or the cluster state. Below is an
-example of how to configure a Teleport auth server to store the recorded
+example of how to configure a Teleport Auth Service to store the recorded
 sessions in a GCS bucket.
 
 ```yaml
@@ -1295,7 +1295,7 @@ teleport:
 - Audit log settings above are optional. If specified, Teleport will store the audit log in Firestore
   and the session recordings **must** be stored in a GCS bucket, i.e. both `audit_xxx` settings must
   be present. If they are not set, Teleport will default to a local filesystem for the audit log, i.e.
-  `/var/lib/teleport/log` on an auth server.
+  `/var/lib/teleport/log` on an Auth Service instance.
 
 ## Azure Blob Storage
 
@@ -1312,7 +1312,7 @@ Azure Blob Storage for session storage is available starting from Teleport
 
 Azure Blob Storage can be used as storage for recorded sessions. Azure Blob
 Storage cannot store the audit log or the cluster state. Below is an example of
-how to configure a Teleport auth server to store the recorded sessions in an
+how to configure a Teleport Auth Service instance to store the recorded sessions in an
 Azure Blob Storage storage account.
 
 ```yaml
@@ -1415,7 +1415,7 @@ teleport:
 ```
 
 The SQLite backend and other required data will be written to the Teleport data directory.
-The data directory location for Teleport by default is `/var/lib/teleport`. To modify
+By default, Teleport's data directory is `/var/lib/teleport`. To modify
 the location set the `data_dir` value within the Teleport configuration file.
 
 ```yaml

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -107,7 +107,7 @@ and user records will be stored.
   title="IMPORTANT"
 >
   `etcd` can only currently be used to store Teleport's internal database in a
-  highly-available way. This will allow you to have multiple auth servers in your
+  highly-available way. This will allow you to have multiple Auth Service instances in your
   cluster for an High Availability deployment, but it will not also store Teleport audit events
   for you in the same way that [DynamoDB](#dynamodb) or
   [Firestore](#firestore) will. `etcd` is not designed to handle large volumes of time series data like audit events.
@@ -125,7 +125,7 @@ To configure Teleport for using etcd as a storage backend:
     don't already have a TLS setup.
 - Configure all Teleport Auth Service instances to use etcd in the "storage" section of the config file as shown below.
 - Deploy several Auth Service instances connected to etcd backend.
-- Deploy several Proxy Service instances that have `auth_server` pointed to the auth server to connect to.
+- Deploy several Proxy Service instances that have `auth_server` pointed to the Auth Service to connect to.
 
 ```yaml
 teleport:


### PR DESCRIPTION
SQLite backend section did not mention where the backend will be stored.