### PR TITLE
[v15] Add option to change cgroup root path (enhanced recording)

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -137,6 +137,7 @@ func New(config *servicecfg.BPFConfig) (BPF, error) {
 	// Create a cgroup controller to add/remote cgroups.
 	cgroup, err := controlgroup.New(&controlgroup.Config{
 		MountPath: config.CgroupPath,
+		RootPath:  config.SlicePath,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -137,7 +137,7 @@ func New(config *servicecfg.BPFConfig) (BPF, error) {
 	// Create a cgroup controller to add/remote cgroups.
 	cgroup, err := controlgroup.New(&controlgroup.Config{
 		MountPath: config.CgroupPath,
-		RootPath:  config.SlicePath,
+		RootPath:  config.RootPath,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -54,12 +54,18 @@ var log = logrus.WithFields(logrus.Fields{
 type Config struct {
 	// MountPath is where the cgroupv2 hierarchy is mounted.
 	MountPath string
+	// RootPath directory where the Teleport managed cgroups are going to be
+	// placed.
+	RootPath string
 }
 
 // CheckAndSetDefaults checks BPF configuration.
 func (c *Config) CheckAndSetDefaults() error {
 	if c.MountPath == "" {
 		c.MountPath = defaults.CgroupPath
+	}
+	if c.RootPath == "" {
+		c.RootPath = teleportRoot
 	}
 	return nil
 }
@@ -82,7 +88,7 @@ func New(config *Config) (*Service, error) {
 
 	s := &Service{
 		Config:       config,
-		teleportRoot: filepath.Join(config.MountPath, teleportRoot, uuid.New().String()),
+		teleportRoot: filepath.Join(config.MountPath, config.RootPath, uuid.New().String()),
 	}
 
 	// Mount the cgroup2 filesystem.

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -81,6 +81,52 @@ func TestRootCreate(t *testing.T) {
 	require.NoDirExists(t, service.teleportRoot)
 }
 
+// TestRootCreateCustomRootPath given a service configured with a custom root
+// path, cgroups must be placed on the correct path.
+func TestRootCreateCustomRootPath(t *testing.T) {
+	// This test must be run as root. Only root can create cgroups.
+	if !isRoot() {
+		t.Skip("Tests for package cgroup can only be run as root.")
+	}
+
+	t.Parallel()
+
+	for _, rootPath := range []string{
+		"custom",
+		"/custom",
+		"nested/custom",
+		"/deep/nested/custom",
+	} {
+		t.Run(rootPath, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			service, err := New(&Config{
+				MountPath: dir,
+				RootPath:  rootPath,
+			})
+			require.NoError(t, err)
+			defer service.Close(false)
+
+			sessionID := uuid.New().String()
+			err = service.Create(sessionID)
+			require.NoError(t, err)
+
+			cgroupPath := path.Join(service.teleportRoot, sessionID)
+			require.DirExists(t, cgroupPath)
+			require.Contains(t, cgroupPath, rootPath)
+
+			err = service.Remove(sessionID)
+			require.NoError(t, err)
+			require.NoDirExists(t, cgroupPath)
+
+			// Teardown
+			err = service.Close(false)
+			require.NoError(t, err)
+			require.NoDirExists(t, service.teleportRoot)
+		})
+	}
+}
+
 // TestRootCleanup tests the ability for Teleport to remove and cleanup all
 // cgroups which is performed upon startup.
 func TestRootCleanup(t *testing.T) {

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -97,6 +97,7 @@ func TestRootCreateCustomRootPath(t *testing.T) {
 		"nested/custom",
 		"/deep/nested/custom",
 	} {
+		rootPath := rootPath
 		t.Run(rootPath, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1570,6 +1570,9 @@ type BPF struct {
 
 	// CgroupPath controls where cgroupv2 hierarchy is mounted.
 	CgroupPath string `yaml:"cgroup_path"`
+
+	// RootPath root directory for the Teleport cgroups.
+	RootPath string `yaml:"root_path"`
 }
 
 // Parse will parse the enhanced session recording configuration.
@@ -1581,6 +1584,7 @@ func (b *BPF) Parse() *servicecfg.BPFConfig {
 		DiskBufferSize:    b.DiskBufferSize,
 		NetworkBufferSize: b.NetworkBufferSize,
 		CgroupPath:        b.CgroupPath,
+		RootPath:          b.RootPath,
 	}
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1572,6 +1572,7 @@ type BPF struct {
 	CgroupPath string `yaml:"cgroup_path"`
 
 	// RootPath root directory for the Teleport cgroups.
+	// Optional, defaults to /teleport
 	RootPath string `yaml:"root_path"`
 }
 

--- a/lib/service/servicecfg/bpf.go
+++ b/lib/service/servicecfg/bpf.go
@@ -36,6 +36,9 @@ type BPFConfig struct {
 
 	// CgroupPath is where the cgroupv2 hierarchy is mounted.
 	CgroupPath string
+
+	// RootPath root directory for the Teleport cgroups.
+	RootPath string
 }
 
 // CheckAndSetDefaults checks BPF configuration.


### PR DESCRIPTION
Backport #38066 to branch/v15

changelog: Added `ssh_service.enhanced_recording.root_path` configuration option to change the cgroup slice path used by the agent.
