### PR TITLE
chore: Bump golangci-lint to v1.56.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Set linter versions
         run: |
-          echo BUF_VERSION=$(make -C build.assets/ print-buf-version) >> $GITHUB_ENV
-          echo GOLANGCI_LINT_VERSION=$(make -C build.assets/ print-golangci-lint-version) >> $GITHUB_ENV
+          echo BUF_VERSION=$(cd build.assets; make print-buf-version) >> $GITHUB_ENV
+          echo GOLANGCI_LINT_VERSION=$(cd build.assets; make print-golangci-lint-version) >> $GITHUB_ENV
 
       - name: Print linter versions
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,9 +23,6 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport16
 
-    env:
-      GOLANGCI_LINT_VERSION: v1.56.1
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +33,16 @@ jobs:
       - name: Check for no changes after `go mod tidy`
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
+
+      - name: Set linter versions
+        run: |
+          echo BUF_VERSION=$(make -C build.assets/ print-buf-version) >> $GITHUB_ENV
+          echo GOLANGCI_LINT_VERSION=$(make -C build.assets/ print-golangci-lint-version) >> $GITHUB_ENV
+
+      - name: Print linter versions
+        run: |
+          echo "BUF_VERSION=$BUF_VERSION"
+          echo "GOLANGCI_LINT_VERSION=$GOLANGCI_LINT_VERSION"
 
       # Run various golangci-lint checks.
       # TODO(codingllama): Using go.work could save a bunch of repetition here.
@@ -70,7 +77,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@88db93f5d74ffa329bb43e42aa95cd822697d214 # v1.29.0
         with:
           github_token: ${{ github.token }}
-          version: v1.29.0
+          version: ${{ env.BUF_VERSION }}
       - uses: bufbuild/buf-lint-action@044d13acb1f155179c606aaa2e53aea304d22058 # v1.1.0
       - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1.1.3

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -319,7 +319,8 @@ RUN go install github.com/daixiang0/gci@v0.12.1
 RUN go install gotest.tools/gotestsum@v1.10.1
 
 # Install golangci-lint.
-RUN VERSION='v1.56.1'; \
+ARG GOLANGCI_LINT_VERSION # eg, v1.56.1
+RUN VERSION="$GOLANGCI_LINT_VERSION"; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -141,6 +141,7 @@ buildbox:
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
@@ -585,6 +586,20 @@ test-docs: docsbox
 .PHONY:print-go-version
 print-go-version:
 	@echo $(GOLANG_VERSION)
+
+#
+# Print the golangci-lint version used by Teleport.
+#
+.PHONY:print-golangci-lint-version
+print-golangci-lint-version:
+	@echo $(GOLANGCI_LINT_VERSION)
+
+#
+# Print the Buf version used by Teleport.
+#
+.PHONY:print-buf-version
+print-buf-version:
+	@echo $(BUF_VERSION)
 
 #
 # Print the Rust version used to build Teleport.

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.0
-GOLANGCI_LINT_VERSION ?= v1.56.1
+GOLANGCI_LINT_VERSION ?= v1.56.2
 
 NODE_VERSION ?= 18.19.1
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,6 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.0
+GOLANGCI_LINT_VERSION ?= v1.56.1
 
 NODE_VERSION ?= 18.19.1
 

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -37,6 +37,7 @@ type Client struct {
 
 // New creates and connects a new Client based on opts.
 func New(cfg Config) (*Client, error) {
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	return nil, errors.New("the real rdpclient.Client implementation was not included in this build")
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -855,6 +855,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 	tdpConn.OnSend = s.makeTDPSendHandler(ctx, recorder, delay, tdpConn, audit)
 	tdpConn.OnRecv = s.makeTDPReceiveHandler(ctx, recorder, delay, tdpConn, audit)
 	width, height := desktop.GetScreenSize()
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	rdpc, err := rdpclient.New(rdpclient.Config{
 		Log: log,
 		GenerateUserCert: func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error) {
@@ -877,6 +878,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 		windowsUser = rdpc.GetClientUsername()
 		audit.windowsUser = windowsUser
 	}
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	if err != nil {
 		startEvent := audit.makeSessionStart(err)
 		s.record(ctx, recorder, startEvent)


### PR DESCRIPTION
Update golangci-lint to the latest patch.

I've taken this opportunity to (finally) pull the linter versions from build.assets/versions.mk, so we don't need to touch the actions on every update.

* https://github.com/golangci/golangci-lint/releases/tag/v1.56.2