### PR TITLE
Migrate discord access plugin tests

### DIFF
--- a/integrations/access/discord/testlib/helpers.go
+++ b/integrations/access/discord/testlib/helpers.go
@@ -1,0 +1,63 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testlib
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
+	"github.com/gravitational/teleport/integrations/access/discord"
+)
+
+func (s *DiscordSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
+	t := s.T()
+	t.Helper()
+
+	for {
+		rawData, err := s.Ruler().PollAccessRequestPluginData(ctx, "discord", reqID)
+		require.NoError(t, err)
+		data, err := accessrequest.DecodePluginData(rawData)
+		require.NoError(t, err)
+		if cond(data) {
+			return data
+		}
+	}
+}
+
+func parseMessageField(msg discord.DiscordMsg, field string) (string, error) {
+	if msg.Text == "" {
+		return "", trace.Errorf("message does not contain text")
+	}
+
+	matches := msgFieldRegexp.FindAllStringSubmatch(msg.Text, -1)
+	if matches == nil {
+		return "", trace.Errorf("cannot parse fields from text %s", msg.Text)
+	}
+	var fields []string
+	for _, match := range matches {
+		if match[1] == field {
+			return match[2], nil
+		}
+		fields = append(fields, match[1])
+	}
+	return "", trace.Errorf("cannot find field %s in %v", field, fields)
+}

--- a/integrations/access/discord/testlib/message.go
+++ b/integrations/access/discord/testlib/message.go
@@ -1,0 +1,51 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testlib
+
+import (
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
+	"github.com/gravitational/teleport/integrations/access/discord"
+)
+
+type MessageSlice []discord.DiscordMsg
+type MessageSet map[accessrequest.MessageData]struct{}
+
+func (slice MessageSlice) Len() int {
+	return len(slice)
+}
+
+func (slice MessageSlice) Less(i, j int) bool {
+	if slice[i].Channel < slice[j].Channel {
+		return true
+	}
+	return slice[i].DiscordID < slice[j].DiscordID
+}
+
+func (slice MessageSlice) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+func (set MessageSet) Add(msg accessrequest.MessageData) {
+	set[msg] = struct{}{}
+}
+
+func (set MessageSet) Contains(msg accessrequest.MessageData) bool {
+	_, ok := set[msg]
+	return ok
+}

--- a/integrations/access/discord/testlib/oss_integration_test.go
+++ b/integrations/access/discord/testlib/oss_integration_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,35 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package discord
+package testlib
 
 import (
-	"github.com/gravitational/teleport/integrations/access/accessrequest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 )
 
-type MessageSlice []DiscordMsg
-type MessageSet map[accessrequest.MessageData]struct{}
-
-func (slice MessageSlice) Len() int {
-	return len(slice)
-}
-
-func (slice MessageSlice) Less(i, j int) bool {
-	if slice[i].Channel < slice[j].Channel {
-		return true
+func TestDiscordPluginOSS(t *testing.T) {
+	discordSuite := &DiscordSuite{
+		AccessRequestSuite: &integration.AccessRequestSuite{
+			AuthHelper: &integration.OSSAuthHelper{},
+		},
 	}
-	return slice[i].DiscordID < slice[j].DiscordID
-}
-
-func (slice MessageSlice) Swap(i, j int) {
-	slice[i], slice[j] = slice[j], slice[i]
-}
-
-func (set MessageSet) Add(msg accessrequest.MessageData) {
-	set[msg] = struct{}{}
-}
-
-func (set MessageSet) Contains(msg accessrequest.MessageData) bool {
-	_, ok := set[msg]
-	return ok
+	suite.Run(t, discordSuite)
 }


### PR DESCRIPTION
This PR migrates discord access plugins tests to [the new access plugin integration suite](https://github.com/gravitational/teleport/pull/38175).

It does not perform any changes to the Discord plugin code. The test have mostly been untouched, no test was added or removed. Contexts have been introduced for each test and have the same value as the previous ones. I want to align all context deadlines later once all plugins are migrated.

As the tests were not super readable, I tried dropping a few comments to describe what we want to test and what each part of the test does. Let me know if this helps or is overkill.

Once this PR is merged, I will be able to open a PR in teleport.e to add tests with an enterprise auth for the advanced workflow features.