### PR TITLE
fix: Let callers specify the DOCKER_BUILDER_NAME

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -86,7 +86,7 @@ RELEASE_TARGET ?= release
 # The awk command looks for the first line that has "docker" in the second (DRIVER) column.
 # -F '[ *]+': there may be an asterisk between the first and second column if that record is the default,
 # so just subsume the asterisk into the field separator.
-DOCKER_BUILDER_NAME = $(shell docker buildx ls 2>/dev/null | awk -F '[ *]+' '$$2 == "docker" {print $$1}')
+DOCKER_BUILDER_NAME ?= $(shell docker buildx ls 2>/dev/null | awk -F '[ *]+' '$$2 == "docker" {print $$1}')
 
 .PHONY:print-docker-builder-name
 print-docker-builder-name:


### PR DESCRIPTION
Let callers override the scripted DOCKER_BUILDER_NAME, which lets folks run commands like `make enter DOCKER_BUILDER_NAME=desktop-linux`.

See also https://github.com/gravitational/teleport/pull/37559#issuecomment-1953062734.