### PR TITLE
Migrate mattermost access plugin tests

### DIFF
--- a/integrations/access/mattermost/testlib/helpers.go
+++ b/integrations/access/mattermost/testlib/helpers.go
@@ -1,0 +1,60 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testlib
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/integrations/access/accessrequest"
+	"github.com/gravitational/teleport/integrations/access/mattermost"
+)
+
+func (s *MattermostSuite) checkPluginData(ctx context.Context, reqID string, cond func(accessrequest.PluginData) bool) accessrequest.PluginData {
+	t := s.T()
+	t.Helper()
+
+	for {
+		rawData, err := s.Ruler().PollAccessRequestPluginData(ctx, "mattermost", reqID)
+		require.NoError(t, err)
+		data, err := accessrequest.DecodePluginData(rawData)
+		require.NoError(t, err)
+		if cond(data) {
+			return data
+		}
+	}
+}
+
+func parsePostField(post mattermost.Post, field string) (string, error) {
+	text := post.Message
+	matches := msgFieldRegexp.FindAllStringSubmatch(text, -1)
+	if matches == nil {
+		return "", trace.Errorf("cannot parse fields from text %s", text)
+	}
+	var fields []string
+	for _, match := range matches {
+		if match[1] == field {
+			return match[2], nil
+		}
+		fields = append(fields, match[1])
+	}
+	return "", trace.Errorf("cannot find field %s in %v", field, fields)
+}

--- a/integrations/access/mattermost/testlib/message.go
+++ b/integrations/access/mattermost/testlib/message.go
@@ -16,17 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mattermost
+package testlib
 
 import (
-	"context"
-	"sync/atomic"
-
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/accessrequest"
+	"github.com/gravitational/teleport/integrations/access/mattermost"
 )
 
-type MattermostPostSlice []Post
+type MattermostPostSlice []mattermost.Post
 type MattermostDataPostSet map[accessrequest.MessageData]struct{}
 
 func (slice MattermostPostSlice) Len() int {
@@ -51,21 +48,4 @@ func (set MattermostDataPostSet) Add(msg accessrequest.MessageData) {
 func (set MattermostDataPostSet) Contains(msg accessrequest.MessageData) bool {
 	_, ok := set[msg]
 	return ok
-}
-
-type fakeStatusSink struct {
-	status atomic.Pointer[types.PluginStatus]
-}
-
-func (s *fakeStatusSink) Emit(_ context.Context, status types.PluginStatus) error {
-	s.status.Store(&status)
-	return nil
-}
-
-func (s *fakeStatusSink) Get() types.PluginStatus {
-	status := s.status.Load()
-	if status == nil {
-		panic("expected status to be set, but it has not been")
-	}
-	return *status
 }

--- a/integrations/access/mattermost/testlib/oss_integration_test.go
+++ b/integrations/access/mattermost/testlib/oss_integration_test.go
@@ -1,0 +1,36 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testlib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/gravitational/teleport/integrations/lib/testing/integration"
+)
+
+func TestMattermostPluginOSS(t *testing.T) {
+	mattermostSuite := &MattermostSuite{
+		AccessRequestSuite: &integration.AccessRequestSuite{
+			AuthHelper: &integration.OSSAuthHelper{},
+		},
+	}
+	suite.Run(t, mattermostSuite)
+}


### PR DESCRIPTION
This PR migrates Mattermost access plugins tests to https://github.com/gravitational/teleport/pull/38175.

It does not perform any changes to the Mattermost plugin code.

Test changes are the following:
- the message posting test now passes a recipient through the config, and a recipient through suggested reviewers. Before it was only using suggested reviewers and was not covering static config.

As the tests were not super readable, I tried dropping a few comments to describe what we want to test and what each part of the test does. Let me know if this helps or is overkill.

Once this PR is merged, I will be able to open a PR in teleport.e to add tests with an enterprise auth for the advanced workflow features.