### PR TITLE
build: Generate centos7 archive when building linux-amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ clean-ui:
 
 # RELEASE_DIR is where release artifact files are put, such as tarballs, packages, etc.
 $(RELEASE_DIR):
-	mkdir $@
+	mkdir -p $@
 
 .PHONY:
 export
@@ -478,6 +478,11 @@ build-archive: | $(RELEASE_DIR)
 	echo $(GITTAG) > teleport/VERSION
 	tar $(TAR_FLAGS) -c teleport | gzip -n > $(RELEASE).tar.gz
 	cp $(RELEASE).tar.gz $(RELEASE_DIR)
+	# linux-amd64 generates a centos7-compatible archive. Make a copy with the -centos7 label,
+	# for the releases page. We should probably drop that at some point.
+	$(if $(filter linux-amd64,$(OS)-$(ARCH)), \
+		cp $(RELEASE).tar.gz $(RELEASE_DIR)/$(subst amd64,amd64-centos7,$(RELEASE)).tar.gz \
+	)
 	rm -rf teleport
 	@echo "---> Created $(RELEASE).tar.gz."
 


### PR DESCRIPTION
When building a linux-amd64 archive, make a copy of it with the
`centos7` tag as the linux-amd64 build works on centos7. We stopped
doing a centos7-specific build a while ago, but we still have the
archive on our releases page.

This helps unify the `release-amd64` and `release-amd64-centos7`
targets, which currently do the same thing except for the GitHub Actions
workflow that creates the centos7 archive only for the latter target.
This will allow us to get rid of that target as that latter target will
no longer be called when Drone is removed.

Also add a `-p` when making RELEASE_DIR as sometimes the parent
directory has not yet been created.

Update `e` ref.

Companion: https://github.com/gravitational/teleport.e/pull/3500
Issue: https://github.com/gravitational/teleport/issues/20729
Test-run: https://github.com/gravitational/teleport.e/actions/runs/7970766106
Test-run: https://github.com/gravitational/teleport.e/actions/runs/7971816767
