### PR TITLE
[v13] chore: Bump golangci-lint to v1.56.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,9 +24,6 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport13
 
-    env:
-      GOLANGCI_LINT_VERSION: v1.56.1
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,6 +34,16 @@ jobs:
       - name: Check for no changes after `go mod tidy`
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
+
+      - name: Set linter versions
+        run: |
+          echo BUF_VERSION=$(cd build.assets; make print-buf-version) >> $GITHUB_ENV
+          echo GOLANGCI_LINT_VERSION=$(cd build.assets; make print-golangci-lint-version) >> $GITHUB_ENV
+
+      - name: Print linter versions
+        run: |
+          echo "BUF_VERSION=$BUF_VERSION"
+          echo "GOLANGCI_LINT_VERSION=$GOLANGCI_LINT_VERSION"
 
       # Run various golangci-lint checks.
       # TODO(codingllama): Using go.work could save a bunch of repetition here.
@@ -77,7 +84,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@88db93f5d74ffa329bb43e42aa95cd822697d214 # v1.29.0
         with:
           github_token: ${{ github.token }}
-          version: v1.29.0
+          version: ${{ env.BUF_VERSION }}
       - uses: bufbuild/buf-lint-action@044d13acb1f155179c606aaa2e53aea304d22058 # v1.1.0
       - name: buf breaking from parent to self
         uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1.1.3

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -285,7 +285,8 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.12.1
 
 # Install golangci-lint.
-RUN VERSION='v1.56.1'; \
+ARG GOLANGCI_LINT_VERSION # eg, v1.56.1
+RUN VERSION="$GOLANGCI_LINT_VERSION"; \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$VERSION/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$VERSION"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -130,6 +130,7 @@ buildbox:
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
@@ -559,6 +560,20 @@ test-docs: docsbox
 .PHONY:print-go-version
 print-go-version:
 	@echo $(GOLANG_VERSION)
+
+#
+# Print the golangci-lint version used by Teleport.
+#
+.PHONY:print-golangci-lint-version
+print-golangci-lint-version:
+	@echo $(GOLANGCI_LINT_VERSION)
+
+#
+# Print the Buf version used by Teleport.
+#
+.PHONY:print-buf-version
+print-buf-version:
+	@echo $(BUF_VERSION)
 
 #
 # Print the Rust version used to build Teleport.

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -2,6 +2,7 @@
 # This file can be included in other Makefiles to avoid duplication.
 
 GOLANG_VERSION ?= go1.21.7
+GOLANGCI_LINT_VERSION ?= v1.56.2
 
 NODE_VERSION ?= 18.19.1
 

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -35,6 +35,7 @@ type Client struct {
 
 // New creates and connects a new Client based on opts.
 func New(cfg Config) (*Client, error) {
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	return nil, errors.New("the real rdpclient.Client implementation was not included in this build")
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -904,6 +904,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 	tdpConn.OnSend = s.makeTDPSendHandler(ctx, sw, delay, tdpConn, audit)
 	tdpConn.OnRecv = s.makeTDPReceiveHandler(ctx, sw, delay, tdpConn, audit)
 
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	rdpc, err := rdpclient.New(rdpclient.Config{
 		Log: log,
 		GenerateUserCert: func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error) {
@@ -924,6 +925,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 		windowsUser = rdpc.GetClientUsername()
 		audit.windowsUser = windowsUser
 	}
+	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	if err != nil {
 		startEvent := audit.makeSessionStart(err)
 		s.emit(ctx, sw, startEvent)


### PR DESCRIPTION
Backport #38404 to branch/v13.

Update golangci-lint to the latest patch.

I've taken this opportunity to (finally) pull the linter versions from build.assets/versions.mk, so we don't need to touch the actions on every update.

* https://github.com/golangci/golangci-lint/releases/tag/v1.56.2