### PR TITLE
Add auto enrolling capability to EKS Discover flow

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
@@ -28,7 +28,10 @@ import DatabaseService from 'teleport/services/databases/databases';
 import * as discoveryService from 'teleport/services/discovery/discovery';
 import { ComponentWrapper } from 'teleport/Discover/Fixtures/databases';
 import cfg from 'teleport/config';
-import { DISCOVERY_GROUP_CLOUD } from 'teleport/services/discovery/discovery';
+import {
+  DISCOVERY_GROUP_CLOUD,
+  DEFAULT_DISCOVERY_GROUP_NON_CLOUD,
+} from 'teleport/services/discovery/discovery';
 
 import { EnrollRdsDatabase } from './EnrollRdsDatabase';
 
@@ -207,7 +210,7 @@ describe('test EnrollRdsDatabase.tsx', () => {
     // Second array are the parameters that this api got called with,
     // we are interested in the second parameter.
     expect(createDiscoveryConfig.mock.calls[0][1]['discoveryGroup']).toBe(
-      'aws-prod'
+      DEFAULT_DISCOVERY_GROUP_NON_CLOUD
     );
 
     expect(DatabaseService.prototype.createDatabase).not.toHaveBeenCalled();

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
@@ -33,6 +33,7 @@ import { CheckedEksCluster } from './EnrollEksCluster';
 
 type Props = {
   items: CheckedEksCluster[];
+  autoDiscovery: boolean;
   fetchStatus: FetchStatus;
   fetchNextPage(): void;
 
@@ -42,6 +43,7 @@ type Props = {
 
 export const ClustersList = ({
   items = [],
+  autoDiscovery,
   fetchStatus = '',
   fetchNextPage,
   onSelectCluster,
@@ -63,7 +65,7 @@ export const ClustersList = ({
                 isChecked={isChecked}
                 onChange={onSelectCluster}
                 value={item.name}
-                {...disabledStates(item)}
+                {...disabledStates(item, autoDiscovery)}
               />
             );
           },
@@ -71,13 +73,15 @@ export const ClustersList = ({
         {
           key: 'name',
           headerText: 'Name',
-          render: item => <Cell {...disabledStates(item)}>{item.name}</Cell>,
+          render: item => (
+            <Cell {...disabledStates(item, autoDiscovery)}>{item.name}</Cell>
+          ),
         },
         {
           key: 'labels',
           headerText: 'Labels',
           render: item => (
-            <Cell {...disabledStates(item)}>
+            <Cell {...disabledStates(item, autoDiscovery)}>
               <Labels labels={item.labels} />
             </Cell>
           ),
@@ -89,7 +93,7 @@ export const ClustersList = ({
             <StatusCell
               status={getStatus(item)}
               statusText={item.status}
-              {...disabledStates(item)}
+              {...disabledStates(item, autoDiscovery)}
             />
           ),
         },
@@ -117,9 +121,11 @@ function getStatus(item: CheckedEksCluster) {
   }
 }
 
-function disabledStates(item: CheckedEksCluster) {
+function disabledStates(item: CheckedEksCluster, autoDiscovery: boolean) {
   const disabled =
-    getStatus(item) !== ItemStatus.Success || item.kubeServerExists;
+    getStatus(item) !== ItemStatus.Success ||
+    item.kubeServerExists ||
+    autoDiscovery;
 
   let disabledText = `This EKS cluster is already enrolled and is a part of this cluster`;
   switch (item.status) {
@@ -132,11 +138,8 @@ function disabledStates(item: CheckedEksCluster) {
     case 'deleting':
       disabledText = 'Not available';
   }
-
-  if (item.status === 'failed') {
-    disabledText = 'Not available, try refreshing the list';
-  } else if (item.status === 'deleting') {
-    disabledText = 'Not available';
+  if (autoDiscovery) {
+    disabledText = 'All eligible EKS clusters will be enrolled automatically';
   }
 
   return { disabled, disabledText };

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -101,6 +101,11 @@ const successEnrollmentHandler = rest.post(
   }
 );
 
+const discoveryConfigHandler = rest.post(
+  cfg.api.discoveryConfigPath,
+  (req, res, ctx) => res(ctx.json({}))
+);
+
 export const ClustersList = () => <Component />;
 
 ClustersList.parameters = {
@@ -108,6 +113,7 @@ ClustersList.parameters = {
     handlers: [
       tokenHandler,
       successEnrollmentHandler,
+      discoveryConfigHandler,
       rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) => {
         {
           return res(ctx.json({ clusters: eksClusters }));
@@ -135,6 +141,7 @@ ClustersListInCloud.parameters = {
     handlers: [
       tokenHandler,
       successEnrollmentHandler,
+      discoveryConfigHandler,
       rest.post(cfg.getListEKSClustersUrl(integrationName), (req, res, ctx) => {
         {
           return res(ctx.json({ clusters: eksClusters }));

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -411,7 +411,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
                 }
               >
                 <Box ml={2} mr={1}>
-                  Auto-enroll all EKS clusters for selected region.
+                  Auto-enroll all EKS clusters for selected region
                 </Box>
                 <ToolTipInfo>
                   Auto-enroll will automatically identify all EKS clusters from

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -421,7 +421,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
               </Toggle>
               <Toggle
                 isToggled={isAppDiscoveryEnabled}
-                onToggle={() => setAppDiscoveryEnabled(!isAppDiscoveryEnabled)}
+                onToggle={() => setAppDiscoveryEnabled(isEnabled => !isEnabled)}
               >
                 <Box ml={2} mr={1}>
                   Enable Kubernetes App Discovery

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -403,36 +403,32 @@ export function EnrollEksCluster(props: AgentStepProps) {
       {showContent && (
         <>
           <Box mb={2}>
-            <Box>
-              <Toggle
-                isToggled={isAutoDiscoveryEnabled}
-                onToggle={() =>
-                  setAutoDiscoveryEnabled(isEnabled => !isEnabled)
-                }
-              >
-                <Box ml={2} mr={1}>
-                  Auto-enroll all EKS clusters for selected region
-                </Box>
-                <ToolTipInfo>
-                  Auto-enroll will automatically identify all EKS clusters from
-                  the selected region and register them as Kubernetes resources
-                  in your infrastructure.
-                </ToolTipInfo>
-              </Toggle>
-              <Toggle
-                isToggled={isAppDiscoveryEnabled}
-                onToggle={() => setAppDiscoveryEnabled(isEnabled => !isEnabled)}
-              >
-                <Box ml={2} mr={1}>
-                  Enable Kubernetes App Discovery
-                </Box>
-                <ToolTipInfo>
-                  Teleport's Kubernetes App Discovery will automatically
-                  identify and enroll to Teleport HTTP applications running
-                  inside a Kubernetes cluster.
-                </ToolTipInfo>
-              </Toggle>
-            </Box>
+            <Toggle
+              isToggled={isAutoDiscoveryEnabled}
+              onToggle={() => setAutoDiscoveryEnabled(isEnabled => !isEnabled)}
+            >
+              <Box ml={2} mr={1}>
+                Auto-enroll all EKS clusters for selected region
+              </Box>
+              <ToolTipInfo>
+                Auto-enroll will automatically identify all EKS clusters from
+                the selected region and register them as Kubernetes resources in
+                your infrastructure.
+              </ToolTipInfo>
+            </Toggle>
+            <Toggle
+              isToggled={isAppDiscoveryEnabled}
+              onToggle={() => setAppDiscoveryEnabled(isEnabled => !isEnabled)}
+            >
+              <Box ml={2} mr={1}>
+                Enable Kubernetes App Discovery
+              </Box>
+              <ToolTipInfo>
+                Teleport's Kubernetes App Discovery will automatically identify
+                and enroll to Teleport HTTP applications running inside a
+                Kubernetes cluster.
+              </ToolTipInfo>
+            </Toggle>
           </Box>
           {showTable && (
             <ClustersList

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -17,12 +17,12 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Box, ButtonSecondary, ButtonText, Link, Text, Toggle } from 'design';
+import { Box, ButtonSecondary, ButtonText, Flex, Link, Text, Toggle } from 'design';
 import styled from 'styled-components';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
 
-import useAttempt from 'shared/hooks/useAttemptNext';
+import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
 import { ToolTipInfo } from 'shared/components/ToolTip';
 import { getErrMessage } from 'shared/utils/errorType';
 
@@ -33,6 +33,12 @@ import {
   AwsEksCluster,
 } from 'teleport/services/integrations';
 
+import {
+  DISCOVERY_GROUP_CLOUD,
+  DEFAULT_DISCOVERY_GROUP_NON_CLOUD,
+  DiscoveryConfig,
+  createDiscoveryConfig,
+} from 'teleport/services/discovery';
 import { AwsRegionSelector } from 'teleport/Discover/Shared/AwsRegionSelector';
 import { ConfigureIamPerms } from 'teleport/Discover/Shared/Aws/ConfigureIamPerms';
 import { isIamPermError } from 'teleport/Discover/Shared/Aws/error';
@@ -43,8 +49,16 @@ import { generateCmd } from 'teleport/Discover/Kubernetes/HelmChart/HelmChart';
 import { Kube } from 'teleport/services/kube';
 
 import { JoinToken } from 'teleport/services/joinToken';
+import cfg from 'teleport/config';
 
-import { Header } from '../../Shared';
+import {
+  ActionButtons,
+  Header,
+  ResourceKind,
+  SelfHostedAutoDiscoverDirections,
+  AutoEnrollDialog,
+} from '../../Shared';
+
 
 import { ClustersList } from './EksClustersList';
 import ManualHelmDialog from './ManualHelmDialog';
@@ -94,13 +108,21 @@ export function EnrollEksCluster(props: AgentStepProps) {
       status: 'notStarted',
     });
   const [isAppDiscoveryEnabled, setAppDiscoveryEnabled] = useState(true);
+  const [isAutoDiscoveryEnabled, setAutoDiscoveryEnabled] = useState(true);
   const [isAgentWaitingDialogShown, setIsAgentWaitingDialogShown] =
     useState(false);
   const [isManualHelmDialogShown, setIsManualHelmDialogShown] = useState(false);
   const [waitingResourceId, setWaitingResourceId] = useState('');
-  // join token will be set only if user opens ManualHelmDialog,
+  const [discoveryGroupName, setDiscoveryGroupName] = useState(() =>
+    cfg.isCloud ? DISCOVERY_GROUP_CLOUD : DEFAULT_DISCOVERY_GROUP_NON_CLOUD
+  );
+  const [autoDiscoveryCfg, setAutoDiscoveryCfg] = useState<DiscoveryConfig>();
+  const { attempt: autoDiscoverAttempt, setAttempt: setAutoDiscoverAttempt } =
+    useAttempt('');
+ // join token will be set only if user opens ManualHelmDialog,
   // we delay it to avoid premature admin action MFA confirmation request.
   const [joinToken, setJoinToken] = useState<JoinToken>(null);
+
   const ctx = useTeleport();
 
   function fetchClustersWithNewRegion(region: Regions) {
@@ -193,6 +215,64 @@ export function EnrollEksCluster(props: AgentStepProps) {
     });
   }
 
+  function handleAndEmitRequestError(
+    err: Error,
+    cfg: { errorPrefix?: string; setAttempt?(attempt: Attempt): void }
+  ) {
+    const message = getErrMessage(err);
+    if (cfg.setAttempt) {
+      cfg.setAttempt({
+        status: 'failed',
+        statusText: `${cfg.errorPrefix}${message}`,
+      });
+    }
+    emitErrorEvent(`${cfg.errorPrefix}${message}`);
+  }
+
+  async function enableAutoDiscovery() {
+    setAutoDiscoverAttempt({ status: 'processing' });
+
+    let discoveryConfig = autoDiscoveryCfg;
+    if (!discoveryConfig) {
+      try {
+        discoveryConfig = await createDiscoveryConfig(
+          ctx.storeUser.getClusterId(),
+          {
+            name: crypto.randomUUID(),
+            discoveryGroup: cfg.isCloud
+              ? DISCOVERY_GROUP_CLOUD
+              : discoveryGroupName,
+            aws: [
+              {
+                types: ['eks'],
+                regions: [tableData.currRegion],
+                tags: { '*': ['*'] },
+                integration: agentMeta.awsIntegration.name,
+                kubeAppDiscovery: isAppDiscoveryEnabled,
+              },
+            ],
+          }
+        );
+        setAutoDiscoveryCfg(discoveryConfig);
+      } catch (err) {
+        handleAndEmitRequestError(err, {
+          errorPrefix: 'failed to create discovery config: ',
+          setAttempt: setAutoDiscoverAttempt,
+        });
+        return;
+      }
+    }
+
+    setAutoDiscoverAttempt({ status: 'success' });
+    props.updateAgentMeta({
+      ...(agentMeta as EksMeta),
+      autoDiscovery: {
+        config: discoveryConfig,
+      },
+      awsRegion: tableData.currRegion,
+    } as EksMeta);
+  }
+
   async function enroll() {
     const integrationName = (agentMeta as EksMeta).awsIntegration.name;
     setEnrollmentState({ status: 'enrolling' });
@@ -245,6 +325,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
 
   async function handleOnProceed() {
     props.updateAgentMeta({
+      ...props.agentMeta,
       kube: confirmedCluster,
       resourceName: confirmedCluster.name,
     } as EksMeta);
@@ -253,6 +334,19 @@ export function EnrollEksCluster(props: AgentStepProps) {
   }
 
   const hasIamPermError = isIamPermError(fetchClustersAttempt);
+  const showContent =
+    !hasIamPermError &&
+    tableData.currRegion &&
+    fetchClustersAttempt.status === 'success';
+
+  // (Temp)
+  // Self hosted auto enroll is different from cloud.
+  // For cloud, we already run the discovery service for customer.
+  // For on-prem, user has to run their own discovery service.
+  // We hide the clusters table for on-prem if they are wanting auto discover
+  // because it takes up so much space to give them instructions.
+  // Future work will simply provide user a script so we can show the table then.
+  const showTable = cfg.isCloud || !isAutoDiscoveryEnabled;
 
   const closeEnrollmentDialog = () => {
     setEnrollmentState({ status: 'notStarted' });
@@ -318,54 +412,95 @@ export function EnrollEksCluster(props: AgentStepProps) {
         clear={clear}
         disableSelector={fetchClustersAttempt.status === 'processing'}
       />
-      {!hasIamPermError && tableData.currRegion && (
+      {showContent && (
         <>
           <Box mb={2}>
-            <Toggle
-              isToggled={isAppDiscoveryEnabled}
-              onToggle={() => setAppDiscoveryEnabled(!isAppDiscoveryEnabled)}
-            >
-              <Box ml={2} mr={1}>
-                Enable Kubernetes App Discovery
-              </Box>
-              <ToolTipInfo>
-                Teleport's Kubernetes App Discovery will automatically identify
-                and enroll to Teleport HTTP applications running inside a
-                Kubernetes cluster.
-              </ToolTipInfo>
-            </Toggle>
-          </Box>
-          <ClustersList
-            items={tableData.items}
-            fetchStatus={tableData.fetchStatus}
-            selectedCluster={selectedCluster}
-            onSelectCluster={setSelectedCluster}
-            fetchNextPage={fetchNextPage}
-          />
-          <StyledBox mb={5} mt={5}>
-            <Text mb={2}>Automatically enroll selected EKS cluster</Text>
-            <ButtonSecondary
-              width="215px"
-              type="submit"
-              onClick={enroll}
-              disabled={enrollmentNotAllowed}
-              mt={2}
-              mb={2}
-            >
-              Enroll EKS Cluster
-            </ButtonSecondary>
-            <Box>
-              <ButtonText
-                disabled={enrollmentNotAllowed}
-                onClick={() => {
-                  setIsManualHelmDialogShown(b => !b);
-                }}
-                pl={0}
+            <Flex alignItems="center" gap={3}>
+              <Toggle
+                isToggled={isAutoDiscoveryEnabled}
+                onToggle={() =>
+                  setAutoDiscoveryEnabled(!isAutoDiscoveryEnabled)
+                }
               >
+                <Box ml={2} mr={1}>
+                  Auto-enroll all EKS clusters for selected region.
+                </Box>
+                <ToolTipInfo>
+                  Auto-enroll will automatically identify all EKS clusters from
+                  the selected region and register them as Kubernetes resources
+                  in your infrastructure.
+                </ToolTipInfo>
+              </Toggle>
+              <Toggle
+                isToggled={isAppDiscoveryEnabled}
+                onToggle={() => setAppDiscoveryEnabled(!isAppDiscoveryEnabled)}
+              >
+                <Box ml={2} mr={1}>
+                  Enable Kubernetes App Discovery
+                </Box>
+                <ToolTipInfo>
+                  Teleport's Kubernetes App Discovery will automatically
+                  identify and enroll to Teleport HTTP applications running
+                  inside a Kubernetes cluster.
+                </ToolTipInfo>
+              </Toggle>
+            </Flex>
+          </Box>
+          {showTable && (
+            <ClustersList
+              items={tableData.items}
+              autoDiscovery={isAutoDiscoveryEnabled}
+              fetchStatus={tableData.fetchStatus}
+              selectedCluster={selectedCluster}
+              onSelectCluster={setSelectedCluster}
+              fetchNextPage={fetchNextPage}
+            />
+          )}
+          {!cfg.isCloud && isAutoDiscoveryEnabled && (
+            <SelfHostedAutoDiscoverDirections
+              clusterPublicUrl={ctx.storeUser.state.cluster.publicURL}
+              discoveryGroupName={discoveryGroupName}
+              setDiscoveryGroupName={setDiscoveryGroupName}
+            />
+          )}
+          {!isAutoDiscoveryEnabled && (
+            <StyledBox mb={5} mt={5}>
+              <Text mb={2}>Automatically enroll selected EKS cluster</Text>
+              <ButtonPrimary
+                width="215px"
+                type="submit"
+                onClick={enroll}
+                disabled={enrollmentNotAllowed}
+                mt={2}
+                mb={2}
+              >
+                Enroll EKS Cluster
+              </ButtonPrimary>
+              <Box>
+                <ButtonText
+                  disabled={enrollmentNotAllowed}
+                  onClick={() => {
+                    setIsManualHelmDialogShown(b => !b);
+                  }}
+                  pl={0}
+                >
                 Or enroll manually
-              </ButtonText>
-            </Box>
-          </StyledBox>
+                </ButtonText>
+              </Box>
+            </StyledBox>
+          )}
+          {isAutoDiscoveryEnabled && (
+            <ActionButtons
+              onProceed={enableAutoDiscovery}
+              disableProceed={
+                fetchClustersAttempt.status === 'processing' ||
+                fetchClustersAttempt.status === 'failed' ||
+                (!isAutoDiscoveryEnabled && !selectedCluster) ||
+                hasIamPermError ||
+                (!cfg.isCloud && !discoveryGroupName)
+              }
+            />
+          )}
         </>
       )}
       {hasIamPermError && (
@@ -414,6 +549,16 @@ export function EnrollEksCluster(props: AgentStepProps) {
             setIsAgentWaitingDialogShown(false);
           }}
           next={handleOnProceed}
+        />
+      )}
+      {autoDiscoverAttempt.status != '' && (
+        <AutoEnrollDialog
+          attempt={autoDiscoverAttempt}
+          next={props.nextStep}
+          close={() => setAutoDiscoverAttempt({ status: '' })}
+          retry={enableAutoDiscovery}
+          region={tableData.currRegion}
+          notifyAboutDelay={true}
         />
       )}
     </Box>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -215,20 +215,6 @@ export function EnrollEksCluster(props: AgentStepProps) {
     });
   }
 
-  function handleAndEmitRequestError(
-    err: Error,
-    cfg: { errorPrefix?: string; setAttempt?(attempt: Attempt): void }
-  ) {
-    const message = getErrMessage(err);
-    if (cfg.setAttempt) {
-      cfg.setAttempt({
-        status: 'failed',
-        statusText: `${cfg.errorPrefix}${message}`,
-      });
-    }
-    emitErrorEvent(`${cfg.errorPrefix}${message}`);
-  }
-
   async function enableAutoDiscovery() {
     setAutoDiscoverAttempt({ status: 'processing' });
 
@@ -255,11 +241,13 @@ export function EnrollEksCluster(props: AgentStepProps) {
         );
         setAutoDiscoveryCfg(discoveryConfig);
       } catch (err) {
-        handleAndEmitRequestError(err, {
-          errorPrefix: 'failed to create discovery config: ',
-          setAttempt: setAutoDiscoverAttempt,
+        const message = getErrMessage(err);
+        setAutoDiscoverAttempt({
+          status: 'failed',
+          statusText: `failed to create discovery config: ${message}`,
         });
-        return;
+
+        emitErrorEvent(`failed to create discovery config: ${message}`);
       }
     }
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -404,19 +404,6 @@ export function EnrollEksCluster(props: AgentStepProps) {
         <>
           <Box mb={2}>
             <Toggle
-              isToggled={isAutoDiscoveryEnabled}
-              onToggle={() => setAutoDiscoveryEnabled(isEnabled => !isEnabled)}
-            >
-              <Box ml={2} mr={1}>
-                Auto-enroll all EKS clusters for selected region
-              </Box>
-              <ToolTipInfo>
-                Auto-enroll will automatically identify all EKS clusters from
-                the selected region and register them as Kubernetes resources in
-                your infrastructure.
-              </ToolTipInfo>
-            </Toggle>
-            <Toggle
               isToggled={isAppDiscoveryEnabled}
               onToggle={() => setAppDiscoveryEnabled(isEnabled => !isEnabled)}
             >
@@ -427,6 +414,19 @@ export function EnrollEksCluster(props: AgentStepProps) {
                 Teleport's Kubernetes App Discovery will automatically identify
                 and enroll to Teleport HTTP applications running inside a
                 Kubernetes cluster.
+              </ToolTipInfo>
+            </Toggle>
+            <Toggle
+              isToggled={isAutoDiscoveryEnabled}
+              onToggle={() => setAutoDiscoveryEnabled(isEnabled => !isEnabled)}
+            >
+              <Box ml={2} mr={1}>
+                Auto-enroll all EKS clusters for selected region
+              </Box>
+              <ToolTipInfo>
+                Auto-enroll will automatically identify all EKS clusters from
+                the selected region and register them as Kubernetes resources in
+                your infrastructure.
               </ToolTipInfo>
             </Toggle>
           </Box>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -403,7 +403,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       {showContent && (
         <>
           <Box mb={2}>
-            <Flex alignItems="center" gap={3}>
+            <Box>
               <Toggle
                 isToggled={isAutoDiscoveryEnabled}
                 onToggle={() =>
@@ -432,7 +432,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
                   inside a Kubernetes cluster.
                 </ToolTipInfo>
               </Toggle>
-            </Flex>
+            </Box>
           </Box>
           {showTable && (
             <ClustersList

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -539,7 +539,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
           next={handleOnProceed}
         />
       )}
-      {autoDiscoverAttempt.status != '' && (
+      {autoDiscoverAttempt.status !== '' && (
         <AutoEnrollDialog
           attempt={autoDiscoverAttempt}
           next={props.nextStep}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -253,7 +253,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
 
     setAutoDiscoverAttempt({ status: 'success' });
     props.updateAgentMeta({
-      ...(agentMeta as EksMeta),
+      ...agentMeta,
       autoDiscovery: {
         config: discoveryConfig,
       },

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
 
-import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
+import useAttempt from 'shared/hooks/useAttemptNext';
 import { ToolTipInfo } from 'shared/components/ToolTip';
 import { getErrMessage } from 'shared/utils/errorType';
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -407,7 +407,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
               <Toggle
                 isToggled={isAutoDiscoveryEnabled}
                 onToggle={() =>
-                  setAutoDiscoveryEnabled(isEnabled => !isEnabled);
+                  setAutoDiscoveryEnabled(isEnabled => !isEnabled)
                 }
               >
                 <Box ml={2} mr={1}>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -407,7 +407,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
               <Toggle
                 isToggled={isAutoDiscoveryEnabled}
                 onToggle={() =>
-                  setAutoDiscoveryEnabled(!isAutoDiscoveryEnabled)
+                  setAutoDiscoveryEnabled(isEnabled => !isEnabled);
                 }
               >
                 <Box ml={2} mr={1}>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Box, ButtonSecondary, ButtonText, Flex, Link, Text, Toggle } from 'design';
+import { Box, ButtonPrimary, ButtonText, Link, Text, Toggle } from 'design';
 import styled from 'styled-components';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
@@ -54,11 +54,9 @@ import cfg from 'teleport/config';
 import {
   ActionButtons,
   Header,
-  ResourceKind,
   SelfHostedAutoDiscoverDirections,
   AutoEnrollDialog,
 } from '../../Shared';
-
 
 import { ClustersList } from './EksClustersList';
 import ManualHelmDialog from './ManualHelmDialog';
@@ -119,7 +117,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
   const [autoDiscoveryCfg, setAutoDiscoveryCfg] = useState<DiscoveryConfig>();
   const { attempt: autoDiscoverAttempt, setAttempt: setAutoDiscoverAttempt } =
     useAttempt('');
- // join token will be set only if user opens ManualHelmDialog,
+  // join token will be set only if user opens ManualHelmDialog,
   // we delay it to avoid premature admin action MFA confirmation request.
   const [joinToken, setJoinToken] = useState<JoinToken>(null);
 
@@ -468,7 +466,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
                   }}
                   pl={0}
                 >
-                Or enroll manually
+                  Or enroll manually
                 </ButtonText>
               </Box>
             </StyledBox>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -114,7 +114,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
   const [isManualHelmDialogShown, setIsManualHelmDialogShown] = useState(false);
   const [waitingResourceId, setWaitingResourceId] = useState('');
   const [discoveryGroupName, setDiscoveryGroupName] = useState(() =>
-    cfg.isCloud ? DISCOVERY_GROUP_CLOUD : DEFAULT_DISCOVERY_GROUP_NON_CLOUD
+    cfg.isCloud ? '' : DEFAULT_DISCOVERY_GROUP_NON_CLOUD
   );
   const [autoDiscoveryCfg, setAutoDiscoveryCfg] = useState<DiscoveryConfig>();
   const { attempt: autoDiscoverAttempt, setAttempt: setAutoDiscoverAttempt } =

--- a/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
@@ -41,6 +41,12 @@ export const WithTraits = () => (
   </MemoryRouter>
 );
 
+export const WithTraitsAutoDiscovery = () => (
+  <MemoryRouter>
+    <SetupAccess {...setAutoDiscovery(props)} />
+  </MemoryRouter>
+);
+
 export const NoAccess = () => (
   <MemoryRouter>
     <SetupAccess {...props} canEditUser={false} />
@@ -52,6 +58,27 @@ export const SsoUser = () => (
     <SetupAccess {...props} isSsoUser={true} />
   </MemoryRouter>
 );
+
+function setAutoDiscovery(props: State): State {
+  const copy = { ...props, agentMeta: { ...props.agentMeta } };
+  copy.agentMeta.autoDiscovery = {
+    config: {
+      name: 'some-name',
+      discoveryGroup: 'some-group',
+      aws: [
+        {
+          types: ['eks'],
+          regions: ['us-east-1'],
+          tags: {},
+          kubeAppDiscovery: true,
+          integration: 'some-integration',
+        },
+      ],
+    },
+  };
+
+  return copy;
+}
 
 const props: State = {
   attempt: {

--- a/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
@@ -43,7 +43,27 @@ export const WithTraits = () => (
 
 export const WithTraitsAutoDiscovery = () => (
   <MemoryRouter>
-    <SetupAccess {...setAutoDiscovery(props)} />
+    <SetupAccess
+      {...props}
+      agentMeta={{
+        ...props.agentMeta,
+        autoDiscovery: {
+          config: {
+            name: 'some-name',
+            discoveryGroup: 'some-group',
+            aws: [
+              {
+                types: ['eks'],
+                regions: ['us-east-1'],
+                tags: {},
+                kubeAppDiscovery: true,
+                integration: 'some-integration',
+              },
+            ],
+          },
+        },
+      }}
+    />
   </MemoryRouter>
 );
 
@@ -58,27 +78,6 @@ export const SsoUser = () => (
     <SetupAccess {...props} isSsoUser={true} />
   </MemoryRouter>
 );
-
-function setAutoDiscovery(props: State): State {
-  const copy = { ...props, agentMeta: { ...props.agentMeta } };
-  copy.agentMeta.autoDiscovery = {
-    config: {
-      name: 'some-name',
-      discoveryGroup: 'some-group',
-      aws: [
-        {
-          types: ['eks'],
-          regions: ['us-east-1'],
-          tags: {},
-          kubeAppDiscovery: true,
-          integration: 'some-integration',
-        },
-      ],
-    },
-  };
-
-  return copy;
-}
 
 const props: State = {
   attempt: {

--- a/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.tsx
@@ -51,7 +51,6 @@ export function SetupAccess(props: State) {
   const [selectedUsers, setSelectedUsers] = useState<Option[]>([]);
 
   const wantAutoDiscover = !!agentMeta.autoDiscovery;
-  // debugger;
   useEffect(() => {
     if (props.attempt.status === 'success') {
       setSelectedGroups(initSelectedOptions('kubeGroups'));

--- a/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Box } from 'design';
+import { Box, Text } from 'design';
 
 import {
   SelectCreatable,
@@ -41,6 +41,7 @@ export function SetupAccess(props: State) {
     initSelectedOptions,
     getFixedOptions,
     getSelectableOptions,
+    agentMeta,
     ...restOfProps
   } = props;
   const [groupInputValue, setGroupInputValue] = useState('');
@@ -49,6 +50,8 @@ export function SetupAccess(props: State) {
   const [userInputValue, setUserInputValue] = useState('');
   const [selectedUsers, setSelectedUsers] = useState<Option[]>([]);
 
+  const wantAutoDiscover = !!agentMeta.autoDiscovery;
+  // debugger;
   useEffect(() => {
     if (props.attempt.status === 'success') {
       setSelectedGroups(initSelectedOptions('kubeGroups'));
@@ -85,7 +88,17 @@ export function SetupAccess(props: State) {
   }
 
   function handleOnProceed() {
-    onProceed({ kubeGroups: selectedGroups, kubeUsers: selectedUsers });
+    let numStepsToIncrement;
+    // Skip test connection since test connection currently
+    // only supports one resource testing and auto enrolling
+    // enrolls resources > 1.
+    if (wantAutoDiscover) {
+      numStepsToIncrement = 2;
+    }
+    onProceed(
+      { kubeGroups: selectedGroups, kubeUsers: selectedUsers },
+      numStepsToIncrement
+    );
   }
 
   const hasTraits = selectedGroups.length > 0 || selectedUsers.length > 0;
@@ -101,7 +114,15 @@ export function SetupAccess(props: State) {
       traitDescription="users and groups"
       hasTraits={hasTraits}
       onProceed={handleOnProceed}
+      wantAutoDiscover={wantAutoDiscover}
     >
+      {wantAutoDiscover && (
+        <Text mb={3}>
+          Since auto-discovery is enabled, make sure to include all Kubernetes
+          users and groups that will be used to connect to the discovered
+          clusters.
+        </Text>
+      )}
       <Box mb={4}>
         Kubernetes Groups
         <SelectCreatable

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
@@ -37,7 +37,11 @@ export type AutoEnrollDialog = {
   close(): void;
   next(): void;
   region: string;
-  notifyAboutDelay: boolean; // show notification that resources might take some time to appear after setup has finished.
+/**
+   * show notification that resources might take some
+   * time to appear after setup has finished.
+   */
+  notifyAboutDelay: boolean;
 };
 
 export function AutoEnrollDialog({

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
@@ -37,7 +37,7 @@ export type AutoEnrollDialog = {
   close(): void;
   next(): void;
   region: string;
-  skipDeployment: boolean;
+  notifyAboutDelay: boolean;
 };
 
 export function AutoEnrollDialog({
@@ -46,7 +46,7 @@ export function AutoEnrollDialog({
   close,
   next,
   region,
-  skipDeployment,
+  notifyAboutDelay,
 }: AutoEnrollDialog) {
   let content: JSX.Element;
   if (attempt.status === 'failed') {
@@ -83,12 +83,11 @@ export function AutoEnrollDialog({
           <Icons.Check size="small" ml={1} mr={2} color="success.main" />
           <Text>
             Discovery config successfully created.
-            {skipDeployment && (
+            {notifyAboutDelay && (
               <>
                 {' '}
                 The discovery service can take a few minutes to finish
-                auto-enrolling RDS databases found in region{' '}
-                <Mark>{region}</Mark>.
+                auto-enrolling resources found in region <Mark>{region}</Mark>.
               </>
             )}
           </Text>

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
@@ -37,7 +37,7 @@ export type AutoEnrollDialog = {
   close(): void;
   next(): void;
   region: string;
-/**
+  /**
    * show notification that resources might take some
    * time to appear after setup has finished.
    */

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/AutoEnrollDialog.tsx
@@ -37,7 +37,7 @@ export type AutoEnrollDialog = {
   close(): void;
   next(): void;
   region: string;
-  notifyAboutDelay: boolean;
+  notifyAboutDelay: boolean; // show notification that resources might take some time to appear after setup has finished.
 };
 
 export function AutoEnrollDialog({

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
@@ -30,7 +30,7 @@ const discoveryGroupToolTip = `Discovery group name is used to group discovered 
 This parameter is used to prevent Discovery Agents watching different sets of cloud resources from \
 colliding against each other and deleting resources created by another services.`;
 
-const discoveryServiceToolTip = `The Discovery Service, is responsible for watching your \
+const discoveryServiceToolTip = `The Discovery Service is responsible for watching your \
 cloud provider and checking if there are any new resources or if there have been any \
 modifications to previously discovered resources.`;
 

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoverDirections.tsx
@@ -1,0 +1,186 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Box, Flex, Input, Text } from 'design';
+import styled from 'styled-components';
+
+import { ToolTipInfo } from 'shared/components/ToolTip';
+
+import React from 'react';
+
+import { Mark } from 'teleport/Discover/Shared';
+import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
+import { Tabs } from 'teleport/components/Tabs';
+
+const discoveryGroupToolTip = `Discovery group name is used to group discovered resources into different sets. \
+This parameter is used to prevent Discovery Agents watching different sets of cloud resources from \
+colliding against each other and deleting resources created by another services.`;
+
+const discoveryServiceToolTip = `The Discovery Service, is responsible for watching your \
+cloud provider and checking if there are any new resources or if there have been any \
+modifications to previously discovered resources.`;
+
+export const SelfHostedAutoDiscoverDirections = ({
+  clusterPublicUrl,
+  discoveryGroupName,
+  setDiscoveryGroupName,
+}: {
+  clusterPublicUrl: string;
+  discoveryGroupName: string;
+  setDiscoveryGroupName(n: string): void;
+}) => {
+  const yamlContent = `version: v3
+teleport:
+  join_params:
+    token_name: "<YOUR_JOIN_TOKEN_FROM_STEP_1>"
+    method: token
+  proxy_server: "${clusterPublicUrl}"
+auth_service:
+  enabled: off
+proxy_service:
+  enabled: off
+ssh_service:
+  enabled: off
+discovery_service:
+  enabled: "yes"
+  discovery_group: "${discoveryGroupName}"`;
+
+  return (
+    <Box mt={2}>
+      <Flex alignItems="center">
+        <Text>
+          Auto-enrolling requires you to configure a{' '}
+          <Mark>Discovery Service</Mark>
+        </Text>
+        <ToolTipInfo children={discoveryServiceToolTip} />
+      </Flex>
+      <br />
+      <StyledBox mb={5}>
+        <Text bold>Step 1: Create a Join Token</Text>
+        <Text mb={2}>
+          Run the following command against your Teleport Auth Service and save
+          it in <Mark>/tmp/token</Mark> on the host that will run the Discovery
+          Service.
+        </Text>
+        <TextSelectCopyMulti
+          lines={[
+            {
+              text: `tctl tokens add --type=discovery`,
+            },
+          ]}
+        />
+      </StyledBox>
+      <StyledBox mb={5}>
+        <Flex alignItems="center">
+          <Text bold mr={1}>
+            Step 2: Define a Discovery Group name{' '}
+          </Text>
+          <ToolTipInfo children={discoveryGroupToolTip} />
+        </Flex>
+        <Box mt={3} width="260px">
+          <Input
+            value={discoveryGroupName}
+            onChange={e => setDiscoveryGroupName(e.target.value)}
+            hasError={discoveryGroupName.length == 0}
+          />
+        </Box>
+      </StyledBox>
+      <StyledBox mb={5}>
+        <Text bold mr={1}>
+          Step 3: Create a teleport.yaml file
+        </Text>
+        <Text mb={2}>
+          Use this template to create a <Mark>teleport.yaml</Mark> on the host
+          that will run the Discovery Service.
+        </Text>
+        <TextSelectCopyMulti lines={[{ text: yamlContent }]} bash={false} />
+      </StyledBox>
+      <StyledBox mb={5}>
+        <Text bold mr={1}>
+          Step 4: Start Discovery Service
+        </Text>
+        <Text mb={2}>
+          Configure the Discovery Service to start automatically when the host
+          boots up by creating a systemd service for it. The instructions depend
+          on how you installed the Discovery Service.
+        </Text>
+        <Tabs
+          tabs={[
+            {
+              title: 'Package Manager',
+              content: (
+                <Box px={2} pb={2}>
+                  <Text mb={2}>
+                    On the host where you will run the Discovery Service, enable
+                    and start Teleport:
+                  </Text>
+                  <TextSelectCopyMulti
+                    lines={[
+                      {
+                        text: `sudo systemctl enable teleport`,
+                      },
+                      {
+                        text: `sudo systemctl start teleport`,
+                      },
+                    ]}
+                  />
+                </Box>
+              ),
+            },
+            {
+              title: `TAR Archive`,
+              content: (
+                <Box px={2} pb={2}>
+                  <Text mb={2}>
+                    On the host where you will run the Discovery Service, create
+                    a systemd service configuration for Teleport, enable the
+                    Teleport service, and start Teleport:
+                  </Text>
+                  <TextSelectCopyMulti
+                    lines={[
+                      {
+                        text: `sudo teleport install systemd -o /etc/systemd/system/teleport.service`,
+                      },
+                      {
+                        text: `sudo systemctl enable teleport`,
+                      },
+                      {
+                        text: `sudo systemctl start teleport`,
+                      },
+                    ]}
+                  />
+                </Box>
+              ),
+            },
+          ]}
+        />
+        <Text mt={2}>
+          You can check the status of the Discovery Service with{' '}
+          <Mark>systemctl status teleport</Mark> and view its logs with{' '}
+          <Mark>journalctl -fu teleport</Mark>.
+        </Text>
+      </StyledBox>
+    </Box>
+  );
+};
+
+const StyledBox = styled(Box)`
+  max-width: 1000px;
+  background-color: ${props => props.theme.colors.spotBackground[0]};
+  padding: ${props => `${props.theme.space[3]}px`};
+  border-radius: ${props => `${props.theme.space[2]}px`};
+`;

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoveryDirections.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/SelfHostedAutoDiscoveryDirections.story.tsx
@@ -1,0 +1,34 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+
+import { SelfHostedAutoDiscoverDirections } from './SelfHostedAutoDiscoverDirections';
+
+export default {
+  title: 'Teleport/Discover/Shared/SelfHostedAutoDiscoveryDirections',
+};
+
+export const Directions = () => {
+  return (
+    <SelfHostedAutoDiscoverDirections
+      clusterPublicUrl="https://teleport.example.com"
+      discoveryGroupName="test-group"
+      setDiscoveryGroupName={() => {}}
+    />
+  );
+};

--- a/web/packages/teleport/src/Discover/Shared/AutoDiscovery/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/AutoDiscovery/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { AutoEnrollDialog } from './AutoEnrollDialog';
+export { SelfHostedAutoDiscoverDirections } from './SelfHostedAutoDiscoverDirections';

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
@@ -61,15 +61,17 @@ export function useUserTraits() {
   let staticTraits = initUserTraits();
   switch (resourceSpec.kind) {
     case ResourceKind.Kubernetes:
-      const kube = (agentMeta as KubeMeta).kube;
-      staticTraits.kubeUsers = arrayStrDiff(
-        kube.users,
-        dynamicTraits.kubeUsers
-      );
-      staticTraits.kubeGroups = arrayStrDiff(
-        kube.groups,
-        dynamicTraits.kubeGroups
-      );
+      if (!wantAutoDiscover) {
+        const kube = (agentMeta as KubeMeta).kube;
+        staticTraits.kubeUsers = arrayStrDiff(
+          kube.users,
+          dynamicTraits.kubeUsers
+        );
+        staticTraits.kubeGroups = arrayStrDiff(
+          kube.groups,
+          dynamicTraits.kubeGroups
+        );
+      }
       break;
 
     case ResourceKind.Server:
@@ -135,10 +137,13 @@ export function useUserTraits() {
           }
         });
 
-        nextStep({
-          kubeUsers: [...newDynamicKubeUsers],
-          kubeGroups: [...newDynamicKubeGroups],
-        });
+        nextStep(
+          {
+            kubeUsers: [...newDynamicKubeUsers],
+            kubeGroups: [...newDynamicKubeGroups],
+          },
+          numStepsToIncrement
+        );
         break;
 
       case ResourceKind.Server:

--- a/web/packages/teleport/src/Discover/Shared/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/index.ts
@@ -43,6 +43,10 @@ export {
   RadioCell,
   StatusCell,
 } from './Aws';
+export {
+  AutoEnrollDialog,
+  SelfHostedAutoDiscoverDirections,
+} from './AutoDiscovery';
 export { StyledBox } from './StyledBox';
 
 export type { DiscoverLabel } from './LabelsCreater';

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -491,7 +491,7 @@ type BaseMeta = {
     // requiredVpcsAndSubnets is a map of required vpcs for auto discovery.
     // If this is empty, then a user can skip deploying db agents.
     // If >0, auto discovery requires deploying db agents.
-    requiredVpcsAndSubnets: Record<string, string[]>;
+    requiredVpcsAndSubnets?: Record<string, string[]>;
   };
 };
 

--- a/web/packages/teleport/src/services/discovery/discovery.ts
+++ b/web/packages/teleport/src/services/discovery/discovery.ts
@@ -23,12 +23,14 @@ import { AwsMatcher, DiscoveryConfig } from './types';
 // when creating a discovery config.
 export const DISCOVERY_GROUP_CLOUD = 'cloud-discovery-group';
 
+export const DEFAULT_DISCOVERY_GROUP_NON_CLOUD = 'aws-prod';
+
 export function createDiscoveryConfig(
   clusterId: string,
   req: DiscoveryConfig
 ): Promise<DiscoveryConfig> {
   return api
-    .post(cfg.getDiscoveryConfigUrl(clusterId), req)
+    .post(cfg.getDiscoveryConfigUrl(clusterId), makeDiscoveryConfigReq(req))
     .then(makeDiscoveryConfig);
 }
 
@@ -42,15 +44,40 @@ export function makeDiscoveryConfig(rawResp: DiscoveryConfig): DiscoveryConfig {
   };
 }
 
-function makeAws(rawResp: AwsMatcher[]) {
-  if (!rawResp) {
+function makeAws(rawAwsMatchers): AwsMatcher[] {
+  if (!rawAwsMatchers) {
     return [];
   }
 
-  return rawResp.map(a => ({
+  return rawAwsMatchers.map(a => ({
     types: a.types || [],
     regions: a.regions || [],
     tags: a.tags || {},
     integration: a.integration,
+    kubeAppDiscovery: !!a.kube_app_discovery,
+  }));
+}
+
+function makeDiscoveryConfigReq(inputReq: DiscoveryConfig) {
+  const { name, discoveryGroup, aws } = inputReq;
+
+  return {
+    name,
+    discoveryGroup,
+    aws: makeAwsMatchersReq(aws),
+  };
+}
+
+function makeAwsMatchersReq(inputMatchers: AwsMatcher[]) {
+  if (!inputMatchers) {
+    return [];
+  }
+
+  return inputMatchers.map(a => ({
+    types: a.types || [],
+    regions: a.regions || [],
+    tags: a.tags || {},
+    integration: a.integration,
+    kube_app_discovery: !!a.kubeAppDiscovery,
   }));
 }

--- a/web/packages/teleport/src/services/discovery/discovery.ts
+++ b/web/packages/teleport/src/services/discovery/discovery.ts
@@ -30,7 +30,11 @@ export function createDiscoveryConfig(
   req: DiscoveryConfig
 ): Promise<DiscoveryConfig> {
   return api
-    .post(cfg.getDiscoveryConfigUrl(clusterId), makeDiscoveryConfigReq(req))
+    .post(cfg.getDiscoveryConfigUrl(clusterId), {
+      name: req.name,
+      discoveryGroup: req.discoveryGroup,
+      aws: makeAwsMatchersReq(req.aws),
+    })
     .then(makeDiscoveryConfig);
 }
 
@@ -56,16 +60,6 @@ function makeAws(rawAwsMatchers): AwsMatcher[] {
     integration: a.integration,
     kubeAppDiscovery: !!a.kube_app_discovery,
   }));
-}
-
-function makeDiscoveryConfigReq(inputReq: DiscoveryConfig) {
-  const { name, discoveryGroup, aws } = inputReq;
-
-  return {
-    name,
-    discoveryGroup,
-    aws: makeAwsMatchersReq(aws),
-  };
 }
 
 function makeAwsMatchersReq(inputMatchers: AwsMatcher[]) {

--- a/web/packages/teleport/src/services/discovery/types.ts
+++ b/web/packages/teleport/src/services/discovery/types.ts
@@ -27,20 +27,22 @@ export type DiscoveryConfig = {
   aws: AwsMatcher[];
 };
 
-type AwsMatcherDatabaseTypes = 'ec2' | 'rds';
+type AwsMatcherTypes = 'rds' | 'eks' | 'ec2';
 
-// AWSMatcher matches AWS EC2 instances and AWS Databases
+// AWSMatcher matches AWS EC2 instances, AWS EKS clusters and AWS Databases
 export type AwsMatcher = {
-  // types are AWS database types to match, "ec2", "rds", "redshift", "elasticache",
+  // types are AWS types to match, "ec2", "eks", "rds", "redshift", "elasticache",
   // or "memorydb".
-  types: AwsMatcherDatabaseTypes[];
-  // regions are AWS regions to query for databases.
+  types: AwsMatcherTypes[];
+  // regions are AWS regions to query for resources.
   regions: Regions[];
   // tags are AWS resource tags to match.
   tags: Labels;
   // integration is the integration name used to generate credentials to interact with AWS APIs.
   // Environment credentials will not be used when this value is set.
   integration: string;
+  // kubeAppDiscovery specifies if Kubernetes App Discovery should be enabled for a discovered cluster.
+  kubeAppDiscovery?: boolean;
 };
 
 type Labels = Record<string, string[]>;


### PR DESCRIPTION
This PR adds ability to setup autoenrollment of EKS clusters in the Discover UI using discover configs.

Autoenrollment of EKS is very similar to autoenrollment of RDS databases, so it follows same pattern, even a bit simpler because we don't need to think about deploying DB services. I extracted shared components -`SelfHostedAutoDiscoverDirections` and `AutoEnrollDialog`.

Demo in action: https://www.loom.com/share/5e4e6bb2d6494338ad96cad7964dc711


Changelog: Add auto-enrolling capabilities to EKS discover flow in the web UI