### PR TITLE
[v14] chore: Bump gci to v0.12.3

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -310,7 +310,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.12.1
+RUN go install github.com/daixiang0/gci@v0.12.3
 
 # Install gotestsum.
 RUN go install gotest.tools/gotestsum@v1.10.1


### PR DESCRIPTION
Backport #38400 to branch/v14