### PR TITLE
fix: Avoid tsh panic on Windows Server 2019

### DIFF
--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -61,6 +61,14 @@ func newNativeImpl() *nativeImpl {
 			Debug("WebAuthnWin: failed to load WebAuthn.dll (it's likely missing)")
 		return n
 	}
+	// Load WebAuthNGetApiVersionNumber explicitly too, it avoids a panic on some
+	// Windows Server 2019 installs.
+	if err := procWebAuthNGetApiVersionNumber.Find(); err != nil {
+		log.
+			WithError(err).
+			Debug("WebAuthnWin: failed to load WebAuthNGetApiVersionNumber")
+		return n
+	}
 
 	v, err := webAuthNGetApiVersionNumber()
 	if err != nil {
@@ -69,6 +77,10 @@ func newNativeImpl() *nativeImpl {
 	}
 	n.webauthnAPIVersion = v
 	n.isAvailable = v > 0
+
+	if !n.isAvailable {
+		return n
+	}
 
 	n.hasPlatformUV, err = isUVPlatformAuthenticatorAvailable()
 	if err != nil {


### PR DESCRIPTION
Some Windows installs appear to contain a WebAuthn.dll without WebAuthNGetApiVersionNumber, which leads to a panic. This PR aims to fix that.

<details>
<summary>Error on Windows Server 2019</summary>

```
panic: Failed to find WebAuthNGetApiVersionNumber procedure in WebAuthn.dll: The specified procedure could not be found.

goroutine 1 [running]:
golang.org/x/sys/windows.(*LazyProc).mustFind(...)
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sys@v0.16.0/windows/dll_windows.go:325
golang.org/x/sys/windows.(*LazyProc).Addr(...)
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sys@v0.16.0/windows/dll_windows.go:333
github.com/gravitational/teleport/lib/auth/webauthnwin.webAuthNGetApiVersionNumber()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/zsyscall_windows.go:83 +0xb4
github.com/gravitational/teleport/lib/auth/webauthnwin.newNativeImpl()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/webauthn_windows.go:65 +0xad
github.com/gravitational/teleport/lib/auth/webauthnwin.init()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/webauthn_windows.go:36 +0x169
```
</details>

[WebAuthNGetApiVersionNumber is a v1 procedure on WebAuthn.dll][1], so in its absence we disable WebAuthn support as well (as all bets are off in which other functions may or may not exist).

[1]: https://github.com/microsoft/webauthn/blob/c4d6cdf14be7b9fdaafde20278b6975f1c163fc0/webauthn.h#L58.

Changelog: Avoid tsh/WebAuthn.dll panic on Windows Server 2019