### PR TITLE
Clarify on-prem usage reporting and trusted clusters

### DIFF
--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -39,8 +39,8 @@ anonymization key that's generated and embedded in the license file at
 download time and never shared with us. This makes it infeasible for anyone
 without access to the cluster to deanonymize the data we store.
 
-Each cluster in a [Trusted Clusters](admin/trustedclusters.mdx) setup is
-responsible for reporting about the interactions with its own resources;
+Each cluster in a [Trusted Clusters](./architecture/trustedclusters.mdx) setup
+is responsible for reporting about the interactions with its own resources;
 therefore, all clusters will periodically reach out to Teleport Cloud to report
 usage, and should all be using the same license file for correct aggregate
 measurement.

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -39,6 +39,12 @@ anonymization key that's generated and embedded in the license file at
 download time and never shared with us. This makes it infeasible for anyone
 without access to the cluster to deanonymize the data we store.
 
+Each cluster in a [Trusted Clusters](admin/trustedclusters.mdx) setup is
+responsible for reporting about the interactions with its own resources;
+therefore, all clusters will periodically reach out to Teleport Cloud to report
+usage, and should all be using the same license file for correct aggregate
+measurement.
+
 The code that aggregates and anonymizes this data can be found in our [GitHub
 repository](https://github.com/gravitational/teleport/tree/master/lib/usagereporter/teleport/aggregating).
 


### PR DESCRIPTION
The current docs for usage reporting fail to mention that all clusters in a trusted cluster scenario are going to report on their own events separately; this PR adds a paragraph to clarify that.