### PR TITLE
docs: updates to access graph instructions

### DIFF
--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -41,18 +41,18 @@ The host CA can be retrieved and saved into a file in one of the following ways:
 <Tabs>
 <TabItem label="Via curl">
 ```code
-$ mkdir /etc/access_graph
-$ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=tls-host' > /etc/access_graph/teleport_host_ca.pem
+$ sudo mkdir /etc/access_graph
+$ curl -s 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=tls-host' | sudo tee /etc/access_graph/teleport_host_ca.pem
 ```
 </TabItem>
 
 <TabItem label="Via tctl">
 ```code
-$ mkdir /etc/access_graph
+$ sudo mkdir /etc/access_graph
 $ tsh login --proxy=<Var name="teleport.example.com" />
 $ tctl get cert_authorities --format=json \
     | jq -r '.[] | select(.spec.type == "host") | .spec.active_keys.tls[].cert' \
-    | base64 -d > /etc/access_graph/teleport_host_ca.pem
+    | base64 -d | sudo tee /etc/access_graph/teleport_host_ca.pem
 ```
 </TabItem>
 </Tabs>
@@ -90,7 +90,7 @@ registration_cas:
 Finally, start the TAG service using Docker as follows:
 
 ```console
-$ docker run -v <path-to-config>:/app/config.yaml -v /etc/access_graph:/etc/access_graph public.ecr.aws/gravitational/access-graph:(=access_graph.version=)
+$ docker run -p 50051:50051 -v <path-to-config>:/app/config.yaml -v /etc/access_graph:/etc/access_graph public.ecr.aws/gravitational/access-graph:(=access_graph.version=)
 ```
 
 ## Step 2/3. Update the Teleport Auth Service configuration


### PR DESCRIPTION
- Adds port mapping in `docker run` so the service is exposed on the host
- Include `sudo` and `tee` usage to creating directories and writing to files in protected dirs. Typically users aren't running as `root` to start.