### PR TITLE
Require device trust for initial device registration endpoints

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3089,7 +3089,7 @@ func (a *Server) CreateRegisterChallenge(ctx context.Context, req *proto.CreateR
 		}
 		username = token.GetUser()
 
-	case req.ExistingMFAResponse != nil: // Authenticated user without token, tsh.
+	default: // Authenticated user without token, tsh.
 		var err error
 		username, err = authz.GetClientUsername(ctx)
 		if err != nil {
@@ -3112,9 +3112,6 @@ func (a *Server) CreateRegisterChallenge(ctx context.Context, req *proto.CreateR
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-	default:
-		return nil, trace.BadParameter("either a token or an MFA response are required")
 	}
 
 	regChal, err := a.createRegisterChallenge(ctx, &newRegisterChallengeRequest{

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -532,7 +532,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 			DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
 			DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
 		})
-		assert.ErrorContains(t, err, "token or an MFA response")
+		assert.ErrorContains(t, err, "second factor authentication required")
 
 		// Acquire and solve an authn challenge.
 		authnChal, err := authClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6321,7 +6321,7 @@ func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.C
 	// Device trust: authorize device before issuing a privileged token without an MFA response.
 	if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 		if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "device trust is required for users to create a privileged token without an MFA check")
 		}
 	}
 
@@ -6338,7 +6338,7 @@ func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *prot
 		// Device trust: authorize device before issuing a register challenge without an MFA response or privilege token.
 		if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 			if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
-				return nil, trace.Wrap(err)
+				return nil, trace.Wrap(err, "device trust is required for users to register their first MFA device")
 			}
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6319,6 +6319,11 @@ func (a *ServerWithRoles) CreateAuthenticateChallenge(ctx context.Context, req *
 // CreatePrivilegeToken is implemented by AuthService.CreatePrivilegeToken.
 func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePrivilegeTokenRequest) (*types.UserTokenV3, error) {
 	// Device trust: authorize device before issuing a privileged token without an MFA response.
+	//
+	// This is an exceptional case for that that results in a "privilege_exception" token, which can
+	// used to register a user's first MFA device thorugh the WebUI. Since a register challenge can
+	// be created on behalf of the user using this token (e.g. by the Proxy Service), we must enforce
+	// the device trust requirement seen in [CreatePrivilegeToken] here instead.
 	if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 		if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
 			return nil, trace.Wrap(err, "device trust is required for users to create a privileged token without an MFA check")
@@ -6336,6 +6341,7 @@ func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *prot
 		}
 
 		// Device trust: authorize device before issuing a register challenge without an MFA response or privilege token.
+		// This is an exceptional case for users registering their first MFA challenge through `tsh`.
 		if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 			if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
 				return nil, trace.Wrap(err, "device trust is required for users to register their first MFA device")

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6318,6 +6318,13 @@ func (a *ServerWithRoles) CreateAuthenticateChallenge(ctx context.Context, req *
 
 // CreatePrivilegeToken is implemented by AuthService.CreatePrivilegeToken.
 func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePrivilegeTokenRequest) (*types.UserTokenV3, error) {
+	// Device trust: authorize device before issuing a privileged token without an MFA response.
+	if mfaResp := req.GetExistingMFAResponse(); mfaResp == nil || (mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil) {
+		if err := a.authorizeDevice(ctx); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	return a.authServer.CreatePrivilegeToken(ctx, req)
 }
 
@@ -6329,12 +6336,27 @@ func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *prot
 		if !authz.IsLocalOrRemoteUser(a.context) {
 			return nil, trace.BadParameter("only end users are allowed issue registration challenges without a privilege token")
 		}
+		// Device trust: authorize device before issuing a register challenge without an MFA response or token.
+		if req.ExistingMFAResponse.GetTOTP() == nil && req.ExistingMFAResponse.GetWebauthn() == nil {
+			if err := a.authorizeDevice(ctx); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
 	}
 
 	// The following serve as means of authentication for this RPC:
 	//   - privilege token (or equivalent)
 	//   - authenticated user using non-Proxy identity
 	return a.authServer.CreateRegisterChallenge(ctx, req)
+}
+
+func (a *ServerWithRoles) authorizeDevice(ctx context.Context) error {
+	authPref, err := a.authServer.GetAuthPreference(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = dtauthz.VerifyTLSUser(authPref.GetDeviceTrust(), a.context.Identity.GetIdentity())
+	return trace.Wrap(err)
 }
 
 // GetAccountRecoveryCodes is implemented by AuthService.GetAccountRecoveryCodes.

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1029,7 +1029,8 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	assertAccessDenied := func(t *testing.T, err error) {
-		assert.ErrorIs(t, err, dtauthz.ErrTrustedDeviceRequired)
+		assert.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+		assert.ErrorContains(t, err, dtauthz.ErrTrustedDeviceRequired.Error())
 	}
 
 	tests := []struct {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -989,11 +989,9 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 	authServer := testServer.Auth()
 
 	// Create a user for testing.
-	user, role, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	user, _, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	username := user.GetName()
-	_, err = authServer.UpsertRole(ctx, role)
-	require.NoError(t, err)
 
 	// Create clients with and without device extensions.
 	clientWithoutDevice, err := testServer.NewClient(TestUser(username))
@@ -1076,17 +1074,14 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 			})
 
 			t.Run("CreatePrivilegeTokenRequest", func(t *testing.T) {
-				_, err := test.client.CreatePrivilegeToken(ctx, &proto.CreatePrivilegeTokenRequest{
-					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
-				})
+				_, err := test.client.CreatePrivilegeToken(ctx, &proto.CreatePrivilegeTokenRequest{})
 				test.assertErr(t, err)
 			})
 
 			t.Run("CreateRegisterChallenge", func(t *testing.T) {
 				_, err := test.client.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
-					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
-					DeviceType:          proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
-					DeviceUsage:         proto.DeviceUsage_DEVICE_USAGE_MFA,
+					DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
 				})
 				test.assertErr(t, err)
 			})


### PR DESCRIPTION
Changelog: When device trust is required and MFA is optional, users will need to add their first MFA device from a trusted device.

Note: This this will make it impossible for a user to add their first MFA device from the WebUI, as device trust is not yet supported in the WebUI. They can instead add it with `tsh`. It may also be worth adding device management to Teleport Connect. A fix for device trust in the WebUI may be developed soon - https://github.com/gravitational/teleport.e/issues/3236.