### PR TITLE
Fix docs typo

### DIFF
--- a/docs/pages/desktop-access/reference/configuration.mdx
+++ b/docs/pages/desktop-access/reference/configuration.mdx
@@ -48,7 +48,7 @@ that `windows_desktop_service.listen_addr` is *unset*, and point
 By default, Teleport will set the screen size of the remote desktop session
 based on the size of your browser window. In some cases, you may wish to
 configure specific hosts to use a specific screen size. To do this, set the
-`screen_size` attribute on the `windows_desktop_resource`:
+`screen_size` attribute on the `windows_desktop` resource:
 
 ```yaml
 kind: windows_desktop


### PR DESCRIPTION
No backport necessary, as this was caught before the backport merged