### PR TITLE
[v14] fix: Tidy examples/api-sync-roles/go.mod

### DIFF
--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.19
+go 1.21
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20231017180506-30211ac889e5


### PR DESCRIPTION
Updates the min Go version for the module, as required by its dependencies is Go 1.21.