### PR TITLE
[v15] Fix hostname resolution for connections in leaf clusters

### DIFF
--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -236,6 +236,9 @@ func (h *Handler) executeCommand(
 			LocalAccessPoint:   h.auth.accessPoint,
 			mfaFuncCache:       mfaCacheFn,
 			buffer:             buffer,
+			HostNameResolver: func(serverID string) (string, error) {
+				return serverID, nil
+			},
 		}
 
 		handler, err := newCommandHandler(ctx, commandHandlerConfig)
@@ -467,6 +470,7 @@ func newCommandHandler(ctx context.Context, cfg CommandHandlerConfig) (*commandH
 			router:             cfg.Router,
 			localAccessPoint:   cfg.LocalAccessPoint,
 			tracer:             cfg.tracer,
+			resolver:           cfg.HostNameResolver,
 		},
 		mfaAuthCache: cfg.mfaFuncCache,
 		buffer:       cfg.buffer,
@@ -499,6 +503,9 @@ type CommandHandlerConfig struct {
 	// Anything requests that should be made on behalf of the user should
 	// use [UserAuthClient].
 	LocalAccessPoint localAccessPoint
+	// HostNameResolver allows the hostname to be determined from a server UUID
+	// so that a friendly name can be displayed in the console tab.
+	HostNameResolver func(serverID string) (hostname string, err error)
 	// tracer is used to create spans
 	tracer oteltrace.Tracer
 	// mfaFuncCache is used to cache the MFA auth method

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -135,6 +135,7 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 			interactiveCommand: cfg.InteractiveCommand,
 			router:             cfg.Router,
 			tracer:             cfg.tracer,
+			resolver:           cfg.HostNameResolver,
 		},
 		displayLogin:    cfg.DisplayLogin,
 		term:            cfg.Term,
@@ -161,6 +162,9 @@ type TerminalHandlerConfig struct {
 	// Requests that should be made on behalf of the user should
 	// use [UserAuthClient].
 	LocalAccessPoint localAccessPoint
+	// HostNameResolver allows the hostname to be determined from a server UUID
+	// so that a friendly name can be displayed in the console tab.
+	HostNameResolver func(serverID string) (hostname string, err error)
 	// DisplayLogin is the login name to display in the UI.
 	DisplayLogin string
 	// SessionData is the data to send to the client on the initial session creation.
@@ -275,6 +279,8 @@ type sshBaseHandler struct {
 	localAccessPoint localAccessPoint
 	// interactiveCommand is a command to execute.
 	interactiveCommand []string
+	// resolver looks up the hostname for the server UUID.
+	resolver func(serverID string) (hostname string, err error)
 }
 
 // localAccessPoint is a subset of the cache used to look up
@@ -282,7 +288,6 @@ type sshBaseHandler struct {
 type localAccessPoint interface {
 	GetUser(ctx context.Context, username string, withSecrets bool) (types.User, error)
 	GetRole(ctx context.Context, name string) (types.Role, error)
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 }
 
 // TerminalHandler connects together an SSH session with a web-based
@@ -370,11 +375,12 @@ func (t *TerminalHandler) writeSessionData(ctx context.Context) error {
 		// not be ok since this bypasses user RBAC, however, since at this point we have already
 		// established a connection to the target host via the user identity, the user MUST have
 		// access to the target host.
-		server, err := t.localAccessPoint.GetNode(ctx, apidefaults.Namespace, sessionDataTemp.ServerID)
+
+		hostname, err := t.resolver(sessionDataTemp.ServerID)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		sessionDataTemp.ServerHostname = server.GetHostname()
+		sessionDataTemp.ServerHostname = hostname
 
 		sessionMetadataResponse, err := json.Marshal(siteSessionGenerateResponse{Session: sessionDataTemp})
 		if err != nil {


### PR DESCRIPTION
Backport #38358 to branch/v15

changelog: Fixes an issue that prevented the Web UI from properly displaying the hostname of servers in leaf clusters.
