### PR TITLE
build: Add `tag-publish` recipe to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1164,6 +1164,19 @@ update-tag:
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
 	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
 
+# Publishes a tag build.
+# Starts a tag publish run using e/.github/workflows/tag-publish.yaml
+# for the tag v$(VERSION).
+.PHONY: tag-publish
+tag-publish:
+	@which gh >/dev/null 2>&1 || { echo 'gh command needed. https://github.com/cli/cli'; exit 1; }
+	gh workflow run tag-publish.yaml \
+		--repo gravitational/teleport.e \
+		--ref "v$(VERSION)" \
+		-f "oss-teleport-repo=$(shell gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+		-f "oss-teleport-ref=v$(VERSION)"
+	@echo See runs at: https://github.com/gravitational/teleport.e/actions/workflows/tag-publish.yaml
+
 .PHONY: test-package
 test-package: remove-temp-files
 	go test -v ./$(p)


### PR DESCRIPTION
Add a `tag-publish` recipe to the Makefile to start a workflow run of
the tag-publish workflow. The tag published is the current version tag
as defined by `$(VERSION)` in the Makefile. The version of the
`tag-publish` workflow used is that one tagged with `v$(VERSION)`.

Issue: https://github.com/gravitational/teleport/issues/20732