### PR TITLE
[v13] fix: Avoid tsh panic on Windows Server 2019

### DIFF
--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -57,6 +57,14 @@ func newNativeImpl() *nativeImpl {
 			Debug("WebAuthnWin: failed to load WebAuthn.dll (it's likely missing)")
 		return n
 	}
+	// Load WebAuthNGetApiVersionNumber explicitly too, it avoids a panic on some
+	// Windows Server 2019 installs.
+	if err := procWebAuthNGetApiVersionNumber.Find(); err != nil {
+		log.
+			WithError(err).
+			Debug("WebAuthnWin: failed to load WebAuthNGetApiVersionNumber")
+		return n
+	}
 
 	v, err := webAuthNGetApiVersionNumber()
 	if err != nil {
@@ -65,6 +73,10 @@ func newNativeImpl() *nativeImpl {
 	}
 	n.webauthnAPIVersion = v
 	n.isAvailable = v > 0
+
+	if !n.isAvailable {
+		return n
+	}
 
 	n.hasPlatformUV, err = isUVPlatformAuthenticatorAvailable()
 	if err != nil {


### PR DESCRIPTION
Backport #38444 to branch/v13

changelog: Fixed tsh/WebAuthn.dll panic on Windows Server 2019
