### PR TITLE
Fix incorrect color of resource cards after changing the theme

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -289,7 +289,8 @@ const CardOuterContainer = styled(Box)`
     `}
   transition: all 150ms;
 
-  ${CardContainer}:hover & {
+  // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
+  ${CardContainer}:hover && {
     background-color: ${props => props.theme.colors.levels.surface};
 
     // We use a pseudo element for the shadow with position: absolute in order to prevent


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/38170

It looks like there is a bug (?) in `styled-components` starting from v5.2.0, where replacing dynamic classes work differently than before https://github.com/styled-components/styled-components/issues/3678. 
Changing the theme adds a new class, so after going through dark -> light -> dark, we have two classes with the same names:
![image](https://github.com/gravitational/teleport/assets/20583051/21324cdb-fcc8-4830-9518-ccf42d435f2b)

Using double ampersand fixed the problem. We have to backport it only to v15, in v14 we have styled components v5.1.0 which works fine.

Changelog: Fixed incorrect color of resource cards after changing the theme in Web UI and Connect.