### PR TITLE
Remove `inetutils-telnet` from legacy Ubuntu OCI due to CVE-2021-40491

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04 AS teleport
 
 # Install dumb-init and ca-certificates. The dumb-init package is to ensure
-# signals and orphaned processes are are handled correctly. The ca-certificate
+# signals and orphaned processes are are handled correctly. The ca-certificates
 # package is installed because the base Ubuntu image does not come with any
 # certificate authorities. libelf1 is a dependency introduced by Teleport 7.0.
 #
@@ -24,8 +24,6 @@ FROM ubuntu:20.04 AS teleport
 #   * ping
 #   * ping4
 #   * ping6
-# * inetutils-telnet
-#   * telnet
 # * netcat
 #   * netcat
 # * tcpdump
@@ -43,7 +41,7 @@ RUN apt-get update && \
     # Install dependencies
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates dumb-init libelf1 && \
     # Install tools
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y net-tools iputils-ping inetutils-telnet netcat tcpdump busybox && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y net-tools iputils-ping netcat tcpdump busybox && \
     busybox --install -s && \
     update-ca-certificates && \
     # Cleanup


### PR DESCRIPTION
Ubuntu only fixed CVE-2021-40491 in their paid ESM offering (as `inetutils` is part of `universe`, not `main`), and it's causing security scanners to complain.

While the recommended option is to move to our distroless OCIs which do not have this package installed at all (and are updated daily), an easy fix is just to remove `inetutils-telnet` from the image (as `netcat` is already included).

References:
* https://ubuntu.com/security/CVE-2021-40491
* https://ubuntu.com/security/notices/USN-5177-1
* https://ubuntu.com/security/esm

changelog: Remove `telnet` from legacy Ubuntu OCI due to CVE-2021-40491. Use `nc` instead.