### PR TITLE
[v13] Fix logging output for teleport configure commands. (#38257)

### DIFF
--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -18,13 +18,13 @@ package awsoidc
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -243,7 +243,7 @@ func createBoundaryPolicyForTaskRole(ctx context.Context, clt DeployServiceIAMCo
 		return trace.Wrap(convertedErr)
 	}
 
-	log.Printf("TaskRole: Boundary Policy %q created.\n", req.TaskRoleBoundaryPolicyName)
+	logrus.Infof("TaskRole: Boundary Policy %q created.\n", req.TaskRoleBoundaryPolicyName)
 	return nil
 }
 
@@ -273,7 +273,7 @@ func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, re
 		return trace.Wrap(convertedErr)
 	}
 
-	log.Printf("TaskRole: Role %q created with Boundary %q.\n", req.TaskRole, policyARNForRoleBoundary)
+	logrus.Infof("TaskRole: Role %q created with Boundary %q.\n", req.TaskRole, policyARNForRoleBoundary)
 	return nil
 }
 
@@ -300,7 +300,7 @@ func addPolicyToTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClien
 		return trace.Wrap(err)
 	}
 
-	log.Printf("TaskRole: IAM Policy %q added to Role %q.\n", req.TaskRole, req.TaskRole)
+	logrus.Infof("TaskRole: IAM Policy %q added to Role %q.\n", req.TaskRole, req.TaskRole)
 	return nil
 }
 
@@ -329,6 +329,6 @@ func addPolicyToIntegrationRole(ctx context.Context, clt DeployServiceIAMConfigu
 		return trace.Wrap(err)
 	}
 
-	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleDeployServicePolicy, req.IntegrationRole)
+	logrus.Infof("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleDeployServicePolicy, req.IntegrationRole)
 	return nil
 }

--- a/lib/integrations/awsoidc/eice_iam_config.go
+++ b/lib/integrations/awsoidc/eice_iam_config.go
@@ -18,11 +18,11 @@ package awsoidc
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 )
@@ -140,6 +140,6 @@ func ConfigureEICEIAM(ctx context.Context, clt EICEIAMConfigureClient, req EICEI
 		return trace.Wrap(err)
 	}
 
-	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleEICEPolicy, req.IntegrationRole)
+	logrus.Infof("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleEICEPolicy, req.IntegrationRole)
 	return nil
 }

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -18,7 +18,6 @@ package awsoidc
 
 import (
 	"context"
-	"log"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -26,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -164,7 +164,7 @@ func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMC
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	log.Printf("Using the following thumbprint: %s", thumbprint)
+	logrus.Infof("Using the following thumbprint: %s", thumbprint)
 
 	createOIDCResp, err := clt.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
 		ThumbprintList: []string{thumbprint},
@@ -178,12 +178,12 @@ func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMC
 		}
 		return trace.Wrap(err)
 	}
-	log.Printf("IAM OpenID Connect Provider created: url=%q arn=%q.", req.ProxyPublicAddress, aws.ToString(createOIDCResp.OpenIDConnectProviderArn))
+	logrus.Infof("IAM OpenID Connect Provider created: url=%q arn=%q.", req.ProxyPublicAddress, aws.ToString(createOIDCResp.OpenIDConnectProviderArn))
 
 	if err := createIdPIAMRole(ctx, clt, req); err != nil {
 		return trace.Wrap(err)
 	}
-	log.Printf("IAM Role %q created.", req.IntegrationRole)
+	logrus.Infof("IAM Role %q created.", req.IntegrationRole)
 
 	return nil
 }

--- a/lib/integrations/awsoidc/listdatabases_iam_config.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 )
@@ -91,7 +91,7 @@ func ConfigureListDatabasesIAM(ctx context.Context, clt ListDatabasesIAMConfigur
 		return trace.Wrap(err)
 	}
 
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"policy": defaultPolicyNameForListDatabases,
 		"role":   req.IntegrationRole,
 	}).Info("Added Inline Policy to IAM Role")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -919,6 +919,9 @@ func onJoinOpenSSH(clf config.CommandLineFlags, conf *servicecfg.Config) error {
 func onIntegrationConfDeployService(params config.IntegrationConfDeployServiceIAM) error {
 	ctx := context.Background()
 
+	// Ensure we print output to the user. LogLevel at this point was set to Error.
+	utils.InitLogger(utils.LoggingForDaemon, log.InfoLevel)
+
 	iamClient, err := awsoidc.NewDeployServiceIAMConfigureClient(ctx, params.Region)
 	if err != nil {
 		return trace.Wrap(err)
@@ -941,6 +944,9 @@ func onIntegrationConfDeployService(params config.IntegrationConfDeployServiceIA
 func onIntegrationConfEICEIAM(params config.IntegrationConfEICEIAM) error {
 	ctx := context.Background()
 
+	// Ensure we print output to the user. LogLevel at this point was set to Error.
+	utils.InitLogger(utils.LoggingForDaemon, log.InfoLevel)
+
 	iamClient, err := awsoidc.NewEICEIAMConfigureClient(ctx, params.Region)
 	if err != nil {
 		return trace.Wrap(err)
@@ -959,6 +965,9 @@ func onIntegrationConfEICEIAM(params config.IntegrationConfEICEIAM) error {
 
 func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error {
 	ctx := context.Background()
+
+	// Ensure we print output to the user. LogLevel at this point was set to Error.
+	utils.InitLogger(utils.LoggingForDaemon, log.InfoLevel)
 
 	iamClient, err := awsoidc.NewIdPIAMConfigureClient(ctx, params.Region)
 	if err != nil {
@@ -984,7 +993,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 
 	// Ensure we show progress to the user.
 	// LogLevel at this point is set to Error.
-	log.SetLevel(log.InfoLevel)
+	utils.InitLogger(utils.LoggingForDaemon, log.InfoLevel)
 
 	if params.Region == "" {
 		return trace.BadParameter("region is required")


### PR DESCRIPTION
Backport #38257 to branch/v13

Manual backport, some configure commands were missing and we're not using `slog` package in v13

Changelog: Fixed logging output for `teleport configure ...` commands.