### PR TITLE
[v13] tsh: skip invalid profiles instead of failing

### DIFF
--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -225,7 +225,8 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 		}
 		status, err := s.ReadProfileStatus(profileName)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			s.log.WithError(err).Warnf("skipping profile %q due to error", profileName)
+			continue
 		}
 		profiles = append(profiles, status)
 	}


### PR DESCRIPTION
Backport #38330 to branch/v13

changelog: Ensured that tsh continues to function if one of its profiles is invalid.
