### PR TITLE
fix: Make WebSessionV2.WithoutSecrets truly return a copy

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
@@ -185,11 +186,12 @@ func (ws *WebSessionV2) GetIdleTimeout() time.Duration {
 	return ws.Spec.IdleTimeout.Duration()
 }
 
-// WithoutSecrets returns copy of the object but without secrets
+// WithoutSecrets returns a copy of the WebSession without secrets.
 func (ws *WebSessionV2) WithoutSecrets() WebSession {
-	ws.Spec.Priv = nil
-	ws.Spec.SAMLSession = nil
-	return ws
+	cp := proto.Clone(ws).(*WebSessionV2)
+	cp.Spec.Priv = nil
+	cp.Spec.SAMLSession = nil
+	return cp
 }
 
 // SetConsumedAccessRequestID sets the ID of the access request from which additional roles to assume were obtained.


### PR DESCRIPTION
Change WithoutSecrets so it doesn't modify the session, but instead returns a copy.

Related to https://github.com/gravitational/teleport.e/issues/3236.