### PR TITLE
Add the cluster configuration RPC service

### DIFF
--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -1,0 +1,260 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/modules"
+)
+
+// Cache is used by the [Service] to query cluster config resources.
+type Cache interface {
+	GetAuthPreference(context.Context) (types.AuthPreference, error)
+}
+
+// Backend is used by the [Service] to mutate cluster config resources.
+type Backend interface {
+	CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+}
+
+// ServiceConfig contain dependencies required to create a [Service].
+type ServiceConfig struct {
+	Cache      Cache
+	Backend    Backend
+	Authorizer authz.Authorizer
+}
+
+// Service implements the teleport.clusterconfig.v1.ClusterConfigService RPC service.
+type Service struct {
+	clusterconfigpb.UnimplementedClusterConfigServiceServer
+
+	cache      Cache
+	backend    Backend
+	authorizer authz.Authorizer
+}
+
+// NewService validates the provided configuration and returns a [Service].
+func NewService(cfg ServiceConfig) (*Service, error) {
+	switch {
+	case cfg.Cache == nil:
+		return nil, trace.BadParameter("cache service is required")
+	case cfg.Backend == nil:
+		return nil, trace.BadParameter("backend service is required")
+	case cfg.Authorizer == nil:
+		return nil, trace.BadParameter("authorizer is required")
+	}
+
+	return &Service{cache: cfg.Cache, backend: cfg.Backend, authorizer: cfg.Authorizer}, nil
+}
+
+// GetAuthPreference returns the locally cached auth preference.
+func (s Service) GetAuthPreference(ctx context.Context, _ *clusterconfigpb.GetAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pref, err := s.cache.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := pref.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", pref, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// CreateAuthPreference creates a new auth preference if one does not exist. This
+// is an internal API and is not exposed via [clusterconfigv1.ClusterConfigServiceServer]. It
+// is only meant to be called directly from the first time an Auth instance is started.
+func (s Service) CreateAuthPreference(ctx context.Context, p types.AuthPreference) (types.AuthPreference, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzCtx, string(types.RoleAuth)) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if p.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(p.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := s.backend.CreateAuthPreference(ctx, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := created.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", created, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// UpdateAuthPreference conditional updates an existing auth preference if the value
+// wasn't concurrently modified.
+func (s Service) UpdateAuthPreference(ctx context.Context, req *clusterconfigpb.UpdateAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if req.AuthPreference.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req.AuthPreference.SetOrigin(types.OriginDynamic)
+
+	updated, err := s.backend.UpdateAuthPreference(ctx, req.AuthPreference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := updated.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", updated, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+func (s Service) UpsertAuthPreference(ctx context.Context, req *clusterconfigpb.UpsertAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Support reused MFA for bulk tctl create requests.
+	if err := authzCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if req.AuthPreference.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req.AuthPreference.SetOrigin(types.OriginDynamic)
+
+	updated, err := s.backend.UpsertAuthPreference(ctx, req.AuthPreference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := updated.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", updated, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// ResetAuthPreference restores the auth preferences to the default value.
+func (s Service) ResetAuthPreference(ctx context.Context, req *clusterconfigpb.ResetAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	defaultPreference := types.DefaultAuthPreference()
+	const iterationLimit = 3
+	// Attempt a few iterations in case the conditional update fails
+	// due to spurious networking conditions.
+	for i := 0; i < iterationLimit; i++ {
+		pref, err := s.cache.GetAuthPreference(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if pref.Origin() == types.OriginConfigFile {
+			return nil, trace.BadParameter("auth preference has been defined via the config file and cannot be reset back to defaults dynamically.")
+		}
+
+		defaultPreference.SetRevision(pref.GetRevision())
+
+		reset, err := s.backend.UpdateAuthPreference(ctx, defaultPreference)
+		if err != nil {
+			if trace.IsCompareFailed(err) {
+				continue
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		authPrefV2, ok := reset.(*types.AuthPreferenceV2)
+		if !ok {
+			return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", reset, authPrefV2))
+		}
+
+		return authPrefV2, nil
+	}
+
+	return nil, trace.LimitExceeded("failed to reset networking config within %v iterations", iterationLimit)
+}

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -1,0 +1,580 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestCreateAuthPreference(t *testing.T) {
+	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+		Role:     types.RoleAuth,
+		Username: string(types.RoleAuth),
+	}, nil)
+	require.NoError(t, err, "creating auth role context")
+
+	cases := []struct {
+		name       string
+		modules    modules.Modules
+		authorizer authz.Authorizer
+		preference func(p types.AuthPreference)
+		assertion  func(t *testing.T, created types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized built in role",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authz.ContextForBuiltinRole(authz.BuiltinRole{
+					Role:     types.RoleProxy,
+					Username: string(types.RoleProxy),
+				}, nil)
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating auth preferences", err)
+			},
+		},
+		{
+			name: "authorized built in auth",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected hardware key policy to be rejected in OSS", err)
+			},
+		},
+		{
+			name: "creation allowed when hardware key policy is set in enterprise",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.SetDeviceTrust(&types.DeviceTrust{
+					Mode: constants.DeviceTrustModeRequired,
+				})
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected device trust mode conflict to prevent creation", err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.modules != nil {
+				modules.SetTestModules(t, test.modules)
+			}
+
+			var opts []serviceOpt
+			if test.authorizer != nil {
+				opts = append(opts, withAuthorizer(test.authorizer))
+			}
+
+			env, err := newTestEnv(opts...)
+			require.NoError(t, err, "creating test service")
+
+			pref := types.DefaultAuthPreference()
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			created, err := env.CreateAuthPreference(context.Background(), pref)
+			test.assertion(t, created, err)
+		})
+	}
+}
+
+func TestGetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), unauthorized user to be prevented from getting auth preferences", err)
+			},
+		}, {
+			name: "authorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetAuthPreference(context.Background(), &clusterconfigpb.GetAuthPreferenceRequest{})
+			test.assertion(t, err)
+			if err == nil {
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			}
+		})
+	}
+}
+
+func TestUpdateAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "updated",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpdateAuthPreference(context.Background(), &clusterconfigpb.UpdateAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestUpsertAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "access prevented",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "upserted",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpsertAuthPreference(context.Background(), &clusterconfigpb.UpsertAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestResetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		modules    modules.Modules
+		preference types.AuthPreference
+		assertion  func(t *testing.T, reset types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "config file origin prevents reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func() types.AuthPreference {
+				p := types.DefaultAuthPreference()
+				p.SetOrigin(types.OriginConfigFile)
+				return p
+			}(),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			p := types.DefaultAuthPreference()
+			if test.preference != nil {
+				p = test.preference
+			}
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(p))
+			require.NoError(t, err, "creating test service")
+
+			reset, err := env.ResetAuthPreference(context.Background(), &clusterconfigpb.ResetAuthPreferenceRequest{})
+			test.assertion(t, reset, err)
+		})
+	}
+}
+
+type fakeChecker struct {
+	services.AccessChecker
+	rules map[string][]string
+}
+
+func (f fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string) error {
+	verbs, ok := f.rules[kind]
+	if !ok {
+		return trace.AccessDenied("no allow rules for kind")
+	}
+
+	if !slices.Contains(verbs, verb) {
+		return trace.AccessDenied("verb %s not allowed", verb)
+	}
+
+	return nil
+}
+
+type envConfig struct {
+	authorizer            authz.Authorizer
+	defaultAuthPreference types.AuthPreference
+}
+type serviceOpt = func(config *envConfig)
+
+func withAuthorizer(authz authz.Authorizer) serviceOpt {
+	return func(config *envConfig) {
+		config.authorizer = authz
+	}
+}
+
+func withDefaultAuthPreference(p types.AuthPreference) serviceOpt {
+	return func(config *envConfig) {
+		config.defaultAuthPreference = p
+	}
+}
+
+type env struct {
+	*clusterconfigv1.Service
+	backend           clusterconfigv1.Backend
+	defaultPreference types.AuthPreference
+}
+
+func newTestEnv(opts ...serviceOpt) (*env, error) {
+	bk, err := memory.New(memory.Config{})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating memory backend")
+	}
+
+	storage, err := local.NewClusterConfigurationService(bk)
+	if err != nil {
+		return nil, trace.Wrap(err, "created cluster configuration storage service")
+	}
+
+	var cfg envConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	service := struct{ services.ClusterConfiguration }{ClusterConfiguration: storage}
+	svc, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
+		Cache:      service,
+		Backend:    service,
+		Authorizer: cfg.authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating users service")
+	}
+
+	var defaultPreference types.AuthPreference
+	if cfg.defaultAuthPreference != nil {
+		defaultPreference, err = service.CreateAuthPreference(context.Background(), cfg.defaultAuthPreference)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating default auth preference")
+		}
+	}
+
+	return &env{
+		Service:           svc,
+		backend:           service,
+		defaultPreference: defaultPreference,
+	}, nil
+}


### PR DESCRIPTION
The new clusterconfigv1.Service implements the gRPC service defined in teleport.clusterconfig.v1.ClusterConfigService. The initial implementation is restricted to supporting cluster auth preferences. Support for remaining cluster configuration resources will come in a series of future PRs. Once all of the resources are covered the service will be added to the Auth server and consumers of the old API will be migrated.