### PR TITLE
[v14] Give access list warning for review in CLI in more user friendly manner

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4371,9 +4371,9 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 			var msg string
 			nextAuditDate := accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly)
 			if time.Now().After(accessList.Spec.Audit.NextAuditDate) {
-				msg = fmt.Sprintf("review was required on %v", nextAuditDate)
+				msg = fmt.Sprintf("review is overdue (%v)", nextAuditDate)
 			} else {
-				msg = fmt.Sprintf("review date is %v", nextAuditDate)
+				msg = fmt.Sprintf("review is required by %v", nextAuditDate)
 			}
 			fmt.Printf("\t%s (%v)\n", accessList.Spec.Title, msg)
 		}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4367,7 +4367,6 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 
 	if len(accessListsToReview) > 0 {
 		fmt.Printf("Access lists that need to be reviewed:\n")
-		// date time format layout
 		for _, accessList := range accessListsToReview {
 			var msg string
 			nextAuditDate := accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4368,15 +4368,13 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 	if len(accessListsToReview) > 0 {
 		fmt.Printf("Access lists that need to be reviewed:\n")
 		// date time format layout
-		const YYYYMMDD = "2006-01-02"
 		for _, accessList := range accessListsToReview {
-			d := time.Until(accessList.Spec.Audit.NextAuditDate).Round(time.Minute)
-			nextAuditDate := accessList.Spec.Audit.NextAuditDate.Format(YYYYMMDD)
 			var msg string
-			if d > 0 {
-				msg = fmt.Sprintf("review date is %v", nextAuditDate)
-			} else {
+			nextAuditDate := accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly)
+			if time.Now().After(accessList.Spec.Audit.NextAuditDate) {
 				msg = fmt.Sprintf("review was required on %v", nextAuditDate)
+			} else {
+				msg = fmt.Sprintf("review date is %v", nextAuditDate)
 			}
 			fmt.Printf("\t%s (%v)\n", accessList.Spec.Title, msg)
 		}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4367,13 +4367,16 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 
 	if len(accessListsToReview) > 0 {
 		fmt.Printf("Access lists that need to be reviewed:\n")
+		// date time format layout
+		const YYYYMMDD = "2006-01-02"
 		for _, accessList := range accessListsToReview {
 			d := time.Until(accessList.Spec.Audit.NextAuditDate).Round(time.Minute)
+			nextAuditDate := accessList.Spec.Audit.NextAuditDate.Format(YYYYMMDD)
 			var msg string
 			if d > 0 {
-				msg = fmt.Sprintf("%v left to review", d.String())
+				msg = fmt.Sprintf("review date is %v", nextAuditDate)
 			} else {
-				msg = fmt.Sprintf("review was required %v ago", (-d).String())
+				msg = fmt.Sprintf("review was required on %v", nextAuditDate)
 			}
 			fmt.Printf("\t%s (%v)\n", accessList.Spec.Title, msg)
 		}


### PR DESCRIPTION
Backport #38494 to branch/v14

changelog: Displays review dates for access lists in dates, not remaining hours in tsh.
