### PR TITLE
Add missing redirects

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -3188,6 +3188,16 @@
       "source": "/application-access/enroll-kubernetes-applications/reference/",
       "destination": "/auto-discovery/kubernetes-applications/reference/",
       "permanent": true
+    },
+    {
+      "source": "/server-access/guides/openssh/openssh-manual-install/",
+      "destination": "/server-access/openssh/openssh-manual-install/",
+      "permanent": true
+    },
+    {
+      "source": "/server-access/guides/openssh/openssh/",
+      "destination": "/server-access/openssh/openssh/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
The changes in #38161 reorganized pages in the Server Access section of the docs, but did not add redirects for these pages. This change adds the missing redirects.