### PR TITLE
Prevent page reload after clicking 'Reconnect'

### DIFF
--- a/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
+++ b/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
@@ -74,7 +74,8 @@ export function OfflineGateway(props: {
       )}
       <Flex
         as="form"
-        onSubmit={() => {
+        onSubmit={e => {
+          e.preventDefault();
           setReconnectRequested(true);
           props.reconnect(props.gatewayPort.isSupported ? port : undefined);
         }}


### PR DESCRIPTION
When I was adding an `OfflineGateway` component, I forgot to call `preventDefault()` in `onSubmit` handler. This causes the page reload, fortunately only in the dev mode.  

I also inspected all other `onSubmit` handlers in Connect, we have `preventDefault()` in them. 