### PR TITLE
[v15] Fix incorrect color of resource cards after changing the theme

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -289,7 +289,8 @@ const CardOuterContainer = styled(Box)`
     `}
   transition: all 150ms;
 
-  ${CardContainer}:hover & {
+  // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
+  ${CardContainer}:hover && {
     background-color: ${props => props.theme.colors.levels.surface};
 
     // We use a pseudo element for the shadow with position: absolute in order to prevent


### PR DESCRIPTION
Backport #38496 to branch/v15

changelog: Fixed incorrect color of resource cards after changing the theme in Web UI and Connect
