### PR TITLE
Fix accidental form submission on back button

### DIFF
--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
@@ -208,10 +208,10 @@ export function ReauthenticateStep({
               />
             )}
             <Flex gap={2}>
-              <ButtonPrimary block={true} type="submit">
+              <ButtonPrimary type="submit" block={true}>
                 Verify my identity
               </ButtonPrimary>
-              <ButtonSecondary block={true} onClick={onClose}>
+              <ButtonSecondary type="button" block={true}>
                 Cancel
               </ButtonSecondary>
             </Flex>
@@ -499,12 +499,12 @@ export function SaveDeviceStep({
               />
             )}
             <Flex gap={2}>
-              <ButtonPrimary block={true} type="submit">
+              <ButtonPrimary type="submit" block={true}>
                 {usage === 'passwordless'
                   ? 'Save the Passkey'
                   : 'Save the MFA method'}
               </ButtonPrimary>
-              <ButtonSecondary block={true} onClick={prev}>
+              <ButtonSecondary type="button" block={true} onClick={prev}>
                 Back
               </ButtonSecondary>
             </Flex>

--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
@@ -211,7 +211,7 @@ export function ReauthenticateStep({
               <ButtonPrimary type="submit" block={true}>
                 Verify my identity
               </ButtonPrimary>
-              <ButtonSecondary type="button" block={true}>
+              <ButtonSecondary type="button" block={true} onClick={onClose}>
                 Cancel
               </ButtonSecondary>
             </Flex>


### PR DESCRIPTION
This PR fixes an omission where the form's submit handler is executed under the hood even if we pressed the back button. This went unnoticed, because most of the time, either the form gets torn down or validation prevents further action.