### PR TITLE
Fix menu positioning to be below the clicked element

### DIFF
--- a/web/packages/shared/components/AwsLaunchButton.tsx
+++ b/web/packages/shared/components/AwsLaunchButton.tsx
@@ -65,7 +65,7 @@ export class AwsLaunchButton extends React.Component<Props> {
             horizontal: 'right',
           }}
           anchorOrigin={{
-            vertical: 'center',
+            vertical: 'bottom',
             horizontal: 'right',
           }}
           getContentAnchorEl={null}

--- a/web/packages/shared/components/MenuAction/MenuActionButton.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionButton.tsx
@@ -79,7 +79,7 @@ export default class MenuActionIcon extends React.Component<
             horizontal: 'right',
           }}
           anchorOrigin={{
-            vertical: 'center',
+            vertical: 'bottom',
             horizontal: 'right',
           }}
           {...menuProps}

--- a/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
@@ -70,7 +70,7 @@ export default class MenuActionIcon extends React.Component<
           open={open}
           onClose={this.onClose}
           anchorOrigin={{
-            vertical: 'center',
+            vertical: 'bottom',
             horizontal: 'center',
           }}
           transformOrigin={{

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -89,7 +89,7 @@ const NodeConnect = ({ node }: { node: Node }) => {
         horizontal: 'right',
       }}
       anchorOrigin={{
-        vertical: 'center',
+        vertical: 'bottom',
         horizontal: 'right',
       }}
     />
@@ -129,7 +129,7 @@ const DesktopConnect = ({ desktop }: { desktop: Desktop }) => {
         horizontal: 'right',
       }}
       anchorOrigin={{
-        vertical: 'center',
+        vertical: 'bottom',
         horizontal: 'right',
       }}
     />

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -81,7 +81,7 @@ export function ConnectServerActionButton(props: {
         horizontal: 'right',
       }}
       anchorOrigin={{
-        vertical: 'center',
+        vertical: 'bottom',
         horizontal: 'right',
       }}
     />
@@ -167,7 +167,7 @@ export function ConnectDatabaseActionButton(props: {
         horizontal: 'right',
       }}
       anchorOrigin={{
-        vertical: 'center',
+        vertical: 'bottom',
         horizontal: 'right',
       }}
     />


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/37260
This PR fixes an issue where our menus would overlap with the clicked element. 
![image (9)](https://github.com/gravitational/teleport/assets/5201977/cb4140d1-4f72-46e2-a46c-94d0efd2af73)

Updated version looks like this
![Screenshot 2024-02-22 at 10 41 32 AM](https://github.com/gravitational/teleport/assets/5201977/d21706d0-bb47-446b-b4e0-f914ce93f7a1)


This wasn't an issue with the component and just with how we were passing in our props. My guess is the first implementation had it at "center" and then we all just copy-pasted it from there. 