### PR TITLE
remove unused `GenerateIdPServiceProviderFromFields` func

### DIFF
--- a/lib/services/saml_idp_service_provider.go
+++ b/lib/services/saml_idp_service_provider.go
@@ -106,24 +106,6 @@ func UnmarshalSAMLIdPServiceProvider(data []byte, opts ...MarshalOption) (types.
 	return nil, trace.BadParameter("unsupported SAML IdP service provider resource version %q", h.Version)
 }
 
-// GenerateIdPServiceProviderFromFields takes `name` and `entityDescriptor` fields and returns a SAMLIdPServiceProvider.
-func GenerateIdPServiceProviderFromFields(name string, entityDescriptor string) (types.SAMLIdPServiceProvider, error) {
-	if len(name) == 0 {
-		return nil, trace.BadParameter("missing name")
-	}
-	if len(entityDescriptor) == 0 {
-		return nil, trace.BadParameter("missing entity descriptor")
-	}
-
-	var s types.SAMLIdPServiceProviderV1
-	s.SetName(name)
-	s.SetEntityDescriptor(entityDescriptor)
-	if err := s.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &s, nil
-}
-
 // supportedACSBindings is the set of AssertionConsumerService bindings that teleport supports.
 var supportedACSBindings = map[string]struct{}{
 	saml.HTTPPostBinding:     {},


### PR DESCRIPTION
The `GenerateIdPServiceProviderFromFields` func was initially used in [upsertSAMLIdPServiceProviderHandle](https://github.com/gravitational/teleport.e/blob/master/lib/web/plugin.go#L177) handler, which is used to process SAML IdP service provider create request coming from Web UI. 

The func implements field validation, which is redundant we already do that in [SAMLIdPServiceProviderV1.CheckAndSetDefaults](https://github.com/gravitational/teleport/blob/master/api/types/saml_idp_service_provider.go#L225). 

I removed it entirely in my [PR](https://github.com/gravitational/teleport.e/pull/3034/files#diff-0d56602231d0b3ec70520c48c0c84449bf6f76e27aa9aafcc460a88230e0e1bf) as it is also not a good strategy to have two different func validating inputs for a same resource type and action (it will be tricky to keep both in sync). 

My PR was added in `e` and I missed to remove this func back then.
