### PR TITLE
Web: Show Questionnaire to new OSS users

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -57,7 +57,7 @@ import {
 import { NavigationCategory } from 'teleport/Navigation/categories';
 import { TopBarProps } from 'teleport/TopBar/TopBar';
 import { useUser } from 'teleport/User/UserContext';
-import { QuestionnaireProps } from 'teleport/Welcome/NewCredentials';
+import { QuestionnaireProps } from 'teleport/Welcome/Shared/types';
 
 import { MainContainer } from './MainContainer';
 import { OnboardDiscover } from './OnboardDiscover';

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
@@ -29,6 +29,7 @@ import cfg from 'teleport/config';
 import { loginFlows } from 'teleport/Welcome/NewCredentials/constants';
 
 import useToken from '../useToken';
+import { Questionnaire as OpenSourceQuestionnaire } from '../Questionnaire/Questionnaire';
 
 import { Expired } from './Expired';
 import { LoginFlow, NewCredentialsProps } from './types';
@@ -43,11 +44,16 @@ import { RegisterSuccess } from './Success';
  */
 export function Container({ tokenId = '', resetMode = false }) {
   const state = useToken(tokenId);
+  const [displayOpenSourceQuestionnaire, setDisplayOpenSourceQuestionnaire] =
+    useState(!cfg.isEnterprise && !resetMode);
+
   return (
     <NewCredentials
       {...state}
       resetMode={resetMode}
       isDashboard={cfg.isDashboard}
+      displayOnboardingQuestionnaire={displayOpenSourceQuestionnaire}
+      setDisplayOnboardingQuestionnaire={setDisplayOpenSourceQuestionnaire}
     />
   );
 }
@@ -118,6 +124,22 @@ export function NewCredentials(props: NewCredentialsProps) {
           username={resetToken.user}
           onSubmit={() => setDisplayOnboardingQuestionnaire(false)}
           onboard={true}
+        />
+      </OnboardCard>
+    );
+  }
+
+  if (
+    success &&
+    !cfg.isEnterprise &&
+    !resetMode &&
+    displayOnboardingQuestionnaire &&
+    setDisplayOnboardingQuestionnaire
+  ) {
+    return (
+      <OnboardCard>
+        <OpenSourceQuestionnaire
+          onSubmit={() => setDisplayOnboardingQuestionnaire(false)}
         />
       </OnboardCard>
     );

--- a/web/packages/teleport/src/Welcome/NewCredentials/types.ts
+++ b/web/packages/teleport/src/Welcome/NewCredentials/types.ts
@@ -26,6 +26,8 @@ import { ReactElement } from 'react';
 
 import { RecoveryCodes, ResetToken } from 'teleport/services/auth';
 
+import { QuestionnaireProps } from '../Shared/types';
+
 export type UseTokenState = {
   auth2faType: Auth2faType;
   primaryAuthType: PrimaryAuthType;
@@ -40,13 +42,6 @@ export type UseTokenState = {
   redirect: () => void;
   success: boolean;
   finishedRegister: () => void;
-};
-
-// Note: QuestionnaireProps is duplicated in Enterprise (e-teleport/Welcome/Questionnaire/Questionnaire)
-export type QuestionnaireProps = {
-  onboard: boolean;
-  username?: string;
-  onSubmit?: () => void;
 };
 
 // Note: InviteCollaboratorsCardProps is duplicated in Enterprise

--- a/web/packages/teleport/src/Welcome/Questionnaire/Company.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Company.tsx
@@ -1,0 +1,63 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Option } from 'shared/components/Select';
+import FieldInput from 'shared/components/FieldInput';
+import FieldSelect from 'shared/components/FieldSelect';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import { EmployeeSelectOptions } from './constants';
+import { CompanyProps, EmployeeOption } from './types';
+
+export const Company = ({
+  updateFields,
+  companyName,
+  numberOfEmployees,
+}: CompanyProps) => (
+  <>
+    <FieldInput
+      label="Company Name"
+      rule={requiredField('Company Name is required')}
+      id="company-name"
+      type="text"
+      value={companyName}
+      placeholder="ex. GitHub"
+      onChange={e => {
+        updateFields({ companyName: e.target.value });
+      }}
+    />
+    <FieldSelect
+      label="Number of Employees"
+      rule={requiredField('Number of Employees is required')}
+      placeholder="Select Company Size"
+      onChange={(e: Option<EmployeeOption>) =>
+        updateFields({ employeeCount: e.value })
+      }
+      value={
+        numberOfEmployees
+          ? {
+              label: numberOfEmployees,
+              value: numberOfEmployees,
+            }
+          : null
+      }
+      options={EmployeeSelectOptions}
+    />
+  </>
+);

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.story.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.story.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { WelcomeWrapper } from 'design/Onboard/WelcomeWrapper';
+import { OnboardCard } from 'design/Onboard/OnboardCard';
+
+import { Questionnaire } from './Questionnaire';
+
+export default {
+  title: 'Teleport/Welcome/Questionnaire',
+  args: { userContext: true },
+};
+
+export const Full = () => {
+  return (
+    <WelcomeWrapper>
+      <OnboardCard>
+        <Questionnaire onSubmit={() => null} />
+      </OnboardCard>
+    </WelcomeWrapper>
+  );
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
+
+import { Questionnaire } from './Questionnaire';
+
+describe('questionnaire', () => {
+  let spyFetch;
+  beforeEach(() => {
+    spyFetch = jest.spyOn(global, 'fetch').mockResolvedValue(null);
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  test('loads each question and expected', async () => {
+    const mockSubmit = jest.fn();
+    render(<Questionnaire onSubmit={mockSubmit} />);
+
+    expect(screen.getByText('Tell us about yourself')).toBeInTheDocument();
+    expect(screen.getByLabelText('Company Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Number of Employees')).toBeInTheDocument();
+    expect(screen.getByLabelText('Which Team are you on?')).toBeInTheDocument();
+    expect(screen.getByLabelText('Job Title')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Which infrastructure resources do you need to access frequently?'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /skip/i }));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows validation errors', async () => {
+    const mockSubmit = jest.fn();
+    render(<Questionnaire onSubmit={mockSubmit} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/i }));
+
+    expect(
+      screen.getByLabelText('Company Name is required')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Number of Employees is required')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Team is required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Job Title is required')).toBeInTheDocument();
+    expect(screen.getByText('Resource is required')).toBeInTheDocument();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  test('form submission', async () => {
+    const mockSubmit = jest.fn();
+    render(<Questionnaire onSubmit={mockSubmit} />);
+
+    const companyNameInput: HTMLInputElement =
+      screen.getByLabelText('Company Name');
+    fireEvent.change(companyNameInput, { target: { value: 'Teleport' } });
+    expect(companyNameInput.value).toBe('Teleport');
+
+    await userEvent.click(screen.getByText(/Select Company Size/i));
+    await userEvent.click(screen.getByText(/5000+/i));
+
+    await userEvent.click(screen.getByText(/Select Team/i));
+    await userEvent.click(screen.getByText(/Legal/i));
+
+    await userEvent.click(screen.getByText(/Select Job Title/i));
+    await userEvent.click(screen.getByText(/VP/i));
+
+    await userEvent.click(screen.getByText(/Applications/i));
+    await userEvent.click(screen.getByText(/Desktops/i));
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/i }));
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+    const formData = new FormData();
+    formData.set('title', 'VP');
+    formData.set('teamsize', '5000+');
+    formData.set('team', 'LEGAL');
+    formData.set('company', 'Teleport');
+    formData.set(
+      'access_needs',
+      JSON.stringify(['RESOURCE_WEB_APPLICATIONS', 'RESOURCE_WINDOWS_DESKTOPS'])
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const sentFormData = spyFetch.mock.calls[0][1].body;
+    const gotFormData = Object.fromEntries(sentFormData.entries());
+
+    expect(Object.fromEntries(formData.entries())).toEqual(gotFormData);
+  });
+});

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
@@ -29,7 +29,11 @@ import { useQuestionnaire } from 'teleport/Welcome/Questionnaire/useQuestionnair
  * -F "teamsize=200" \
  * -F "team=Development Team" \
  * -F "company=ACME Corp" \
- * -F "access_needs=ssh,k8s
+ * -F "access_needs=["RESOURCE_WEB_APPLICATIONS","RESOURCE_KUBERNETES"]
+ *
+ * Note: New API added to CLI Survey Endpoint.
+ * Added to same endpoint as the CURL post install message.
+ * https://github.com/gravitational/peopleware/blob/main/rfd/0001-adoption-metrics.md
  */
 const PRODUCT_SURVEY_ENDPOINT = 'https://usage.teleport.dev/productsurvey';
 

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
@@ -1,0 +1,74 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Validator } from 'shared/components/Validation';
+
+import { QuestionnaireComponent } from 'teleport/Welcome/Questionnaire';
+import { useQuestionnaire } from 'teleport/Welcome/Questionnaire/useQuestionnaire';
+
+/**
+ * Endpoint expects form data fields in the following format:
+ * curl -X POST https://usage.teleport.dev/productsurvey \
+ * -F "title=Eng" \
+ * -F "teamsize=200" \
+ * -F "team=Development Team" \
+ * -F "company=ACME Corp" \
+ * -F "access_needs=ssh,k8s
+ */
+const PRODUCT_SURVEY_ENDPOINT = 'https://usage.teleport.dev/productsurvey';
+
+export const Questionnaire = ({ onSubmit }: { onSubmit(): void }) => {
+  const { formFields, updateForm } = useQuestionnaire();
+
+  const submitForm = async (validator: Validator, isSkipping = false) => {
+    if (isSkipping) {
+      onSubmit();
+      return;
+    }
+
+    if (!validator.validate()) {
+      return;
+    }
+
+    let formData = new FormData();
+    formData.set('title', formFields.role);
+    formData.set('teamsize', formFields.employeeCount);
+    formData.set('team', formFields.team);
+    formData.set('company', formFields.companyName);
+    formData.set('access_needs', JSON.stringify(formFields.resources));
+
+    // Ignore any errors.
+    fetch(PRODUCT_SURVEY_ENDPOINT, {
+      method: 'POST',
+      body: formData,
+    });
+
+    // Callback to continue flow
+    onSubmit();
+  };
+
+  return (
+    <QuestionnaireComponent
+      submitForm={submitForm}
+      updateForm={updateForm}
+      formFields={formFields}
+      canSkip={true}
+    />
+  );
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
@@ -73,13 +73,6 @@ export function QuestionnaireComponent({
             <Flex gap={3} mt={3}>
               {canSkip ? (
                 <>
-                  <ButtonSecondary
-                    width="50%"
-                    size="large"
-                    onClick={() => submitForm(validator, true)}
-                  >
-                    Skip
-                  </ButtonSecondary>
                   <ButtonPrimary
                     width="50%"
                     size="large"
@@ -87,6 +80,13 @@ export function QuestionnaireComponent({
                   >
                     Submit
                   </ButtonPrimary>
+                  <ButtonSecondary
+                    width="50%"
+                    size="large"
+                    onClick={() => submitForm(validator, true)}
+                  >
+                    Skip
+                  </ButtonSecondary>
                 </>
               ) : (
                 <ButtonPrimary

--- a/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
@@ -1,0 +1,106 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { ButtonPrimary, Indicator, Text, Flex, ButtonSecondary } from 'design';
+import Validation, { Validator } from 'shared/components/Validation';
+import { Attempt } from 'shared/hooks/useAttemptNext';
+
+import { Role } from './Role';
+import { Resources } from './Resources';
+import { Company } from './Company';
+import { QuestionnaireFormFields } from './types';
+
+export type QuestionnaireComponentProps = {
+  formFields: QuestionnaireFormFields;
+  updateForm(f: QuestionnaireFormFields): void;
+  attempt?: Attempt;
+  submitForm(v: Validator, skip?: boolean): Promise<void>;
+  wantFullSurvey?: boolean;
+  canSkip?: boolean;
+};
+
+export function QuestionnaireComponent({
+  attempt,
+  submitForm,
+  wantFullSurvey = true,
+  formFields,
+  updateForm,
+  canSkip = false,
+}: QuestionnaireComponentProps) {
+  if (attempt?.status === 'processing') {
+    return <Indicator />;
+  }
+  return (
+    <>
+      <Text typography="h2" mb={4}></Text>
+      Tell us about yourself
+      <Validation>
+        {({ validator }) => (
+          <>
+            {wantFullSurvey && (
+              <Company
+                companyName={formFields.companyName}
+                numberOfEmployees={formFields.employeeCount}
+                updateFields={updateForm}
+              />
+            )}
+            <Role
+              role={formFields.role}
+              team={formFields.team}
+              teamName={formFields.teamName}
+              updateFields={updateForm}
+            />
+            <Resources
+              checked={formFields.resources}
+              updateFields={updateForm}
+            />
+            <Flex gap={3} mt={3}>
+              {canSkip ? (
+                <>
+                  <ButtonPrimary
+                    width="50%"
+                    size="large"
+                    onClick={() => submitForm(validator)}
+                  >
+                    Submit
+                  </ButtonPrimary>
+                  <ButtonSecondary
+                    width="50%"
+                    size="large"
+                    onClick={() => submitForm(validator, true)}
+                  >
+                    Skip
+                  </ButtonSecondary>
+                </>
+              ) : (
+                <ButtonPrimary
+                  width="100%"
+                  size="large"
+                  onClick={() => submitForm(validator)}
+                >
+                  Submit
+                </ButtonPrimary>
+              )}
+            </Flex>
+          </>
+        )}
+      </Validation>
+    </>
+  );
+}

--- a/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/QuestionnaireComponent.tsx
@@ -73,13 +73,6 @@ export function QuestionnaireComponent({
             <Flex gap={3} mt={3}>
               {canSkip ? (
                 <>
-                  <ButtonPrimary
-                    width="50%"
-                    size="large"
-                    onClick={() => submitForm(validator)}
-                  >
-                    Submit
-                  </ButtonPrimary>
                   <ButtonSecondary
                     width="50%"
                     size="large"
@@ -87,6 +80,13 @@ export function QuestionnaireComponent({
                   >
                     Skip
                   </ButtonSecondary>
+                  <ButtonPrimary
+                    width="50%"
+                    size="large"
+                    onClick={() => submitForm(validator)}
+                  >
+                    Submit
+                  </ButtonPrimary>
                 </>
               ) : (
                 <ButtonPrimary

--- a/web/packages/teleport/src/Welcome/Questionnaire/ResourceWrapper.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/ResourceWrapper.ts
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+import { Flex } from 'design';
+
+export const ResourceWrapper = styled(Flex)`
+  flex-direction: column;
+  height: 100%;
+  background-color: ${props => props.theme.colors.levels.surface};
+  padding: 12px;
+  gap: 8px;
+  border-radius: ${props => props.theme.radii[2]}px;
+
+  border: ${({ isSelected, invalid, theme }) => {
+    if (isSelected) {
+      return `1px solid ${theme.colors.brand}`;
+    }
+    if (invalid) {
+      return `1px solid ${theme.colors.error.main}`;
+    }
+    return `1px solid ${theme.colors.levels.elevated}`;
+  }};
+
+  &:hover {
+    background-color: ${props => props.theme.colors.spotBackground[0]};
+    box-shadow: ${({ theme }) => theme.boxShadow[2]};
+  }
+
+  &:focus-within {
+    background-color: ${props => props.theme.colors.spotBackground[1]};
+    border: 1px solid ${props => props.theme.colors.text.slightlyMuted};
+  }
+`;

--- a/web/packages/teleport/src/Welcome/Questionnaire/Resources.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Resources.tsx
@@ -1,0 +1,117 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Flex, LabelInput, Text } from 'design';
+import React from 'react';
+import Image from 'design/Image';
+import { CheckboxInput } from 'design/Checkbox';
+import { useRule } from 'shared/components/Validation';
+import { Option } from 'shared/components/Select';
+
+import {
+  GetResourceIcon,
+  requiredResourceField,
+  ResourceOptions,
+} from './constants';
+
+import { ResourceOption, ResourcesProps } from './types';
+import { ResourceWrapper } from './ResourceWrapper';
+
+export const Resources = ({ checked, updateFields }: ResourcesProps) => {
+  const { valid, message } = useRule(requiredResourceField(checked));
+
+  const updateResources = (r: Option<string, ResourceOption>) => {
+    const selected = r.value as ResourceOption;
+    let updated = checked;
+    if (updated.includes(selected)) {
+      updated = updated.filter(r => r !== (selected as ResourceOption));
+    } else {
+      updated.push(selected);
+    }
+
+    updateFields({ resources: updated });
+  };
+
+  const renderCheck = (resource: Option<string, ResourceOption>) => {
+    const isSelected = checked.includes(resource.value as ResourceOption);
+    return (
+      <label
+        htmlFor={`box-${resource.value}`}
+        data-testid={`box-${resource.value}`}
+        key={resource.value}
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        onClick={() => updateResources(resource)}
+      >
+        <ResourceWrapper isSelected={isSelected} invalid={!valid}>
+          <CheckboxInput
+            aria-labelledby="resources"
+            data-testid={`check-${resource.value}`}
+            role="checkbox"
+            type="checkbox"
+            name={resource.label}
+            readOnly
+            checked={checked.includes(resource.value as ResourceOption)}
+            rule={requiredResourceField(checked)}
+            style={{
+              alignSelf: 'flex-end',
+              margin: '0',
+              outline: 'none',
+            }}
+          />
+          <Flex
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="space-around"
+            height="100%"
+            gap={2}
+          >
+            <Image
+              src={GetResourceIcon(resource.label)}
+              height="64px"
+              width="64px"
+            />
+            <Text textAlign="center" typography="paragraph2">
+              {resource.label}
+            </Text>
+          </Flex>
+        </ResourceWrapper>
+      </label>
+    );
+  };
+
+  return (
+    <>
+      <Flex gap={1} mb={1}>
+        <LabelInput htmlFor={'resources'} hasError={!valid}>
+          {valid
+            ? `Which infrastructure resources do you need to access frequently?`
+            : message}
+          <i>&nbsp;Select all that apply.</i>
+        </LabelInput>
+      </Flex>
+      <Flex gap={2} alignItems="flex-start" height="160px">
+        {ResourceOptions.map((r: Option<string, ResourceOption>) =>
+          renderCheck(r)
+        )}
+      </Flex>
+    </>
+  );
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from 'design/utils/testing';
+
+import React from 'react';
+
+import Validation from 'shared/components/Validation';
+
+import { RoleProps, TeamOption } from './types';
+import { Role } from './Role';
+
+const makeProps = (): RoleProps => {
+  return {
+    role: undefined,
+    team: undefined,
+    teamName: '',
+    updateFields: () => {},
+  };
+};
+
+test('hides custom team input for explicit fields', () => {
+  const props = makeProps();
+  render(
+    <Validation>
+      <Role {...props} />
+    </Validation>
+  );
+
+  expect(screen.queryByLabelText('Team Name')).not.toBeInTheDocument();
+});
+
+test('shows custom team input', () => {
+  const props = makeProps();
+  props.team = 'OTHER' as TeamOption;
+  render(
+    <Validation>
+      <Role {...props} />
+    </Validation>
+  );
+
+  expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
@@ -1,0 +1,73 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Option } from 'shared/components/Select';
+import FieldSelect from 'shared/components/FieldSelect';
+import { requiredField } from 'shared/components/Validation/rules';
+import FieldInput from 'shared/components/FieldInput';
+
+import { RoleProps, TeamOption, TitleOption } from './types';
+import { teamSelectOptions, titleSelectOptions } from './constants';
+
+export const Role = ({ team, teamName, role, updateFields }: RoleProps) => (
+  <>
+    <FieldSelect
+      label="Which Team are you on?"
+      rule={requiredField('Team is required')}
+      placeholder="Select Team"
+      onChange={(e: Option<TeamOption>) => updateFields({ team: e.value })}
+      options={teamSelectOptions}
+      value={
+        team
+          ? {
+              value: team,
+              label: TeamOption[team],
+            }
+          : null
+      }
+    />
+    {TeamOption[team] === TeamOption.OTHER && (
+      <FieldInput
+        id="team-name"
+        type="text"
+        label="Team Name"
+        rule={requiredField('Team Name is required')}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          updateFields({ teamName: e.target.value })
+        }
+        value={teamName}
+      />
+    )}
+    <FieldSelect
+      label="Job Title"
+      rule={requiredField('Job Title is required')}
+      placeholder="Select Job Title"
+      onChange={(e: Option<TitleOption>) => updateFields({ role: e.value })}
+      options={titleSelectOptions}
+      value={
+        role
+          ? {
+              value: role,
+              label: TitleOption[role],
+            }
+          : null
+      }
+    />
+  </>
+);

--- a/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
@@ -1,0 +1,94 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import application from 'design/assets/resources/appplication.png';
+import desktop from 'design/assets/resources/desktop.png';
+import database from 'design/assets/resources/database.png';
+import kubernetes from 'design/assets/resources/kubernetes.png';
+import stack from 'design/assets/resources/stack.png';
+import { Option } from 'shared/components/Select';
+import { assertUnreachable } from 'shared/utils/assertUnreachable';
+
+import { Resource } from 'gen-proto-ts/teleport/userpreferences/v1/onboard_pb';
+
+import {
+  EmployeeOption,
+  ResourceOption,
+  TeamOption,
+  TitleOption,
+} from './types';
+
+export const EmployeeSelectOptions: Option<string, EmployeeOption>[] =
+  Object.keys(EmployeeOption).map(key => ({
+    value: EmployeeOption[key],
+    label: EmployeeOption[key],
+  }));
+
+export const teamSelectOptions: Option<string, TeamOption>[] = (
+  Object.keys(TeamOption) as Array<keyof typeof TeamOption>
+).map(key => ({
+  value: key,
+  label: TeamOption[key],
+}));
+
+export const titleSelectOptions: Option<string, TitleOption>[] = (
+  Object.keys(TitleOption) as Array<keyof typeof TitleOption>
+).map(key => ({
+  value: key,
+  label: TitleOption[key],
+}));
+
+export const ResourceOptions: Option<string, ResourceOption>[] = Object.keys(
+  ResourceOption
+).map(key => ({
+  value: key,
+  label: ResourceOption[key],
+}));
+
+export const GetResourceIcon = (key: ResourceOption) => {
+  switch (key) {
+    case ResourceOption.RESOURCE_WEB_APPLICATIONS:
+      return application;
+    case ResourceOption.RESOURCE_WINDOWS_DESKTOPS:
+      return desktop;
+    case ResourceOption.RESOURCE_SERVER_SSH:
+      return stack;
+    case ResourceOption.RESOURCE_DATABASES:
+      return database;
+    case ResourceOption.RESOURCE_KUBERNETES:
+      return kubernetes;
+    default:
+      return assertUnreachable(key);
+  }
+};
+
+export const requiredResourceField = (value: ResourceOption[]) => () => {
+  const valid = !!value.length;
+  return {
+    valid,
+    message: 'Resource is required',
+  };
+};
+
+export const resourceMapping: { [key in ResourceOption]: Resource } = {
+  [ResourceOption.RESOURCE_WINDOWS_DESKTOPS]: Resource.WINDOWS_DESKTOPS,
+  [ResourceOption.RESOURCE_SERVER_SSH]: Resource.SERVER_SSH,
+  [ResourceOption.RESOURCE_DATABASES]: Resource.DATABASES,
+  [ResourceOption.RESOURCE_KUBERNETES]: Resource.KUBERNETES,
+  [ResourceOption.RESOURCE_WEB_APPLICATIONS]: Resource.WEB_APPLICATIONS,
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/index.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { QuestionnaireComponent } from './QuestionnaireComponent';

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -47,8 +47,8 @@ export enum EmployeeOption {
   FOUR = '200-499',
   FIVE = '500-999',
   SIX = '1000-4999',
-  SEVEN = '5000+',
-  EIGHT = '10,000+',
+  SEVEN = '5,000-9,999',
+  EIGHT = '10,000-19,999',
   NINE = '20,000+',
 }
 

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type QuestionProps = {
+  updateFields: (fields: Partial<QuestionnaireFormFields>) => void;
+};
+
+export type CompanyProps = QuestionProps & {
+  companyName: string;
+  numberOfEmployees: EmployeeOption;
+};
+
+export type RoleProps = QuestionProps & {
+  role: TitleOption;
+  team: TeamOption;
+  teamName: string;
+};
+
+export type ResourceType = {
+  label: ResourceOption;
+  image: string;
+};
+
+export type ResourcesProps = QuestionProps & {
+  checked: ResourceOption[];
+};
+
+export enum EmployeeOption {
+  ONE = '0-19',
+  TWO = '20-199',
+  THREE = '200-499',
+  FOUR = '500-999',
+  FIVE = '1000-4999',
+  SIX = '5000+',
+}
+
+export enum TeamOption {
+  SOFTWARE_ENGINEERING = 'Software Engineering',
+  DEVOPS_ENGINEERING = 'DevOps Engineering',
+  IT = 'IT',
+  SUPPORT = 'Support',
+  FINANCE = 'Finance',
+  LEGAL = 'Legal',
+  OTHER = 'Other (free-form field)',
+}
+
+export enum TitleOption {
+  INDIVIDUAL_CONTRIBUTOR = 'Individual contributor',
+  MANAGER = 'Manager',
+  DIRECTOR = 'Director',
+  VP = 'VP',
+  C_SUITE_OWNER = 'C-Suite/Owner',
+}
+
+export type ResourceKey = keyof typeof ResourceOption;
+
+export enum ResourceOption {
+  RESOURCE_WEB_APPLICATIONS = 'Web Applications',
+  RESOURCE_WINDOWS_DESKTOPS = 'Windows Desktops',
+  RESOURCE_SERVER_SSH = 'Server/SSH',
+  RESOURCE_DATABASES = 'Databases',
+  RESOURCE_KUBERNETES = 'Kubernetes',
+}
+
+export type QuestionnaireFormFields = {
+  companyName: string;
+  employeeCount: EmployeeOption;
+  role: TitleOption;
+  team: TeamOption;
+  resources: ResourceOption[];
+  teamName: string;
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -41,12 +41,15 @@ export type ResourcesProps = QuestionProps & {
 };
 
 export enum EmployeeOption {
-  ONE = '0-19',
-  TWO = '20-199',
-  THREE = '200-499',
-  FOUR = '500-999',
-  FIVE = '1000-4999',
-  SIX = '5000+',
+  ONE = '1 - 9',
+  TWO = '10-19',
+  THREE = '20-199',
+  FOUR = '200-499',
+  FIVE = '500-999',
+  SIX = '1000-4999',
+  SEVEN = '5000+',
+  EIGHT = '10,000+',
+  NINE = '20,000+',
 }
 
 export enum TeamOption {

--- a/web/packages/teleport/src/Welcome/Questionnaire/useQuestionnaire.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/useQuestionnaire.ts
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import { QuestionnaireFormFields } from 'teleport/Welcome/Questionnaire/types';
+
+export function useQuestionnaire() {
+  const [formFields, setFormFields] = useState<QuestionnaireFormFields>({
+    companyName: '',
+    employeeCount: undefined,
+    team: undefined,
+    teamName: '',
+    role: undefined,
+    resources: [],
+  });
+
+  const updateForm = (fields: Partial<QuestionnaireFormFields>) => {
+    setFormFields({
+      role: fields.role ?? formFields.role,
+      team: fields.team ?? formFields.team,
+      teamName: fields.teamName ?? formFields.teamName,
+      resources: fields.resources ?? formFields.resources,
+      companyName: fields.companyName ?? formFields.companyName,
+      employeeCount: fields.employeeCount ?? formFields.employeeCount,
+    });
+  };
+
+  return {
+    formFields,
+    setFormFields,
+    updateForm,
+  };
+}

--- a/web/packages/teleport/src/Welcome/Shared/types.ts
+++ b/web/packages/teleport/src/Welcome/Shared/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type QuestionnaireProps = {
+  // Onboard indicates if the questionnaire is being shown during onboarding (true) or
+  // after login (false). This impacts the submission of the form.
+  onboard: boolean;
+  // Username is optional; it is only required during the onboarding flow to submit a posthog event.
+  // After login, we use the auth endpoint to set the user.
+  username?: string;
+  // onSubmit is an optional callback to handle parent interaction.
+  onSubmit?: () => void;
+};


### PR DESCRIPTION
suggest reviewing by commit, commit 1 is moving files

- [ ] requires https://github.com/gravitational/teleport/pull/38598

Show the same questionnaire that used to be for new cloud user only, to every new user for community version of teleport

This PR uses same exact form as existed in enterprise.
PR is largely moving shareable files into OSS and made a shareable questionnaire component.

enterprise changes: https://github.com/gravitational/teleport.e/pull/3528

cc @benarent 

Only difference in the form is that OSS questionnaire is `skippable`:

<img width="710" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/321d8b4a-6497-42c1-b561-3950ca59b7e4">
