### PR TITLE
Bump timeout in `WaitForActiveTunnelConnections`

### DIFF
--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -158,7 +158,7 @@ func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnelclient.Ser
 		_, err = cluster.GetClient()
 		assert.NoError(t, err, "cluster not yet available")
 	},
-		30*time.Second,
+		90*time.Second,
 		time.Second,
 		"Active tunnel connections did not reach %v in the expected time frame %v", expectedCount, 30*time.Second,
 	)


### PR DESCRIPTION
Investigating flakiness in `TestIntegrations/Discovery` showed that it can legitimately take over 30 seconds for some expected tunnels to show up, purely depending on how unlucky we get when hitting the load balancer in the test.

This PR "fixes" the flakiness by bumping the timeout to 90 seconds, while we search for a more sensible way to speed up the tunnel reconnection process in tests.

Temporarily works around #26663.