### PR TITLE
Add event constants for DeviceWebToken creation

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -633,6 +633,12 @@ const (
 	// Device enroll tokens are issued by either a device admin or during
 	// client-side auto-enrollment.
 	DeviceEnrollTokenCreateEvent = "device.token.create"
+	// DeviceWebTokenCreateEvent is emitted when a new device web token is issued.
+	// Device web tokens are issued during Web login for users that own a suitable
+	// trusted device.
+	// Tokens are spent in exchange for a single on-behalf-of device
+	// authentication attempt.
+	DeviceWebTokenCreateEvent = "device.webtoken.create"
 
 	// BotJoinEvent is emitted when a bot joins
 	BotJoinEvent = "bot.join"

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -456,6 +456,8 @@ const (
 	DeviceAuthenticateCode = "TV006I"
 	// DeviceUpdateCode is the device update code.
 	DeviceUpdateCode = "TV007I"
+	// DeviceWebTokenCreateCode is the device web token creation code.
+	DeviceWebTokenCreateCode = "TV008I"
 
 	// LoginRuleCreateCode is the login rule create code.
 	LoginRuleCreateCode = "TLR00I"


### PR DESCRIPTION
Add the event "type" and "code" constants for DeviceWebToken creation.

See [RFD 0009e][1].

https://github.com/gravitational/teleport.e/issues/3236

[1]: https://github.com/gravitational/teleport.e/pull/3489/files#diff-fb36e70f063f6e16e3b3964322039f3a50e399a5428f44b7eb615e6670405511R506