### PR TITLE
Support writing certs to virtual profile

### DIFF
--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -60,6 +60,8 @@ func newTestAuthority(t *testing.T) testAuthority {
 	}
 }
 
+const testDBName = "example-db"
+
 // makeSignedKey helper returns a new user key signed by CAPriv key.
 func (s *testAuthority) makeSignedKey(t *testing.T, idx KeyIndex, makeExpired bool) *Key {
 	priv, err := s.keygen.GeneratePrivateKey()
@@ -107,7 +109,7 @@ func (s *testAuthority) makeSignedKey(t *testing.T, idx KeyIndex, makeExpired bo
 	key.Cert = cert
 	key.TLSCert = tlsCert
 	key.TrustedCerts = []auth.TrustedCerts{s.trustedCerts}
-	key.DBTLSCerts["example-db"] = tlsCert
+	key.DBTLSCerts[testDBName] = tlsCert
 	return key
 }
 

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -666,6 +666,7 @@ func (ms *MemKeyStore) DeleteKey(idx KeyIndex) error {
 	// We're not sure which part of the virtual path belongs to the key, so we burn everything
 	for _, env := range os.Environ() {
 		if strings.HasPrefix(env, VirtualPathEnvPrefix) {
+			env = strings.Split(env, "=")[0]
 			// Files might not be here, we can ignore the errors
 			_ = deleteFileIfEnvVar(env)
 		}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -578,19 +578,19 @@ func (ms *MemKeyStore) AddKey(key *Key) error {
 	}
 
 	for kube, cert := range key.KubeTLSCerts {
-		envName = VirtualPathEnvName(VirtualPathKubernetes, []string{kube})
+		envName = VirtualPathEnvName(VirtualPathKubernetes, VirtualPathKubernetesParams(kube))
 		if err := writeBytesIfEnvVar(cert, envName); err != nil {
 			return trace.Wrap(err, "writing kube certs to virtual profile")
 		}
 	}
 	for app, cert := range key.AppTLSCerts {
-		envName = VirtualPathEnvName(VirtualPathApp, []string{app})
+		envName = VirtualPathEnvName(VirtualPathApp, VirtualPathAppParams(app))
 		if err := writeBytesIfEnvVar(cert, envName); err != nil {
 			return trace.Wrap(err, "writing app certs to virtual profile")
 		}
 	}
 	for db, cert := range key.DBTLSCerts {
-		envName = VirtualPathEnvName(VirtualPathDatabase, []string{db})
+		envName = VirtualPathEnvName(VirtualPathDatabase, VirtualPathDatabaseParams(db))
 		if err := writeBytesIfEnvVar(cert, envName); err != nil {
 			return trace.Wrap(err, "writing db certs to virtual profile")
 		}

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -138,7 +138,7 @@ func TestVirtualPath(t *testing.T) {
 	// Delete everything but they key, check if the cert is gone and the key still here
 	err = keyStore.DeleteUserCerts(idx, WithDBCerts{})
 	require.NoError(t, err)
-	dbContent, err = os.ReadFile(dbPath)
+	_, err = os.ReadFile(dbPath)
 	require.Error(t, err, "DB certs should be deleted")
 	keyContent, err = os.ReadFile(keyPath)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestVirtualPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that the key file got removed
-	keyContent, err = os.ReadFile(keyPath)
+	_, err = os.ReadFile(keyPath)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
Naive attempt to fix https://github.com/gravitational/teleport/issues/38592

The in-memory key and trust store now lookup the virtual profile env vars and write certs/keys when possible.