### PR TITLE
Allow Survey URL in connect-src for index CSP

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 // Mutex protected cache for memoizing functions which construct the CSP header string.
@@ -177,6 +178,12 @@ func getIndexContentSecurityPolicy(withStripe, withWasm bool) cspMap {
 
 	if withWasm {
 		cspMaps = append(cspMaps, wasmSecurityPolicy)
+	}
+
+	// Allows a URL for collecting surveys and feedback:
+	// https://github.com/gravitational/peopleware/blob/main/rfd/0001-adoption-metrics.md
+	if modules.GetModules().BuildType() == modules.BuildOSS {
+		cspMaps = append(cspMaps, cspMap{"connect-src": {"https://usage.teleport.dev"}})
 	}
 
 	return combineCSPMaps(cspMaps...)

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -375,6 +375,8 @@ func TestSetIndexContentSecurityPolicy_EnterpriseBuild(t *testing.T) {
 			}
 		})
 	}
+
+	indexCSPStringCache = newCSPCache()
 }
 
 func TestSetIndexContentSecurityPolicy_OSSBuild(t *testing.T) {
@@ -432,6 +434,8 @@ func TestSetIndexContentSecurityPolicy_OSSBuild(t *testing.T) {
 			}
 		})
 	}
+
+	indexCSPStringCache = newCSPCache()
 }
 
 func TestSetAppLaunchContentSecurityPolicy(t *testing.T) {


### PR DESCRIPTION
required in this PR https://github.com/gravitational/teleport/pull/38561. it's a questionnaire we show to new community users, and it sends the questionnaire info to this survey collecting URL `https://usage.teleport.dev`

