### PR TITLE
docs: update iam joining helm example

### DIFF
--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -254,7 +254,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --set proxyAddr=${PROXY?} \
   --set joinParams.method=iam \
   --set joinParams.tokenName=<Var name="kube-iam-token"/> \
-  --set serviceAccount.create=false  \
+  --set serviceAccount.create=false \
   --set serviceAccount.name=<Var name="teleport-kube-agent-sa"/> \
   --create-namespace \
   --namespace=<Var name="teleport-agent"/> \

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -246,14 +246,16 @@ Switch `kubectl` to the Kubernetes cluster and run:
 # Deploy a Kubernetes agent. It dials back to the Teleport cluster tele.example.com.
 $ CLUSTER=iam-cluster
 $ PROXY=tele.example.com:443
+# Install the Teleport Kubernetes agent. Does not create a service account and uses the existing
+#   service account. See serviceAccount.create and serviceAccount.name parameters.
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=${CLUSTER?} \
   --set roles="kube\,app\,discovery" \
   --set proxyAddr=${PROXY?} \
   --set joinParams.method=iam \
   --set joinParams.tokenName=<Var name="kube-iam-token"/> \
-  --set serviceAccount.create=false # do not create a new service account # \
-  --set serviceAccount.name=<Var name="teleport-kube-agent-sa"/> # use the existing service account # \
+  --set serviceAccount.create=false  \
+  --set serviceAccount.name=<Var name="teleport-kube-agent-sa"/> \
   --create-namespace \
   --namespace=<Var name="teleport-agent"/> \
   --version (=teleport.version=)


### PR DESCRIPTION
`#` comments  in a line that is a continued line command breaks copy and paste so it becomes multiple lines.  Attempting to use gets a multiple command attempt instead of one line as intended. Could not find another example with comments like this.

Reported in https://goteleport.slack.com/archives/CEZH6UL64/p1708871457857789