### PR TITLE
Add improvements for the EKS Discover UI.

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -332,6 +332,7 @@ func enrollEKSCluster(ctx context.Context, log logrus.FieldLogger, clock clockwo
 	if alreadyInstalled, err := clt.CheckAgentAlreadyInstalled(ctx, kubeClientGetter, log); err != nil {
 		return "", trace.Wrap(err, "could not check if teleport-kube-agent is already installed.")
 	} else if alreadyInstalled {
+		// Web UI relies on the text of this error message. If changed, sync with EnrollEksCluster.tsx
 		return "", trace.AlreadyExists("teleport-kube-agent is already installed on the cluster %q", clusterName)
 	}
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -221,7 +221,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       } else if (
         result.error &&
         !result.error.message.includes(
-          'teleport-kube-agent is already installed'
+          'teleport-kube-agent is already installed on the cluster'
         )
       ) {
         setEnrollmentState({

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Box, ButtonSecondary, ButtonText, Text, Toggle } from 'design';
+import { Box, ButtonSecondary, ButtonText, Link, Text, Toggle } from 'design';
 import styled from 'styled-components';
 import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
@@ -218,7 +218,12 @@ export function EnrollEksCluster(props: AgentStepProps) {
         emitErrorEvent(
           'unknown error: no results came back from enrolling the EKS cluster.'
         );
-      } else if (result.error) {
+      } else if (
+        result.error &&
+        !result.error.message.includes(
+          'teleport-kube-agent is already installed'
+        )
+      ) {
         setEnrollmentState({
           status: 'error',
           error: `Cluster enrollment error: ${result.error}`,
@@ -293,6 +298,17 @@ export function EnrollEksCluster(props: AgentStepProps) {
       {fetchClustersAttempt.status === 'failed' && !hasIamPermError && (
         <Danger mt={3}>{fetchClustersAttempt.statusText}</Danger>
       )}
+      <Text mt={4} mb={-3}>
+        <b>Note:</b> EKS enrollment will work only with clusters that have
+        access entries authentication mode enabled, see{' '}
+        <Link
+          href="https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html#authentication-modes"
+          target="_blank"
+          color="text.main"
+        >
+          documentation.
+        </Link>
+      </Text>
       <Text mt={4}>
         Select the AWS Region you would like to see EKS clusters for:
       </Text>
@@ -346,7 +362,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
                 }}
                 pl={0}
               >
-                Or click here to see instructions for manual enrollment
+                Or do manual enrollment
               </ButtonText>
             </Box>
           </StyledBox>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -298,7 +298,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
       {fetchClustersAttempt.status === 'failed' && !hasIamPermError && (
         <Danger mt={3}>{fetchClustersAttempt.statusText}</Danger>
       )}
-      <Text mt={4} mb={-3}>
+      <Text mt={4}>
         <b>Note:</b> EKS enrollment will work only with clusters that have
         access entries authentication mode enabled, see{' '}
         <Link
@@ -309,7 +309,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
           documentation.
         </Link>
       </Text>
-      <Text mt={4}>
+      <Text mt={1}>
         Select the AWS Region you would like to see EKS clusters for:
       </Text>
       <AwsRegionSelector

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -362,7 +362,7 @@ export function EnrollEksCluster(props: AgentStepProps) {
                 }}
                 pl={0}
               >
-                Or do manual enrollment
+                Or enroll manually
               </ButtonText>
             </Box>
           </StyledBox>


### PR DESCRIPTION
This PR adds a few small improvements to the Discover EKS flow - 
- Add a note informing user about access entries auth mode requirements
- Change label text for the manual instructions.
- If we encounter an error about agent already installed on the cluster, just skip to the step 2 "waiting" (there's small time window when this can happen).