### PR TITLE
[v15] Avoid busting the layer cache when installing `osslsigncode` in buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -187,9 +187,9 @@ RUN apt-get -y update && \
 # Code Signing Certificate needs us to use osslsigncode >= 2.6, which
 # allows the use of legacy OpenSSL algorithms. This is not yet provided
 # by Ubuntu, so we will have to fetch it ourselves.
-RUN --mount=type=bind,target=/context \
+RUN --mount=type=bind,source=download-hashes/osslsigncode.sha256,target=/context/osslsigncode.sha256 \
     curl -L https://github.com/mtrojnar/osslsigncode/releases/download/2.6/osslsigncode-2.6-ubuntu-22.04.zip -o osslsigncode.zip \
-    && sha256sum --strict -c /context/download-hashes/osslsigncode.sha256 \
+    && sha256sum --strict -c /context/osslsigncode.sha256 \
     && unzip -d /tmp/osslsigncode osslsigncode.zip \
     && install -m 0755 /tmp/osslsigncode/bin/osslsigncode /usr/bin \
     && rm -rf /tmp/osslsigncode \


### PR DESCRIPTION
Backport #38289 to branch/v15