### PR TITLE
Remove otel from dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,6 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
-      # The latest otel version contains a data race. Ignore any updates until the issue
-      # is resolved.
-      - dependency-name: go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws
-      - dependency-name: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-      - dependency-name: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-      - dependency-name: go.opentelemetry.io/otel
-      - dependency-name: go.opentelemetry.io/otel/exporters/otlp/otlptrace
-      - dependency-name: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
-      - dependency-name: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
-      - dependency-name: go.opentelemetry.io/otel/metric
-      - dependency-name: go.opentelemetry.io/otel/sdk
-      - dependency-name: go.opentelemetry.io/otel/trace
       # Breaks backwards compatibility
       - dependency-name: github.com/gravitational/ttlmap
       # Must be kept in-sync with libbpf


### PR DESCRIPTION
The latest version of otel has fixed the data races that were preventing us from upgrading. Removing the dependencies from the ignore list so that dependabot can update them.



<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/CHANGELOG.md">go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc's changelog</a>.</em></p>
<blockquote>
<h2>[1.24.0/0.49.0/0.18.0/0.4.0] - 2024-02-23</h2>
<p>This release is the last to support [Go 1.20].
The next release will require at least [Go 1.21].</p>
<h3>Added</h3>
<ul>
<li>Support [Go 1.22]. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/5082">#5082</a>)</li>
<li>Add support for Summary metrics to <code>go.opentelemetry.io/contrib/bridges/prometheus</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/5089">#5089</a>)</li>
<li>Add support for Exponential (native) Histograms in <code>go.opentelemetry.io/contrib/bridges/prometheus</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/5093">#5093</a>)</li>
</ul>
<h3>Removed</h3>
<ul>
<li>The deprecated <code>RequestCount</code> constant in <code>go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp</code> is removed. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/4894">#4894</a>)</li>
<li>The deprecated <code>RequestContentLength</code> constant in <code>go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp</code> is removed. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/4894">#4894</a>)</li>
<li>The deprecated <code>ResponseContentLength</code> constant in <code>go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp</code> is removed. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/4894">#4894</a>)</li>
<li>The deprecated <code>ServerLatency</code> constant in <code>go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp</code> is removed. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/4894">#4894</a>)</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Retrieving the body bytes count in <code>go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp</code> does not cause a data race anymore. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-go-contrib/issues/5080">#5080</a>)</li>
</ul>