### PR TITLE
chore: Group large dependency "families" separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     ignore:
+      # AWS, otel and k8s have their own groups.
+      - dependency-name: github.com/aws/*
+      - dependency-name: go.opentelemetry.io/*
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
       # Breaks backwards compatibility
       - dependency-name: github.com/gravitational/ttlmap
       # Must be kept in-sync with libbpf
@@ -43,6 +48,83 @@ updates:
       interval: weekly
       day: "sunday"
       time: "09:00" # 9am UTC
+    open-pull-requests-limit: 10
+    groups:
+      go:
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - codingllama
+      - jentfoo
+      - rosstimothy
+      - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
+
+  # Group certain dependencies together.
+  # These contain numerous packages and are either frequently updated (AWS) or
+  # better updated in lockstep (k8s, otel).
+  # AWS group.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    allow:
+      - dependency-name: github.com/aws/*
+    open-pull-requests-limit: 10
+    groups:
+      go:
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - codingllama
+      - jentfoo
+      - rosstimothy
+      - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
+  # otel group.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    allow:
+      - dependency-name: go.opentelemetry.io/*
+    open-pull-requests-limit: 10
+    groups:
+      go:
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - codingllama
+      - jentfoo
+      - rosstimothy
+      - zmb3
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
+  # k8s group.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "sunday"
+      time: "09:00" # 9am UTC
+    allow:
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
     open-pull-requests-limit: 10
     groups:
       go:


### PR DESCRIPTION
Group big dependency "families" together in order to make reviews easier and certain updates safer.

Ideally some groups, like otel, would include "/" and "/api", but I don't see an option to do that.

This should also solve the problem of recent dependabot PRs not having changelogs, or having a trimmed description, because too many packages are updated at once.