### PR TITLE
Prevent overflow in sort functions provided to slices.SortFunc

### DIFF
--- a/api/types/instance.go
+++ b/api/types/instance.go
@@ -295,7 +295,7 @@ func (i *InstanceV1) AppendControlLog(entries ...InstanceControlLogEntry) {
 		i.Spec.ControlLog[idx].Time = entry.Time.UTC()
 	}
 	slices.SortFunc(i.Spec.ControlLog, func(a, b InstanceControlLogEntry) int {
-		return int(a.Time.UnixNano() - b.Time.UnixNano())
+		return a.Time.Compare(b.Time)
 	})
 }
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -19,6 +19,7 @@
 package auth
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -1445,7 +1446,7 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 	slices.SortFunc(resources, func(a, b types.Resource) int {
 		priorityA := ResourceApplyPriority[a.GetKind()]
 		priorityB := ResourceApplyPriority[b.GetKind()]
-		return priorityA - priorityB
+		return cmp.Compare(priorityA, priorityB)
 	})
 	for _, resource := range resources {
 		// Unwrap "new style" resources.

--- a/lib/auth/migration/migration.go
+++ b/lib/auth/migration/migration.go
@@ -19,6 +19,7 @@
 package migration
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"slices"
@@ -97,7 +98,7 @@ func Apply(ctx context.Context, b backend.Backend, opts ...func(c *applyConfig))
 	}()
 
 	slices.SortFunc(cfg.migrations, func(a, b migration) int {
-		return int(a.Version() - b.Version())
+		return cmp.Compare(a.Version(), b.Version())
 	})
 
 	current, err := getCurrentMigration(ctx, b)

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -19,6 +19,7 @@
 package azsessions
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -324,7 +325,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	// cleaned up before a new attempt
 
 	parts = slices.Clone(parts)
-	slices.SortFunc(parts, func(a, b events.StreamPart) int { return int(a.Number - b.Number) })
+	slices.SortFunc(parts, func(a, b events.StreamPart) int { return cmp.Compare(a.Number, b.Number) })
 
 	partURLs := make([]string, 0, len(parts))
 	for _, part := range parts {
@@ -496,7 +497,7 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 		}
 	}
 
-	slices.SortFunc(parts, func(a, b events.StreamPart) int { return int(a.Number - b.Number) })
+	slices.SortFunc(parts, func(a, b events.StreamPart) int { return cmp.Compare(a.Number, b.Number) })
 
 	return parts, nil
 }


### PR DESCRIPTION
Replaces subtraction based comparisions with calls to cmp.Compare for all ordered types to avoid overflows.