### PR TITLE
[v15] Remove quiet/silent flags from authz checks

### DIFF
--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -111,7 +111,7 @@ func (a *Service) CreateAssistantConversation(ctx context.Context, req *assist.C
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -130,7 +130,7 @@ func (a *Service) UpdateAssistantConversationInfo(ctx context.Context, req *assi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -153,7 +153,7 @@ func (a *Service) GetAssistantConversations(ctx context.Context, req *assist.Get
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -172,7 +172,7 @@ func (a *Service) DeleteAssistantConversation(ctx context.Context, req *assist.D
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -190,7 +190,7 @@ func (a *Service) GetAssistantMessages(ctx context.Context, req *assist.GetAssis
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -209,7 +209,7 @@ func (a *Service) CreateAssistantMessage(ctx context.Context, req *assist.Create
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindAssistant, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindAssistant, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -242,7 +242,6 @@ func (a *Service) IsAssistEnabled(ctx context.Context, _ *assist.IsAssistEnabled
 		checkErr := authCtx.Checker.CheckAccessToRule(
 			&services.Context{User: authCtx.User},
 			defaults.Namespace, types.KindAssistant, types.VerbRead,
-			false, /* silent */
 		)
 		if checkErr != nil {
 			return nil, trace.Wrap(err)
@@ -272,7 +271,7 @@ func (a *Service) GetAssistantEmbeddings(ctx context.Context, msg *assist.GetAss
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, msg.Kind, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(msg.Kind, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -94,7 +94,7 @@ func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace, re
 	}
 	var errs []error
 	for _, verb := range verbs {
-		errs = append(errs, a.context.Checker.CheckAccessToRule(ctx, namespace, resource, verb, false))
+		errs = append(errs, a.context.Checker.CheckAccessToRule(ctx, namespace, resource, verb))
 	}
 	if err := trace.NewAggregate(errs...); err != nil {
 		return err
@@ -103,17 +103,10 @@ func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace, re
 }
 
 type actionConfig struct {
-	quiet   bool
 	context authz.Context
 }
 
 type actionOption func(*actionConfig)
-
-func quietAction(quiet bool) actionOption {
-	return func(cfg *actionConfig) {
-		cfg.quiet = quiet
-	}
-}
 
 func (a *ServerWithRoles) withOptions(opts ...actionOption) actionConfig {
 	cfg := actionConfig{context: a.context}
@@ -130,7 +123,7 @@ func (c actionConfig) action(namespace, resource string, verbs ...string) error 
 	}
 	var errs []error
 	for _, verb := range verbs {
-		errs = append(errs, c.context.Checker.CheckAccessToRule(&services.Context{User: c.context.User}, namespace, resource, verb, c.quiet))
+		errs = append(errs, c.context.Checker.CheckAccessToRule(&services.Context{User: c.context.User}, namespace, resource, verb))
 	}
 	if err := trace.NewAggregate(errs...); err != nil {
 		return err
@@ -150,7 +143,7 @@ func (a *ServerWithRoles) currentUserAction(username string) error {
 		return nil
 	}
 	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User},
-		apidefaults.Namespace, types.KindUser, types.VerbCreate, true)
+		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
 // authConnectorAction is a special checker that grants access to auth
@@ -158,8 +151,8 @@ func (a *ServerWithRoles) currentUserAction(username string) error {
 // If not, it checks if the requester has the meta KindAuthConnector access
 // (which grants access to all connectors).
 func (a *ServerWithRoles) authConnectorAction(namespace string, resource string, verb string) error {
-	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb, true); err != nil {
-		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, types.KindAuthConnector, verb, false); err != nil {
+	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb); err != nil {
+		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, types.KindAuthConnector, verb); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -169,7 +162,7 @@ func (a *ServerWithRoles) authConnectorAction(namespace string, resource string,
 // actionForListWithCondition extracts a restrictive filter condition to be
 // added to a list query after a simple resource check fails.
 func (a *ServerWithRoles) actionForListWithCondition(namespace, resource, identifier string) (*types.WhereExpr, error) {
-	origErr := a.withOptions(quietAction(true)).action(namespace, resource, types.VerbList)
+	origErr := a.action(namespace, resource, types.VerbList)
 	if origErr == nil || !trace.IsAccessDenied(origErr) {
 		return nil, trace.Wrap(origErr)
 	}
@@ -186,7 +179,7 @@ func (a *ServerWithRoles) actionForListWithCondition(namespace, resource, identi
 // rule context after a simple resource check fails.
 func (a *ServerWithRoles) actionWithExtendedContext(namespace, kind, verb string, extendContext func(*services.Context) error) error {
 	ruleCtx := &services.Context{User: a.context.User}
-	origErr := a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb, true)
+	origErr := a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb)
 	if origErr == nil || !trace.IsAccessDenied(origErr) {
 		return trace.Wrap(origErr)
 	}
@@ -195,7 +188,7 @@ func (a *ServerWithRoles) actionWithExtendedContext(namespace, kind, verb string
 		// Return the original AccessDenied to avoid leaking information.
 		return trace.Wrap(origErr)
 	}
-	return trace.Wrap(a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb, false))
+	return trace.Wrap(a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb))
 }
 
 // actionForKindSession is a special checker that grants access to session
@@ -443,13 +436,13 @@ func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles 
 		}
 
 		// Skip past it if there's a deny rule in place blocking access.
-		if err := a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSSHSession, verb, true /* silent */); err != nil {
+		if err := a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSSHSession, verb); err != nil {
 			return false
 		}
 	}
 
 	ruleCtx := &services.Context{User: a.context.User, SessionTracker: tracker}
-	if a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSessionTracker, types.VerbList, true /* silent */) == nil {
+	if a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSessionTracker, types.VerbList) == nil {
 		return true
 	}
 
@@ -965,7 +958,7 @@ func (a *ServerWithRoles) GetClusterAlerts(ctx context.Context, query types.GetC
 	// with permissions to view all resources of kind 'cluster_alert' can opt into viewing all alerts
 	// regardless of labels for management/debug purposes.
 	var resourceLevelPermit bool
-	if query.WithUntargeted && a.withOptions(quietAction(true)).action(apidefaults.Namespace, types.KindClusterAlert, types.VerbRead, types.VerbList) == nil {
+	if query.WithUntargeted && a.action(apidefaults.Namespace, types.KindClusterAlert, types.VerbRead, types.VerbList) == nil {
 		resourceLevelPermit = true
 	}
 
@@ -1004,7 +997,7 @@ Outer:
 				continue Verbs
 			}
 
-			if a.withOptions(quietAction(true)).action(apidefaults.Namespace, rv[0], rv[1]) == nil {
+			if a.action(apidefaults.Namespace, rv[0], rv[1]) == nil {
 				// user holds at least one of the resource:verb pairs specified by
 				// the verb-permit label.
 				filtered = append(filtered, alert)
@@ -1380,7 +1373,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 			actionVerbs = []string{types.VerbList}
 		}
 
-		resourceAccessMap[kind] = a.withOptions(quietAction(true)).action(apidefaults.Namespace, kind, actionVerbs...)
+		resourceAccessMap[kind] = a.action(apidefaults.Namespace, kind, actionVerbs...)
 	}
 
 	// Apply any requested additional search_as_roles and/or preview_as_roles
@@ -2310,7 +2303,7 @@ type accessChecker interface {
 }
 
 func (a *ServerWithRoles) GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error) {
-	if err := a.withOptions(quietAction(true)).action(apidefaults.Namespace, types.KindAccessRequest, types.VerbList, types.VerbRead); err != nil {
+	if err := a.action(apidefaults.Namespace, types.KindAccessRequest, types.VerbList, types.VerbRead); err != nil {
 		// Users are allowed to read + list their own access requests and
 		// requests they are allowed to review, unless access was *explicitly*
 		// denied. This means deny rules block the action but allow rules are
@@ -2495,12 +2488,12 @@ func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter types.Plugin
 	case types.KindAccessRequest, types.KindAccessList:
 		// for backwards compatibility, we allow list/read against kinds to also grant list/read for
 		// access request related plugin data.
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, filter.Kind, types.VerbList) != nil {
+		if a.action(apidefaults.Namespace, filter.Kind, types.VerbList) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbList); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, filter.Kind, types.VerbRead) != nil {
+		if a.action(apidefaults.Namespace, filter.Kind, types.VerbRead) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbRead); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2517,7 +2510,7 @@ func (a *ServerWithRoles) UpdatePluginData(ctx context.Context, params types.Plu
 	case types.KindAccessRequest, types.KindAccessList:
 		// for backwards compatibility, we allow update against access requests to also grant update for
 		// access request related plugin data.
-		if a.withOptions(quietAction(true)).action(apidefaults.Namespace, params.Kind, types.VerbUpdate) != nil {
+		if a.action(apidefaults.Namespace, params.Kind, types.VerbUpdate) != nil {
 			if err := a.action(apidefaults.Namespace, types.KindAccessPluginData, types.VerbUpdate); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -101,7 +101,7 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -128,7 +128,7 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -147,7 +147,7 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -171,7 +171,7 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -195,7 +195,7 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -219,7 +219,7 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -237,7 +237,7 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindDiscoveryConfig, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -41,7 +41,7 @@ func (s *Service) GenerateAWSOIDCToken(ctx context.Context, _ *integrationpb.Gen
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUse); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return s.generateAWSOIDCTokenWithoutAuthZ(ctx)
@@ -207,7 +207,7 @@ func (s *AWSOIDCService) ListDatabases(ctx context.Context, req *integrationpb.L
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUse); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -254,7 +254,7 @@ func (s *AWSOIDCService) DeployDatabaseService(ctx context.Context, req *integra
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUse); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -133,7 +133,7 @@ func (s *Service) ListIntegrations(ctx context.Context, req *integrationpb.ListI
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -164,7 +164,7 @@ func (s *Service) GetIntegration(ctx context.Context, req *integrationpb.GetInte
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	integration, err := s.cache.GetIntegration(ctx, req.GetName())
@@ -187,7 +187,7 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -211,7 +211,7 @@ func (s *Service) UpdateIntegration(ctx context.Context, req *integrationpb.Upda
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -235,7 +235,7 @@ func (s *Service) DeleteIntegration(ctx context.Context, req *integrationpb.Dele
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -253,7 +253,7 @@ func (s *Service) DeleteAllIntegrations(ctx context.Context, _ *integrationpb.De
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindIntegration, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -162,7 +162,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -196,7 +196,7 @@ func (bs *BotService) ListBots(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -247,11 +247,11 @@ func (bs *BotService) createBotAuthz(ctx context.Context) (*authz.Context, error
 		return nil, trace.Wrap(err)
 	}
 
-	originalErr := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbCreate)
+	originalErr := authCtx.CheckAccessToKind(types.KindBot, types.VerbCreate)
 	if originalErr != nil {
 		// TODO(noah): DELETE IN 16.0.0
 		for _, kind := range []string{types.KindUser, types.KindRole, types.KindToken} {
-			if err := authCtx.CheckAccessToKind(false, kind, types.VerbCreate); err != nil {
+			if err := authCtx.CheckAccessToKind(kind, types.VerbCreate); err != nil {
 				return nil, originalErr
 			}
 		}
@@ -381,7 +381,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -430,7 +430,7 @@ func (bs *BotService) UpdateBot(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -556,11 +556,11 @@ func (bs *BotService) deleteBotAuthz(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	originalErr := authCtx.CheckAccessToKind(false, types.KindBot, types.VerbDelete)
+	originalErr := authCtx.CheckAccessToKind(types.KindBot, types.VerbDelete)
 	if originalErr != nil {
 		// TODO(noah): DELETE IN 16.0.0
 		for _, kind := range []string{types.KindUser, types.KindRole, types.KindToken} {
-			if err := authCtx.CheckAccessToKind(false, kind, types.VerbDelete); err != nil {
+			if err := authCtx.CheckAccessToKind(kind, types.VerbDelete); err != nil {
 				return originalErr
 			}
 		}

--- a/lib/auth/machineid/machineidv1/bot_service_legacy.go
+++ b/lib/auth/machineid/machineidv1/bot_service_legacy.go
@@ -44,7 +44,7 @@ func (bs *BotService) GetBotUsersLegacy(ctx context.Context) ([]types.User, erro
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindUser, types.VerbList, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/okta/service.go
+++ b/lib/auth/okta/service.go
@@ -116,7 +116,7 @@ func (s *Service) ListOktaImportRules(ctx context.Context, req *oktapb.ListOktaI
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -147,7 +147,7 @@ func (s *Service) GetOktaImportRule(ctx context.Context, req *oktapb.GetOktaImpo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	importRule, err := s.oktaImportRules.GetOktaImportRule(ctx, req.GetName())
@@ -170,7 +170,7 @@ func (s *Service) CreateOktaImportRule(ctx context.Context, req *oktapb.CreateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.CreateOktaImportRule(ctx, req.GetImportRule())
@@ -191,7 +191,7 @@ func (s *Service) UpdateOktaImportRule(ctx context.Context, req *oktapb.UpdateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedRule, err := s.oktaImportRules.UpdateOktaImportRule(ctx, req.GetImportRule())
@@ -212,7 +212,7 @@ func (s *Service) DeleteOktaImportRule(ctx context.Context, req *oktapb.DeleteOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteOktaImportRule(ctx, req.GetName()))
@@ -225,7 +225,7 @@ func (s *Service) DeleteAllOktaImportRules(ctx context.Context, _ *oktapb.Delete
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaImportRule, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaImportRule, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteAllOktaImportRules(ctx))
@@ -238,7 +238,7 @@ func (s *Service) ListOktaAssignments(ctx context.Context, req *oktapb.ListOktaA
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbList, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -269,7 +269,7 @@ func (s *Service) GetOktaAssignment(ctx context.Context, req *oktapb.GetOktaAssi
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	assignment, err := s.oktaAssignments.GetOktaAssignment(ctx, req.GetName())
@@ -292,7 +292,7 @@ func (s *Service) CreateOktaAssignment(ctx context.Context, req *oktapb.CreateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.CreateOktaAssignment(ctx, req.GetAssignment())
@@ -313,7 +313,7 @@ func (s *Service) UpdateOktaAssignment(ctx context.Context, req *oktapb.UpdateOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	returnedAssignment, err := s.oktaAssignments.UpdateOktaAssignment(ctx, req.GetAssignment())
@@ -334,7 +334,7 @@ func (s *Service) UpdateOktaAssignmentStatus(ctx context.Context, req *oktapb.Up
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	err = s.oktaAssignments.UpdateOktaAssignmentStatus(ctx, req.GetName(), types.OktaAssignmentStatusProtoToString(req.GetStatus()),
@@ -349,7 +349,7 @@ func (s *Service) DeleteOktaAssignment(ctx context.Context, req *oktapb.DeleteOk
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteOktaAssignment(ctx, req.GetName()))
@@ -362,7 +362,7 @@ func (s *Service) DeleteAllOktaAssignments(ctx context.Context, _ *oktapb.Delete
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindOktaAssignment, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindOktaAssignment, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteAllOktaAssignments(ctx))

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -113,7 +113,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err = authzCtx.CheckAccessToResource(false, contextCA, readVerb); err != nil {
+	if err = authzCtx.CheckAccessToResource(contextCA, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -124,7 +124,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err = authzCtx.CheckAccessToResource(false, ca, readVerb); err != nil {
+	if err = authzCtx.CheckAccessToResource(ca, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -149,7 +149,7 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, verbs[0], verbs[1:]...); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindCertAuthority, verbs[0], verbs[1:]...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -179,7 +179,7 @@ func (s *Service) DeleteCertAuthority(ctx context.Context, req *trustpb.DeleteCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindCertAuthority, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -209,7 +209,7 @@ func (s *Service) UpsertCertAuthority(ctx context.Context, req *trustpb.UpsertCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authzCtx.CheckAccessToResource(false, req.CertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authzCtx.CheckAccessToResource(req.CertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -232,7 +232,7 @@ func (s *Service) RotateCertAuthority(ctx context.Context, req *trustpb.RotateCe
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(false, types.KindCertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindCertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -283,7 +283,7 @@ func (s *Service) RotateExternalCertAuthority(ctx context.Context, req *trustpb.
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToResource(false, req.CertAuthority, types.VerbRotate); err != nil {
+	if err := authCtx.CheckAccessToResource(req.CertAuthority, types.VerbRotate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -366,7 +366,6 @@ func (s *Service) GenerateHostCert(
 		},
 	}
 	if err = authCtx.CheckAccessToRule(
-		false,
 		ruleCtx,
 		types.KindHostCert,
 		types.VerbCreate,

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -106,7 +106,7 @@ type fakeChecker struct {
 	checks []check
 }
 
-func (f *fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, rule string, verb string, silent bool) error {
+func (f *fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, rule string, verb string) error {
 	c := check{rule, verb}
 	f.checks = append(f.checks, c)
 	if f.allow[c] {

--- a/lib/auth/userloginstate/service.go
+++ b/lib/auth/userloginstate/service.go
@@ -98,7 +98,7 @@ func (s *Service) GetUserLoginStates(ctx context.Context, _ *userloginstatev1.Ge
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -124,7 +124,7 @@ func (s *Service) GetUserLoginState(ctx context.Context, req *userloginstatev1.G
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbRead); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -143,7 +143,7 @@ func (s *Service) UpsertUserLoginState(ctx context.Context, req *userloginstatev
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -167,7 +167,7 @@ func (s *Service) DeleteUserLoginState(ctx context.Context, req *userloginstatev
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -186,7 +186,7 @@ func (s *Service) DeleteAllUserLoginStates(ctx context.Context, _ *userloginstat
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUserLoginState, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -128,7 +128,7 @@ func currentUserAction(authzContext authz.Context, username string) error {
 		return nil
 	}
 	return authzContext.Checker.CheckAccessToRule(&services.Context{User: authzContext.User},
-		apidefaults.Namespace, types.KindUser, types.VerbCreate, true)
+		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
 func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*types.UserV2, error) {
@@ -192,7 +192,7 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 		// their own info.
 		if err := currentUserAction(*authCtx, req.Name); err != nil {
 			// not current user, perform normal permission check.
-			if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbRead); err != nil {
+			if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbRead); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
@@ -218,7 +218,7 @@ func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbCreate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -290,7 +290,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *userspb.UpdateUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -377,7 +377,7 @@ func (s *Service) UpsertUser(ctx context.Context, req *userspb.UpsertUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -467,7 +467,7 @@ func (s *Service) DeleteUser(ctx context.Context, req *userspb.DeleteUserRequest
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbDelete); err != nil {
+	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -556,7 +556,7 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 			return nil, trace.AccessDenied("this request can be only executed by an admin")
 		}
 	} else {
-		if err := authCtx.CheckAccessToKind(true, types.KindUser, types.VerbList, types.VerbRead); err != nil {
+		if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbList, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -118,7 +118,7 @@ type check struct {
 	kind, verb string
 }
 
-func (f *fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string, silent bool) error {
+func (f *fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string) error {
 	c := check{kind, verb}
 	f.checks = append(f.checks, c)
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1373,30 +1373,30 @@ func ClientUserMetadataWithUser(ctx context.Context, user string) apievents.User
 }
 
 // CheckAccessToKind will ensure that the user has access to the given verbs for the given kind.
-func (c *Context) CheckAccessToKind(quiet bool, kind string, verb string, additionalVerbs ...string) error {
+func (c *Context) CheckAccessToKind(kind string, verb string, additionalVerbs ...string) error {
 	ruleCtx := &services.Context{
 		User: c.User,
 	}
 
-	return c.CheckAccessToRule(quiet, ruleCtx, kind, verb, additionalVerbs...)
+	return c.CheckAccessToRule(ruleCtx, kind, verb, additionalVerbs...)
 }
 
 // CheckAccessToResource will ensure that the user has access to the given verbs for the given resource.
-func (c *Context) CheckAccessToResource(quiet bool, resource types.Resource, verb string, additionalVerbs ...string) error {
+func (c *Context) CheckAccessToResource(resource types.Resource, verb string, additionalVerbs ...string) error {
 	ruleCtx := &services.Context{
 		User:     c.User,
 		Resource: resource,
 	}
 
-	return c.CheckAccessToRule(quiet, ruleCtx, resource.GetKind(), verb, additionalVerbs...)
+	return c.CheckAccessToRule(ruleCtx, resource.GetKind(), verb, additionalVerbs...)
 }
 
 // CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
 // Prefer to use [Context.CheckAccessToKind] or [Context.CheckAccessToResource] for common checks.
-func (c *Context) CheckAccessToRule(quiet bool, ruleCtx *services.Context, kind string, verb string, additionalVerbs ...string) error {
+func (c *Context) CheckAccessToRule(ruleCtx *services.Context, kind string, verb string, additionalVerbs ...string) error {
 	var errs []error
 	for _, verb := range append(additionalVerbs, verb) {
-		if err := c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet); err != nil {
+		if err := c.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -60,7 +60,7 @@ type AccessChecker interface {
 	CheckAccessToRemoteCluster(cluster types.RemoteCluster) error
 
 	// CheckAccessToRule checks access to a rule within a namespace.
-	CheckAccessToRule(context RuleContext, namespace string, rule string, verb string, silent bool) error
+	CheckAccessToRule(context RuleContext, namespace string, rule string, verb string) error
 
 	// CheckLoginDuration checks if role set can login up to given duration and
 	// returns a combined list of allowed logins.

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1499,7 +1499,8 @@ func TestCheckAccessToServer(t *testing.T) {
 				{server: serverWorker, login: "root", hasAccess: true},
 				{server: serverDB, login: "root", hasAccess: true},
 			},
-		}, {
+		},
+		{
 			name: "cluster requires hardware key pin, MFA not verified",
 			roles: []*types.RoleV6{
 				newRole(func(r *types.RoleV6) {
@@ -1533,7 +1534,8 @@ func TestCheckAccessToServer(t *testing.T) {
 				{server: serverWorker, login: "root", hasAccess: true},
 				{server: serverDB, login: "root", hasAccess: true},
 			},
-		}, {
+		},
+		{
 			name: "cluster requires hardware key touch and pin, MFA not verified",
 			roles: []*types.RoleV6{
 				newRole(func(r *types.RoleV6) {
@@ -2389,7 +2391,7 @@ func TestCheckRuleAccess(t *testing.T) {
 		}
 		for j, check := range tc.checks {
 			comment := fmt.Sprintf("test case %v '%v', check %v", i, tc.name, j)
-			result := set.CheckAccessToRule(&check.context, check.namespace, check.rule, check.verb, false)
+			result := set.CheckAccessToRule(&check.context, check.namespace, check.rule, check.verb)
 			if check.hasAccess {
 				require.NoError(t, result, comment)
 			} else {
@@ -2584,14 +2586,13 @@ func TestGuessIfAccessIsPossible(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			params := test.params
-			const silent = true
 			for _, verb := range params.verbs {
-				err := test.roles.CheckAccessToRule(&params.ctx, params.namespace, params.resource, verb, silent)
+				err := test.roles.CheckAccessToRule(&params.ctx, params.namespace, params.resource, verb)
 				if gotAccess, wantAccess := err == nil, test.wantRuleAccess; gotAccess != wantAccess {
 					t.Errorf("CheckAccessToRule(verb=%q) returned err = %v=q, wantAccess = %v", verb, err, wantAccess)
 				}
 
-				err = test.roles.GuessIfAccessIsPossible(&params.ctx, params.namespace, params.resource, verb, silent)
+				err = test.roles.GuessIfAccessIsPossible(&params.ctx, params.namespace, params.resource, verb)
 				if gotAccess, wantAccess := err == nil, test.wantGuessAccess; gotAccess != wantAccess {
 					t.Errorf("GuessIfAccessIsPossible(verb=%q) returned err = %q, wantAccess = %v", verb, err, wantAccess)
 				}

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -112,7 +112,7 @@ func hasAccess(roleSet RoleSet, ctx *Context, kind string, verbs ...string) bool
 	for _, verb := range verbs {
 		// Since this check occurs often and does not imply the caller is trying to
 		// ResourceAccess any resource, silence any logging done on the proxy.
-		if err := roleSet.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, kind, verb, true); err != nil {
+		if err := roleSet.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, kind, verb); err != nil {
 			return false
 		}
 	}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/37832 to branch/v15

Note: once merged, the e ref will be temporarily erroneous until https://github.com/gravitational/teleport.e/pull/3540 is merged and the e ref is updated. https://github.com/gravitational/teleport.e/pull/3540 cannot be merged first due to its dependence on this PR.