### PR TITLE
[v15] Require device trust for initial device registration endpoints

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3093,7 +3093,7 @@ func (a *Server) CreateRegisterChallenge(ctx context.Context, req *proto.CreateR
 		}
 		username = token.GetUser()
 
-	case req.ExistingMFAResponse != nil: // Authenticated user without token, tsh.
+	default: // Authenticated user without token, tsh.
 		var err error
 		username, err = authz.GetClientUsername(ctx)
 		if err != nil {
@@ -3116,9 +3116,6 @@ func (a *Server) CreateRegisterChallenge(ctx context.Context, req *proto.CreateR
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-	default:
-		return nil, trace.BadParameter("either a token or an MFA response are required")
 	}
 
 	regChal, err := a.createRegisterChallenge(ctx, &newRegisterChallengeRequest{

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -532,7 +532,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 			DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
 			DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
 		})
-		assert.ErrorContains(t, err, "token or an MFA response")
+		assert.ErrorContains(t, err, "second factor authentication required")
 
 		// Acquire and solve an authn challenge.
 		authnChal, err := authClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6338,7 +6338,7 @@ func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.C
 	// Device trust: authorize device before issuing a privileged token without an MFA response.
 	if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 		if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "device trust is required for users to create a privileged token without an MFA check")
 		}
 	}
 
@@ -6355,7 +6355,7 @@ func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *prot
 		// Device trust: authorize device before issuing a register challenge without an MFA response or privilege token.
 		if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
 			if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
-				return nil, trace.Wrap(err)
+				return nil, trace.Wrap(err, "device trust is required for users to register their first MFA device")
 			}
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6336,8 +6336,8 @@ func (a *ServerWithRoles) CreateAuthenticateChallenge(ctx context.Context, req *
 // CreatePrivilegeToken is implemented by AuthService.CreatePrivilegeToken.
 func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePrivilegeTokenRequest) (*types.UserTokenV3, error) {
 	// Device trust: authorize device before issuing a privileged token without an MFA response.
-	if mfaResp := req.GetExistingMFAResponse(); mfaResp == nil || (mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil) {
-		if err := a.authorizeDevice(ctx); err != nil {
+	if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
+		if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -6347,15 +6347,14 @@ func (a *ServerWithRoles) CreatePrivilegeToken(ctx context.Context, req *proto.C
 
 // CreateRegisterChallenge is implemented by AuthService.CreateRegisterChallenge.
 func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *proto.CreateRegisterChallengeRequest) (*proto.MFARegisterChallenge, error) {
-	switch {
-	case req.TokenID != "":
-	case req.ExistingMFAResponse != nil:
+	if req.TokenID == "" {
 		if !authz.IsLocalOrRemoteUser(a.context) {
 			return nil, trace.BadParameter("only end users are allowed issue registration challenges without a privilege token")
 		}
-		// Device trust: authorize device before issuing a register challenge without an MFA response or token.
-		if req.ExistingMFAResponse.GetTOTP() == nil && req.ExistingMFAResponse.GetWebauthn() == nil {
-			if err := a.authorizeDevice(ctx); err != nil {
+
+		// Device trust: authorize device before issuing a register challenge without an MFA response or privilege token.
+		if mfaResp := req.GetExistingMFAResponse(); mfaResp.GetTOTP() == nil && mfaResp.GetWebauthn() == nil {
+			if err := a.enforceGlobalModeTrustedDevice(ctx); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
@@ -6367,11 +6366,14 @@ func (a *ServerWithRoles) CreateRegisterChallenge(ctx context.Context, req *prot
 	return a.authServer.CreateRegisterChallenge(ctx, req)
 }
 
-func (a *ServerWithRoles) authorizeDevice(ctx context.Context) error {
-	authPref, err := a.authServer.GetAuthPreference(ctx)
+// enforceGlobalModeTrustedDevice is used to enforce global device trust requirements
+// for key endpoints.
+func (a *ServerWithRoles) enforceGlobalModeTrustedDevice(ctx context.Context) error {
+	authPref, err := a.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	err = dtauthz.VerifyTLSUser(authPref.GetDeviceTrust(), a.context.Identity.GetIdentity())
 	return trace.Wrap(err)
 }

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -990,11 +990,9 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 	authServer := testServer.Auth()
 
 	// Create a user for testing.
-	user, role, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	user, _, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	username := user.GetName()
-	_, err = authServer.UpsertRole(ctx, role)
-	require.NoError(t, err)
 
 	// Create clients with and without device extensions.
 	clientWithoutDevice, err := testServer.NewClient(TestUser(username))
@@ -1077,17 +1075,14 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 			})
 
 			t.Run("CreatePrivilegeTokenRequest", func(t *testing.T) {
-				_, err := test.client.CreatePrivilegeToken(ctx, &proto.CreatePrivilegeTokenRequest{
-					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
-				})
+				_, err := test.client.CreatePrivilegeToken(ctx, &proto.CreatePrivilegeTokenRequest{})
 				test.assertErr(t, err)
 			})
 
 			t.Run("CreateRegisterChallenge", func(t *testing.T) {
 				_, err := test.client.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
-					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
-					DeviceType:          proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
-					DeviceUsage:         proto.DeviceUsage_DEVICE_USAGE_MFA,
+					DeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage: proto.DeviceUsage_DEVICE_USAGE_MFA,
 				})
 				test.assertErr(t, err)
 			})

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1030,7 +1030,8 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	assertAccessDenied := func(t *testing.T, err error) {
-		assert.ErrorIs(t, err, dtauthz.ErrTrustedDeviceRequired)
+		assert.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+		assert.ErrorContains(t, err, dtauthz.ErrTrustedDeviceRequired.Error())
 	}
 
 	tests := []struct {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -68,6 +68,7 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
+	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -973,6 +974,123 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 					test.assertErr(t, err)
 				})
 			}
+		})
+	}
+}
+
+// Test that device trust is required for a user registering their first MFA device.
+func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
+	})
+
+	testServer := newTestTLSServer(t)
+
+	ctx := context.Background()
+	authServer := testServer.Auth()
+
+	// Create a user for testing.
+	user, role, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	require.NoError(t, err, "CreateUserAndRole failed")
+	username := user.GetName()
+	_, err = authServer.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	// Create clients with and without device extensions.
+	clientWithoutDevice, err := testServer.NewClient(TestUser(username))
+	require.NoError(t, err, "NewClient failed")
+
+	clientWithDevice, err := testServer.NewClient(
+		TestUserWithDeviceExtensions(username, tlsca.DeviceExtensions{
+			DeviceID:     "deviceid1",
+			AssetTag:     "assettag1",
+			CredentialID: "credentialid1",
+		}))
+	require.NoError(t, err, "NewClient failed")
+
+	// updateAuthPref is a helper used throughout the test.
+	updateAuthPref := func(t *testing.T, modify func(ap types.AuthPreference)) {
+		authPref, err := authServer.GetAuthPreference(ctx)
+		require.NoError(t, err, "GetAuthPreference failed")
+
+		modify(authPref)
+
+		require.NoError(t,
+			authServer.SetAuthPreference(ctx, authPref),
+			"SetAuthPreference failed")
+	}
+
+	// Enable webauthn
+	updateAuthPref(t, func(authPref types.AuthPreference) {
+		authPref.SetSecondFactor(constants.SecondFactorOptional)
+		authPref.SetWebauthn(&types.Webauthn{
+			RPID: "localhost",
+		})
+	})
+
+	assertSuccess := func(t *testing.T, err error) {
+		assert.NoError(t, err)
+	}
+	assertAccessDenied := func(t *testing.T, err error) {
+		assert.ErrorIs(t, err, dtauthz.ErrTrustedDeviceRequired)
+	}
+
+	tests := []struct {
+		name               string
+		clusterDeviceMode  string
+		client             *Client
+		skipLoginCerts     bool // aka non-MFA issuance.
+		skipSingleUseCerts bool // aka MFA/streaming issuance.
+		assertErr          func(t *testing.T, err error)
+	}{
+		{
+			name:              "mode=optional without extensions",
+			clusterDeviceMode: constants.DeviceTrustModeOptional,
+			client:            clientWithoutDevice,
+			assertErr:         assertSuccess,
+		},
+		{
+			name:              "mode=optional with extensions",
+			clusterDeviceMode: constants.DeviceTrustModeOptional,
+			client:            clientWithDevice,
+			assertErr:         assertSuccess,
+		},
+		{
+			name:              "nok: mode=required without extensions",
+			clusterDeviceMode: constants.DeviceTrustModeRequired,
+			client:            clientWithoutDevice,
+			assertErr:         assertAccessDenied,
+		},
+		{
+			name:              "mode=required with extensions",
+			clusterDeviceMode: constants.DeviceTrustModeRequired,
+			client:            clientWithDevice,
+			assertErr:         assertSuccess,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			updateAuthPref(t, func(ap types.AuthPreference) {
+				ap.SetDeviceTrust(&types.DeviceTrust{
+					Mode: test.clusterDeviceMode,
+				})
+			})
+
+			t.Run("CreatePrivilegeTokenRequest", func(t *testing.T) {
+				_, err := test.client.CreatePrivilegeToken(ctx, &proto.CreatePrivilegeTokenRequest{
+					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
+				})
+				test.assertErr(t, err)
+			})
+
+			t.Run("CreateRegisterChallenge", func(t *testing.T) {
+				_, err := test.client.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+					ExistingMFAResponse: &proto.MFAAuthenticateResponse{},
+					DeviceType:          proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+					DeviceUsage:         proto.DeviceUsage_DEVICE_USAGE_MFA,
+				})
+				test.assertErr(t, err)
+			})
 		})
 	}
 }


### PR DESCRIPTION
Backport #38451 to branch/v15

changelog: When device trust is required and MFA is optional, users will need to add their first MFA device from a trusted device.
