### PR TITLE
[v14] Add tag build support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ clean-ui:
 
 # RELEASE_DIR is where release artifact files are put, such as tarballs, packages, etc.
 $(RELEASE_DIR):
-	mkdir $@
+	mkdir -p $@
 
 .PHONY:
 export
@@ -475,6 +475,11 @@ build-archive: | $(RELEASE_DIR)
 	echo $(GITTAG) > teleport/VERSION
 	tar $(TAR_FLAGS) -c teleport | gzip -n > $(RELEASE).tar.gz
 	cp $(RELEASE).tar.gz $(RELEASE_DIR)
+	# linux-amd64 generates a centos7-compatible archive. Make a copy with the -centos7 label,
+	# for the releases page. We should probably drop that at some point.
+	$(if $(filter linux-amd64,$(OS)-$(ARCH)), \
+		cp $(RELEASE).tar.gz $(RELEASE_DIR)/$(subst amd64,amd64-centos7,$(RELEASE)).tar.gz \
+	)
 	rm -rf teleport
 	@echo "---> Created $(RELEASE).tar.gz."
 

--- a/Makefile
+++ b/Makefile
@@ -1146,6 +1146,19 @@ update-tag:
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
 	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
 
+# Publishes a tag build.
+# Starts a tag publish run using e/.github/workflows/tag-publish.yaml
+# for the tag v$(VERSION).
+.PHONY: tag-publish
+tag-publish:
+	@which gh >/dev/null 2>&1 || { echo 'gh command needed. https://github.com/cli/cli'; exit 1; }
+	gh workflow run tag-publish.yaml \
+		--repo gravitational/teleport.e \
+		--ref "v$(VERSION)" \
+		-f "oss-teleport-repo=$(shell gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+		-f "oss-teleport-ref=v$(VERSION)"
+	@echo See runs at: https://github.com/gravitational/teleport.e/actions/workflows/tag-publish.yaml
+
 .PHONY: test-package
 test-package: remove-temp-files
 	go test -v ./$(p)

--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,8 @@ $(BUILDDIR)/tctl:
 $(BUILDDIR)/teleport: ensure-webassets bpf-bytecode rdpclient
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "webassets_embed $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(WEBASSETS_TAG) $(RDPCLIENT_TAG) $(PIV_BUILD_TAG)" -o $(BUILDDIR)/teleport $(BUILDFLAGS) ./tool/teleport
 
-# NOTE: Any changes to the `tsh` build here must be copied to `windows.go` in Dronegen until
-# 		we can use this Makefile for native Windows builds.
+# NOTE: Any changes to the `tsh` build here must be copied to `build.assets/windows/build.ps1`
+# until we can use this Makefile for native Windows builds.
 .PHONY: $(BUILDDIR)/tsh
 $(BUILDDIR)/tsh: KUBECTL_VERSION ?= $(shell go run ./build.assets/kubectl-version/main.go)
 $(BUILDDIR)/tsh: KUBECTL_SETVERSION ?= -X k8s.io/component-base/version.gitVersion=$(KUBECTL_VERSION)
@@ -1134,8 +1134,13 @@ $(VERSRC): Makefile
 # 3. Run `make update-version`
 # 4. Commit version changes to git
 # 5. Make sure it all builds (`make release` or equivalent)
+# 6. Run `make update-tag` to tag repos with $(VERSION)
+# 7. Run `make tag-build` to build the tag on GitHub Actions
+# 8. Run `make tag-publish` after `make-build` tag has completed to
+#    publish the built artifacts.
 #
-# After the above is done, run `make update-tag` and follow your build on Drone.
+# GHA tag builds: https://github.com/gravitational/teleport.e/actions/workflows/tag-build.yaml
+# GHA tag publish: https://github.com/gravitational/teleport.e/actions/workflows/tag-publish.yaml
 .PHONY: update-tag
 update-tag: TAG_REMOTE ?= origin
 update-tag:
@@ -1145,6 +1150,19 @@ update-tag:
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
 	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
+
+# Builds a tag build on GitHub Actions.
+# Starts a tag publish run using e/.github/workflows/tag-build.yaml
+# for the tag v$(VERSION).
+.PHONY: tag-build
+tag-build:
+	@which gh >/dev/null 2>&1 || { echo 'gh command needed. https://github.com/cli/cli'; exit 1; }
+	gh workflow run tag-build.yaml \
+		--repo gravitational/teleport.e \
+		--ref "v$(VERSION)" \
+		-f "oss-teleport-repo=$(shell gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+		-f "oss-teleport-ref=v$(VERSION)"
+	@echo See runs at: https://github.com/gravitational/teleport.e/actions/workflows/tag-build.yaml
 
 # Publishes a tag build.
 # Starts a tag publish run using e/.github/workflows/tag-publish.yaml


### PR DESCRIPTION
Backport teleport PRs that update the `Makefile` for tag build support:

* build: Generate centos7 archive when building linux-amd64 (#38415)
* build: Add tag-publish recipe to Makefile (#38475)
* build: Add tag-build recipe to Makefile (#38481)

The backports were clean with the exception of the last which conflicted
due to a `teleport-hot-reload` target added on master and not
branch/v14, with a trivial resolution.

Companion: https://github.com/gravitational/teleport.e/pull/3546
Backport: https://github.com/gravitational/teleport/pull/38415
Backport: https://github.com/gravitational/teleport/pull/38475
Backport: https://github.com/gravitational/teleport/pull/38481
Issue: https://github.com/gravitational/teleport/issues/20729
Issue: https://github.com/gravitational/teleport/issues/20732
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8058413194
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8060109069

---

This PR will not be merged until after the companion PR has been merged,
at which point an `e` ref update commit will be added to this PR to
point at that merged PR.