### PR TITLE
Remove deprecated `GenerateHostCert` HTTP RPC

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -97,10 +97,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// TODO(Joerger): DELETE IN v16.0.0, migrated to gRPC
 	srv.POST("/:version/authorities/:type/rotate/external", srv.WithAuth(srv.rotateExternalCertAuthority))
 
-	// Generating certificates for user and host authorities
-	// TODO(noah): DELETE IN 16.0.0 as replaced with gRPC equiv
-	srv.POST("/:version/ca/host/certs", srv.WithAuth(srv.generateHostCert))
-
 	// Operations on users
 	// TODO(tross): DELETE IN 16.0.0
 	srv.POST("/:version/users", srv.WithAuth(srv.upsertUser))
@@ -529,35 +525,6 @@ func rawMessage(data []byte, err error) (interface{}, error) {
 	}
 	m := json.RawMessage(data)
 	return &m, nil
-}
-
-type generateHostCertReq struct {
-	Key         []byte            `json:"key"`
-	HostID      string            `json:"hostname"`
-	NodeName    string            `json:"node_name"`
-	Principals  []string          `json:"principals"`
-	ClusterName string            `json:"auth_domain"`
-	Roles       types.SystemRoles `json:"roles"`
-	TTL         time.Duration     `json:"ttl"`
-}
-
-// TODO(noah): DELETE IN 16.0.0 as replaced with gRPC equiv
-func (s *APIServer) generateHostCert(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
-	var req *generateHostCertReq
-	if err := httplib.ReadJSON(r, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if len(req.Roles) != 1 {
-		return nil, trace.BadParameter("exactly one system role is required")
-	}
-
-	cert, err := auth.GenerateHostCert(r.Context(), req.Key, req.HostID, req.NodeName, req.Principals, req.ClusterName, req.Roles[0], req.TTL)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return string(cert), nil
 }
 
 func (s *APIServer) registerUsingToken(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4960,10 +4960,6 @@ func TestGenerateHostCert(t *testing.T) {
 			client, err := srv.NewClient(TestUser(user.GetName()))
 			require.NoError(t, err)
 
-			// Calls deprecated HTTP endpoint to verify migrated code works
-			// fine.
-			_, err = client.generateHostCertHTTP(ctx, pub, "", "", test.principals, clusterName, types.RoleNode, 0)
-			require.True(t, test.expect(err))
 			// Try by calling new gRPC endpoint directly
 			_, err = client.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
 				Key:         pub,
@@ -4974,10 +4970,6 @@ func TestGenerateHostCert(t *testing.T) {
 				Role:        string(types.RoleNode),
 				Ttl:         durationpb.New(0),
 			})
-			require.True(t, test.expect(err))
-			// Finally try calling the wrapper method that should call through
-			// to the gRPC client.
-			_, err = client.GenerateHostCert(ctx, pub, "", "", test.principals, clusterName, types.RoleNode, 0)
 			require.True(t, test.expect(err))
 		})
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -42,6 +42,7 @@ import (
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -693,11 +694,6 @@ type IdentityService interface {
 	// ChangePassword changes user password
 	ChangePassword(ctx context.Context, req *proto.ChangePasswordRequest) error
 
-	// GenerateHostCert takes the public key in the Open SSH ``authorized_keys``
-	// plain text format, signs it using Host Certificate Authority private key and returns the
-	// resulting certificate.
-	GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
-
 	// GenerateUserCerts takes the public key in the OpenSSH `authorized_keys` plain
 	// text format, signs it using User Certificate Authority signing key and
 	// returns the resulting certificates.
@@ -826,6 +822,9 @@ type ClientI interface {
 
 	types.WebSessionsGetter
 	types.WebTokensGetter
+
+	// TrustClient returns a client to the Trust service.
+	TrustClient() trustpb.TrustServiceClient
 
 	// DevicesClient returns a Device Trust client.
 	// Clients connecting to non-Enterprise clusters, or older Teleport versions,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -47,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	eventtypes "github.com/gravitational/teleport/api/types/events"
@@ -2759,9 +2761,15 @@ func TestClusterConfigContext(t *testing.T) {
 	// we are recording at the nodes not at the proxy, the proxy may
 	// need to generate host certs if a client wants to connect to an
 	// agentless node
-	_, err = proxy.GenerateHostCert(ctx, pub,
-		"a", "b", nil,
-		"localhost", types.RoleProxy, 0)
+	_, err = proxy.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
+		Key:         pub,
+		HostId:      "a",
+		NodeName:    "b",
+		Principals:  nil,
+		ClusterName: "localhost",
+		Role:        string(types.RoleProxy),
+		Ttl:         durationpb.New(0),
+	})
 	require.NoError(t, err)
 
 	// update cluster config to record at the proxy
@@ -2773,9 +2781,15 @@ func TestClusterConfigContext(t *testing.T) {
 	require.NoError(t, err)
 
 	// try and generate a host cert
-	_, err = proxy.GenerateHostCert(ctx, pub,
-		"a", "b", nil,
-		"localhost", types.RoleProxy, 0)
+	_, err = proxy.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
+		Key:         pub,
+		HostId:      "a",
+		NodeName:    "b",
+		Principals:  nil,
+		ClusterName: "localhost",
+		Role:        string(types.RoleProxy),
+		Ttl:         durationpb.New(0),
+	})
 	require.NoError(t, err)
 }
 

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -27,7 +27,9 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/types/known/durationpb"
 
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -139,18 +141,18 @@ func (c *certificateCache) generateHostCert(ctx context.Context, principals []st
 		return nil, trace.Wrap(err)
 	}
 
-	certBytes, err := c.authClient.GenerateHostCert(
-		ctx,
-		pubBytes,
-		principals[0],
-		principals[0],
-		principals,
-		clusterName,
-		types.RoleNode,
-		0)
+	res, err := c.authClient.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
+		Key:         pubBytes,
+		HostId:      principals[0],
+		NodeName:    principals[0],
+		ClusterName: clusterName,
+		Role:        string(types.RoleNode),
+		Ttl:         durationpb.New(0),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	certBytes := res.SshCertificate
 
 	// create a *ssh.Certificate
 	privateKey, err := ssh.ParsePrivateKey(privBytes)

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -145,6 +145,7 @@ func (c *certificateCache) generateHostCert(ctx context.Context, principals []st
 		Key:         pubBytes,
 		HostId:      principals[0],
 		NodeName:    principals[0],
+		Principals:  principals,
 		ClusterName: clusterName,
 		Role:        string(types.RoleNode),
 		Ttl:         durationpb.New(0),

--- a/lib/tbot/config/bot.go
+++ b/lib/tbot/config/bot.go
@@ -20,10 +20,10 @@ package config
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -46,8 +46,10 @@ type provider interface {
 	// Config returns the current bot config
 	Config() *BotConfig
 
-	// GenerateHostCert uses the impersonatedClient to call GenerateHostCert.
-	GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
+	// GenerateHostCert uses the impersonatedClient to call trust.v1.GenerateHostCert.
+	GenerateHostCert(
+		ctx context.Context, req *trustpb.GenerateHostCertRequest,
+	) (*trustpb.GenerateHostCertResponse, error)
 
 	// GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.
 	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)

--- a/lib/tbot/config/bot_test.go
+++ b/lib/tbot/config/bot_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -143,15 +144,13 @@ func (p *mockProvider) AuthPing(_ context.Context) (*proto.PingResponse, error) 
 }
 
 func (p *mockProvider) GenerateHostCert(
-	ctx context.Context,
-	key []byte, hostID, nodeName string, principals []string,
-	clusterName string, role types.SystemRole, ttl time.Duration,
-) ([]byte, error) {
+	ctx context.Context, req *trustpb.GenerateHostCertRequest,
+) (*trustpb.GenerateHostCertResponse, error) {
 	// We could generate a cert easily enough here, but the template generates a
 	// random key each run so the resulting cert will change too.
 	// The CA fixture isn't even a cert but we never examine it, so it'll do the
 	// job.
-	return []byte(fixtures.SSHCAPublicKey), nil
+	return &trustpb.GenerateHostCertResponse{SshCertificate: []byte(fixtures.SSHCAPublicKey)}, nil
 }
 
 func (p *mockProvider) ProxyPing(ctx context.Context) (*webclient.PingResponse, error) {

--- a/lib/tbot/config/template_ssh_host_cert.go
+++ b/lib/tbot/config/template_ssh_host_cert.go
@@ -23,7 +23,9 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/durationpb"
 
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
@@ -130,19 +132,20 @@ func (c *templateSSHHostCert) render(
 
 	// For now, we'll reuse the bot's regular TTL, and hostID and nodeName are
 	// left unset.
-	key.Cert, err = bot.GenerateHostCert(
-		ctx,
-		key.MarshalSSHPublicKey(),
-		"",
-		"",
-		c.principals,
-		clusterName,
-		types.RoleNode,
-		bot.Config().CertificateTTL,
+	res, err := bot.GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
+		Key:         key.MarshalSSHPublicKey(),
+		HostId:      "",
+		NodeName:    "",
+		Principals:  c.principals,
+		ClusterName: clusterName,
+		Role:        string(types.RoleNode),
+		Ttl:         durationpb.New(bot.Config().CertificateTTL),
+	},
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	key.Cert = res.SshCertificate
 
 	cfg := identityfile.WriteConfig{
 		OutputPath: defaultSSHHostCertPrefix,

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -782,8 +783,10 @@ func (op *outputProvider) GetRemoteClusters(opts ...services.MarshalOption) ([]t
 }
 
 // GenerateHostCert uses the impersonatedClient to call GenerateHostCert.
-func (op *outputProvider) GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
-	return op.impersonatedClient.GenerateHostCert(ctx, key, hostID, nodeName, principals, clusterName, role, ttl)
+func (op *outputProvider) GenerateHostCert(
+	ctx context.Context, req *trustpb.GenerateHostCertRequest,
+) (*trustpb.GenerateHostCertResponse, error) {
+	return op.impersonatedClient.TrustClient().GenerateHostCert(ctx, req)
 }
 
 // GetCertAuthority uses the impersonatedClient to call GetCertAuthority.

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -471,6 +471,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.Clie
 		Key:         key.MarshalSSHPublicKey(),
 		HostId:      "",
 		NodeName:    "",
+		Principals:  principals,
 		ClusterName: clusterName,
 		Role:        string(types.RoleNode),
 		Ttl:         durationpb.New(0),

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -32,11 +32,13 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/keygen"
@@ -465,12 +467,19 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.Clie
 	}
 	clusterName := cn.GetClusterName()
 
-	key.Cert, err = clusterAPI.GenerateHostCert(ctx, key.MarshalSSHPublicKey(),
-		"", "", principals,
-		clusterName, types.RoleNode, 0)
+	res, err := clusterAPI.TrustClient().GenerateHostCert(ctx, &trustpb.GenerateHostCertRequest{
+		Key:         key.MarshalSSHPublicKey(),
+		HostId:      "",
+		NodeName:    "",
+		ClusterName: clusterName,
+		Role:        string(types.RoleNode),
+		Ttl:         durationpb.New(0),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	key.Cert = res.SshCertificate
+
 	hostCAs, err := clusterAPI.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Removes the deprecated HTTP implementation of `GenerateHostCert`. Calls have been using the gRPC endpoint since v15.