### PR TITLE
Fix WatchStatus event on AccessPlugin example

### DIFF
--- a/examples/access-plugin-minimal/watcherjob.go
+++ b/examples/access-plugin-minimal/watcherjob.go
@@ -28,7 +28,7 @@ func (g *googleSheetsClient) HandleEvent(ctx context.Context, event types.Event)
 		return nil
 	}
 
-	if _, ok := event.Resource.(types.WatchStatus); ok {
+	if _, ok := event.Resource.(*types.WatchStatusV1); ok {
 		fmt.Println("Successfully started listening for Access Requests...")
 		return nil
 	}

--- a/examples/access-plugin-minimal/watcherjob.go
+++ b/examples/access-plugin-minimal/watcherjob.go
@@ -28,7 +28,16 @@ func (g *googleSheetsClient) HandleEvent(ctx context.Context, event types.Event)
 		return nil
 	}
 
-	r := event.Resource.(types.AccessRequest)
+	if _, ok := event.Resource.(types.WatchStatus); ok {
+		fmt.Println("Successfully started listening for Access Requests...")
+		return nil
+	}
+
+	r, ok := event.Resource.(types.AccessRequest)
+	if !ok {
+		fmt.Printf("Unknown (%T) event received, skipping.\n", event.Resource)
+		return nil
+	}
 
 	if r.GetState() == types.RequestState_PENDING {
 		if err := g.createRow(r); err != nil {


### PR DESCRIPTION
After subscribing to events, we should always receive an event saying that it either succeeded or failed.
This information comes in a `WatchStatus` event.

This PR changes the code to ensure we catch this new case.
It also adds a safeguard when casting events to AccessRequest to ensure we log in case of an error instead throwing a panic.

Demo:
![image](https://github.com/gravitational/teleport/assets/689271/8b898dcf-5a0c-47e7-98c5-a939b36d6adc)
```
> go run teleport-sheets
Starting the watcher job
Successfully started listening for Access Requests...
Successfully created a row
```