### PR TITLE
Filter terminated sessions out of tsh sessions ls ouput

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3108,7 +3108,9 @@ func onListSessions(cf *CLIConf) error {
 
 func sortAndFilterSessions(sessions []types.SessionTracker, kinds []types.SessionKind) []types.SessionTracker {
 	filtered := slices.DeleteFunc(sessions, func(st types.SessionTracker) bool {
-		return !slices.Contains(kinds, st.GetSessionKind())
+		return !slices.Contains(kinds, st.GetSessionKind()) ||
+			(st.GetState() != types.SessionState_SessionStateRunning &&
+				st.GetState() != types.SessionState_SessionStatePending)
 	})
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].GetCreated().Before(filtered[j].GetCreated())


### PR DESCRIPTION
This fixes a small oversight in #37740.
(`GetActiveSessionTrackers` also includes terminated sessions)

Changelog: filter terminated sessions from the `tsh sessions ls` output.