### PR TITLE
Update the document title for web sessions

### DIFF
--- a/web/packages/teleport/src/Console/usePageTitle.tsx
+++ b/web/packages/teleport/src/Console/usePageTitle.tsx
@@ -22,7 +22,7 @@ import * as stores from './stores/types';
 
 export default function usePageTitle(doc: stores.Document) {
   const title =
-    doc && doc.title ? `${doc.clusterId} • ${doc.title}` : 'Console';
+    doc && doc.title ? `${doc.title} • ${doc.clusterId}` : 'Console';
   React.useEffect(() => {
     document.title = title;
   }, [title]);

--- a/web/packages/teleport/src/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/useDesktopSession.tsx
@@ -82,7 +82,7 @@ export default function useDesktopSession() {
     useState(false);
 
   document.title = useMemo(
-    () => `${clusterId} • ${username}@${hostname}`,
+    () => `${username}@${hostname} • ${clusterId}`,
     [clusterId, hostname, username]
   );
 

--- a/web/packages/teleport/src/Player/Player.tsx
+++ b/web/packages/teleport/src/Player/Player.tsx
@@ -51,7 +51,7 @@ export default function Player() {
   const validRecordingType = validRecordingTypes.includes(recordingType);
   const validDurationMs = Number.isInteger(durationMs) && durationMs > 0;
 
-  document.title = `${clusterId} • Play ${sid}`;
+  document.title = `Play ${sid} • ${clusterId}`;
 
   function onLogout() {
     session.logout();


### PR DESCRIPTION
Put the session information before the cluster name. This makes it easier to identify tabs when the long titles start to get truncated.

Fixes #38637

Changelog: Make it easier to identify Teleport browser tabs by placing the session information before the cluster name.