### PR TITLE
[v15] helm: Set resource request/limit on wait-auth-update initContainer

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -109,6 +109,10 @@ spec:
             - wait
             - no-resolve
             - '{{ include "teleport-cluster.auth.previousVersionServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if $proxy.resources }}
+          resources:
+  {{- toYaml $proxy.resources | nindent 12 }}
+{{- end }}
 {{- if $proxy.securityContext }}
           securityContext: {{- toYaml $proxy.securityContext | nindent 12 }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -109,9 +109,16 @@ spec:
             - wait
             - no-resolve
             - '{{ include "teleport-cluster.auth.previousVersionServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+# propagating through the limits from the main resources section would double the requested amounts
+# and may prevent scheduling on the cluster. as such, we hardcode small limits for this tiny container.
 {{- if $proxy.resources }}
           resources:
-  {{- toYaml $proxy.resources | nindent 12 }}
+            requests:
+              cpu: 0.1
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
 {{- end }}
 {{- if $proxy.securityContext }}
           securityContext: {{- toYaml $proxy.securityContext | nindent 12 }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -7,6 +7,13 @@ should provision initContainer correctly when set in values:
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.0.2
       name: wait-auth-update
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
     - args:
       - echo test
       image: alpine
@@ -166,6 +173,114 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             values:
             - proxy
         topologyKey: kubernetes.io/hostname
+should set resources for wait-auth-update initContainer when set in values:
+  1: |
+    affinity:
+      podAntiAffinity: null
+    automountServiceAccountToken: false
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - teleport
+            - wait
+            - duration
+            - 30s
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3080
+        name: tls
+        protocol: TCP
+      - containerPort: 3023
+        name: sshproxy
+        protocol: TCP
+      - containerPort: 3024
+        name: sshtun
+        protocol: TCP
+      - containerPort: 3026
+        name: kube
+        protocol: TCP
+      - containerPort: 3036
+        name: mysql
+        protocol: TCP
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: proxy-serviceaccount-token
+        readOnly: true
+    initContainers:
+    - command:
+      - teleport
+      - wait
+      - no-resolve
+      - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
+      name: wait-auth-update
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+    serviceAccountName: RELEASE-NAME-proxy
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - name: proxy-serviceaccount-token
+      projected:
+        sources:
+        - serviceAccountToken:
+            path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
+    - configMap:
+        name: RELEASE-NAME-proxy
+      name: config
+    - emptyDir: {}
+      name: data
 should set resources when set in values:
   1: |
     affinity:
@@ -244,6 +359,13 @@ should set resources when set in values:
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
       image: public.ecr.aws/gravitational/teleport-distroless:15.0.2
       name: wait-auth-update
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
     volumes:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -181,7 +181,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:15.0.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -248,8 +248,8 @@ should set resources for wait-auth-update initContainer when set in values:
       - teleport
       - wait
       - no-resolve
-      - RELEASE-NAME-auth-v15.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:16.0.0-dev
+      - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:15.0.2
       name: wait-auth-update
       resources:
         limits:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -9,11 +9,11 @@ should provision initContainer correctly when set in values:
       name: wait-auth-update
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
           cpu: 1
-          memory: 2Gi
+          memory: 512Mi
+        requests:
+          cpu: 0.1
+          memory: 256Mi
     - args:
       - echo test
       image: alpine
@@ -253,11 +253,11 @@ should set resources for wait-auth-update initContainer when set in values:
       name: wait-auth-update
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
           cpu: 1
-          memory: 2Gi
+          memory: 512Mi
+        requests:
+          cpu: 0.1
+          memory: 256Mi
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
     volumes:
@@ -361,11 +361,11 @@ should set resources when set in values:
       name: wait-auth-update
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
           cpu: 1
-          memory: 2Gi
+          memory: 512Mi
+        requests:
+          cpu: 0.1
+          memory: 256Mi
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
     volumes:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -224,6 +224,25 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set resources for wait-auth-update initContainer when set in values
+    template: proxy/deployment.yaml
+    values:
+      - ../.lint/resources.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: 2Gi
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 4Gi
+      - matchSnapshot:
+          path: spec.template.spec
 
   - it: should not set securityContext for initContainers when is empty object (default value)
     template: proxy/deployment.yaml

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -231,16 +231,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].resources.requests.cpu
-          value: 1
+          value: 0.1
       - equal:
           path: spec.template.spec.initContainers[0].resources.requests.memory
-          value: 2Gi
+          value: 256Mi
       - equal:
           path: spec.template.spec.initContainers[0].resources.limits.cpu
-          value: 2
+          value: 1
       - equal:
           path: spec.template.spec.initContainers[0].resources.limits.memory
-          value: 4Gi
+          value: 512Mi
       - matchSnapshot:
           path: spec.template.spec
 


### PR DESCRIPTION
Backport #38672 to branch/v15

changelog: Resource limits are now correctly applied to the `wait-auth-update` initContainer in the `teleport-cluster` Helm chart.
