### PR TITLE
Refactor Presence service to add ListRemoteClusters, context.Context and returning updated/created RemoteClusters

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3301,7 +3301,7 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	require.Len(t, servers, 2)
 
 	// check that remote cluster has been provisioned
-	remoteClusters, err := main.Process.GetAuthServer().GetRemoteClusters()
+	remoteClusters, err := main.Process.GetAuthServer().GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Len(t, remoteClusters, 1)
 	require.Equal(t, clusterAux, remoteClusters[0].GetName())
@@ -3323,7 +3323,7 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	require.NoError(t, err)
 
 	// check that remote cluster has been re-provisioned
-	remoteClusters, err = main.Process.GetAuthServer().GetRemoteClusters()
+	remoteClusters, err = main.Process.GetAuthServer().GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Len(t, remoteClusters, 1)
 	require.Equal(t, clusterAux, remoteClusters[0].GetName())

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -671,7 +671,7 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 		"Two clusters do not see each other: tunnels are not working.")
 
 	require.Eventually(t, func() bool {
-		tc, err := main.Process.GetAuthServer().GetRemoteCluster(aux.Secrets.SiteName)
+		tc, err := main.Process.GetAuthServer().GetRemoteCluster(ctx, aux.Secrets.SiteName)
 		if err != nil {
 			return false
 		}
@@ -949,7 +949,7 @@ func testKubeTrustedClustersSNI(t *testing.T, suite *KubeSuite) {
 		"Two clusters do not see each other: tunnels are not working.")
 
 	require.Eventually(t, func() bool {
-		tc, err := main.Process.GetAuthServer().GetRemoteCluster(aux.Secrets.SiteName)
+		tc, err := main.Process.GetAuthServer().GetRemoteCluster(ctx, aux.Secrets.SiteName)
 		if err != nil {
 			return false
 		}

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -243,10 +243,10 @@ type ReadProxyAccessPoint interface {
 	GetWebToken(context.Context, types.GetWebTokenRequest) (types.WebToken, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 
 	// GetKubernetesServers returns a list of kubernetes servers registered in the cluster
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
@@ -376,10 +376,10 @@ type ReadRemoteProxyAccessPoint interface {
 	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 
 	// GetKubernetesServers returns a list of kubernetes servers registered in the cluster
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
@@ -989,10 +989,10 @@ type Cache interface {
 	GetWebToken(context.Context, types.GetWebTokenRequest) (types.WebToken, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 
 	// GetKubernetesServers returns a list of kubernetes servers registered in the cluster
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -243,7 +243,7 @@ type ReadProxyAccessPoint interface {
 	GetWebToken(context.Context, types.GetWebTokenRequest) (types.WebToken, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
@@ -376,7 +376,7 @@ type ReadRemoteProxyAccessPoint interface {
 	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
@@ -989,7 +989,7 @@ type Cache interface {
 	GetWebToken(context.Context, types.GetWebTokenRequest) (types.WebToken, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1009,7 +1009,7 @@ func (s *APIServer) createRemoteCluster(auth *ServerWithRoles, w http.ResponseWr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.CreateRemoteCluster(conn); err != nil {
+	if err := auth.CreateRemoteCluster(r.Context(), conn); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -1017,7 +1017,7 @@ func (s *APIServer) createRemoteCluster(auth *ServerWithRoles, w http.ResponseWr
 
 // getRemoteClusters returns a list of remote clusters
 func (s *APIServer) getRemoteClusters(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	clusters, err := auth.GetRemoteClusters()
+	clusters, err := auth.GetRemoteClusters(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1034,7 +1034,7 @@ func (s *APIServer) getRemoteClusters(auth *ServerWithRoles, w http.ResponseWrit
 
 // getRemoteCluster returns a remote cluster by name
 func (s *APIServer) getRemoteCluster(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	cluster, err := auth.GetRemoteCluster(p.ByName("cluster"))
+	cluster, err := auth.GetRemoteCluster(r.Context(), p.ByName("cluster"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1052,7 +1052,7 @@ func (s *APIServer) deleteRemoteCluster(auth *ServerWithRoles, w http.ResponseWr
 
 // deleteAllRemoteClusters deletes all remote clusters
 func (s *APIServer) deleteAllRemoteClusters(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteAllRemoteClusters()
+	err := auth.DeleteAllRemoteClusters(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -128,11 +128,9 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/tunnelconnections", srv.WithAuth(srv.deleteAllTunnelConnections))
 
 	// Remote clusters
-	srv.POST("/:version/remoteclusters", srv.WithAuth(srv.createRemoteCluster))
 	srv.GET("/:version/remoteclusters/:cluster", srv.WithAuth(srv.getRemoteCluster))
 	srv.GET("/:version/remoteclusters", srv.WithAuth(srv.getRemoteClusters))
 	srv.DELETE("/:version/remoteclusters/:cluster", srv.WithAuth(srv.deleteRemoteCluster))
-	srv.DELETE("/:version/remoteclusters", srv.WithAuth(srv.deleteAllRemoteClusters))
 
 	// Reverse tunnels
 	srv.POST("/:version/reversetunnels", srv.WithAuth(srv.upsertReverseTunnel))
@@ -994,27 +992,6 @@ func (s *APIServer) deleteAllTunnelConnections(auth *ServerWithRoles, w http.Res
 	return message("ok"), nil
 }
 
-type createRemoteClusterRawReq struct {
-	// RemoteCluster is marshaled remote cluster resource
-	RemoteCluster json.RawMessage `json:"remote_cluster"`
-}
-
-// createRemoteCluster creates remote cluster
-func (s *APIServer) createRemoteCluster(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	var req createRemoteClusterRawReq
-	if err := httplib.ReadJSON(r, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	conn, err := services.UnmarshalRemoteCluster(req.RemoteCluster)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := auth.CreateRemoteCluster(r.Context(), conn); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
-}
-
 // getRemoteClusters returns a list of remote clusters
 func (s *APIServer) getRemoteClusters(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	clusters, err := auth.GetRemoteClusters(r.Context())
@@ -1044,15 +1021,6 @@ func (s *APIServer) getRemoteCluster(auth *ServerWithRoles, w http.ResponseWrite
 // deleteRemoteCluster deletes remote cluster by name
 func (s *APIServer) deleteRemoteCluster(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteRemoteCluster(r.Context(), p.ByName("cluster"))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
-}
-
-// deleteAllRemoteClusters deletes all remote clusters
-func (s *APIServer) deleteAllRemoteClusters(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteAllRemoteClusters(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1515,7 +1515,7 @@ var (
 
 // refreshRemoteClusters updates connection status of all remote clusters.
 func (a *Server) refreshRemoteClusters(ctx context.Context, rnd *insecurerand.Rand) {
-	remoteClusters, err := a.Services.GetRemoteClusters()
+	remoteClusters, err := a.Services.GetRemoteClusters(ctx)
 	if err != nil {
 		log.WithError(err).Error("Failed to load remote clusters for status refresh")
 		return
@@ -2582,7 +2582,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	}
 	if req.routeToCluster != clusterName {
 		// Authorize access to a remote cluster.
-		rc, err := a.GetRemoteCluster(req.routeToCluster)
+		rc, err := a.GetRemoteCluster(ctx, req.routeToCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -263,7 +263,8 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	// Register the leaf cluster.
 	leaf, err := types.NewRemoteCluster("leaf.localhost")
 	require.NoError(t, err)
-	require.NoError(t, s.a.CreateRemoteCluster(leaf))
+	leaf, err = s.a.CreateRemoteCluster(ctx, leaf)
+	require.NoError(t, err)
 
 	user := "user1"
 	pass := []byte("abcdef123456")

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -263,7 +263,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	// Register the leaf cluster.
 	leaf, err := types.NewRemoteCluster("leaf.localhost")
 	require.NoError(t, err)
-	leaf, err = s.a.CreateRemoteCluster(ctx, leaf)
+	_, err = s.a.CreateRemoteCluster(ctx, leaf)
 	require.NoError(t, err)
 
 	user := "user1"

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4631,14 +4631,6 @@ func (a *ServerWithRoles) DeleteAllTunnelConnections() error {
 	return a.authServer.DeleteAllTunnelConnections()
 }
 
-func (a *ServerWithRoles) CreateRemoteCluster(ctx context.Context, conn types.RemoteCluster) error {
-	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbCreate); err != nil {
-		return trace.Wrap(err)
-	}
-	_, err := a.authServer.CreateRemoteCluster(ctx, conn)
-	return trace.Wrap(err)
-}
-
 func (a *ServerWithRoles) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) error {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
@@ -4692,13 +4684,6 @@ func (a *ServerWithRoles) DeleteRemoteCluster(ctx context.Context, clusterName s
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteRemoteCluster(ctx, clusterName)
-}
-
-func (a *ServerWithRoles) DeleteAllRemoteClusters(ctx context.Context) error {
-	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbList, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteAllRemoteClusters(ctx)
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4631,25 +4631,27 @@ func (a *ServerWithRoles) DeleteAllTunnelConnections() error {
 	return a.authServer.DeleteAllTunnelConnections()
 }
 
-func (a *ServerWithRoles) CreateRemoteCluster(conn types.RemoteCluster) error {
+func (a *ServerWithRoles) CreateRemoteCluster(ctx context.Context, conn types.RemoteCluster) error {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.CreateRemoteCluster(conn)
+	_, err := a.authServer.CreateRemoteCluster(ctx, conn)
+	return trace.Wrap(err)
 }
 
 func (a *ServerWithRoles) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) error {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpdateRemoteCluster(ctx, rc)
+	_, err := a.authServer.UpdateRemoteCluster(ctx, rc)
+	return trace.Wrap(err)
 }
 
-func (a *ServerWithRoles) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
+func (a *ServerWithRoles) GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error) {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cluster, err := a.authServer.GetRemoteCluster(clusterName)
+	cluster, err := a.authServer.GetRemoteCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4659,11 +4661,11 @@ func (a *ServerWithRoles) GetRemoteCluster(clusterName string) (types.RemoteClus
 	return cluster, nil
 }
 
-func (a *ServerWithRoles) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (a *ServerWithRoles) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteClusters, err := a.authServer.GetRemoteClusters(opts...)
+	remoteClusters, err := a.authServer.GetRemoteClusters(ctx, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4692,11 +4694,11 @@ func (a *ServerWithRoles) DeleteRemoteCluster(ctx context.Context, clusterName s
 	return a.authServer.DeleteRemoteCluster(ctx, clusterName)
 }
 
-func (a *ServerWithRoles) DeleteAllRemoteClusters() error {
+func (a *ServerWithRoles) DeleteAllRemoteClusters(ctx context.Context) error {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbList, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteAllRemoteClusters()
+	return a.authServer.DeleteAllRemoteClusters(ctx)
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4661,11 +4661,11 @@ func (a *ServerWithRoles) GetRemoteCluster(ctx context.Context, clusterName stri
 	return cluster, nil
 }
 
-func (a *ServerWithRoles) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (a *ServerWithRoles) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	if err := a.action(apidefaults.Namespace, types.KindRemoteCluster, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteClusters, err := a.authServer.GetRemoteClusters(ctx, opts...)
+	remoteClusters, err := a.authServer.GetRemoteClusters(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -524,6 +524,26 @@ func (c *Client) IntegrationAWSOIDCClient() integrationv1.AWSOIDCServiceClient {
 	return integrationv1.NewAWSOIDCServiceClient(c.APIClient.GetConnection())
 }
 
+// ListRemoteClusters returns a page of remote clusters.
+func (c *Client) ListRemoteClusters(ctx context.Context, pageSize int, nextToken string) ([]types.RemoteCluster, string, error) {
+	return nil, "", trace.NotImplemented("ListRemoteClusters is not implemented yet")
+}
+
+// UpdateRemoteCluster updates a remote cluster.
+func (c *Client) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
+	// This is a little weird during the migration period of the old endpoints
+	// to grpc. Here, we need to call Update via gRPC and Get via HTTP.
+	err := c.APIClient.UpdateRemoteCluster(ctx, rc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	fetchedRC, err := c.HTTPClient.GetRemoteCluster(ctx, rc.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return fetchedRC, nil
+}
+
 // UpsertUser user updates user entry.
 // TODO(tross): DELETE IN 16.0.0
 func (c *Client) UpsertUser(ctx context.Context, user types.User) (types.User, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -361,6 +361,16 @@ func (c *Client) DeleteAllReverseTunnels() error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// DeleteAllRemoteClusters not implemented: can only be called locally.
+func (c *Client) DeleteAllRemoteClusters(ctx context.Context) error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
+// CreateRemoteCluster not implemented: can only be called locally.
+func (c *Client) CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
 // DeleteAllNamespaces not implemented: can only be called locally.
 func (c *Client) DeleteAllNamespaces() error {
 	return trace.NotImplemented(notImplementedMessage)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1177,7 +1177,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 	require.NoError(t, err)
 
 	// create remote cluster
-	leaf, err = srv.Auth().CreateRemoteCluster(ctx, leaf)
+	_, err = srv.Auth().CreateRemoteCluster(ctx, leaf)
 	require.NoError(t, err)
 
 	// Create a fake user.

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1177,7 +1177,8 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 	require.NoError(t, err)
 
 	// create remote cluster
-	require.NoError(t, srv.Auth().CreateRemoteCluster(leaf))
+	leaf, err = srv.Auth().CreateRemoteCluster(ctx, leaf)
+	require.NoError(t, err)
 
 	// Create a fake user.
 	user, role, err := CreateUserAndRole(srv.Auth(), "mfa-user", []string{"role"}, nil)

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -490,8 +490,8 @@ func (c *HTTPClient) DeleteAllTunnelConnections() error {
 }
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *HTTPClient) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	out, err := c.Get(context.TODO(), c.Endpoint("remoteclusters"), url.Values{})
+func (c *HTTPClient) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+	out, err := c.Get(ctx, c.Endpoint("remoteclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -511,11 +511,11 @@ func (c *HTTPClient) GetRemoteClusters(opts ...services.MarshalOption) ([]types.
 }
 
 // GetRemoteCluster returns a remote cluster by name
-func (c *HTTPClient) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
+func (c *HTTPClient) GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error) {
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name")
 	}
-	out, err := c.Get(context.TODO(), c.Endpoint("remoteclusters", clusterName), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("remoteclusters", clusterName), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -532,22 +532,31 @@ func (c *HTTPClient) DeleteRemoteCluster(ctx context.Context, clusterName string
 }
 
 // DeleteAllRemoteClusters deletes all remote clusters
-func (c *HTTPClient) DeleteAllRemoteClusters() error {
-	_, err := c.Delete(context.TODO(), c.Endpoint("remoteclusters"))
+func (c *HTTPClient) DeleteAllRemoteClusters(ctx context.Context) error {
+	_, err := c.Delete(ctx, c.Endpoint("remoteclusters"))
 	return trace.Wrap(err)
 }
 
 // CreateRemoteCluster creates remote cluster resource
-func (c *HTTPClient) CreateRemoteCluster(rc types.RemoteCluster) error {
+func (c *HTTPClient) CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
 	data, err := services.MarshalRemoteCluster(rc)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	args := &createRemoteClusterRawReq{
 		RemoteCluster: data,
 	}
-	_, err = c.PostJSON(context.TODO(), c.Endpoint("remoteclusters"), args)
-	return trace.Wrap(err)
+	_, err = c.PostJSON(ctx, c.Endpoint("remoteclusters"), args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	returned, err := c.GetRemoteCluster(ctx, rc.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return returned, trace.Wrap(err)
 }
 
 // UpsertAuthServer is used by auth servers to report their presence

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -490,7 +490,7 @@ func (c *HTTPClient) DeleteAllTunnelConnections() error {
 }
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *HTTPClient) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (c *HTTPClient) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	out, err := c.Get(ctx, c.Endpoint("remoteclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -531,34 +531,6 @@ func (c *HTTPClient) DeleteRemoteCluster(ctx context.Context, clusterName string
 	return trace.Wrap(err)
 }
 
-// DeleteAllRemoteClusters deletes all remote clusters
-func (c *HTTPClient) DeleteAllRemoteClusters(ctx context.Context) error {
-	_, err := c.Delete(ctx, c.Endpoint("remoteclusters"))
-	return trace.Wrap(err)
-}
-
-// CreateRemoteCluster creates remote cluster resource
-func (c *HTTPClient) CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
-	data, err := services.MarshalRemoteCluster(rc)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	args := &createRemoteClusterRawReq{
-		RemoteCluster: data,
-	}
-	_, err = c.PostJSON(ctx, c.Endpoint("remoteclusters"), args)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	returned, err := c.GetRemoteCluster(ctx, rc.GetName())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return returned, trace.Wrap(err)
-}
-
 // UpsertAuthServer is used by auth servers to report their presence
 // to other auth servers in form of hearbeat expiring after ttl period.
 func (c *HTTPClient) UpsertAuthServer(ctx context.Context, s types.Server) error {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1390,7 +1390,7 @@ func migrateRemoteClusters(ctx context.Context, asrv *Server) error {
 			continue
 		}
 		// remote cluster already exists
-		_, err = asrv.Services.GetRemoteCluster(certAuthority.GetName())
+		_, err = asrv.Services.GetRemoteCluster(ctx, certAuthority.GetName())
 		if err == nil {
 			log.Debugf("Migrations: remote cluster already exists for cert authority %q.", certAuthority.GetName())
 			continue
@@ -1411,7 +1411,7 @@ func migrateRemoteClusters(ctx context.Context, asrv *Server) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = asrv.CreateRemoteCluster(remoteCluster)
+		_, err = asrv.CreateRemoteCluster(ctx, remoteCluster)
 		if err != nil {
 			if !trace.IsAlreadyExists(err) {
 				return trace.Wrap(err)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1568,7 +1568,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	// Create remote cluster so create access request doesn't err due to non existent cluster
 	rc, err := types.NewRemoteCluster("foobar")
 	require.NoError(t, err)
-	err = testSrv.AuthServer.AuthServer.CreateRemoteCluster(rc)
+	rc, err = testSrv.AuthServer.AuthServer.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
 
 	// Create approved resource request
@@ -2425,7 +2425,7 @@ func TestGenerateCerts(t *testing.T) {
 		// but can renew their own cert, for example set route to cluster
 		rc, err := types.NewRemoteCluster("cluster-remote")
 		require.NoError(t, err)
-		err = srv.Auth().CreateRemoteCluster(rc)
+		rc, err = srv.Auth().CreateRemoteCluster(ctx, rc)
 		require.NoError(t, err)
 
 		userCerts, err = impersonatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
@@ -2454,7 +2454,7 @@ func TestGenerateCerts(t *testing.T) {
 
 		rc1, err := types.NewRemoteCluster("cluster1")
 		require.NoError(t, err)
-		err = srv.Auth().CreateRemoteCluster(rc1)
+		rc1, err = srv.Auth().CreateRemoteCluster(ctx, rc1)
 		require.NoError(t, err)
 
 		// User can renew their certificates, however the TTL will be limited
@@ -2554,7 +2554,7 @@ func TestGenerateCerts(t *testing.T) {
 		meta := rc2.GetMetadata()
 		meta.Labels = map[string]string{"env": "prod"}
 		rc2.SetMetadata(meta)
-		err = srv.Auth().CreateRemoteCluster(rc2)
+		rc2, err = srv.Auth().CreateRemoteCluster(ctx, rc2)
 		require.NoError(t, err)
 
 		// User can't generate certificates for leaf cluster they don't have access

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -3900,7 +3900,7 @@ func TestEvents(t *testing.T) {
 		ConfigS:       clt,
 		LocalConfigS:  testSrv.Auth(),
 		EventsS:       clt,
-		PresenceS:     clt,
+		PresenceS:     testSrv.Auth(),
 		CAS:           clt,
 		ProvisioningS: clt,
 		Access:        clt,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1286,7 +1286,7 @@ func TestRemoteClustersCRUD(t *testing.T) {
 	require.NoError(t, err)
 	updated, err := clt.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
-	require.Equal(t, updated.GetConnectionStatus(), teleport.RemoteClusterStatusOnline)
+	require.Equal(t, teleport.RemoteClusterStatusOnline, updated.GetConnectionStatus())
 	// Ensure other fields unchanged
 	require.Empty(t,
 		cmp.Diff(

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1568,7 +1568,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	// Create remote cluster so create access request doesn't err due to non existent cluster
 	rc, err := types.NewRemoteCluster("foobar")
 	require.NoError(t, err)
-	rc, err = testSrv.AuthServer.AuthServer.CreateRemoteCluster(ctx, rc)
+	_, err = testSrv.AuthServer.AuthServer.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
 
 	// Create approved resource request

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -459,10 +459,10 @@ func (a *Server) updateRemoteClusterStatus(ctx context.Context, netConfig types.
 }
 
 // GetRemoteClusters returns remote clusters with updated statuses
-func (a *Server) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (a *Server) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteClusters, err := a.Services.GetRemoteClusters(ctx, opts...)
+	remoteClusters, err := a.Services.GetRemoteClusters(ctx)
 	return remoteClusters, trace.Wrap(err)
 }
 

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -353,7 +353,7 @@ func (a *Server) addCertAuthorities(ctx context.Context, trustedCluster types.Tr
 func (a *Server) DeleteRemoteCluster(ctx context.Context, clusterName string) error {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	_, err := a.GetRemoteCluster(clusterName)
+	_, err := a.GetRemoteCluster(ctx, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -385,10 +385,10 @@ func (a *Server) DeleteRemoteCluster(ctx context.Context, clusterName string) er
 }
 
 // GetRemoteCluster returns remote cluster by name
-func (a *Server) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
+func (a *Server) GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteCluster, err := a.Services.GetRemoteCluster(clusterName)
+	remoteCluster, err := a.Services.GetRemoteCluster(ctx, clusterName)
 	return remoteCluster, trace.Wrap(err)
 }
 
@@ -412,7 +412,8 @@ func (a *Server) updateRemoteClusterStatus(ctx context.Context, netConfig types.
 		// wasn't already).
 		if remoteCluster.GetConnectionStatus() != teleport.RemoteClusterStatusOffline {
 			remoteCluster.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
-			if err := a.UpdateRemoteCluster(ctx, remoteCluster); err != nil {
+			_, err := a.UpdateRemoteCluster(ctx, remoteCluster)
+			if err != nil {
 				// if the cluster was concurrently updated, ignore the update.  either
 				// the update was consistent with our view of the world, in which case
 				// retrying would be pointless, or the update was not consistent, in which
@@ -440,7 +441,8 @@ func (a *Server) updateRemoteClusterStatus(ctx context.Context, netConfig types.
 		remoteCluster.SetLastHeartbeat(lastConn.GetLastHeartbeat().UTC())
 	}
 	if prevConnectionStatus != remoteCluster.GetConnectionStatus() || !prevLastHeartbeat.Equal(remoteCluster.GetLastHeartbeat()) {
-		if err := a.UpdateRemoteCluster(ctx, remoteCluster); err != nil {
+		_, err := a.UpdateRemoteCluster(ctx, remoteCluster)
+		if err != nil {
 			// if the cluster was concurrently updated, ignore the update.  either
 			// the update was consistent with our view of the world, in which case
 			// retrying would be pointless, or the update was not consistent, in which
@@ -457,10 +459,10 @@ func (a *Server) updateRemoteClusterStatus(ctx context.Context, netConfig types.
 }
 
 // GetRemoteClusters returns remote clusters with updated statuses
-func (a *Server) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (a *Server) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteClusters, err := a.Services.GetRemoteClusters(opts...)
+	remoteClusters, err := a.Services.GetRemoteClusters(ctx, opts...)
 	return remoteClusters, trace.Wrap(err)
 }
 
@@ -523,7 +525,7 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *Va
 	}
 	remoteCluster.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
-	err = a.CreateRemoteCluster(remoteCluster)
+	_, err = a.CreateRemoteCluster(ctx, remoteCluster)
 	if err != nil {
 		if !trace.IsAlreadyExists(err) {
 			return nil, trace.Wrap(err)

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -48,7 +48,8 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 	rc, err := types.NewRemoteCluster("rc")
 	require.NoError(t, err)
-	require.NoError(t, a.CreateRemoteCluster(rc))
+	rc, err = a.CreateRemoteCluster(ctx, rc)
+	require.NoError(t, err)
 
 	// This scenario deals with only one remote cluster, so it never hits the limit on status updates.
 	// TestRefreshRemoteClusters focuses on verifying the update limit logic.
@@ -57,7 +58,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	wantRC := rc
 	// Initially, no tunnels exist and status should be "offline".
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
-	gotRC, err := a.GetRemoteCluster(rc.GetName())
+	gotRC, err := a.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
@@ -88,7 +89,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// the latest tunnel heartbeat.
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOnline)
 	wantRC.SetLastHeartbeat(tc2.GetLastHeartbeat())
-	gotRC, err = a.GetRemoteCluster(rc.GetName())
+	gotRC, err = a.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
@@ -101,7 +102,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// The last_heartbeat should remain the same, since tc1 has an older
 	// heartbeat.
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOnline)
-	gotRC, err = a.GetRemoteCluster(rc.GetName())
+	gotRC, err = a.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
@@ -113,7 +114,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// The status should switch to "offline".
 	// The last_heartbeat should remain the same.
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
-	gotRC, err = a.GetRemoteCluster(rc.GetName())
+	gotRC, err = a.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 }
@@ -168,7 +169,8 @@ func TestRefreshRemoteClusters(t *testing.T) {
 				rc, err := types.NewRemoteCluster(fmt.Sprintf("rc-%03d", i))
 				rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 				require.NoError(t, err)
-				require.NoError(t, a.CreateRemoteCluster(rc))
+				rc, err = a.CreateRemoteCluster(ctx, rc)
+				require.NoError(t, err)
 				allClusters[rc.GetName()] = rc
 
 				if i < tt.clustersNeedUpdate {
@@ -186,7 +188,7 @@ func TestRefreshRemoteClusters(t *testing.T) {
 
 			a.refreshRemoteClusters(ctx, rnd)
 
-			clusters, err := a.GetRemoteClusters()
+			clusters, err := a.GetRemoteClusters(ctx)
 			require.NoError(t, err)
 
 			var updated int
@@ -330,7 +332,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 			require.True(t, services.CertAuthoritiesEquivalent(localCA, returnedCA))
 		}
 
-		rcs, err := a.GetRemoteClusters()
+		rcs, err := a.GetRemoteClusters(ctx)
 		require.NoError(t, err)
 		require.Len(t, rcs, 1)
 		require.Equal(t, leafClusterCA.GetName(), rcs[0].GetName())

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -60,7 +60,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 	gotRC, err := a.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	require.Empty(t, cmp.Diff(wantRC, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	// Create several tunnel connections.
 	lastHeartbeat := a.clock.Now().UTC()

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2040,7 +2040,7 @@ type remoteClustersCacheKey struct {
 var _ map[remoteClustersCacheKey]struct{} // compile-time hashability check
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *Cache) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (c *Cache) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetRemoteClusters")
 	defer span.End()
 
@@ -2051,7 +2051,7 @@ func (c *Cache) GetRemoteClusters(ctx context.Context, opts ...services.MarshalO
 	defer rg.Release()
 	if !rg.IsCacheRead() {
 		cachedRemotes, err := utils.FnCacheGet(ctx, c.fnCache, remoteClustersCacheKey{}, func(ctx context.Context) ([]types.RemoteCluster, error) {
-			remotes, err := rg.reader.GetRemoteClusters(ctx, opts...)
+			remotes, err := rg.reader.GetRemoteClusters(ctx)
 			return remotes, err
 		})
 		if err != nil || cachedRemotes == nil {
@@ -2064,7 +2064,7 @@ func (c *Cache) GetRemoteClusters(ctx context.Context, opts ...services.MarshalO
 		}
 		return remotes, nil
 	}
-	return rg.reader.GetRemoteClusters(ctx, opts...)
+	return rg.reader.GetRemoteClusters(ctx)
 }
 
 // GetRemoteCluster returns a remote cluster by name

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2040,8 +2040,8 @@ type remoteClustersCacheKey struct {
 var _ map[remoteClustersCacheKey]struct{} // compile-time hashability check
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *Cache) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	ctx, span := c.Tracer.Start(context.TODO(), "cache/GetRemoteClusters")
+func (c *Cache) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRemoteClusters")
 	defer span.End()
 
 	rg, err := readCollectionCache(c, c.collections.remoteClusters)
@@ -2051,7 +2051,7 @@ func (c *Cache) GetRemoteClusters(opts ...services.MarshalOption) ([]types.Remot
 	defer rg.Release()
 	if !rg.IsCacheRead() {
 		cachedRemotes, err := utils.FnCacheGet(ctx, c.fnCache, remoteClustersCacheKey{}, func(ctx context.Context) ([]types.RemoteCluster, error) {
-			remotes, err := rg.reader.GetRemoteClusters(opts...)
+			remotes, err := rg.reader.GetRemoteClusters(ctx, opts...)
 			return remotes, err
 		})
 		if err != nil || cachedRemotes == nil {
@@ -2064,12 +2064,12 @@ func (c *Cache) GetRemoteClusters(opts ...services.MarshalOption) ([]types.Remot
 		}
 		return remotes, nil
 	}
-	return rg.reader.GetRemoteClusters(opts...)
+	return rg.reader.GetRemoteClusters(ctx, opts...)
 }
 
 // GetRemoteCluster returns a remote cluster by name
-func (c *Cache) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
-	ctx, span := c.Tracer.Start(context.TODO(), "cache/GetRemoteCluster")
+func (c *Cache) GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRemoteCluster")
 	defer span.End()
 
 	rg, err := readCollectionCache(c, c.collections.remoteClusters)
@@ -2079,7 +2079,7 @@ func (c *Cache) GetRemoteCluster(clusterName string) (types.RemoteCluster, error
 	defer rg.Release()
 	if !rg.IsCacheRead() {
 		cachedRemote, err := utils.FnCacheGet(ctx, c.fnCache, remoteClustersCacheKey{clusterName}, func(ctx context.Context) (types.RemoteCluster, error) {
-			remote, err := rg.reader.GetRemoteCluster(clusterName)
+			remote, err := rg.reader.GetRemoteCluster(ctx, clusterName)
 			return remote, err
 		})
 		if err != nil {
@@ -2088,17 +2088,31 @@ func (c *Cache) GetRemoteCluster(clusterName string) (types.RemoteCluster, error
 
 		return cachedRemote.Clone(), nil
 	}
-	rc, err := rg.reader.GetRemoteCluster(clusterName)
+	rc, err := rg.reader.GetRemoteCluster(ctx, clusterName)
 	if trace.IsNotFound(err) && rg.IsCacheRead() {
 		// release read lock early
 		rg.Release()
 		// fallback is sane because this method is never used
 		// in construction of derivative caches.
-		if rc, err := c.Config.Presence.GetRemoteCluster(clusterName); err == nil {
+		if rc, err := c.Config.Presence.GetRemoteCluster(ctx, clusterName); err == nil {
 			return rc, nil
 		}
 	}
 	return rc, trace.Wrap(err)
+}
+
+// ListRemoteClusters returns a page of remote clusters.
+func (c *Cache) ListRemoteClusters(ctx context.Context, pageSize int, nextToken string) ([]types.RemoteCluster, string, error) {
+	_, span := c.Tracer.Start(ctx, "cache/ListRemoteClusters")
+	defer span.End()
+
+	rg, err := readCollectionCache(c, c.collections.remoteClusters)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer rg.Release()
+	remoteClusters, token, err := rg.reader.ListRemoteClusters(ctx, pageSize, nextToken)
+	return remoteClusters, token, trace.Wrap(err)
 }
 
 // GetUser is a part of auth.Cache implementation.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1648,19 +1648,25 @@ func TestRemoteClusters(t *testing.T) {
 		newResource: func(name string) (types.RemoteCluster, error) {
 			return types.NewRemoteCluster(name)
 		},
-		create: modifyNoContext(p.presenceS.CreateRemoteCluster),
+		create: func(ctx context.Context, rc types.RemoteCluster) error {
+			_, err := p.presenceS.CreateRemoteCluster(ctx, rc)
+			return err
+		},
 		list: func(ctx context.Context) ([]types.RemoteCluster, error) {
-			return p.presenceS.GetRemoteClusters()
+			return p.presenceS.GetRemoteClusters(ctx)
 		},
 		cacheGet: func(ctx context.Context, name string) (types.RemoteCluster, error) {
-			return p.cache.GetRemoteCluster(name)
+			return p.cache.GetRemoteCluster(ctx, name)
 		},
-		cacheList: func(_ context.Context) ([]types.RemoteCluster, error) {
-			return p.cache.GetRemoteClusters()
+		cacheList: func(ctx context.Context) ([]types.RemoteCluster, error) {
+			return p.cache.GetRemoteClusters(ctx)
 		},
-		update: p.presenceS.UpdateRemoteCluster,
-		deleteAll: func(_ context.Context) error {
-			return p.presenceS.DeleteAllRemoteClusters()
+		update: func(ctx context.Context, rc types.RemoteCluster) error {
+			_, err := p.presenceS.UpdateRemoteCluster(ctx, rc)
+			return err
+		},
+		deleteAll: func(ctx context.Context) error {
+			return p.presenceS.DeleteAllRemoteClusters(ctx)
 		},
 	})
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -800,7 +800,7 @@ func (remoteClusterExecutor) getReader(cache *Cache, cacheOK bool) remoteCluster
 }
 
 type remoteClusterGetter interface {
-	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 	ListRemoteClusters(ctx context.Context, pageSize int, pageToken string) ([]types.RemoteCluster, string, error)
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -767,7 +767,7 @@ var _ executor[types.TunnelConnection, tunnelConnectionGetter] = tunnelConnectio
 type remoteClusterExecutor struct{}
 
 func (remoteClusterExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]types.RemoteCluster, error) {
-	return cache.Presence.GetRemoteClusters()
+	return cache.Presence.GetRemoteClusters(ctx)
 }
 
 func (remoteClusterExecutor) upsert(ctx context.Context, cache *Cache, resource types.RemoteCluster) error {
@@ -778,11 +778,12 @@ func (remoteClusterExecutor) upsert(ctx context.Context, cache *Cache, resource 
 			return trace.Wrap(err)
 		}
 	}
-	return trace.Wrap(cache.presenceCache.CreateRemoteCluster(resource))
+	_, err = cache.presenceCache.CreateRemoteCluster(ctx, resource)
+	return trace.Wrap(err)
 }
 
 func (remoteClusterExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.presenceCache.DeleteAllRemoteClusters()
+	return cache.presenceCache.DeleteAllRemoteClusters(ctx)
 }
 
 func (remoteClusterExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
@@ -799,8 +800,9 @@ func (remoteClusterExecutor) getReader(cache *Cache, cacheOK bool) remoteCluster
 }
 
 type remoteClusterGetter interface {
-	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
+	ListRemoteClusters(ctx context.Context, pageSize int, pageToken string) ([]types.RemoteCluster, string, error)
 }
 
 var _ executor[types.RemoteCluster, remoteClusterGetter] = remoteClusterExecutor{}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -212,7 +212,7 @@ func (proxy *ProxyClient) GetLeafClusters(ctx context.Context) ([]types.RemoteCl
 	}
 	defer clt.Close()
 
-	remoteClusters, err := clt.GetRemoteClusters()
+	remoteClusters, err := clt.GetRemoteClusters(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -112,7 +112,7 @@ type SiteGetter interface {
 // RemoteClusterGetter provides access to remote cluster resources
 type RemoteClusterGetter interface {
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 }
 
 // RouterConfig contains all the dependencies required
@@ -368,7 +368,7 @@ func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, check
 		return nil, trace.Wrap(err)
 	}
 
-	rc, err := r.clusterGetter.GetRemoteCluster(clusterName)
+	rc, err := r.clusterGetter.GetRemoteCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -414,7 +414,7 @@ func (s *server) periodicFunctions() {
 
 			connectedRemoteClusters := s.getRemoteClusters()
 
-			remoteClusters, err := s.localAccessPoint.GetRemoteClusters()
+			remoteClusters, err := s.localAccessPoint.GetRemoteClusters(s.ctx)
 			if err != nil {
 				s.log.WithError(err).Warn("Failed to get remote clusters")
 			}

--- a/lib/reversetunnelclient/api_with_roles.go
+++ b/lib/reversetunnelclient/api_with_roles.go
@@ -19,6 +19,8 @@
 package reversetunnelclient
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -30,7 +32,7 @@ import (
 // ClusterGetter is an interface that defines GetRemoteCluster method
 type ClusterGetter interface {
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 }
 
 // NewTunnelWithRoles returns new authorizing tunnel
@@ -57,6 +59,7 @@ type TunnelWithRoles struct {
 
 // GetSites returns a list of connected remote sites
 func (t *TunnelWithRoles) GetSites() ([]RemoteSite, error) {
+	ctx := context.TODO()
 	clusters, err := t.tunnel.GetSites()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -67,7 +70,7 @@ func (t *TunnelWithRoles) GetSites() ([]RemoteSite, error) {
 			out = append(out, cluster)
 			continue
 		}
-		rc, err := t.access.GetRemoteCluster(cluster.GetName())
+		rc, err := t.access.GetRemoteCluster(ctx, cluster.GetName())
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return nil, trace.Wrap(err)
@@ -88,6 +91,7 @@ func (t *TunnelWithRoles) GetSites() ([]RemoteSite, error) {
 
 // GetSite returns remote site this node belongs to
 func (t *TunnelWithRoles) GetSite(clusterName string) (RemoteSite, error) {
+	ctx := context.TODO()
 	cluster, err := t.tunnel.GetSite(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -95,7 +99,7 @@ func (t *TunnelWithRoles) GetSite(clusterName string) (RemoteSite, error) {
 	if t.localCluster == cluster.GetName() {
 		return cluster, nil
 	}
-	rc, err := t.access.GetRemoteCluster(clusterName)
+	rc, err := t.access.GetRemoteCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -80,7 +80,7 @@ type ClusterGetter interface {
 	// GetClusterName returns the local cluster name
 	GetClusterName(opts ...MarshalOption) (types.ClusterName, error)
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 }
 
 // ValidateAccessRequestClusterNames checks that the clusters in the access request exist
@@ -97,7 +97,7 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 		if resourceID.ClusterName == localClusterName.GetClusterName() {
 			continue
 		}
-		_, err := cg.GetRemoteCluster(resourceID.ClusterName)
+		_, err := cg.GetRemoteCluster(context.TODO(), resourceID.ClusterName)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err, "failed to fetch remote cluster %q", resourceID.ClusterName)
 		}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -1803,7 +1803,7 @@ func (mcg mockClusterGetter) GetClusterName(opts ...MarshalOption) (types.Cluste
 	return mcg.localCluster, nil
 }
 
-func (mcg mockClusterGetter) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
+func (mcg mockClusterGetter) GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error) {
 	if cluster, ok := mcg.remoteClusters[clusterName]; ok {
 		return cluster, nil
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -765,7 +765,7 @@ func (s *PresenceService) GetAndUpdateRemoteCluster(
 			return nil, trace.Wrap(err)
 		}
 
-		if updated.GetName() != existing.GetName() {
+		if updated.GetName() != name {
 			return nil, trace.BadParameter("metadata.name: cannot be updated")
 		}
 

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -861,6 +861,7 @@ func (s *PresenceService) ListRemoteClusters(
 	next := ""
 	if len(clusters) > pageSize {
 		next = backend.GetPaginationKey(clusters[pageSize])
+		clear(clusters[pageSize:])
 		// Truncate the last item that was used to determine next row existence.
 		clusters = clusters[:pageSize]
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -775,7 +775,7 @@ func (s *PresenceService) GetAndUpdateRemoteCluster(
 		}
 
 		lease, err := s.ConditionalUpdate(ctx, backend.Item{
-			Key:      backend.Key(remoteClustersPrefix, updated.GetName()),
+			Key:      backend.Key(remoteClustersPrefix, name),
 			Value:    updatedValue,
 			Expires:  updated.Expiry(),
 			Revision: updated.GetRevision(),

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -709,7 +709,7 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 	// could cause conditional update to fail. This is needed because of the
 	// unusual way updates are handled in this method meaning that the revision
 	// in the provided remote cluster is not used. We should eventually make a
-	// breaking change to this behaviour.
+	// breaking change to this behavior.
 	const iterationLimit = 3
 	for i := 0; i < iterationLimit; i++ {
 		existing, err := s.GetRemoteCluster(ctx, rc.GetName())

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -767,12 +767,13 @@ func (s *PresenceService) PatchRemoteCluster(
 
 		switch {
 		case updated.GetName() != name:
-			return nil, trace.BadParameter("metadata.name: cannot be updated")
+			return nil, trace.BadParameter("metadata.name: cannot be patched")
 		case updated.GetRevision() != existing.GetRevision():
-			// If they've provided a revision, and it doesn't match the revision
-			// of the resource we just fetched, we know the conditional update
-			// will fail, so we exit early to avoid the write.
-			return nil, backend.ErrConditionFailed
+			// We don't allow revision to be specified when performing a patch.
+			// This is because it creates some complex semantics. Instead they
+			// should use the Update method if they wish to specify the
+			// revision.
+			return nil, trace.BadParameter("metadata.revision: cannot be patched")
 		}
 
 		updatedValue, err := services.MarshalRemoteCluster(updated)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -778,7 +778,7 @@ func (s *PresenceService) GetAndUpdateRemoteCluster(
 			Key:      backend.Key(remoteClustersPrefix, name),
 			Value:    updatedValue,
 			Expires:  updated.Expiry(),
-			Revision: updated.GetRevision(),
+			Revision: existing.GetRevision(),
 		})
 		if err != nil {
 			if trace.IsCompareFailed(err) {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -734,8 +734,8 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 }
 
 // GetRemoteClusters returns a list of remote clusters
-// Prefer ListRemoteClusters
-func (s *PresenceService) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+// Prefer ListRemoteClusters. This will eventually be deprecated.
+func (s *PresenceService) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	startKey := backend.ExactKey(remoteClustersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
@@ -745,7 +745,10 @@ func (s *PresenceService) GetRemoteClusters(ctx context.Context, opts ...service
 	clusters := make([]types.RemoteCluster, len(result.Items))
 	for i, item := range result.Items {
 		cluster, err := services.UnmarshalRemoteCluster(item.Value,
-			services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
+			services.WithResourceID(item.ID),
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision),
+		)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -735,6 +735,7 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 
 // GetRemoteClusters returns a list of remote clusters
 // Prefer ListRemoteClusters. This will eventually be deprecated.
+// TODO(noah): REMOVE IN 17.0.0 - replace calls with ListRemoteClusters
 func (s *PresenceService) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	startKey := backend.ExactKey(remoteClustersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -734,6 +734,7 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 }
 
 // GetRemoteClusters returns a list of remote clusters
+// Prefer ListRemoteClusters
 func (s *PresenceService) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
 	startKey := backend.ExactKey(remoteClustersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -765,6 +765,10 @@ func (s *PresenceService) GetAndUpdateRemoteCluster(
 			return nil, trace.Wrap(err)
 		}
 
+		if updated.GetName() != existing.GetName() {
+			return nil, trace.BadParameter("metadata.name: cannot be updated")
+		}
+
 		updatedValue, err := services.MarshalRemoteCluster(updated)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -783,8 +787,8 @@ func (s *PresenceService) GetAndUpdateRemoteCluster(
 			}
 			return nil, trace.Wrap(err)
 		}
-		existing.SetRevision(lease.Revision)
-		return existing, nil
+		updated.SetRevision(lease.Revision)
+		return updated, nil
 	}
 	return nil, trace.CompareFailed("failed to update remote cluster within %v iterations", iterationLimit)
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -155,7 +155,7 @@ func TestPresenceService_ListRemoteClusters(t *testing.T) {
 	rcs, pageToken, err := presenceBackend.ListRemoteClusters(ctx, 0, "")
 	require.NoError(t, err)
 	require.Empty(t, pageToken)
-	require.Len(t, rcs, 0)
+	require.Empty(t, rcs)
 
 	// Create a few remote clusters
 	for i := 0; i < 10; i++ {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -173,6 +173,15 @@ func TestPresenceService_PatchRemoteCluster(t *testing.T) {
 	fetchedRC, err := presenceBackend.GetRemoteCluster(ctx, rc.GetName())
 	require.NoError(t, err)
 	require.Equal(t, teleport.RemoteClusterStatusOnline, fetchedRC.GetConnectionStatus())
+	// Ensure other fields unchanged
+	require.Empty(t,
+		cmp.Diff(
+			rc,
+			fetchedRC,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
+			cmpopts.IgnoreFields(types.RemoteClusterStatusV3{}, "Connection"),
+		),
+	)
 
 	// Ensure that name cannot be updated
 	_, err = presenceBackend.PatchRemoteCluster(

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -138,7 +138,7 @@ func TestRemoteClusterCRUD(t *testing.T) {
 	// make sure it's really gone
 	err = presenceBackend.DeleteRemoteCluster(ctx, "foo")
 	require.Error(t, err)
-	require.ErrorIs(t, err, trace.NotFound("key /remoteClusters/foo is not found"))
+	require.ErrorIs(t, err, trace.NotFound("key \"/remoteClusters/foo\" is not found"))
 }
 
 func TestPresenceService_PatchRemoteCluster(t *testing.T) {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -140,7 +140,7 @@ func TestRemoteClusterCRUD(t *testing.T) {
 	require.ErrorIs(t, err, trace.NotFound("key /remoteClusters/foo is not found"))
 }
 
-func TestPresenceService_GetAndUpdateRemoteCluster(t *testing.T) {
+func TestPresenceService_PatchRemoteCluster(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -156,7 +156,7 @@ func TestPresenceService_GetAndUpdateRemoteCluster(t *testing.T) {
 	_, err = presenceBackend.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
 
-	updatedRC, err := presenceBackend.GetAndUpdateRemoteCluster(
+	updatedRC, err := presenceBackend.PatchRemoteCluster(
 		ctx,
 		rc.GetName(),
 		func(rc types.RemoteCluster) (types.RemoteCluster, error) {
@@ -174,7 +174,7 @@ func TestPresenceService_GetAndUpdateRemoteCluster(t *testing.T) {
 	require.Equal(t, teleport.RemoteClusterStatusOnline, fetchedRC.GetConnectionStatus())
 
 	// Ensure that name cannot be updated
-	_, err = presenceBackend.GetAndUpdateRemoteCluster(
+	_, err = presenceBackend.PatchRemoteCluster(
 		ctx,
 		rc.GetName(),
 		func(rc types.RemoteCluster) (types.RemoteCluster, error) {

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -98,7 +98,6 @@ func TestCRUD(t *testing.T) {
 	t.Run("TestSAMLCRUD", tt.suite.SAMLCRUD)
 	t.Run("TestTunnelConnectionsCRUD", tt.suite.TunnelConnectionsCRUD)
 	t.Run("TestGithubConnectorCRUD", tt.suite.GithubConnectorCRUD)
-	t.Run("TestRemoteClustersCRUD", tt.suite.RemoteClustersCRUD)
 	t.Run("TestEvents", tt.suite.Events)
 	t.Run("TestEventsClusterConfig", tt.suite.EventsClusterConfig)
 	t.Run("TestNetworkRestrictions", func(t *testing.T) { tt.suite.NetworkRestrictions(t) })

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -189,7 +189,7 @@ type Presence interface {
 
 	// GetRemoteClusters returns a list of remote clusters
 	// Prefer ListRemoteClusters
-	GetRemoteClusters(ctx context.Context, opts ...MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 
 	// ListRemoteClusters returns a page of remote clusters
 	ListRemoteClusters(ctx context.Context, pageSize int, pageToken string) ([]types.RemoteCluster, string, error)

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -182,22 +182,26 @@ type Presence interface {
 	DeleteAllTunnelConnections() error
 
 	// CreateRemoteCluster creates a remote cluster
-	CreateRemoteCluster(types.RemoteCluster) error
+	CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error)
 
 	// UpdateRemoteCluster updates a remote cluster
-	UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) error
+	UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error)
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters(opts ...MarshalOption) ([]types.RemoteCluster, error)
+	// Prefer ListRemoteClusters
+	GetRemoteClusters(ctx context.Context, opts ...MarshalOption) ([]types.RemoteCluster, error)
+
+	// ListRemoteClusters returns a page of remote clusters
+	ListRemoteClusters(ctx context.Context, pageSize int, pageToken string) ([]types.RemoteCluster, string, error)
 
 	// GetRemoteCluster returns a remote cluster by name
-	GetRemoteCluster(clusterName string) (types.RemoteCluster, error)
+	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 
 	// DeleteRemoteCluster deletes remote cluster by name
 	DeleteRemoteCluster(ctx context.Context, clusterName string) error
 
 	// DeleteAllRemoteClusters deletes all remote clusters
-	DeleteAllRemoteClusters() error
+	DeleteAllRemoteClusters(ctx context.Context) error
 
 	// GetApplicationServers returns all registered application servers.
 	GetApplicationServers(context.Context, string) ([]types.AppServer, error)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1098,8 +1098,9 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 
 	rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
-	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
+	got, err := s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
+	require.Zero(t, cmp.Diff(got, rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.True(t, trace.IsAlreadyExists(err))
@@ -1117,8 +1118,9 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	// test delete individual connection
-	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
+	got, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
+	require.Zero(t, cmp.Diff(got, rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
 	out, err = s.PresenceS.GetRemoteClusters(ctx)
 	require.NoError(t, err)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1086,6 +1086,10 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
 }
 
+// RemoteClustersCRUD tests CRUD functionality for remote clusters.
+// TODO(noah): DELETE IN V17.0.0
+// We can replace this with specific tests in the `local` package and in the
+// provisioning grpc service.
 func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "example.com"

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1086,58 +1086,6 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 	require.NotEqual(t, updated.GetDisplay(), upserted.GetDisplay())
 }
 
-// RemoteClustersCRUD tests CRUD functionality for remote clusters.
-// TODO(noah): DELETE IN V17.0.0
-// We can replace this with specific tests in the `local` package and in the
-// provisioning grpc service.
-func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
-	ctx := context.Background()
-	clusterName := "example.com"
-	out, err := s.PresenceS.GetRemoteClusters(ctx)
-	require.NoError(t, err)
-	require.Empty(t, out)
-
-	rc, err := types.NewRemoteCluster(clusterName)
-	require.NoError(t, err)
-
-	rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
-
-	got, err := s.PresenceS.CreateRemoteCluster(ctx, rc)
-	require.NoError(t, err)
-	require.Zero(t, cmp.Diff(got, rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-
-	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
-	require.True(t, trace.IsAlreadyExists(err))
-
-	out, err = s.PresenceS.GetRemoteClusters(ctx)
-	require.NoError(t, err)
-	require.Len(t, out, 1)
-	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-
-	err = s.PresenceS.DeleteAllRemoteClusters(ctx)
-	require.NoError(t, err)
-
-	out, err = s.PresenceS.GetRemoteClusters(ctx)
-	require.NoError(t, err)
-	require.Empty(t, out)
-
-	// test delete individual connection
-	got, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
-	require.NoError(t, err)
-	require.Zero(t, cmp.Diff(got, rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-
-	out, err = s.PresenceS.GetRemoteClusters(ctx)
-	require.NoError(t, err)
-	require.Len(t, out, 1)
-	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
-
-	err = s.PresenceS.DeleteRemoteCluster(ctx, clusterName)
-	require.NoError(t, err)
-
-	err = s.PresenceS.DeleteRemoteCluster(ctx, clusterName)
-	require.True(t, trace.IsNotFound(err))
-}
-
 // AuthPreference tests authentication preference service
 func (s *ServicesTestSuite) AuthPreference(t *testing.T) {
 	ctx := context.Background()

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1089,7 +1089,7 @@ func (s *ServicesTestSuite) GithubConnectorCRUD(t *testing.T) {
 func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "example.com"
-	out, err := s.PresenceS.GetRemoteClusters()
+	out, err := s.PresenceS.GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Empty(t, out)
 
@@ -1098,29 +1098,29 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 
 	rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
-	err = s.PresenceS.CreateRemoteCluster(rc)
+	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
 
-	err = s.PresenceS.CreateRemoteCluster(rc)
+	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.True(t, trace.IsAlreadyExists(err))
 
-	out, err = s.PresenceS.GetRemoteClusters()
+	out, err = s.PresenceS.GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
-	err = s.PresenceS.DeleteAllRemoteClusters()
+	err = s.PresenceS.DeleteAllRemoteClusters(ctx)
 	require.NoError(t, err)
 
-	out, err = s.PresenceS.GetRemoteClusters()
+	out, err = s.PresenceS.GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Empty(t, out)
 
 	// test delete individual connection
-	err = s.PresenceS.CreateRemoteCluster(rc)
+	_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
 	require.NoError(t, err)
 
-	out, err = s.PresenceS.GetRemoteClusters()
+	out, err = s.PresenceS.GetRemoteClusters(ctx)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], rc, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
@@ -1830,9 +1830,10 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				rc, err := types.NewRemoteCluster("example.com")
 				rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 				require.NoError(t, err)
-				require.NoError(t, s.PresenceS.CreateRemoteCluster(rc))
+				_, err = s.PresenceS.CreateRemoteCluster(ctx, rc)
+				require.NoError(t, err)
 
-				out, err := s.PresenceS.GetRemoteClusters()
+				out, err := s.PresenceS.GetRemoteClusters(ctx)
 				require.NoError(t, err)
 
 				err = s.PresenceS.DeleteRemoteCluster(ctx, rc.GetName())

--- a/lib/tbot/config/bot.go
+++ b/lib/tbot/config/bot.go
@@ -50,7 +50,7 @@ type provider interface {
 	GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
 
 	// GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.
-	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
 
 	// GetCertAuthority uses the impersonatedClient to call GetCertAuthority.
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)

--- a/lib/tbot/config/bot.go
+++ b/lib/tbot/config/bot.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // provider is an interface that allows Templates to fetch information they
@@ -50,7 +49,7 @@ type provider interface {
 	GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
 
 	// GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.
-	GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 
 	// GetCertAuthority uses the impersonatedClient to call GetCertAuthority.
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)

--- a/lib/tbot/config/bot_test.go
+++ b/lib/tbot/config/bot_test.go
@@ -75,7 +75,7 @@ func newMockProvider(cfg *BotConfig) *mockProvider {
 	}
 }
 
-func (p *mockProvider) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (p *mockProvider) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	rc, err := types.NewRemoteCluster(p.remoteClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tbot/config/template_ssh_client.go
+++ b/lib/tbot/config/template_ssh_client.go
@@ -76,11 +76,11 @@ func (c *templateSSHClient) describe() []FileDescription {
 }
 
 func getClusterNames(
-	bot provider, connectedClusterName string,
+	ctx context.Context, bot provider, connectedClusterName string,
 ) ([]string, error) {
 	allClusterNames := []string{connectedClusterName}
 
-	leafClusters, err := bot.GetRemoteClusters()
+	leafClusters, err := bot.GetRemoteClusters(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -113,7 +113,7 @@ func (c *templateSSHClient) render(
 		return trace.BadParameter("proxy %+v has no usable public address: %v", ping.ProxyPublicAddr, err)
 	}
 
-	clusterNames, err := getClusterNames(bot, ping.ClusterName)
+	clusterNames, err := getClusterNames(ctx, bot, ping.ClusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -777,8 +777,8 @@ type outputProvider struct {
 }
 
 // GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.
-func (op *outputProvider) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	return op.impersonatedClient.GetRemoteClusters(opts...)
+func (op *outputProvider) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+	return op.impersonatedClient.GetRemoteClusters(ctx, opts...)
 }
 
 // GenerateHostCert uses the impersonatedClient to call GenerateHostCert.

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -777,8 +777,8 @@ type outputProvider struct {
 }
 
 // GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.
-func (op *outputProvider) GetRemoteClusters(ctx context.Context, opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	return op.impersonatedClient.GetRemoteClusters(ctx, opts...)
+func (op *outputProvider) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
+	return op.impersonatedClient.GetRemoteClusters(ctx)
 }
 
 // GenerateHostCert uses the impersonatedClient to call GenerateHostCert.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2558,7 +2558,7 @@ func (h *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprout
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteClusters, err := clt.GetRemoteClusters()
+	remoteClusters, err := clt.GetRemoteClusters(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -968,7 +968,7 @@ func (a *AuthCommand) checkLeafCluster(clusterAPI auth.ClientI) error {
 		return nil
 	}
 
-	clusters, err := clusterAPI.GetRemoteClusters()
+	clusters, err := clusterAPI.GetRemoteClusters(context.TODO())
 	if err != nil {
 		return trace.WrapWithMessage(err, "couldn't load leaf clusters")
 	}

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -443,7 +443,7 @@ func (c *mockClient) GetProxies() ([]types.Server, error) {
 	return c.proxies, nil
 }
 
-func (c *mockClient) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
+func (c *mockClient) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	return c.remoteClusters, nil
 }
 

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1718,7 +1718,7 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt auth.ClientI) e
 
 	switch rc.ref.Kind {
 	case types.KindRemoteCluster:
-		cluster, err := clt.GetRemoteCluster(rc.ref.Name)
+		cluster, err := clt.GetRemoteCluster(ctx, rc.ref.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1730,7 +1730,7 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt auth.ClientI) e
 		if !expiry.IsZero() {
 			cluster.SetExpiry(expiry)
 		}
-		if err = clt.UpdateRemoteCluster(ctx, cluster); err != nil {
+		if _, err = clt.UpdateRemoteCluster(ctx, cluster); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("cluster %v has been updated\n", rc.ref.Name)
@@ -1924,13 +1924,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 		return &trustedClusterCollection{trustedClusters: []types.TrustedCluster{trustedCluster}}, nil
 	case types.KindRemoteCluster:
 		if rc.ref.Name == "" {
-			remoteClusters, err := client.GetRemoteClusters()
+			remoteClusters, err := client.GetRemoteClusters(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &remoteClusterCollection{remoteClusters: remoteClusters}, nil
 		}
-		remoteCluster, err := client.GetRemoteCluster(rc.ref.Name)
+		remoteCluster, err := client.GetRemoteCluster(ctx, rc.ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tsh/common/config.go
+++ b/tool/tsh/common/config.go
@@ -73,7 +73,7 @@ func onConfig(cf *CLIConf) error {
 	}
 	defer rootAuthClient.Close()
 
-	leafClusters, err := rootAuthClient.GetRemoteClusters()
+	leafClusters, err := rootAuthClient.GetRemoteClusters(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2993,7 +2993,7 @@ func onListClusters(cf *CLIConf) error {
 		}
 		defer rootAuthClient.Close()
 
-		leafClusters, err = rootAuthClient.GetRemoteClusters()
+		leafClusters, err = rootAuthClient.GetRemoteClusters(cf.Context)
 		return trace.Wrap(err)
 	})
 	if err != nil {


### PR DESCRIPTION
Prerequisite of https://github.com/gravitational/teleport/issues/38669

Changes:
- Wires context through to the existing methods
- Adds support for conditional updates
- Returns the updated and created RemoteClusters
- Removes unused MarshalOptions
- Introduces new ListRemoteClusters method
- Removes unused Create/Delete HTTP API methods

The most interesting place to look is `lib/services/local/presence.go`. Everything else is pretty much just rearranging everything for the new signatures.

There will be a follow up PR to introduce a new Presence gRPC service with the RemoteCluster methods added. We'll add this in v16 and add client calls which fallback to the HTTP methods, in v17, we'll remove the old HTTP methods.
