### PR TITLE
Enforce MFA for admin actions for users with registered webauthn devices

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -160,6 +160,9 @@ type AuthorizerAccessPoint interface {
 type MFAAuthenticator interface {
 	// ValidateMFAAuthResponse validates an MFA challenge response.
 	ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, requiredExtensions *mfav1.ChallengeExtensions) (*MFAAuthData, error)
+
+	// GetMFADevices returns all mfa devices for the user defined in the token or the user defined in context.
+	GetMFADevices(ctx context.Context, req *proto.GetMFADevicesRequest) (*proto.GetMFADevicesResponse, error)
 }
 
 // MFAAuthData contains a user's MFA authentication data for a validated MFA response.

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -462,6 +462,10 @@ func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, aut
 		// If admin action MFA is not strictly enforced but webauthn is enabled, check if the
 		// user has a registered webauthn device so we can opportunistically enforce it.
 		if authpref.IsSecondFactorWebauthnAllowed() {
+			if a.mfaAuthenticator == nil {
+				return false, trace.Errorf("failed to validate MFA auth response, authorizer missing mfaAuthenticator field")
+			}
+
 			mfaDevices, err := a.mfaAuthenticator.GetMFADevices(ctx, nil)
 			if err != nil {
 				return false, trace.Wrap(err)

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -454,6 +454,10 @@ func (a *fakeMFAAuthenticator) ValidateMFAAuthResponse(ctx context.Context, resp
 	return mfaData, nil
 }
 
+func (a *fakeMFAAuthenticator) GetMFADevices(ctx context.Context, req *proto.GetMFADevicesRequest) (*proto.GetMFADevicesResponse, error) {
+	return nil, nil
+}
+
 func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	ctx := context.Background()
 	client, watcher, _ := newTestResources(t)


### PR DESCRIPTION
In v15, we released MFA for admin actions in a limited scope, only affecting clusters where `cap.second_factor=webauthn`.

This PR extends the feature to cover all users with a webauthn device registered. This change is primarily aimed at development, as this will increase the number of new/existing features tested with MFA for admin actions through the normal development cycle. 

This will not be backported and may be reverted before v16 is released if necessary.