### PR TITLE
Consolidate webasset bundle to single chunks

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -69,6 +69,19 @@ export function createViteConfig(
         outDir: outputDirectory,
         assetsDir: 'app',
         emptyOutDir: true,
+        rollupOptions: {
+          output: {
+            // removes hashing from our entry point file
+            entryFileNames: 'app/app.js',
+            // assist is still lazy loaded and the telemetry bundle breaks any
+            // websocket connections if included in the bundle. We will leave these two
+            // files out of the bundle but without hashing so they are still discoverable.
+            // TODO (avatus): find out why this breaks websocket connectivity and unchunk
+            chunkFileNames: 'app/[name].js',
+            // this will remove hashing from asset (non-js) files.
+            assetFileNames: `app/[name].[ext]`,
+          },
+        },
       },
       plugins: [
         react({

--- a/web/packages/teleport/src/AccessRequests/index.ts
+++ b/web/packages/teleport/src/AccessRequests/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { LockedAccessRequests as default } from './LockedAccessRequests/LockedAccessRequests';
+export { LockedAccessRequests } from './LockedAccessRequests/LockedAccessRequests';

--- a/web/packages/teleport/src/Account/Account.test.tsx
+++ b/web/packages/teleport/src/Account/Account.test.tsx
@@ -21,7 +21,7 @@ import { render, screen, waitFor } from 'design/utils/testing';
 import { ContextProvider } from 'teleport';
 import TeleportContext from 'teleport/teleportContext';
 
-import Account from 'teleport/Account/Account';
+import { AccountPage as Account } from 'teleport/Account/Account';
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 

--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -53,7 +53,7 @@ export interface AccountPageProps {
   enterpriseComponent?: React.ComponentType<EnterpriseComponentProps>;
 }
 
-export default function AccountPage({ enterpriseComponent }: AccountPageProps) {
+export function AccountPage({ enterpriseComponent }: AccountPageProps) {
   const ctx = useTeleport();
   const isSso = ctx.storeUser.isSso();
   const manageDevicesState = useManageDevices(ctx);

--- a/web/packages/teleport/src/Account/AccountNew.ts
+++ b/web/packages/teleport/src/Account/AccountNew.ts
@@ -18,7 +18,7 @@
 
 // Compatibility aliases to prevent e/ from breaking.
 // TODO(bl-nero): Remove these once e/ stops referring to them.
-import Account from './Account';
+import { Account } from './Account';
 export type { EnterpriseComponentProps } from './Account';
 
 export default Account;

--- a/web/packages/teleport/src/Account/index.ts
+++ b/web/packages/teleport/src/Account/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Account from './Account';
-export default Account;
+export { AccountPage, Account } from './Account';

--- a/web/packages/teleport/src/AppLauncher/index.ts
+++ b/web/packages/teleport/src/AppLauncher/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { AppLauncher as default } from './AppLauncher';
+export { AppLauncher } from './AppLauncher';

--- a/web/packages/teleport/src/Audit/Audit.story.tsx
+++ b/web/packages/teleport/src/Audit/Audit.story.tsx
@@ -22,7 +22,7 @@ import { createMemoryHistory } from 'history';
 
 import { ContextProvider, Context } from 'teleport';
 
-import Audit from './Audit';
+import { AuditContainer as Audit } from './Audit';
 import EventList from './EventList';
 import { events, eventsSample } from './fixtures';
 

--- a/web/packages/teleport/src/Audit/Audit.tsx
+++ b/web/packages/teleport/src/Audit/Audit.tsx
@@ -37,7 +37,7 @@ import EventList from './EventList';
 
 import useAuditEvents, { State } from './useAuditEvents';
 
-export default function Container() {
+export function AuditContainer() {
   const teleCtx = useTeleport();
   const { clusterId } = useStickyClusterId();
   const state = useAuditEvents(teleCtx, clusterId);

--- a/web/packages/teleport/src/Audit/index.tsx
+++ b/web/packages/teleport/src/Audit/index.tsx
@@ -16,6 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Audit from './Audit';
-
-export default Audit;
+export { Audit, AuditContainer } from './Audit';

--- a/web/packages/teleport/src/AuthConnectors/index.ts
+++ b/web/packages/teleport/src/AuthConnectors/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import AuthConnectors from './AuthConnectors';
-export default AuthConnectors;
+export { AuthConnectors } from './AuthConnectors';

--- a/web/packages/teleport/src/Bots/Add/index.tsx
+++ b/web/packages/teleport/src/Bots/Add/index.tsx
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { AddBots as default } from './AddBots';
+export { AddBots } from './AddBots';

--- a/web/packages/teleport/src/Bots/index.ts
+++ b/web/packages/teleport/src/Bots/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { Bots as default } from './List/Bots';
+export { Bots } from './List/Bots';

--- a/web/packages/teleport/src/Clusters/index.ts
+++ b/web/packages/teleport/src/Clusters/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Clusters as default } from './Clusters';
+export { Clusters } from './Clusters';

--- a/web/packages/teleport/src/Console/index.tsx
+++ b/web/packages/teleport/src/Console/index.tsx
@@ -24,7 +24,7 @@ import ConsoleContextProvider from './consoleContextProvider';
 
 // Main entry point to Console where it initializes ContextProvider with the
 // instance of ConsoleContext.
-export default function Index() {
+export function ConsoleWithContext() {
   const [ctx] = React.useState(() => {
     return new ConsoleContext();
   });

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -40,7 +40,7 @@ import TopBar from './TopBar';
 import type { State, WebsocketAttempt } from './useDesktopSession';
 import type { WebAuthnState } from 'teleport/lib/useWebAuthn';
 
-export default function Container() {
+export function DesktopSessionContainer() {
   const state = useDesktopSession();
   return <DesktopSession {...state} />;
 }

--- a/web/packages/teleport/src/DesktopSession/index.ts
+++ b/web/packages/teleport/src/DesktopSession/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import DesktopSession from './DesktopSession';
-export default DesktopSession;
+export { DesktopSession, DesktopSessionContainer } from './DesktopSession';

--- a/web/packages/teleport/src/DeviceTrust/index.ts
+++ b/web/packages/teleport/src/DeviceTrust/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { DeviceTrustLocked as default } from './DeviceTrustLocked';
+export { DeviceTrustLocked } from './DeviceTrustLocked';

--- a/web/packages/teleport/src/Discover/index.tsx
+++ b/web/packages/teleport/src/Discover/index.tsx
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { Discover as default } from './Discover';
+export { Discover } from './Discover';

--- a/web/packages/teleport/src/HeadlessRequest/index.ts
+++ b/web/packages/teleport/src/HeadlessRequest/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { HeadlessRequest as default } from './HeadlessRequest';
+export { HeadlessRequest } from './HeadlessRequest';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { AwsOidc as default } from './AwsOidc';
+export { AwsOidc } from './AwsOidc';

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { lazy } from 'react';
+import React from 'react';
 
 import cfg from 'teleport/config';
 import { Route } from 'teleport/components/Router';
 import { IntegrationKind } from 'teleport/services/integrations';
 
-const EnrollAwsOidc = lazy(() => import('./AwsOidc'));
+import { AwsOidc } from './AwsOidc';
 
 export function getRoutesToEnrollIntegrations() {
   return [
@@ -30,7 +30,7 @@ export function getRoutesToEnrollIntegrations() {
       key={IntegrationKind.AwsOidc}
       exact
       path={cfg.getIntegrationEnrollRoute(IntegrationKind.AwsOidc)}
-      component={EnrollAwsOidc}
+      component={AwsOidc}
     />,
   ];
 }

--- a/web/packages/teleport/src/Integrations/Enroll/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/index.ts
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { IntegrationEnroll as default } from './IntegrationEnroll';
+export { IntegrationEnroll } from './IntegrationEnroll';
 
 export { IntegrationTiles } from './IntegrationTiles';
 export { getRoutesToEnrollIntegrations } from './IntegrationRoute';

--- a/web/packages/teleport/src/Integrations/index.ts
+++ b/web/packages/teleport/src/Integrations/index.ts
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { Integrations as default } from './Integrations';
+export { Integrations } from './Integrations';
 export { IntegrationList } from './IntegrationList';
 export { IntegrationTile } from './Enroll/common';

--- a/web/packages/teleport/src/LocksV2/Locks/index.ts
+++ b/web/packages/teleport/src/LocksV2/Locks/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { Locks as default } from './Locks';
+export { Locks } from './Locks';

--- a/web/packages/teleport/src/LocksV2/NewLock/LockCheckout/index.ts
+++ b/web/packages/teleport/src/LocksV2/NewLock/LockCheckout/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { LockCheckout as default } from './LockCheckout';
+export { LockCheckout } from './LockCheckout';

--- a/web/packages/teleport/src/LocksV2/NewLock/index.ts
+++ b/web/packages/teleport/src/LocksV2/NewLock/index.ts
@@ -16,6 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-import NewLockWrapper from './NewLock';
-export default NewLockWrapper;
+export { NewLockView } from './NewLock';

--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -18,9 +18,9 @@
 
 import React from 'react';
 
-import LoginSuccess from './LoginSuccess';
-import { LoginFailed } from './LoginFailed';
-import { Login } from './Login';
+import { LoginSuccess } from './LoginSuccess';
+import { LoginFailedComponent as LoginFailed } from './LoginFailed';
+import { LoginComponent as Login } from './Login';
 import { State } from './useLogin';
 
 export default {

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -23,7 +23,7 @@ import auth from 'teleport/services/auth/auth';
 import history from 'teleport/services/history';
 import cfg from 'teleport/config';
 
-import Login from './Login';
+import { Login } from './Login';
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -26,12 +26,12 @@ import Logo from 'teleport/components/LogoHero';
 import useLogin, { State } from './useLogin';
 import Motd from './Motd';
 
-export default function Container() {
+export function Login() {
   const state = useLogin();
-  return <Login {...state} />;
+  return <LoginComponent {...state} />;
 }
 
-export function Login({
+export function LoginComponent({
   attempt,
   onLogin,
   onLoginWithWebauthn,

--- a/web/packages/teleport/src/Login/LoginFailed.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.tsx
@@ -23,21 +23,21 @@ import { Route, Switch } from 'teleport/components/Router';
 import LogoHero from 'teleport/components/LogoHero';
 import cfg from 'teleport/config';
 
-export default function Container() {
+export function LoginFailed() {
   return (
     <Switch>
       <Route path={cfg.routes.loginErrorCallback}>
-        <LoginFailed message="unable to process callback" />
+        <LoginFailedComponent message="unable to process callback" />
       </Route>
       <Route path={cfg.routes.loginErrorUnauthorized}>
-        <LoginFailed message="You are not authorized, please contact your SSO administrator." />
+        <LoginFailedComponent message="You are not authorized, please contact your SSO administrator." />
       </Route>
       <Route component={LoginFailed} />
     </Switch>
   );
 }
 
-export function LoginFailed({ message }: { message?: string }) {
+export function LoginFailedComponent({ message }: { message?: string }) {
   const defaultMsg = "unable to login, please check Teleport's log for details";
   return (
     <>

--- a/web/packages/teleport/src/Login/LoginSuccess.test.tsx
+++ b/web/packages/teleport/src/Login/LoginSuccess.test.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { render } from 'design/utils/testing';
 
-import LoginSuccess from './LoginSuccess';
+import { LoginSuccess } from './LoginSuccess';
 
 test('renders', () => {
   const { container } = render(<LoginSuccess />);

--- a/web/packages/teleport/src/Login/LoginSuccess.tsx
+++ b/web/packages/teleport/src/Login/LoginSuccess.tsx
@@ -21,7 +21,7 @@ import { CardSuccessLogin } from 'design';
 
 import LogoHero from 'teleport/components/LogoHero';
 
-export default function LoginSuccess() {
+export function LoginSuccess() {
   return (
     <>
       <LogoHero />

--- a/web/packages/teleport/src/Login/index.ts
+++ b/web/packages/teleport/src/Login/index.ts
@@ -16,9 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Login from './Login';
-import LoginFailed from './LoginFailed';
-import LoginSuccess from './LoginSuccess';
-
-export default Login;
-export { LoginFailed, LoginSuccess };
+export { Login } from './Login';
+export { LoginFailed } from './LoginFailed';
+export { LoginSuccess } from './LoginSuccess';

--- a/web/packages/teleport/src/Main/index.ts
+++ b/web/packages/teleport/src/Main/index.ts
@@ -17,7 +17,7 @@
  */
 
 export {
-  Main as default,
+  Main,
   useContentMinWidthContext,
   useNoMinWidth,
   HorizontalSplit,

--- a/web/packages/teleport/src/Nodes/index.ts
+++ b/web/packages/teleport/src/Nodes/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Nodes from './Nodes';
-export default Nodes;
+export { Nodes } from './Nodes';

--- a/web/packages/teleport/src/Player/Player.story.tsx
+++ b/web/packages/teleport/src/Player/Player.story.tsx
@@ -24,7 +24,7 @@ import { createMemoryHistory } from 'history';
 
 import { Router, Route } from 'teleport/components/Router';
 
-import PlayerComponent from './Player';
+import { Player } from './Player';
 
 export default {
   title: 'Teleport/Player',
@@ -40,7 +40,7 @@ export const SSH = () => {
     <Router history={history}>
       <Flex m={-3}>
         <Route path="/web/cluster/:clusterId/session/:sid">
-          <PlayerComponent />
+          <Player />
         </Route>
       </Flex>
     </Router>
@@ -59,7 +59,7 @@ export const Desktop = () => {
     <Router history={history}>
       <Flex m={-3}>
         <Route path="/web/cluster/:clusterId/session/:sid">
-          <PlayerComponent />
+          <Player />
         </Route>
       </Flex>
     </Router>
@@ -76,7 +76,7 @@ export const RecordingTypeError = () => {
     <Router history={history}>
       <Flex m={-3}>
         <Route path="/web/cluster/:clusterId/session/:sid">
-          <PlayerComponent />
+          <Player />
         </Route>
       </Flex>
     </Router>
@@ -95,7 +95,7 @@ export const DurationMsError = () => {
     <Router history={history}>
       <Flex m={-3}>
         <Route path="/web/cluster/:clusterId/session/:sid">
-          <PlayerComponent />
+          <Player />
         </Route>
       </Flex>
     </Router>

--- a/web/packages/teleport/src/Player/Player.tsx
+++ b/web/packages/teleport/src/Player/Player.tsx
@@ -38,7 +38,7 @@ import Tabs, { TabItem } from './PlayerTabs';
 
 const validRecordingTypes = ['ssh', 'k8s', 'desktop'];
 
-export default function Player() {
+export function Player() {
   const { sid, clusterId } = useParams<UrlPlayerParams>();
   const { search } = useLocation();
 

--- a/web/packages/teleport/src/Player/index.ts
+++ b/web/packages/teleport/src/Player/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Player from './Player';
-export default Player;
+export { Player } from './Player';

--- a/web/packages/teleport/src/Recordings/Recordings.story.tsx
+++ b/web/packages/teleport/src/Recordings/Recordings.story.tsx
@@ -24,7 +24,7 @@ import { Context, ContextProvider } from 'teleport';
 
 import { makeRecording } from 'teleport/services/recordings/makeRecording';
 
-import Recordings from './Recordings';
+import { RecordingsContainer as Recordings } from './Recordings';
 
 export default {
   title: 'Teleport/Recordings',

--- a/web/packages/teleport/src/Recordings/Recordings.tsx
+++ b/web/packages/teleport/src/Recordings/Recordings.tsx
@@ -36,7 +36,7 @@ import RecordingsList from './RecordingsList';
 
 import useRecordings, { State } from './useRecordings';
 
-export default function Container() {
+export function RecordingsContainer() {
   const ctx = useTeleport();
   const state = useRecordings(ctx);
   return <Recordings {...state} />;

--- a/web/packages/teleport/src/Recordings/index.ts
+++ b/web/packages/teleport/src/Recordings/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Recordings from './Recordings';
-export default Recordings;
+export { Recordings, RecordingsContainer } from './Recordings';

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -36,7 +36,7 @@ import useRoles, { State } from './useRoles';
 
 import templates from './templates';
 
-export default function Container() {
+export function RolesContainer() {
   const ctx = useTeleport();
   const state = useRoles(ctx);
   return <Roles {...state} />;

--- a/web/packages/teleport/src/Roles/index.ts
+++ b/web/packages/teleport/src/Roles/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Roles from './Roles';
-export default Roles;
+export { Roles, RolesContainer } from './Roles';

--- a/web/packages/teleport/src/Sessions/Sessions.tsx
+++ b/web/packages/teleport/src/Sessions/Sessions.tsx
@@ -34,7 +34,7 @@ import { CtaEvent } from 'teleport/services/userEvent';
 import SessionList from './SessionList';
 import useSessions from './useSessions';
 
-export default function Container() {
+export function SessionsContainer() {
   const ctx = useTeleport();
   const { clusterId } = useStickerClusterId();
   const state = useSessions(ctx, clusterId);

--- a/web/packages/teleport/src/Sessions/index.js
+++ b/web/packages/teleport/src/Sessions/index.js
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Sessions from './Sessions';
-export default Sessions;
+export { SessionsContainer } from './Sessions';

--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -29,11 +29,7 @@ import cfg from 'teleport/config';
 import { ButtonLockedFeature } from 'teleport/components/ButtonLockedFeature';
 import { CtaEvent } from 'teleport/services/userEvent';
 
-export default function Container({
-  children,
-}: {
-  children?: React.ReactNode;
-}) {
+export function SupportContainer({ children }: { children?: React.ReactNode }) {
   const ctx = useTeleport();
   const cluster = ctx.storeUser.state.cluster;
 

--- a/web/packages/teleport/src/Support/index.ts
+++ b/web/packages/teleport/src/Support/index.ts
@@ -16,7 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Support from './Support';
-
-// export as default for use with React.lazy
-export default Support;
+export { SupportContainer as Support } from './Support';

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import ThemeProvider from 'design/ThemeProvider';
 
 import { Route, Router, Switch } from 'teleport/components/Router';
@@ -32,10 +32,21 @@ import { NewCredentials } from 'teleport/Welcome/NewCredentials';
 import TeleportContextProvider from './TeleportContextProvider';
 import TeleportContext from './teleportContext';
 import cfg from './config';
+import { AppLauncher } from './AppLauncher';
+import { LoginFailedComponent as LoginFailed } from './Login/LoginFailed';
+import { LoginSuccess } from './Login/LoginSuccess';
+import { Login } from './Login';
+import { Welcome } from './Welcome';
+
+import { ConsoleWithContext as Console } from './Console';
+import { Player } from './Player';
+import { DesktopSessionContainer as DesktopSession } from './DesktopSession';
+
+import { HeadlessRequest } from './HeadlessRequest';
+
+import { Main } from './Main';
 
 import type { History } from 'history';
-
-const AppLauncher = lazy(() => import('./AppLauncher'));
 
 const Teleport: React.FC<Props> = props => {
   const { ctx, history } = props;
@@ -73,19 +84,6 @@ const Teleport: React.FC<Props> = props => {
     </CatchError>
   );
 };
-
-const LoginFailed = lazy(() => import('./Login/LoginFailed'));
-const LoginSuccess = lazy(() => import('./Login/LoginSuccess'));
-const Login = lazy(() => import('./Login'));
-const Welcome = lazy(() => import('./Welcome'));
-
-const Console = lazy(() => import('./Console'));
-const Player = lazy(() => import('./Player'));
-const DesktopSession = lazy(() => import('./DesktopSession'));
-
-const HeadlessRequest = lazy(() => import('./HeadlessRequest'));
-
-const Main = lazy(() => import('./Main'));
 
 function publicOSSRoutes() {
   return [

--- a/web/packages/teleport/src/TrustedClusters/index.ts
+++ b/web/packages/teleport/src/TrustedClusters/index.ts
@@ -17,4 +17,4 @@
  */
 
 import TrustedClusters from './TrustedClusters';
-export default TrustedClusters;
+export { TrustedClusters };

--- a/web/packages/teleport/src/UnifiedResources/index.ts
+++ b/web/packages/teleport/src/UnifiedResources/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// export as default for use with React.lazy
-export { UnifiedResources as default } from './UnifiedResources';
+export { UnifiedResources } from './UnifiedResources';

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -31,7 +31,7 @@ import UserDelete from './UserDelete';
 import UserReset from './UserReset';
 import useUsers, { State, UsersContainerProps } from './useUsers';
 
-export default function Container(props: UsersContainerProps) {
+export function UsersContainer(props: UsersContainerProps) {
   const state = useUsers(props);
   return <Users {...state} />;
 }

--- a/web/packages/teleport/src/Users/index.ts
+++ b/web/packages/teleport/src/Users/index.ts
@@ -16,6 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Users from './Users';
-
-export default Users;
+export { UsersContainer as Users } from './Users';

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { LazyExoticComponent, ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { useAttempt } from 'shared/hooks';
 
 import { User } from 'teleport/services/user';
@@ -181,12 +181,8 @@ type EmailPasswordResetElement = (
 ) => ReactElement;
 
 export type UsersContainerProps = {
-  InviteCollaborators?:
-    | LazyExoticComponent<InviteCollaboratorsElement>
-    | InviteCollaboratorsElement;
-  EmailPasswordReset?:
-    | LazyExoticComponent<EmailPasswordResetElement>
-    | EmailPasswordResetElement;
+  InviteCollaborators?: InviteCollaboratorsElement;
+  EmailPasswordReset?: EmailPasswordResetElement;
 };
 
 export type State = ReturnType<typeof useUsers>;

--- a/web/packages/teleport/src/Welcome/Welcome.story.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.story.tsx
@@ -23,7 +23,7 @@ import { WelcomeWrapper } from 'design/Onboard/WelcomeWrapper';
 
 import { NewCredentials } from 'teleport/Welcome/NewCredentials';
 
-import Welcome from './Welcome';
+import { Welcome } from './Welcome';
 import { CardWelcome } from './CardWelcome';
 
 export default { title: 'Teleport/Welcome' };

--- a/web/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -32,7 +32,7 @@ import { userEventService } from 'teleport/services/userEvent';
 
 import { NewCredentials } from 'teleport/Welcome/NewCredentials';
 
-import Welcome from './Welcome';
+import { Welcome } from './Welcome';
 
 const invitePath = '/web/invite/5182';
 const inviteContinuePath = '/web/invite/5182/continue';

--- a/web/packages/teleport/src/Welcome/Welcome.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.tsx
@@ -37,7 +37,7 @@ type WelcomeProps = {
   NewCredentials: (props: NewCredentialsContainerProps) => JSX.Element;
 };
 
-export default function Welcome({ NewCredentials }: WelcomeProps) {
+export function Welcome({ NewCredentials }: WelcomeProps) {
   const { tokenId } = useParams<{ tokenId: string }>();
   const { search } = useLocation();
 

--- a/web/packages/teleport/src/Welcome/index.ts
+++ b/web/packages/teleport/src/Welcome/index.ts
@@ -16,6 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Welcome from './Welcome';
-
-export default Welcome;
+export { Welcome } from './Welcome';

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { lazy } from 'react';
+import React from 'react';
 
 import {
   AddCircle,
@@ -44,38 +44,32 @@ import {
   ManagementSection,
   NavigationCategory,
 } from 'teleport/Navigation/categories';
+import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
 
 import { NavTitle } from './types';
 
+import { AuditContainer as Audit } from './Audit';
+import { SessionsContainer as Sessions } from './Sessions';
+import { UnifiedResources } from './UnifiedResources';
+import { Account } from './Account';
+import { Support } from './Support';
+import { Clusters } from './Clusters';
+import { Nodes } from './Nodes';
+import { TrustedClusters } from './TrustedClusters';
+import { Users } from './Users';
+import { RolesContainer as Roles } from './Roles';
+import { DeviceTrustLocked } from './DeviceTrust';
+import { RecordingsContainer as Recordings } from './Recordings';
+import { AuthConnectors } from './AuthConnectors';
+import { Locks } from './LocksV2/Locks';
+import { NewLockView } from './LocksV2/NewLock';
+import { Discover } from './Discover';
+import { LockedAccessRequests } from './AccessRequests';
+import { Integrations } from './Integrations';
+import { Bots } from './Bots';
+import { AddBots } from './Bots/Add';
+
 import type { FeatureFlags, TeleportFeature } from './types';
-
-const Audit = lazy(() => import('./Audit'));
-const Sessions = lazy(() => import('./Sessions'));
-const UnifiedResources = lazy(() => import('./UnifiedResources'));
-const Account = lazy(() => import('./Account'));
-const Support = lazy(() => import('./Support'));
-const Clusters = lazy(() => import('./Clusters'));
-const Nodes = lazy(() => import('./Nodes'));
-const Trust = lazy(() => import('./TrustedClusters'));
-const Users = lazy(() => import('./Users'));
-const Roles = lazy(() => import('./Roles'));
-const DeviceTrust = lazy(() => import('./DeviceTrust'));
-const Recordings = lazy(() => import('./Recordings'));
-const AuthConnectors = lazy(() => import('./AuthConnectors'));
-const Locks = lazy(() => import('./LocksV2/Locks'));
-const NewLock = lazy(() => import('./LocksV2/NewLock'));
-const Discover = lazy(() => import('./Discover'));
-const LockedAccessRequests = lazy(() => import('./AccessRequests'));
-const Integrations = lazy(() => import('./Integrations'));
-const IntegrationEnroll = lazy(
-  () => import('@gravitational/teleport/src/Integrations/Enroll')
-);
-const Bots = lazy(() => import('./Bots'));
-const AddBots = lazy(() => import('./Bots/Add'));
-
-// ****************************
-// Resource Features
-// ****************************
 
 class AccessRequests implements TeleportFeature {
   category = NavigationCategory.Resources;
@@ -341,7 +335,7 @@ export class FeatureNewLock implements TeleportFeature {
     title: 'Create New Lock',
     path: cfg.routes.newLock,
     exact: true,
-    component: NewLock,
+    component: NewLockView,
   };
 
   hasAccess(flags: FeatureFlags) {
@@ -527,7 +521,7 @@ export class FeatureTrust implements TeleportFeature {
   route = {
     title: 'Trusted Clusters',
     path: cfg.routes.trustedClusters,
-    component: Trust,
+    component: TrustedClusters,
   };
 
   hasAccess(flags: FeatureFlags) {
@@ -550,7 +544,7 @@ class FeatureDeviceTrust implements TeleportFeature {
     title: 'Manage Trusted Devices',
     path: cfg.routes.deviceTrust,
     exact: true,
-    component: DeviceTrust,
+    component: DeviceTrustLocked,
   };
 
   hasAccess(flags: FeatureFlags) {


### PR DESCRIPTION
Refer to the ["Why" section of this RFD](https://github.com/gravitational/teleport/pull/35757/files#diff-dd7eef5f499a7ee372ff250562b5347616bd13b343cba2654506b8f3c652a907R17) for info on the issue solved with this PR.

This PR will configure vite to pipe all code chunks together. So techincally, this isn't removing code splitting, but in reality just not splitting the code. The benefits of this way are
1. we do not have to remove any of our dynamically imported code as it will just import it all at build time
2. in the future, we can take advantage of the code splitting function (right now its essentially an empty anonymous function) to have more fine grained control over the code splitting in the future. 

This ignores fonts/images/wasm, and only affects javascript and css files. We will now have a single javascript and css file load on initial page load. This will increase latency slightly as there is a larger file to download but it will remove any other network requests for javascript files after (since it has the entire bundle) and *usually* the javascript file and css file will be cached by the browser anyway so this initial latency increase should only happen once per version (or however their browser may be set up).

Quick loom videos showing the error and fix
https://www.loom.com/share/bcae5d79b14a4e6e8df8e0603ace0f04
https://www.loom.com/share/2ce5386941c849dca6a142089d927aa3
