### PR TITLE
Update Hardware Key support docs - OpenSSH Server access unsupported

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -50,7 +50,7 @@ like `tctl edit`. With touch required, hardware key support provides better secu
 
     - Desktop access.
     - Application access.
-    - OpenSSH Server access (agentless or legacy).
+    - OpenSSH server access (agentless or legacy).
 
   If you require users to have a hardware key to access your infrastructure, they won't be able to
   use any of the unsupported features either because the hardware key can't be accessed or because

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -50,6 +50,7 @@ like `tctl edit`. With touch required, hardware key support provides better secu
 
     - Desktop access.
     - Application access.
+    - OpenSSH Server access (agentless or legacy).
 
   If you require users to have a hardware key to access your infrastructure, they won't be able to
   use any of the unsupported features either because the hardware key can't be accessed or because


### PR DESCRIPTION
Add OpenSSH Server access to list of unsupported features for Hardware Key support. This feature was released in v13 without Hardware Key support, but was never explicitly marked as unsupported.

Related issue - https://github.com/gravitational/teleport/issues/38710