### PR TITLE
[v15] Fix a regression issue that caused the re-login dialog reason and proxy errors to not be displayed

### DIFF
--- a/web/packages/teleterm/src/helpers.ts
+++ b/web/packages/teleterm/src/helpers.ts
@@ -35,6 +35,12 @@ import {
   PtyEventStartError,
   PtyServerEvent,
 } from 'teleterm/sharedProcess/api/protogen/ptyHostService_pb';
+import {
+  ReloginRequest,
+  SendNotificationRequest,
+  CannotProxyGatewayConnection,
+  GatewayCertExpired,
+} from 'teleterm/services/tshdEvents';
 
 export function resourceOneOfIsServer(
   resource: PaginatedResource['resource']
@@ -107,6 +113,7 @@ export function ptyEventOneOfIsExit(
 } {
   return event.oneofKind === 'exit';
 }
+
 export function ptyEventOneOfIsStartError(
   event: PtyClientEvent['event'] | PtyServerEvent['event']
 ): event is {
@@ -114,6 +121,24 @@ export function ptyEventOneOfIsStartError(
   startError: PtyEventStartError;
 } {
   return event.oneofKind === 'startError';
+}
+
+export function notificationRequestOneOfIsCannotProxyGatewayConnection(
+  subject: SendNotificationRequest['subject']
+): subject is {
+  oneofKind: 'cannotProxyGatewayConnection';
+  cannotProxyGatewayConnection: CannotProxyGatewayConnection;
+} {
+  return subject.oneofKind === 'cannotProxyGatewayConnection';
+}
+
+export function reloginReasonOneOfIsGatewayCertExpired(
+  reason: ReloginRequest['reason']
+): reason is {
+  oneofKind: 'gatewayCertExpired';
+  gatewayCertExpired: GatewayCertExpired;
+} {
+  return reason.oneofKind === 'gatewayCertExpired';
 }
 
 export function connectEventOneOfIsClusterLogin(

--- a/web/packages/teleterm/src/services/tshdEvents/index.ts
+++ b/web/packages/teleterm/src/services/tshdEvents/index.ts
@@ -31,22 +31,18 @@ import { filterSensitiveProperties } from 'teleterm/services/tshd/interceptors';
 
 export interface ReloginRequest extends api.ReloginRequest {
   rootClusterUri: uri.RootClusterUri;
-  gatewayCertExpired?: GatewayCertExpired;
 }
 export interface GatewayCertExpired extends api.GatewayCertExpired {
   gatewayUri: uri.GatewayUri;
   targetUri: uri.DatabaseUri;
 }
 
-export interface SendNotificationRequest extends api.SendNotificationRequest {
-  cannotProxyGatewayConnection?: CannotProxyGatewayConnection;
-}
+export type SendNotificationRequest = api.SendNotificationRequest;
 export interface CannotProxyGatewayConnection
   extends api.CannotProxyGatewayConnection {
   gatewayUri: uri.GatewayUri;
   targetUri: uri.DatabaseUri;
 }
-
 export type PromptMfaRequest = api.PromptMFARequest & {
   rootClusterUri: uri.RootClusterUri;
 };

--- a/web/packages/teleterm/src/ui/services/relogin/reloginService.ts
+++ b/web/packages/teleterm/src/ui/services/relogin/reloginService.ts
@@ -23,6 +23,7 @@ import {
   ClusterConnectReason,
 } from 'teleterm/ui/services/modals';
 import { ClustersService } from 'teleterm/ui/services/clusters';
+import { reloginReasonOneOfIsGatewayCertExpired } from 'teleterm/helpers';
 
 export class ReloginService {
   constructor(
@@ -38,13 +39,13 @@ export class ReloginService {
     this.mainProcessClient.forceFocusWindow();
     let reason: ClusterConnectReason;
 
-    if (request.gatewayCertExpired) {
+    if (reloginReasonOneOfIsGatewayCertExpired(request.reason)) {
       const gateway = this.clustersService.findGateway(
-        request.gatewayCertExpired.gatewayUri
+        request.reason.gatewayCertExpired.gatewayUri
       );
       reason = {
         kind: 'reason.gateway-cert-expired',
-        targetUri: request.gatewayCertExpired.targetUri,
+        targetUri: request.reason.gatewayCertExpired.targetUri,
         gateway: gateway,
       };
     }

--- a/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
+++ b/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
@@ -21,6 +21,7 @@ import { SendNotificationRequest } from 'teleterm/services/tshdEvents';
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import { NotificationsService } from 'teleterm/ui/services/notifications';
 import { routing } from 'teleterm/ui/uri';
+import { notificationRequestOneOfIsCannotProxyGatewayConnection } from 'teleterm/helpers';
 
 export class TshdNotificationsService {
   constructor(
@@ -29,9 +30,11 @@ export class TshdNotificationsService {
   ) {}
 
   sendNotification(request: SendNotificationRequest) {
-    if (request.cannotProxyGatewayConnection) {
+    if (
+      notificationRequestOneOfIsCannotProxyGatewayConnection(request.subject)
+    ) {
       const { gatewayUri, targetUri, error } =
-        request.cannotProxyGatewayConnection;
+        request.subject.cannotProxyGatewayConnection;
       const gateway = this.clustersService.findGateway(gatewayUri);
       const clusterName = routing.parseClusterName(targetUri);
       let targetName: string;


### PR DESCRIPTION
Backport #38664 to branch/v15

changelog: Fixed a regression with Teleport Connect not showing the re-login reason and connection errors when accessing databases, Kube clusters, and apps with an expired cert
