### PR TITLE
`tctl`: Properly quote resource after create/update

### DIFF
--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -149,7 +149,7 @@ func (c *AlertCommand) Ack(ctx context.Context, client auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("Successfully acknowledged alert '%s'. Alerts with this ID won't be pushed for %s.\n", c.alertID, c.ttl)
+	fmt.Printf("Successfully acknowledged alert %q. Alerts with this ID won't be pushed for %s.\n", c.alertID, c.ttl)
 
 	return nil
 }
@@ -163,7 +163,7 @@ func (c *AlertCommand) ClearAck(ctx context.Context, client auth.ClientI) error 
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("Successfully cleared acknowledgement for alert '%s'. Alerts with this ID will resume being pushed.\n", c.alertID)
+	fmt.Printf("Successfully cleared acknowledgement for alert %q. Alerts with this ID will resume being pushed.\n", c.alertID)
 
 	return nil
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -382,7 +382,7 @@ func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client auth.
 	if err := client.UpsertCertAuthority(ctx, certAuthority); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("certificate authority '%s' has been updated\n", certAuthority.GetName())
+	fmt.Printf("certificate authority %q has been updated\n", certAuthority.GetName())
 	return nil
 }
 
@@ -456,12 +456,12 @@ func (rc *ResourceCommand) createRole(ctx context.Context, client auth.ClientI, 
 	}
 	roleExists := (err == nil)
 	if roleExists && !rc.IsForced() {
-		return trace.AlreadyExists("role '%s' already exists", roleName)
+		return trace.AlreadyExists("role %q already exists", roleName)
 	}
 	if _, err := client.UpsertRole(ctx, role); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("role '%s' has been %s\n", roleName, UpsertVerb(roleExists, rc.IsForced()))
+	fmt.Printf("role %q has been %s\n", roleName, UpsertVerb(roleExists, rc.IsForced()))
 	return nil
 }
 
@@ -482,7 +482,7 @@ func (rc *ResourceCommand) updateRole(ctx context.Context, client auth.ClientI, 
 	if _, err := client.UpdateRole(ctx, role); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("role '%s' has been updated\n", role.GetName())
+	fmt.Printf("role %q has been updated\n", role.GetName())
 	return nil
 }
 
@@ -940,20 +940,20 @@ func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client auth.
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("authentication connector '%s' has been updated\n", upserted.GetName())
+		fmt.Printf("authentication connector %q has been updated\n", upserted.GetName())
 		return nil
 	}
 
 	created, err := client.CreateOIDCConnector(ctx, conn)
 	if err != nil {
 		if trace.IsAlreadyExists(err) {
-			return trace.AlreadyExists("connector '%s' already exists, use -f flag to override", conn.GetName())
+			return trace.AlreadyExists("connector %q already exists, use -f flag to override", conn.GetName())
 		}
 
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("authentication connector '%s' has been created\n", created.GetName())
+	fmt.Printf("authentication connector %q has been created\n", created.GetName())
 	return nil
 }
 
@@ -985,7 +985,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.
 	}
 	exists := (err == nil)
 	if !rc.IsForced() && exists {
-		return trace.AlreadyExists("connector '%s' already exists, use -f flag to override", connectorName)
+		return trace.AlreadyExists("connector %q already exists, use -f flag to override", connectorName)
 	}
 
 	// If the connector being pushed to the backend does not have a signing key
@@ -999,7 +999,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.
 	if _, err = client.UpsertSAMLConnector(ctx, conn); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("authentication connector '%s' has been %s\n", connectorName, UpsertVerb(exists, rc.IsForced()))
+	fmt.Printf("authentication connector %q has been %s\n", connectorName, UpsertVerb(exists, rc.IsForced()))
 	return nil
 }
 
@@ -1013,7 +1013,7 @@ func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client auth.
 	if _, err = client.UpdateSAMLConnector(ctx, conn); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("authentication connector '%s' has been updated\n", conn.GetName())
+	fmt.Printf("authentication connector %q has been updated\n", conn.GetName())
 	return nil
 }
 
@@ -1077,7 +1077,7 @@ func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, cli
 			return trace.Wrap(err)
 		}
 	}
-	fmt.Printf("SAML IdP service provider '%s' has been %s\n", serviceProviderName, UpsertVerb(exists, rc.IsForced()))
+	fmt.Printf("SAML IdP service provider %q has been %s\n", serviceProviderName, UpsertVerb(exists, rc.IsForced()))
 	return nil
 }
 
@@ -1138,7 +1138,7 @@ func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client auth
 			return trace.Wrap(err)
 		}
 	}
-	fmt.Printf("Okta import rule '%s' has been %s\n", importRule.GetName(), UpsertVerb(exists, rc.IsForced()))
+	fmt.Printf("Okta import rule %q has been %s\n", importRule.GetName(), UpsertVerb(exists, rc.IsForced()))
 	return nil
 }
 


### PR DESCRIPTION
Before:
```
$ tctl create -f bootstrap.yaml
user "marco" has been updated
role 'my-role' has been created
```

After
```
$ tctl create -f bootstrap.yaml
user "marco" has been updated
role "my-role" has been created
```