### PR TITLE
Improve error message in Connect when helper process fails to start

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -29,6 +29,7 @@
     "@grpc/grpc-js": "1.8.8",
     "node-forge": "^1.3.1",
     "node-pty": "1.1.0-beta5",
+    "ring-buffer-ts": "^1.2.0",
     "split2": "4.1.0",
     "strip-ansi": "^7.1.0",
     "tar-fs": "^3.0.3",

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
@@ -149,6 +149,7 @@ export class AgentRunner {
     process.stderr.setEncoding('utf-8');
     process.stderr.on('data', (error: string) => {
       stderrOutput += error;
+      // TODO(ravicious): Pipe into KeepLastChunks instead.
       stderrOutput = processAgentOutput(stderrOutput);
       this.agentProcesses.get(rootClusterUri).logs = stderrOutput;
     });

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -34,7 +34,11 @@ import { ChannelCredentials } from '@grpc/grpc-js';
 
 import { FileStorage, RuntimeSettings } from 'teleterm/types';
 import { subscribeToFileStorageEvents } from 'teleterm/services/fileStorage';
-import { LoggerColor, createFileLoggerService } from 'teleterm/services/logger';
+import {
+  LoggerColor,
+  KeepLastChunks,
+  createFileLoggerService,
+} from 'teleterm/services/logger';
 import {
   ChildProcessAddresses,
   MainProcessIpc,
@@ -82,7 +86,9 @@ export default class MainProcess {
   private readonly logger: Logger;
   private readonly configService: ConfigService;
   private tshdProcess: ChildProcess;
+  private tshdProcessLastLogs: KeepLastChunks<string>;
   private sharedProcess: ChildProcess;
+  private sharedProcessLastLogs: KeepLastChunks<string>;
   private appStateFileStorage: FileStorage;
   private configFileStorage: FileStorage;
   private resolvedChildProcessAddresses: Promise<ChildProcessAddresses>;
@@ -176,13 +182,19 @@ export default class MainProcess {
 
     this.logProcessExitAndError('tshd', this.tshdProcess);
 
-    createFileLoggerService({
+    const loggerService = createFileLoggerService({
       dev: this.settings.dev,
       dir: this.settings.logsDir,
       name: TSHD_LOGGER_NAME,
       loggerNameColor: LoggerColor.Cyan,
       passThroughMode: true,
-    }).pipeProcessOutputIntoLogger(this.tshdProcess);
+    });
+
+    this.tshdProcessLastLogs = new KeepLastChunks(NO_OF_LAST_LOGS_KEPT);
+    loggerService.pipeProcessOutputIntoLogger(
+      this.tshdProcess,
+      this.tshdProcessLastLogs
+    );
   }
 
   private initSharedProcess() {
@@ -196,13 +208,19 @@ export default class MainProcess {
 
     this.logProcessExitAndError('shared process', this.sharedProcess);
 
-    createFileLoggerService({
+    const loggerService = createFileLoggerService({
       dev: this.settings.dev,
       dir: this.settings.logsDir,
       name: SHARED_PROCESS_LOGGER_NAME,
       loggerNameColor: LoggerColor.Yellow,
       passThroughMode: true,
-    }).pipeProcessOutputIntoLogger(this.sharedProcess);
+    });
+
+    this.sharedProcessLastLogs = new KeepLastChunks(NO_OF_LAST_LOGS_KEPT);
+    loggerService.pipeProcessOutputIntoLogger(
+      this.sharedProcess,
+      this.sharedProcessLastLogs
+    );
   }
 
   private initResolvingChildProcessAddresses(): void {
@@ -215,7 +233,8 @@ export default class MainProcess {
           this.logger,
           this.settings,
           'the tsh daemon',
-          TSHD_LOGGER_NAME
+          TSHD_LOGGER_NAME,
+          this.tshdProcessLastLogs
         )
       ),
       resolveNetworkAddress(
@@ -226,7 +245,8 @@ export default class MainProcess {
           this.logger,
           this.settings,
           'the shared helper process',
-          SHARED_PROCESS_LOGGER_NAME
+          SHARED_PROCESS_LOGGER_NAME,
+          this.sharedProcessLastLogs
         )
       ),
     ]).then(([tsh, shared]) => ({ tsh, shared }));
@@ -635,11 +655,17 @@ async function createGrpcCredentials(
   return grpcCreds.createClientCredentials(mainProcessKeyPair, tshdCert);
 }
 
+// The number of lines was chosen by looking at logs from the shared process when the glibc version
+// is too old and making sure that we'd have been able to see the actual issue in the error dialog.
+// See the PR description for the logs: https://github.com/gravitational/teleport/pull/38724
+const NO_OF_LAST_LOGS_KEPT = 25;
+
 function rewrapResolveError(
   logger: Logger,
   runtimeSettings: RuntimeSettings,
   processName: string,
-  processLoggerName: string
+  processLoggerName: string,
+  processLastLogs: KeepLastChunks<string>
 ) {
   return (error: unknown) => {
     if (!(error instanceof ResolveError)) {
@@ -653,9 +679,15 @@ function rewrapResolveError(
       runtimeSettings.logsDir,
       `${processLoggerName}.log`
     );
+    // TODO(ravicious): It'd have been ideal to get the logs from the file instead of keeping last n
+    // lines in memory.
+    // We tried to use winston.Logger.prototype.query for that but it kept returning no results,
+    // even with structured logging turned on.
+    const lastLogs = processLastLogs.getChunks().join('\n');
 
     throw new Error(
-      `Could not communicate with ${processName}. For more details, check logs at ${logPath}`
+      `Could not communicate with ${processName}.\n\n` +
+        `Last logs from ${logPath}:\n${lastLogs}`
     );
   };
 }

--- a/web/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
+++ b/web/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
@@ -127,7 +127,7 @@ function waitForMatchInStdout(
   });
 }
 
-class ResolveError extends Error {
+export class ResolveError extends Error {
   constructor(requestedAddress: string, process: ChildProcess, reason: string) {
     super(
       `Could not resolve address (${requestedAddress}) for process ${process.spawnfile}: ${reason}.`

--- a/web/packages/teleterm/src/services/logger/keepLastChunks.test.ts
+++ b/web/packages/teleterm/src/services/logger/keepLastChunks.test.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,5 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from './loggerService';
-export { KeepLastChunks } from './keepLastChunks';
+import { KeepLastChunks } from './keepLastChunks';
+
+describe('keepLastChunks', () => {
+  it('keeps last n chunks', () => {
+    const stream = new KeepLastChunks(3);
+
+    ['foo', 'bar', 'lorem', 'ipsum', 'dolor'].forEach(string => {
+      stream.write(string);
+    });
+    stream.end();
+
+    expect(stream.getChunks()).toEqual(['lorem', 'ipsum', 'dolor']);
+  });
+});

--- a/web/packages/teleterm/src/services/logger/keepLastChunks.ts
+++ b/web/packages/teleterm/src/services/logger/keepLastChunks.ts
@@ -1,0 +1,52 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import stream from 'node:stream';
+
+import { RingBuffer } from 'ring-buffer-ts';
+
+/**
+ * A writeable stream that keeps the last n chunks.
+ *
+ * Useful for keeping last lines of stdout/stderr from a child process.
+ */
+export class KeepLastChunks<Chunk> extends stream.Writable {
+  private chunks: RingBuffer<Chunk>;
+
+  constructor(noOfChunks: number) {
+    super({
+      // Support any kind of objects as chunks.
+      objectMode: true,
+    });
+    this.chunks = new RingBuffer(noOfChunks);
+  }
+
+  _write(
+    chunk: Chunk,
+    encoding: BufferEncoding,
+    next: (error?: Error | null) => void
+  ): void {
+    this.chunks.add(chunk);
+
+    next();
+  }
+
+  getChunks(): Chunk[] {
+    return this.chunks.toArray();
+  }
+}

--- a/web/packages/teleterm/src/services/logger/types.ts
+++ b/web/packages/teleterm/src/services/logger/types.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { KeepLastChunks } from './keepLastChunks';
+
 import type { ChildProcess } from 'node:child_process';
 
 export interface Logger {
@@ -29,5 +31,8 @@ export interface LoggerService {
 }
 
 export interface NodeLoggerService extends LoggerService {
-  pipeProcessOutputIntoLogger(childProcess: ChildProcess): void;
+  pipeProcessOutputIntoLogger(
+    childProcess: ChildProcess,
+    lastLogs?: KeepLastChunks<string>
+  ): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13796,6 +13796,11 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+ring-buffer-ts@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ring-buffer-ts/-/ring-buffer-ts-1.2.0.tgz#8bbbfd82ad2e218d7447056f47e5eda7547b9b2f"
+  integrity sha512-dkGqA7YHZgXp1dWwcNIsmt+4EgHK1RmY9sp7eqHLLfTkhYhQQ4agAwqgED7hJakELMaXkBgZ5568vqaI3/wV6Q==
+
 roarr@^2.15.3:
   version "2.15.4"
   resolved "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd"


### PR DESCRIPTION
Examples of error reports that we got during the last two weeks:

| Examples | |
| --- | --- |
| ![screenshot_2024-02-27_at_10 37 35___am](https://github.com/gravitational/teleport/assets/27113/713c91d4-c179-4bc7-8fdc-2f5f83379535) | ![screenshot_2024-02-19_at_12 10 08___pm](https://github.com/gravitational/teleport/assets/27113/9378dec0-f98a-410d-9dd4-2bb5ce077957) |

The error doesn't mean much to the user. What ends up happening is that we ask the user to pull up logs from the relevant process. Those logs contain the actual error. In the case of the first screenshot, the problem was with a Linux distro having an old glibc version, in the second screenshot Windows Server 2019 didn't have the exact Webauthn API that tsh expected.

<details>
<summary>Logs from mentioned errors</summary>

glibc version (log from the shared process)

```
innerError Error: Cannot find module '../build/Debug/pty.node'
Require stack:
- /opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js
- /opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/index.js
- /opt/Teleport Connect/resources/app.asar/build/app/main/sharedProcess.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1084:15)
    at Module._load (node:internal/modules/cjs/loader:929:27)
    at c._load (node:electron/js2c/node_init:2:13672)
    at Module.require (node:internal/modules/cjs/loader:1150:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js:34:15)
    at Module._compile (node:internal/modules/cjs/loader:1271:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1326:10)
    at Module.load (node:internal/modules/cjs/loader:1126:32)
    at Module._load (node:internal/modules/cjs/loader:967:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js',
    '/opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/index.js',
    '/opt/Teleport Connect/resources/app.asar/build/app/main/sharedProcess.js'
  ]
}
/opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js:40
        throw outerError;
        ^

Error: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /opt/Teleport Connect/resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node)
    at process.func [as dlopen] (node:electron/js2c/node_init:2:2214)
    at Module._extensions..node (node:internal/modules/cjs/loader:1356:18)
    at Object.func [as .node] (node:electron/js2c/node_init:2:2441)
    at Module.load (node:internal/modules/cjs/loader:1126:32)
    at Module._load (node:internal/modules/cjs/loader:967:12)
    at c._load (node:electron/js2c/node_init:2:13672)
    at Module.require (node:internal/modules/cjs/loader:1150:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/opt/Teleport Connect/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js:29:11)
    at Module._compile (node:internal/modules/cjs/loader:1271:14) {
  code: 'ERR_DLOPEN_FAILED'
}

Node.js v18.18.2
```

Missing Webauthn API (log from the tsh daemon)

```
panic: Failed to find WebAuthNGetApiVersionNumber procedure in WebAuthn.dll: The specified procedure could not be found.

goroutine 1 [running]:
golang.org/x/sys/windows.(*LazyProc).mustFind(...)
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sys@v0.16.0/windows/dll_windows.go:325
golang.org/x/sys/windows.(*LazyProc).Addr(...)
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sys@v0.16.0/windows/dll_windows.go:333
github.com/gravitational/teleport/lib/auth/webauthnwin.webAuthNGetApiVersionNumber()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/zsyscall_windows.go:83 +0xb4
github.com/gravitational/teleport/lib/auth/webauthnwin.newNativeImpl()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/webauthn_windows.go:65 +0xad
github.com/gravitational/teleport/lib/auth/webauthnwin.init()
	C:/a/teleport.e/teleport.e/lib/auth/webauthnwin/webauthn_windows.go:36 +0x169
```

</details>

But we know where the logs are and we're able to even show them so that when someone submits a screenshot we can avoid this back-and-forth completely.

Arguably, it'd have been better to just read the logs from disk. However, Winston rotates logfiles, so after a while you end up with `shared.log`, `shared1.log` and so on. I couldn't find a way to easily establish which file is the current file. So instead I decided to capture the last 25 lines from each process. We already do something similar for Connect My Computer.

The number 25 was chosen by looking at the logs from the glibc error (see above) and making sure that we'd have been able to see the actual issue in the dialog.

Here's how it looks with the changes:

<img width="520" alt="error box with logs" src="https://github.com/gravitational/teleport/assets/27113/dee6866d-69d4-4d04-9900-e1e1a98d2f12">

---

It's worth mentioning that since we added the tsh client to the main process, if any helper process fails to start we show the error box and quit the app.

https://github.com/gravitational/teleport/blob/3d8d39fd2057818ccc4db7866b28c3ea30328492/web/packages/teleterm/src/main.ts#L160-L177

Arguably, this only needs to happen if the tshd process fails to start and can disregard failures related to the shared process completely, but I don't have the time to untangle this at the moment.