### PR TITLE
Add admin user in the `teleport-cluster` guide

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -284,9 +284,9 @@ While we encourage Teleport users to authenticate via their single sign-on
 provider, local users are a reliable fallback for cases when the SSO provider is
 down. 
 
-To demonstrate how to create a local user and authenticate to Teleport in order
-to access your Kubernetes cluster, let's create a local user who has access to
-Kubernetes group `system:masters` via the Teleport role `member`.
+In this section, we will  create a local user who has access to Kubernetes group
+`system:masters` via the Teleport role `member`. This user also has the built-in
+`access` and `editor` roles for administrative privileges.
 
 Paste the following role specification into a file called `member.yaml`:
 
@@ -304,7 +304,7 @@ Paste the following role specification into a file called `member.yaml`:
    with the name of the local Teleport user you want to create:
 
    ```code
-   $ kubectl exec -ti deployment/teleport-cluster-auth -- tctl users add <Var name="myuser" /> --roles=member
+   $ kubectl exec -ti deployment/teleport-cluster-auth -- tctl users add <Var name="myuser" /> --roles=member,access,editor
    User "myuser" has been created but requires a password. Share this URL with the user to
    complete user setup, link is valid for 1h:
    


### PR DESCRIPTION
Closes #10583

The local user we show how to create in the `teleport-cluster` guide only has privileges to access Kubernetes resources, but does not have administrative access to the cluster (e.g., to manage dynamic resources).

This change takes the approach of the Linux server guide (the index page of the docs) and shows how to add a user with the `editor,access` roles in addition to a role that can access Kubernetes clusters.