### PR TITLE
Remove ResetSessionRecordingConfig with incorrect return type

### DIFF
--- a/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service.pb.go
@@ -815,7 +815,7 @@ var file_teleport_clusterconfig_v1_clusterconfig_service_proto_rawDesc = []byte{
 	0x6e, 0x66, 0x69, 0x67, 0x56, 0x32, 0x52, 0x0b, 0x61, 0x75, 0x64, 0x69, 0x74, 0x43, 0x6f, 0x6e,
 	0x66, 0x69, 0x67, 0x22, 0x20, 0x0a, 0x1e, 0x52, 0x65, 0x73, 0x65, 0x74, 0x43, 0x6c, 0x75, 0x73,
 	0x74, 0x65, 0x72, 0x41, 0x75, 0x64, 0x69, 0x74, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x65,
-	0x71, 0x75, 0x65, 0x73, 0x74, 0x32, 0x86, 0x0f, 0x0a, 0x14, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x32, 0x86, 0x0e, 0x0a, 0x14, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65,
 	0x72, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x7c,
 	0x0a, 0x1a, 0x47, 0x65, 0x74, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77,
 	0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x3c, 0x2e, 0x74,
@@ -873,14 +873,6 @@ var file_teleport_clusterconfig_v1_clusterconfig_service_proto_rawDesc = []byte{
 	0x65, 0x63, 0x6f, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x65,
 	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1f, 0x2e, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2e, 0x53, 0x65,
 	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f,
-	0x6e, 0x66, 0x69, 0x67, 0x56, 0x32, 0x12, 0x7e, 0x0a, 0x1b, 0x52, 0x65, 0x73, 0x65, 0x74, 0x53,
-	0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x43,
-	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x3d, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74,
-	0x2e, 0x63, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x76,
-	0x31, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x74, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x65,
-	0x63, 0x6f, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x65, 0x71,
-	0x75, 0x65, 0x73, 0x74, 0x1a, 0x20, 0x2e, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2e, 0x43, 0x6c, 0x75,
-	0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x43, 0x6f,
 	0x6e, 0x66, 0x69, 0x67, 0x56, 0x32, 0x12, 0x61, 0x0a, 0x11, 0x47, 0x65, 0x74, 0x41, 0x75, 0x74,
 	0x68, 0x50, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x33, 0x2e, 0x74, 0x65,
 	0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2e, 0x63, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x63, 0x6f,
@@ -996,33 +988,31 @@ var file_teleport_clusterconfig_v1_clusterconfig_service_proto_depIdxs = []int32
 	4,  // 12: teleport.clusterconfig.v1.ClusterConfigService.GetSessionRecordingConfig:input_type -> teleport.clusterconfig.v1.GetSessionRecordingConfigRequest
 	5,  // 13: teleport.clusterconfig.v1.ClusterConfigService.UpdateSessionRecordingConfig:input_type -> teleport.clusterconfig.v1.UpdateSessionRecordingConfigRequest
 	6,  // 14: teleport.clusterconfig.v1.ClusterConfigService.UpsertSessionRecordingConfig:input_type -> teleport.clusterconfig.v1.UpsertSessionRecordingConfigRequest
-	7,  // 15: teleport.clusterconfig.v1.ClusterConfigService.ResetSessionRecordingConfig:input_type -> teleport.clusterconfig.v1.ResetSessionRecordingConfigRequest
-	8,  // 16: teleport.clusterconfig.v1.ClusterConfigService.GetAuthPreference:input_type -> teleport.clusterconfig.v1.GetAuthPreferenceRequest
-	9,  // 17: teleport.clusterconfig.v1.ClusterConfigService.UpdateAuthPreference:input_type -> teleport.clusterconfig.v1.UpdateAuthPreferenceRequest
-	10, // 18: teleport.clusterconfig.v1.ClusterConfigService.UpsertAuthPreference:input_type -> teleport.clusterconfig.v1.UpsertAuthPreferenceRequest
-	11, // 19: teleport.clusterconfig.v1.ClusterConfigService.ResetAuthPreference:input_type -> teleport.clusterconfig.v1.ResetAuthPreferenceRequest
-	12, // 20: teleport.clusterconfig.v1.ClusterConfigService.GetClusterAuditConfig:input_type -> teleport.clusterconfig.v1.GetClusterAuditConfigRequest
-	13, // 21: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterAuditConfig:input_type -> teleport.clusterconfig.v1.UpdateClusterAuditConfigRequest
-	14, // 22: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterAuditConfig:input_type -> teleport.clusterconfig.v1.UpsertClusterAuditConfigRequest
-	15, // 23: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterAuditConfig:input_type -> teleport.clusterconfig.v1.ResetClusterAuditConfigRequest
-	16, // 24: teleport.clusterconfig.v1.ClusterConfigService.GetClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
-	16, // 25: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
-	16, // 26: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
-	16, // 27: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
-	17, // 28: teleport.clusterconfig.v1.ClusterConfigService.GetSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
-	17, // 29: teleport.clusterconfig.v1.ClusterConfigService.UpdateSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
-	17, // 30: teleport.clusterconfig.v1.ClusterConfigService.UpsertSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
-	16, // 31: teleport.clusterconfig.v1.ClusterConfigService.ResetSessionRecordingConfig:output_type -> types.ClusterNetworkingConfigV2
-	18, // 32: teleport.clusterconfig.v1.ClusterConfigService.GetAuthPreference:output_type -> types.AuthPreferenceV2
-	18, // 33: teleport.clusterconfig.v1.ClusterConfigService.UpdateAuthPreference:output_type -> types.AuthPreferenceV2
-	18, // 34: teleport.clusterconfig.v1.ClusterConfigService.UpsertAuthPreference:output_type -> types.AuthPreferenceV2
-	18, // 35: teleport.clusterconfig.v1.ClusterConfigService.ResetAuthPreference:output_type -> types.AuthPreferenceV2
-	19, // 36: teleport.clusterconfig.v1.ClusterConfigService.GetClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
-	19, // 37: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
-	19, // 38: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
-	19, // 39: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
-	24, // [24:40] is the sub-list for method output_type
-	8,  // [8:24] is the sub-list for method input_type
+	8,  // 15: teleport.clusterconfig.v1.ClusterConfigService.GetAuthPreference:input_type -> teleport.clusterconfig.v1.GetAuthPreferenceRequest
+	9,  // 16: teleport.clusterconfig.v1.ClusterConfigService.UpdateAuthPreference:input_type -> teleport.clusterconfig.v1.UpdateAuthPreferenceRequest
+	10, // 17: teleport.clusterconfig.v1.ClusterConfigService.UpsertAuthPreference:input_type -> teleport.clusterconfig.v1.UpsertAuthPreferenceRequest
+	11, // 18: teleport.clusterconfig.v1.ClusterConfigService.ResetAuthPreference:input_type -> teleport.clusterconfig.v1.ResetAuthPreferenceRequest
+	12, // 19: teleport.clusterconfig.v1.ClusterConfigService.GetClusterAuditConfig:input_type -> teleport.clusterconfig.v1.GetClusterAuditConfigRequest
+	13, // 20: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterAuditConfig:input_type -> teleport.clusterconfig.v1.UpdateClusterAuditConfigRequest
+	14, // 21: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterAuditConfig:input_type -> teleport.clusterconfig.v1.UpsertClusterAuditConfigRequest
+	15, // 22: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterAuditConfig:input_type -> teleport.clusterconfig.v1.ResetClusterAuditConfigRequest
+	16, // 23: teleport.clusterconfig.v1.ClusterConfigService.GetClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
+	16, // 24: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
+	16, // 25: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
+	16, // 26: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterNetworkingConfig:output_type -> types.ClusterNetworkingConfigV2
+	17, // 27: teleport.clusterconfig.v1.ClusterConfigService.GetSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
+	17, // 28: teleport.clusterconfig.v1.ClusterConfigService.UpdateSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
+	17, // 29: teleport.clusterconfig.v1.ClusterConfigService.UpsertSessionRecordingConfig:output_type -> types.SessionRecordingConfigV2
+	18, // 30: teleport.clusterconfig.v1.ClusterConfigService.GetAuthPreference:output_type -> types.AuthPreferenceV2
+	18, // 31: teleport.clusterconfig.v1.ClusterConfigService.UpdateAuthPreference:output_type -> types.AuthPreferenceV2
+	18, // 32: teleport.clusterconfig.v1.ClusterConfigService.UpsertAuthPreference:output_type -> types.AuthPreferenceV2
+	18, // 33: teleport.clusterconfig.v1.ClusterConfigService.ResetAuthPreference:output_type -> types.AuthPreferenceV2
+	19, // 34: teleport.clusterconfig.v1.ClusterConfigService.GetClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
+	19, // 35: teleport.clusterconfig.v1.ClusterConfigService.UpdateClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
+	19, // 36: teleport.clusterconfig.v1.ClusterConfigService.UpsertClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
+	19, // 37: teleport.clusterconfig.v1.ClusterConfigService.ResetClusterAuditConfig:output_type -> types.ClusterAuditConfigV2
+	23, // [23:38] is the sub-list for method output_type
+	8,  // [8:23] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name

--- a/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/clusterconfig_service_grpc.pb.go
@@ -41,7 +41,6 @@ const (
 	ClusterConfigService_GetSessionRecordingConfig_FullMethodName     = "/teleport.clusterconfig.v1.ClusterConfigService/GetSessionRecordingConfig"
 	ClusterConfigService_UpdateSessionRecordingConfig_FullMethodName  = "/teleport.clusterconfig.v1.ClusterConfigService/UpdateSessionRecordingConfig"
 	ClusterConfigService_UpsertSessionRecordingConfig_FullMethodName  = "/teleport.clusterconfig.v1.ClusterConfigService/UpsertSessionRecordingConfig"
-	ClusterConfigService_ResetSessionRecordingConfig_FullMethodName   = "/teleport.clusterconfig.v1.ClusterConfigService/ResetSessionRecordingConfig"
 	ClusterConfigService_GetAuthPreference_FullMethodName             = "/teleport.clusterconfig.v1.ClusterConfigService/GetAuthPreference"
 	ClusterConfigService_UpdateAuthPreference_FullMethodName          = "/teleport.clusterconfig.v1.ClusterConfigService/UpdateAuthPreference"
 	ClusterConfigService_UpsertAuthPreference_FullMethodName          = "/teleport.clusterconfig.v1.ClusterConfigService/UpsertAuthPreference"
@@ -70,8 +69,6 @@ type ClusterConfigServiceClient interface {
 	UpdateSessionRecordingConfig(ctx context.Context, in *UpdateSessionRecordingConfigRequest, opts ...grpc.CallOption) (*types.SessionRecordingConfigV2, error)
 	// UpsertSessionRecordingConfig overwrites the active session recording configuration.
 	UpsertSessionRecordingConfig(ctx context.Context, in *UpsertSessionRecordingConfigRequest, opts ...grpc.CallOption) (*types.SessionRecordingConfigV2, error)
-	// ResetSessionRecordingConfig restores the active session recording configuration to default settings.
-	ResetSessionRecordingConfig(ctx context.Context, in *ResetSessionRecordingConfigRequest, opts ...grpc.CallOption) (*types.ClusterNetworkingConfigV2, error)
 	// GetAuthPreference retrieves the active auth preference.
 	GetAuthPreference(ctx context.Context, in *GetAuthPreferenceRequest, opts ...grpc.CallOption) (*types.AuthPreferenceV2, error)
 	// UpdateAuthPreference updates the auth preference.
@@ -155,15 +152,6 @@ func (c *clusterConfigServiceClient) UpdateSessionRecordingConfig(ctx context.Co
 func (c *clusterConfigServiceClient) UpsertSessionRecordingConfig(ctx context.Context, in *UpsertSessionRecordingConfigRequest, opts ...grpc.CallOption) (*types.SessionRecordingConfigV2, error) {
 	out := new(types.SessionRecordingConfigV2)
 	err := c.cc.Invoke(ctx, ClusterConfigService_UpsertSessionRecordingConfig_FullMethodName, in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *clusterConfigServiceClient) ResetSessionRecordingConfig(ctx context.Context, in *ResetSessionRecordingConfigRequest, opts ...grpc.CallOption) (*types.ClusterNetworkingConfigV2, error) {
-	out := new(types.ClusterNetworkingConfigV2)
-	err := c.cc.Invoke(ctx, ClusterConfigService_ResetSessionRecordingConfig_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +248,6 @@ type ClusterConfigServiceServer interface {
 	UpdateSessionRecordingConfig(context.Context, *UpdateSessionRecordingConfigRequest) (*types.SessionRecordingConfigV2, error)
 	// UpsertSessionRecordingConfig overwrites the active session recording configuration.
 	UpsertSessionRecordingConfig(context.Context, *UpsertSessionRecordingConfigRequest) (*types.SessionRecordingConfigV2, error)
-	// ResetSessionRecordingConfig restores the active session recording configuration to default settings.
-	ResetSessionRecordingConfig(context.Context, *ResetSessionRecordingConfigRequest) (*types.ClusterNetworkingConfigV2, error)
 	// GetAuthPreference retrieves the active auth preference.
 	GetAuthPreference(context.Context, *GetAuthPreferenceRequest) (*types.AuthPreferenceV2, error)
 	// UpdateAuthPreference updates the auth preference.
@@ -305,9 +291,6 @@ func (UnimplementedClusterConfigServiceServer) UpdateSessionRecordingConfig(cont
 }
 func (UnimplementedClusterConfigServiceServer) UpsertSessionRecordingConfig(context.Context, *UpsertSessionRecordingConfigRequest) (*types.SessionRecordingConfigV2, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpsertSessionRecordingConfig not implemented")
-}
-func (UnimplementedClusterConfigServiceServer) ResetSessionRecordingConfig(context.Context, *ResetSessionRecordingConfigRequest) (*types.ClusterNetworkingConfigV2, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ResetSessionRecordingConfig not implemented")
 }
 func (UnimplementedClusterConfigServiceServer) GetAuthPreference(context.Context, *GetAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAuthPreference not implemented")
@@ -468,24 +451,6 @@ func _ClusterConfigService_UpsertSessionRecordingConfig_Handler(srv interface{},
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ClusterConfigServiceServer).UpsertSessionRecordingConfig(ctx, req.(*UpsertSessionRecordingConfigRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _ClusterConfigService_ResetSessionRecordingConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ResetSessionRecordingConfigRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ClusterConfigServiceServer).ResetSessionRecordingConfig(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: ClusterConfigService_ResetSessionRecordingConfig_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClusterConfigServiceServer).ResetSessionRecordingConfig(ctx, req.(*ResetSessionRecordingConfigRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -668,10 +633,6 @@ var ClusterConfigService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpsertSessionRecordingConfig",
 			Handler:    _ClusterConfigService_UpsertSessionRecordingConfig_Handler,
-		},
-		{
-			MethodName: "ResetSessionRecordingConfig",
-			Handler:    _ClusterConfigService_ResetSessionRecordingConfig_Handler,
 		},
 		{
 			MethodName: "GetAuthPreference",

--- a/api/proto/teleport/clusterconfig/v1/clusterconfig_service.proto
+++ b/api/proto/teleport/clusterconfig/v1/clusterconfig_service.proto
@@ -37,8 +37,6 @@ service ClusterConfigService {
   rpc UpdateSessionRecordingConfig(UpdateSessionRecordingConfigRequest) returns (types.SessionRecordingConfigV2);
   // UpsertSessionRecordingConfig overwrites the active session recording configuration.
   rpc UpsertSessionRecordingConfig(UpsertSessionRecordingConfigRequest) returns (types.SessionRecordingConfigV2);
-  // ResetSessionRecordingConfig restores the active session recording configuration to default settings.
-  rpc ResetSessionRecordingConfig(ResetSessionRecordingConfigRequest) returns (types.ClusterNetworkingConfigV2);
 
   // GetAuthPreference retrieves the active auth preference.
   rpc GetAuthPreference(GetAuthPreferenceRequest) returns (types.AuthPreferenceV2);


### PR DESCRIPTION
The cluster config RPC service had a typo in the return type of ResetSessionRecordingConfig. Since our proto linter doesn't allow renaming, this removes the RPC entirely so that it can be added with the correct signature in a follow up. This service was only recently introduced, and is not exposed in any way with the Auth grpc server so removal is a safe operation.