### PR TITLE
docs: remove enterprise version advisory for ip pinning/hardware key

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -5,10 +5,6 @@ description: Hardware Key Support
 
 ## Introduction
 
-<Admonition type="warning" title="Enterprise">
-  Hardware Key Support requires Teleport Enterprise.
-</Admonition>
-
 By default, `tsh`, Teleport Connect, and other Teleport clients store a user's key and certificates directly
 on their filesystem. If a user's filesystem is compromised, any of their active Teleport user keys and certificates
 would also be compromised.

--- a/docs/pages/access-controls/guides/ip-pinning.mdx
+++ b/docs/pages/access-controls/guides/ip-pinning.mdx
@@ -3,10 +3,6 @@ title: "IP Pinning "
 description: How to enable IP pinning for Teleport users
 ---
 
-<Admonition type="warning">
-IP Pinning requires Teleport Enterprise.
-</Admonition>
-
 IP Pinning is a security feature that helps protect against unauthorized access by ensuring that
 Teleport users can only access resources from the IP address they used during the login process.
 This helps minimize the risk of compromised credentials being used from different locations.


### PR DESCRIPTION
At the top doc pages we have what is applicable now.  These advisories are not displayed in Device Trust for example which has Team, Ent and Cloud applicability. 