### PR TITLE
Change CONTRIBUTING link for docs contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,4 @@ Instructions for contributing changes to the Teleport Helm chart are available
 # Contributing to Docs
 
 See our public resources for docs contributors:
-https://goteleport.com/docs/contributing/documentation/
+https://github.com/gravitational/docs


### PR DESCRIPTION
Link to `gravitational/docs`, where docs contribution instructions now live, instead of the docs site.