### PR TITLE
[v14] Remove ScopedBlocks from the docs (#38698)

### DIFF
--- a/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
+++ b/docs/pages/database-access/guides/clickhouse-self-hosted.mdx
@@ -23,12 +23,14 @@ This guide will help you to:
 - Set up Teleport to access your self-hosted ClickHouse database.
 - Connect to your database through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem label="Self-Hosted">
 ![Teleport Database Access Self-hosted ClickHouse](../../../img/database-access/guides/clickhouse_selfhosted_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem label="Teleport Cloud">
 ![Teleport Database Access ClickHouse Cloud](../../../img/database-access/guides/clickhouse_selfhosted_cloud.png)
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 ## Prerequisites
 


### PR DESCRIPTION
There was a lingering one in the self-hosted ClickHouse guide. Remove it to help with the Mintlify migration and render diagrams as expected.