### PR TITLE
Return the DeviceWebToken as part of CreateSessionResponse

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2087,7 +2087,7 @@ type CreateSessionResponse struct {
 	SessionInactiveTimeoutMS int `json:"sessionInactiveTimeout"`
 	// DeviceWebToken is the token used to perform on-behalf-of device
 	// authentication.
-	// If not nil it should be forwared to Connect for the device authentication
+	// If not nil it should be forwarded to Connect for the device authentication
 	// ceremony.
 	DeviceWebToken *types.DeviceWebToken `json:"deviceWebToken,omitempty"`
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2085,6 +2085,11 @@ type CreateSessionResponse struct {
 	// a user WebUI session can be left idle before being logged out
 	// by the server. A zero value means there is no idle timeout set.
 	SessionInactiveTimeoutMS int `json:"sessionInactiveTimeout"`
+	// DeviceWebToken is the token used to perform on-behalf-of device
+	// authentication.
+	// If not nil it should be forwared to Connect for the device authentication
+	// ceremony.
+	DeviceWebToken *types.DeviceWebToken `json:"deviceWebToken,omitempty"`
 }
 
 func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
@@ -2107,6 +2112,7 @@ func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
 		Token:                    token.GetName(),
 		TokenExpiresIn:           int(token.Expiry().Sub(sctx.cfg.Parent.clock.Now()) / time.Second),
 		SessionInactiveTimeoutMS: int(sctx.cfg.Session.GetIdleTimeout().Milliseconds()),
+		DeviceWebToken:           sctx.cfg.Session.GetDeviceWebToken(),
 	}, nil
 }
 

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -352,7 +352,7 @@ func TestAuthenticate_deviceWebToken(t *testing.T) {
 	proxy := pack.proxies[0]
 	clock := pack.clock
 
-	// Mimic a successfully create DeviceWebToken, regarldess of any parameters.
+	// Mimic a valid DeviceWebToken, regardless of any parameters.
 	wantToken := &types.DeviceWebToken{
 		Id:    "this is an opaque token ID",
 		Token: "this is an opaque token Token",

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -19,27 +19,36 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base32"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/modules"
 )
 
@@ -335,6 +344,158 @@ func TestAuthenticate_rateLimiting(t *testing.T) {
 			require.True(t, trace.IsLimitExceeded(err), "got err = %v, want LimitExceeded", err)
 		})
 	}
+}
+
+func TestAuthenticate_deviceWebToken(t *testing.T) {
+	pack := newWebPack(t, 1 /* numProxies */)
+	authServer := pack.server.AuthServer.AuthServer
+	proxy := pack.proxies[0]
+	clock := pack.clock
+
+	// Mimic a successfully create DeviceWebToken, regarldess of any parameters.
+	wantToken := &types.DeviceWebToken{
+		Id:    "this is an opaque token ID",
+		Token: "this is an opaque token Token",
+	}
+	authServer.SetCreateDeviceWebTokenFunc(func(context.Context, *devicepb.DeviceWebToken) (*devicepb.DeviceWebToken, error) {
+		return &devicepb.DeviceWebToken{
+			Id:    wantToken.Id,
+			Token: wantToken.Token,
+		}, nil
+	})
+
+	ctx := context.Background()
+
+	t.Run("login using OTP", func(t *testing.T) {
+		// Create a user with password + OTP.
+		const user = "llama1"
+		const pass = "mysupersecretpassword!!1!"
+		otpSecret := newOTPSharedSecret()
+		proxy.createUser(ctx, t, user, user, pass, otpSecret, nil /* roles */)
+
+		sessionResp := loginWebOTP(t, ctx, loginWebOTPParams{
+			webClient: proxy.newClient(t),
+			clock:     clock,
+			user:      user,
+			password:  pass,
+			otpSecret: otpSecret,
+		})
+		assert.Equal(t, wantToken, sessionResp.DeviceWebToken, "WebSession DeviceWebToken mismatch")
+	})
+
+	t.Run("login using WebAuthn", func(t *testing.T) {
+		rpID := pack.server.TLS.ClusterName()
+		mfaResp := configureClusterForMFA(t, pack, &types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOptional,
+			Webauthn: &types.Webauthn{
+				RPID: rpID,
+			},
+		})
+
+		sessionResp := loginWebMFA(ctx, t, loginWebMFAParams{
+			webClient:     proxy.newClient(t),
+			rpID:          rpID,
+			user:          mfaResp.User,
+			password:      mfaResp.Password,
+			authenticator: mfaResp.WebDev.Key,
+		})
+		assert.Equal(t, wantToken, sessionResp.DeviceWebToken, "WebSession DeviceWebToken mismatch")
+	})
+}
+
+// newOTPSharedSecret returns an OTP shared secret, encoded as a base32 string.
+func newOTPSharedSecret() string {
+	return base32.StdEncoding.EncodeToString([]byte("supersecretsecret!!1!"))
+}
+
+type loginWebOTPParams struct {
+	webClient      *TestWebClient
+	clock          clockwork.Clock
+	user, password string
+	otpSecret      string // base32-encoded shared OTP secret
+}
+
+// loginWebOTP logins the user using the /webapi/sessions/new endpoint.
+//
+// This is a lower-level utility for tests that want access to the returned
+// CreateSessionResponse.
+func loginWebOTP(t *testing.T, ctx context.Context, params loginWebOTPParams) *CreateSessionResponse {
+	webClient := params.webClient
+	clock := params.clock
+
+	code, err := totp.GenerateCode(params.otpSecret, clock.Now())
+	require.NoError(t, err, "GenerateCode failed")
+
+	// Prepare request JSON body.
+	reqBody, err := json.Marshal(&CreateSessionReq{
+		User:              params.user,
+		Pass:              params.password,
+		SecondFactorToken: code,
+	})
+	require.NoError(t, err, "Marshal failed")
+
+	// Prepare request with CSRF token.
+	url := webClient.Endpoint("webapi", "sessions", "web")
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	require.NoError(t, err, "NewRequestWithContext failed")
+	const csrfToken = "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
+	addCSRFCookieToReq(req, csrfToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(csrf.HeaderName, csrfToken)
+
+	resp, err := webClient.HTTPClient().Do(req)
+	require.NoError(t, err, "Do failed")
+
+	// Drain body, then close, then handle error.
+	sessionResp := &CreateSessionResponse{}
+	err = json.NewDecoder(resp.Body).Decode(sessionResp)
+	_ = resp.Body.Close()
+	require.NoError(t, err, "Unmarshal failed")
+
+	return sessionResp
+}
+
+type loginWebMFAParams struct {
+	webClient      *TestWebClient
+	rpID           string
+	user, password string
+	authenticator  *mocku2f.Key
+}
+
+// loginWebMFA logins the user using /webapi/mfa/login/begin and
+// /webapi/mfa/login/finishsession.
+//
+// This is a lower-level utility for tests that want access to the returned
+// CreateSessionResponse.
+func loginWebMFA(ctx context.Context, t *testing.T, params loginWebMFAParams) *CreateSessionResponse {
+	webClient := params.webClient
+
+	beginResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "begin"), &client.MFAChallengeRequest{
+		User: params.user,
+		Pass: params.password,
+	})
+	require.NoError(t, err)
+
+	authChallenge := &client.MFAAuthenticateChallenge{}
+	require.NoError(t, json.Unmarshal(beginResp.Bytes(), authChallenge))
+	require.NotNil(t, authChallenge.WebauthnChallenge)
+
+	// Sign Webauthn challenge (requires user interaction in real-world
+	// scenarios).
+	key := params.authenticator
+	assertionResp, err := key.SignAssertion("https://"+params.rpID, authChallenge.WebauthnChallenge)
+	require.NoError(t, err)
+
+	// 2nd login step: reply with signed challenge.
+	sessionResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "finishsession"), &client.AuthenticateWebUserRequest{
+		User:                      params.user,
+		WebauthnAssertionResponse: assertionResp,
+	})
+	require.NoError(t, err)
+	createSessionResp := &CreateSessionResponse{}
+	require.NoError(t, json.Unmarshal(sessionResp.Bytes(), createSessionResp))
+	return createSessionResp
 }
 
 type configureMFAResp struct {


### PR DESCRIPTION
Return the DeviceWebToken created by Auth (#38704) all the way from the Proxy to the Web UI.

https://github.com/gravitational/teleport.e/issues/3236