### PR TITLE
Prevent the debug flag from overriding trace logging

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2260,7 +2260,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 			log.SetLevel(log.DebugLevel)
 			cfg.Log.SetLevel(log.DebugLevel)
 		} else {
-			if fileConf.Logger.Severity != "trace" {
+			if strings.ToLower(fileConf.Logger.Severity) != "trace" {
 				fileConf.Logger.Severity = teleport.DebugLevel
 			}
 		}


### PR DESCRIPTION
If the log severity in the config file was set to TRACE, which gets parsed correctly when setting initial log level, AND teleport is started with `-d/--debug` the log level was being downgraded from the more verbose trace level to debug because the comparison was case sensitive. By changing the comparison to be case insensitive the more verbose option is now used even when `-d/--debug` is applied.