### PR TITLE
Remove curly braces from proto comment

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1321,7 +1321,7 @@ message ProvisionTokenSpecV2GitLab {
   message Rule {
     // Sub roughly uniquely identifies the workload. Example:
     // `project_path:mygroup/my-project:ref_type:branch:ref:main`
-    // project_path:{group}/{project}:ref_type:{type}:ref:{branch_name}
+    // project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME
     //
     // This field supports simple "glob-style" matching:
     // - Use '*' to match zero or more characters.

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -4083,7 +4083,7 @@ var xxx_messageInfo_ProvisionTokenSpecV2GitLab proto.InternalMessageInfo
 type ProvisionTokenSpecV2GitLab_Rule struct {
 	// Sub roughly uniquely identifies the workload. Example:
 	// `project_path:mygroup/my-project:ref_type:branch:ref:main`
-	// project_path:{group}/{project}:ref_type:{type}:ref:{branch_name}
+	// project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME
 	//
 	// This field supports simple "glob-style" matching:
 	// - Use '*' to match zero or more characters.


### PR DESCRIPTION
When we generate the Teleport Terraform provider from `types.proto`, and generate the Terraform reference from the provider, the curly braces prevent the Terraform reference from rendering on Mintlify. This change rmeoves the curly braces.