### PR TITLE
[v14] Update grpc-tools-node-protoc-ts to 5.3.2 to support optionals.

### DIFF
--- a/buf-js.gen.yaml
+++ b/buf-js.gen.yaml
@@ -14,7 +14,7 @@ plugins:
     opt: grpc_js
     path: grpc_tools_node_protoc_plugin
 
-  # https://github.com/agreatfool/grpc_tools_node_protoc_ts/tree/v5.0.1
+  # https://github.com/agreatfool/grpc_tools_node_protoc_ts/tree/v5.3.2
   - name: ts
     strategy: all
     out: gen/proto/js

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -20,5 +20,5 @@ BUF_VERSION ?= v1.29.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4
-NODE_PROTOC_TS_VERSION ?= 5.0.1
+NODE_PROTOC_TS_VERSION ?= 5.3.2
 PROTOC_VERSION ?= 3.20.3


### PR DESCRIPTION
grpc-tools-node-protoc-ts has been updated to ensure support of proto3 optional fields.

Note: This only applies to v14 and v13.

Follow on: https://github.com/gravitational/teleport/pull/38769