### PR TITLE
[v15] Require admin MFA for get/list CAs with secrets

### DIFF
--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -101,7 +101,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		readVerb = types.VerbRead
 
 		// Require admin MFA to read secrets.
-		if err := authCtx.AuthorizeAdminAction(); err != nil {
+		if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -91,9 +91,19 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 
 // GetCertAuthority retrieves the matching certificate authority.
 func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuthorityRequest) (*types.CertAuthorityV2, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	readVerb := types.VerbReadNoSecrets
 	if req.IncludeKey {
 		readVerb = types.VerbRead
+
+		// Require admin MFA to read secrets.
+		if err := authCtx.AuthorizeAdminAction(); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Before looking up the requested CA perform RBAC on a dummy CA to
@@ -108,12 +118,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	authzCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err = authzCtx.CheckAccessToResource(contextCA, readVerb); err != nil {
+	if err = authCtx.CheckAccessToResource(contextCA, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -124,7 +129,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err = authzCtx.CheckAccessToResource(ca, readVerb); err != nil {
+	if err = authCtx.CheckAccessToResource(ca, readVerb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -138,15 +143,20 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 
 // GetCertAuthorities retrieves the cert authorities with the specified type.
 func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAuthoritiesRequest) (*trustpb.GetCertAuthoritiesResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	verbs := []string{types.VerbList, types.VerbReadNoSecrets}
 
 	if req.IncludeKey {
 		verbs = append(verbs, types.VerbRead)
-	}
 
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
+		// Require admin MFA to read secrets.
+		if err := authCtx.AuthorizeAdminAction(); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err := authCtx.CheckAccessToKind(types.KindCertAuthority, verbs[0], verbs[1:]...); err != nil {

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -99,11 +99,6 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 	readVerb := types.VerbReadNoSecrets
 	if req.IncludeKey {
 		readVerb = types.VerbRead
-
-		// Require admin MFA to read secrets.
-		if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	// Before looking up the requested CA perform RBAC on a dummy CA to
@@ -120,6 +115,13 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 
 	if err = authCtx.CheckAccessToResource(contextCA, readVerb); err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// Require admin MFA to read secrets.
+	if req.IncludeKey {
+		if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Retrieve the requested CA and perform RBAC on it to ensure that

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -154,7 +154,7 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		verbs = append(verbs, types.VerbRead)
 
 		// Require admin MFA to read secrets.
-		if err := authCtx.AuthorizeAdminAction(); err != nil {
+		if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 )
@@ -59,6 +61,11 @@ func (m *mockAuthClient) GetCertAuthority(ctx context.Context, id types.CertAuth
 		}
 	}
 	return m.server.GetCertAuthority(ctx, id, loadKeys)
+}
+
+func (m *mockAuthClient) PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	// return MFA not required to gracefully skip the MFA prompt.
+	return nil, &mfa.ErrMFANotRequired
 }
 
 func TestExportAuthorities(t *testing.T) {

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -63,7 +63,7 @@ func TestAdminActionMFA(t *testing.T) {
 
 	t.Run("Users", s.testUsers)
 	t.Run("Bots", s.testBots)
-	t.Run("AuthSign", s.testAuthSign)
+	t.Run("Auth", s.testAuth)
 	t.Run("Roles", s.testRoles)
 	t.Run("AccessRequests", s.testAccessRequests)
 	t.Run("Tokens", s.testTokens)
@@ -179,7 +179,7 @@ func (s *adminActionTestSuite) testBots(t *testing.T) {
 	})
 }
 
-func (s *adminActionTestSuite) testAuthSign(t *testing.T) {
+func (s *adminActionTestSuite) testAuth(t *testing.T) {
 	ctx := context.Background()
 
 	user, err := types.NewUser("teleuser")
@@ -194,12 +194,24 @@ func (s *adminActionTestSuite) testAuthSign(t *testing.T) {
 	identityFilePath := filepath.Join(t.TempDir(), "identity")
 
 	t.Run("AuthCommands", func(t *testing.T) {
-		t.Run("Impersonation", func(t *testing.T) {
-			s.testCommand(t, ctx, adminActionTestCase{
+		for name, tc := range map[string]adminActionTestCase{
+			"auth sign --user=impersonate": {
 				command:    fmt.Sprintf("auth sign --out=%v --user=%v --overwrite", identityFilePath, user.GetName()),
 				cliCommand: &tctl.AuthCommand{},
+			},
+			"auth export": {
+				command:    fmt.Sprintf("auth export --keys"),
+				cliCommand: &tctl.AuthCommand{},
+			},
+			"auth export --type": {
+				command:    fmt.Sprintf("auth export --keys --type=user"),
+				cliCommand: &tctl.AuthCommand{},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				s.testCommand(t, ctx, tc)
 			})
-		})
+		}
 
 		// Renewing certs for yourself should not require admin MFA.
 		t.Run("RenewCerts", func(t *testing.T) {

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -200,11 +200,11 @@ func (s *adminActionTestSuite) testAuth(t *testing.T) {
 				cliCommand: &tctl.AuthCommand{},
 			},
 			"auth export": {
-				command:    fmt.Sprintf("auth export --keys"),
+				command:    "auth export --keys",
 				cliCommand: &tctl.AuthCommand{},
 			},
 			"auth export --type": {
-				command:    fmt.Sprintf("auth export --keys --type=user"),
+				command:    "auth export --keys --type=user",
 				cliCommand: &tctl.AuthCommand{},
 			},
 		} {

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -470,6 +470,7 @@ func (s *adminActionTestSuite) testCertAuthority(t *testing.T) {
 		resource:        ca,
 		resourceCreate:  createCertAuthority,
 		resourceCleanup: deleteCertAuthority,
+		testGetList:     true,
 	})
 
 	s.testEditCommand(t, ctx, editCommandTestCase{
@@ -868,7 +869,7 @@ func (s *adminActionTestSuite) testResourceCommand(t *testing.T, ctx context.Con
 	if tc.testGetList {
 		t.Run("tctl get", func(t *testing.T) {
 			s.testCommand(t, ctx, adminActionTestCase{
-				command:    fmt.Sprintf("get %v", getResourceRef(tc.resource)),
+				command:    fmt.Sprintf("get --with-secrets %v", getResourceRef(tc.resource)),
 				cliCommand: &tctl.ResourceCommand{},
 				setup:      tc.resourceCreate,
 				cleanup:    tc.resourceCleanup,
@@ -877,7 +878,7 @@ func (s *adminActionTestSuite) testResourceCommand(t *testing.T, ctx context.Con
 
 		t.Run("tctl list", func(t *testing.T) {
 			s.testCommand(t, ctx, adminActionTestCase{
-				command:    fmt.Sprintf("get %v", tc.resource.GetKind()),
+				command:    fmt.Sprintf("get --with-secrets %v", tc.resource.GetKind()),
 				cliCommand: &tctl.ResourceCommand{},
 				setup:      tc.resourceCreate,
 				cleanup:    tc.resourceCleanup,

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -47,6 +47,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -898,7 +899,6 @@ func (rc *ResourceCommand) createUIConfig(ctx context.Context, client auth.Clien
 	}
 	fmt.Printf("ui_config %q has been set\n", uic.GetName())
 	return nil
-
 }
 
 func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
@@ -1819,7 +1819,21 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 		}
 		return &reverseTunnelCollection{tunnels: []types.ReverseTunnel{tunnel}}, nil
 	case types.KindCertAuthority:
-		if rc.ref.SubKind == "" && rc.ref.Name == "" {
+		getAll := rc.ref.SubKind == "" && rc.ref.Name == ""
+
+		// Prompt for admin action MFA if secrets were requested.
+		if rc.withSecrets {
+			// allow reuse for multiple calls to GetCertAuthorities with different ca types.
+			allowReuse := getAll
+			mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, allowReuse)
+			if err == nil {
+				ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
+			} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
+				return nil, trace.Wrap(err)
+			}
+		}
+
+		if getAll {
 			var allAuthorities []types.CertAuthority
 			for _, caType := range types.CertAuthTypes {
 				authorities, err := client.GetCertAuthorities(ctx, caType, rc.withSecrets)
@@ -1834,6 +1848,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			}
 			return &authorityCollection{cas: allAuthorities}, nil
 		}
+
 		id := types.CertAuthID{Type: types.CertAuthType(rc.ref.SubKind), DomainName: rc.ref.Name}
 		authority, err := client.GetCertAuthority(ctx, id, rc.withSecrets)
 		if err != nil {


### PR DESCRIPTION
Backport #38529 to branch/v15

changelog: When teleport is configured to require MFA for admin actions, MFA is required to get certificate authority secrets. Ex: `tctl auth export --keys` or `tctl get cert_authority/host/root.example.com --with-secrets`.
