### PR TITLE
docs: update usage based address to show port number

### DIFF
--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -10,7 +10,7 @@ the billing metrics we calculate.
 ## Anonymized usage data
 
 The commercial editions of Teleport send anonymized information to Teleport's
-cloud infrastructure at `reporting-teleport.teleportinfra.sh`.
+cloud infrastructure at `https://reporting-teleport.teleportinfra.sh`.
 This information contains the following:
 
 - Teleport license identifier.

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -10,7 +10,7 @@ the billing metrics we calculate.
 ## Anonymized usage data
 
 The commercial editions of Teleport send anonymized information to Teleport's
-cloud infrastructure at `https://reporting-teleport.teleportinfra.sh`.
+cloud infrastructure at `reporting-teleport.teleportinfra.sh:443`.
 This information contains the following:
 
 - Teleport license identifier.


### PR DESCRIPTION
Often we get questions on what port the host is conencting to. This allows for knowing which port it would connect to.