### PR TITLE
Add white-space: pre-wrap to FailedApp

### DIFF
--- a/web/packages/teleterm/src/ui/components/App.tsx
+++ b/web/packages/teleterm/src/ui/components/App.tsx
@@ -39,7 +39,14 @@ export const FailedApp = (props: { message: string }) => {
         ThemeProvider to provide a theme, it needs to use StaticThemeProvider to provide one.
       */}
       <StaticThemeProvider theme={darkTheme}>
-        <Failed alignSelf={'baseline'} message={props.message} />
+        <Failed
+          message={props.message}
+          alignSelf={'baseline'}
+          width="600px"
+          css={`
+            white-space: pre-wrap;
+          `}
+        />
       </StaticThemeProvider>
     </StyledApp>
   );


### PR DESCRIPTION
This way it can properly show last logs when ResolveError gets caught. I forgot to check it on master since it uses `dialog.showErrorBox` instead. I noticed it only when backporting to v14.

I'm going to wait for this PR to land before backporting #38724.

| Before | After |
| --- | --- |
| <img width="871" alt="before" src="https://github.com/gravitational/teleport/assets/27113/94033ca1-4ba6-4aba-a8a9-aa26552a28d4"> | <img width="871" alt="after" src="https://github.com/gravitational/teleport/assets/27113/a323a662-d9e6-4ee5-b640-3d5bb3ce30e1"> |
