### PR TITLE
[v15] Ignore the status field in access list operator tests.

### DIFF
--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -153,6 +153,7 @@ func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 	} else {
 		opts = append(opts, cmpopts.IgnoreFields(accesslist.Audit{}, "Notifications"))
 	}
+	opts = append(opts, cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"))
 
 	diff := cmp.Diff(
 		tResource,


### PR DESCRIPTION
Backport #38776 to branch/v15