### PR TITLE
Move lib/web tests to new web login helpers

### DIFF
--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -366,7 +366,7 @@ func TestAuthenticate_deviceWebToken(t *testing.T) {
 		otpSecret := newOTPSharedSecret()
 		proxy.createUser(ctx, t, user, user, pass, otpSecret, nil /* roles */)
 
-		sessionResp, _ := mustLoginWebOTP(t, ctx, loginWebOTPParams{
+		sessionResp, _ := loginWebOTP(t, ctx, loginWebOTPParams{
 			webClient: proxy.newClient(t),
 			clock:     clock,
 			user:      user,

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -19,21 +19,16 @@
 package web
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"encoding/base32"
 	"encoding/json"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -44,11 +39,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/modules"
 )
 
@@ -402,100 +395,6 @@ func TestAuthenticate_deviceWebToken(t *testing.T) {
 		})
 		assert.Equal(t, wantToken, sessionResp.DeviceWebToken, "WebSession DeviceWebToken mismatch")
 	})
-}
-
-// newOTPSharedSecret returns an OTP shared secret, encoded as a base32 string.
-func newOTPSharedSecret() string {
-	return base32.StdEncoding.EncodeToString([]byte("supersecretsecret!!1!"))
-}
-
-type loginWebOTPParams struct {
-	webClient      *TestWebClient
-	clock          clockwork.Clock
-	user, password string
-	otpSecret      string // base32-encoded shared OTP secret
-}
-
-// loginWebOTP logins the user using the /webapi/sessions/new endpoint.
-//
-// This is a lower-level utility for tests that want access to the returned
-// CreateSessionResponse.
-func loginWebOTP(t *testing.T, ctx context.Context, params loginWebOTPParams) *CreateSessionResponse {
-	webClient := params.webClient
-	clock := params.clock
-
-	code, err := totp.GenerateCode(params.otpSecret, clock.Now())
-	require.NoError(t, err, "GenerateCode failed")
-
-	// Prepare request JSON body.
-	reqBody, err := json.Marshal(&CreateSessionReq{
-		User:              params.user,
-		Pass:              params.password,
-		SecondFactorToken: code,
-	})
-	require.NoError(t, err, "Marshal failed")
-
-	// Prepare request with CSRF token.
-	url := webClient.Endpoint("webapi", "sessions", "web")
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
-	require.NoError(t, err, "NewRequestWithContext failed")
-	const csrfToken = "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
-	addCSRFCookieToReq(req, csrfToken)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(csrf.HeaderName, csrfToken)
-
-	resp, err := webClient.HTTPClient().Do(req)
-	require.NoError(t, err, "Do failed")
-
-	// Drain body, then close, then handle error.
-	sessionResp := &CreateSessionResponse{}
-	err = json.NewDecoder(resp.Body).Decode(sessionResp)
-	_ = resp.Body.Close()
-	require.NoError(t, err, "Unmarshal failed")
-
-	return sessionResp
-}
-
-type loginWebMFAParams struct {
-	webClient      *TestWebClient
-	rpID           string
-	user, password string
-	authenticator  *mocku2f.Key
-}
-
-// loginWebMFA logins the user using /webapi/mfa/login/begin and
-// /webapi/mfa/login/finishsession.
-//
-// This is a lower-level utility for tests that want access to the returned
-// CreateSessionResponse.
-func loginWebMFA(ctx context.Context, t *testing.T, params loginWebMFAParams) *CreateSessionResponse {
-	webClient := params.webClient
-
-	beginResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "begin"), &client.MFAChallengeRequest{
-		User: params.user,
-		Pass: params.password,
-	})
-	require.NoError(t, err)
-
-	authChallenge := &client.MFAAuthenticateChallenge{}
-	require.NoError(t, json.Unmarshal(beginResp.Bytes(), authChallenge))
-	require.NotNil(t, authChallenge.WebauthnChallenge)
-
-	// Sign Webauthn challenge (requires user interaction in real-world
-	// scenarios).
-	key := params.authenticator
-	assertionResp, err := key.SignAssertion("https://"+params.rpID, authChallenge.WebauthnChallenge)
-	require.NoError(t, err)
-
-	// 2nd login step: reply with signed challenge.
-	sessionResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "finishsession"), &client.AuthenticateWebUserRequest{
-		User:                      params.user,
-		WebauthnAssertionResponse: assertionResp,
-	})
-	require.NoError(t, err)
-	createSessionResp := &CreateSessionResponse{}
-	require.NoError(t, json.Unmarshal(sessionResp.Bytes(), createSessionResp))
-	return createSessionResp
 }
 
 type configureMFAResp struct {

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -366,7 +366,7 @@ func TestAuthenticate_deviceWebToken(t *testing.T) {
 		otpSecret := newOTPSharedSecret()
 		proxy.createUser(ctx, t, user, user, pass, otpSecret, nil /* roles */)
 
-		sessionResp := loginWebOTP(t, ctx, loginWebOTPParams{
+		sessionResp, _ := mustLoginWebOTP(t, ctx, loginWebOTPParams{
 			webClient: proxy.newClient(t),
 			clock:     clock,
 			user:      user,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -656,8 +655,7 @@ type authPack struct {
 func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPack {
 	login := s.user
 	pass := "abcdef123456"
-	rawSecret := "def456"
-	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
+	otpSecret := newOTPSharedSecret()
 
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
@@ -938,7 +936,7 @@ func TestCSRF(t *testing.T) {
 	// create a valid user
 	user := "csrfuser"
 	pass := "abcdef123456"
-	otpSecret := base32.StdEncoding.EncodeToString([]byte("def456"))
+	otpSecret := newOTPSharedSecret()
 	s.createUser(t, user, user, pass, otpSecret)
 
 	// create a valid login form request
@@ -1020,8 +1018,7 @@ func TestWebSessionsBadInput(t *testing.T) {
 	s := newWebSuite(t)
 	user := "bob"
 	pass := "abcdef123456"
-	rawSecret := "def456"
-	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
+	otpSecret := newOTPSharedSecret()
 
 	err := s.server.Auth().UpsertPassword(user, []byte(pass))
 	require.NoError(t, err)
@@ -4800,7 +4797,7 @@ func TestDeleteMFA(t *testing.T) {
 		devName := devName
 		t.Run(devName, func(t *testing.T) {
 			t.Parallel()
-			otpSecret := base32.StdEncoding.EncodeToString([]byte(devName))
+			otpSecret := newOTPSharedSecret()
 			dev, err := services.NewTOTPDevice(devName, otpSecret, env.clock.Now())
 			require.NoError(t, err)
 			err = env.server.Auth().UpsertMFADevice(ctx, pack.user, dev)
@@ -7995,7 +7992,7 @@ func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Ro
 	require.NoError(t, err)
 	loginUser := u.Username
 
-	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
+	otpSecret := newOTPSharedSecret()
 
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -668,7 +668,7 @@ func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPac
 	s.createUser(t, user, login, pass, otpSecret, roles...)
 
 	ctx := context.Background()
-	sessionResp, httpResp := mustLoginWebOTP(t, ctx, loginWebOTPParams{
+	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
 		webClient: s.client(t),
 		clock:     s.clock,
 		user:      user,
@@ -952,14 +952,14 @@ func TestCSRF(t *testing.T) {
 		cookieCSRF: &encodedToken1,
 		headerCSRF: &encodedToken1,
 	}
-	mustLoginWebOTP(t, ctx, validReq)
+	loginWebOTP(t, ctx, validReq)
 
 	// invalid
 	for i := range invalid {
 		req := validReq
 		req.cookieCSRF = &invalid[i].cookieToken
 		req.headerCSRF = &invalid[i].reqToken
-		_, httpResp, err := loginWebOTP(ctx, req)
+		httpResp, _, err := rawLoginWebOTP(ctx, req)
 		require.NoError(t, err, "Login via /webapi/sessions/new failed unexpectedly")
 		assert.Equal(t, http.StatusForbidden, httpResp.StatusCode, "HTTP status code mismatch")
 	}
@@ -2520,7 +2520,7 @@ func TestLogin(t *testing.T) {
 	ctx := context.Background()
 
 	const ua = "test-ua"
-	sessionResp, httpResp := mustLoginWebOTP(t, ctx, loginWebOTPParams{
+	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
 		webClient: clt,
 		user:      user,
 		password:  pass,
@@ -7999,7 +7999,7 @@ func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Ro
 
 	r.createUser(context.Background(), t, teleportUser, loginUser, pass, otpSecret, roles)
 
-	sessionResp, httpResp := mustLoginWebOTP(t, ctx, loginWebOTPParams{
+	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
 		webClient: r.newClient(t),
 		clock:     r.clock,
 		user:      teleportUser,

--- a/lib/web/login_helper_test.go
+++ b/lib/web/login_helper_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
@@ -34,7 +35,8 @@ import (
 
 // newOTPSharedSecret returns an OTP shared secret, encoded as a base32 string.
 func newOTPSharedSecret() string {
-	return base32.StdEncoding.EncodeToString([]byte("supersecretsecret!!1!"))
+	secret := uuid.NewString()
+	return base32.StdEncoding.EncodeToString([]byte(secret))
 }
 
 type loginWebOTPParams struct {

--- a/lib/web/login_helper_test.go
+++ b/lib/web/login_helper_test.go
@@ -1,0 +1,127 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/base32"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/httplib/csrf"
+	"github.com/jonboulle/clockwork"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+)
+
+// newOTPSharedSecret returns an OTP shared secret, encoded as a base32 string.
+func newOTPSharedSecret() string {
+	return base32.StdEncoding.EncodeToString([]byte("supersecretsecret!!1!"))
+}
+
+type loginWebOTPParams struct {
+	webClient      *TestWebClient
+	clock          clockwork.Clock
+	user, password string
+	otpSecret      string // base32-encoded shared OTP secret
+}
+
+// loginWebOTP logins the user using the /webapi/sessions/new endpoint.
+//
+// This is a lower-level utility for tests that want access to the returned
+// CreateSessionResponse.
+func loginWebOTP(t *testing.T, ctx context.Context, params loginWebOTPParams) *CreateSessionResponse {
+	webClient := params.webClient
+	clock := params.clock
+
+	code, err := totp.GenerateCode(params.otpSecret, clock.Now())
+	require.NoError(t, err, "GenerateCode failed")
+
+	// Prepare request JSON body.
+	reqBody, err := json.Marshal(&CreateSessionReq{
+		User:              params.user,
+		Pass:              params.password,
+		SecondFactorToken: code,
+	})
+	require.NoError(t, err, "Marshal failed")
+
+	// Prepare request with CSRF token.
+	url := webClient.Endpoint("webapi", "sessions", "web")
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	require.NoError(t, err, "NewRequestWithContext failed")
+	const csrfToken = "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
+	addCSRFCookieToReq(req, csrfToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(csrf.HeaderName, csrfToken)
+
+	resp, err := webClient.HTTPClient().Do(req)
+	require.NoError(t, err, "Do failed")
+
+	// Drain body, then close, then handle error.
+	sessionResp := &CreateSessionResponse{}
+	err = json.NewDecoder(resp.Body).Decode(sessionResp)
+	_ = resp.Body.Close()
+	require.NoError(t, err, "Unmarshal failed")
+
+	return sessionResp
+}
+
+type loginWebMFAParams struct {
+	webClient      *TestWebClient
+	rpID           string
+	user, password string
+	authenticator  *mocku2f.Key
+}
+
+// loginWebMFA logins the user using /webapi/mfa/login/begin and
+// /webapi/mfa/login/finishsession.
+//
+// This is a lower-level utility for tests that want access to the returned
+// CreateSessionResponse.
+func loginWebMFA(ctx context.Context, t *testing.T, params loginWebMFAParams) *CreateSessionResponse {
+	webClient := params.webClient
+
+	beginResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "begin"), &client.MFAChallengeRequest{
+		User: params.user,
+		Pass: params.password,
+	})
+	require.NoError(t, err)
+
+	authChallenge := &client.MFAAuthenticateChallenge{}
+	require.NoError(t, json.Unmarshal(beginResp.Bytes(), authChallenge))
+	require.NotNil(t, authChallenge.WebauthnChallenge)
+
+	// Sign Webauthn challenge (requires user interaction in real-world
+	// scenarios).
+	key := params.authenticator
+	assertionResp, err := key.SignAssertion("https://"+params.rpID, authChallenge.WebauthnChallenge)
+	require.NoError(t, err)
+
+	// 2nd login step: reply with signed challenge.
+	sessionResp, err := webClient.PostJSON(ctx, webClient.Endpoint("webapi", "mfa", "login", "finishsession"), &client.AuthenticateWebUserRequest{
+		User:                      params.user,
+		WebauthnAssertionResponse: assertionResp,
+	})
+	require.NoError(t, err)
+	createSessionResp := &CreateSessionResponse{}
+	require.NoError(t, json.Unmarshal(sessionResp.Bytes(), createSessionResp))
+	return createSessionResp
+}


### PR DESCRIPTION
A bit of housekeeping, following up from #38754.

Tests that call /webapi/sessions/new now use the same set of helper functions. Helpers are not tied to particular environments and function correctly (eg, always do CSRF).

No production code is changed.