### PR TITLE
Adds a test for `SCARD_IOCTL_CANCEL`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bitflags 2.4.2",
  "ironrdp-pdu",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1263,12 +1263,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bit_field",
  "bitflags 2.4.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bit_field",
  "bitflags 2.4.2",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bitflags 2.4.2",
  "ironrdp-error",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bitflags 2.4.2",
  "ironrdp-connector",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bitflags 2.4.2",
  "ironrdp-pdu",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=86b8e1429fd5c951cac6e983c8b7504140aca376#86b8e1429fd5c951cac6e983c8b7504140aca376"
 dependencies = [
  "bytes",
  "ironrdp-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,13 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
-# ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08", features = ["rustls"]}
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "86b8e1429fd5c951cac6e983c8b7504140aca376" }

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,7 +9,7 @@ GOLANGCI_LINT_VERSION ?= v1.56.2
 NODE_VERSION ?= 18.19.1
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.71.1
+RUST_VERSION ?= 1.76.0
 WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport


### PR DESCRIPTION
The test confirms that an infinite timeout `IOCTL_GETSTATUSCHANGEW` that gets `SCARD_IOCTL_CANCEL`-ed works properly.

Also updates `RUST_VERSION` to `1.76.0`, and updates the IronRDP hash to its latest.

This is causing ARM builds to fail, pending a resolution to: https://github.com/rust-lang/rust/issues/121814