### PR TITLE
[v14] Use time-based event index for app session events

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -578,7 +578,7 @@ func testAuditEvents(p *Pack, t *testing.T) {
 			expectedEvent,
 			event,
 			cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
-			cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "Time"),
+			cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "Time", "Index"),
 			cmpopts.IgnoreFields(apievents.AppSessionChunk{}, "SessionChunkID"),
 		))
 	})

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -438,8 +438,9 @@ func (l *Log) createPutItem(sessionID string, in apievents.AuditEvent) (*dynamod
 		return nil, trace.Wrap(err)
 	}
 	return &dynamodb.PutItemInput{
-		Item:      av,
-		TableName: aws.String(l.Tablename),
+		Item:                av,
+		TableName:           aws.String(l.Tablename),
+		ConditionExpression: aws.String("attribute_not_exists(SessionID) AND attribute_not_exists(EventIndex)"),
 	}, nil
 }
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -441,14 +441,12 @@ func TestEmitSessionEventsSameIndex(t *testing.T) {
 	tt := setupDynamoContext(t)
 	sessionID := session.NewID()
 
-	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 0)))
-	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 1)))
-	require.Error(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 1)))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 0)))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
+	require.Error(t, tt.log.EmitAuditEvent(ctx, generateEvent(sessionID, 1)))
 }
 
-func generateEvent(t *testing.T, sessionID session.ID, index int64) apievents.AuditEvent {
-	t.Helper()
-
+func generateEvent(sessionID session.ID, index int64) apievents.AuditEvent {
 	return &apievents.AppSessionChunk{
 		Metadata: apievents.Metadata{
 			Type:        events.AppSessionChunkEvent,

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -33,10 +33,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -429,6 +431,44 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 			err := test.config.CheckAndSetDefaults()
 			test.assertionFn(t, test.config, err)
 		})
+	}
+}
+
+// TestEmitSessionEventsSameIndex given events that share the same session ID
+// and index, the emit should fail, avoiding any event to get overwriteen.
+func TestEmitSessionEventsSameIndex(t *testing.T) {
+	ctx := context.Background()
+	tt := setupDynamoContext(t)
+	sessionID := session.NewID()
+
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 0)))
+	require.NoError(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 1)))
+	require.Error(t, tt.log.EmitAuditEvent(ctx, generateEvent(t, sessionID, 1)))
+}
+
+func generateEvent(t *testing.T, sessionID session.ID, index int64) apievents.AuditEvent {
+	t.Helper()
+
+	return &apievents.AppSessionChunk{
+		Metadata: apievents.Metadata{
+			Type:        events.AppSessionChunkEvent,
+			Code:        events.AppSessionChunkCode,
+			ClusterName: "root",
+			Index:       index,
+		},
+		ServerMetadata: apievents.ServerMetadata{
+			ServerID:        uuid.New().String(),
+			ServerNamespace: apidefaults.Namespace,
+		},
+		SessionMetadata: apievents.SessionMetadata{
+			SessionID: sessionID.String(),
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppURI:        "nginx",
+			AppPublicAddr: "https://nginx",
+			AppName:       "nginx",
+		},
+		SessionChunkID: uuid.New().String(),
 	}
 }
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -435,7 +435,7 @@ func TestConfig_CheckAndSetDefaults(t *testing.T) {
 }
 
 // TestEmitSessionEventsSameIndex given events that share the same session ID
-// and index, the emit should fail, avoiding any event to get overwriteen.
+// and index, the emit should fail, avoiding any event to get overwritten.
 func TestEmitSessionEventsSameIndex(t *testing.T) {
 	ctx := context.Background()
 	tt := setupDynamoContext(t)

--- a/lib/events/recorder/recorder.go
+++ b/lib/events/recorder/recorder.go
@@ -85,6 +85,10 @@ type Config struct {
 
 	// BackoffDuration is a duration of the backoff before the next try.
 	BackoffDuration time.Duration
+
+	// StartTime represents the time the recorder statarted. If not zero, this
+	// value is used to generate the events index.
+	StartTime time.Time
 }
 
 // New returns a [events.SessionPreparerRecorder]. If session recording is disabled,
@@ -110,6 +114,7 @@ func New(cfg Config) (events.SessionPreparerRecorder, error) {
 		Clock:       cfg.Clock,
 		UID:         cfg.UID,
 		ClusterName: cfg.ClusterName,
+		StartTime:   cfg.StartTime,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/recorder/recorder.go
+++ b/lib/events/recorder/recorder.go
@@ -86,7 +86,7 @@ type Config struct {
 	// BackoffDuration is a duration of the backoff before the next try.
 	BackoffDuration time.Duration
 
-	// StartTime represents the time the recorder statarted. If not zero, this
+	// StartTime represents the time the recorder started. If not zero, this
 	// value is used to generate the events index.
 	StartTime time.Time
 }

--- a/lib/events/setter.go
+++ b/lib/events/setter.go
@@ -139,7 +139,7 @@ func (c *Preparer) PrepareSessionEvent(event apievents.AuditEvent) (apievents.Pr
 
 func (c *Preparer) nextIndex() int64 {
 	if !c.cfg.StartTime.IsZero() {
-		return c.cfg.Clock.Now().Sub(c.cfg.StartTime).Nanoseconds()
+		return c.cfg.Clock.Since(c.cfg.StartTime).Nanoseconds()
 	}
 
 	return int64(c.eventIndex.Add(1) - 1)

--- a/lib/events/setter.go
+++ b/lib/events/setter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -58,6 +59,10 @@ type PreparerConfig struct {
 
 	// ClusterName defines the name of this teleport cluster.
 	ClusterName string
+
+	// StartTime represents the time the recorder statarted. If not zero, this
+	// value is used to generate the events index.
+	StartTime time.Time
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -108,8 +113,7 @@ func (c *Preparer) PrepareSessionEvent(event apievents.AuditEvent) (apievents.Pr
 		srv.SetServerID(c.cfg.ServerID)
 	}
 
-	// ensure index is incremented and loaded atomically
-	event.SetIndex(int64(c.eventIndex.Add(1) - 1))
+	event.SetIndex(c.nextIndex())
 
 	preparedEvent := preparedSessionEvent{
 		event: event,
@@ -131,6 +135,14 @@ func (c *Preparer) PrepareSessionEvent(event apievents.AuditEvent) (apievents.Pr
 	c.lastPrintEvent = printEvent
 
 	return preparedEvent, nil
+}
+
+func (c *Preparer) nextIndex() int64 {
+	if !c.cfg.StartTime.IsZero() {
+		return c.cfg.Clock.Now().Sub(c.cfg.StartTime).Nanoseconds()
+	}
+
+	return int64(c.eventIndex.Add(1) - 1)
 }
 
 type preparedSessionEvent struct {

--- a/lib/events/setter.go
+++ b/lib/events/setter.go
@@ -60,7 +60,7 @@ type PreparerConfig struct {
 	// ClusterName defines the name of this teleport cluster.
 	ClusterName string
 
-	// StartTime represents the time the recorder statarted. If not zero, this
+	// StartTime represents the time the recorder started. If not zero, this
 	// value is used to generate the events index.
 	StartTime time.Time
 }

--- a/lib/events/setter_test.go
+++ b/lib/events/setter_test.go
@@ -37,7 +37,7 @@ func TestPreparerIncrementalIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
-		e, err := preparer.PrepareSessionEvent(generateEvent(t))
+		e, err := preparer.PrepareSessionEvent(generateEvent())
 		require.NoError(t, err)
 		require.Equal(t, int64(i), e.GetAuditEvent().GetIndex(), "unexpected event index")
 	}
@@ -56,7 +56,7 @@ func TestPreparerTimeBasedIndex(t *testing.T) {
 
 	var lastIndex int64
 	for i := 0; i < 9; i++ {
-		e, err := preparer.PrepareSessionEvent(generateEvent(t))
+		e, err := preparer.PrepareSessionEvent(generateEvent())
 		require.NoError(t, err)
 		require.Greater(t, e.GetAuditEvent().GetIndex(), lastIndex, "expected a larger index")
 		lastIndex = e.GetAuditEvent().GetIndex()
@@ -89,11 +89,11 @@ func TestPreparerTimeBasedIndexCollisions(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 9; i++ {
-		evtOne, err := preparerOne.PrepareSessionEvent(generateEvent(t))
+		evtOne, err := preparerOne.PrepareSessionEvent(generateEvent())
 		require.NoError(t, err)
 		idxOne := evtOne.GetAuditEvent().GetIndex()
 
-		evtTwo, err := preparerTwo.PrepareSessionEvent(generateEvent(t))
+		evtTwo, err := preparerTwo.PrepareSessionEvent(generateEvent())
 		require.NoError(t, err)
 		idxTwo := evtTwo.GetAuditEvent().GetIndex()
 
@@ -102,9 +102,7 @@ func TestPreparerTimeBasedIndexCollisions(t *testing.T) {
 	}
 }
 
-func generateEvent(t *testing.T) apievents.AuditEvent {
-	t.Helper()
-
+func generateEvent() apievents.AuditEvent {
 	return &apievents.AppSessionChunk{
 		Metadata: apievents.Metadata{
 			Type:        AppSessionChunkEvent,

--- a/lib/events/setter_test.go
+++ b/lib/events/setter_test.go
@@ -1,0 +1,125 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/session"
+)
+
+func TestPreparerIncrementalIndex(t *testing.T) {
+	sessionID := session.NewID()
+	preparer, err := NewPreparer(PreparerConfig{
+		SessionID:   sessionID,
+		ClusterName: "root",
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		e, err := preparer.PrepareSessionEvent(generateEvent(t))
+		require.NoError(t, err)
+		require.Equal(t, int64(i), e.GetAuditEvent().GetIndex(), "unexpected event index")
+	}
+}
+
+func TestPreparerTimeBasedIndex(t *testing.T) {
+	clock := clockwork.NewRealClock()
+	preparer, err := NewPreparer(PreparerConfig{
+		SessionID:   session.NewID(),
+		ServerID:    uuid.New().String(),
+		ClusterName: "root",
+		Clock:       clock,
+		StartTime:   clock.Now(),
+	})
+	require.NoError(t, err)
+
+	var lastIndex int64
+	for i := 0; i < 9; i++ {
+		e, err := preparer.PrepareSessionEvent(generateEvent(t))
+		require.NoError(t, err)
+		require.Greater(t, e.GetAuditEvent().GetIndex(), lastIndex, "expected a larger index")
+		lastIndex = e.GetAuditEvent().GetIndex()
+	}
+}
+
+func TestPreparerTimeBasedIndexCollisions(t *testing.T) {
+	serverID := uuid.New().String()
+	sessionID := session.NewID()
+	clusterName := "root"
+	clock := clockwork.NewRealClock()
+	loginTime := clock.Now()
+
+	preparerOne, err := NewPreparer(PreparerConfig{
+		SessionID:   sessionID,
+		ServerID:    serverID,
+		ClusterName: clusterName,
+		Clock:       clock,
+		StartTime:   loginTime,
+	})
+	require.NoError(t, err)
+
+	preparerTwo, err := NewPreparer(PreparerConfig{
+		SessionID:   sessionID,
+		ServerID:    serverID,
+		ClusterName: clusterName,
+		Clock:       clock,
+		StartTime:   loginTime,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 9; i++ {
+		evtOne, err := preparerOne.PrepareSessionEvent(generateEvent(t))
+		require.NoError(t, err)
+		idxOne := evtOne.GetAuditEvent().GetIndex()
+
+		evtTwo, err := preparerTwo.PrepareSessionEvent(generateEvent(t))
+		require.NoError(t, err)
+		idxTwo := evtTwo.GetAuditEvent().GetIndex()
+
+		require.NotEqual(t, idxOne, idxTwo)
+		require.Greater(t, idxTwo, idxOne)
+	}
+}
+
+func generateEvent(t *testing.T) apievents.AuditEvent {
+	t.Helper()
+
+	return &apievents.AppSessionChunk{
+		Metadata: apievents.Metadata{
+			Type:        AppSessionChunkEvent,
+			Code:        AppSessionChunkCode,
+			ClusterName: "root",
+		},
+		ServerMetadata: apievents.ServerMetadata{
+			ServerID:        uuid.New().String(),
+			ServerNamespace: apidefaults.Namespace,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppURI:        "nginx",
+			AppPublicAddr: "https://nginx",
+			AppName:       "nginx",
+		},
+		SessionChunkID: uuid.New().String(),
+	}
+}

--- a/lib/events/setter_test.go
+++ b/lib/events/setter_test.go
@@ -110,7 +110,7 @@ func generateEvent() apievents.AuditEvent {
 			ClusterName: "root",
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        uuid.New().String(),
+			ServerID:        uuid.NewString(),
 			ServerNamespace: apidefaults.Namespace,
 		},
 		AppMetadata: apievents.AppMetadata{
@@ -118,6 +118,6 @@ func generateEvent() apievents.AuditEvent {
 			AppPublicAddr: "https://nginx",
 			AppName:       "nginx",
 		},
-		SessionChunkID: uuid.New().String(),
+		SessionChunkID: uuid.NewString(),
 	}
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -775,7 +775,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 
 	// Add user certificate into the context after the monitor connection
 	// initialization to ensure value is present on the context.
-	ctx = authz.ContextWithUserCertificate(ctx, certFromConn(tlsConn))
+	ctx = authz.ContextWithUserCertificate(ctx, leafCertFromConn(tlsConn))
 
 	// Application access supports plain TCP connections which are handled
 	// differently than HTTP requests from web apps.
@@ -1187,8 +1187,8 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tl
 	}
 }
 
-// certFromConnState returns the leaf certificate from the connection.
-func certFromConn(tlsConn *tls.Conn) *x509.Certificate {
+// leafCertFromConn returns the leaf certificate from the connection.
+func leafCertFromConn(tlsConn *tls.Conn) *x509.Certificate {
 	state := tlsConn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
 		return nil

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1130,14 +1130,12 @@ func (s *Server) getProxyPort() string {
 // sessionStartTime fetches the session start time based on the the certificate
 // valid date.
 func (s *Server) sessionStartTime(ctx context.Context) time.Time {
-	var startTime time.Time
 	if userCert, err := authz.UserCertificateFromContext(ctx); err == nil {
-		startTime = userCert.NotBefore
-	} else {
-		s.log.Warn("Unable to retrieve session start time from certificate.")
+		return userCert.NotBefore
 	}
 
-	return startTime
+	s.log.Warn("Unable to retrieve session start time from certificate.")
+	return time.Time{}
 }
 
 // CopyAndConfigureTLS can be used to copy and modify an existing *tls.Config
@@ -1189,10 +1187,10 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tl
 	}
 }
 
-// certFromConnState returns certificate from the connection.
+// certFromConnState returns the leaf certificate from the connection.
 func certFromConn(tlsConn *tls.Conn) *x509.Certificate {
 	state := tlsConn.ConnectionState()
-	if len(state.PeerCertificates) != 1 {
+	if len(state.PeerCertificates) == 0 {
 		return nil
 	}
 

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -22,6 +22,7 @@ package app
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"net"
 	"net/http"
@@ -772,6 +773,10 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 		}
 	}
 
+	// Add user certificate into the context after the monitor connection
+	// initializion to avoid it from being lost.
+	ctx = authz.ContextWithUserCertificate(ctx, certFromConn(tlsConn))
+
 	// Application access supports plain TCP connections which are handled
 	// differently than HTTP requests from web apps.
 	if app.IsTCP() {
@@ -898,7 +903,7 @@ func (s *Server) serveSession(w http.ResponseWriter, r *http.Request, identity *
 	// minutes. Used to stream session chunks to the Audit Log.
 	ttl := min(identity.Expires.Sub(s.c.Clock.Now()), 5*time.Minute)
 	session, err := utils.FnCacheGetWithTTL(r.Context(), s.cache, identity.RouteToApp.SessionID, ttl, func(ctx context.Context) (*sessionChunk, error) {
-		session, err := s.newSessionChunk(ctx, identity, app, opts...)
+		session, err := s.newSessionChunk(ctx, identity, app, s.sessionStartTime(r.Context()), opts...)
 		return session, trace.Wrap(err)
 	})
 	if err != nil {
@@ -1084,10 +1089,10 @@ func (s *Server) newHTTPServer(clusterName string) *http.Server {
 // newTCPServer creates a server that proxies TCP applications.
 func (s *Server) newTCPServer() (*tcpServer, error) {
 	return &tcpServer{
-		newAudit: func(sessionID string) (common.Audit, error) {
+		newAudit: func(ctx context.Context, sessionID string) (common.Audit, error) {
 			// Audit stream is using server context, not session context,
 			// to make sure that session is uploaded even after it is closed.
-			rec, err := s.newSessionRecorder(s.closeContext, sessionID)
+			rec, err := s.newSessionRecorder(s.closeContext, s.sessionStartTime(ctx), sessionID)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1120,6 +1125,20 @@ func (s *Server) getProxyPort() string {
 		return strconv.Itoa(defaults.HTTPListenPort)
 	}
 	return port
+}
+
+// sessionStartTime fetches the session start time based on the the certificate
+// valid date. If the certificate cannot be retrieve from the context, return
+// zero start time and emit a warning log.
+func (s *Server) sessionStartTime(ctx context.Context) time.Time {
+	var startTime time.Time
+	if userCert, err := authz.UserCertificateFromContext(ctx); err == nil {
+		startTime = userCert.NotBefore
+	} else {
+		s.log.Warn("Unable to retrieve session start time from certificate.")
+	}
+
+	return startTime
 }
 
 // CopyAndConfigureTLS can be used to copy and modify an existing *tls.Config
@@ -1169,4 +1188,14 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tl
 		tlsCopy.ClientCAs = pool
 		return tlsCopy, nil
 	}
+}
+
+// certFromConnState returns the connection certificate from the connection.
+func certFromConn(tlsConn *tls.Conn) *x509.Certificate {
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) != 1 {
+		return nil
+	}
+
+	return state.PeerCertificates[0]
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -774,7 +774,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	}
 
 	// Add user certificate into the context after the monitor connection
-	// initializion to avoid it from being lost.
+	// initialization to ensure value is present on the context.
 	ctx = authz.ContextWithUserCertificate(ctx, certFromConn(tlsConn))
 
 	// Application access supports plain TCP connections which are handled
@@ -1128,8 +1128,7 @@ func (s *Server) getProxyPort() string {
 }
 
 // sessionStartTime fetches the session start time based on the the certificate
-// valid date. If the certificate cannot be retrieve from the context, return
-// zero start time and emit a warning log.
+// valid date.
 func (s *Server) sessionStartTime(ctx context.Context) time.Time {
 	var startTime time.Time
 	if userCert, err := authz.UserCertificateFromContext(ctx); err == nil {
@@ -1190,7 +1189,7 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client auth.AccessCache, tl
 	}
 }
 
-// certFromConnState returns the connection certificate from the connection.
+// certFromConnState returns certificate from the connection.
 func certFromConn(tlsConn *tls.Conn) *x509.Certificate {
 	state := tlsConn.ConnectionState()
 	if len(state.PeerCertificates) != 1 {

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -965,7 +965,6 @@ func TestRequestAuditEvents(t *testing.T) {
 						Type:        events.AppSessionChunkEvent,
 						Code:        events.AppSessionChunkCode,
 						ClusterName: "root.example.com",
-						Index:       0,
 					},
 					AppMetadata: apievents.AppMetadata{
 						AppURI:        app.Spec.URI,
@@ -977,7 +976,7 @@ func TestRequestAuditEvents(t *testing.T) {
 					expectedEvent,
 					event,
 					cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
-					cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time"),
+					cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time", "Index"),
 					cmpopts.IgnoreFields(apievents.AppSessionChunk{}, "SessionChunkID"),
 				))
 			case events.AppSessionRequestEvent:
@@ -987,7 +986,6 @@ func TestRequestAuditEvents(t *testing.T) {
 						Type:        events.AppSessionRequestEvent,
 						Code:        events.AppSessionRequestCode,
 						ClusterName: "root.example.com",
-						Index:       1,
 					},
 					AppMetadata: apievents.AppMetadata{
 						AppURI:        app.Spec.URI,
@@ -1002,7 +1000,7 @@ func TestRequestAuditEvents(t *testing.T) {
 					expectedEvent,
 					event,
 					cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
-					cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time"),
+					cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time", "Index"),
 					cmpopts.IgnoreFields(apievents.AppSessionChunk{}, "SessionChunkID"),
 				))
 			}
@@ -1055,7 +1053,7 @@ func TestRequestAuditEvents(t *testing.T) {
 		expectedEvent,
 		searchEvents[0],
 		cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
-		cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time"),
+		cmpopts.IgnoreFields(apievents.Metadata{}, "ID", "ClusterName", "Time", "Index"),
 		cmpopts.IgnoreFields(apievents.AppSessionChunk{}, "SessionChunkID"),
 	))
 }

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -31,7 +31,7 @@ import (
 )
 
 type tcpServer struct {
-	newAudit func(sessionID string) (common.Audit, error)
+	newAudit func(ctx context.Context, sessionID string) (common.Audit, error)
 	hostID   string
 	log      logrus.FieldLogger
 }
@@ -53,7 +53,7 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 		return trace.Wrap(err)
 	}
 
-	audit, err := s.newAudit(identity.RouteToApp.SessionID)
+	audit, err := s.newAudit(ctx, identity.RouteToApp.SessionID)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #38495 to branch/v14

changelog: Fix application access events being overwritten when using DynamoDB as event storage.
