### PR TITLE
fix: `fetchAndSetEntityDescriptor`: return non-nil error if http status is not `200`

### DIFF
--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -112,13 +112,14 @@ func (s *SAMLIdPServiceProviderService) GetSAMLIdPServiceProvider(ctx context.Co
 // CreateSAMLIdPServiceProvider creates a new SAML IdP service provider resource.
 func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context.Context, sp types.SAMLIdPServiceProvider) error {
 	if sp.GetEntityDescriptor() == "" {
-		if err := s.fetchAndSetEntityDescriptor(sp); err != nil {
+		// fetchAndSetEntityDescriptor is expected to return error if it fails
+		// to set entity descriptor. Let's still be defensive and double check
+		// for sp.GetEntityDescriptor() value.
+		if err := s.fetchAndSetEntityDescriptor(sp); err != nil || sp.GetEntityDescriptor() == "" {
 			// We aren't interested in checking error type as any occurrence of error mean entity descriptor was not set.
-			// But a debug log should be helpful to indicate source of error.
-			s.log.Debugf("Failed to fetch entity descriptor from %s. %s.", sp.GetEntityID(), err.Error())
-
 			if err := s.generateAndSetEntityDescriptor(sp); err != nil {
-				return trace.BadParameter("could not generate entity descriptor with given entity_id and acs_url.")
+				return trace.BadParameter("could not generate entity descriptor with given entity_id %q and acs_url %q: %v",
+					sp.GetEntityID(), sp.GetACSURL(), err)
 			}
 		}
 	}
@@ -256,7 +257,7 @@ func (s *SAMLIdPServiceProviderService) fetchAndSetEntityDescriptor(sp types.SAM
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return trace.Wrap(trace.ReadError(resp.StatusCode, nil))
+		return trace.NotFound("entity descriptor not found on the given endpoint")
 	}
 
 	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
@@ -277,7 +278,7 @@ func (s *SAMLIdPServiceProviderService) fetchAndSetEntityDescriptor(sp types.SAM
 // generateAndSetEntityDescriptor generates and sets Service Provider entity descriptor
 // with ACS URL, Entity ID and unspecified NameID format.
 func (s *SAMLIdPServiceProviderService) generateAndSetEntityDescriptor(sp types.SAMLIdPServiceProvider) error {
-	s.log.Infof("Generating a default entity_descriptor with entity_id %s and acs_url %s.", sp.GetEntityID(), sp.GetACSURL())
+	s.log.Infof("Generating a default entity_descriptor with entity_id %q and acs_url %q.", sp.GetEntityID(), sp.GetACSURL())
 
 	acsURL, err := url.Parse(sp.GetACSURL())
 	if err != nil {

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -113,9 +113,9 @@ func (s *SAMLIdPServiceProviderService) GetSAMLIdPServiceProvider(ctx context.Co
 func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context.Context, sp types.SAMLIdPServiceProvider) error {
 	if sp.GetEntityDescriptor() == "" {
 		// fetchAndSetEntityDescriptor is expected to return error if it fails
-		// to set entity descriptor. Let's still be defensive and double check
-		// for sp.GetEntityDescriptor() value.
-		if err := s.fetchAndSetEntityDescriptor(sp); err != nil || sp.GetEntityDescriptor() == "" {
+		// to fetch a valid entity descriptor.
+		if err := s.fetchAndSetEntityDescriptor(sp); err != nil {
+			s.log.Debugf("Failed to fetch entity descriptor from %q. %v.", sp.GetEntityID(), err)
 			// We aren't interested in checking error type as any occurrence of error mean entity descriptor was not set.
 			if err := s.generateAndSetEntityDescriptor(sp); err != nil {
 				return trace.BadParameter("could not generate entity descriptor with given entity_id %q and acs_url %q: %v",
@@ -257,7 +257,7 @@ func (s *SAMLIdPServiceProviderService) fetchAndSetEntityDescriptor(sp types.SAM
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return trace.NotFound("entity descriptor not found on the given endpoint")
+		return trace.Wrap(trace.BadParameter("unexpected response status: %q", resp.StatusCode))
 	}
 
 	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)

--- a/lib/services/local/saml_idp_service_provider_test.go
+++ b/lib/services/local/saml_idp_service_provider_test.go
@@ -323,6 +323,8 @@ func TestCreateSAMLIdPServiceProvider_fetchAndSetEntityDescriptor(t *testing.T) 
 		switch r.RequestURI {
 		case "/status-not-ok":
 			w.WriteHeader(http.StatusNotFound)
+		case "/status-302-found":
+			w.WriteHeader(http.StatusFound)
 		case "/invalid-metadata":
 			fmt.Fprintln(w, "test")
 		default:
@@ -342,6 +344,11 @@ func TestCreateSAMLIdPServiceProvider_fetchAndSetEntityDescriptor(t *testing.T) 
 		{
 			name:     "status not ok",
 			entityID: fmt.Sprintf("%s/status-not-ok", testSPServer.URL),
+			wantErr:  true,
+		},
+		{
+			name:     "status 302 found",
+			entityID: fmt.Sprintf("%s/status-302-found", testSPServer.URL),
 			wantErr:  true,
 		},
 		{


### PR DESCRIPTION
Fixes a bug where  `fetchAndSetEntityDescriptor` returned non-nil error when it failed to set entity descriptor.

**Background**: `fetchAndSetEntityDescriptor` tries to fetch and set SAML service provider entity descriptor from given endpoint. It was implemented in a way that it should return error if it fails to fetch and set entity descriptor.

If it fails to set entity descriptor, the `generateAndSetEntityDescriptor` func will generate the entity descriptor with given `entity_id` and `acs_url` values. 

**Bug**: In situation where remote endpoint would return HTTP status code above `200` and below `400`, the `fetchAndSetEntityDescriptor` was returning early with a nil error, even when it still failed to set the entity descriptor. And since the `generateAndSetEntityDescriptor` is only called if `fetchAndSetEntityDescriptor` returns error, we would never set the entity descriptor in such case. 

**Root cause**: incorrect use of `trace.ReadError()`.
The `trace.ReadError()` returns non-nil error if `statusCode >= http.StatusOK && statusCode < http.StatusBadRequest`. So in scenario where, say a redirect response was received, `fetchAndSetEntityDescriptor` would return with non-nil error,  without setting the entity descriptor, defeating the logic which follows.

The existing test only included `404`, empty message and a valid message so it failed to catch the `302` redirect case. 

**Fix**:
- return `trace.BadParameter` error regardless of HTTP status code except for `200`. We aren't interested in parsing error type as any error in this func means entity descriptor is not set. 
- updated test to also include `302` redirect. 


changelog: Fixed an issue in SAML IdP entity descriptor generator process, which would fail to generate entity descriptor if the configured Entity ID endpoint would return HTTP status code above `200` and below `400` .