### PR TITLE
Add remote port forwarding for Teleport nodes

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -31,10 +31,10 @@ import (
 	"os"
 	"os/user"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -242,6 +242,10 @@ type Server struct {
 	proxySigner PROXYHeaderSigner
 	// caGetter is used to get host CA of the cluster to verify signed PROXY headers
 	caGetter CertAuthorityGetter
+
+	// remoteForwardingMap holds the remote port forwarding listeners that need
+	// to be closed when forwarding finishes, keyed by listen addr.
+	remoteForwardingMap utils.SyncMap[string, io.Closer]
 }
 
 // TargetMetadata returns metadata about the server.
@@ -343,7 +347,18 @@ func (s *Server) close() {
 // Close closes listening socket and stops accepting connections
 func (s *Server) Close() error {
 	s.close()
-	return s.srv.Close()
+	// Close the server first so we don't accept any new forwarding connections
+	// after we've closed them all.
+	errors := []error{s.srv.Close()}
+	s.remoteForwardingMap.Range(func(_ string, closer io.Closer) bool {
+		if closer != nil {
+			if err := closer.Close(); err != nil {
+				errors = append(errors, err)
+			}
+		}
+		return true
+	})
+	return trace.NewAggregate(errors...)
 }
 
 // Shutdown performs graceful shutdown
@@ -358,8 +373,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 	// wait until connections drain off
 	err := s.srv.Shutdown(ctx)
-	s.close()
-	return err
+	return trace.NewAggregate(err, s.Close())
 }
 
 // Start starts server
@@ -1096,70 +1110,15 @@ func (s *Server) getServerResource() (types.Resource, error) {
 
 // getDirectTCPIPForwarder sets up a connection-level subprocess that handles forwarding connections. Subsequent
 // calls from the same connection context reuse the same forwarder.
-func (s *Server) getDirectTCPIPForwardDialer(ctx *srv.ServerContext) (sshutils.TCPIPForwardDialer, error) {
-	if d, ok := ctx.Parent().GetDirectTCPIPForwardDialer(); ok {
+func (s *Server) getDirectTCPIPForwardDialer(scx *srv.ServerContext) (sshutils.TCPIPForwardDialer, error) {
+	if d, ok := scx.Parent().GetDirectTCPIPForwardDialer(); ok {
 		return d, nil
 	}
 
-	dialerConn, listenerConn, err := uds.NewSocketpair(uds.SocketTypeDatagram)
+	proc, err := s.startForwardingSubprocess(scx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer listenerConn.Close()
-
-	listenerFD, err := listenerConn.File()
-	if err != nil {
-		dialerConn.Close()
-		return nil, trace.Wrap(err)
-	}
-	defer listenerFD.Close()
-
-	// Create command to re-exec Teleport which will handle forwarding. The
-	// reason it's not done directly is because the PAM stack needs to be called
-	// from the child process.
-	cmd, err := srv.ConfigureCommand(ctx, listenerFD)
-	if err != nil {
-		dialerConn.Close()
-		return nil, trace.Wrap(err)
-	}
-
-	// Propagate stderr from the spawned Teleport process to log any errors.
-	cmd.Stderr = os.Stderr
-
-	// Start the child process that will be used to make the actual connection
-	// to the target host.
-	if err := cmd.Start(); err != nil {
-		dialerConn.Close()
-		return nil, trace.Wrap(err)
-	}
-
-	cdone := make(chan struct{})
-	var explicitlyClosed atomic.Bool
-
-	go func() {
-		defer close(cdone)
-		// ensure unexpected cmd failures get logged
-		if err := cmd.Wait(); err != nil && !explicitlyClosed.Load() {
-			s.Logger.Warnf("Forwarder process exited early with unexpected error: %v", err)
-		}
-	}()
-
-	closer := utils.CloseFunc(func() error {
-		// set flag indicating that the exit of the child is expected (changes logging behavior).
-		explicitlyClosed.Store(true)
-		dialerConn.Close()
-
-		// we expect closing the dialer to cause the child process to exit, but its
-		// best to verify.
-		select {
-		case <-cdone:
-		case <-time.After(time.Second * 3):
-			// forcibly kill the child.
-			s.Logger.Warn("Forcibly terminating forwarder subprocess.")
-			cmd.Process.Kill()
-		}
-		return nil
-	})
 
 	// set up a dial function that sends the address + fd as a unix datagram message. the forwarder subprocess
 	// interprets all such messages in this way, and will dial the specified address and proxy all traffic
@@ -1178,7 +1137,7 @@ func (s *Server) getDirectTCPIPForwardDialer(ctx *srv.ServerContext) (sshutils.T
 		}
 		defer remoteFD.Close()
 
-		_, _, err = dialerConn.WriteWithFDs([]byte(addr), []*os.File{remoteFD})
+		_, _, err = proc.Conn.WriteWithFDs([]byte(addr), []*os.File{remoteFD})
 		if err != nil {
 			local.Close()
 			return nil, trace.Wrap(err)
@@ -1188,18 +1147,195 @@ func (s *Server) getDirectTCPIPForwardDialer(ctx *srv.ServerContext) (sshutils.T
 	}
 
 	// try to register with the parent context.
-	if other, ok := ctx.Parent().TrySetDirectTCPIPForwardDialer(dialer); !ok {
+	if other, ok := scx.Parent().TrySetDirectTCPIPForwardDialer(dialer); !ok {
 		// another forwarder was concurrently created. this isn't actually a problem, multiple forwarders
 		// being registered is harmless, but it does result in slightly higher resource utilization, so its
 		// preferable to use the existing forwarder and close ours in the background.
-		go closer.Close()
+		go proc.Close()
 		return other, nil
 	}
 
 	// successfully registered this dialer, add closer to context.
-	ctx.Parent().AddCloser(closer)
+	scx.Parent().AddCloser(proc)
 
 	return dialer, nil
+}
+
+// listenTCPIP creates a new listener in the forwarding process.
+func (s *Server) listenTCPIP(scx *srv.ServerContext, addr string) (*net.TCPListener, error) {
+	proc, err := s.getTCPIPForwardProcess(scx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Create a socket to receive new connections on.
+	localConn, remoteConn, err := uds.NewSocketpair(uds.SocketTypeDatagram)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer localConn.Close()
+	defer remoteConn.Close()
+	remoteFD, err := remoteConn.File()
+	if err != nil {
+		localConn.Close()
+		return nil, trace.Wrap(err)
+	}
+	defer remoteFD.Close()
+	_, _, err = proc.Conn.WriteWithFDs([]byte(addr), []*os.File{remoteFD})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// The forwarding process may have chosen its own port, so we need to get the
+	// new listen address.
+	fileCh := make(chan *os.File)
+	// Read addr in another goroutine so we can cancel it if the forwarding process
+	// stops.
+	go func() {
+		defer close(fileCh)
+
+		fbuf := make([]*os.File, 1)
+		if _, fn, _ := localConn.ReadWithFDs(nil, fbuf); fn == 0 {
+			fileCh <- nil
+		}
+		select {
+		case fileCh <- fbuf[0]:
+		case <-proc.Done:
+			fbuf[0].Close()
+		}
+	}()
+
+	var listenerFD *os.File
+	select {
+	case <-proc.Done:
+		localConn.Close()
+		return nil, trace.Errorf("forwarding process is closed")
+	case listenerFD = <-fileCh:
+	}
+
+	if listenerFD == nil {
+		return nil, trace.BadParameter("forwarding process did not return a listener")
+	}
+	if err := validateListenerSocket(scx, localConn.UnixConn, listenerFD); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	listener, err := net.FileListener(listenerFD)
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		return nil, trace.BadParameter("listener is not a TCPListener")
+	}
+	return tcpListener, trace.Wrap(err)
+}
+
+func controlSyscallConn(conn syscall.Conn, f func(fd uintptr) error) error {
+	syscallConn, err := conn.SyscallConn()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if cErr := syscallConn.Control(func(fd uintptr) {
+		err = f(fd)
+	}); cErr != nil {
+		return trace.Wrap(cErr)
+	}
+	return trace.Wrap(err)
+}
+
+// getDirectTCPIPForwarder sets up a connection-level subprocess that handles
+// remote forwarding connections. Subsequent calls from the same connection
+// context reuse the same forwarder.
+func (s *Server) getTCPIPForwardProcess(scx *srv.ServerContext) (*sshutils.TCPIPForwardProcess, error) {
+	if proc, ok := scx.Parent().GetTCPIPForwardProcess(); ok {
+		return proc, nil
+	}
+
+	proc, err := s.startForwardingSubprocess(scx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Try to register with the parent context.
+	if otherProc, ok := scx.Parent().TrySetTCPIPForwardProcess(proc); !ok {
+		// Another forwarder was concurrently created. this isn't actually a problem, multiple forwarders
+		// being registered is harmless, but it does result in slightly higher resource utilization, so its
+		// preferable to use the existing forwarder and close ours in the background.
+		go proc.Close()
+		return otherProc, nil
+	}
+
+	scx.Parent().AddCloser(proc)
+	return proc, nil
+}
+
+// startForwardingSubprocess launches the forwarding process. It returns a
+// conn to communicate with the process and a close func to close the process
+// when finished.
+func (s *Server) startForwardingSubprocess(scx *srv.ServerContext) (*sshutils.TCPIPForwardProcess, error) {
+	// Create the socket to communicate over.
+	remoteConn, localConn, err := uds.NewSocketpair(uds.SocketTypeDatagram)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer remoteConn.Close()
+	remoteFD, err := remoteConn.File()
+	if err != nil {
+		localConn.Close()
+		return nil, trace.Wrap(err)
+	}
+	defer remoteFD.Close()
+
+	// Create command to re-exec Teleport which will handle forwarding. The
+	// reason it's not done directly is because the PAM stack needs to be called
+	// from the child process.
+	cmd, err := srv.ConfigureCommand(scx, remoteFD)
+	if err != nil {
+		localConn.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	// Propagate stderr from the spawned Teleport process to log any errors.
+	cmd.Stderr = os.Stderr
+
+	// Start the child process that will be used to listen for connections.
+	if err := cmd.Start(); err != nil {
+		localConn.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	cdone := make(chan struct{})
+	var explicitlyClosed atomic.Bool
+
+	go func() {
+		defer close(cdone)
+		defer localConn.Close()
+		// Ensure unexpected cmd failures get logged.
+		if err := cmd.Wait(); err != nil && !explicitlyClosed.Load() {
+			s.Logger.Warnf("Remote forwarder process exited early with unexpected error: %v", err)
+		}
+	}()
+
+	processCloser := utils.CloseFunc(func() error {
+		// Set flag indicating that the exit of the child is expected (changes logging behavior).
+		explicitlyClosed.Store(true)
+		localConn.Close()
+
+		// We expect closing the conn to cause the child process to exit, but it's
+		// best to verify.
+		select {
+		case <-cdone:
+		case <-time.After(time.Second * 3):
+			// forcibly kill the child.
+			s.Logger.Warn("Forcibly terminating remote forwarder subprocess.")
+			cmd.Process.Kill()
+		}
+		return nil
+	})
+
+	return &sshutils.TCPIPForwardProcess{
+		Conn:   localConn,
+		Done:   cdone,
+		Closer: processCloser,
+	}, nil
 }
 
 // serveAgent will build the a sock path for this user and serve an SSH agent on unix socket.
@@ -1259,6 +1395,20 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 				if err := r.Reply(false, nil); err != nil {
 					s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
 				}
+			}
+		}
+	case teleport.TCPIPForwardRequest:
+		if err := s.handleTCPIPForwardRequest(ctx, ccx, r); err != nil {
+			s.Logger.WithError(err).Warn("failed to handle tcpip forward request")
+			if err := r.Reply(false, nil); err != nil {
+				s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
+			}
+		}
+	case teleport.CancelTCPIPForwardRequest:
+		if err := s.handleCancelTCPIPForwardRequest(ctx, ccx, r); err != nil {
+			s.Logger.WithError(err).Warn("failed to handle cancel tcpip forward request")
+			if err := r.Reply(false, nil); err != nil {
+				s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
 			}
 		}
 	default:
@@ -1414,7 +1564,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 // canPortForward determines if port forwarding is allowed for the current
 // user/role/node combo. Returns nil if port forwarding is allowed, non-nil
 // if denied.
-func (s *Server) canPortForward(scx *srv.ServerContext, channel ssh.Channel) error {
+func (s *Server) canPortForward(scx *srv.ServerContext) error {
 	// Is the node configured to allow port forwarding?
 	if !s.allowTCPForwarding {
 		return trace.AccessDenied("node does not allow port forwarding")
@@ -1456,8 +1606,8 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	scx.IsTestStub = s.isTestStub
 	scx.AddCloser(channel)
 	scx.ExecType = teleport.ChanDirectTCPIP
-	scx.SrcAddr = net.JoinHostPort(req.Orig, strconv.Itoa(int(req.OrigPort)))
-	scx.DstAddr = net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
+	scx.SrcAddr = sshutils.JoinHostPort(req.Orig, req.OrigPort)
+	scx.DstAddr = sshutils.JoinHostPort(req.Host, req.Port)
 	scx.SetAllowFileCopying(s.allowFileCopying)
 	defer scx.Close()
 
@@ -1465,7 +1615,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 
 	// Bail out now if TCP port forwarding is not allowed for this node/user/role
 	// combo
-	if err = s.canPortForward(scx, channel); err != nil {
+	if err = s.canPortForward(scx); err != nil {
 		writeStderr(channel, err.Error())
 		return
 	}
@@ -2115,6 +2265,114 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	case <-wch:
 	case <-ctx.Done():
 	}
+}
+
+// createForwardingContext creates a server context for a user intending to
+// port forward. It returns an error if the user is not allowed to port forward.
+func (s *Server) createForwardingContext(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) (context.Context, *srv.ServerContext, error) {
+	req, err := sshutils.ParseTCPIPForwardReq(r.Payload)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	identityContext, err := s.authHandlers.CreateIdentityContext(ccx.ServerConn)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	// On regular server in "normal" mode "tcpip-forward" requests from
+	// SessionJoinPrincipal should be rejected, otherwise it's possible to use
+	// the "-teleport-internal-join" user to bypass RBAC.
+	if identityContext.Login == teleport.SSHSessionJoinPrincipal {
+		log.Errorf("Request rejected, %q with SessionJoinPrincipal in forward node must be blocked", r.Type)
+		err := trace.AccessDenied("attempted %q request in join-only mode", r.Type)
+		if replyErr := r.Reply(false, []byte(utils.FormatErrorWithNewline(err))); replyErr != nil {
+			s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
+		}
+		// Disable default reply by caller, we already handled it.
+		r.WantReply = false
+		return nil, nil, err
+	}
+
+	// Create context for this request.
+	ctx, scx, err := srv.NewServerContext(ctx, ccx, s, identityContext)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	listenAddr := sshutils.JoinHostPort(req.Addr, req.Port)
+	scx.IsTestStub = s.isTestStub
+	scx.ExecType = teleport.TCPIPForwardRequest
+	scx.SrcAddr = listenAddr
+	scx.DstAddr = ccx.NetConn.RemoteAddr().String()
+	scx.SetAllowFileCopying(s.allowFileCopying)
+
+	if err := s.canPortForward(scx); err != nil {
+		scx.Close()
+		return nil, nil, trace.Wrap(err)
+	}
+	return ctx, scx, nil
+}
+
+// handleTCPIPForwardRequest handles remote port forwarding requests.
+func (s *Server) handleTCPIPForwardRequest(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) error {
+	ctx, scx, err := s.createForwardingContext(ctx, ccx, r)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer scx.Close()
+	listener, err := s.listenTCPIP(scx, scx.SrcAddr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Set the src addr again since it may have been updated with a new port.
+	scx.SrcAddr = listener.Addr().String()
+	event := scx.GetPortForwardEvent()
+	if err := s.EmitAuditEvent(ctx, &event); err != nil {
+		s.Logger.WithError(err).Warn("Failed to emit audit event.")
+	}
+	if err := sshutils.StartRemoteListener(ctx, scx.ConnectionContext.ServerConn, scx.SrcAddr, listener); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Report addr back to the client.
+	if r.WantReply {
+		var payload []byte
+		req, err := sshutils.ParseTCPIPForwardReq(r.Payload)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if req.Port == 0 {
+			payload = ssh.Marshal(struct {
+				Port uint32
+			}{Port: uint32(listener.Addr().(*net.TCPAddr).Port)})
+		}
+
+		if err := r.Reply(true, payload); err != nil {
+			s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
+		}
+	}
+
+	s.remoteForwardingMap.Store(scx.SrcAddr, listener)
+	return nil
+}
+
+// handleCancelTCPIPForwardRequest handles canceling a previously requested
+// remote forwarded port.
+func (s *Server) handleCancelTCPIPForwardRequest(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) error {
+	_, scx, err := s.createForwardingContext(ctx, ccx, r)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer scx.Close()
+
+	listener, ok := s.remoteForwardingMap.LoadAndDelete(scx.SrcAddr)
+	if !ok {
+		return trace.NotFound("no remote forwarding listener at %v", scx.SrcAddr)
+	}
+	if err := r.Reply(true, nil); err != nil {
+		s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
+	}
+	return trace.Wrap(listener.Close())
 }
 
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {

--- a/lib/srv/regular/sshserver_darwin.go
+++ b/lib/srv/regular/sshserver_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+// +build darwin
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package regular
+
+import (
+	"net"
+	"os"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sys/unix"
+
+	"github.com/gravitational/teleport/lib/srv"
+)
+
+// validateListenerSocket checks that the socket and listener file descriptor
+// sent from the forwarding process have the expected properties.
+func validateListenerSocket(_ *srv.ServerContext, _ *net.UnixConn, listenerFD *os.File) error {
+	if err := controlSyscallConn(listenerFD, func(fd uintptr) error {
+		// Verify the socket type
+		if sockType, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_TYPE); err != nil {
+			return trace.Wrap(err)
+		} else if sockType != unix.SOCK_STREAM {
+			return trace.AccessDenied("socket is not of the expected type (STREAM)")
+		}
+
+		// Verify that reuse is not enabled on the socket
+		if reuseAddr, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR); err != nil {
+			return trace.Wrap(err)
+		} else if reuseAddr != 0 {
+			return trace.AccessDenied("SO_REUSEADDR is enabled on the socket")
+		}
+		if reusePort, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT); err != nil {
+			// Some systems may not support SO_REUSEPORT, so we ignore the error here
+		} else if reusePort != 0 {
+			return trace.AccessDenied("SO_REUSEPORT is enabled on the socket")
+		}
+
+		// Verify that the listener is already listening.
+		if acceptConn, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ACCEPTCONN); err != nil {
+			return trace.Wrap(err)
+		} else if acceptConn == 0 {
+			return trace.AccessDenied("SO_ACCEPTCONN is not set, socket is not listening")
+		}
+
+		return nil
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/srv/regular/sshserver_linux.go
+++ b/lib/srv/regular/sshserver_linux.go
@@ -1,0 +1,96 @@
+//go:build linux
+// +build linux
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package regular
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"strconv"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sys/unix"
+
+	"github.com/gravitational/teleport/lib/srv"
+)
+
+// validateListenerSocket checks that the socket and listener file descriptor
+// sent from the forwarding process have the expected properties.
+func validateListenerSocket(scx *srv.ServerContext, controlConn *net.UnixConn, listenerFD *os.File) error {
+	// Get the credentials of the client connected to the socket.
+	var cred *unix.Ucred
+	var err error
+	if err := controlSyscallConn(controlConn, func(fd uintptr) error {
+		cred, err = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+		return err
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Check that the user connected to the socket is who we expect.
+	usr, err := user.Lookup(scx.Identity.Login)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if expectedUid, err := strconv.Atoi(usr.Uid); err != nil {
+		return trace.Wrap(err)
+	} else if int(cred.Uid) != expectedUid {
+		return trace.AccessDenied("unexpected user UID for the socket: %v", cred.Uid)
+	}
+	if expectedGid, err := strconv.Atoi(usr.Gid); err != nil {
+		return trace.Wrap(err)
+	} else if int(cred.Gid) != expectedGid {
+		return trace.AccessDenied("unexpected user GID for the socket: %v", cred.Gid)
+	}
+
+	if err := controlSyscallConn(listenerFD, func(fd uintptr) error {
+		// Verify the socket type
+		if sockType, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_TYPE); err != nil {
+			return trace.Wrap(err)
+		} else if sockType != unix.SOCK_STREAM {
+			return trace.AccessDenied("socket is not of the expected type (STREAM)")
+		}
+
+		// Verify that reuse is not enabled on the socket
+		if reuseAddr, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR); err != nil {
+			return trace.Wrap(err)
+		} else if reuseAddr != 0 {
+			return trace.AccessDenied("SO_REUSEADDR is enabled on the socket")
+		}
+		if reusePort, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT); err != nil {
+			// Some systems may not support SO_REUSEPORT, so we ignore the error here
+		} else if reusePort != 0 {
+			return trace.AccessDenied("SO_REUSEPORT is enabled on the socket")
+		}
+
+		// Verify that the listener is already listening.
+		if acceptConn, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ACCEPTCONN); err != nil {
+			return trace.Wrap(err)
+		} else if acceptConn == 0 {
+			return trace.AccessDenied("SO_ACCEPTCONN is not set, socket is not listening")
+		}
+
+		return nil
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/srv/regular/sshserver_linux_test.go
+++ b/lib/srv/regular/sshserver_linux_test.go
@@ -1,0 +1,149 @@
+//go:build linux
+// +build linux
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package regular
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/utils/uds"
+)
+
+func TestValidateListenerSocket(t *testing.T) {
+	t.Parallel()
+
+	newSocketFiles := func(t *testing.T) (*uds.Conn, *os.File) {
+		left, right, err := uds.NewSocketpair(uds.SocketTypeStream)
+		require.NoError(t, err)
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		tcpListener := listener.(*net.TCPListener)
+		listenerFD, err := tcpListener.File()
+		require.NoError(t, err)
+
+		conn, err := tcpListener.SyscallConn()
+		require.NoError(t, err)
+		err2 := conn.Control(func(descriptor uintptr) {
+			// Disable address reuse to prevent socket replacement.
+			err = syscall.SetsockoptInt(int(descriptor), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 0)
+		})
+		require.NoError(t, err2)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			require.NoError(t, left.Close())
+			require.NoError(t, right.Close())
+		})
+		return left, listenerFD
+	}
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		user        string
+		mutateFiles func(*testing.T, *uds.Conn, *os.File) (*uds.Conn, *os.File)
+		mutateConn  func(*testing.T, *os.File)
+		assert      require.ErrorAssertionFunc
+	}{
+		{
+			name:   "ok",
+			user:   u.Username,
+			assert: require.NoError,
+		},
+		{
+			name:   "wrong user",
+			user:   "fake-user",
+			assert: require.Error,
+		},
+		{
+			name: "socket type not STREAM",
+			user: u.Username,
+			mutateFiles: func(t *testing.T, conn *uds.Conn, file *os.File) (*uds.Conn, *os.File) {
+				left, right, err := uds.NewSocketpair(uds.SocketTypeDatagram)
+				require.NoError(t, err)
+				listenerFD, err := right.File()
+				require.NoError(t, err)
+				require.NoError(t, right.Close())
+				t.Cleanup(func() {
+					require.NoError(t, left.Close())
+					require.NoError(t, listenerFD.Close())
+				})
+				return left, listenerFD
+			},
+			assert: require.Error,
+		},
+		{
+			name: "SO_REUSEADDR enabled",
+			user: u.Username,
+			mutateConn: func(t *testing.T, file *os.File) {
+				fd := file.Fd()
+				err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				require.NoError(t, err)
+			},
+			assert: require.Error,
+		},
+		{
+			name: "listener socket is not listening",
+			user: u.Username,
+			mutateFiles: func(t *testing.T, conn *uds.Conn, file *os.File) (*uds.Conn, *os.File) {
+				left, right, err := uds.NewSocketpair(uds.SocketTypeStream)
+				require.NoError(t, err)
+				listenerFD, err := right.File()
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, left.Close())
+					require.NoError(t, listenerFD.Close())
+				})
+				return left, listenerFD
+			},
+			assert: require.Error,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scx := &srv.ServerContext{
+				Identity: srv.IdentityContext{
+					Login: tc.user,
+				},
+			}
+			conn, listenerFD := newSocketFiles(t)
+			if tc.mutateFiles != nil {
+				conn, listenerFD = tc.mutateFiles(t, conn, listenerFD)
+			}
+			if tc.mutateConn != nil {
+				tc.mutateConn(t, listenerFD)
+			}
+			err := validateListenerSocket(scx, conn.UnixConn, listenerFD)
+			tc.assert(t, err)
+		})
+	}
+}

--- a/lib/srv/regular/sshserver_other.go
+++ b/lib/srv/regular/sshserver_other.go
@@ -1,3 +1,6 @@
+//go:build !darwin && !linux
+// +build !darwin,!linux
+
 /*
  * Teleport
  * Copyright (C) 2024  Gravitational, Inc.
@@ -15,30 +18,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-package sshutils
+package regular
 
 import (
 	"net"
-	"strconv"
+	"os"
+	"runtime"
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/srv"
 )
 
-// JoinHostPort is a wrapper for net.JoinHostPort that takes a uint32 port.
-func JoinHostPort(host string, port uint32) string {
-	return net.JoinHostPort(host, strconv.Itoa(int(port)))
-}
-
-// SplitHostPort is a wrapper for net.SplitHostPort that returns a uint32 port.
-// Note that unlike net.SplitHostPort, a missing port is valid and will return
-// a zero port.
-func SplitHostPort(addrString string) (string, uint32, error) {
-	addr, err := utils.ParseHostPortAddr(addrString, 0)
-	if err != nil {
-		return "", 0, trace.Wrap(err)
-	}
-	return addr.Host(), uint32(addr.Port(0)), nil
+func validateListenerSocket(scx *srv.ServerContext, controlConn *net.UnixConn, listenerFD *os.File) error {
+	return trace.BadParameter("remote forwarding is not implemented for %s", runtime.GOOS)
 }

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -31,10 +31,34 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/utils/uds"
 )
 
 // TCPIPForwardDialer represents a dialer used to handle TCPIP forward requests.
 type TCPIPForwardDialer func(string) (net.Conn, error)
+
+// TCPIPForwardProcess represents an instance of a port forwarding process.
+type TCPIPForwardProcess struct {
+	// Conn is the socket used to request a dialer or listener in the process.
+	Conn *uds.Conn
+	// Done signals when the process completes.
+	Done <-chan struct{}
+	// Closer contains and extra io.Closer to run when the process as a whole
+	// is closed.
+	Closer io.Closer
+}
+
+// Close stops the process and frees up its related resources.
+func (p *TCPIPForwardProcess) Close() error {
+	var errs []error
+	if p.Conn != nil {
+		errs = append(errs, p.Conn.Close())
+	}
+	if p.Closer != nil {
+		errs = append(errs, p.Closer.Close())
+	}
+	return trace.NewAggregate(errs...)
+}
 
 // ConnectionContext manages connection-level state.
 type ConnectionContext struct {
@@ -62,6 +86,9 @@ type ConnectionContext struct {
 	// tcpipForwardDialer is a lazily initialized dialer used to handle all tcpip
 	// forwarding requests.
 	tcpipForwardDialer TCPIPForwardDialer
+	// tcpipForwardProcess is a lazily initialized connection to the subprocess that
+	// handles remote port forwarding.
+	tcpipForwardProcess *TCPIPForwardProcess
 
 	// closers is a list of io.Closer that will be called when session closes
 	// this is handy as sometimes client closes session, in this case resources
@@ -263,6 +290,26 @@ func (c *ConnectionContext) AddCloser(closer io.Closer) {
 		return
 	}
 	c.closers = append(c.closers, closer)
+}
+
+// TrySetTCPIPForwardProcess attempts to registers a TCPIPForwardProcess. If a
+// different process was concurrently registered, ok is false and the previously
+// registered process is returned.
+func (c *ConnectionContext) TrySetTCPIPForwardProcess(proc *TCPIPForwardProcess) (*TCPIPForwardProcess, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.tcpipForwardProcess != nil {
+		return c.tcpipForwardProcess, false
+	}
+	c.tcpipForwardProcess = proc
+	return proc, true
+}
+
+// GetTCPIPForwardProcess gets the registered TCPIPForwardProcess if one exists.
+func (c *ConnectionContext) GetTCPIPForwardProcess() (*TCPIPForwardProcess, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.tcpipForwardProcess, c.tcpipForwardProcess != nil
 }
 
 // takeClosers returns all resources that should be closed and sets the properties to null

--- a/lib/sshutils/ctx_test.go
+++ b/lib/sshutils/ctx_test.go
@@ -19,52 +19,17 @@
 package sshutils
 
 import (
-	"errors"
-	"io"
 	"testing"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	errCloseWrite = errors.New("write closed")
-	errClose      = errors.New("channel closed")
-)
-
-type fakeReaderWriter struct{}
-
-func (n fakeReaderWriter) Read(_ []byte) (int, error) {
-	return 0, io.EOF
-}
-
-func (n fakeReaderWriter) Write(b []byte) (int, error) {
-	return len(b), nil
-}
-
-type mockChannel struct {
-	fakeReaderWriter
-}
-
-func (mc *mockChannel) Close() error {
-	return errClose
-}
-
-func (mc *mockChannel) CloseWrite() error {
-	return errCloseWrite
-}
-
-func (mc *mockChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
-	return false, nil
-}
-
-func (mc *mockChannel) Stderr() io.ReadWriter {
-	return fakeReaderWriter{}
-}
-
 func TestAgentChannelClose(t *testing.T) {
 	aChannel := agentChannel{
-		ch: &mockChannel{},
+		ch: &mockChannel{
+			ReadWriter: fakeReaderWriter{},
+		},
 	}
 	// Ensure write part of channel is closed first
 	require.EqualError(t, aChannel.Close(),

--- a/lib/sshutils/mock.go
+++ b/lib/sshutils/mock.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sshutils
+
+import (
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	errCloseWrite = errors.New("write closed")
+	errClose      = errors.New("channel closed")
+)
+
+type fakeReaderWriter struct{}
+
+func (n fakeReaderWriter) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (n fakeReaderWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+type mockChannel struct {
+	io.ReadWriter
+}
+
+func (mc *mockChannel) Close() error {
+	return errClose
+}
+
+func (mc *mockChannel) CloseWrite() error {
+	return errCloseWrite
+}
+
+func (mc *mockChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	return false, nil
+}
+
+func (mc *mockChannel) Stderr() io.ReadWriter {
+	return fakeReaderWriter{}
+}
+
+type mockSSHConn struct {
+	mockChan *mockChannel
+}
+
+func (mc *mockSSHConn) OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	return mc.mockChan, make(<-chan *ssh.Request), nil
+}

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -51,6 +51,32 @@ type PTYReqParams struct {
 	Modes string
 }
 
+// ForwardedTCPIPRequest specifies parameters for opening a port forwarding
+// channel from the server.
+type ForwardedTCPIPRequest struct {
+	Addr     string
+	Port     uint32
+	OrigAddr string
+	OrigPort uint32
+}
+
+// CheckAndSetDefaults checks and sets default values.
+func (req *ForwardedTCPIPRequest) CheckAndSetDefaults() error {
+	if req.Addr == "" {
+		return trace.BadParameter("missing field Addr")
+	}
+	if req.Port == 0 {
+		return trace.BadParameter("missing field Port")
+	}
+	if req.OrigAddr == "" {
+		return trace.BadParameter("missing field OrigAddr")
+	}
+	if req.OrigPort == 0 {
+		return trace.BadParameter("missing field OrigPort")
+	}
+	return nil
+}
+
 // TerminalModes converts encoded terminal modes into a ssh.TerminalModes map.
 // The encoding is described in: https://tools.ietf.org/html/rfc4254#section-8
 //

--- a/lib/sshutils/tcpip.go
+++ b/lib/sshutils/tcpip.go
@@ -19,9 +19,16 @@
 package sshutils
 
 import (
+	"context"
+	"io"
+	"net"
+
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // DirectTCPIPReq represents the payload of an SSH "direct-tcpip" or
@@ -54,4 +61,72 @@ type TCPIPForwardReq struct {
 	Addr string
 	// Port is the port to listen on.
 	Port uint32
+}
+
+// ParseTCPIPForwardReq parses an SSH request's payload into a TCPIPForwardReq.
+func ParseTCPIPForwardReq(data []byte) (*TCPIPForwardReq, error) {
+	var r TCPIPForwardReq
+	if err := ssh.Unmarshal(data, &r); err != nil {
+		log.Infof("failed to parse TCP IP Forward request: %v", err)
+		return nil, trace.Wrap(err)
+	}
+	return &r, nil
+}
+
+type channelOpener interface {
+	OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error)
+}
+
+// StartRemoteListener listens on the given listener and forwards any accepted
+// connections over a new "forwarded-tcpip" channel.
+func StartRemoteListener(ctx context.Context, sshConn channelOpener, srcAddr string, listener net.Listener) error {
+	srcHost, srcPort, err := SplitHostPort(srcAddr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				if !utils.IsOKNetworkError(err) {
+					log.WithError(err).Warn("failed to accept connection")
+				}
+				return
+			}
+			logger := log.WithFields(log.Fields{
+				"srcAddr":    srcAddr,
+				"remoteAddr": conn.RemoteAddr().String(),
+			})
+
+			dstHost, dstPort, err := SplitHostPort(conn.RemoteAddr().String())
+			if err != nil {
+				logger.WithError(err).Warn("failed to parse addr")
+				return
+			}
+
+			req := ForwardedTCPIPRequest{
+				Addr:     srcHost,
+				Port:     srcPort,
+				OrigAddr: dstHost,
+				OrigPort: dstPort,
+			}
+			if err := req.CheckAndSetDefaults(); err != nil {
+				logger.WithError(err).Warn("failed to create forwarded tcpip request")
+				return
+			}
+			reqBytes := ssh.Marshal(req)
+
+			ch, rch, err := sshConn.OpenChannel(teleport.ChanForwardedTCPIP, reqBytes)
+			if err != nil {
+				logger.WithError(err).Warn("failed to open channel")
+				continue
+			}
+			go ssh.DiscardRequests(rch)
+			go io.Copy(io.Discard, ch.Stderr())
+			go utils.ProxyConn(ctx, conn, ch)
+		}
+	}()
+
+	return nil
 }

--- a/lib/sshutils/tcpip_test.go
+++ b/lib/sshutils/tcpip_test.go
@@ -1,0 +1,63 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sshutils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartRemoteListener(t *testing.T) {
+	// Create a test server to act as the other side of the channel.
+	tsrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hello, world")
+	}))
+	t.Cleanup(tsrv.Close)
+	testSrvConn, err := net.Dial("tcp", tsrv.Listener.Addr().String())
+	require.NoError(t, err)
+
+	sshConn := &mockSSHConn{
+		mockChan: &mockChannel{
+			ReadWriter: testSrvConn,
+		},
+	}
+
+	// Start the remote listener.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, StartRemoteListener(ctx, sshConn, "127.0.0.1:12345", listener))
+
+	// Check that dialing listener makes it all the way to the test http server.
+	resp, err := http.Get("http://" + listener.Addr().String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "Hello, world", string(body))
+}

--- a/lib/sshutils/utils_test.go
+++ b/lib/sshutils/utils_test.go
@@ -27,3 +27,53 @@ func TestJoinHostPort(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "example.com:1234", JoinHostPort("example.com", 1234))
 }
+
+func TestSplitHostPort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		addr       string
+		expectHost string
+		expectPort uint32
+		assertErr  assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "empty",
+			assertErr: assert.Error,
+		},
+		{
+			name:       "full host and port",
+			addr:       "example.com:1234",
+			expectHost: "example.com",
+			expectPort: 1234,
+			assertErr:  assert.NoError,
+		},
+		{
+			name:       "without port",
+			addr:       "example.com",
+			expectHost: "example.com",
+			assertErr:  assert.NoError,
+		},
+		{
+			name:       "ipv6 addr",
+			addr:       "[::1]:80",
+			expectHost: "::1",
+			expectPort: 80,
+			assertErr:  assert.NoError,
+		},
+		{
+			name:       "ipv6 addr without port",
+			addr:       "[::1]",
+			expectHost: "::1",
+			assertErr:  assert.NoError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, err := SplitHostPort(tc.addr)
+			tc.assertErr(t, err)
+			assert.Equal(t, tc.expectHost, host)
+			assert.Equal(t, tc.expectPort, port)
+		})
+	}
+}

--- a/lib/utils/uds/socketpair_other.go
+++ b/lib/utils/uds/socketpair_other.go
@@ -22,7 +22,6 @@ package uds
 
 import (
 	"errors"
-	"syscall"
 
 	"github.com/gravitational/trace"
 )

--- a/lib/utils/uds/uds_other.go
+++ b/lib/utils/uds/uds_other.go
@@ -21,9 +21,9 @@
 package uds
 
 import (
+	"errors"
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/gravitational/trace"
 )


### PR DESCRIPTION
This change adds support for remote port forwarding (`ssh -R`) for Teleport nodes.

Changelog: Added remote port forwarding for Teleport nodes