### PR TITLE
Clarify home directory creation in host user creation docs

### DIFF
--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -192,8 +192,8 @@ field.
 
 The Teleport SSH Service executes `useradd` to create new users on the host, and
 returns an error if it cannot find the `useradd` binary. The `useradd` command
-creates a new home directory with the name of the new host user and adds the
-user to the groups specified in the Teleport user's roles.
+adds the user to the groups specified in the Teleport user's roles, and Teleport
+separately creates a new home directory with the name of the new host user.
 
 The SSH Service executes
 `useradd --no-create-home --home-dir <home> <username> --groups <groups> --uid <uid> --gid <gid>`


### PR DESCRIPTION
This change updates the host user creation docs to clarify which responsibilities of creating a user are handled by `useradd` vs. Teleport.