### PR TITLE
[v14] Leverage the inventory control stream to report updater metrics (#38654)

### DIFF
--- a/lib/auth/periodic.go
+++ b/lib/auth/periodic.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/mod/semver"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	vc "github.com/gravitational/teleport/lib/versioncontrol"
 )
@@ -112,7 +113,7 @@ func newInstanceMetricsPeriodic() *instanceMetricsPeriodic {
 }
 
 // VisitInstance adds an instance to ongoing aggregations.
-func (i *instanceMetricsPeriodic) VisitInstance(instance types.Instance) {
+func (i *instanceMetricsPeriodic) VisitInstance(instance proto.UpstreamInventoryHello) {
 	i.totalInstances++
 	if upgrader := instance.GetExternalUpgrader(); upgrader != "" {
 		if _, exists := i.upgraderCounts[upgrader]; !exists {

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -23,20 +23,21 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
 
 func TestInstanceMetricsPeriodic(t *testing.T) {
 	tts := []struct {
 		desc           string
-		specs          []types.InstanceSpecV1
+		instances      []proto.UpstreamInventoryHello
 		expectedCounts map[string]map[string]int
 		upgraders      []string
 		expectEnrolled int
 	}{
 		{
 			desc: "mixed",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "14.0.0"},
 				{ExternalUpgrader: "unit", ExternalUpgraderVersion: "13.0.0"},
@@ -66,7 +67,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "all-unenrolled",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{},
 				{},
 			},
@@ -78,7 +79,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "all-enrolled",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "unit", ExternalUpgraderVersion: "13.0.0"},
@@ -102,7 +103,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "nil version",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube"},
 				{ExternalUpgrader: "unit"},
 			},
@@ -130,10 +131,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			periodic := newInstanceMetricsPeriodic()
 
-			for _, upgrader := range tt.specs {
-				instance, err := types.NewInstance(uuid.New().String(), upgrader)
-				require.NoError(t, err)
-
+			for _, instance := range tt.instances {
 				periodic.VisitInstance(instance)
 			}
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/38654 to branch/v14

changelog: Fixes an issue with over counting of reported Teleport updater metrics