### PR TITLE
[v13] Leverage the inventory control stream to report updater metrics (#38654)

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1096,7 +1096,6 @@ func (a *Server) doInstancePeriodics(ctx context.Context) {
 	skipControlPlane := modules.GetModules().Features().Cloud
 
 	// set up aggregators for our periodics
-	imp := newInstanceMetricsPeriodic()
 	uep := newUpgradeEnrollPeriodic()
 
 	// stream all instances to all aggregators
@@ -1109,7 +1108,6 @@ func (a *Server) doInstancePeriodics(ctx context.Context) {
 			}
 		}
 
-		imp.VisitInstance(instances.Item())
 		uep.VisitInstance(instances.Item())
 	}
 
@@ -1118,21 +1116,7 @@ func (a *Server) doInstancePeriodics(ctx context.Context) {
 		return
 	}
 
-	// set instance metric values
-	totalInstancesMetric.Set(float64(imp.TotalInstances()))
-	enrolledInUpgradesMetric.Set(float64(imp.TotalEnrolledInUpgrades()))
-
-	// reset upgrader counts
-	upgraderCountsMetric.Reset()
-
-	for upgraderType, upgraderVersions := range imp.upgraderCounts {
-		for version, count := range upgraderVersions {
-			upgraderCountsMetric.With(prometheus.Labels{
-				teleport.TagUpgrader: upgraderType,
-				teleport.TagVersion:  version,
-			}).Set(float64(count))
-		}
-	}
+	a.updateUpdaterVersionMetrics()
 
 	// create/delete upgrade enroll prompt as appropriate
 	enrollMsg, shouldPrompt := uep.GenerateEnrollPrompt()
@@ -1315,6 +1299,32 @@ func (a *Server) doReleaseAlertSync(ctx context.Context, current vc.Target, visi
 		err := a.DeleteClusterAlert(ctx, secAlertID)
 		if err != nil && !trace.IsNotFound(err) {
 			log.Warnf("Failed to delete %s alert: %v", secAlertID, err)
+		}
+	}
+}
+
+// updateUpdaterVersionMetrics leverages the inventory control stream to report the
+// number of teleport updaters installed and their versions. To get an accurate representation
+// of versions in an entire cluster the metric must be aggregated with all auth instances.
+func (a *Server) updateUpdaterVersionMetrics() {
+	imp := newInstanceMetricsPeriodic()
+
+	// record versions for all connected resources
+	a.inventory.Iter(func(handle inventory.UpstreamHandle) {
+		imp.VisitInstance(handle.Hello())
+	})
+
+	totalInstancesMetric.Set(float64(imp.TotalInstances()))
+	enrolledInUpgradesMetric.Set(float64(imp.TotalEnrolledInUpgrades()))
+
+	// reset the gauges so that any versions that fall off are removed from exported metrics
+	upgraderCountsMetric.Reset()
+	for upgraderType, upgraderVersions := range imp.upgraderCounts {
+		for version, count := range upgraderVersions {
+			upgraderCountsMetric.With(prometheus.Labels{
+				teleport.TagUpgrader: upgraderType,
+				teleport.TagVersion:  version,
+			}).Set(float64(count))
 		}
 	}
 }

--- a/lib/auth/periodic.go
+++ b/lib/auth/periodic.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/mod/semver"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	vc "github.com/gravitational/teleport/lib/versioncontrol"
 )
@@ -112,7 +113,7 @@ func newInstanceMetricsPeriodic() *instanceMetricsPeriodic {
 }
 
 // VisitInstance adds an instance to ongoing aggregations.
-func (i *instanceMetricsPeriodic) VisitInstance(instance types.Instance) {
+func (i *instanceMetricsPeriodic) VisitInstance(instance proto.UpstreamInventoryHello) {
 	i.totalInstances++
 	if upgrader := instance.GetExternalUpgrader(); upgrader != "" {
 		if _, exists := i.upgraderCounts[upgrader]; !exists {

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -23,20 +23,21 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
 
 func TestInstanceMetricsPeriodic(t *testing.T) {
 	tts := []struct {
 		desc           string
-		specs          []types.InstanceSpecV1
+		instances      []proto.UpstreamInventoryHello
 		expectedCounts map[string]map[string]int
 		upgraders      []string
 		expectEnrolled int
 	}{
 		{
 			desc: "mixed",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "14.0.0"},
 				{ExternalUpgrader: "unit", ExternalUpgraderVersion: "13.0.0"},
@@ -66,7 +67,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "all-unenrolled",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{},
 				{},
 			},
@@ -78,7 +79,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "all-enrolled",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "kube", ExternalUpgraderVersion: "13.0.0"},
 				{ExternalUpgrader: "unit", ExternalUpgraderVersion: "13.0.0"},
@@ -102,7 +103,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		},
 		{
 			desc: "nil version",
-			specs: []types.InstanceSpecV1{
+			instances: []proto.UpstreamInventoryHello{
 				{ExternalUpgrader: "kube"},
 				{ExternalUpgrader: "unit"},
 			},
@@ -130,10 +131,7 @@ func TestInstanceMetricsPeriodic(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			periodic := newInstanceMetricsPeriodic()
 
-			for _, upgrader := range tt.specs {
-				instance, err := types.NewInstance(uuid.New().String(), upgrader)
-				require.NoError(t, err)
-
+			for _, instance := range tt.instances {
 				periodic.VisitInstance(instance)
 			}
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/38654 to branch/v13

changelog: Fixes an issue with over counting of reported Teleport updater metrics