### PR TITLE
Update docs for `tbot-distroless` image

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -225,7 +225,7 @@ image.
 Whilst the `teleport-distroless` image also includes `tbot`, using the `tbot`
 specific image should be preferred for Machine ID deployments. This image is
 smaller, improving pull times, and has a smaller attack surface. In addition,
-the image contains tweaks to improve the experience of running `tbot` in a
+the image is customized in order to improve the experience of running `tbot` in a
 container environment.
 
 To learn more, read the

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -214,6 +214,30 @@ Alternatively, you can use the debug variant of the image, which contains [busyb
 $ docker run -it --entrypoint="" public.ecr.aws/gravitational/teleport-distroless -debug:(=teleport.latest_oss_docker_image=) busybox sh
 ```
 
+#### Machine ID (tbot)
+
+We also provide a slimmed down distroless image that only contains the `tbot`
+binary for use with Teleport Machine ID. The latest release can be found at
+`public.ecr.aws/gravitational/tbot-distroless:(=teleport.version=)` and the
+version tagging follows the same pattern as the main `teleport-distroless`
+image.
+
+Whilst the `teleport-distroless` image also includes `tbot`, using the `tbot`
+specific image should be preferred for Machine ID deployments. This image is
+smaller, improving pull times, and has a smaller attack surface. In addition,
+the image contains tweaks to improve the experience of running `tbot` in a
+container environment.
+
+To learn more, read the
+[Deploying Machine ID on Kubernetes](./machine-id/deployment/kubernetes.mdx)
+guide.
+
+<Admonition type="warning" title="FIPS Support">
+This image includes the non-FIPS version of the `tbot` binary. If you require
+FIPS support, you should continue to use the
+`public.ecr.aws/gravitational/teleport-ent-fips-distroless` image.
+</Admonition>
+
 ### Running Teleport on Docker
 
 When running a container from one of the images listed above, consider the

--- a/docs/pages/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-id/deployment/kubernetes.mdx
@@ -240,9 +240,7 @@ spec:
     spec:
       containers:
         - name: tbot
-          image: public.ecr.aws/gravitational/teleport-distroless:(=teleport.version=)
-          command:
-            - tbot
+          image: public.ecr.aws/gravitational/tbot-distroless:(=teleport.version=)
           args:
             - start
             - -c


### PR DESCRIPTION
We can backport this to v15, but need to wait for the next v14/13 releases before we can backport to those as those images are not published yet.