### PR TITLE
Skip auto-update blockmaps when building Connect

### DIFF
--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -132,6 +132,9 @@ module.exports = {
   },
   dmg: {
     artifactName: '${productName}-${version}-${arch}.${ext}',
+    // Turn off blockmaps since we don't support automatic updates.
+    // https://github.com/electron-userland/electron-builder/issues/2900#issuecomment-730571696
+    writeUpdateInfo: false,
     contents: [
       {
         x: 130,
@@ -155,6 +158,11 @@ module.exports = {
         to: './bin/tsh.exe',
       },
     ].filter(Boolean),
+  },
+  nsis: {
+    // Turn off blockmaps since we don't support automatic updates.
+    // https://github.com/electron-userland/electron-builder/issues/2900#issuecomment-730571696
+    differentialPackage: false,
   },
   rpm: {
     artifactName: '${name}-${version}.${arch}.${ext}',


### PR DESCRIPTION
Running `yarn package-term` would create a file called `Teleport Connect-<version>.dmg.blockmap` in `web/packages/teleterm/build/release`. [`.blockmap` files are used for automatic updates](https://github.com/electron-userland/electron-builder/issues/2851) which we currently do not support. They can be turned off [by using undocumented config options](https://github.com/electron-userland/electron-builder/issues/2900#issuecomment-730571696).

Skipping their generation should speed up the build by a few seconds.

I'm currently running [a tag build](https://github.com/gravitational/teleport.e/actions/runs/8109496872/job/22164829398) (15.1.0-dev.ravicious.1) to verify that this doesn't impact the build process for some weird reason.