### PR TITLE
Fix missing error check

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -179,7 +179,7 @@ func ToUnstructured(evt AuditEvent) (*auditlogpb.EventUnstructured, error) {
 	}
 
 	str := &structpb.Struct{}
-	if str.UnmarshalJSON(payload); err != nil {
+	if err := str.UnmarshalJSON(payload); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -961,7 +961,7 @@ func applyAuthConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 
 	if fc.Auth.AccessMonitoring != nil {
-		if fc.Auth.AccessMonitoring.CheckAndSetDefaults(); err != nil {
+		if err := fc.Auth.AccessMonitoring.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err, "failed to validate access monitoring config")
 		}
 		cfg.Auth.AccessMonitoring = fc.Auth.AccessMonitoring


### PR DESCRIPTION
Correctly assign the `err` variable before checking for errors