### PR TITLE
Attempt to make TestClient_DialHost more reliable

### DIFF
--- a/api/client/proxy/transport/transportv1/client_test.go
+++ b/api/client/proxy/transport/transportv1/client_test.go
@@ -239,7 +239,7 @@ func TestClient_DialHost(t *testing.T) {
 				return trail.ToGRPC(trace.NotImplemented("not implemented"))
 			case req.DialTarget.Cluster == "payload-too-large":
 				// send the initial cluster details
-				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil {
+				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil && !errors.Is(err, io.EOF) {
 					return trail.ToGRPC(trace.Wrap(err))
 				}
 
@@ -255,7 +255,7 @@ func TestClient_DialHost(t *testing.T) {
 					if err := server.Send(&transportv1pb.ProxySSHResponse{
 						Details: nil,
 						Frame:   &transportv1pb.ProxySSHResponse_Ssh{Ssh: &transportv1pb.Frame{Payload: bytes.Repeat([]byte{0}, 1001)}},
-					}); err != nil {
+					}); err != nil && !errors.Is(err, io.EOF) {
 						return trail.ToGRPC(trace.Wrap(err))
 					}
 				case *transportv1pb.ProxySSHRequest_Agent:
@@ -265,7 +265,7 @@ func TestClient_DialHost(t *testing.T) {
 				return nil
 			case req.DialTarget.Cluster == "echo":
 				// send the initial cluster details
-				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil {
+				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil && !errors.Is(err, io.EOF) {
 					return trail.ToGRPC(trace.Wrap(err))
 				}
 
@@ -281,7 +281,7 @@ func TestClient_DialHost(t *testing.T) {
 					if err := server.Send(&transportv1pb.ProxySSHResponse{
 						Details: nil,
 						Frame:   &transportv1pb.ProxySSHResponse_Ssh{Ssh: &transportv1pb.Frame{Payload: f.Ssh.Payload}},
-					}); err != nil {
+					}); err != nil && !errors.Is(err, io.EOF) {
 						return trail.ToGRPC(trace.Wrap(err))
 					}
 				case *transportv1pb.ProxySSHRequest_Agent:
@@ -290,7 +290,7 @@ func TestClient_DialHost(t *testing.T) {
 				return nil
 			case req.DialTarget.Cluster == "forward":
 				// send the initial cluster details
-				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil {
+				if err := server.Send(&transportv1pb.ProxySSHResponse{Details: &transportv1pb.ClusterDetails{FipsEnabled: true}}); err != nil && !errors.Is(err, io.EOF) {
 					return trail.ToGRPC(trace.Wrap(err))
 				}
 
@@ -306,7 +306,7 @@ func TestClient_DialHost(t *testing.T) {
 					if err := server.Send(&transportv1pb.ProxySSHResponse{
 						Details: nil,
 						Frame:   &transportv1pb.ProxySSHResponse_Ssh{Ssh: &transportv1pb.Frame{Payload: f.Ssh.Payload}},
-					}); err != nil {
+					}); err != nil && !errors.Is(err, io.EOF) {
 						return trail.ToGRPC(trace.Wrap(err))
 					}
 				case *transportv1pb.ProxySSHRequest_Agent:
@@ -360,7 +360,7 @@ func TestClient_DialHost(t *testing.T) {
 				if err := server.Send(&transportv1pb.ProxySSHResponse{
 					Details: nil,
 					Frame:   &transportv1pb.ProxySSHResponse_Ssh{Ssh: &transportv1pb.Frame{Payload: keys[0].Blob}},
-				}); err != nil {
+				}); err != nil && !errors.Is(err, io.EOF) {
 					return trail.ToGRPC(trace.Wrap(err))
 				}
 				return nil


### PR DESCRIPTION
Takes inspiration from https://github.com/gravitational/teleport.e/pull/1944 which addressed similar EOF error showing up when driving streams in tests.

From https://pkg.go.dev/google.golang.org/grpc#ClientStream.SendMsg:

> // SendMsg is generally called by generated code. On error, SendMsg aborts
> // the stream. If the error was generated by the client, the status is
> // returned directly; otherwise, io.EOF is returned and the status of
> // the stream may be discovered using RecvMsg.



Closes https://github.com/gravitational/teleport/issues/32799