### PR TITLE
[v15] Properly check `AccessList.status` for nillness

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -94,7 +94,7 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 	}
 
 	var memberCount *uint32
-	if msg.Status.MemberCount != nil {
+	if msg.Status != nil && msg.Status.MemberCount != nil {
 		memberCount = new(uint32)
 		*memberCount = *msg.Status.MemberCount
 	}

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -185,6 +185,14 @@ func TestFromProtoNils(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("status", func(t *testing.T) {
+		msg := ToProto(newAccessList(t, "access-list"))
+		msg.Status = nil
+
+		_, err := FromProto(msg)
+		require.NoError(t, err)
+	})
+
 	t.Run("member_count", func(t *testing.T) {
 		msg := ToProto(newAccessList(t, "access-list"))
 		msg.Status.MemberCount = nil


### PR DESCRIPTION
Backport #38850 to branch/v15

Changelog: Fixed panic when an older `tsh` or proxy changes an access list.
