### PR TITLE
Tweak docs to account for the timeout in SIGHUP/SIGQUIT

### DIFF
--- a/docs/pages/management/admin/daemon.mdx
+++ b/docs/pages/management/admin/daemon.mdx
@@ -141,7 +141,7 @@ $ sudo systemctl reload teleport
 
 This will perform a graceful restart, i.e. the Teleport daemon will fork a new
 process to handle new incoming requests, leaving the old daemon process running
-until existing clients disconnect.
+until existing clients disconnect (with a timeout of 30 hours).
 
 <Admonition title="Upgrading" type="tip">
 

--- a/docs/pages/reference/signals.mdx
+++ b/docs/pages/reference/signals.mdx
@@ -16,7 +16,7 @@ $ kill -SIG
 | Signal | Teleport Daemon Behavior |
 | - | - |
 | `USR1` | Dumps diagnostics/debugging information into syslog. |
-| `QUIT`| Graceful shutdown. The daemon will wait until connections are dropped. |
-| `TERM` , `INT` or `KILL` | Immediate non-graceful shutdown. All existing connections will be dropped. |
+| `QUIT`| Graceful shutdown. The daemon will stop accepting new connections and it will wait (for up to 30 hours) until existing connections are closed before exiting. |
+| `TERM`, `INT` | Immediate non-graceful shutdown. All existing connections will be closed after a very short delay. |
 | `USR2` | Forks a new Teleport daemon to serve new connections. |
-| `HUP` | Forks a new Teleport daemon to serve new connections **and** initiates the graceful shutdown of the existing process when there are no more clients connected to it. |
+| `HUP` | Forks a new Teleport daemon to serve new connections **and** initiates the graceful shutdown of the existing process, same as `SIGQUIT`. |


### PR DESCRIPTION
This PR mentions that graceful shutdown and graceful reload/restart now have a 30 hour timeout.

Part of #30415.