### PR TITLE
[v14] Filter terminated sessions out of tsh sessions ls ouput

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3189,7 +3189,9 @@ func onListSessions(cf *CLIConf) error {
 
 func sortAndFilterSessions(sessions []types.SessionTracker, kinds []types.SessionKind) []types.SessionTracker {
 	filtered := slices.DeleteFunc(sessions, func(st types.SessionTracker) bool {
-		return !slices.Contains(kinds, st.GetSessionKind())
+		return !slices.Contains(kinds, st.GetSessionKind()) ||
+			(st.GetState() != types.SessionState_SessionStateRunning &&
+				st.GetState() != types.SessionState_SessionStatePending)
 	})
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].GetCreated().Before(filtered[j].GetCreated())


### PR DESCRIPTION
Backport #38685 to branch/v14

changelog: filter terminated sessions from the `tsh sessions ls` output.
