### PR TITLE
fix access request test cache sync

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -196,6 +196,43 @@ func TestAccessRequest(t *testing.T) {
 	t.Run("deny", func(t *testing.T) { testAccessRequestDenyRules(t, testPack) })
 }
 
+// waitForAccessRequests is a helper for writing access request tests that need to wait for access request CRUD. the supplied condition is
+// repeatedly called with the contents of the access request cache until it returns true or a reasonably long timeout is exceeded. this is
+// similar to require.Eventually except that it is safe to use normal (test-failing) assertions within the supplied condition closure.
+func waitForAccessRequests(t *testing.T, ctx context.Context, getter services.AccessRequestGetter, condition func([]*types.AccessRequestV3) bool) {
+	t.Helper()
+
+	timeout := time.After(time.Second * 30)
+	for {
+		var reqs []*types.AccessRequestV3
+		var nextKey string
+	Paginate:
+		for {
+			rsp, err := getter.ListAccessRequests(ctx, &proto.ListAccessRequestsRequest{
+				Limit:    1_000,
+				StartKey: nextKey,
+			})
+			require.NoError(t, err, "ListAccessRequests API call should succeed")
+
+			reqs = append(reqs, rsp.AccessRequests...)
+			nextKey = rsp.NextKey
+			if nextKey == "" {
+				break Paginate
+			}
+		}
+
+		if condition(reqs) {
+			return
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 150):
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for access request condition to pass")
+		}
+	}
+}
+
 // TestListAccessRequests tests some basic functionality of the ListAccessRequests API, including access-control,
 // filtering, sort, and pagination.
 func TestListAccessRequests(t *testing.T) {
@@ -290,6 +327,11 @@ func TestListAccessRequests(t *testing.T) {
 		orderedIDs = append(orderedIDs, rr.GetName())
 	}
 
+	// wait for all written requests to propagate to cache
+	waitForAccessRequests(t, ctx, tlsServer.Auth(), func(reqs []*types.AccessRequestV3) bool {
+		return len(reqs) == len(orderedIDs)
+	})
+
 	var reqs []*types.AccessRequestV3
 	var observedIDs []string
 	var nextKey string
@@ -380,6 +422,7 @@ func TestListAccessRequests(t *testing.T) {
 	// set requests to a variety of states so that state-based ordering
 	// is distinctly different from time-based ordering.
 	var deny bool
+	expectStates := make(map[string]types.RequestState)
 	for i, id := range observedIDs {
 		if i%2 == 0 {
 			// leave half the requests as pending
@@ -395,7 +438,18 @@ func TestListAccessRequests(t *testing.T) {
 			RequestID: id,
 			State:     state,
 		}))
+		expectStates[id] = state
 	}
+
+	// wait until all requests in cache to present the expected state
+	waitForAccessRequests(t, ctx, tlsServer.Auth(), func(reqs []*types.AccessRequestV3) bool {
+		for _, r := range reqs {
+			if expected, ok := expectStates[r.GetName()]; ok && r.GetState() != expected {
+				return false
+			}
+		}
+		return true
+	})
 
 	// aggregate requests by descending state ordering
 	reqs = nil


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/38633 introduced a new access request cache that is always enabled on auth, but one of the tests wasn't properly waiting for changes to propagate to the cache, leading to flakiness.  This PR adds a helper for waiting on access request change propagation and uses it to fix the new test that was flaky.

Note: I looked through the various existing access request tests in `lib/auth` to see if they needed to be updated as well, but it seems like our existing coverage in `lib/auth` was limited to single-request lookups, which are always routed to the real backend.

Fixes https://github.com/gravitational/teleport/issues/38878