### PR TITLE
AWS-OIDC: add `ListRolePolicies` and `ListAttachedRolePolicies`

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -364,6 +364,9 @@ func StatementAccessGraphAWSSync() *Statement {
 			"iam:ListAttachedGroupPolicies",
 			"iam:GetPolicy",
 			"iam:GetPolicyVersion",
+			"iam:ListRolePolicies",
+			"iam:ListAttachedRolePolicies",
+			"iam:GetRolePolicy",
 		},
 		Resources: allResources,
 	}

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -137,7 +137,7 @@ type AWSClients interface {
 	// GetAWSKMSClient returns AWS KMS client for the specified region.
 	GetAWSKMSClient(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (kmsiface.KMSAPI, error)
 	// GetAWSS3Client returns AWS S3 client.
-	GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error)
+	GetAWSS3Client(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error)
 }
 
 // AzureClients is an interface for Azure-specific API clients
@@ -549,8 +549,8 @@ func (c *cloudClients) GetAWSIAMClient(ctx context.Context, region string, opts 
 }
 
 // GetAWSS3Client returns AWS S3 client.
-func (c *cloudClients) GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
-	session, err := c.GetAWSSession(ctx, "", opts...)
+func (c *cloudClients) GetAWSS3Client(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
+	session, err := c.GetAWSSession(ctx, region, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1105,8 +1105,8 @@ func (c *TestCloudClients) GetAWSIAMClient(ctx context.Context, region string, o
 }
 
 // GetAWSS3Client returns AWS S3 client.
-func (c *TestCloudClients) GetAWSS3Client(ctx context.Context, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
-	_, err := c.GetAWSSession(ctx, "", opts...)
+func (c *TestCloudClients) GetAWSS3Client(ctx context.Context, region string, opts ...AWSAssumeRoleOptionFn) (s3iface.S3API, error) {
+	_, err := c.GetAWSSession(ctx, region, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -20,7 +20,6 @@ package aws_sync
 
 import (
 	"context"
-	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // pollAWSS3Buckets is a function that returns a function that fetches

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -20,6 +20,7 @@ package aws_sync
 
 import (
 	"context"
+	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -65,8 +66,14 @@ func (a *awsFetcher) fetchS3Buckets(ctx context.Context) ([]*accessgraphv1alpha.
 		}
 	}
 
+	region := awsutil.GetKnownRegions()[0]
+	if len(a.Regions) > 0 {
+		region = a.Regions[0]
+	}
+
 	s3Client, err := a.CloudClients.GetAWSS3Client(
 		ctx,
+		region,
 		a.getAWSOptions()...,
 	)
 	if err != nil {


### PR DESCRIPTION
This PR adds missing `iam:ListAttachedRolePolicies` and `iam:ListRolePolicies` IAM permissions to TAG setup wizard.

This complements PR https://github.com/gravitational/teleport/pull/38071