### PR TITLE
Add remote port forwarding to testplan and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -212,6 +212,10 @@ as well as an upgrade of the previous version of Teleport.
   - [ ] tsh ssh -L \<node-remote-cluster\>
   - [ ] tsh ssh -L \<agentless-node\>
   - [ ] tsh ssh -L \<agentless-node-remote-cluster\>
+  - [ ] tsh ssh -R \<regular-node\>
+  - [ ] tsh ssh -R \<node-remote-cluster\>
+  - [ ] tsh ssh -R \<agentless-node\>
+  - [ ] tsh ssh -R \<agentless-node-remote-cluster\>
   - [ ] tsh ls
   - [ ] tsh clusters
 
@@ -237,6 +241,10 @@ as well as an upgrade of the previous version of Teleport.
   - [ ] ssh -L \<node-remote-cluster\>
   - [ ] ssh -L \<agentless-node\>
   - [ ] ssh -L \<agentless-node-remote-cluster\>
+  - [ ] ssh -R \<regular-node\>
+  - [ ] ssh -R \<node-remote-cluster\>
+  - [ ] ssh -R \<agentless-node\>
+  - [ ] ssh -R \<agentless-node-remote-cluster\>
 
 - [ ] Verify proxy jump functionality
   Log into leaf cluster via root, shut down the root proxy and verify proxy jump works.

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -1123,6 +1123,7 @@ $ tsh ssh [<flags>] <[user@]host> [<command>...]
 | `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
 | `-L, --forward` | none | none | Forward localhost connections to remote server |
 | `-D, --dynamic-forward` | none | none | Forward localhost connections to remote server using SOCKS5 |
+| `-R, --remote-forward` | none | none | Forward remote connections to localhost |
 | `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
 | `--local` | none | | Execute command on localhost after connecting to SSH node |
 | `-t, --tty` | `file` | | Allocate TTY |


### PR DESCRIPTION
This change adds remote port forwarding to the docs and testplan.