### PR TITLE
[v15] Bump mio from 0.8.9 to 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
Backport #38946 to branch/v15