### PR TITLE
Add web support for the "device.webtoken.create" event

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -195,6 +195,7 @@ const EventIconMap: Record<EventCode, any> = {
   [eventCodes.DEVICE_ENROLL_TOKEN_CREATE]: Icons.Info,
   [eventCodes.DEVICE_ENROLL_TOKEN_SPENT]: Icons.Info,
   [eventCodes.DEVICE_UPDATE]: Icons.Info,
+  [eventCodes.DEVICE_WEB_TOKEN_CREATE]: Icons.Info,
   [eventCodes.MFA_DEVICE_ADD]: Icons.Info,
   [eventCodes.MFA_DEVICE_DELETE]: Icons.Info,
   [eventCodes.BILLING_CARD_CREATE]: Icons.CreditCard,

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -419,12 +419,12 @@ exports[`list of all events 1`] = `
             </strong>
              - 
             <strong>
-              227
+              228
             </strong>
              of
              
             <strong>
-              227
+              228
             </strong>
           </div>
           <button
@@ -551,6 +551,60 @@ exports[`list of all events 1`] = `
         </tr>
       </thead>
       <tbody>
+        <tr>
+          <td
+            style="vertical-align: inherit;"
+          >
+            <div
+              class="c20"
+            >
+              <span
+                class="c21 icon icon-info"
+              >
+                <svg
+                  fill="currentColor"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  width="20"
+                >
+                  <path
+                    d="M11.625 8.8125C12.1428 8.8125 12.5625 8.39277 12.5625 7.875C12.5625 7.35723 12.1428 6.9375 11.625 6.9375C11.1072 6.9375 10.6875 7.35723 10.6875 7.875C10.6875 8.39277 11.1072 8.8125 11.625 8.8125Z"
+                  />
+                  <path
+                    d="M10.5 11.25C10.5 10.8358 10.8358 10.5 11.25 10.5C11.6478 10.5 12.0294 10.658 12.3107 10.9393C12.592 11.2206 12.75 11.6022 12.75 12V15.75C13.1642 15.75 13.5 16.0858 13.5 16.5C13.5 16.9142 13.1642 17.25 12.75 17.25C12.3522 17.25 11.9706 17.092 11.6893 16.8107C11.408 16.5294 11.25 16.1478 11.25 15.75V12C10.8358 12 10.5 11.6642 10.5 11.25Z"
+                  />
+                  <path
+                    clip-rule="evenodd"
+                    d="M12 2.25C6.61522 2.25 2.25 6.61522 2.25 12C2.25 17.3848 6.61522 21.75 12 21.75C17.3848 21.75 21.75 17.3848 21.75 12C21.75 6.61522 17.3848 2.25 12 2.25ZM3.75 12C3.75 7.44365 7.44365 3.75 12 3.75C16.5563 3.75 20.25 7.44365 20.25 12C20.25 16.5563 16.5563 20.25 12 20.25C7.44365 20.25 3.75 16.5563 3.75 12Z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              Device Web Token Create
+            </div>
+          </td>
+          <td
+            style="word-break: break-word;"
+          >
+            User [llama] has issued a device web token
+          </td>
+          <td
+            style="min-width: 120px;"
+          >
+            2024-03-05T17:18:43.296Z
+          </td>
+          <td
+            align="right"
+          >
+            <button
+              class="c22"
+              kind="border"
+              width="87px"
+            >
+              Details
+            </button>
+          </td>
+        </tr>
         <tr>
           <td
             style="vertical-align: inherit;"

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -2855,6 +2855,23 @@ export const events = [
   },
   {
     cluster_name: 'im-a-cluster-name',
+    code: 'TV008I',
+    device:{
+      asset_tag: 'M2CQVQV64R',
+      credential_id: 'c7572891-8426-4e62-874f-c793029d53a6',
+      device_id: 'f84f6b35-6226-4e73-8205-3bcbd7d12970',
+      os_type: 2
+    },
+    ei: 0,
+    event: 'device.webtoken.create',
+    success: true,
+    time: '2024-03-05T17:18:43.296Z',
+    uid: 'b1361d51-70fa-4f1b-803c-a252c2877707',
+    user: 'llama',
+    user_kind: 1
+  },
+  {
+    cluster_name: 'im-a-cluster-name',
     code: 'TLR00I',
     ei: 0,
     event: 'login_rule.create',

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -2856,11 +2856,11 @@ export const events = [
   {
     cluster_name: 'im-a-cluster-name',
     code: 'TV008I',
-    device:{
+    device: {
       asset_tag: 'M2CQVQV64R',
       credential_id: 'c7572891-8426-4e62-874f-c793029d53a6',
       device_id: 'f84f6b35-6226-4e73-8205-3bcbd7d12970',
-      os_type: 2
+      os_type: 2,
     },
     ei: 0,
     event: 'device.webtoken.create',
@@ -2868,7 +2868,7 @@ export const events = [
     time: '2024-03-05T17:18:43.296Z',
     uid: 'b1361d51-70fa-4f1b-803c-a252c2877707',
     user: 'llama',
-    user_kind: 1
+    user_kind: 1,
   },
   {
     cluster_name: 'im-a-cluster-name',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1359,6 +1359,14 @@ export const formatters: Formatters = {
         ? `User [${user}] has updated a device`
         : `User [${user}] has failed to update a device`,
   },
+  [eventCodes.DEVICE_WEB_TOKEN_CREATE]: {
+    type: 'device.webtoken.create',
+    desc: 'Device Web Token Create',
+    format: ({ user, status, success }) =>
+      success || (status && status.success)
+        ? `User [${user}] has issued a device web token`
+        : `User [${user}] has failed to issue a device web token`,
+  },
   [eventCodes.X11_FORWARD]: {
     type: 'x11-forward',
     desc: 'X11 Forwarding Requested',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -120,6 +120,7 @@ export const eventCodes = {
   DEVICE_ENROLL: 'TV005I',
   DEVICE_AUTHENTICATE: 'TV006I',
   DEVICE_UPDATE: 'TV007I',
+  DEVICE_WEB_TOKEN_CREATE: 'TV008I',
   EXEC_FAILURE: 'T3002E',
   EXEC: 'T3002I',
   GITHUB_CONNECTOR_CREATED: 'T8000I',
@@ -1209,6 +1210,9 @@ export type RawEvents = {
     typeof eventCodes.DEVICE_AUTHENTICATE
   >;
   [eventCodes.DEVICE_UPDATE]: RawDeviceEvent<typeof eventCodes.DEVICE_UPDATE>;
+  [eventCodes.DEVICE_WEB_TOKEN_CREATE]: RawDeviceEvent<
+    typeof eventCodes.DEVICE_WEB_TOKEN_CREATE
+  >;
   [eventCodes.UNKNOWN]: RawEvent<
     typeof eventCodes.UNKNOWN,
     {


### PR DESCRIPTION
Map "device.webtoken.create" and "TV008I" in the Web UI.

https://github.com/gravitational/teleport.e/issues/3236