### PR TITLE
Fix MySQL Server version auto-update

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -265,7 +265,7 @@ func TestAccessMySQL(t *testing.T) {
 		withSelfHostedMySQL("mysql"),
 		withSelfHostedMySQL("version-update-test",
 			// Set an older version in DB spec.
-			withMySQLServerVersionInSpec("6.6.6-before"),
+			withMySQLServerVersionInDBSpec("6.6.6-before"),
 			// Set a newer version in TestServer.
 			withMySQLServerVersion("8.8.8-after"),
 		),
@@ -345,7 +345,7 @@ func TestAccessMySQL(t *testing.T) {
 	}
 
 	t.Run("server version update on connection", func(t *testing.T) {
-		// Force the db version to be something else.
+		// Confirm the server version configured in the spec.
 		db, err := testCtx.server.getProxiedDatabase("version-update-test")
 		require.NoError(t, err)
 		require.Equal(t, "6.6.6-before", db.GetMySQLServerVersion())
@@ -2783,7 +2783,7 @@ func withMySQLServerVersion(version string) selfHostedMySQLOption {
 	}
 }
 
-func withMySQLServerVersionInSpec(version string) selfHostedMySQLOption {
+func withMySQLServerVersionInDBSpec(version string) selfHostedMySQLOption {
 	return func(opts *selfHostedMySQLOptions) {
 		opts.databaseOptions = append(opts.databaseOptions, func(db *types.DatabaseV3) {
 			db.Spec.MySQL.ServerVersion = version

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -259,17 +259,7 @@ func TestAccessPostgres(t *testing.T) {
 // on the configured RBAC rules.
 func TestAccessMySQL(t *testing.T) {
 	ctx := context.Background()
-	testCtx := setupTestContext(
-		ctx,
-		t,
-		withSelfHostedMySQL("mysql"),
-		withSelfHostedMySQL("version-update-test",
-			// Set an older version in DB spec.
-			withMySQLServerVersionInDBSpec("6.6.6-before"),
-			// Set a newer version in TestServer.
-			withMySQLServerVersion("8.8.8-after"),
-		),
-	)
+	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
 	tests := []struct {
@@ -343,26 +333,39 @@ func TestAccessMySQL(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
 
-	t.Run("server version update on connection", func(t *testing.T) {
-		// Confirm the server version configured in the spec.
-		db, err := testCtx.server.getProxiedDatabase("version-update-test")
-		require.NoError(t, err)
-		require.Equal(t, "6.6.6-before", db.GetMySQLServerVersion())
+func TestMySQLServerVersionUpdateOnConnection(t *testing.T) {
+	ctx := context.Background()
+	testCtx := setupTestContext(
+		ctx,
+		t,
+		withSelfHostedMySQL("mysql",
+			// Set an older version in DB spec.
+			withMySQLServerVersionInDBSpec("6.6.6-before"),
+			// Set a newer version in TestServer.
+			withMySQLServerVersion("8.8.8-after"),
+		),
+	)
+	go testCtx.startHandlingConnections()
 
-		// Connect.
-		testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"alice"}, []string{types.Wildcard})
-		mysqlConn, err := testCtx.mysqlClient("alice", "version-update-test", "alice")
-		require.NoError(t, err)
-		defer mysqlConn.Close()
-		_, err = mysqlConn.Execute("select 1")
-		require.NoError(t, err)
+	// Confirm the server version configured in the spec.
+	db, err := testCtx.server.getProxiedDatabase("mysql")
+	require.NoError(t, err)
+	require.Equal(t, "6.6.6-before", db.GetMySQLServerVersion())
 
-		// Check if proxied database is updated.
-		updatedDB, err := testCtx.server.getProxiedDatabase("version-update-test")
-		require.NoError(t, err)
-		require.Equal(t, "8.8.8-after", updatedDB.GetMySQLServerVersion())
-	})
+	// Connect.
+	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"alice"}, []string{types.Wildcard})
+	mysqlConn, err := testCtx.mysqlClient("alice", "mysql", "alice")
+	require.NoError(t, err)
+	defer mysqlConn.Close()
+	_, err = mysqlConn.Execute("select 1")
+	require.NoError(t, err)
+
+	// Check if proxied database is updated.
+	updatedDB, err := testCtx.server.getProxiedDatabase("mysql")
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8-after", updatedDB.GetMySQLServerVersion())
 }
 
 // TestAccessRedis verifies access scenarios to a Redis database based

--- a/lib/srv/db/common/engines.go
+++ b/lib/srv/db/common/engines.go
@@ -119,8 +119,8 @@ type EngineConfig struct {
 	GetUserProvisioner func(AutoUsers) *UserProvisioner
 	// UpdateProxiedDatabase finds the proxied database by name and uses the
 	// provided function to update the database's status. Returns
-	// trace.NotFound if the name is not found or forwards the error from the
-	// provided callback function.
+	// trace.NotFound if the name is not found otherwise forwards the error
+	// from the provided callback function.
 	UpdateProxiedDatabase func(string, func(types.Database) error) error
 }
 

--- a/lib/srv/db/common/engines.go
+++ b/lib/srv/db/common/engines.go
@@ -117,6 +117,9 @@ type EngineConfig struct {
 	DataDir string
 	// GetUserProvisioner is automatic database users creation handler.
 	GetUserProvisioner func(AutoUsers) *UserProvisioner
+	// UpdateProxiedDatabase finds the proxied database by name and provide a
+	// function to update its status.
+	UpdateProxiedDatabase func(string, func(types.Database) error) error
 }
 
 // CheckAndSetDefaults validates the config and sets default values.

--- a/lib/srv/db/common/engines.go
+++ b/lib/srv/db/common/engines.go
@@ -117,8 +117,10 @@ type EngineConfig struct {
 	DataDir string
 	// GetUserProvisioner is automatic database users creation handler.
 	GetUserProvisioner func(AutoUsers) *UserProvisioner
-	// UpdateProxiedDatabase finds the proxied database by name and provide a
-	// function to update its status.
+	// UpdateProxiedDatabase finds the proxied database by name and uses the
+	// provided function to update the database's status. Returns
+	// trace.NotFound if the name is not found or forwards the error from the
+	// provided callback function.
 	UpdateProxiedDatabase func(string, func(types.Database) error) error
 }
 

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -164,18 +164,25 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 func (e *Engine) updateServerVersion(sessionCtx *common.Session, serverConn *client.Conn) error {
 	serverVersion := serverConn.GetServerVersion()
 	statusVersion := sessionCtx.Database.GetMySQLServerVersion()
+
 	// Update only when needed.
-	// Note that sessionCtx.Database is a copy of the database cached by
-	// database service. Call UpdateProxiedDatabase to do the update instead of
-	// setting the copy.
-	if serverVersion != "" && serverVersion != statusVersion {
-		return trace.Wrap(e.UpdateProxiedDatabase(sessionCtx.Database.GetName(), func(db types.Database) error {
-			db.SetMySQLServerVersion(serverVersion)
-			e.Log.WithField("server-version", serverVersion).Debug("Updated MySQL server version.")
-			return nil
-		}))
+	if serverVersion == "" || serverVersion == statusVersion {
+		return nil
 	}
 
+	// Note that sessionCtx.Database is a copy of the database cached by
+	// database service. Call e.UpdateProxiedDatabase to do the update instead of
+	// setting the copy.
+	doUpdate := func(db types.Database) error {
+		db.SetMySQLServerVersion(serverVersion)
+		return nil
+	}
+
+	if err := e.UpdateProxiedDatabase(sessionCtx.Database.GetName(), doUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+
+	e.Log.WithField("server-version", serverVersion).Debug("Updated MySQL server version.")
 	return nil
 }
 

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -616,13 +616,12 @@ func (s *Server) getProxiedDatabase(name string) (types.Database, error) {
 	defer s.mu.RUnlock()
 	// don't call s.getProxiedDatabases() as this will call RLock and
 	// potentially deadlock.
-	for _, db := range s.proxiedDatabases {
-		if db.GetName() == name {
-			return s.copyDatabaseWithUpdatedLabelsLocked(db), nil
-		}
+	db, found := s.proxiedDatabases[name]
+	if !found {
+		return nil, trace.NotFound("%q not found among registered databases: %v",
+			name, s.proxiedDatabases)
 	}
-	return nil, trace.NotFound("%q not found among registered databases: %v",
-		name, s.proxiedDatabases)
+	return s.copyDatabaseWithUpdatedLabelsLocked(db), nil
 }
 
 // copyDatabaseWithUpdatedLabelsLocked will inject updated dynamic and cloud labels into
@@ -1107,12 +1106,11 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 		UpdateProxiedDatabase: func(name string, doUpdate func(types.Database) error) error {
 			s.mu.Lock()
 			defer s.mu.Unlock()
-			for _, db := range s.proxiedDatabases {
-				if db.GetName() == name {
-					return trace.Wrap(doUpdate(db))
-				}
+			db, found := s.proxiedDatabases[name]
+			if !found {
+				return trace.NotFound("%q not found among registered databases", name)
 			}
-			return trace.NotFound("%q not found among registered databases", name)
+			return trace.Wrap(doUpdate(db))
 		},
 	})
 }

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -1104,6 +1104,16 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 				Clock:      s.cfg.Clock,
 			}
 		},
+		UpdateProxiedDatabase: func(name string, doUpdate func(types.Database) error) error {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			for _, db := range s.proxiedDatabases {
+				if db.GetName() == name {
+					return trace.Wrap(doUpdate(db))
+				}
+			}
+			return trace.NotFound("%q not found among registered databases", name)
+		},
 	})
 }
 


### PR DESCRIPTION
Partially fix:
- #38948

Changelog: Fixed an issue that the server version of the registered MySQL databases is not automatically updated upon new connections

The MySQL engine can automatically update the MySQL server version upon a new connection. This functionality broke when we started passing database copies to the engines which makes the update ineffective.