### PR TITLE
[v14] build: Use buildx and caching for buildboxes, push to ghcr.io

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -124,8 +124,7 @@ build-binaries-fips: buildbox-centos7-fips webassets
 #
 .PHONY:buildbox
 buildbox:
-	$(call PULL_ON_CI,$(BUILDBOX))
-	DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -139,7 +138,9 @@ buildbox:
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX) .
 
 # Builds a Docker buildbox for FIPS
@@ -155,8 +156,7 @@ buildbox-fips: buildbox-centos7-fips
 .PHONY:buildbox-centos7
 buildbox-centos7:
 	$(REQUIRE_HOST_ARCH)
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7))
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -166,7 +166,9 @@ buildbox-centos7:
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
 
 #
@@ -174,8 +176,7 @@ buildbox-centos7:
 #
 .PHONY:buildbox-centos7-fips
 buildbox-centos7-fips:
-	$(call PULL_ON_CI,$(BUILDBOX_CENTOS7_FIPS))
-	docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
@@ -184,7 +185,9 @@ buildbox-centos7-fips:
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
 #
@@ -194,16 +197,16 @@ buildbox-centos7-fips:
 #
 .PHONY:buildbox-arm
 buildbox-arm:
-	$(call PULL_ON_CI,$(BUILDBOX_ARM))
-	docker build \
+	docker buildx build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
-		--cache-from $(BUILDBOX) \
-		--cache-from $(BUILDBOX_ARM) \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--cache-to type=inline \
+		--cache-from $(BUILDBOX_ARM) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -217,12 +220,13 @@ endif
 #
 .PHONY:buildbox-node
 buildbox-node:
-	$(call PULL_ON_CI,$(BUILDBOX_NODE))
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--cache-to type=inline \
 		--cache-from $(BUILDBOX_NODE) \
+		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_NODE) -f Dockerfile-node .
 
 #

--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -1,7 +1,7 @@
 # Those variables are extracted from build.assets/Makefile so they can be imported
 # by other Makefiles
 BUILDBOX_VERSION ?= teleport14
-BUILDBOX_BASE_NAME ?= public.ecr.aws/gravitational/teleport-buildbox
+BUILDBOX_BASE_NAME ?= ghcr.io/gravitational/teleport-buildbox
 
 BUILDBOX = $(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)
 BUILDBOX_CENTOS7 = $(BUILDBOX_BASE_NAME)-centos7:$(BUILDBOX_VERSION)


### PR DESCRIPTION
Explicitly use `docker buildx build` (instead of `DOCKER_BUILDKIT=1`) to
build the buildbox images, use `--cache-to type=inline` for caching
instead of pulling the image first on CI, and push the image to the
registry if `PUSH=1`.

Push the buildbox images to ghcr.io as our single source of buildbox
images. branch/v15 and master use ghcr.io.

This is a roll-up of changes made iteratively on master / branch/v15
where we have arrived at a solution that seems to build all buildboxes
with any buildx builder and to cache effectively so we reduce build
times. This aligns the branch/v14 build of the buildboxes with the later
branches.

Backport: https://github.com/gravitational/teleport/pull/34950 (partial)
Backport: https://github.com/gravitational/teleport/pull/37559 (partial)
Issue: https://github.com/gravitational/teleport/issues/34281
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8165487223 (build)
Test-run: https://github.com/gravitational/teleport.e/actions/runs/8167190984 (cached)