### PR TITLE
Fix Assume Start Time Validation

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -832,18 +832,18 @@ func NewAccessRequestAllowedPromotions(promotions []*AccessRequestAllowedPromoti
 func ValidateAssumeStartTime(assumeStartTime time.Time, accessExpiry time.Time, creationTime time.Time) error {
 	// Guard against requesting a start time before the request creation time.
 	if assumeStartTime.Before(creationTime) {
-		return trace.BadParameter("assume start time has to be greater than: %q", creationTime.Format(time.RFC3339))
+		return trace.BadParameter("assume start time has to be after %v", creationTime.Format(time.RFC3339))
 	}
 	// Guard against requesting a start time after access expiry.
 	if assumeStartTime.After(accessExpiry) || assumeStartTime.Equal(accessExpiry) {
-		return trace.BadParameter("assume start time cannot equal or exceed access expiry time at: %q",
+		return trace.BadParameter("assume start time must be prior to access expiry time at %v",
 			accessExpiry.Format(time.RFC3339))
 	}
 	// Access expiry can be greater than constants.MaxAssumeStartDuration, but start time
 	// should be on or before constants.MaxAssumeStartDuration.
 	maxAssumableStartTime := creationTime.Add(constants.MaxAssumeStartDuration)
 	if maxAssumableStartTime.Before(accessExpiry) && assumeStartTime.After(maxAssumableStartTime) {
-		return trace.BadParameter("assume start time is too far in the future, latest time allowed %q",
+		return trace.BadParameter("assume start time is too far in the future, latest time allowed is %v",
 			maxAssumableStartTime.Format(time.RFC3339))
 	}
 

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils"
 )
 
@@ -825,4 +826,26 @@ func NewAccessRequestAllowedPromotions(promotions []*AccessRequestAllowedPromoti
 	return &AccessRequestAllowedPromotions{
 		Promotions: promotions,
 	}
+}
+
+// ValidateAssumeStartTime returns error if start time is in an invalid range.
+func ValidateAssumeStartTime(assumeStartTime time.Time, accessExpiry time.Time, creationTime time.Time) error {
+	// Guard against requesting a start time before the request creation time.
+	if assumeStartTime.Before(creationTime) {
+		return trace.BadParameter("assume start time has to be greater than: %q", creationTime.Format(time.RFC3339))
+	}
+	// Guard against requesting a start time after access expiry.
+	if assumeStartTime.After(accessExpiry) || assumeStartTime.Equal(accessExpiry) {
+		return trace.BadParameter("assume start time cannot equal or exceed access expiry time at: %q",
+			accessExpiry.Format(time.RFC3339))
+	}
+	// Access expiry can be greater than constants.MaxAssumeStartDuration, but start time
+	// should be on or before constants.MaxAssumeStartDuration.
+	maxAssumableStartTime := creationTime.Add(constants.MaxAssumeStartDuration)
+	if maxAssumableStartTime.Before(accessExpiry) && assumeStartTime.After(maxAssumableStartTime) {
+		return trace.BadParameter("assume start time is too far in the future, latest time allowed %q",
+			maxAssumableStartTime.Format(time.RFC3339))
+	}
+
+	return nil
 }

--- a/api/types/access_request_test.go
+++ b/api/types/access_request_test.go
@@ -18,7 +18,11 @@ package types
 
 import (
 	"testing"
+	"time"
 
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +30,39 @@ func TestAssertAccessRequestImplementsResourceWithLabels(t *testing.T) {
 	ar, err := NewAccessRequest("test", "test", "test")
 	require.NoError(t, err)
 	require.Implements(t, (*ResourceWithLabels)(nil), ar)
+}
+
+func TestValidateAssumeStartTime(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	creation := clock.Now().UTC()
+	day := 24 * time.Hour
+
+	expiry := creation.Add(12 * day)
+	maxAssumeStartDuration := creation.Add(constants.MaxAssumeStartDuration)
+
+	// Start time too far in the future.
+	invalidMaxedAssumeStartTime := creation.Add(constants.MaxAssumeStartDuration + (1 * day))
+	err := ValidateAssumeStartTime(invalidMaxedAssumeStartTime, expiry, creation)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorIs(t, err, trace.BadParameter("assume start time is too far in the future, latest time allowed %q",
+		maxAssumeStartDuration.Format(time.RFC3339)))
+
+	// Expired start time.
+	invalidExpiredAssumeStartTime := creation.Add(100 * day)
+	err = ValidateAssumeStartTime(invalidExpiredAssumeStartTime, expiry, creation)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorIs(t, err, trace.BadParameter("assume start time cannot equal or exceed access expiry time at: %q",
+		expiry.Format(time.RFC3339)))
+
+	// Before creation start time.
+	invalidBeforeCreationStartTime := creation.Add(-10 * day)
+	err = ValidateAssumeStartTime(invalidBeforeCreationStartTime, expiry, creation)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorIs(t, err, trace.BadParameter("assume start time has to be greater than: %q",
+		creation.Format(time.RFC3339)))
+
+	// Valid start time.
+	validStartTime := creation.Add(6 * day)
+	err = ValidateAssumeStartTime(validStartTime, expiry, creation)
+	require.NoError(t, err)
 }

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1520,7 +1520,162 @@ func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 	}
 }
 
-func TestAccessRequest_AssumeStartTime(t *testing.T) {
+func TestAssumeStartTime_CreateAccessRequestV2(t *testing.T) {
+	ctx := context.Background()
+	s := createAccessRequestWithStartTime(t)
+
+	testCases := []struct {
+		name      string
+		startTime time.Time
+		errCheck  require.ErrorAssertionFunc
+	}{
+		{
+			name:      "too far in the future",
+			startTime: s.invalidMaxedAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time is too far in the future")
+			},
+		},
+		{
+			name:      "after access expiry time",
+			startTime: s.invalidExpiredAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time must be prior to access expiry time")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := services.NewAccessRequest(s.requesterUserName, "admins")
+			require.NoError(t, err)
+			req.SetMaxDuration(s.maxDuration)
+			req.SetAssumeStartTime(tc.startTime)
+			_, err = s.requesterClient.CreateAccessRequestV2(ctx, req)
+			tc.errCheck(t, err)
+		})
+	}
+}
+
+func TestAssumeStartTime_SubmitAccessReview(t *testing.T) {
+	ctx := context.Background()
+	s := createAccessRequestWithStartTime(t)
+
+	testCases := []struct {
+		name      string
+		startTime time.Time
+		errCheck  require.ErrorAssertionFunc
+	}{
+		{
+			name:      "too far in the future",
+			startTime: s.invalidMaxedAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time is too far in the future")
+			},
+		},
+		{
+			name:      "after access expiry time",
+			startTime: s.invalidExpiredAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time must be prior to access expiry time")
+			},
+		},
+		{
+			name:      "valid submission",
+			startTime: s.validStartTime,
+			errCheck:  require.NoError,
+		},
+	}
+	review := types.AccessReviewSubmission{
+		RequestID: s.createdRequest.GetName(),
+		Review: types.AccessReview{
+			Author:        "admin",
+			ProposedState: types.RequestState_APPROVED,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			review.Review.AssumeStartTime = &tc.startTime
+			resp, err := s.testPack.tlsServer.AuthServer.AuthServer.SubmitAccessReview(ctx, review)
+			tc.errCheck(t, err)
+			if err == nil {
+				require.Equal(t, tc.startTime, *resp.GetAssumeStartTime())
+			}
+		})
+	}
+}
+
+func TestAssumeStartTime_SetAccessRequestState(t *testing.T) {
+	ctx := context.Background()
+	s := createAccessRequestWithStartTime(t)
+
+	testCases := []struct {
+		name      string
+		startTime time.Time
+		errCheck  require.ErrorAssertionFunc
+	}{
+		{
+			name:      "too far in the future",
+			startTime: s.invalidMaxedAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time is too far in the future")
+			},
+		},
+		{
+			name:      "after access expiry time",
+			startTime: s.invalidExpiredAssumeStartTime,
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+				require.ErrorContains(t, err, "assume start time must be prior to access expiry time")
+			},
+		},
+		{
+			name:      "valid set state",
+			startTime: s.validStartTime,
+			errCheck:  require.NoError,
+		},
+	}
+	update := types.AccessRequestUpdate{
+		RequestID: s.createdRequest.GetName(),
+		State:     types.RequestState_APPROVED,
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			update.AssumeStartTime = &tc.startTime
+			err := s.testPack.tlsServer.Auth().SetAccessRequestState(ctx, update)
+			tc.errCheck(t, err)
+			if err == nil {
+				resp, err := s.testPack.tlsServer.AuthServer.AuthServer.GetAccessRequests(ctx, types.AccessRequestFilter{})
+				require.NoError(t, err)
+				require.Len(t, resp, 1)
+				require.Equal(t, tc.startTime, *resp[0].GetAssumeStartTime())
+			}
+		})
+	}
+}
+
+type accessRequestWithStartTime struct {
+	testPack                      *accessRequestTestPack
+	requesterClient               *Client
+	invalidMaxedAssumeStartTime   time.Time
+	invalidExpiredAssumeStartTime time.Time
+	validStartTime                time.Time
+	maxDuration                   time.Time
+	requesterUserName             string
+	createdRequest                types.AccessRequest
+}
+
+func createAccessRequestWithStartTime(t *testing.T) accessRequestWithStartTime {
+	t.Helper()
+
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -1534,107 +1689,33 @@ func TestAccessRequest_AssumeStartTime(t *testing.T) {
 
 	t.Cleanup(func() { require.NoError(t, requesterClient.Close()) })
 
-	clock := clockwork.NewFakeClock()
-	now := clock.Now().UTC()
+	now := time.Now().UTC()
 	day := 24 * time.Hour
 
-	maxDuration := clock.Now().UTC().Add(12 * day)
+	maxDuration := time.Now().UTC().Add(12 * day)
 
 	invalidMaxedAssumeStartTime := now.Add(constants.MaxAssumeStartDuration + (1 * day))
 	invalidExpiredAssumeStartTime := now.Add(100 * day)
 	validStartTime := now.Add(6 * day)
 
-	var createdReq types.AccessRequest
+	// create the access request object
+	req, err := services.NewAccessRequest(requesterUserName, "admins")
+	require.NoError(t, err)
+	req.SetMaxDuration(maxDuration)
 
-	t.Run("CreateAccessRequest, request a specific start time", func(t *testing.T) {
-		// create the access request object
-		req, err := services.NewAccessRequest(requesterUserName, "admins")
-		require.NoError(t, err)
-		req.SetMaxDuration(maxDuration)
+	req.SetAssumeStartTime(validStartTime)
+	createdReq, err := requesterClient.CreateAccessRequestV2(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, validStartTime, *createdReq.GetAssumeStartTime())
 
-		// invalid, greater than constants.MaxAssumeStartDuration
-		req.SetAssumeStartTime(invalidMaxedAssumeStartTime)
-		_, err = requesterClient.CreateAccessRequestV2(ctx, req)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time is too far in the future")
-
-		// invalid, after access expiry time
-		req.SetAssumeStartTime(invalidExpiredAssumeStartTime)
-		_, err = requesterClient.CreateAccessRequestV2(ctx, req)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time cannot equal or exceed access expiry time")
-
-		// valid start time
-		req.SetAssumeStartTime(validStartTime)
-		createdReq, err = requesterClient.CreateAccessRequestV2(ctx, req)
-		require.NoError(t, err)
-		require.Equal(t, validStartTime, *createdReq.GetAssumeStartTime())
-	})
-
-	var changedStartTime time.Time
-	t.Run("SubmitAccessReview, initial change requested start time", func(t *testing.T) {
-		review := types.AccessReviewSubmission{
-			RequestID: createdReq.GetName(),
-			Review: types.AccessReview{
-				Author:        "admin",
-				ProposedState: types.RequestState_APPROVED,
-			},
-		}
-
-		// invalid, greater than constants.MaxAssumeStartDuration
-		review.Review.AssumeStartTime = &invalidMaxedAssumeStartTime
-		_, err := testPack.tlsServer.AuthServer.AuthServer.SubmitAccessReview(ctx, review)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time is too far in the future")
-
-		// invalid, after access expiry time
-		review.Review.AssumeStartTime = &invalidExpiredAssumeStartTime
-		_, err = testPack.tlsServer.AuthServer.AuthServer.SubmitAccessReview(ctx, review)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time cannot equal or exceed access expiry time")
-
-		// valid, changed start time
-		changedStartTime = validStartTime.Add(-day * 2)
-		review.Review.AssumeStartTime = &changedStartTime
-		resp, err := testPack.tlsServer.AuthServer.AuthServer.SubmitAccessReview(ctx, review)
-		require.NoError(t, err)
-		require.Equal(t, changedStartTime, *resp.GetAssumeStartTime())
-	})
-
-	t.Run("SetAccessRequestState, subsequent change changed start time", func(t *testing.T) {
-		// double check current assume start time was from previous results.
-		resp, err := testPack.tlsServer.AuthServer.AuthServer.GetAccessRequests(ctx, types.AccessRequestFilter{})
-		require.NoError(t, err)
-		require.Len(t, resp, 1)
-		require.Equal(t, changedStartTime, *resp[0].GetAssumeStartTime())
-
-		update := types.AccessRequestUpdate{
-			RequestID: createdReq.GetName(),
-			State:     types.RequestState_APPROVED,
-		}
-
-		// invalid, greater than constants.MaxAssumeStartDuration
-		update.AssumeStartTime = &invalidMaxedAssumeStartTime
-		err = testPack.tlsServer.Auth().SetAccessRequestState(ctx, update)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time is too far in the future")
-
-		// invalid, after access expiry time
-		update.AssumeStartTime = &invalidExpiredAssumeStartTime
-		err = testPack.tlsServer.Auth().SetAccessRequestState(ctx, update)
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
-		require.Contains(t, err.Error(), "assume start time cannot equal or exceed access expiry time")
-
-		// valid, changed again start time
-		changedAgainStartTime := changedStartTime.Add(-day * 2)
-		update.AssumeStartTime = &changedAgainStartTime
-		err = testPack.tlsServer.Auth().SetAccessRequestState(ctx, update)
-		require.NoError(t, err)
-
-		// double check accesss request was updated.
-		resp, err = testPack.tlsServer.AuthServer.AuthServer.GetAccessRequests(ctx, types.AccessRequestFilter{})
-		require.NoError(t, err)
-		require.Len(t, resp, 1)
-		require.Equal(t, changedAgainStartTime, *resp[0].GetAssumeStartTime())
-	})
+	return accessRequestWithStartTime{
+		testPack:                      testPack,
+		requesterClient:               requesterClient,
+		invalidMaxedAssumeStartTime:   invalidMaxedAssumeStartTime,
+		invalidExpiredAssumeStartTime: invalidExpiredAssumeStartTime,
+		validStartTime:                validStartTime,
+		maxDuration:                   maxDuration,
+		requesterUserName:             requesterUserName,
+		createdRequest:                createdReq,
+	}
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4986,7 +4986,7 @@ func (a *Server) submitAccessReview(
 
 	// final permission checks and review application must be done by the local backend
 	// service, as their validity depends upon optimistic locking.
-	req, err := a.ApplyAccessReview(ctx, params, checker, a.clock)
+	req, err := a.ApplyAccessReview(ctx, params, checker)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4986,7 +4986,7 @@ func (a *Server) submitAccessReview(
 
 	// final permission checks and review application must be done by the local backend
 	// service, as their validity depends upon optimistic locking.
-	req, err := a.ApplyAccessReview(ctx, params, checker)
+	req, err := a.ApplyAccessReview(ctx, params, checker, a.clock)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -48,9 +48,9 @@ const (
 	// A day is sometimes 23 hours, sometimes 25 hours, usually 24 hours.
 	day = 24 * time.Hour
 
-	// maxAccessDuration is the maximum duration that an access request can be
+	// MaxAccessDuration is the maximum duration that an access request can be
 	// granted for.
-	maxAccessDuration = 14 * day
+	MaxAccessDuration = 14 * day
 
 	// requestTTL is the the TTL for an access request, i.e. the amount of time that
 	// the access request can be reviewed. Defaults to 1 week.
@@ -272,7 +272,7 @@ type DynamicAccessExt interface {
 	// CreateAccessRequest stores a new access request.
 	CreateAccessRequest(ctx context.Context, req types.AccessRequest) error
 	// ApplyAccessReview applies a review to a request in the backend and returns the post-application state.
-	ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker ReviewPermissionChecker) (types.AccessRequest, error)
+	ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker ReviewPermissionChecker, clock clockwork.Clock) (types.AccessRequest, error)
 	// UpsertAccessRequest creates or updates an access request.
 	UpsertAccessRequest(ctx context.Context, req types.AccessRequest) error
 	// DeleteAllAccessRequests deletes all existent access requests.
@@ -377,15 +377,15 @@ func ValidateAccessPredicates(role types.Role) error {
 	}
 
 	if maxDuration := role.GetAccessRequestConditions(types.Allow).MaxDuration; maxDuration.Duration() != 0 &&
-		maxDuration.Duration() > maxAccessDuration {
-		return trace.BadParameter("max access duration must be less than or equal to %v", maxAccessDuration)
+		maxDuration.Duration() > MaxAccessDuration {
+		return trace.BadParameter("max access duration must be less than or equal to %v", MaxAccessDuration)
 	}
 
 	return nil
 }
 
 // ApplyAccessReview attempts to apply the specified access review to the specified request.
-func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author UserState) error {
+func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author UserState, clock clockwork.Clock) error {
 	if rev.Author != author.GetName() {
 		return trace.BadParameter("mismatched review author (expected %q, got %q)", rev.Author, author)
 	}
@@ -426,8 +426,8 @@ func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author U
 	req.SetReviews(append(req.GetReviews(), rev))
 
 	if rev.AssumeStartTime != nil {
-		if rev.AssumeStartTime.After(req.GetAccessExpiry()) {
-			return trace.BadParameter("request start time is after expiry")
+		if err := types.ValidateAssumeStartTime(*rev.AssumeStartTime, req.GetAccessExpiry(), req.GetCreationTime()); err != nil {
+			return trace.Wrap(err)
 		}
 		req.SetAssumeStartTime(*rev.AssumeStartTime)
 	}
@@ -1222,6 +1222,13 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		req.SetAccessExpiry(accessTTL)
 		// Adjusted max access duration is equal to the access expiry time.
 		req.SetMaxDuration(accessTTL)
+
+		if req.GetAssumeStartTime() != nil {
+			assumeStartTime := *req.GetAssumeStartTime()
+			if err := types.ValidateAssumeStartTime(assumeStartTime, accessTTL, req.GetCreationTime()); err != nil {
+				return trace.Wrap(err)
+			}
+		}
 	}
 
 	return nil
@@ -1242,13 +1249,13 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest) (
 	// For dry run requests, use the maximum possible duration.
 	// This prevents the time drift that can occur as the value is set on the client side.
 	if req.GetDryRun() {
-		maxDuration = maxAccessDuration
+		maxDuration = MaxAccessDuration
 	} else if maxDuration < 0 {
 		return 0, trace.BadParameter("invalid maxDuration: must be greater than creation time")
 	}
 
-	if maxDuration > maxAccessDuration {
-		return 0, trace.BadParameter("max_duration must be less than or equal to %v", maxAccessDuration)
+	if maxDuration > MaxAccessDuration {
+		return 0, trace.BadParameter("max_duration must be less than or equal to %v", MaxAccessDuration)
 	}
 
 	minAdjDuration := maxDuration

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -272,7 +272,7 @@ type DynamicAccessExt interface {
 	// CreateAccessRequest stores a new access request.
 	CreateAccessRequest(ctx context.Context, req types.AccessRequest) error
 	// ApplyAccessReview applies a review to a request in the backend and returns the post-application state.
-	ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker ReviewPermissionChecker, clock clockwork.Clock) (types.AccessRequest, error)
+	ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker ReviewPermissionChecker) (types.AccessRequest, error)
 	// UpsertAccessRequest creates or updates an access request.
 	UpsertAccessRequest(ctx context.Context, req types.AccessRequest) error
 	// DeleteAllAccessRequests deletes all existent access requests.
@@ -385,7 +385,7 @@ func ValidateAccessPredicates(role types.Role) error {
 }
 
 // ApplyAccessReview attempts to apply the specified access review to the specified request.
-func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author UserState, clock clockwork.Clock) error {
+func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author UserState) error {
 	if rev.Author != author.GetName() {
 		return trace.BadParameter("mismatched review author (expected %q, got %q)", rev.Author, author)
 	}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -644,7 +644,7 @@ func TestReviewThresholds(t *testing.T) {
 					propose:         approve,
 					assumeStartTime: clock.Now().UTC().Add(10000 * time.Hour),
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorIs(tt, err, trace.BadParameter("request start time is after expiry"), i...)
+						require.ErrorContains(tt, err, "assume start time must be prior to access expiry time", i...)
 					},
 				},
 			},

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -154,7 +153,7 @@ func (s *DynamicAccessService) SetAccessRequestState(ctx context.Context, params
 }
 
 // ApplyAccessReview applies a review to a request and returns the post-application state.
-func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker services.ReviewPermissionChecker, clock clockwork.Clock) (types.AccessRequest, error) {
+func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params types.AccessReviewSubmission, checker services.ReviewPermissionChecker) (types.AccessRequest, error) {
 	if err := params.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -188,7 +187,7 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 		}
 
 		// run the application logic
-		if err := services.ApplyAccessReview(req, params.Review, checker.UserState, clock); err != nil {
+		if err := services.ApplyAccessReview(req, params.Review, checker.UserState); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -626,7 +626,7 @@ func defaultAllowAccessRequestConditions(enterprise bool) map[string]*types.Acce
 				SearchAsRoles: []string{
 					teleport.SystemOktaAccessRoleName,
 				},
-				MaxDuration: types.NewDuration(maxAccessDuration),
+				MaxDuration: types.NewDuration(MaxAccessDuration),
 			},
 		}
 	}

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
@@ -261,10 +260,6 @@ func (c *AccessRequestCommand) Approve(ctx context.Context, client *auth.Client)
 		parsedAssumeStartTime, err := time.Parse(time.RFC3339, c.assumeStartTimeRaw)
 		if err != nil {
 			return trace.BadParameter("parsing assume-start-time (required format RFC3339 e.g 2023-12-12T23:20:50.52Z): %v", err)
-		}
-		if time.Until(parsedAssumeStartTime) > constants.MaxAssumeStartDuration {
-			return trace.BadParameter("assume-start-time too far in future: latest date %q",
-				parsedAssumeStartTime.Add(constants.MaxAssumeStartDuration).Format(time.RFC3339))
 		}
 		assumeStartTime = &parsedAssumeStartTime
 	}

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -222,7 +222,6 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 		table.AddRow([]string{"Access Expires:", req.GetAccessExpiry().Local().Format(time.DateTime)})
 	}
 	if req.GetAssumeStartTime() != nil {
-		table.AddRow([]string{"Assume Start Time (UTC):", req.GetAssumeStartTime().UTC().Format(time.RFC822)})
 		table.AddRow([]string{"Assume Start Time:", req.GetAssumeStartTime().Local().Format(time.DateTime)})
 	}
 	table.AddRow([]string{"Status:", req.GetState().String()})

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -223,6 +223,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 	if req.GetAssumeStartTime() != nil {
 		table.AddRow([]string{"Assume Start Time (UTC):", req.GetAssumeStartTime().UTC().Format(time.RFC822)})
+		table.AddRow([]string{"Assume Start Time:", req.GetAssumeStartTime().Local().Format(time.DateTime)})
 	}
 	table.AddRow([]string{"Status:", req.GetState().String()})
 

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/api/accessrequest"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/constants"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -317,10 +316,6 @@ func onRequestReview(cf *CLIConf) error {
 			return trace.BadParameter("parsing assume-start-time (required format RFC3339 e.g 2023-12-12T23:20:50.52Z): %v", err)
 		}
 		parsedAssumeStartTime = &assumeStartTime
-		if time.Until(*parsedAssumeStartTime) > constants.MaxAssumeStartDuration {
-			return trace.BadParameter("assume-start-time too far in future: latest date %q",
-				parsedAssumeStartTime.Add(constants.MaxAssumeStartDuration).Format(time.RFC3339))
-		}
 	}
 
 	var state types.RequestState

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2471,10 +2471,6 @@ func createAccessRequest(cf *CLIConf) (types.AccessRequest, error) {
 			return nil, trace.BadParameter("parsing assume-start-time (required format RFC3339 e.g 2023-12-12T23:20:50.52Z): %v", err)
 		}
 
-		if time.Until(assumeStartTime) > constants.MaxAssumeStartDuration {
-			return nil, trace.BadParameter("assume-start-time too far in future: latest date %q",
-				assumeStartTime.Add(constants.MaxAssumeStartDuration).Format(time.RFC3339))
-		}
 		req.SetAssumeStartTime(assumeStartTime)
 	}
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/35436

While testing i ran into some issues. Fixes the following:
- Set modified start time from `tctl requests approve` (we allowed modifying in client, but was not being set in the backend)
- Removed incorrect validation in the client, and placed validation near backend (this also avoids us having to repeat validation for other clients like teleterm and web)
- Correct calculation of `maxest start time` allowed in the error message when user goes too far
- Correct start time validation
    - Start time should be after or equal to request creation time
        - Note that creation time will always be set before validation starts so it’ll never be a zero value
          - When creating, we validate after the creation time was set
          - When reviewing or updating, we validate after we retrieve the created request
    - Start time should be before access expiry
    - Start time cannot exceed `constants.MaxAssumeStartTimeDuration` FROM the creation date (eg: if the const was 1 week max, then the start time cannot exceed one week from creation time, even if access expiry is set for 2 weeks)
- When printing tsh request, use local date time format to display start time, since access expiry also uses the same format (it was confusing to display two different time formats)

Extra context, we allow modifying assume start time in the following places and is where the validations are placed:

- CreateAccessRequestV2
- SubmitAccessReview
- SetAccessRequestState (used with tctl)

Manual Testing:

```bash
# Starting profile:
> Profile URL:        https://proxy.0.0.0.0.nip.io:3080
  Logged in as:       sevy
  Cluster:            im-a-cluster-name
  Roles:              requester
  Kubernetes:         disabled
  Valid until:        2024-03-06 10:59:38 -0800 PST [valid for 12h0m0s]
  Extensions:         login-ip, permit-port-forwarding, permit-pty, private-key-policy

# requesting pass the expiry
$ ./tsh request create --roles=access --assume-start-time=2024-03-09T23:20:50.52Z 
Creating request...
ERROR: assume start time cannot equal or exceed access expiry time at: "2024-03-06T18:59:37Z"

# requesting before the creation time
$ ./tsh request create --roles=access --assume-start-time=2023-03-09T23:20:50.52Z 
Creating request...
ERROR: assume start time has to be greater than: "2024-03-06T07:00:06Z"

# requesting too far into future (currently the const limits to 1 week)
# the max duration was increased in the role to 14 days
$ ./tsh request create --roles=access --assume-start-time=2024-03-13T23:20:50.52Z --max-duration=12d
Creating request...
ERROR: assume start time is too far in the future, latest time allowed "2024-03-13T07:04:25Z"

# valid request and consistent time display
$ ./tsh request create --roles=access --assume-start-time=2024-03-10T23:20:50.52Z --max-duration=13d
Creating request...
Request ID:        018e1294-df3d-7ae5-a00d-7a964e39a54f 
Username:          sevy                                 
Roles:             access                               
Reason:            [none]                               
Reviewers:         [none] (suggested)                   
Access Expires:    2024-03-19 00:05:30                  
Assume Start Time: 2024-03-10 16:20:50                  
Status:            PENDING  

Waiting for request approval...

Approval received, getting updated certificates...

# approved with `tctl requests approve` with a modified start time
ERROR: access request "018e1294-df3d-7ae5-a00d-7a964e39a54f" can not be assumed until 2024-03-07 23:20:50.52 +0000 UTC
```

changelog: Fixes allowing invalid access request start time date to be set