### PR TITLE
Add rotate360 keyframes

### DIFF
--- a/web/packages/design/src/Indicator/Indicator.jsx
+++ b/web/packages/design/src/Indicator/Indicator.jsx
@@ -22,6 +22,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import { Spinner as SpinnerIcon } from '../Icon';
+import { rotate360 } from '../keyframes';
 
 const DelayValueMap = {
   none: 0,
@@ -74,20 +75,11 @@ const StyledSpinner = styled(SpinnerIcon)`
   display: inline-block;
 
   svg {
-    animation: anim-rotate 1.5s infinite linear;
+    animation: ${rotate360} 1.5s infinite linear;
     ${({ size = '48px' }) => `
     height: ${size};
     width: ${size};
   `}
-  }
-
-  @keyframes anim-rotate {
-    0% {
-      transform: rotate(0);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
   }
 `;
 

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -88,3 +88,4 @@ export {
   Toggle,
 };
 export type { TextAreaProps } from './TextArea';
+export * from './keyframes';

--- a/web/packages/design/src/keyframes.ts
+++ b/web/packages/design/src/keyframes.ts
@@ -1,0 +1,34 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keyframes } from 'styled-components';
+
+/**
+ * Full rotation of an element.
+ *
+ * @example
+ * import { rotate360 } from 'design'
+ *
+ * const Spinner = styled.div`
+ *   animation: ${rotate360} 1s linear infinite;
+ * `
+ */
+export const rotate360 = keyframes`
+  from { transform: rotate(0deg);   }
+  to   { transform: rotate(360deg); }
+`;

--- a/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
+++ b/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
@@ -27,7 +27,7 @@ import { Text, Box } from 'design';
 import { ClusterDropdown } from './ClusterDropdown';
 
 export default {
-  title: 'ClusterDropdown',
+  title: 'Shared/ClusterDropdown',
 };
 
 const fetchClusters = () => null;

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
@@ -17,7 +17,8 @@
  */
 
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { rotate360 } from 'design';
 
 import { MonospacedOutput } from 'teleport/Assist/shared/MonospacedOutput';
 
@@ -47,12 +48,6 @@ const Header = styled.div`
   padding-right: 20px;
 `;
 
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
-
 const Spinner = styled.div`
   width: 20px;
   height: 20px;
@@ -67,7 +62,7 @@ const Spinner = styled.div`
     border: 3px solid ${p => p.theme.colors.text.main};
     border-color: ${p => p.theme.colors.text.main} transparent
       ${p => p.theme.colors.text.main} transparent;
-    animation: ${spin} 1.2s linear infinite;
+    animation: ${rotate360} 1.2s linear infinite;
   }
 `;
 

--- a/web/packages/teleport/src/Assist/MessageBox/MessageBox.tsx
+++ b/web/packages/teleport/src/Assist/MessageBox/MessageBox.tsx
@@ -24,15 +24,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { rotate360 } from 'design';
 
 import { useAssist } from 'teleport/Assist/context/AssistContext';
-
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
 
 interface MessageBoxProps {
   disabled?: boolean;
@@ -58,7 +53,7 @@ const Spinner = styled.div`
     border: 3px solid ${p => p.theme.colors.text.main};
     border-color: ${p => p.theme.colors.text.main} transparent
       ${p => p.theme.colors.text.main} transparent;
-    animation: ${spin} 1.2s linear infinite;
+    animation: ${rotate360} 1.2s linear infinite;
   }
 `;
 

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Spinner } from 'design/Icon';
-import { Box, Flex } from 'design';
+import { Box, Flex, rotate360 } from 'design';
 
 import auth from 'teleport/services/auth';
 import { useParams } from 'teleport/components/Router';
@@ -138,13 +138,5 @@ export function HeadlessRequest() {
 const Spin = styled(Box)`
   line-height: 12px;
   font-size: 24px;
-  animation: spin 1s linear infinite;
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
+  animation: ${rotate360} 1s linear infinite;
 `;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/ProgressBar.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/ProgressBar.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
-import { Flex, Box } from 'design';
+import { Flex, Box, rotate360 } from 'design';
 import * as icons from 'design/Icon';
 import { decomposeColor, emphasize } from 'design/theme/utils/colorManipulator';
 import { AttemptStatus } from 'shared/hooks/useAsync';
@@ -161,13 +161,5 @@ const Spinner = styled.div`
   width: 24px;
   height: 24px;
   position: absolute;
-  animation: spinner 4s linear infinite;
-  @keyframes spinner {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
+  animation: ${rotate360} 4s linear infinite;
 `;


### PR DESCRIPTION
When working on the UI for VNet, I had to add yet another spinning element. This PR adds a single keyframes definition to the design package and it refactors existing callsites which use keyframes for the spinning animation.

This way the next time I have to implement something that is spinning, I won't have to recall how to use `animation` and how to use `keyframes` with other parts of styled-components.