### PR TITLE
Fix auth connector imports

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -36,7 +36,7 @@ import DeleteConnectorDialog from './DeleteConnectorDialog';
 import useAuthConnectors, { State } from './useAuthConnectors';
 import templates from './templates';
 
-export default function Container() {
+export function AuthConnectorsContainer() {
   const state = useAuthConnectors();
   return <AuthConnectors {...state} />;
 }

--- a/web/packages/teleport/src/AuthConnectors/index.ts
+++ b/web/packages/teleport/src/AuthConnectors/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { AuthConnectors } from './AuthConnectors';
+export { AuthConnectors, AuthConnectorsContainer } from './AuthConnectors';

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -60,7 +60,7 @@ import { Users } from './Users';
 import { RolesContainer as Roles } from './Roles';
 import { DeviceTrustLocked } from './DeviceTrust';
 import { RecordingsContainer as Recordings } from './Recordings';
-import { AuthConnectors } from './AuthConnectors';
+import { AuthConnectorsContainer as AuthConnectors } from './AuthConnectors';
 import { Locks } from './LocksV2/Locks';
 import { NewLockView } from './LocksV2/NewLock';
 import { Discover } from './Discover';


### PR DESCRIPTION
This PR fixes the import for auth connectors. I missed the container default export when removing code splitting