### PR TITLE
Support `tsh login -i`

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -106,6 +106,10 @@ type Profile struct {
 
 	// PIVSlot is a specific piv slot that Teleport clients should use for hardware key support.
 	PIVSlot keys.PIVSlot `yaml:"piv_slot"`
+
+	// MissingClusterDetails means this profile was created with limited cluster details.
+	// Missing cluster details should be loaded into the profile by pinging the proxy.
+	MissingClusterDetails bool
 }
 
 // Copy returns a shallow copy of p, or nil if p is nil.

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -835,7 +835,12 @@ func LoadIdentityFileIntoClientStore(store *client.Store, identityFile, proxyAdd
 		return trace.Wrap(err)
 	}
 
-	// Load the client key from the agent.
+	// This key may already exist in a tsh profile, delete it before overwriting
+	// it with the identity key to avoid leaving app/db/kube certs from the old key.
+	if err := store.DeleteKey(key.KeyIndex); err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
 	if err := store.AddKey(key); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -448,10 +448,11 @@ func TestNewClientStoreFromIdentityFile(t *testing.T) {
 	retrievedProfile, err := clientStore.GetProfile(currentProfile)
 	require.NoError(t, err)
 	require.Equal(t, &profile.Profile{
-		WebProxyAddr:     key.ProxyHost + ":3080",
-		SiteName:         key.ClusterName,
-		Username:         key.Username,
-		PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+		WebProxyAddr:          key.ProxyHost + ":3080",
+		SiteName:              key.ClusterName,
+		Username:              key.Username,
+		PrivateKeyPolicy:      keys.PrivateKeyPolicyNone,
+		MissingClusterDetails: true,
 	}, retrievedProfile)
 
 	retrievedKey, err := clientStore.GetKey(key.KeyIndex, client.WithAllCerts...)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1123,6 +1123,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	mfa := newMFACommand(app)
 
 	flatten := app.Command("flatten", "Flattens an identity file into a profile stored in ~/.tsh or TELEPORT_HOME.")
+	flatten.Arg("identity", "Identity file").StringVar(&cf.IdentityFileIn)
 
 	config := app.Command("config", "Print OpenSSH configuration details.")
 	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
@@ -4156,9 +4157,6 @@ func refuseArgs(command string, args []string) error {
 func onFlatten(cf *CLIConf) error {
 	// Save the identity file path for later
 	identityFile := cf.IdentityFileIn
-	if identityFile == "" {
-		return trace.BadParameter("-i must be specified")
-	}
 	if cf.Proxy == "" {
 		return trace.BadParameter("--proxy must be specified")
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3116,7 +3116,9 @@ func onListSessions(cf *CLIConf) error {
 
 func sortAndFilterSessions(sessions []types.SessionTracker, kinds []types.SessionKind) []types.SessionTracker {
 	filtered := slices.DeleteFunc(sessions, func(st types.SessionTracker) bool {
-		return !slices.Contains(kinds, st.GetSessionKind())
+		return !slices.Contains(kinds, st.GetSessionKind()) ||
+			(st.GetState() != types.SessionState_SessionStateRunning &&
+				st.GetState() != types.SessionState_SessionStatePending)
 	})
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].GetCreated().Before(filtered[j].GetCreated())

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3564,15 +3564,16 @@ func makeClientForProxy(cf *CLIConf, proxy string) (*client.TeleportClient, erro
 
 	// If we are missing client profile information, ping the webproxy
 	// for proxy info and load it into the client config.
-	if profileError != nil || cf.IdentityFileIn != "" {
+	if profileError != nil || profile.MissingClusterDetails {
 		log.Debug("Pinging the proxy to fetch listening addresses for non-web ports.")
 		_, err := tc.Ping(cf.Context)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		// Identityfile uses a placeholder profile. Save missing profile info.
-		if cf.IdentityFileIn != "" {
+		// This is a placeholder profile created from limited cluster details.
+		// Save missing cluster details gathererd during Ping.
+		if profileError == nil && profile.MissingClusterDetails {
 			if err := tc.SaveProfile(true); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -4160,38 +4161,26 @@ func onFlatten(cf *CLIConf) error {
 		return trace.BadParameter("--proxy must be specified")
 	}
 
-	// Making a client validates the connection and builds a valid profile for us
-	tc, err := makeClientForProxy(cf, cf.Proxy)
-	if err != nil {
-		return trace.Wrap(err, "making client for proxy")
-	}
-	profile := tc.Profile()
-
-	// We clear the identity flag and create a new client store.
-	// Because the identity flag is unset, it will be backed by the filesystem (in ~/.tsh or TELEPORT_HOME).
+	// We clear the identity flag so that the client store will be backed
+	// by the filesystem instead (in ~/.tsh or TELEPORT_HOME).
 	cf.IdentityFileIn = ""
-	store, err := initClientStore(cf, cf.Proxy)
+
+	// Load client config as normal to parse client inputs and add defaults.
+	c, err := loadClientConfigFromCLIConf(cf, cf.Proxy)
 	if err != nil {
-		return trace.Wrap(err, "initializing client store")
+		return trace.Wrap(err)
 	}
 
-	// Now we extract the key from the identity file and load it into our new store.
-	key, err := identityfile.KeyFromIdentityFile(identityFile, cf.Proxy, cf.SiteName)
-	if err != nil {
-		return trace.Wrap(err, "loading key from identity file")
+	// Load the identity file key and partial profile into the client store.
+	if err := identityfile.LoadIdentityFileIntoClientStore(c.ClientStore, identityFile, c.WebProxyAddr, c.SiteName); err != nil {
+		return trace.Wrap(err)
 	}
 
-	if err = store.AddKey(key); err != nil {
-		return trace.Wrap(err, "adding key into the client store")
-	}
+	fmt.Printf("Successfully flattened Identity file %q into a tsh profile.\n", identityFile)
 
-	// Finally we also save the profile built by the client into our new store.
-	if err := store.SaveProfile(profile, true); err != nil {
-		return trace.Wrap(err, "saving profile")
-	}
-
-	fmt.Printf("Identity file %q flattented into a tsh profile.", identityFile)
-	return nil
+	// onStatus will ping the proxy to fill in cluster profile information missing in the
+	// client store, then print the login status.
+	return trace.Wrap(onStatus(cf))
 }
 
 // onShow reads an identity file (a public SSH key or a cert) and dumps it to stdout

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1753,7 +1753,11 @@ func onLogin(cf *CLIConf) error {
 	}
 
 	if cf.IdentityFileIn != "" {
-		return trace.Wrap(flattenIdentity(cf), "converting identity file into a local profile")
+		err := flattenIdentity(cf)
+		if err != nil {
+			return trace.Wrap(err, "converting identity file into a local profile")
+		}
+		return nil
 	}
 
 	switch cf.IdentityFormat {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4157,9 +4157,6 @@ func refuseArgs(command string, args []string) error {
 func onFlatten(cf *CLIConf) error {
 	// Save the identity file path for later
 	identityFile := cf.IdentityFileIn
-	if cf.Proxy == "" {
-		return trace.BadParameter("--proxy must be specified")
-	}
 
 	// We clear the identity flag so that the client store will be backed
 	// by the filesystem instead (in ~/.tsh or TELEPORT_HOME).
@@ -4169,6 +4166,11 @@ func onFlatten(cf *CLIConf) error {
 	c, err := loadClientConfigFromCLIConf(cf, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	// Proxy address may be loaded from existing tsh profile or from --proxy flag.
+	if c.WebProxyAddr == "" {
+		return trace.BadParameter("No proxy address specified, missed --proxy flag?")
 	}
 
 	// Load the identity file key and partial profile into the client store.

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5416,6 +5416,7 @@ func TestFlatten(t *testing.T) {
 	_, err = clt.Ping(context.Background())
 	require.NoError(t, err)
 
-	// Test execution: validate that flattening fails if a profile already exists.
-	require.Error(t, onFlatten(&conf), "expecting an error when overwriting an existing profile")
+	// Test execution: validate that flattening succeeds if a profile already exists.
+	conf.IdentityFileIn = identityPath
+	require.NoError(t, onFlatten(&conf), "unexpected error when overwriting a tsh profile with tsh flatten")
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5407,7 +5407,7 @@ func TestFlatten(t *testing.T) {
 		HomePath:           freshHome,
 		Context:            context.Background(),
 	}
-	require.NoError(t, onFlatten(&conf))
+	require.NoError(t, flattenIdentity(&conf))
 
 	// Test execution: validate that the newly created profile can be used to build a valid client.
 	clt, err := makeClient(&conf)
@@ -5418,5 +5418,5 @@ func TestFlatten(t *testing.T) {
 
 	// Test execution: validate that flattening succeeds if a profile already exists.
 	conf.IdentityFileIn = identityPath
-	require.NoError(t, onFlatten(&conf), "unexpected error when overwriting a tsh profile with tsh flatten")
+	require.NoError(t, flattenIdentity(&conf), "unexpected error when overwriting a tsh profile")
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5389,7 +5389,7 @@ func TestFlatten(t *testing.T) {
 		IdentityFormat:     identityfile.FormatFile,
 		HomePath:           home,
 		AuthConnector:      connector.GetName(),
-		MockSSOLogin:       mockSSOLogin(t, authServer, alice),
+		MockSSOLogin:       mockSSOLogin(authServer, alice),
 		Context:            context.Background(),
 	}
 	require.NoError(t, onLogin(&conf))


### PR DESCRIPTION
This is another attempt of solving https://github.com/gravitational/teleport/issues/38592

This PR adds support for `tsh login -i identity.pem`. The command tests cluster connectivity and flattens the identity file into a local tsh profile. SUbsequent commands don't need an identity anymore. This is also a workaround for the `tsh apps login` issue when using an identity (tsh puts certs in an in-memory store, which is lost when tsh exist).

This is useful if you have a long-lived identity file for a service user and want to run the command as this user. (MachineID is better, but it's not always available).

Supersedes: https://github.com/gravitational/teleport/pull/38594

changelog: Support logging in with an identity file with `tsh login -i identity.pem`. This allows running `tsh app login` in CI environments where MachineID is impossible.