### PR TITLE
Use an absolute path in `ExecReload` in `teleport.service`

### DIFF
--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 


### PR DESCRIPTION
In #37773, we changed the `ExecReload` in the systemd service file to use `pkill`, but while doing so, we ended up making it a relative path, which is only valid for systemd 239+, while Ubuntu 18.04 uses systemd 237 and CentOS 7 uses systemd 219.

This PR changes `ExecReload` to use `/bin/sh` (absolute path) to launch `pkill`.

Fixes #39001

changelog: fix compatibility of the Teleport service file with older versions of systemd