### PR TITLE
[v15] Use an absolute path in `ExecReload` in `teleport.service`

### DIFF
--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 


### PR DESCRIPTION
Backport #39028 to branch/v15

changelog: fix compatibility of the Teleport service file with older versions of systemd
