### PR TITLE
[v14] Remove Teleport Team mentions from the docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -31,18 +31,12 @@
             {
               "title": "Teleport Cloud Agents (Linux)",
               "slug": "/upgrading/cloud-linux/",
-              "forScopes": [
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["cloud"]
             },
             {
               "title": "Teleport Cloud Agents (Kubernetes)",
               "slug": "/upgrading/cloud-kubernetes/",
-              "forScopes": [
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["cloud"]
             },
             {
               "title": "Self-Hosted Linux",
@@ -76,11 +70,7 @@
         {
           "title": "Usage Reporting and Billing",
           "slug": "/usage-billing/",
-          "forScopes": [
-            "cloud",
-            "team",
-            "enterprise"
-          ]
+          "forScopes": ["cloud", "enterprise"]
         },
         {
           "title": "Upcoming Releases",
@@ -93,10 +83,7 @@
         {
           "title": "Teleport Assist",
           "slug": "/ai-assist/",
-          "forScopes": [
-            "oss",
-            "team"
-          ]
+          "forScopes": ["oss"]
         }
       ]
     },
@@ -109,19 +96,17 @@
           "slug": "/choose-an-edition/introduction/"
         },
         {
-          "title": "Teleport Team",
-          "slug": "/choose-an-edition/teleport-team/",
-          "forScopes": [
-            "team"
-          ]
-        },
-        {
           "title": "Teleport Enterprise Cloud",
           "slug": "/choose-an-edition/teleport-cloud/introduction/",
           "forScopes": [
             "cloud"
           ],
           "entries": [
+            {
+              "title": "Get Started",
+              "slug": "/choose-an-edition/teleport-cloud/get-started/",
+              "forScopes": ["cloud"]
+            },
             {
               "title": "Architecture",
               "slug": "/choose-an-edition/teleport-cloud/architecture/",
@@ -410,12 +395,7 @@
         {
           "title": "Single Sign-On (SSO)",
           "slug": "/access-controls/sso/",
-          "forScopes": [
-            "oss",
-            "team",
-            "enterprise",
-            "cloud"
-          ],
+          "forScopes": ["oss", "enterprise", "cloud"],
           "entries": [
             {
               "title": "Active Directory (ADFS)",
@@ -435,7 +415,8 @@
             },
             {
               "title": "GitHub",
-              "slug": "/access-controls/sso/github-sso/"
+              "slug": "/access-controls/sso/github-sso/",
+              "forScopes": ["oss", "enterprise", "cloud"]
             },
             {
               "title": "GitLab",
@@ -482,47 +463,27 @@
         {
           "title": "Teleport as an IdP",
           "slug": "/access-controls/idps/",
-          "forScopes": [
-            "enterprise",
-            "cloud",
-            "team"
-          ],
+          "forScopes": ["enterprise", "cloud"],
           "entries": [
             {
               "title": "SAML Identity Provider Guide",
               "slug": "/access-controls/idps/saml-guide/",
-              "forScopes": [
-                "enterprise",
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["enterprise", "cloud"]
             },
             {
               "title": "SAML Attribute Mapping",
               "slug": "/access-controls/idps/saml-attribute-mapping/",
-              "forScopes": [
-                "enterprise",
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["enterprise", "cloud"]
             },
             {
               "title": "Authenticate to Grafana with Teleport SAML",
               "slug": "/access-controls/idps/saml-grafana/",
-              "forScopes": [
-                "enterprise",
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["enterprise", "cloud"]
             },
             {
               "title": "SAML Identity Provider Reference",
               "slug": "/access-controls/idps/saml-reference/",
-              "forScopes": [
-                "enterprise",
-                "cloud",
-                "team"
-              ]
+              "forScopes": ["enterprise", "cloud"]
             }
           ]
         },
@@ -572,8 +533,7 @@
           "slug": "/access-controls/device-trust/",
           "forScopes": [
             "enterprise",
-            "cloud",
-            "team"
+            "cloud"
           ],
           "entries": [
             {
@@ -581,8 +541,7 @@
               "slug": "/access-controls/device-trust/guide/",
               "forScopes": [
                 "enterprise",
-                "cloud",
-                "team"
+                "cloud"
               ]
             },
             {
@@ -590,8 +549,7 @@
               "slug": "/access-controls/device-trust/device-management/",
               "forScopes": [
                 "enterprise",
-                "cloud",
-                "team"
+                "cloud"
               ]
             },
             {
@@ -599,8 +557,7 @@
               "slug": "/access-controls/device-trust/enforcing-device-trust/",
               "forScopes": [
                 "enterprise",
-                "cloud",
-                "team"
+                "cloud"
               ]
             },
             {
@@ -643,7 +600,6 @@
           "title": "Access Graph",
           "slug": "/access-controls/access-graph/",
           "forScopes": [
-            "team",
             "enterprise"
           ],
           "entries": [
@@ -2683,7 +2639,7 @@
     },
     {
       "source": "/cloud/getting-started/",
-      "destination": "/choose-an-edition/teleport-team/",
+      "destination": "/choose-an-edition/teleport-cloud/get-started/",
       "permanent": true
     },
     {
@@ -2948,7 +2904,7 @@
     },
     {
       "source": "/deploy-a-cluster/teleport-cloud/getting-started/",
-      "destination": "/choose-an-edition/teleport-team/",
+      "destination": "/choose-an-edition/teleport-cloud/get-started/",
       "permanent": true
     },
     {
@@ -3048,7 +3004,7 @@
     },
     {
       "source": "/choose-an-edition/teleport-cloud/getting-started/",
-      "destination": "/choose-an-edition/teleport-team/",
+      "destination": "/choose-an-edition/teleport-cloud/get-started/",
       "permanent": true
     },
     {

--- a/docs/pages/access-controls/access-graph.mdx
+++ b/docs/pages/access-controls/access-graph.mdx
@@ -4,8 +4,7 @@ description: A reference for Teleport Access Graph.
 ---
 
 <Admonition type="tip" title="Preview">
-  Teleport Access Graph is currently in Preview. Currently, it is only available
-  to Teleport Team users, and only visualizes access to resources enrolled with your Teleport clusters.
+  Teleport Access Graph is currently in Preview.
 </Admonition>
 
 Teleport Access Graph visualizes and helps you understand access to your
@@ -16,6 +15,10 @@ questions like:
 - What resources can a specific user access?
 - What users can access a specific resource?
 - What are the relationships between users, roles, and resources?
+
+Teleport Access Graph is a feature of the [Teleport
+Policy](https://goteleport.com/platform/policy/) product that is only available
+to Teleport Enterprise customers.
 
 After logging into the Teleport UI, go to the Management tab. If enabled, Access Graph options can be found
 under the Permission Management section.

--- a/docs/pages/access-controls/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted-helm.mdx
@@ -14,9 +14,9 @@ and enable the Access Graph feature in your Teleport cluster.
 
 The full listing of supported parameters can be found in the [`teleport-access-graph` Helm chart reference](../../reference/helm-reference/teleport-access-graph.mdx).
 
-Teleport Access Graph is enabled by default for Teleport Team users.
-You can skip the setup process and start using Access Graph right away
-by signing up for a [Teleport Team trial](https://goteleport.com/signup/).
+Teleport Access Graph is a feature of the [Teleport
+Policy](https://goteleport.com/platform/policy/) product that is only available
+to Teleport Enterprise customers.
 
 ## Prerequisites
 

--- a/docs/pages/access-controls/access-graph/self-hosted.mdx
+++ b/docs/pages/access-controls/access-graph/self-hosted.mdx
@@ -11,9 +11,9 @@ to collect information about resources and access.
 This guide will help you set up the TAG service
 and enable the Access Graph feature in your Teleport cluster.
 
-Teleport Access Graph is enabled by default for Teleport Team users.
-You can skip the setup process here and start using Access Graph right away
-by signing up for a [Teleport Team trial](https://goteleport.com/signup/).
+Teleport Access Graph is a feature of the [Teleport
+Policy](https://goteleport.com/platform/policy/) product that is only available
+to Teleport Enterprise customers.
 
 ## Prerequisites
 

--- a/docs/pages/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/access-controls/idps/saml-guide.mdx
@@ -24,7 +24,7 @@ authenticate to external services.
 
 The minimum configuration values required to add a service provider are:
 1. **Entity ID:** The SAML metadata endpoint of the service provider.
-2. **ACS URL:** The endpoint where users will be redirected after SAML authentication. ACS URL
+1. **ACS URL:** The endpoint where users will be redirected after SAML authentication. ACS URL
 is also referred to as SAML SSO URL.
 
 The following `saml_idp_service_provider` spec is a reference for adding samltest.id to Teleport:

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -12,9 +12,8 @@ Teleport.
 
 - A GitHub organization with at least one team. 
 
-  In Teleport Community Edition and Teleport Team, this organization must not
-  have external SSO set up, or Teleport will refuse to create the GitHub
-  authentication connector.
+  In Teleport Community Edition, this organization must not have external SSO
+  set up, or Teleport will refuse to create the GitHub authentication connector.
 
   In Teleport Enterprise and Enterprise Cloud, organization can be hosted from
   either GitHub Cloud or GitHub Enterprise Server.

--- a/docs/pages/agents/deploy-agents-terraform.mdx
+++ b/docs/pages/agents/deploy-agents-terraform.mdx
@@ -36,7 +36,7 @@ see how an agent pool works. After you are familiar with the setup, apply the
 lessons from this guide to protect your infrastructure. You can get started with
 a demo cluster using:
 - A demo deployment on a [Linux server](../index.mdx)
-- A [Teleport Team trial](https://goteleport.com/signup)
+- A [Teleport Enterprise Cloud trial](https://goteleport.com/signup)
 
 </Admonition>
 

--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -28,15 +28,9 @@ Before you get started with Teleport Assist, make sure you have the following:
 - **OpenAI Account**: You will need an active OpenAI account with GPT-4 API
   access as Teleport Assist relies on OpenAI services.
 
-<Notice type="note">
-If you don't have access to OpenAI GPT-4 API, you can still try out Teleport
-Assist by signing up for a
-[Teleport Team plan](https://goteleport.com/pricing/).
-</Notice>
-
 Teleport Assist currently doesn't support Teleport clusters using the etcd backend.
 If your installation is using etcd, you can create a new cluster with
-any other backend or sign up for the Teleport Team plan.
+any other backend.
 
 ## Step 1/3. Generate an OpenAI API key
 

--- a/docs/pages/choose-an-edition/introduction.mdx
+++ b/docs/pages/choose-an-edition/introduction.mdx
@@ -8,15 +8,6 @@ which edition is most appropriate for your use case.
 
 ## Editions
 
-### Teleport Team
-
-Teleport Team makes it easier for small organizations to get started enabling
-secure access to their infrastructure. It includes a subset of Teleport
-Enterprise Cloud features, and teams can switch to Teleport Enterprise Cloud as
-they scale up.
-
-[Read more about Teleport Team](./teleport-team.mdx).
-
 ### Teleport Enterprise Cloud
 
 Our team at Teleport manages the Auth and Proxy Services, giving you a running

--- a/docs/pages/choose-an-edition/teleport-cloud/external-audit-storage.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/external-audit-storage.mdx
@@ -24,8 +24,7 @@ above.
 ## Prerequisites
 
 1. A Teleport Enterprise Cloud account. If you do not have one, [sign
-   up](https://goteleport.com/signup/) for a Teleport Team account and upgrade
-   to Teleport Enterprise Cloud.
+   up](https://goteleport.com/signup/) for a free trial.
 1. To store and query audit events and session recordings, you need to set up
    the following four components in an AWS account of your choosing. The
    Teleport Web UI walks you through the infrastructure you need to create, but

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -142,7 +142,7 @@ The ability to download recordings for offline viewing will be available in a fu
 
 ### Will Teleport be updated automatically?
 
-The Teleport Auth Service and Teleport Proxy Service for Teleport Team and Teleport Enterprise Cloud
+The Teleport Auth Service and Teleport Proxy Service for Teleport Enterprise Cloud
 are automatically kept up to date with patches and minor releases following the release schedule
 described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
 
@@ -153,10 +153,10 @@ described in [Teleport Upcoming Releases](../../upcoming-releases.mdx).
   during your scheduled maintenance window.
 - Teleport agents are only updated automatically if you enroll them in automatic updates.
 
-If you have Teleport agents connected to a Teleport Team or Teleport Enterprise
-cluster that are more than one major version behind, you might experience
-compatibility issues unless your agents are enrolled in automatic updates. See
-the [Upgrading Overview](../../upgrading/overview.mdx) for more information.
+If you have Teleport agents connected to a Teleport Enterprise Cloud cluster
+that are more than one major version behind, you might experience compatibility
+issues unless your agents are enrolled in automatic updates. See the [Upgrading
+Overview](../../upgrading/overview.mdx) for more information.
 
 To get version information for your agents, see [How can I find version information on
 connected agents?](#how-can-i-find-version-information-on-connected-agents).
@@ -185,9 +185,9 @@ new releases.
 
 ### When are agents automatically updated?
 
-Teleport Team and Teleport Enterprise Cloud must be set to receive automatic updates
-to use the Teleport Cloud version server for automatic agent updates. With automatic 
-agent updates, agents periodically check the version server for new releases and 
+Teleport Enterprise Cloud must be set to receive automatic updates to use the
+Teleport Cloud version server for automatic agent updates. With automatic agent
+updates, agents periodically check the version server for new releases and
 update the software when new versions are found.
 
 If you enroll in automatic agent updates, Teleport agents are automatically 

--- a/docs/pages/choose-an-edition/teleport-cloud/get-started.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/get-started.mdx
@@ -1,60 +1,63 @@
 ---
-title: "Introduction to Teleport Team"
-description: "Teleport Team makes it easy for small organizations set up secure role-based access control for their infrastructure."
+title: "Get Started with Teleport Enterprise Cloud"
+description: "Shows you how to set up a Teleport Enterprise Cloud account and protect your first resource with Teleport."
 tocDepth: 3
 ---
 
-Teleport Team helps small organizations provide secure access to their infrastructure, with 
-minimal configuration and cluster management. 
+Teleport Enterprise Cloud helps organizations provide secure access to their
+infrastructure with minimal configuration and cluster management. 
 
-With Teleport Team, the Teleport Auth Service and Teleport Proxy Service are managed for you as cloud-based services. 
-These services provide you with immediate access to a scalable and fault tolerant certificate authority and reverse 
-proxy that you don't need to manage or maintain. You can focus on enrolling the resources you want to protect and 
-configuring secure role-based access for private and public networks across the globe.
+With Teleport Enterprise Cloud, the Teleport Auth Service and Teleport Proxy
+Service are managed for you as cloud-based services. These services provide you
+with immediate access to a scalable and fault-tolerant certificate authority and
+reverse proxy that you don't need to manage or maintain. You can focus on
+enrolling the resources you want to protect and configuring secure role-based
+access for private and public networks across the globe.
 
-After you start a [free trial](https://goteleport.com/signup) of Teleport Team,
-you can set up role-based access control (RBAC), enable single sign-on with GitHub 
-or the Teleport identity provider, and prevent unauthorized use of organization resources.
-
-![Teleport Team architecture diagram](../../img/team-diagram.png)
+After you start a [free trial](https://goteleport.com/signup) of Teleport
+Enterprise Cloud, you can set up role-based access control (RBAC), enable single
+sign-on, and prevent unauthorized use of organization resources.
 
 <Notice type="tip">
 
-For a detailed comparison of Teleport's editions, including how Teleport Team
-compares to Teleport Enterprise Cloud and Teleport Enterprise, see 
-[Choose an Edition](introduction.mdx).
+For a detailed comparison of Teleport editions, including how Teleport
+Enterprise Cloud compares to Teleport Enterprise, see [Choose an
+Edition](introduction.mdx).
 
 </Notice>
 
-This guide explains how to register a local server with a Teleport Team account. 
-After you register the server, you can access it through the Teleport Web UI in a browser or using the terminal. 
-You can also record your sessions, so you can review them later.
+This guide explains how to register a local server with a Teleport Enterprise
+Cloud account.  After you register the server, you can access it through the
+Teleport Web UI in a browser or using the terminal. You can also record your
+sessions, so you can review them later.
 
 ## Prerequisites
 
-- A Teleport Team account. You can sign up for a free trial at the following page:
+- A Teleport Enterprise Cloud account. You can sign up for a free trial at the
+  following page:
 
   https://goteleport.com/signup/
 
   After you sign up, you receive an email invitation to activate your account.
   Use this account to authenticate your identity when you access the Teleport
-  Team cluster.
+  Enterprise Cloud cluster.
 
 - Docker installed on your workstation. 
 
-  This guide illustrates how to register a server with Teleport Team using a Docker 
-  container and the Teleport SSH Service. 
-  Docker is only required for the local demo environment used in this guide. 
-  You can find installation instructions for Docker on [Docker's website](https://docs.docker.com/get-docker/). 
-  If you want to register servers in Teleport Team without using Docker, see the getting started guide for
-  [server access](../server-access/getting-started.mdx).
+  This guide illustrates how to register a server with Teleport Enterprise Cloud
+  using a Docker container and the Teleport SSH Service. Docker is only required
+  for the local demo environment used in this guide. You can find installation
+  instructions for Docker on [Docker's
+  website](https://docs.docker.com/get-docker/). If you want to register servers
+  in Teleport without using Docker, see the getting started guide for
+  [server access](../../server-access/getting-started.mdx).
 
 - The `tsh` client tool. 
   
-  The `tsh` client tool is only required to access the server from a terminal. 
-  For installation instructions, see [Installation Guide](../installation.mdx). 
-  If you don't install the `tsh` client tool, you can access the server in 
-  Teleport Team using the Web UI through your browser.
+  The `tsh` client tool is only required to access the server from a terminal.
+  For installation instructions, see [Installation Guide](../../installation.mdx).
+  If you don't install the `tsh` client tool, you can access the server in
+  Teleport Enterprise Cloud using the Web UI through your browser.
 
 ## Step 1/5. Spin up a server
 
@@ -63,7 +66,7 @@ To spin up a new server using Docker:
 1. Open a terminal shell on your workstation.
 
 1. Start a Docker container on your workstation to prepare a server that you want enroll 
-as a resource in your Teleport Team cluster:
+as a resource in your Teleport Enterprise Cloud cluster:
    
    ```code
    $ docker run --interactive --tty ubuntu:22.04 /bin/bash
@@ -85,27 +88,27 @@ as a resource in your Teleport Team cluster:
 
 To install the Teleport SSH Service on your server:
 
-1. Open a browser and go to the address for your Teleport Team cluster. For example, if your 
-Teleport Team account is `mytenant`, open `https://mytenant.teleport.sh`.
+1. Open a browser and go to the address for your Teleport cluster. For example,
+   if your Teleport account is `example`, open `https://example.teleport.sh`.
 
-1. Sign in with the account credentials you used to activate your Teleport Team account.
+1. Sign in with the account credentials you used to activate your Teleport account.
    
    The first time you sign in, you are prompted to add your first resource: 
    
-   ![Add your first resource](../../img/cloud/getting-started/add-my-first-resource@2x.png)
+   ![Add your first resource](../../../img/cloud/getting-started/add-my-first-resource@2x.png)
 
 1. Click **Add my first resource** to open **Enroll New Resource**. 
 
 1. Type *server* in the search box to filter the list of resources.
    
-   ![Select resource type](../../img/cloud/getting-started/choose-resource@2x.png)
+   ![Select resource type](../../../img/cloud/getting-started/choose-resource@2x.png)
 
 1. Click *Ubuntu 14.04+* to register the server in the Docker container.
    
    After you select *Ubuntu 14.04+* as the resource type, the script to install and 
    configure the Teleport service is displayed. For example:
    
-   ![Configure resource](../../img/cloud/getting-started/paste-script@2x.png)
+   ![Configure resource](../../../img/cloud/getting-started/paste-script@2x.png)
    
    The Teleport installation script uses `sudo`, which is not installed on your 
    Docker container. Before copying the command to run the installation script, you 
@@ -124,25 +127,25 @@ into the container shell session.
    Leave the script running in the shell. After Teleport is installed on the server, 
    you'll see a message in the Web UI that your new Teleport instance was successfully detected:
    
-   ![Connected successfully](../../img/cloud/getting-started/successfully-connected@2x.png)
+   ![Connected successfully](../../../img/cloud/getting-started/successfully-connected@2x.png)
    
    To continue, click **Next**.
 
 1. Confirm that you want to authenticate as the `root` user and click **Next**:
    
-   ![Choose your user](../../img/cloud/getting-started/set-up-access@2x.png)
+   ![Choose your user](../../../img/cloud/getting-started/set-up-access@2x.png)
 
 1. Click **Test Connection** to verify access to the server.
    
-   ![Start session](../../img/cloud/getting-started/test-connection@2x.png)
+   ![Start session](../../../img/cloud/getting-started/test-connection@2x.png)
 
 ## Step 3/5. Start a session
 
-To start a session on the server you just added to Teleport Team:
+To start a session on the server you just added to Teleport:
 
 1. Click **Start Session** to start an interactive session.
    
-   You should see a terminal prompt in a new browser window. Your Teleport Team 
+   You should see a terminal prompt in a new browser window. Your Teleport 
    account routes your SSH connection through the Teleport Proxy Service, which
    connects to your container through a reverse tunnel. 
    Reverse tunnels allow Teleport to manage access to resources like Kubernetes 
@@ -161,7 +164,7 @@ To start a session on the server you just added to Teleport Team:
 
 ## Step 4/5. Play back your session
 
-As Teleport Team proxies SSH connections to registered servers, it records the
+As Teleport proxies SSH connections to registered servers, it records the
 commands that users execute during their sessions so operators can play them
 back later to investigate issues.
 
@@ -174,7 +177,8 @@ To play back a session in the Teleport Web UI:
    You will see the recording for your interactive session from the previous step listed.
    For example:
    
-   ![Session recordings](../../img/cloud/getting-started/session-recordings@2x.png)
+   ![Session
+   recordings](../../../img/cloud/getting-started/session-recordings@2x.png)
 
 1. Click **Play** to see a full recording of your session.
 
@@ -184,7 +188,7 @@ To access the server using commands in a terminal:
 
 1. Open a new terminal window.
 
-1. Sign in to your Teleport Team cluster by running the `tsh login` command  with the URL 
+1. Sign in to your Teleport cluster by running the `tsh login` command  with the URL 
 of your cluster and the name of your Teleport user:
    
    ```code
@@ -192,7 +196,7 @@ of your cluster and the name of your Teleport user:
    ```
    
    When prompted, authenticate using your password, authenticator app, or hardware key.
-   The command displays information about your Teleport Team cluster and account. For example:
+   The command displays information about your Teleport cluster and account. For example:
    
    ```code
    > Profile URL:      https://mytenant.teleport.sh:443
@@ -227,21 +231,18 @@ of your cluster and the name of your Teleport user:
 
 ## Next steps
 
-This guide introduced how you can use Teleport Team to protect your
-infrastructure by demonstrating how to register a server with your Teleport Team 
+This guide introduced how you can use Teleport Enterprise Cloud to protect your
+infrastructure by demonstrating how to register a server with your Teleport
 cluster. 
 
-You can provide secure access to more of your infrastructure through 
-Teleport Team by deploying one or more Teleport **agents** and configuring
-role-based access control for users. Agents proxy traffic to all of 
-your infrastructure resources—including servers, databases, Kubernetes
-clusters, cloud provider APIs, and Windows desktops. Role-based access control
-ensures that only authorized users are allowed access to those resources.
+You can provide secure access to more of your infrastructure through Teleport by
+deploying one or more Teleport **agents** and configuring role-based access
+control for users. 
+
+Agents proxy traffic to all of your infrastructure resources—including servers,
+databases, Kubernetes clusters, cloud provider APIs, and Windows desktops.
+Role-based access control ensures that only authorized users are allowed access
+to those resources.
 
 To learn more information about deploying agents, see [Deploy Teleport Agents 
-with Terraform](../agents/deploy-agents-terraform.mdx).
-
-You can deploy a limited number of agents and protect a limited number of resources
-during the free trial. After you finish the free trial, charges for Teleport Team 
-are based on the number of active users, protected resources, and authorizations performed. 
-Check the [pricing page](https://goteleport.com/pricing/) for detailed billing information.
+with Terraform](../../agents/deploy-agents-terraform.mdx).

--- a/docs/pages/choose-an-edition/teleport-cloud/introduction.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/introduction.mdx
@@ -7,10 +7,10 @@ videoBanner: 1jhKOtBinm4
 Teleport Enterprise Cloud is a managed service to provide access to secure
 infrastructure all over the world without passwords or shared secrets.
 
-When you [sign up for a Teleport Team account](https://goteleport.com/signup/)
-(which you can upgrade to a Teleport Enterprise Cloud account), you will receive
-a subdomain of `teleport.sh` that is dedicated to your tenant and points to the
-Teleport Proxy Service. 
+When you [sign up for a Teleport Enterprise Cloud
+account](https://goteleport.com/signup/), you will receive a subdomain of
+`teleport.sh` that is dedicated to your tenant and points to the Teleport Proxy
+Service. 
 
 Our Teleport Enterprise Cloud team handles the following tasks for you:
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
@@ -22,9 +22,8 @@ organizations with particular security needs and compliance requirements.
 Teleport Enterprise Cloud offers most of the functionality available in
 self-hosted deployments of Teleport Enterprise. If you are interested in trying
 Teleport for the first time, we recommend signing up for a [free
-trial](https://goteleport.com/signup) of Teleport Team, which manages the
-Teleport Auth Service and Proxy Service for you. You can then upgrade your
-account to Teleport Enterprise Cloud. 
+trial](https://goteleport.com/signup) of Teleport Enterprise Cloud, which
+manages the Teleport Auth Service and Proxy Service for you.
 
 Once you have determined that your organization would benefit most from Teleport
 Enterprise, [contact sales](https://goteleport.com/signup/enterprise/) to

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -132,15 +132,6 @@ on GitHub.
 You can find a detailed comparison of the features available in each Teleport 
 edition in [Choose an edition](./choose-an-edition/introduction.mdx).
 
-### Teleport Team
-
-Teleport Team makes it easier for small organizations to get started with
-enabling secure access to their infrastructure. It includes a subset of Teleport
-Enterprise Cloud features, and teams can switch to Teleport Enterprise Cloud
-as they scale up their Teleport usage.
-
-[Read more about Teleport Team](choose-an-edition/teleport-team.mdx).
-
 ### Teleport Enterprise Cloud
 
 **Teleport Enterprise Cloud** is a managed deployment of the **Teleport Auth

--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -61,8 +61,8 @@ on a plain TCP load balancer (e.g. NLB in AWS).
 </TabItem>
 <TabItem scope={["cloud","team"]} label="Cloud-Hosted">
 
-In Teleport Team and Teleport Enterprise Cloud, the Proxy Service uses the
-following ports for Database Service client traffic:
+In Teleport Enterprise Cloud, the Proxy Service uses the following ports for
+Database Service client traffic:
 
 |Configuration setting|Port|
 |---|---|

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -58,12 +58,12 @@ proxy_service:
 ```
 
 </TabItem>
-<TabItem scope={["team","cloud"]} label="Cloud-Hosted">
+<TabItem label="Cloud-Hosted">
 
-Teleport Team and Teleport Enterprise Cloud automatically configure the Teleport
-Proxy Service with the following settings that are relevant to database access.
-This reference configuration uses `mytenant.teleport.sh` in place of your
-Teleport Team/Enterprise Cloud tenant address.
+Teleport Enterprise Cloud automatically configures the Teleport Proxy Service
+with the following settings that are relevant to database access. This reference
+configuration uses `example.teleport.sh` in place of your Teleport Enterprise
+Cloud tenant address:
 
 ```yaml
 proxy_service:

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -56,7 +56,7 @@ $ curl -o teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe https://cd
 ```
 
 </TabItem>
-<TabItem scope={["team", "cloud"]} label="Teleport Team/Teleport Enterprise Cloud">
+<TabItem label="Teleport Enterprise Cloud">
 
 3. Download the Teleport Windows Auth setup program:
 

--- a/docs/pages/documentation-overview.mdx
+++ b/docs/pages/documentation-overview.mdx
@@ -30,8 +30,8 @@ probably need to consult at some point:
 
 - [Installation](./installation.mdx): How to install Teleport binaries on your
   environment. If you are just getting started with Teleport, we recommend
-  spinning up a [demo cluster](./index.mdx) or signing up for a [Teleport Team
-  trial](https://goteleport.com/signup).
+  spinning up a [demo cluster](./index.mdx) or signing up for a [Teleport
+  Enterprise Cloud trial](https://goteleport.com/signup).
 - [Frequently Asked Questions](./faq.mdx): If this page does not answer your
   question, try our AI-assisted search box on the left sidebar.
 - [Usage Reporting and Billing](./usage-billing.mdx): How Teleport calculates
@@ -46,7 +46,6 @@ probably need to consult at some point:
 After trying out Teleport, you are ready to deploy a cluster to your
 infrastructure. Teleport has four editions: 
 
-- Teleport Team
 - Teleport Enterprise Cloud
 - Teleport Enterprise
 - Teleport Community Edition

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -83,9 +83,8 @@ time you run `tsh`.
 
 ## How is Open Source different from Enterprise?
 
-Teleport provides four editions:
+Teleport provides three editions:
 
-- Teleport Team
 - Teleport Enterprise
 - Teleport Enterprise Cloud
 - Teleport Community Edition

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -2,10 +2,10 @@
 type="tip" 
 >
 
-Teleport Team takes care of this setup for you so you can provide secure access
-to your infrastructure right away.
+Teleport Enterprise Cloud takes care of this setup for you so you can provide
+secure access to your infrastructure right away.
 
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
-Teleport Team.
+Teleport Enterprise Cloud.
 
 </Notice>

--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -2,8 +2,8 @@
 <TabItem scope={["cloud","team"]} label="Cloud-Hosted">
 
 Run the `configure` command to generate a sample configuration. Replace
-`mytenant.teleport.sh` with the DNS name of your Teleport Team or Teleport
-Enterprise Cloud tenant:
+`mytenant.teleport.sh` with the DNS name of your Teleport Enterprise Cloud
+tenant:
 
 ```code
 $ teleport-event-handler configure . mytenant.teleport.sh:443

--- a/docs/pages/includes/database-access/create-user.mdx
+++ b/docs/pages/includes/database-access/create-user.mdx
@@ -5,7 +5,7 @@ To modify an existing user to provide access to the Database Service, see [Datab
 </Admonition>
 
 <Tabs>
-<TabItem scope={["oss","team"]} label="Teleport Team/Community Edition">
+<TabItem scope={["oss","team"]} label="Teleport Community Edition">
 Create a local Teleport user with the built-in `access` role:
 
 ```code

--- a/docs/pages/includes/database-access/db-configure-start.mdx
+++ b/docs/pages/includes/database-access/db-configure-start.mdx
@@ -25,7 +25,7 @@ $ sudo teleport db configure create \
 ```
 
 </TabItem>
-<TabItem scope={["cloud","team"]} label="Teleport Team/Community Edition">
+<TabItem scope={["cloud","team"]} label="Teleport Community Edition">
 
 ```code
 $ sudo teleport db configure create \

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -1,62 +1,81 @@
 ### Access controls
 
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|[Access Requests](../access-controls/guides/dual-authz.mdx)|Limited|✔|✔|✖|
-|[Single Sign-On](../access-controls/sso.mdx)|GitHub|GitHub, Google Workspace, OIDC, SAML, Teleport|GitHub, Google Workspace, OIDC, SAML, Teleport|GitHub, Teleport|
-|[Role-Based Access Control](../access-controls/guides/role-templates.mdx)|✔|✔|✔|✔|
-|[Moderated Sessions](../access-controls/guides/moderated-sessions.mdx)|✖|✔|✔|✖|
-|[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|✖|
-|[Dual Authorization](../access-controls/guides/dual-authz.mdx)|✖|✔|✔|✖|
-|[Hardware Key Support](../access-controls/guides/hardware-key-support.mdx)|✖|✔|✔|✖|
-
-### Infrastructure access
-
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|[Application Access](../application-access/getting-started.mdx)|✔|✔|✔|✔|
-|[Server Access](../server-access/getting-started.mdx)|✔|✔|✔|✔|
-|[Database Access](../database-access/getting-started.mdx)|✔|✔|✔|✔|
-|[Desktop Access](../desktop-access/getting-started.mdx)|✔|✔|✔|✔|
-|[Kubernetes Access](../kubernetes-access/getting-started.mdx)|✔|✔|✔|✔|
-|[Machine ID](../machine-id/getting-started.mdx)|✔|✔|✔|✔|
-|Agentless Integration with [OpenSSH Servers](../server-access/guides/openssh.mdx)|✔|✔|✔|✔|
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|[Dual Authorization](../access-controls/guides/dual-authz.mdx)|✖|✔|✔|
+|[Hardware Key Support](../access-controls/guides/hardware-key-support.mdx)|✖|✔|✔|
+|[Moderated Sessions](../access-controls/guides/moderated-sessions.mdx)|✖|✔|✔|
+|[Role-Based Access Control](../access-controls/guides/role-templates.mdx)|✔|✔|✔|
+|[Single Sign-On](../access-controls/sso.mdx)|GitHub|GitHub, Google Workspace, OIDC, SAML, Teleport|GitHub, Google Workspace, OIDC, SAML, Teleport|
 
 ### Audit logging and session recording
 
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|[Structured Audit Logs](../reference/audit.mdx)|✔|✔|✔|✔|
-|[Session Recording with Playback](../architecture/session-recording.mdx)|✔|✔|✔|✔|
-|[Recording Proxy Mode](../server-access/guides/recording-proxy-mode.mdx)|✔|✔|✖|✖|
-|[Enhanced Session Recording](../server-access/guides/bpf-session-recording.mdx)|✔|✔|✔|✔|
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|[Enhanced Session Recording](../server-access/guides/bpf-session-recording.mdx)|✔|✔|✔|
+|[Recording Proxy Mode](../server-access/guides/recording-proxy-mode.mdx)|✔|✔|✖|
+|[Session Recording with Playback](../architecture/session-recording.mdx)|✔|✔|✔|
+|[Structured Audit Logs](../reference/audit.mdx)|✔|✔|✔|
 
 ### Compliance
 
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|[FedRAMP Control](../access-controls/compliance-frameworks/fedramp.mdx)|✖|✔|✖|✖|
-|PCI DSS Features|Limited|✔|✔|Limited|
-|SOC 2 Features|Limited|✔|✔|Limited|
-|FIPS-compliant binaries available for FedRAMP High|✖|✔|✖|✖|
-|IP-Based Restrictions|✖|✔|✔|✖|
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|[FedRAMP Control](../access-controls/compliance-frameworks/fedramp.mdx)|✖|✔|✖|
+|FIPS-compliant binaries available for FedRAMP High|✖|✔|✖|
+|IP-Based Restrictions|✖|✔|✔|
+|PCI DSS Features|Limited|✔|✔|
+|SOC 2 Features|Limited|✔|✔|
+
+### Identity
+
+_Available as an add-on to Teleport Enterprise_
+
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|Access Monitoring & Response|✖|✔|✔|
+|[Access Lists & Access Reviews](../access-controls/access-lists.mdx)|✖|✔|✔|
+|[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|
+|[Endpoint Management: Jamf](../access-controls/device-trust/jamf-integration.mdx)|✖|✔|✔|
+|[JIT Access Requests](../access-controls/guides/dual-authz.mdx)|Limited|✔|✔|
+|Session & Identity Locks|✖|✔|✔|
+
+### Infrastructure access
+
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|Agentless Integration with [OpenSSH Servers](../server-access/guides/openssh/openssh.mdx)|✔|✔|✔|
+|[Application Access](../application-access/getting-started.mdx)|✔|✔|✔|
+|[Database Access](../database-access/getting-started.mdx)|✔|✔|✔|
+|[Desktop Access](../desktop-access/introduction.mdx)|✔|✔|✔|
+|[Kubernetes Access](../kubernetes-access/getting-started.mdx)|✔|✔|✔|
+|[Machine ID](../machine-id/getting-started.mdx)|✔|✔|✔|
+|[Server Access](../server-access/getting-started.mdx)|✔|✔|✔|
+
+### Audit logging and session recording
+
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|Annual or multi-year contracts, volume discounts|✖|✔|✔|
+|Anonymized Usage Tracking|Opt-in|✔|✔|
+|License|Apache 2|Commercial|Commercial|
 
 ### Operations
 
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|Auth and Proxy Service Management|Self-hosted|Self-hosted|Fully managed|Fully managed|
-|Proxy Service domain name|Custom|Custom|A subdomain of `teleport.sh`|A subdomain of `teleport.sh`|
-|Version support|All supported releases available to install and download.|All supported releases available to install and download.|Deploys last stable release with 2-3 week lag for stability.|Deploys last stable release with 2-3 week lag for stability.|
-|[Backend support](../reference/backends.mdx)|Any S3-compatible storage for session records, many managed backends for custom audit log storage.|Any S3-compatible storage for session records, many managed backends for custom audit log storage|All data is stored in DynamoDB and S3 with server-side encryption.|All data is stored in DynamoDB and S3 with server-side encryption.|
-|Data storage location|Can store data anywhere in the world, on most managed cloud backends|Can store data anywhere in the world, on most managed cloud backends|Data is stored in Teleport's AWS infrastructure with audit logs/sessions optionally in customer AWS accounts. Proxy Service instances are deployed across the world for low-latency access.|Data is stored in Teleport's AWS infrastructure. Proxy Service instances are deployed across the world for low-latency access.|
-|[Hardware Security Module support](../choose-an-edition/teleport-enterprise/hsm.mdx) for encryption at rest|✖|✔|✖|✖|
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|Auth Service and Proxy Service Management|Self-hosted|Self-hosted|Fully managed|
+|[Backend support](../reference/backends.mdx)|Any S3-compatible storage for session records, many managed backends for custom audit log storage.|Any S3-compatible storage for session records, many managed backends for custom audit log storage|All data is stored in DynamoDB and S3 with server-side encryption.|
+|Data storage location|Can store data anywhere in the world, on most managed cloud backends|Can store data anywhere in the world, on most managed cloud backends|Data is stored in Teleport's AWS infrastructure with audit logs/sessions optionally in customer AWS accounts. Proxy Service instances are deployed across the world for low-latency access.|
+|[Hardware Security Module support](../choose-an-edition/teleport-enterprise/hsm.mdx) for encryption at rest|✖|✔|✖|
+|Proxy Service domain name|Custom|Custom|A subdomain of `teleport.sh`|
+|Version support|All supported releases available to install and download.|All supported releases available to install and download.|Deploys last stable release with 2-3 week lag for stability.|
 
 ### Support
 
-||Open Source|Enterprise|Cloud|Team|
-|---|---|---|---|---|
-|Support|Community|24x7 support with premium SLAs and account managers|24x7 support with premium SLAs and account managers|Community|
+||Community Edition|Enterprise|Cloud|
+|---|---|---|---|
+|Support|Community|24x7 support with premium SLAs and account managers|24x7 support with premium SLAs and account managers|
 
 ### Licensing and usage management
 

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -22,30 +22,6 @@ Proxy: (=teleport.url=)
 ```
 
 </TabItem>  
-<TabItem scope="team" label="Teleport Team">
-
-- A Teleport Team account. If you don't have an account, sign 
-up to begin your [free trial](https://goteleport.com/signup/).
-
-- The Enterprise `tctl` admin tool and `tsh` client tool, version >= (=cloud.version=).
-  
-  You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
-
-To check version information, run the `tctl version` and `tsh version` commands.
-For example:
-
-```code
-$ tctl version
-# Teleport Enterprise v(=cloud.version=) git:(=teleport.git=) go(=teleport.golang=)
-  
-$ tsh version
-# Teleport v(=cloud.version=) go(=teleport.golang=)
-Proxy version: (=cloud.version=)
-Proxy: (=teleport.url=)
-```
-
-</TabItem>
-
 <TabItem
   scope={["enterprise"]} label="Teleport Enterprise">
 
@@ -75,9 +51,8 @@ Proxy: (=teleport.url=)
 <TabItem scope={["cloud"]}
   label="Teleport Enterprise Cloud">
 
-- A Teleport Enterprise Cloud account. If you don't have an account, 
-  sign up to begin a [free trial](https://goteleport.com/signup/)  of Teleport Team
-  and upgrade to Teleport Enterprise Cloud. 
+- A Teleport Enterprise Cloud account. If you don't have an account, sign up to
+  begin a [free trial](https://goteleport.com/signup/). 
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
 

--- a/docs/pages/includes/ent-vs-community-faq.mdx
+++ b/docs/pages/includes/ent-vs-community-faq.mdx
@@ -1,4 +1,4 @@
-Teleport Team, Enterprise, and Enterprise Cloud customers should use the Enterprise release of the 
+Teleport Enterprise and Enterprise Cloud customers should use the Enterprise release of the 
 `teleport` binary for agents. Running the Community Edition binary could result in
 incompatibility to these cluster editions for certain features.
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -6,22 +6,6 @@ Select an edition, then follow the instructions for that edition to install Tele
   (!docs/pages/includes/install-linux-oss.mdx!)
 
   </TabItem>
-  <TabItem label="Teleport Team">
-  (!docs/pages/includes/cloud/install-linux-cloud.mdx!)
-
-  (!docs/pages/includes/repo-channels.mdx!)
-
-  <Details title="Is my Teleport instance compatible with Teleport Team?">
-
-  Before installing a `teleport` binary with a version besides
-  v(=cloud.major_version=), read our compatibility rules to ensure that the
-  binary is compatible with Teleport Cloud.
-
-  (!docs/pages/includes/compatibility.mdx!)
-
-  </Details>
-
-  </TabItem>
   <TabItem label="Teleport Enterprise">
   (!docs/pages/includes/install-linux-ent-self-hosted.mdx!)
 

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -9,11 +9,6 @@ To install `tsh` on Windows, run the following commands in **PowerShell** (these
   (!docs/pages/includes/install-windows-tsh.mdx version="(=teleport.version=)" !)
  
 </TabItem>
-<TabItem label="Teleport Team" scope="team">
-
-  (!docs/pages/includes/install-windows-tsh.mdx version="(=teleport.version=)" !)
- 
-</TabItem>
 <TabItem label="Teleport Enterprise" scope="enterprise">
 
   (!docs/pages/includes/install-windows-tsh.mdx version="(=teleport.version=)" !)

--- a/docs/pages/includes/no-oss-prereqs-tabs.mdx
+++ b/docs/pages/includes/no-oss-prereqs-tabs.mdx
@@ -1,23 +1,4 @@
 <Tabs>
-<TabItem scope="team" label="Teleport Team">
-
-- A Teleport Team account. If you do not have one, visit the [signup
-  page](https://goteleport.com/signup/) to begin your free trial.
-
-- The Enterprise `tctl` admin tool and `tsh` client tool version >=
-  (=cloud.version=).
-
-    You can download these tools from the [Cloud Downloads page](../choose-an-edition/teleport-cloud/downloads.mdx).
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
-
-  $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
 <TabItem
   scope={["enterprise"]} label="Teleport Enterprise">
 

--- a/docs/pages/includes/plugins/enroll.mdx
+++ b/docs/pages/includes/plugins/enroll.mdx
@@ -1,6 +1,6 @@
 {{ name="this integration" }}
-In Teleport Team and Teleport Enterprise Cloud, Teleport manages {{ name }} for
-you, and you can enroll {{ name }} from the Teleport Web UI.
+In Teleport Enterprise Cloud, Teleport manages {{ name }} for you, and you can
+enroll {{ name }} from the Teleport Web UI.
 
 Visit the Teleport Web UI and find the dropdown menu on the upper left of the
 screen. Select the **Management** option.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -23,8 +23,8 @@ Community Edition. Once you deploy the cluster, you can configure RBAC, register
 resources, and protect your small-scale demo environments or home lab.
 
 You can also get started right away with a production-ready Teleport cluster by
-signing up for a [free trial of Teleport
-Team](./choose-an-edition/teleport-team.mdx).
+signing up for a [free trial of Teleport Enterprise
+Cloud](https://goteleport.com/signup/).
 
 ## Set up a demo cluster
 
@@ -48,9 +48,9 @@ We will run the following Teleport services:
 ### Prerequisites
 
 You will need the following to deploy a demo Teleport cluster. If your
-environment doesn't meet the prerequisites above, you can get started with
-Teleport by signing up for a [free trial of Teleport
-Team](https://goteleport.com/signup/).
+environment doesn't meet the prerequisites, you can get started with Teleport by
+signing up for a [free trial of Teleport Enterprise
+Cloud](https://goteleport.com/signup/).
 
 If you want to get a feel for Teleport commands and capabilities without setting
 up any infrastructure, take a look at the browser-based [Teleport

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -183,7 +183,7 @@ Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 Teleport are available from our [Legacy Amazon ECR Public repository](https://gallery.ecr.aws/gravitational/teleport-ent).
 
 </TabItem>
-<TabItem label="Teleport Team/Teleport Enterprise Cloud" scope={["team", "cloud"]}>
+<TabItem label="Teleport Enterprise Cloud" scope={["team", "cloud"]}>
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
@@ -408,7 +408,7 @@ chart.
 ## macOS
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
-<TabItem label="Community/Team" scope={["oss","team"]}>
+<TabItem label="Community Edition" scope={["oss","team"]}>
   <Tabs>
   <TabItem label="Teleport package" >
   You can download one of the following .pkg installers for macOS:

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -23,7 +23,7 @@ For information about other ways to enroll and discover Kubernetes clusters, see
 - Access to a running Teleport cluster, `tctl` admin tool, and `tsh` client tool, 
   version >= (=teleport.version=). 
   
-  For Teleport Enterprise, Teleport Team, and Teleport Enterprise Cloud, you should
+  For Teleport Enterprise and Teleport Enterprise Cloud, you should
   use the Enterprise version of `tctl`. 
   You can verify the tools you have installed by running the following commands:
 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -139,9 +139,9 @@ To complete the steps in this guide, verify your environment meets the following
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
   
-  For Teleport Enterprise, Teleport Team, and Teleport Enterprise cloud, you should have
-  the Enterprise version of `tctl` and `tsh` installed. 
-  You can verify the tools you have installed by running the following commands:
+  For Teleport Enterprise and Teleport Enterprise cloud, you should have the
+  Enterprise version of `tctl` and `tsh` installed.  You can verify the tools
+  you have installed by running the following commands:
 
   ```code
   $ tctl version

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -294,7 +294,7 @@ $ docker stop teleport
   </TabItem>
   </Tabs>
   </TabItem>
-  <TabItem label="Teleport Team/Enterprise Cloud" scope={["team", "cloud"]}>
+  <TabItem label="Teleport Enterprise Cloud" >
 
   <Tabs>
   <TabItem label="Debian/Ubuntu Linux (DEB)">
@@ -303,7 +303,7 @@ $ docker stop teleport
 
   ```code
   $ sudo apt-get -y remove teleport-ent
-  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo apt-get -y remove teleport
   ```
 
@@ -318,7 +318,7 @@ $ docker stop teleport
 
   ```code
   $ sudo dpkg -r teleport-ent
-  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo dpkg -r teleport
   ```
   </Admonition>
@@ -332,7 +332,7 @@ $ docker stop teleport
   $ sudo yum -y remove teleport-ent
   # Optional: Use DNF on newer distributions
   # $ sudo dnf -y remove teleport-ent
-  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo yum -y remove teleport
   # $ sudo dnf -y remove teleport
   ```
@@ -348,7 +348,7 @@ $ docker stop teleport
 
   ```code
   $ sudo rpm -e teleport-ent
-  # NOTE: Older Team/Cloud users may be running Teleport Community Edition binaries instead
+  # NOTE: Older Teleport Enterprise Cloud users may be running Teleport Community Edition binaries instead
   # $ sudo rpm -e teleport
   ```
   </Admonition>

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -124,7 +124,7 @@ For more information, see:
 - [Single Sign-On](../../access-controls/sso.mdx)
 
 </TabItem>
-<TabItem scope={["oss","team"]} label="Teleport Team/Community Edition">
+<TabItem label="Teleport Community Edition">
 
 In addition to users, you can use `tctl` to manage roles and other dynamic
 resources. See our [Teleport Resources Reference](../../reference/resources.mdx).

--- a/docs/pages/management/dynamic-resources.mdx
+++ b/docs/pages/management/dynamic-resources.mdx
@@ -38,9 +38,9 @@ Every resource in Teleport has three required fields:
 
 All other fields are specific to a resource.
 
-While Teleport Enterprise Cloud and Teleport Team do not expose the static
-configuration file to operators, they do use a static configuration file for
-certain settings. Read how Teleport [reconciles static and dynamic
+While Teleport Enterprise Cloud does not expose the static configuration file to
+operators, they do use a static configuration file for certain settings. Read
+how Teleport [reconciles static and dynamic
 resources](#reconciling-the-configuration-file-with-dynamic-resources) to
 understand how to see the values of static configuration settings that also
 appear in dynamic resources.
@@ -232,9 +232,8 @@ its configuration fields to the default values and add the
 <Notice type="tip">
 
 Cloud-hosted Teleport deployments use configuration files, but these are not
-available for operators to modify. Users of Teleport Enterprise Cloud and
-Teleport Team may see configuration resources with the
-`teleport.dev/origin=config-file` label.
+available for operators to modify. Users of Teleport Enterprise Cloud may see
+configuration resources with the `teleport.dev/origin=config-file` label.
 
 </Notice>
 

--- a/docs/pages/management/operations/backup-restore.mdx
+++ b/docs/pages/management/operations/backup-restore.mdx
@@ -47,10 +47,9 @@ Teleport audit logs, logged events have a TTL of 1 year.
 | Firestore | [Follow GCP's guidelines for automated backups](https://firebase.google.com/docs/database/backups) |
 
 </TabItem>
-<TabItem scope={["cloud","team"]} label="Cloud-Hosted">
+<TabItem label="Cloud-Hosted">
 
-Teleport Team and Teleport Enterprise Cloud manage all Auth Service and Proxy
-Service backups.
+Teleport Enterprise Cloud manages all Auth Service and Proxy Service backups.
 
 While Teleport Nodes are stateless, you should ensure that you can restore their
 configuration files.
@@ -225,10 +224,9 @@ also apply to a new cluster being bootstrapped from the state of an old cluster:
     dynamically will need to be re-invited.
 
 </TabItem>
-<TabItem scope={["cloud","team"]} label="Team/Enterprise Cloud">
+<TabItem label="Teleport Enterprise Cloud">
 
-In Teleport Team and Teleport Enterprise Cloud, backend data is managed for you
-automatically. 
+In Teleport Enterprise Cloud, backend data is managed for you automatically. 
 
 If you would like to migrate configuration resources to a self-hosted Teleport
 cluster, follow our recommended backup practice of storing configuration

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -20,9 +20,10 @@ Upgrading Teleport will not enable TLS routing by default and the cluster will
 keep working in backwards-compatibility mode. Follow this guide to migrate your
 Teleport installation to TLS routing.
 
-Teleport Team manages the Proxy Service's networking configuration for you. Get
-started with a [free trial](https://goteleport.com/signup?t_source=docs) of
-Teleport Team.
+Teleport Enterprise Cloud manages the Proxy Service's networking configuration
+for you. Get started with a [free
+trial](https://goteleport.com/signup?t_source=docs) of Teleport Enterprise
+Cloud.
 
 ## Prerequisites
 

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -72,10 +72,10 @@ $ ls -l /var/lib/teleport/log/
 ```
 
 </TabItem>
-<TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
+<TabItem label="Cloud-Hosted">
 
-Teleport Team and Teleport Enterprise Cloud manage the storage of audit logs for
-you. You can access your audit logs via the Teleport Web UI by clicking:
+Teleport Enterprise Cloud manages the storage of audit logs for you. You can
+access your audit logs via the Teleport Web UI by clicking:
 
 **Activity** > **Audit Log**
 
@@ -181,10 +181,9 @@ $ tsh play 4c146ec8-eab6-11e6-b1b3-40167e68e931 --format=json
 ```
 
 </TabItem>
-<TabItem scope={["cloud","team"]} label="Cloud-Hosted">
+<TabItem label="Cloud-Hosted">
 
-Teleport Team and Teleport Enterprise Cloud automatically store recorded
-sessions.
+Teleport Enterprise Cloud automatically stores recorded sessions.
 
 You can replay recorded sessions using the [`tsh play`](./cli/tsh.mdx#tsh-play)
 command or the Web UI.

--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -164,27 +164,6 @@ The user will now be unblocked from login attempts and can attempt to authentica
 ## Authentication connectors
 
 <Tabs>
-<TabItem scope="team" label="Teleport Team">
-
-### GitHub
-
-This connector implements GitHub's OAuth 2.0 authentication flow. Please refer to GitHub's documentation on [Creating an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
-to learn how to create and register an OAuth app.
-
-Here is an example of this setting in a `cluster_auth_preference` resource:
-
-```yaml
-kind: cluster_auth_preference
-metadata:
-  name: cluster-auth-preference
-spec:
-  type: github
-version: v2
-```
-
-See [GitHub OAuth 2.0](../access-controls/sso/github-sso.mdx) for details on how to configure it.
-
-</TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ### GitHub

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -13,10 +13,10 @@ upgrade them manually using the method you used to install Teleport.
 - Familiarity with the [Upgrading Compatibility Overview](./overview.mdx) guide,
   which describes the sequence in which to upgrade components of your cluster.
 
-- Teleport Enterprise Cloud or Teleport Team account. You can determine the
-  current version of these services by running the following command, where
-  `mytenant` is the name of your Teleport Team or Teleport Enterprise Cloud
-  tenant. This requires the [`jq` CLI tool](https://jqlang.github.io/jq/):
+- Teleport Enterprise Cloud. You can determine the current version of these
+  services by running the following command, where `mytenant` is the name of
+  your Teleport Enterprise Cloud tenant. This requires the
+  [`jq` CLI tool](https://jqlang.github.io/jq/):
 
   ```code
   $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'

--- a/docs/pages/upgrading/cloud-linux.mdx
+++ b/docs/pages/upgrading/cloud-linux.mdx
@@ -13,11 +13,10 @@ upgrades or upgrade them manually using the method you used to install Teleport.
 - Familiarity with the [Upgrading Compatibility Overview](./overview.mdx) guide,
   which describes the sequence in which to upgrade components in your cluster.
 
-- A Teleport Enterprise Cloud or Teleport Team account. You can determine the
-  current version of the Auth Service and Proxy Service by running the following
-  command, where `mytenant` is the name of your Teleport Team or Teleport
-  Enterprise Cloud account. This requires the [`jq` CLI
-  tool](https://jqlang.github.io/jq/):
+- A Teleport Enterprise Cloud account. You can determine the current version of
+  the Auth Service and Proxy Service by running the following command, where
+  `mytenant` is the name of your Teleport Enterprise Cloud account. This
+  requires the [`jq` CLI tool](https://jqlang.github.io/jq/):
 
   ```code
   $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -14,10 +14,9 @@ Teleport cluster while preserving compatibility.
 
 (!docs/pages/includes/compatibility.mdx!)
 
-In Teleport Team and Teleport Enterprise Cloud, we manage the Auth and Proxy
-Services for you. You can determine the current version of these services by
-running the following command, where `mytenant` is the name of your Teleport
-Team or Teleport Enterprise Cloud tenant:
+In Teleport Enterprise Cloud, we manage the Auth and Proxy Services for you. You
+can determine the current version of these services by running the following
+command, where `mytenant` is the name of your Teleport Enterprise Cloud tenant:
 
 ```code
 $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'


### PR DESCRIPTION
Backports #38940

- Remove the `team` scope from config.json.
- Edit the Edition comparison table to remove the "Team" column.
- Change the Teleport Team getting started guide to a Teleport Enterprise Cloud getting started guide.
- Remove other Teleport Team mentions from the docs.