### PR TITLE
[v14] Machine ID: Allow the proxy address to be explicitly configured

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -160,6 +160,7 @@ type CLIConf struct {
 
 	// ProxyServer is the teleport proxy address. Unlike `AuthServer` this must
 	// explicitly point to a Teleport proxy.
+	// Example: "example.teleport.sh:443"
 	ProxyServer string
 
 	// Cluster is the name of the Teleport cluster on which resources should
@@ -271,8 +272,11 @@ type BotConfig struct {
 	Outputs    Outputs          `yaml:"outputs,omitempty"`
 	Services   Services         `yaml:"services,omitempty"`
 
-	Debug           bool          `yaml:"debug"`
-	AuthServer      string        `yaml:"auth_server,omitempty"`
+	Debug      bool   `yaml:"debug"`
+	AuthServer string `yaml:"auth_server,omitempty"`
+	// ProxyServer is the teleport proxy address. Unlike `AuthServer` this must
+	// explicitly point to a Teleport proxy.
+	// Example: "example.teleport.sh:443"
 	ProxyServer     string        `yaml:"proxy_server,omitempty"`
 	CertificateTTL  time.Duration `yaml:"certificate_ttl"`
 	RenewalInterval time.Duration `yaml:"renewal_interval"`

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -158,9 +158,9 @@ type CLIConf struct {
 	// should be written to
 	ConfigureOutput string
 
-	// Proxy is the teleport proxy address. Unlike `AuthServer` this must
+	// ProxyServer is the teleport proxy address. Unlike `AuthServer` this must
 	// explicitly point to a Teleport proxy.
-	Proxy string
+	ProxyServer string
 
 	// Cluster is the name of the Teleport cluster on which resources should
 	// be accessed.
@@ -273,7 +273,7 @@ type BotConfig struct {
 
 	Debug           bool          `yaml:"debug"`
 	AuthServer      string        `yaml:"auth_server,omitempty"`
-	Proxy           string        `yaml:"proxy,omitempty"`
+	ProxyServer     string        `yaml:"proxy_server,omitempty"`
 	CertificateTTL  time.Duration `yaml:"certificate_ttl"`
 	RenewalInterval time.Duration `yaml:"renewal_interval"`
 	Oneshot         bool          `yaml:"oneshot"`
@@ -309,11 +309,11 @@ const (
 // a proxy, and the kind of address it is.
 func (conf *BotConfig) Address() (string, AddressKind) {
 	switch {
-	case conf.AuthServer != "" && conf.Proxy != "":
+	case conf.AuthServer != "" && conf.ProxyServer != "":
 		// This is an error case that should be prevented by the validation.
 		return "", AddressKindUnspecified
-	case conf.Proxy != "":
-		return conf.Proxy, AddressKindProxy
+	case conf.ProxyServer != "":
+		return conf.ProxyServer, AddressKindProxy
 	case conf.AuthServer != "":
 		return conf.AuthServer, AddressKindAuth
 	default:
@@ -645,11 +645,11 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 		config.AuthServer = cf.AuthServer
 	}
 
-	if cf.Proxy != "" {
-		if config.Proxy != "" {
+	if cf.ProxyServer != "" {
+		if config.ProxyServer != "" {
 			log.Warnf("CLI parameters are overriding proxy configured in %s", cf.ConfigPath)
 		}
-		config.Proxy = cf.Proxy
+		config.ProxyServer = cf.ProxyServer
 	}
 
 	if cf.CertificateTTL != 0 {

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -273,7 +273,7 @@ func TestBotConfig_YAML(t *testing.T) {
 			name: "minimal config using proxy addr",
 			in: BotConfig{
 				Version:         V2,
-				Proxy:           "example.teleport.sh:443",
+				ProxyServer:     "example.teleport.sh:443",
 				CertificateTTL:  time.Minute,
 				RenewalInterval: time.Second * 30,
 				Outputs: Outputs{

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -269,6 +269,20 @@ func TestBotConfig_YAML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "minimal config using proxy addr",
+			in: BotConfig{
+				Version:         V2,
+				Proxy:           "example.teleport.sh:443",
+				CertificateTTL:  time.Minute,
+				RenewalInterval: time.Second * 30,
+				Outputs: Outputs{
+					&IdentityOutput{
+						Destination: &DestinationMemory{},
+					},
+				},
+			},
+		},
 	}
 
 	testYAML(t, tests)

--- a/lib/tbot/config/template_ssh_client.go
+++ b/lib/tbot/config/template_ssh_client.go
@@ -101,14 +101,14 @@ func (c *templateSSHClient) render(
 	)
 	defer span.End()
 
-	ping, err := bot.AuthPing(ctx)
+	ping, err := bot.ProxyPing(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	proxyHost, proxyPort, err := utils.SplitHostPort(ping.ProxyPublicAddr)
+	proxyHost, proxyPort, err := utils.SplitHostPort(ping.Proxy.SSH.PublicAddr)
 	if err != nil {
-		return trace.BadParameter("proxy %+v has no usable public address: %v", ping.ProxyPublicAddr, err)
+		return trace.BadParameter("proxy %+v has no usable public address: %v", ping.Proxy.SSH.PublicAddr, err)
 	}
 
 	clusterNames, err := getClusterNames(bot, ping.ClusterName)

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config_using_proxy_addr.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config_using_proxy_addr.golden
@@ -4,7 +4,7 @@ outputs:
     destination:
       type: memory
 debug: false
-proxy: example.teleport.sh:443
+proxy_server: example.teleport.sh:443
 certificate_ttl: 1m0s
 renewal_interval: 30s
 oneshot: false

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config_using_proxy_addr.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config_using_proxy_addr.golden
@@ -1,0 +1,11 @@
+version: v2
+outputs:
+  - type: identity
+    destination:
+      type: memory
+debug: false
+proxy: example.teleport.sh:443
+certificate_ttl: 1m0s
+renewal_interval: 30s
+oneshot: false
+fips: false

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -380,10 +380,6 @@ func botIdentityFromToken(ctx context.Context, log logrus.FieldLogger, cfg *conf
 	defer span.End()
 
 	log.Info("Fetching bot identity using token.")
-	addr, err := utils.ParseAddr(cfg.AuthServer)
-	if err != nil {
-		return nil, trace.Wrap(err, "invalid auth server address %+v", cfg.AuthServer)
-	}
 
 	tlsPrivateKey, sshPublicKey, tlsPublicKey, err := generateKeys()
 	if err != nil {
@@ -401,7 +397,6 @@ func botIdentityFromToken(ctx context.Context, log logrus.FieldLogger, cfg *conf
 		ID: auth.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthServers:        []utils.NetAddr{*addr},
 		PublicTLSKey:       tlsPublicKey,
 		PublicSSHKey:       sshPublicKey,
 		CAPins:             cfg.Onboarding.CAPins,
@@ -412,6 +407,24 @@ func botIdentityFromToken(ctx context.Context, log logrus.FieldLogger, cfg *conf
 		FIPS:               cfg.FIPS,
 		CipherSuites:       cfg.CipherSuites(),
 		Insecure:           cfg.Insecure,
+	}
+
+	addr, addrKind := cfg.Address()
+	switch addrKind {
+	case config.AddressKindAuth:
+		parsed, err := utils.ParseAddr(addr)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse addr")
+		}
+		params.AuthServers = []utils.NetAddr{*parsed}
+	case config.AddressKindProxy:
+		parsed, err := utils.ParseAddr(addr)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse addr")
+		}
+		params.ProxyServer = *parsed
+	default:
+		return nil, trace.BadParameter("unsupported address kind: %v", addrKind)
 	}
 
 	if params.JoinMethod == types.JoinMethodAzure {

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -108,11 +108,12 @@ func (b *Bot) Run(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	addr, _ := b.cfg.Address()
 	resolver, err := reversetunnelclient.CachingResolver(
 		ctx,
 		reversetunnelclient.WebClientResolver(&webclient.Config{
 			Context:   ctx,
-			ProxyAddr: b.cfg.AuthServer,
+			ProxyAddr: addr,
 			Insecure:  b.cfg.Insecure,
 		}),
 		nil /* clock */)
@@ -381,8 +382,10 @@ func clientForFacade(
 	}
 
 	authClientConfig := &authclient.Config{
-		TLS:         tlsConfig,
-		SSH:         sshConfig,
+		TLS: tlsConfig,
+		SSH: sshConfig,
+		// TODO(noah): It'd be ideal to distinguish the proxy addr and auth addr
+		// here to avoid pointlessly hitting the address as an auth server.
 		AuthServers: []utils.NetAddr{*parsedAddr},
 		Log:         log,
 		Insecure:    cfg.Insecure,

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -250,6 +250,9 @@ func (b *Bot) preRunChecks(ctx context.Context) (func() error, error) {
 		return nil, trace.BadParameter(
 			"either a proxy or auth address must be set using --proxy, --auth-server or configuration",
 		)
+	case config.AddressKindAuth:
+		// TODO(noah): DELETE IN V17.0.0
+		b.log.Warn("We recently introduced the ability to explicitly configure the address of the Teleport Proxy using --proxy-server. We recommend switching to this if you currently provide the address of the Proxy to --auth-server.")
 	}
 
 	// Ensure they have provided a join method.

--- a/tool/tbot/db.go
+++ b/tool/tbot/db.go
@@ -52,7 +52,7 @@ func onDBCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	args := []string{"-i", identityPath, "db", "--proxy=" + cf.Proxy}
+	args := []string{"-i", identityPath, "db", "--proxy=" + cf.ProxyServer}
 	if cf.Cluster != "" {
 		// If we caught --cluster in our args, pass it through.
 		args = append(args, "--cluster="+cf.Cluster)

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -44,8 +44,9 @@ var log = logrus.WithFields(logrus.Fields{
 })
 
 const (
-	authServerEnvVar = "TELEPORT_AUTH_SERVER"
-	tokenEnvVar      = "TELEPORT_BOT_TOKEN"
+	authServerEnvVar  = "TELEPORT_AUTH_SERVER"
+	tokenEnvVar       = "TELEPORT_BOT_TOKEN"
+	proxyServerEnvVar = "TELEPORT_PROXY"
 )
 
 func main() {
@@ -81,7 +82,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
 	startCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy-server where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
-	startCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").StringVar(&cf.ProxyServer)
+	startCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").Envar(proxyServerEnvVar).StringVar(&cf.ProxyServer)
 	startCmd.Flag("token", "A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
 	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -109,7 +110,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
 	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy-server where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
-	configureCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").StringVar(&cf.ProxyServer)
+	configureCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").Envar(proxyServerEnvVar).StringVar(&cf.ProxyServer)
 	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	configureCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
 	configureCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -133,7 +134,7 @@ func Run(args []string, stdout io.Writer) error {
 	// We're migrating from --proxy to --proxy-server so this flag is hidden
 	// but still supported.
 	// TODO(strideynet): DELETE IN 17.0.0
-	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Hidden().StringVar(&legacyProxyFlag)
+	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Hidden().Envar(proxyServerEnvVar).StringVar(&legacyProxyFlag)
 	dbCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
 	dbCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
 	dbRemaining := config.RemainingArgs(dbCmd.Arg(
@@ -142,7 +143,7 @@ func Run(args []string, stdout io.Writer) error {
 	))
 
 	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
-	proxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").StringVar(&cf.ProxyServer)
+	proxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Envar(proxyServerEnvVar).StringVar(&cf.ProxyServer)
 	// We're migrating from --proxy to --proxy-server so this flag is hidden
 	// but still supported.
 	// TODO(strideynet): DELETE IN 17.0.0

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -80,7 +80,8 @@ func Run(args []string, stdout io.Writer) error {
 	versionCmd := app.Command("version", "Print the version of your tbot binary.")
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
-	startCmd.Flag("auth-server", "Address of the Teleport Auth Server or Proxy Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	startCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	startCmd.Flag("proxy", "Address of the Teleport Proxy Server.").StringVar(&cf.Proxy)
 	startCmd.Flag("token", "A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
 	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -107,7 +108,8 @@ func Run(args []string, stdout io.Writer) error {
 		EnumVar(&cf.LogFormat, config.LogFormatJSON, config.LogFormatText)
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
-	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server (On-Prem installs) or Proxy Server (Cloud installs).").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	configureCmd.Flag("proxy", "Address of the Teleport Proxy Server.").StringVar(&cf.Proxy)
 	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	configureCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
 	configureCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -80,8 +80,8 @@ func Run(args []string, stdout io.Writer) error {
 	versionCmd := app.Command("version", "Print the version of your tbot binary.")
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
-	startCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
-	startCmd.Flag("proxy", "Address of the Teleport Proxy Server.").StringVar(&cf.Proxy)
+	startCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy-server where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	startCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").StringVar(&cf.ProxyServer)
 	startCmd.Flag("token", "A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
 	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -108,8 +108,8 @@ func Run(args []string, stdout io.Writer) error {
 		EnumVar(&cf.LogFormat, config.LogFormatJSON, config.LogFormatText)
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
-	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
-	configureCmd.Flag("proxy", "Address of the Teleport Proxy Server.").StringVar(&cf.Proxy)
+	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server. Prefer using --proxy-server where possible.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	configureCmd.Flag("proxy-server", "Address of the Teleport Proxy Server.").StringVar(&cf.ProxyServer)
 	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	configureCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
 	configureCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -126,8 +126,14 @@ func Run(args []string, stdout io.Writer) error {
 	migrateCmd := app.Command("migrate", "Migrates a config file from an older version to the newest version. Outputs to stdout by default.")
 	migrateCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&cf.ConfigureOutput)
 
+	legacyProxyFlag := ""
+
 	dbCmd := app.Command("db", "Execute database commands through tsh.")
-	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
+	dbCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").StringVar(&cf.ProxyServer)
+	// We're migrating from --proxy to --proxy-server so this flag is hidden
+	// but still supported.
+	// TODO(strideynet): DELETE IN 17.0.0
+	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Hidden().StringVar(&legacyProxyFlag)
 	dbCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
 	dbCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
 	dbRemaining := config.RemainingArgs(dbCmd.Arg(
@@ -136,7 +142,11 @@ func Run(args []string, stdout io.Writer) error {
 	))
 
 	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
-	proxyCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
+	proxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.ProxyServer)
+	// We're migrating from --proxy to --proxy-server so this flag is hidden
+	// but still supported.
+	// TODO(strideynet): DELETE IN 17.0.0
+	proxyCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Hidden().StringVar(&legacyProxyFlag)
 	proxyCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
 	proxyCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
 	proxyRemaining := config.RemainingArgs(proxyCmd.Arg(
@@ -153,6 +163,11 @@ func Run(args []string, stdout io.Writer) error {
 	if err != nil {
 		app.Usage(args)
 		return trace.Wrap(err)
+	}
+
+	if legacyProxyFlag != "" {
+		cf.ProxyServer = legacyProxyFlag
+		log.Warn("The --proxy flag is deprecated and will be removed in v17.0.0. Use --proxy-server instead.")
 	}
 
 	// Remaining args are stored directly to a []string rather than written to

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -142,7 +142,7 @@ func Run(args []string, stdout io.Writer) error {
 	))
 
 	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
-	proxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.ProxyServer)
+	proxyCmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").StringVar(&cf.ProxyServer)
 	// We're migrating from --proxy to --proxy-server so this flag is hidden
 	// but still supported.
 	// TODO(strideynet): DELETE IN 17.0.0

--- a/tool/tbot/main_test.go
+++ b/tool/tbot/main_test.go
@@ -68,6 +68,12 @@ func TestRun_Configure(t *testing.T) {
 				"--fips",
 			}...),
 		},
+		{
+			name: "all parameters provided",
+			args: append(baseArgs, []string{
+				"--proxy", "proxy.example.com:443",
+			}...),
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/tbot/main_test.go
+++ b/tool/tbot/main_test.go
@@ -71,7 +71,7 @@ func TestRun_Configure(t *testing.T) {
 		{
 			name: "all parameters provided",
 			args: append(baseArgs, []string{
-				"--proxy", "proxy.example.com:443",
+				"--proxy-server", "proxy.example.com:443",
 			}...),
 		},
 	}

--- a/tool/tbot/proxy.go
+++ b/tool/tbot/proxy.go
@@ -54,7 +54,7 @@ func onProxyCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
 
 	// TODO(timothyb89):  We could consider supporting a --cluster passthrough
 	//  here as in `tbot db ...`.
-	args := []string{"-i", identityPath, "proxy", "--proxy=" + cf.Proxy}
+	args := []string{"-i", identityPath, "proxy", "--proxy=" + cf.ProxyServer}
 	args = append(args, cf.RemainingArgs...)
 
 	// Pass through the debug flag, and prepend to satisfy argument ordering

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
@@ -8,7 +8,7 @@ storage:
   symlinks: secure
   acls: try
 debug: false
-proxy: proxy.example.com:443
+proxy_server: proxy.example.com:443
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
@@ -8,6 +8,7 @@ storage:
   symlinks: secure
   acls: try
 debug: false
+proxy: proxy.example.com:443
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
@@ -8,7 +8,7 @@ storage:
   symlinks: secure
   acls: try
 debug: false
-proxy: proxy.example.com:443
+proxy_server: proxy.example.com:443
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
@@ -8,6 +8,7 @@ storage:
   symlinks: secure
   acls: try
 debug: false
+proxy: proxy.example.com:443
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false

--- a/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
@@ -8,7 +8,6 @@ storage:
   symlinks: secure
   acls: try
 debug: false
-auth_server: ""
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -167,7 +167,7 @@ certificates:
 > tbot start \
    --destination-dir=./tbot-user \
    --token={{.token}} \
-   --proxy={{.addr}}{{if .join_method}} \
+   --proxy-server={{.addr}}{{if .join_method}} \
    --join-method={{.join_method}}{{end}}
 
 Please note:

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -167,7 +167,7 @@ certificates:
 > tbot start \
    --destination-dir=./tbot-user \
    --token={{.token}} \
-   --auth-server={{.addr}}{{if .join_method}} \
+   --proxy={{.addr}}{{if .join_method}} \
    --join-method={{.join_method}}{{end}}
 
 Please note:


### PR DESCRIPTION
Backport #38727 to branch/v14

changelog: TBot now supports `--proxy-server` for explicitly configuring the Proxy address. We recommend switching to this if you currently specify the address of your Teleport proxy to `--auth-server`.
