### PR TITLE
[v15] Remove `auth.ClientI` from `tbot`

### DIFF
--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -59,7 +59,7 @@ type identityService struct {
 	resolver          reversetunnelclient.Resolver
 
 	mu     sync.Mutex
-	client auth.ClientI
+	client *auth.Client
 	facade *identity.Facade
 }
 
@@ -72,7 +72,7 @@ func (s *identityService) GetIdentity() *identity.Identity {
 
 // GetClient returns the facaded client for the Bot identity for use by other
 // components of `tbot`. Consumers should not call `Close` on the client.
-func (s *identityService) GetClient() auth.ClientI {
+func (s *identityService) GetClient() *auth.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.client
@@ -343,7 +343,7 @@ func botIdentityFromAuth(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	ident *identity.Identity,
-	client auth.ClientI,
+	client *auth.Client,
 	ttl time.Duration,
 ) (*identity.Identity, error) {
 	ctx, span := tracer.Start(ctx, "botIdentityFromAuth")

--- a/lib/tbot/service_ca_rotation.go
+++ b/lib/tbot/service_ca_rotation.go
@@ -129,7 +129,7 @@ const caRotationRetryBackoff = time.Second * 2
 type caRotationService struct {
 	log               logrus.FieldLogger
 	reloadBroadcaster *channelBroadcaster
-	botClient         auth.ClientI
+	botClient         *auth.Client
 	getBotIdentity    getBotIdentityFn
 }
 

--- a/lib/tbot/service_ca_rotation_test.go
+++ b/lib/tbot/service_ca_rotation_test.go
@@ -199,7 +199,7 @@ func rotate( //nolint:unused // used in skipped test
 }
 
 func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T, wg *sync.WaitGroup, //nolint:unused // used in skipped test
-) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig) {
+) (*auth.Client, func() *service.TeleportProcess, *config.FileConfig) {
 	fc, fds := testhelpers.DefaultConfig(t)
 
 	cfg := servicecfg.MakeDefaultConfig()

--- a/lib/tbot/service_outputs.go
+++ b/lib/tbot/service_outputs.go
@@ -60,7 +60,7 @@ const renewalRetryLimit = 5
 type outputsService struct {
 	log               logrus.FieldLogger
 	reloadBroadcaster *channelBroadcaster
-	botClient         auth.ClientI
+	botClient         *auth.Client
 	getBotIdentity    getBotIdentityFn
 	cfg               *config.BotConfig
 	resolver          reversetunnelclient.Resolver
@@ -290,7 +290,7 @@ type identityConfigurator = func(req *proto.UserCertsRequest)
 // certs.
 func (s *outputsService) generateIdentity(
 	ctx context.Context,
-	client auth.ClientI,
+	client *auth.Client,
 	currentIdentity *identity.Identity,
 	output config.Output,
 	defaultRoles []string,
@@ -382,7 +382,7 @@ func (s *outputsService) generateIdentity(
 	return newIdentity, nil
 }
 
-func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Database, error) {
+func getDatabase(ctx context.Context, clt *auth.Client, name string) (types.Database, error) {
 	ctx, span := tracer.Start(ctx, "getDatabase")
 	defer span.End()
 
@@ -406,7 +406,7 @@ func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Data
 	return db, trace.Wrap(err)
 }
 
-func (s *outputsService) getRouteToDatabase(ctx context.Context, client auth.ClientI, output *config.DatabaseOutput) (proto.RouteToDatabase, error) {
+func (s *outputsService) getRouteToDatabase(ctx context.Context, client *auth.Client, output *config.DatabaseOutput) (proto.RouteToDatabase, error) {
 	ctx, span := tracer.Start(ctx, "outputsService/getRouteToDatabase")
 	defer span.End()
 
@@ -440,7 +440,7 @@ func (s *outputsService) getRouteToDatabase(ctx context.Context, client auth.Cli
 	}, nil
 }
 
-func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.KubeCluster, error) {
+func getKubeCluster(ctx context.Context, clt *auth.Client, name string) (types.KubeCluster, error) {
 	ctx, span := tracer.Start(ctx, "getKubeCluster")
 	defer span.End()
 
@@ -464,7 +464,7 @@ func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.K
 	return cluster, trace.Wrap(err)
 }
 
-func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Application, error) {
+func getApp(ctx context.Context, clt *auth.Client, appName string) (types.Application, error) {
 	ctx, span := tracer.Start(ctx, "getApp")
 	defer span.End()
 
@@ -491,7 +491,7 @@ func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Applic
 	return apps[0], nil
 }
 
-func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client auth.ClientI, output *config.ApplicationOutput) (proto.RouteToApp, error) {
+func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identity.Identity, client *auth.Client, output *config.ApplicationOutput) (proto.RouteToApp, error) {
 	ctx, span := tracer.Start(ctx, "outputsService/getRouteToApp")
 	defer span.End()
 
@@ -528,11 +528,11 @@ func (s *outputsService) getRouteToApp(ctx context.Context, botIdentity *identit
 // impersonated identity.
 func (s *outputsService) generateImpersonatedIdentity(
 	ctx context.Context,
-	botClient auth.ClientI,
+	botClient *auth.Client,
 	botIdentity *identity.Identity,
 	output config.Output,
 	defaultRoles []string,
-) (impersonatedIdentity *identity.Identity, impersonatedClient auth.ClientI, err error) {
+) (impersonatedIdentity *identity.Identity, impersonatedClient *auth.Client, err error) {
 	ctx, span := tracer.Start(ctx, "outputsService/generateImpersonatedIdentity")
 	defer span.End()
 
@@ -659,7 +659,7 @@ func fetchDefaultRoles(ctx context.Context, roleGetter services.RoleGetter, iden
 // requests for the same information. This is shared between all of the
 // outputs.
 type outputRenewalCache struct {
-	client auth.ClientI
+	client *auth.Client
 
 	cfg *config.BotConfig
 	mu  sync.Mutex
@@ -771,7 +771,7 @@ type outputProvider struct {
 	*outputRenewalCache
 	// impersonatedClient is a client using the impersonated identity configured
 	// for that output.
-	impersonatedClient auth.ClientI
+	impersonatedClient *auth.Client
 }
 
 // GetRemoteClusters uses the impersonatedClient to call GetRemoteClusters.

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -68,7 +68,7 @@ type SPIFFEWorkloadAPIService struct {
 	botCfg      *config.BotConfig
 	cfg         *config.SPIFFEWorkloadAPIService
 	log         logrus.FieldLogger
-	botClient   auth.ClientI
+	botClient   *auth.Client
 	resolver    reversetunnelclient.Resolver
 	// rootReloadBroadcaster allows the service to listen for CA rotations and
 	// update the trust bundle cache.
@@ -78,7 +78,7 @@ type SPIFFEWorkloadAPIService struct {
 	trustBundleBroadcast *channelBroadcaster
 
 	// client holds the impersonated client for the service
-	client auth.ClientI
+	client *auth.Client
 
 	trustDomain string
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -414,7 +414,7 @@ func clientForFacade(
 	log logrus.FieldLogger,
 	cfg *config.BotConfig,
 	facade *identity.Facade,
-	resolver reversetunnelclient.Resolver) (auth.ClientI, error) {
+	resolver reversetunnelclient.Resolver) (*auth.Client, error) {
 	ctx, span := tracer.Start(ctx, "clientForFacade")
 	defer span.End()
 

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -117,7 +117,7 @@ func MakeAndRunTestAuthServer(t *testing.T, log utils.Logger, fc *config.FileCon
 // MakeDefaultAuthClient reimplements the bare minimum needed to create a
 // default root-level auth client for a Teleport server started by
 // MakeAndRunTestAuthServer.
-func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig) auth.ClientI {
+func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig) *auth.Client {
 	t.Helper()
 
 	cfg := servicecfg.MakeDefaultConfig()
@@ -163,7 +163,7 @@ func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig
 }
 
 // MakeBot creates a server-side bot and returns joining parameters.
-func MakeBot(t *testing.T, client auth.ClientI, name string, roles ...string) (*botconfig.OnboardingConfig, *machineidv1pb.Bot) {
+func MakeBot(t *testing.T, client *auth.Client, name string, roles ...string) (*botconfig.OnboardingConfig, *machineidv1pb.Bot) {
 	ctx := context.TODO()
 	t.Helper()
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{


### PR DESCRIPTION
Backport #39058 to branch/v15