### PR TITLE
Fix .clangd file on lib/devicetrust/native

### DIFF
--- a/lib/devicetrust/native/.clangd
+++ b/lib/devicetrust/native/.clangd
@@ -1,2 +1,2 @@
-lib/devicetrust/native/.clangdCompileFlags:
+CompileFlags:
   Add: [-Wall, -xobjective-c, -fblocks, -fobjc-arc]


### PR DESCRIPTION
I think an accidental file path just slipped into it.

Reference: https://clangd.llvm.org/config#compileflags.