### PR TITLE
[v13] Remove `auth.ClientI` from `tbot`

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -60,7 +60,7 @@ type Config struct {
 
 // Connect creates a valid client connection to the auth service.  It may
 // connect directly to the auth server, or tunnel through the proxy.
-func Connect(ctx context.Context, cfg *Config) (auth.ClientI, error) {
+func Connect(ctx context.Context, cfg *Config) (*auth.Client, error) {
 	cfg.Log.Debugf("Connecting to: %v.", cfg.AuthServers)
 
 	directClient, err := connectViaAuthDirect(cfg)
@@ -86,7 +86,7 @@ func Connect(ctx context.Context, cfg *Config) (auth.ClientI, error) {
 	)
 }
 
-func connectViaAuthDirect(cfg *Config) (auth.ClientI, error) {
+func connectViaAuthDirect(cfg *Config) (*auth.Client, error) {
 	// Try connecting to the auth server directly over TLS.
 	directDialClient, err := auth.NewClient(apiclient.Config{
 		Addrs: utils.NetAddrsToStrings(cfg.AuthServers),
@@ -112,7 +112,7 @@ func connectViaAuthDirect(cfg *Config) (auth.ClientI, error) {
 	return directDialClient, nil
 }
 
-func connectViaProxyTunnel(ctx context.Context, cfg *Config) (auth.ClientI, error) {
+func connectViaProxyTunnel(ctx context.Context, cfg *Config) (*auth.Client, error) {
 	// If direct dial failed, we may have a proxy address in
 	// cfg.AuthServers. Try connecting to the reverse tunnel
 	// endpoint and make a client over that.

--- a/lib/tbot/config/bot.go
+++ b/lib/tbot/config/bot.go
@@ -43,7 +43,7 @@ type Bot interface {
 
 	// AuthenticatedUserClientFromIdentity returns a client backed by a specific
 	// identity.
-	AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (auth.ClientI, error)
+	AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*auth.Client, error)
 
 	// Config returns the current bot config
 	Config() *BotConfig

--- a/lib/tbot/config/bot.go
+++ b/lib/tbot/config/bot.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 )
 
@@ -43,8 +42,15 @@ type Bot interface {
 
 	// AuthenticatedUserClientFromIdentity returns a client backed by a specific
 	// identity.
-	AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*auth.Client, error)
+	AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (AuthClient, error)
 
 	// Config returns the current bot config
 	Config() *BotConfig
+}
+
+type AuthClient interface {
+	Close() error
+	GetDomainName(ctx context.Context) (string, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error)
+	Ping(ctx context.Context) (proto.PingResponse, error)
 }

--- a/lib/tbot/config/bot_test.go
+++ b/lib/tbot/config/bot_test.go
@@ -51,7 +51,7 @@ const (
 
 // mockAuth is a minimal fake auth client, used in tests
 type mockAuth struct {
-	auth.ClientI
+	*auth.Client
 
 	clusterName       string
 	remoteClusterName string
@@ -153,7 +153,7 @@ func (m *mockAuth) Close() error {
 // mockBot is a minimal Bot impl that can be used in tests
 type mockBot struct {
 	cfg  *BotConfig
-	auth auth.ClientI
+	auth *auth.Client
 }
 
 func (b *mockBot) AuthPing(ctx context.Context) (*proto.PingResponse, error) {
@@ -173,7 +173,7 @@ func (b *mockBot) GetCertAuthorities(ctx context.Context, caType types.CertAuthT
 	return b.auth.GetCertAuthorities(ctx, caType, false)
 }
 
-func (b *mockBot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (auth.ClientI, error) {
+func (b *mockBot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*auth.Client, error) {
 	return b.auth, nil
 }
 
@@ -181,7 +181,7 @@ func (b *mockBot) Config() *BotConfig {
 	return b.cfg
 }
 
-func newMockBot(cfg *BotConfig, auth auth.ClientI) *mockBot {
+func newMockBot(cfg *BotConfig, auth *auth.Client) *mockBot {
 	return &mockBot{
 		cfg:  cfg,
 		auth: auth,

--- a/lib/tbot/config/bot_test.go
+++ b/lib/tbot/config/bot_test.go
@@ -153,7 +153,7 @@ func (m *mockAuth) Close() error {
 // mockBot is a minimal Bot impl that can be used in tests
 type mockBot struct {
 	cfg  *BotConfig
-	auth *auth.Client
+	auth AuthClient
 }
 
 func (b *mockBot) AuthPing(ctx context.Context) (*proto.PingResponse, error) {
@@ -173,7 +173,7 @@ func (b *mockBot) GetCertAuthorities(ctx context.Context, caType types.CertAuthT
 	return b.auth.GetCertAuthorities(ctx, caType, false)
 }
 
-func (b *mockBot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*auth.Client, error) {
+func (b *mockBot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (AuthClient, error) {
 	return b.auth, nil
 }
 
@@ -181,7 +181,7 @@ func (b *mockBot) Config() *BotConfig {
 	return b.cfg
 }
 
-func newMockBot(cfg *BotConfig, auth *auth.Client) *mockBot {
+func newMockBot(cfg *BotConfig, auth AuthClient) *mockBot {
 	return &mockBot{
 		cfg:  cfg,
 		auth: auth,

--- a/lib/tbot/config/configtemplate_ssh_client.go
+++ b/lib/tbot/config/configtemplate_ssh_client.go
@@ -91,7 +91,7 @@ func (c *TemplateSSHClient) Describe(destination bot.Destination) []FileDescript
 // using non-filesystem backends.
 var sshConfigUnsupportedWarning sync.Once
 
-func getClusterNames(client auth.ClientI) ([]string, error) {
+func getClusterNames(client *auth.Client) ([]string, error) {
 	cn, err := client.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -216,7 +216,7 @@ func (c *TemplateSSHClient) Render(
 	return nil
 }
 
-func fetchKnownHosts(ctx context.Context, client auth.ClientI, clusterNames []string, proxyHosts string) (string, error) {
+func fetchKnownHosts(ctx context.Context, client *auth.Client, clusterNames []string, proxyHosts string) (string, error) {
 	certAuthorities := make([]types.CertAuthority, 0, len(clusterNames))
 	for _, cn := range clusterNames {
 		ca, err := client.GetCertAuthority(ctx, types.CertAuthID{

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -75,7 +75,7 @@ func generateKeys() (private, sshpub, tlspub []byte, err error) {
 // identity. Note that depending on the connection address given, this may
 // attempt to connect via the proxy and therefore requires both SSH and TLS
 // credentials.
-func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (auth.ClientI, error) {
+func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *identity.Identity) (*auth.Client, error) {
 	if id.SSHCert == nil || id.X509Cert == nil {
 		return nil, trace.BadParameter("auth client requires a fully formed identity")
 	}
@@ -243,7 +243,7 @@ func (b *Bot) generateIdentity(
 	return newIdentity, nil
 }
 
-func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Database, error) {
+func getDatabase(ctx context.Context, clt *auth.Client, name string) (types.Database, error) {
 	servers, err := apiclient.GetAllResources[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindDatabaseServer,
@@ -264,7 +264,7 @@ func getDatabase(ctx context.Context, clt auth.ClientI, name string) (types.Data
 	return db, trace.Wrap(err)
 }
 
-func (b *Bot) getRouteToDatabase(ctx context.Context, client auth.ClientI, dbCfg *config.Database) (proto.RouteToDatabase, error) {
+func (b *Bot) getRouteToDatabase(ctx context.Context, client *auth.Client, dbCfg *config.Database) (proto.RouteToDatabase, error) {
 	if dbCfg.Service == "" {
 		return proto.RouteToDatabase{}, nil
 	}
@@ -295,7 +295,7 @@ func (b *Bot) getRouteToDatabase(ctx context.Context, client auth.ClientI, dbCfg
 	}, nil
 }
 
-func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.KubeCluster, error) {
+func getKubeCluster(ctx context.Context, clt *auth.Client, name string) (types.KubeCluster, error) {
 	servers, err := apiclient.GetAllResources[types.KubeServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindKubeServer,
@@ -316,7 +316,7 @@ func getKubeCluster(ctx context.Context, clt auth.ClientI, name string) (types.K
 	return cluster, trace.Wrap(err)
 }
 
-func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Application, error) {
+func getApp(ctx context.Context, clt *auth.Client, appName string) (types.Application, error) {
 	servers, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindAppServer,
@@ -340,7 +340,7 @@ func getApp(ctx context.Context, clt auth.ClientI, appName string) (types.Applic
 	return apps[0], nil
 }
 
-func (b *Bot) getRouteToApp(ctx context.Context, client auth.ClientI, appCfg *config.App) (proto.RouteToApp, error) {
+func (b *Bot) getRouteToApp(ctx context.Context, client *auth.Client, appCfg *config.App) (proto.RouteToApp, error) {
 	if appCfg.App == "" {
 		return proto.RouteToApp{}, trace.BadParameter("App name must be configured")
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -52,7 +52,7 @@ type Bot struct {
 
 	// These are protected by getter/setters with mutex locks
 	mu         sync.Mutex
-	_client    auth.ClientI
+	_client    *auth.Client
 	_ident     *identity.Identity
 	_authPong  *proto.PingResponse
 	_proxyPong *webclient.PingResponse
@@ -81,14 +81,14 @@ func (b *Bot) Config() *config.BotConfig {
 }
 
 // Client retrieves the current auth client.
-func (b *Bot) Client() auth.ClientI {
+func (b *Bot) Client() *auth.Client {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	return b._client
 }
 
-func (b *Bot) setClient(client auth.ClientI) {
+func (b *Bot) setClient(client *auth.Client) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -342,7 +342,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 		return unlock, trace.Wrap(err)
 	}
 
-	var authClient auth.ClientI
+	var authClient *auth.Client
 
 	b.resolver, err = reversetunnelclient.CachingResolver(
 		ctx,

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -63,7 +63,7 @@ func rotate( //nolint:unused // used in skipped test
 }
 
 func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T, wg *sync.WaitGroup, //nolint:unused // used in skipped test
-) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig) {
+) (*auth.Client, func() *service.TeleportProcess, *config.FileConfig) {
 	fc, fds := testhelpers.DefaultConfig(t)
 
 	cfg := servicecfg.MakeDefaultConfig()

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -149,7 +149,7 @@ func MakeAndRunTestAuthServer(t *testing.T, log utils.Logger, fc *config.FileCon
 }
 
 // MakeBotAuthClient creates a new auth client using a Bot identity.
-func MakeBotAuthClient(t *testing.T, fc *config.FileConfig, ident *identity.Identity) auth.ClientI {
+func MakeBotAuthClient(t *testing.T, fc *config.FileConfig, ident *identity.Identity) *auth.Client {
 	t.Helper()
 
 	cfg := servicecfg.MakeDefaultConfig()
@@ -172,7 +172,7 @@ func MakeBotAuthClient(t *testing.T, fc *config.FileConfig, ident *identity.Iden
 // MakeDefaultAuthClient reimplements the bare minimum needed to create a
 // default root-level auth client for a Teleport server started by
 // MakeAndRunTestAuthServer.
-func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig) auth.ClientI {
+func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig) *auth.Client {
 	t.Helper()
 
 	cfg := servicecfg.MakeDefaultConfig()
@@ -218,7 +218,7 @@ func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig
 }
 
 // MakeBot creates a server-side bot and returns joining parameters.
-func MakeBot(t *testing.T, client auth.ClientI, name string, roles ...string) *proto.CreateBotResponse {
+func MakeBot(t *testing.T, client *auth.Client, name string, roles ...string) *proto.CreateBotResponse {
 	t.Helper()
 
 	bot, err := client.CreateBot(context.Background(), &proto.CreateBotRequest{

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -87,9 +87,7 @@ func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opt
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		if closer, ok := client.(io.Closer); ok {
-			closer.Close()
-		}
+		client.Close()
 	})
 
 	return client


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/39058 to branch/v13