### PR TITLE
AWS OIDC - DeployService: Add ecs:TagResource policy

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -57,6 +57,9 @@ func StatementForECSManageService() *Statement {
 			"ecs:DescribeServices", "ecs:CreateService", "ecs:UpdateService", "ecs:ListServices",
 			"ecs:RegisterTaskDefinition", "ecs:DescribeTaskDefinition", "ecs:DeregisterTaskDefinition",
 
+			// Required if the account has Resource Tagging Authorization enabled in Amazon ECS.
+			"ecs:TagResource",
+
 			// EC2 DescribeSecurityGroups is required so that the user can list the SG and then pick which ones they want to apply to the ECS Service.
 			"ec2:DescribeSecurityGroups",
 		},


### PR DESCRIPTION
If the Resource Tagging Authorization setting is enabled, the client must hold the `ecs:TagResource` policy in order to create resources with Tags.


![image](https://github.com/gravitational/teleport/assets/689271/445edfc9-d3c4-4f3f-b524-e03495bbcd12)

Available in https://us-east-1.console.aws.amazon.com/ecs/v2/account-settings?region=us-east-1