### PR TITLE
[v13] Add rotate360 keyframes

### DIFF
--- a/web/packages/design/src/Indicator/Indicator.jsx
+++ b/web/packages/design/src/Indicator/Indicator.jsx
@@ -19,6 +19,8 @@ import styled from 'styled-components';
 
 import PropTypes from 'prop-types';
 
+import { rotate360 } from '../keyframes';
+
 import { Spinner as SpinnerIcon } from './../Icon';
 
 const DelayValueMap = {
@@ -74,20 +76,11 @@ const StyledSpinner = styled(SpinnerIcon)`
     width: ${fontSize};
   `}
 
-  animation: anim-rotate 2s infinite linear;
+  animation: ${rotate360} 2s infinite linear;
   color: ${props => props.theme.colors.spotBackground[0]}
   display: inline-block;
   margin: 16px;
   opacity: 0.24;
-
-  @keyframes anim-rotate {
-    0% {
-      transform: rotate(0);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
 `;
 
 export default Indicator;

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -84,3 +84,4 @@ export {
   Toggle,
 };
 export type { TextAreaProps } from './TextArea';
+export * from './keyframes';

--- a/web/packages/design/src/keyframes.ts
+++ b/web/packages/design/src/keyframes.ts
@@ -1,0 +1,34 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keyframes } from 'styled-components';
+
+/**
+ * Full rotation of an element.
+ *
+ * @example
+ * import { rotate360 } from 'design'
+ *
+ * const Spinner = styled.div`
+ *   animation: ${rotate360} 1s linear infinite;
+ * `
+ */
+export const rotate360 = keyframes`
+  from { transform: rotate(0deg);   }
+  to   { transform: rotate(360deg); }
+`;

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { rotate360 } from 'design';
 
 import { MonospacedOutput } from 'teleport/Assist/shared/MonospacedOutput';
 
@@ -45,12 +46,6 @@ const Header = styled.div`
   padding-right: 20px;
 `;
 
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
-
 const Spinner = styled.div`
   width: 20px;
   height: 20px;
@@ -65,7 +60,7 @@ const Spinner = styled.div`
     border: 3px solid ${p => p.theme.colors.text.main};
     border-color: ${p => p.theme.colors.text.main} transparent
       ${p => p.theme.colors.text.main} transparent;
-    animation: ${spin} 1.2s linear infinite;
+    animation: ${rotate360} 1.2s linear infinite;
   }
 `;
 

--- a/web/packages/teleport/src/Assist/MessageBox/MessageBox.tsx
+++ b/web/packages/teleport/src/Assist/MessageBox/MessageBox.tsx
@@ -22,15 +22,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { rotate360 } from 'design';
 
 import { useAssist } from 'teleport/Assist/context/AssistContext';
-
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
 
 interface MessageBoxProps {
   disabled?: boolean;
@@ -56,7 +51,7 @@ const Spinner = styled.div`
     border: 3px solid ${p => p.theme.colors.text.main};
     border-color: ${p => p.theme.colors.text.main} transparent
       ${p => p.theme.colors.text.main} transparent;
-    animation: ${spin} 1.2s linear infinite;
+    animation: ${rotate360} 1.2s linear infinite;
   }
 `;
 

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Spinner } from 'design/Icon';
-import { Box, Flex } from 'design';
+import { Box, Flex, rotate360 } from 'design';
 
 import auth from 'teleport/services/auth';
 import { useParams } from 'teleport/components/Router';
@@ -137,13 +137,5 @@ export function HeadlessRequest() {
 const Spin = styled(Box)`
   line-height: 12px;
   font-size: 24px;
-  animation: spin 1s linear infinite;
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
+  animation: ${rotate360} 1s linear infinite;
 `;


### PR DESCRIPTION
Backport #39014.

Manual backport since this release branch doesn't have a story for ClusterDropdown and doesn't use the new svg icons.