### PR TITLE
Update `ExecReload` in all Teleport systemd unit files

### DIFF
--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -11,6 +11,7 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -11,6 +11,6 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-auth.service
+++ b/assets/aws/files/system/teleport-auth.service
@@ -11,7 +11,7 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-auth.service
+++ b/assets/aws/files/system/teleport-auth.service
@@ -11,6 +11,7 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-node.service
+++ b/assets/aws/files/system/teleport-node.service
@@ -12,6 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-node.service
+++ b/assets/aws/files/system/teleport-node.service
@@ -12,7 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-proxy-acm.service
+++ b/assets/aws/files/system/teleport-proxy-acm.service
@@ -13,7 +13,7 @@ RuntimeDirectory=teleport
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-proxy-acm.service
+++ b/assets/aws/files/system/teleport-proxy-acm.service
@@ -13,6 +13,7 @@ RuntimeDirectory=teleport
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport-proxy.service
+++ b/assets/aws/files/system/teleport-proxy.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStartPre=/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/assets/aws/files/system/teleport-proxy.service
+++ b/assets/aws/files/system/teleport-proxy.service
@@ -14,6 +14,7 @@ EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStartPre=/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -12,6 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-all-pre-start
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -12,7 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-all-pre-start
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport/teleport.pid"
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -7,6 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288

--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -11,6 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=auth --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=auth --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -11,6 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -11,7 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=proxy --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
-ExecReload=pkill -HUP -L -F /run/teleport.pid
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -11,6 +11,7 @@ Restart=on-failure
 # --roles='proxy,auth,node' is the default value
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=proxy --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -7,6 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
+# systemd before 239 needs an absolute path
 ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -47,7 +47,8 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --config {{ .TeleportConfigPath }} --pid-file={{ .PIDFile }}
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F \"{{ .PIDFile }}\""
+# systemd before 239 needs an absolute path
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F {{ .PIDFile }}"
 PIDFile={{ .PIDFile }}
 LimitNOFILE={{ .FileDescriptorLimit }}
 

--- a/lib/config/systemd.go
+++ b/lib/config/systemd.go
@@ -47,7 +47,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-{{ .EnvironmentFile }}
 ExecStart={{ .TeleportInstallationFile }} start --config {{ .TeleportConfigPath }} --pid-file={{ .PIDFile }}
-ExecReload=pkill -HUP -L -F "{{ .PIDFile }}"
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F \"{{ .PIDFile }}\""
 PIDFile={{ .PIDFile }}
 LimitNOFILE={{ .FileDescriptorLimit }}
 

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -7,7 +7,8 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --config /etc/teleport.yaml --pid-file=/custom/pid/dir/teleport.pid
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F \"/custom/pid/dir/teleport.pid\""
+# systemd before 239 needs an absolute path
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F /custom/pid/dir/teleport.pid"
 PIDFile=/custom/pid/dir/teleport.pid
 LimitNOFILE=16384
 

--- a/lib/config/testdata/TestWriteSystemdUnitFile.golden
+++ b/lib/config/testdata/TestWriteSystemdUnitFile.golden
@@ -7,7 +7,7 @@ Type=simple
 Restart=on-failure
 EnvironmentFile=-/custom/env/dir/teleport
 ExecStart=/custom/install/dir/teleport start --config /etc/teleport.yaml --pid-file=/custom/pid/dir/teleport.pid
-ExecReload=pkill -HUP -L -F "/custom/pid/dir/teleport.pid"
+ExecReload=/bin/sh -c "exec pkill -HUP -L -F \"/custom/pid/dir/teleport.pid\""
 PIDFile=/custom/pid/dir/teleport.pid
 LimitNOFILE=16384
 


### PR DESCRIPTION
As a followup to #39028, this PR updates the `ExecReload` directive to use an absolute path to `/bin/sh` in all Teleport systemd unit files.

Fixes #39001 