### PR TITLE
Fix kube credentials lock in separate mode

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -727,7 +727,12 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 				if cf.MockSSOLogin != nil {
 					lockTimeout = utils.FSLockRetryDelay
 				}
-				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy, lockTimeout)
+				proxy := cf.Proxy
+				// if proxy is empty, fallback to WebProxyAddr
+				if proxy == "" {
+					proxy = tc.WebProxyAddr
+				}
+				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, proxy, lockTimeout)
 				return trace.Wrap(err)
 			},
 		),


### PR DESCRIPTION
This PR fixes situations where `tsh kube credentials` fails to delete/aquire credentials lock because the proxy is empty.

This happens in separate mode and in that case we should fallback to `WebProxyAddress`.

Changelog: Fix a regression where `tsh kube credentials` fails to re-login when credentials expire.