### PR TITLE
[v15] Fix kube credentials lock in separate mode

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -728,7 +728,12 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 				if cf.MockSSOLogin != nil {
 					lockTimeout = utils.FSLockRetryDelay
 				}
-				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy, lockTimeout)
+				proxy := cf.Proxy
+				// if proxy is empty, fallback to WebProxyAddr
+				if proxy == "" {
+					proxy = tc.WebProxyAddr
+				}
+				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, proxy, lockTimeout)
 				return trace.Wrap(err)
 			},
 		),


### PR DESCRIPTION
Backport #39071 to branch/v15

changelog: Fix a regression where `tsh kube credentials` fails to re-login when credentials expire.
