### PR TITLE
Fix tbot args in manual setup section of Machine ID documentation

### DIFF
--- a/docs/pages/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-id/deployment/github-actions.mdx
@@ -412,7 +412,7 @@ jobs:
         # usage telemetry. This helps us shape the future development of
         # tbot. You can disable this by omitting this.
         TELEPORT_ANONYMOUS_TELEMETRY: 1
-      run: tbot -c ./tbot.yaml
+      run: tbot start -c ./tbot.yaml --oneshot
 ```
 
 Add, commit, and push these two files to the repository. Check the GitHub


### PR DESCRIPTION
`tbot -c ./tbot.yaml` is an invalid command.

`tbot start -c ./tbot.yaml --oneshot` will generate certs that are valid for one TTL, which seems most appropriate for a CI/CD workflow.