### PR TITLE
allow pod lists in kube integration tests

### DIFF
--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -38,7 +38,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get"]
+  verbs: ["get", "list"]
   resourceNames: ["test-pod"]
 - apiGroups: [""]
   resources: ["pods/exec"]


### PR DESCRIPTION
The integration test for https://github.com/gravitational/teleport-private/pull/1362 needs this.