### PR TITLE
[v13] chore: Bump grpcbox base to golang:1.22

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.21
+FROM docker.io/golang:1.22
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \


### PR DESCRIPTION
Backport #39084 to branch/v13