### PR TITLE
ensure moderated file transfers only perform allowed operations

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8307,6 +8307,7 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	// Create and approve a file upload request
 	err = cmdSess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
 		Download: false,
+		Filename: "upload-file",
 		Location: reqFile,
 	})
 	require.NoError(t, err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8281,17 +8281,17 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 
 	// A file not in the request shouldn't be allowed
 	_, err = sftpClient.Open(filepath.Join(tempDir, "bad-file"))
-	require.ErrorContains(t, err, `method \"get\" is not allowed`)
+	require.ErrorContains(t, err, `method get is not allowed`)
 	// Since this is a download no files should be allowed to be written to
 	_, err = sftpClient.OpenFile(filepath.Join(tempDir, reqFile), os.O_WRONLY)
-	require.ErrorContains(t, err, `method \"put\" is not allowed`)
+	require.ErrorContains(t, err, `method put is not allowed`)
 	// Only stats and reads should be allowed
 	err = sftpClient.Mkdir(filepath.Join(tempDir, "new-dir"))
-	require.ErrorContains(t, err, `method \"mkdir\" is not allowed`)
+	require.ErrorContains(t, err, `method mkdir is not allowed`)
 	// Since this is a download no files should be allowed to have
 	// their permissions changed
 	err = sftpClient.Chmod(reqFile, 0o777)
-	require.ErrorContains(t, err, `method \"setstat\" is not allowed`)
+	require.ErrorContains(t, err, `method setstat is not allowed`)
 
 	// Only necessary operations should be allowed
 	_, err = sftpClient.Stat(reqFile)
@@ -8346,13 +8346,13 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 
 	// A file not in the request shouldn't be allowed
 	_, err = sftpClient.Open(filepath.Join(tempDir, "bad-file"))
-	require.ErrorContains(t, err, `method \"get\" is not allowed`)
+	require.ErrorContains(t, err, `method get is not allowed`)
 	// Since this is an upload no files should be allowed to be read from
 	_, err = sftpClient.OpenFile(filepath.Join(tempDir, reqFile), os.O_RDONLY)
-	require.ErrorContains(t, err, `method \"get\" is not allowed`)
+	require.ErrorContains(t, err, `method get is not allowed`)
 	// Only stats, writes, and chmods should be allowed
 	err = sftpClient.Mkdir(filepath.Join(tempDir, "new-dir"))
-	require.ErrorContains(t, err, `method \"mkdir\" is not allowed`)
+	require.ErrorContains(t, err, `method mkdir is not allowed`)
 
 	// Only necessary operations should be allowed
 	_, err = sftpClient.Stat(reqFile)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1410,17 +1410,13 @@ func (c *ServerContext) setApprovedFileTransferRequest(req *FileTransferRequest)
 	c.mu.Unlock()
 }
 
-// GetApprovedFileTransferRequest will return the approved file transfer
+// ConsumeApprovedFileTransferRequest will return the approved file transfer
 // request for this session if there is one present. Note that if an
 // approved request is returned future calls to this method will return
 // nil to prevent an approved request getting reused incorrectly.
-func (c *ServerContext) GetApprovedFileTransferRequest() *FileTransferRequest {
+func (c *ServerContext) ConsumeApprovedFileTransferRequest() *FileTransferRequest {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	if c.approvedFileReq == nil {
-		return nil
-	}
 
 	req := c.approvedFileReq
 	c.approvedFileReq = nil

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -452,6 +452,10 @@ type ServerContext struct {
 
 	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
 	UserCreatedByTeleport bool
+
+	// approvedFileReq is an approved file transfer request that will only be
+	// set when the session's pending file transfer request is approved.
+	approvedFileReq *FileTransferRequest
 }
 
 // NewServerContext creates a new *ServerContext which is used to pass and
@@ -1398,4 +1402,28 @@ func (c *ServerContext) GetPortForwardEvent() apievents.PortForward {
 			Success: true,
 		},
 	}
+}
+
+func (c *ServerContext) setApprovedFileTransferRequest(req *FileTransferRequest) {
+	c.mu.Lock()
+	c.approvedFileReq = req
+	c.mu.Unlock()
+}
+
+// GetApprovedFileTransferRequest will return the approved file transfer
+// request for this session if there is one present. Note that if an
+// approved request is returned future calls to this method will return
+// nil to prevent an approved request getting reused incorrectly.
+func (c *ServerContext) GetApprovedFileTransferRequest() *FileTransferRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.approvedFileReq == nil {
+		return nil
+	}
+
+	req := c.approvedFileReq
+	c.approvedFileReq = nil
+
+	return req
 }

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -21,6 +21,7 @@ package regular
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -44,18 +45,20 @@ import (
 const copyingGoroutines = 2
 
 type sftpSubsys struct {
-	sftpCmd   *exec.Cmd
-	serverCtx *srv.ServerContext
-	errCh     chan error
-	log       *logrus.Entry
+	log *logrus.Entry
+
+	fileTransferReq *srv.FileTransferRequest
+	sftpCmd         *exec.Cmd
+	serverCtx       *srv.ServerContext
+	errCh           chan error
 }
 
-func newSFTPSubsys() (*sftpSubsys, error) {
-	// TODO: add prometheus collectors?
+func newSFTPSubsys(fileTransferReq *srv.FileTransferRequest) (*sftpSubsys, error) {
 	return &sftpSubsys{
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: teleport.ComponentSubsystemSFTP,
 		}),
+		fileTransferReq: fileTransferReq,
 	}, nil
 }
 
@@ -127,8 +130,21 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// TODO: put in cgroup?
 	execRequest.Continue()
+
+	// Send the file transfer request if applicable
+	encodedReq := []byte{0x0}
+	if s.fileTransferReq != nil {
+		encodedReq, err = json.Marshal(s.fileTransferReq)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		encodedReq = append(encodedReq, 0x0)
+	}
+	_, err = chReadPipeIn.Write(encodedReq)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	// Copy the SSH channel to and from the anonymous pipes
 	s.errCh = make(chan error, copyingGoroutines)

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -132,7 +132,10 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	}
 	execRequest.Continue()
 
-	// Send the file transfer request if applicable
+	// Send the file transfer request if applicable. The SFTP process
+	// expects the file transfer request data will end with a null byte,
+	// so if there is no request to send just send a null byte so the
+	// SFTP process can detect that no request was sent.
 	encodedReq := []byte{0x0}
 	if s.fileTransferReq != nil {
 		encodedReq, err = json.Marshal(s.fileTransferReq)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2169,7 +2169,7 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 			return nil, trace.Wrap(err)
 		}
 
-		return newSFTPSubsys()
+		return newSFTPSubsys(ctx.GetApprovedFileTransferRequest())
 	default:
 		return nil, trace.BadParameter("unrecognized subsystem: %v", r.Name)
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2169,7 +2169,7 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 			return nil, trace.Wrap(err)
 		}
 
-		return newSFTPSubsys(ctx.GetApprovedFileTransferRequest())
+		return newSFTPSubsys(ctx.ConsumeApprovedFileTransferRequest())
 	default:
 		return nil, trace.BadParameter("unrecognized subsystem: %v", r.Name)
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1635,6 +1635,8 @@ func (s *session) checkPresence(ctx context.Context) error {
 
 // FileTransferRequest is a request to upload or download a file from a node.
 type FileTransferRequest struct {
+	// ID is a UUID that uniquely identifies a file transfer request
+	// and is unlikely to collide with another file transfer request
 	ID string
 	// Requester is the Teleport User that requested the file transfer
 	Requester string

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -458,7 +458,7 @@ func (s *SessionRegistry) isApprovedFileTransfer(scx *ServerContext) (bool, erro
 		return false, trace.NotFound("Session not found")
 	}
 
-	// aquire the session mutex lock so sess.fileTransferReq doesn't get
+	// acquire the session mutex lock so sess.fileTransferReq doesn't get
 	// written while we're reading it
 	sess.mu.Lock()
 	defer sess.mu.Unlock()

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -148,12 +148,10 @@ func (t *TermHandlers) HandleFileTransferDecision(ctx context.Context, ch ssh.Ch
 	}
 
 	if params.Approved {
-		_, err := session.approveFileTransferRequest(params, scx)
-		return trace.Wrap(err)
+		return trace.Wrap(session.approveFileTransferRequest(params, scx))
 	}
 
-	_, err = session.denyFileTransferRequest(params, scx)
-	return trace.Wrap(err)
+	return trace.Wrap(session.denyFileTransferRequest(params, scx))
 }
 
 // HandleFileTransferRequest handles requests of type "file-transfer-request" which will
@@ -172,8 +170,7 @@ func (t *TermHandlers) HandleFileTransferRequest(ctx context.Context, ch ssh.Cha
 		return nil
 	}
 
-	session.addFileTransferRequest(params, scx)
-	return nil
+	return trace.Wrap(session.addFileTransferRequest(params, scx))
 }
 
 // HandleWinChange handles requests of type "window-change" which update the

--- a/lib/sshutils/sftp/http.go
+++ b/lib/sshutils/sftp/http.go
@@ -38,14 +38,6 @@ import (
 type contextKey string
 
 const (
-	// FileTransferDstPath is the dstPath (location) for the requested file transfer. This would be equal
-	// to the file to be downloaded, or location for a file to be uploaded.
-	FileTransferDstPath string = "TELEPORT_FILE_TRANSFER_DST_PATH"
-	// FileTransferRequestID is an optional parameter id of an file transfer request that has gone through
-	// an approval process during a moderated session to allow a file transfer scp command to be executed
-	// used as a value in the file transfer context and env var for exec session
-	FileTransferRequestID contextKey = "TELEPORT_FILE_TRANSFER_REQUEST_ID"
-
 	// ModeratedSessionID is an optional parameter sent during SCP requests to specify which moderated session
 	// to check for valid FileTransferRequests
 	// used as a value in the file transfer context and env var for exec session

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -239,17 +239,11 @@ func (c *Config) TransferFiles(ctx context.Context, sshClient *ssh.Client) error
 	}
 	defer s.Close()
 
-	// File transfers in a moderated session require these two variables
-	// to check for approval on the ssh server. If they exist in the
-	// context, set them in our env vars
+	// File transfers in a moderated session require this variable
+	// to check for approval on the ssh server
 	if moderatedSessionID, ok := ctx.Value(ModeratedSessionID).(string); ok {
 		s.Setenv(string(ModeratedSessionID), moderatedSessionID)
 	}
-	if fileTransferRequestID, ok := ctx.Value(FileTransferRequestID).(string); ok {
-		s.Setenv(string(FileTransferRequestID), fileTransferRequestID)
-	}
-	// set dstPath in env var to check against file transfer request location
-	s.Setenv(FileTransferDstPath, c.dstPath)
 
 	pe, err := s.StderrPipe()
 	if err != nil {

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -142,8 +142,6 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	ctx := r.Context()
 	if req.fileTransferRequestID != "" {
-		// These values should never exist independently of each other so we can set them at the same time
-		ctx = context.WithValue(ctx, sftp.FileTransferRequestID, req.fileTransferRequestID)
 		ctx = context.WithValue(ctx, sftp.ModeratedSessionID, req.moderatedSessionID)
 	}
 

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -142,9 +142,9 @@ func newDisallowedErr(req *sftp.Request) error {
 	return fmt.Errorf("method %q is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
 }
 
-// checkReq returns an error if the SFTP request isn't allowed based on
-// the approved file transfer request for this session.
-func (s *sftpHandler) checkReq(req *sftp.Request) error {
+// ensureReqIsAllowed returns an error if the SFTP request isn't
+// allowed based on the approved file transfer request for this session.
+func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	if s.allowed == nil {
 		return nil
 	}
@@ -228,7 +228,7 @@ func (s *sftpHandler) Filewrite(req *sftp.Request) (_ io.WriterAt, retErr error)
 }
 
 func (s *sftpHandler) openFile(req *sftp.Request) (*os.File, error) {
-	if err := s.checkReq(req); err != nil {
+	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
 
@@ -275,7 +275,7 @@ func (s *sftpHandler) Filecmd(req *sftp.Request) (retErr error) {
 	if req.Filepath == "" {
 		return os.ErrInvalid
 	}
-	if err := s.checkReq(req); err != nil {
+	if err := s.ensureReqIsAllowed(req); err != nil {
 		return err
 	}
 
@@ -412,7 +412,7 @@ func (s *sftpHandler) Filelist(req *sftp.Request) (_ sftp.ListerAt, retErr error
 	if req.Filepath == "" {
 		return nil, os.ErrInvalid
 	}
-	if err := s.checkReq(req); err != nil {
+	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
 
@@ -453,7 +453,7 @@ func (s *sftpHandler) Lstat(req *sftp.Request) (sftp.ListerAt, error) {
 	if req.Filepath == "" {
 		return nil, os.ErrInvalid
 	}
-	if err := s.checkReq(req); err != nil {
+	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
 

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -115,7 +115,7 @@ type sftpHandler struct {
 func newSFTPHandler(logger *log.Entry, req *srv.FileTransferRequest, homeDir string, events chan<- *apievents.SFTP) (*sftpHandler, error) {
 	var allowed *allowedOps
 	if req != nil {
-		allowed := &allowedOps{
+		allowed = &allowedOps{
 			write: !req.Download,
 		}
 		// make filepaths consistent by ensuring all separators use backslashes
@@ -164,14 +164,14 @@ func (s *sftpHandler) checkReq(req *sftp.Request) error {
 			return fmt.Errorf("%q is not allowed to be written to", req.Filepath)
 		}
 	default:
-		return fmt.Errorf("method %s is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
+		return fmt.Errorf("method %q is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
 	}
 
 	if s.allowed.path == path.Clean(req.Filepath) {
 		return nil
 	}
 
-	return fmt.Errorf("method %s is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
+	return fmt.Errorf("method %q is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
 }
 
 // OpenFile handles 'open' requests when opening a file for reading

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -131,7 +131,7 @@ func newSFTPHandler(logger *log.Entry, req *srv.FileTransferRequest, events chan
 }
 
 func newDisallowedErr(req *sftp.Request) error {
-	return fmt.Errorf("method %q is not allowed on %q", strings.ToLower(req.Method), req.Filepath)
+	return fmt.Errorf("method %s is not allowed on %s", strings.ToLower(req.Method), req.Filepath)
 }
 
 // ensureReqIsAllowed returns an error if the SFTP request isn't
@@ -161,9 +161,9 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	case methodOpen:
 		pflags := req.Pflags()
 		if !s.allowed.write && pflags.Write {
-			return fmt.Errorf("%q is not allowed to be written to", req.Filepath)
+			return fmt.Errorf("%s is not allowed to be written to", req.Filepath)
 		} else if s.allowed.write && pflags.Read {
-			return fmt.Errorf("%q is not allowed to be written to", req.Filepath)
+			return fmt.Errorf("%s is not allowed to be written to", req.Filepath)
 		}
 	case methodSetStat:
 		// only allow chmods for uploads

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -137,6 +137,7 @@ func newDisallowedErr(req *sftp.Request) error {
 // ensureReqIsAllowed returns an error if the SFTP request isn't
 // allowed based on the approved file transfer request for this session.
 func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
+	// no specifically allowed operations, all requests are allowed
 	if s.allowed == nil {
 		return nil
 	}
@@ -157,13 +158,6 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 		// only allow writes for uploads
 		if !s.allowed.write {
 			return newDisallowedErr(req)
-		}
-	case methodOpen:
-		pflags := req.Pflags()
-		if !s.allowed.write && pflags.Write {
-			return fmt.Errorf("%s is not allowed to be written to", req.Filepath)
-		} else if s.allowed.write && pflags.Read {
-			return fmt.Errorf("%s is not allowed to be written to", req.Filepath)
 		}
 	case methodSetStat:
 		// only allow chmods for uploads


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/1055.
Closes https://github.com/gravitational/teleport-private/issues/1391.

To reduce complexity and the risk of file transfer requests getting reused again (see the above issue 1055) pending file transfer requests are now limited to one per session. Creating multiple in-flight file transfer requests for moderated sessions didn't properly work before anyway, so I don't think we're losing anything by doing this. The SFTP server now also only allows necessary operations for the session's approved file transfer request if there is one present.

This change should be backwards compatible as the API for managing file transfer requests has not changed, only previously non-functional behavior has been removed. Since Nodes re-exec themselves to start an SFTP server, Node processes now sending file transfer request info to SFTP server processes shouldn't pose a compatibility issue.

Reviewed already in https://github.com/gravitational/teleport-private/pull/1399, just need approvals to get this merged.

changelog: only allow necessary operations during moderated file transfers and limit in-flight file transfer requests to one per session