### PR TITLE
[v14] Replace `auth.ClientI` references in `tool/tctl` (#39059)

### DIFF
--- a/lib/client/db/database_certificates.go
+++ b/lib/client/db/database_certificates.go
@@ -28,13 +28,20 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
+
+type CertificateSigner interface {
+	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
+	GenerateDatabaseCert(context.Context, *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error)
+}
 
 // GenerateDatabaseCertificatesRequest contains the required fields used to generate database certificates
 // Those certificates will be used by databases to set up mTLS authentication against Teleport
 type GenerateDatabaseCertificatesRequest struct {
-	ClusterAPI         auth.ClientI
+	ClusterAPI         CertificateSigner
 	Principals         []string
 	OutputFormat       identityfile.Format
 	OutputCanOverwrite bool

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -120,7 +120,7 @@ func (c *AccessRequestCommand) Initialize(app *kingpin.Application, config *serv
 }
 
 // TryRun takes the CLI command as an argument (like "access-request list") and executes it.
-func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.requestList.FullCommand():
 		err = c.List(ctx, client)
@@ -144,7 +144,7 @@ func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client au
 	return true, trace.Wrap(err)
 }
 
-func (c *AccessRequestCommand) List(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) List(ctx context.Context, client *auth.Client) error {
 	reqs, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -167,7 +167,7 @@ func (c *AccessRequestCommand) List(ctx context.Context, client auth.ClientI) er
 	return nil
 }
 
-func (c *AccessRequestCommand) Get(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Get(ctx context.Context, client *auth.Client) error {
 	reqs := []types.AccessRequest{}
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		req, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{
@@ -222,7 +222,7 @@ func (c *AccessRequestCommand) splitRoles() []string {
 	return roles
 }
 
-func (c *AccessRequestCommand) Approve(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Approve(ctx context.Context, client *auth.Client) error {
 	if c.delegator != "" {
 		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
@@ -257,7 +257,7 @@ func (c *AccessRequestCommand) Approve(ctx context.Context, client auth.ClientI)
 	return nil
 }
 
-func (c *AccessRequestCommand) Deny(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Deny(ctx context.Context, client *auth.Client) error {
 	if c.delegator != "" {
 		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
@@ -278,7 +278,7 @@ func (c *AccessRequestCommand) Deny(ctx context.Context, client auth.ClientI) er
 	return nil
 }
 
-func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Create(ctx context.Context, client *auth.Client) error {
 	if len(c.roles) == 0 && len(c.requestedResourceIDs) == 0 {
 		c.roles = "*"
 	}
@@ -294,10 +294,10 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) 
 
 	if c.dryRun {
 		users := &struct {
-			auth.ClientI
+			*auth.Client
 			services.UserLoginStatesGetter
 		}{
-			ClientI:               client,
+			Client:                client,
 			UserLoginStatesGetter: client.UserLoginStateClient(),
 		}
 		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), users, req, tlsca.Identity{}, services.ExpandVars(true))
@@ -314,7 +314,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) 
 	return nil
 }
 
-func (c *AccessRequestCommand) Delete(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Delete(ctx context.Context, client *auth.Client) error {
 	var approvedTokens []string
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		// Fetch the requests first to see if they were approved to provide the
@@ -354,7 +354,7 @@ func (c *AccessRequestCommand) Delete(ctx context.Context, client auth.ClientI) 
 	return nil
 }
 
-func (c *AccessRequestCommand) Caps(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Caps(ctx context.Context, client *auth.Client) error {
 	caps, err := client.GetAccessCapabilities(ctx, types.AccessCapabilitiesRequest{
 		User:               c.user,
 		RequestableRoles:   true,
@@ -390,7 +390,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client auth.ClientI) er
 	}
 }
 
-func (c *AccessRequestCommand) Review(ctx context.Context, client auth.ClientI) error {
+func (c *AccessRequestCommand) Review(ctx context.Context, client *auth.Client) error {
 	if c.approve == c.deny {
 		return trace.BadParameter("must supply exactly one of '--approve' or '--deny'")
 	}

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -82,7 +82,7 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *servicecfg.Config) 
 }
 
 // TryRun takes the CLI command as an argument (like "acl ls") and executes it.
-func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.ls.FullCommand():
 		err = c.List(ctx, client)
@@ -101,7 +101,7 @@ func (c *ACLCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI
 }
 
 // List will list access lists visible to the user.
-func (c *ACLCommand) List(ctx context.Context, client auth.ClientI) error {
+func (c *ACLCommand) List(ctx context.Context, client *auth.Client) error {
 	var accessLists []*accesslist.AccessList
 	var nextKey string
 	for {
@@ -128,7 +128,7 @@ func (c *ACLCommand) List(ctx context.Context, client auth.ClientI) error {
 }
 
 // Get will display information about an access list visible to the user.
-func (c *ACLCommand) Get(ctx context.Context, client auth.ClientI) error {
+func (c *ACLCommand) Get(ctx context.Context, client *auth.Client) error {
 	accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -138,7 +138,7 @@ func (c *ACLCommand) Get(ctx context.Context, client auth.ClientI) error {
 }
 
 // UsersAdd will add a user to an access list.
-func (c *ACLCommand) UsersAdd(ctx context.Context, client auth.ClientI) error {
+func (c *ACLCommand) UsersAdd(ctx context.Context, client *auth.Client) error {
 	var expires time.Time
 	if c.expires != "" {
 		var err error
@@ -175,7 +175,7 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client auth.ClientI) error {
 }
 
 // UsersRemove will remove a user to an access list.
-func (c *ACLCommand) UsersRemove(ctx context.Context, client auth.ClientI) error {
+func (c *ACLCommand) UsersRemove(ctx context.Context, client *auth.Client) error {
 	err := client.AccessListClient().DeleteAccessListMember(ctx, c.accessListName, c.userName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -187,7 +187,7 @@ func (c *ACLCommand) UsersRemove(ctx context.Context, client auth.ClientI) error
 }
 
 // UsersList will list the users in an access list.
-func (c *ACLCommand) UsersList(ctx context.Context, client auth.ClientI) error {
+func (c *ACLCommand) UsersList(ctx context.Context, client *auth.Client) error {
 	members, nextToken, err := client.AccessListClient().ListAccessListMembers(ctx, c.accessListName, 0, "")
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -91,7 +91,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 }
 
 // TryRun takes the CLI command as an argument (like "alerts ls") and executes it.
-func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.alertList.FullCommand():
 		err = c.List(ctx, client)
@@ -105,7 +105,7 @@ func (c *AlertCommand) TryRun(ctx context.Context, cmd string, client auth.Clien
 	return true, trace.Wrap(err)
 }
 
-func (c *AlertCommand) ListAck(ctx context.Context, client auth.ClientI) error {
+func (c *AlertCommand) ListAck(ctx context.Context, client *auth.Client) error {
 	acks, err := client.GetAlertAcks(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -123,7 +123,7 @@ func (c *AlertCommand) ListAck(ctx context.Context, client auth.ClientI) error {
 	return nil
 }
 
-func (c *AlertCommand) Ack(ctx context.Context, client auth.ClientI) error {
+func (c *AlertCommand) Ack(ctx context.Context, client *auth.Client) error {
 	if c.clear {
 		return c.ClearAck(ctx, client)
 	}
@@ -152,7 +152,7 @@ func (c *AlertCommand) Ack(ctx context.Context, client auth.ClientI) error {
 	return nil
 }
 
-func (c *AlertCommand) ClearAck(ctx context.Context, client auth.ClientI) error {
+func (c *AlertCommand) ClearAck(ctx context.Context, client *auth.Client) error {
 	req := proto.ClearAlertAcksRequest{
 		AlertID: c.alertID,
 	}
@@ -166,7 +166,7 @@ func (c *AlertCommand) ClearAck(ctx context.Context, client auth.ClientI) error 
 	return nil
 }
 
-func (c *AlertCommand) List(ctx context.Context, client auth.ClientI) error {
+func (c *AlertCommand) List(ctx context.Context, client *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
@@ -238,7 +238,7 @@ func displayAlertsJSON(alerts []types.ClusterAlert) error {
 	return nil
 }
 
-func (c *AlertCommand) Create(ctx context.Context, client auth.ClientI) error {
+func (c *AlertCommand) Create(ctx context.Context, client *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -66,7 +66,7 @@ func (c *AppsCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands like "apps ls".
-func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.appsList.FullCommand():
 		err = c.ListApps(ctx, client)
@@ -78,7 +78,7 @@ func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 // ListApps prints the list of applications that have recently sent heartbeats
 // to the cluster.
-func (c *AppsCommand) ListApps(ctx context.Context, clt auth.ClientI) error {
+func (c *AppsCommand) ListApps(ctx context.Context, clt *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -376,7 +376,7 @@ func (p *pingSrv) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 }
 
 type mockClient struct {
-	auth.ClientI
+	*auth.Client
 
 	clusterName    types.ClusterName
 	userCerts      *proto.Certs

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -84,7 +84,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands.
-func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.botsList.FullCommand():
 		err = c.ListBots(ctx, client)
@@ -103,7 +103,7 @@ func (c *BotsCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 // ListBots writes a listing of the cluster's certificate renewal bots
 // to standard out.
-func (c *BotsCommand) ListBots(ctx context.Context, client auth.ClientI) error {
+func (c *BotsCommand) ListBots(ctx context.Context, client *auth.Client) error {
 	// TODO: consider adding a custom column for impersonator roles, locks, ??
 	users, err := client.GetBotUsers(ctx)
 	if err != nil {
@@ -180,7 +180,7 @@ Please note:
 `))
 
 // AddBot adds a new certificate renewal bot to the cluster.
-func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
+func (c *BotsCommand) AddBot(ctx context.Context, client *auth.Client) error {
 	roles := splitRoles(c.botRoles)
 	if len(roles) == 0 {
 		return trace.BadParameter("at least one role must be specified with --roles")
@@ -236,7 +236,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client auth.ClientI) error {
 	})
 }
 
-func (c *BotsCommand) RemoveBot(ctx context.Context, client auth.ClientI) error {
+func (c *BotsCommand) RemoveBot(ctx context.Context, client *auth.Client) error {
 	if err := client.DeleteBot(ctx, c.botName); err != nil {
 		return trace.WrapWithMessage(err, "error deleting bot")
 	}
@@ -246,7 +246,7 @@ func (c *BotsCommand) RemoveBot(ctx context.Context, client auth.ClientI) error 
 	return nil
 }
 
-func (c *BotsCommand) LockBot(ctx context.Context, client auth.ClientI) error {
+func (c *BotsCommand) LockBot(ctx context.Context, client *auth.Client) error {
 	lockExpiry, err := computeLockExpiry(c.lockExpires, c.lockTTL)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -66,7 +66,7 @@ func (c *DBCommand) Initialize(app *kingpin.Application, config *servicecfg.Conf
 }
 
 // TryRun attempts to run subcommands like "db ls".
-func (c *DBCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *DBCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.dbList.FullCommand():
 		err = c.ListDatabases(ctx, client)
@@ -78,7 +78,7 @@ func (c *DBCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI)
 
 // ListDatabases prints the list of database proxies that have recently sent
 // heartbeats to the cluster.
-func (c *DBCommand) ListDatabases(ctx context.Context, clt auth.ClientI) error {
+func (c *DBCommand) ListDatabases(ctx context.Context, clt *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -55,7 +55,7 @@ func (c *DesktopCommand) Initialize(app *kingpin.Application, config *servicecfg
 }
 
 // TryRun attempts to run subcommands like "desktop ls".
-func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.desktopList.FullCommand():
 		err = c.ListDesktop(ctx, client)
@@ -67,7 +67,7 @@ func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client auth.Cli
 
 // ListDesktop prints the list of desktops that have recently sent heartbeats
 // to the cluster.
-func (c *DesktopCommand) ListDesktop(ctx context.Context, client auth.ClientI) error {
+func (c *DesktopCommand) ListDesktop(ctx context.Context, client *auth.Client) error {
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -105,10 +105,10 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Co
 
 // runner is used as a simple interface for subcommands.
 type runner interface {
-	Run(context.Context, auth.ClientI) error
+	Run(context.Context, *auth.Client) error
 }
 
-func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, authClient auth.ClientI) (match bool, err error) {
+func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, authClient *auth.Client) (match bool, err error) {
 	innerCmd, ok := map[string]runner{
 		"devices add":    &c.add,
 		"devices ls":     &c.ls,
@@ -136,7 +136,7 @@ type deviceAddCommand struct {
 	enrollTTL time.Duration
 }
 
-func (c *deviceAddCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+func (c *deviceAddCommand) Run(ctx context.Context, authClient *auth.Client) error {
 	if _, err := c.setCurrentDevice(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -204,7 +204,7 @@ tsh device enroll --token=%v
 
 type deviceListCommand struct{}
 
-func (c *deviceListCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+func (c *deviceListCommand) Run(ctx context.Context, authClient *auth.Client) error {
 	devices := authClient.DevicesClient()
 
 	// List all devices.
@@ -263,7 +263,7 @@ type deviceRemoveCommand struct {
 	deviceID string
 }
 
-func (c *deviceRemoveCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+func (c *deviceRemoveCommand) Run(ctx context.Context, authClient *auth.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -303,7 +303,7 @@ type deviceEnrollCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceEnrollCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+func (c *deviceEnrollCommand) Run(ctx context.Context, authClient *auth.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -351,7 +351,7 @@ type deviceLockCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceLockCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+func (c *deviceLockCommand) Run(ctx context.Context, authClient *auth.Client) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -59,7 +59,7 @@ func (e *EditCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	$ tctl edit rc/remote`).SetValue(&e.ref)
 }
 
-func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (e *EditCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	if cmd != e.cmd.FullCommand() {
 		return false, nil
 	}

--- a/tool/tctl/common/externalauditstorage_command.go
+++ b/tool/tctl/common/externalauditstorage_command.go
@@ -53,7 +53,7 @@ func (c *ExternalAuditStorageCommand) Initialize(app *kingpin.Application, confi
 }
 
 // TryRun attempts to run subcommands.
-func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.promote.FullCommand():
 		err = c.Promote(ctx, client)
@@ -67,13 +67,13 @@ func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, cl
 
 // Promote calls PromoteToClusterExternalAuditStorage, which results in enabling
 // External Audit Storage in the cluster based on existing draft.
-func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt auth.ClientI) error {
+func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt *auth.Client) error {
 	return trace.Wrap(clt.ExternalAuditStorageClient().PromoteToClusterExternalAuditStorage(ctx))
 }
 
 // Generate creates an External Audit Storage configuration with randomized
 // resource names and saves it as the current draft.
-func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt auth.ClientI) error {
+func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt *auth.Client) error {
 	_, err := clt.ExternalAuditStorageClient().GenerateDraftExternalAuditStorage(ctx, c.integrationName, c.region)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -64,7 +64,7 @@ func withInsecure(insecure bool) optionsFunc {
 	}
 }
 
-func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opts ...optionsFunc) auth.ClientI {
+func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opts ...optionsFunc) *auth.Client {
 	var options options
 	for _, v := range opts {
 		v(&options)
@@ -94,7 +94,7 @@ func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opt
 
 type cliCommand interface {
 	Initialize(app *kingpin.Application, cfg *servicecfg.Config)
-	TryRun(ctx context.Context, cmd string, client auth.ClientI) (bool, error)
+	TryRun(ctx context.Context, cmd string, client *auth.Client) (bool, error)
 }
 
 func runCommand(t *testing.T, fc *config.FileConfig, cmd cliCommand, args []string, opts ...optionsFunc) error {

--- a/tool/tctl/common/idp_command.go
+++ b/tool/tctl/common/idp_command.go
@@ -45,7 +45,7 @@ import (
 // $ tctl idp oidc <command> [<args> ...]
 type subcommandRunner interface {
 	initialize(parent *kingpin.CmdClause, cfg *servicecfg.Config)
-	tryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error)
+	tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
 }
 
 // IdPCommand implements all commands under "tctl idp".
@@ -79,7 +79,7 @@ Examples:
 }
 
 // TryRun calls tryRun for each subcommand, and returns (false, nil) if none of them match.
-func (i *IdPCommand) TryRun(ctx context.Context, cmd string, c auth.ClientI) (match bool, err error) {
+func (i *IdPCommand) TryRun(ctx context.Context, cmd string, c *auth.Client) (match bool, err error) {
 	for _, subcommandRunner := range i.subcommandRunners {
 		match, err = subcommandRunner.tryRun(ctx, cmd, c)
 		if err != nil {
@@ -121,7 +121,7 @@ Examples:
 	s.testAttributeMapping.cmd = testAttrMap
 }
 
-func (s *samlIdPCommand) tryRun(ctx context.Context, cmd string, c auth.ClientI) (match bool, err error) {
+func (s *samlIdPCommand) tryRun(ctx context.Context, cmd string, c *auth.Client) (match bool, err error) {
 	switch cmd {
 	case s.testAttributeMapping.cmd.FullCommand():
 		return true, trace.Wrap(s.testAttributeMapping.run(ctx, c))
@@ -139,7 +139,7 @@ type testAttributeMapping struct {
 	outFormat       string
 }
 
-func (t *testAttributeMapping) run(ctx context.Context, c auth.ClientI) error {
+func (t *testAttributeMapping) run(ctx context.Context, c *auth.Client) error {
 	serviceProvider, err := parseSPFile(t.serviceProvider)
 	if err != nil {
 		return trace.Wrap(err)
@@ -217,7 +217,7 @@ func parseSPFile(fileName string) (types.SAMLIdPServiceProviderV1, error) {
 }
 
 // getUsersFromAPIOrFile parses user from spec file. If file is not found, it fetches user from backend.
-func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c auth.ClientI) ([]*types.UserV2, error) {
+func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c *auth.Client) ([]*types.UserV2, error) {
 	flattenedUsernamesOrFileNames := flattenSlice(usernamesOrFileNames)
 	var users []*types.UserV2
 

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -83,7 +83,7 @@ func (c *InventoryCommand) Initialize(app *kingpin.Application, config *servicec
 }
 
 // TryRun takes the CLI command as an argument (like "inventory status") and executes it.
-func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.inventoryStatus.FullCommand():
 		err = c.Status(ctx, client)
@@ -97,7 +97,7 @@ func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, client auth.C
 	return true, trace.Wrap(err)
 }
 
-func (c *InventoryCommand) Status(ctx context.Context, client auth.ClientI) error {
+func (c *InventoryCommand) Status(ctx context.Context, client *auth.Client) error {
 	rsp, err := client.GetInventoryStatus(ctx, proto.InventoryStatusRequest{
 		Connected: c.getConnected,
 	})
@@ -172,7 +172,7 @@ func printHierarchicalData(data map[string]any, indent string, depth int) {
 	}
 }
 
-func (c *InventoryCommand) List(ctx context.Context, client auth.ClientI) error {
+func (c *InventoryCommand) List(ctx context.Context, client *auth.Client) error {
 	var services []types.SystemRole
 	var err error
 	if c.services != "" {
@@ -245,7 +245,7 @@ func (c *InventoryCommand) List(ctx context.Context, client auth.ClientI) error 
 	}
 }
 
-func (c *InventoryCommand) Ping(ctx context.Context, client auth.ClientI) error {
+func (c *InventoryCommand) Ping(ctx context.Context, client *auth.Client) error {
 	rsp, err := client.PingInventory(ctx, proto.InventoryPingRequest{
 		ServerID:   c.serverID,
 		ControlLog: c.controlLog,

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -66,7 +66,7 @@ func (c *KubeCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands like "kube ls".
-func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.kubeList.FullCommand():
 		err = c.ListKube(ctx, client)
@@ -78,7 +78,7 @@ func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 // ListKube prints the list of kube clusters that have recently sent heartbeats
 // to the cluster.
-func (c *KubeCommand) ListKube(ctx context.Context, clt auth.ClientI) error {
+func (c *KubeCommand) ListKube(ctx context.Context, clt *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/loadtest_command.go
+++ b/tool/tctl/common/loadtest_command.go
@@ -77,7 +77,7 @@ func (c *LoadtestCommand) Initialize(app *kingpin.Application, config *servicecf
 }
 
 // TryRun takes the CLI command as an argument (like "loadtest node-heartbeats") and executes it.
-func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.nodeHeartbeats.FullCommand():
 		err = c.NodeHeartbeats(ctx, client)
@@ -89,7 +89,7 @@ func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, client auth.Cl
 	return true, trace.Wrap(err)
 }
 
-func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client auth.ClientI) error {
+func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *auth.Client) error {
 	infof := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, "[i] "+format+"\n", args...)
 	}
@@ -213,7 +213,7 @@ func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client auth.Client
 	}
 }
 
-func (c *LoadtestCommand) Watch(ctx context.Context, client auth.ClientI) error {
+func (c *LoadtestCommand) Watch(ctx context.Context, client *auth.Client) error {
 	var kinds []types.WatchKind
 	for _, kind := range strings.Split(c.kind, ",") {
 		kind = strings.TrimSpace(kind)

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -65,7 +65,7 @@ func (c *LockCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun attempts to run subcommands.
-func (c *LockCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *LockCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.mainCmd.FullCommand():
 		err = c.CreateLock(ctx, client)
@@ -76,7 +76,7 @@ func (c *LockCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 }
 
 // CreateLock creates a lock for the main `tctl lock` command.
-func (c *LockCommand) CreateLock(ctx context.Context, client auth.ClientI) error {
+func (c *LockCommand) CreateLock(ctx context.Context, client *auth.Client) error {
 	// Locking a node is now deprecated, but we still support it for backwards compatibility.
 	// Previously, locking a node would lock only the `ssh_service` from that node to
 	// access Teleport but didn't prevent any other roles that the same instance could run.

--- a/tool/tctl/common/loginrule/command.go
+++ b/tool/tctl/common/loginrule/command.go
@@ -37,7 +37,7 @@ import (
 
 type subcommand interface {
 	initialize(parent *kingpin.CmdClause, cfg *servicecfg.Config)
-	tryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error)
+	tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
 }
 
 // Command implements all commands under "tctl login_rule".
@@ -60,7 +60,7 @@ func (t *Command) Initialize(app *kingpin.Application, cfg *servicecfg.Config) {
 
 // TryRun calls tryRun for each subcommand, and if none of them match returns
 // (false, nil)
-func (t *Command) TryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error) {
+func (t *Command) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
 	for _, subcommand := range t.subcommands {
 		match, err = subcommand.tryRun(ctx, selectedCommand, c)
 		if err != nil {
@@ -108,7 +108,7 @@ Examples:
   > echo '{"groups": ["example"]}' | tctl login_rule test --resource-file rule.yaml`)
 }
 
-func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error) {
+func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
 	if selectedCommand != t.cmd.FullCommand() {
 		return false, nil
 	}
@@ -120,7 +120,7 @@ func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, c auth
 	return true, trace.Wrap(t.run(ctx, c))
 }
 
-func (t *testCommand) run(ctx context.Context, c auth.ClientI) error {
+func (t *testCommand) run(ctx context.Context, c *auth.Client) error {
 	loginRules, err := parseLoginRuleFiles(t.inputResourceFiles)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -97,7 +97,7 @@ func (c *NodeCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *NodeCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *NodeCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.nodeAdd.FullCommand():
 		err = c.Invite(ctx, client)
@@ -135,7 +135,7 @@ Please note:
 
 // Invite generates a token which can be used to add another SSH node
 // to a cluster
-func (c *NodeCommand) Invite(ctx context.Context, client auth.ClientI) error {
+func (c *NodeCommand) Invite(ctx context.Context, client *auth.Client) error {
 	// parse --roles flag
 	roles, err := types.ParseTeleportRoles(c.roles)
 	if err != nil {
@@ -228,7 +228,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client auth.ClientI) error {
 
 // ListActive retrieves the list of nodes who recently sent heartbeats to
 // to a cluster and prints it to stdout
-func (c *NodeCommand) ListActive(ctx context.Context, clt auth.ClientI) error {
+func (c *NodeCommand) ListActive(ctx context.Context, clt *auth.Client) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -45,7 +45,7 @@ func (p *ProxyCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 }
 
 // ListProxies prints currently connected proxies
-func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI) error {
+func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *auth.Client) error {
 	proxies, err := clusterAPI.GetProxies()
 	if err != nil {
 		return trace.Wrap(err)
@@ -68,7 +68,7 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI)
 }
 
 // TryRun runs the proxy command
-func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case p.lsCmd.FullCommand():
 		err = p.ListProxies(ctx, client)

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -66,7 +66,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, config *service
 }
 
 // TryRun attempts to run subcommands like "recordings ls".
-func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.recordingsList.FullCommand():
 		err = c.ListRecordings(ctx, client)
@@ -76,7 +76,7 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, client auth.
 	return true, trace.Wrap(err)
 }
 
-func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc auth.ClientI) error {
+func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc *auth.Client) error {
 	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.fromUTC, c.toUTC, c.recordingsSince)
 	if err != nil {
 		return trace.Errorf("cannot request recordings: %v", err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -59,7 +59,7 @@ import (
 )
 
 // ResourceCreateHandler is the generic implementation of a resource creation handler
-type ResourceCreateHandler func(context.Context, auth.ClientI, services.UnknownResource) error
+type ResourceCreateHandler func(context.Context, *auth.Client, services.UnknownResource) error
 
 // ResourceKind is the string form of a resource, i.e. "oidc"
 type ResourceKind string
@@ -184,7 +184,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
-func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	// tctl get
 	case rc.getCmd.FullCommand():
@@ -216,7 +216,7 @@ func (rc *ResourceCommand) GetRef() services.Ref {
 }
 
 // Get prints one or many resources of a certain type
-func (rc *ResourceCommand) Get(ctx context.Context, client auth.ClientI) error {
+func (rc *ResourceCommand) Get(ctx context.Context, client *auth.Client) error {
 	if rc.refs.IsAll() {
 		return rc.GetAll(ctx, client)
 	}
@@ -242,7 +242,7 @@ func (rc *ResourceCommand) Get(ctx context.Context, client auth.ClientI) error {
 	return trace.BadParameter("unsupported format")
 }
 
-func (rc *ResourceCommand) GetMany(ctx context.Context, client auth.ClientI) error {
+func (rc *ResourceCommand) GetMany(ctx context.Context, client *auth.Client) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
@@ -261,7 +261,7 @@ func (rc *ResourceCommand) GetMany(ctx context.Context, client auth.ClientI) err
 	return nil
 }
 
-func (rc *ResourceCommand) GetAll(ctx context.Context, client auth.ClientI) error {
+func (rc *ResourceCommand) GetAll(ctx context.Context, client *auth.Client) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
 	allRefs := make([]services.Ref, 0, len(allKinds))
@@ -276,7 +276,7 @@ func (rc *ResourceCommand) GetAll(ctx context.Context, client auth.ClientI) erro
 }
 
 // Create updates or inserts one or many resources
-func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err error) {
+func (rc *ResourceCommand) Create(ctx context.Context, client *auth.Client) (err error) {
 	var reader io.Reader
 	if rc.filename == "" {
 		reader = os.Stdin
@@ -321,7 +321,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 }
 
 // createTrustedCluster implements `tctl create cluster.yaml` command
-func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	tc, err := services.UnmarshalTrustedCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -359,7 +359,7 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client auth
 }
 
 // createCertAuthority creates certificate authority
-func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -372,7 +372,7 @@ func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client auth.
 }
 
 // createGithubConnector creates a Github connector
-func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -381,12 +381,14 @@ func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client aut
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
+
 	exists := (err == nil)
 	if !rc.force && exists {
 		return trace.AlreadyExists("authentication connector %q already exists",
 			connector.GetName())
 	}
 	err = client.UpsertGithubConnector(ctx, connector)
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -396,7 +398,7 @@ func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client aut
 }
 
 // createRole implements `tctl create role.yaml` command.
-func (rc *ResourceCommand) createRole(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createRole(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -473,7 +475,7 @@ func warnAboutDynamicLabelsInDenyRule(logger utils.Logger, r types.Role) {
 }
 
 // createUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) createUser(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUser(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -511,7 +513,7 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client auth.ClientI, 
 }
 
 // createAuthPreference implements `tctl create cap.yaml` command.
-func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -533,7 +535,7 @@ func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client auth
 }
 
 // createClusterNetworkingConfig implements `tctl create netconfig.yaml` command.
-func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -554,7 +556,7 @@ func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, cl
 	return nil
 }
 
-func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	var cmc types.ClusterMaintenanceConfigV1
 	if err := utils.FastUnmarshal(raw.Raw, &cmc); err != nil {
 		return trace.Wrap(err)
@@ -578,7 +580,7 @@ func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, c
 }
 
 // createSessionRecordingConfig implements `tctl create recconfig.yaml` command.
-func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -600,7 +602,7 @@ func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, cli
 }
 
 // createExternalAuditStorage implements `tctl create external_audit_storage` command.
-func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	draft, err := services.UnmarshalExternalAuditStorage(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -621,7 +623,7 @@ func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, clien
 }
 
 // createLock implements `tctl create lock.yaml` command.
-func (rc *ResourceCommand) createLock(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLock(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	lock, err := services.UnmarshalLock(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -647,7 +649,7 @@ func (rc *ResourceCommand) createLock(ctx context.Context, client auth.ClientI, 
 }
 
 // createNetworkRestrictions implements `tctl create net_restrict.yaml` command.
-func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	newNetRestricts, err := services.UnmarshalNetworkRestrictions(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -660,7 +662,7 @@ func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client
 	return nil
 }
 
-func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	wd, err := services.UnmarshalWindowsDesktop(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -674,7 +676,7 @@ func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client auth
 	return nil
 }
 
-func (rc *ResourceCommand) createApp(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createApp(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	app, err := services.UnmarshalApp(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -696,7 +698,7 @@ func (rc *ResourceCommand) createApp(ctx context.Context, client auth.ClientI, r
 	return nil
 }
 
-func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	cluster, err := services.UnmarshalKubeCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -718,7 +720,7 @@ func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabase(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabase(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	database, err := services.UnmarshalDatabase(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -741,7 +743,7 @@ func (rc *ResourceCommand) createDatabase(ctx context.Context, client auth.Clien
 	return nil
 }
 
-func (rc *ResourceCommand) createToken(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createToken(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	token, err := services.UnmarshalProvisionToken(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -755,7 +757,7 @@ func (rc *ResourceCommand) createToken(ctx context.Context, client auth.ClientI,
 	return nil
 }
 
-func (rc *ResourceCommand) createInstaller(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createInstaller(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	inst, err := services.UnmarshalInstaller(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -769,7 +771,7 @@ func (rc *ResourceCommand) createInstaller(ctx context.Context, client auth.Clie
 	return nil
 }
 
-func (rc *ResourceCommand) createUIConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	uic, err := services.UnmarshalUIConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -783,7 +785,7 @@ func (rc *ResourceCommand) createUIConfig(ctx context.Context, client auth.Clien
 
 }
 
-func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNode(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	server, err := services.UnmarshalServer(raw.Raw, types.KindNode)
 	if err != nil {
 		return trace.Wrap(err)
@@ -814,7 +816,7 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, 
 	return nil
 }
 
-func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	conn, err := services.UnmarshalOIDCConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -839,7 +841,7 @@ func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client auth.
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
 	if err != nil {
@@ -874,7 +876,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client auth.
 	return nil
 }
 
-func (rc *ResourceCommand) createLoginRule(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	rule, err := loginrule.UnmarshalLoginRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -901,7 +903,7 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client auth.Clie
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	// Create services.SAMLIdPServiceProvider from raw YAML to extract the service provider name.
 	sp, err := services.UnmarshalSAMLIdPServiceProvider(raw.Raw)
 	if err != nil {
@@ -941,7 +943,7 @@ func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) createDevice(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDevice(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	res, err := services.UnmarshalDevice(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -981,7 +983,7 @@ func (rc *ResourceCommand) createDevice(ctx context.Context, client auth.ClientI
 	return nil
 }
 
-func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	importRule, err := services.UnmarshalOktaImportRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1006,7 +1008,7 @@ func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client auth
 	return nil
 }
 
-func (rc *ResourceCommand) createIntegration(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createIntegration(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	integration, err := services.UnmarshalIntegration(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1054,7 +1056,7 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client auth.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	discoveryConfig, err := services.UnmarshalDiscoveryConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1079,7 +1081,7 @@ func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client aut
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessList(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAccessList(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	accessList, err := services.UnmarshalAccessList(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1103,7 +1105,7 @@ func (rc *ResourceCommand) createAccessList(ctx context.Context, client auth.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	si, err := services.UnmarshalServerInfo(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1132,7 +1134,7 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client auth.Cli
 }
 
 // Delete deletes resource by name
-func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err error) {
+func (rc *ResourceCommand) Delete(ctx context.Context, client *auth.Client) (err error) {
 	singletonResources := []string{
 		types.KindClusterAuthPreference,
 		types.KindClusterMaintenanceConfig,
@@ -1495,7 +1497,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 	return nil
 }
 
-func resetAuthPreference(ctx context.Context, client auth.ClientI) error {
+func resetAuthPreference(ctx context.Context, client *auth.Client) error {
 	storedAuthPref, err := client.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1509,7 +1511,7 @@ func resetAuthPreference(ctx context.Context, client auth.ClientI) error {
 	return trace.Wrap(client.ResetAuthPreference(ctx))
 }
 
-func resetClusterNetworkingConfig(ctx context.Context, client auth.ClientI) error {
+func resetClusterNetworkingConfig(ctx context.Context, client *auth.Client) error {
 	storedNetConfig, err := client.GetClusterNetworkingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1523,7 +1525,7 @@ func resetClusterNetworkingConfig(ctx context.Context, client auth.ClientI) erro
 	return trace.Wrap(client.ResetClusterNetworkingConfig(ctx))
 }
 
-func resetSessionRecordingConfig(ctx context.Context, client auth.ClientI) error {
+func resetSessionRecordingConfig(ctx context.Context, client *auth.Client) error {
 	storedRecConfig, err := client.GetSessionRecordingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1537,12 +1539,12 @@ func resetSessionRecordingConfig(ctx context.Context, client auth.ClientI) error
 	return trace.Wrap(client.ResetSessionRecordingConfig(ctx))
 }
 
-func resetNetworkRestrictions(ctx context.Context, client auth.ClientI) error {
+func resetNetworkRestrictions(ctx context.Context, client *auth.Client) error {
 	return trace.Wrap(client.DeleteNetworkRestrictions(ctx))
 }
 
 // Update updates select resource fields: expiry and labels
-func (rc *ResourceCommand) Update(ctx context.Context, clt auth.ClientI) error {
+func (rc *ResourceCommand) Update(ctx context.Context, clt *auth.Client) error {
 	if rc.ref.Kind == "" || rc.ref.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
@@ -1599,7 +1601,7 @@ func (rc *ResourceCommand) IsForced() bool {
 }
 
 // getCollection lists all resources of a given type
-func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.ClientI) (ResourceCollection, error) {
+func (rc *ResourceCommand) getCollection(ctx context.Context, client *auth.Client) (ResourceCollection, error) {
 	if rc.ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
@@ -1659,18 +1661,14 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 		}
 		return &githubCollection{connectors}, nil
 	case types.KindReverseTunnel:
-		if rc.ref.Name == "" {
-			tunnels, err := client.GetReverseTunnels(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return &reverseTunnelCollection{tunnels: tunnels}, nil
+		if rc.ref.Name != "" {
+			return nil, trace.BadParameter("reverse tunnel cannot be searched by name")
 		}
-		tunnel, err := client.GetReverseTunnel(rc.ref.Name)
+		tunnels, err := client.GetReverseTunnels(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &reverseTunnelCollection{tunnels: []types.ReverseTunnel{tunnel}}, nil
+		return &reverseTunnelCollection{tunnels: tunnels}, nil
 	case types.KindCertAuthority:
 		if rc.ref.SubKind == "" && rc.ref.Name == "" {
 			var allAuthorities []types.CertAuthority
@@ -2349,7 +2347,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }
 
-func getSAMLConnectors(ctx context.Context, client auth.ClientI, name string, withSecrets bool) ([]types.SAMLConnector, error) {
+func getSAMLConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.SAMLConnector, error) {
 	if name == "" {
 		connectors, err := client.GetSAMLConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2364,7 +2362,7 @@ func getSAMLConnectors(ctx context.Context, client auth.ClientI, name string, wi
 	return []types.SAMLConnector{connector}, nil
 }
 
-func getOIDCConnectors(ctx context.Context, client auth.ClientI, name string, withSecrets bool) ([]types.OIDCConnector, error) {
+func getOIDCConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.OIDCConnector, error) {
 	if name == "" {
 		connectors, err := client.GetOIDCConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2379,7 +2377,7 @@ func getOIDCConnectors(ctx context.Context, client auth.ClientI, name string, wi
 	return []types.OIDCConnector{connector}, nil
 }
 
-func getGithubConnectors(ctx context.Context, client auth.ClientI, name string, withSecrets bool) ([]types.GithubConnector, error) {
+func getGithubConnectors(ctx context.Context, client *auth.Client, name string, withSecrets bool) ([]types.GithubConnector, error) {
 	if name == "" {
 		connectors, err := client.GetGithubConnectors(ctx, withSecrets)
 		if err != nil {
@@ -2538,7 +2536,7 @@ $ tctl rm %s`,
 		ref.String(), resDesc, strings.Join(names, "\n"), exampleRef.String())
 }
 
-func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAuditQuery(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2549,14 +2547,12 @@ func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client auth.Cli
 	}
 
 	if err = client.SecReportsClient().UpsertSecurityAuditQuery(ctx, in); err != nil {
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *auth.Client, raw services.UnknownResource) error {
 	in, err := services.UnmarshalSecurityReport(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2567,9 +2563,7 @@ func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client auth
 	}
 
 	if err = client.SecReportsClient().UpsertSecurityReport(ctx, in); err != nil {
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
 	}
 	return nil
 }

--- a/tool/tctl/common/saml_command.go
+++ b/tool/tctl/common/saml_command.go
@@ -47,7 +47,7 @@ func (cmd *SAMLCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Con
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error) {
+func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
 	if selectedCommand == cmd.exportCmd.FullCommand() {
 		return true, trace.Wrap(cmd.export(ctx, c))
 	}
@@ -55,7 +55,7 @@ func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, c au
 }
 
 // export executes 'tctl saml export <connector_name>'
-func (cmd *SAMLCommand) export(ctx context.Context, c auth.ClientI) error {
+func (cmd *SAMLCommand) export(ctx context.Context, c *auth.Client) error {
 	sc, err := c.GetSAMLConnector(ctx, cmd.connectorName, false)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -46,7 +46,7 @@ func (c *StatusCommand) Initialize(app *kingpin.Application, config *servicecfg.
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.status.FullCommand():
 		err = c.Status(ctx, client)
@@ -62,7 +62,7 @@ type caFetchError struct {
 }
 
 // Status is called to execute "status" CLI command.
-func (c *StatusCommand) Status(ctx context.Context, client auth.ClientI) error {
+func (c *StatusCommand) Status(ctx context.Context, client *auth.Client) error {
 	pingRsp, err := client.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -90,7 +90,7 @@ type CLICommand interface {
 
 	// TryRun is executed after the CLI parsing is done. The command must
 	// determine if selectedCommand belongs to it and return match=true
-	TryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error)
+	TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error)
 }
 
 // Run is the same as 'make'. It helps to share the code between different

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -141,7 +141,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, config *servicecfg.
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.tokenAdd.FullCommand():
 		err = c.Add(ctx, client)
@@ -156,7 +156,7 @@ func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client auth.Clie
 }
 
 // Add is called to execute "tokens add ..." command.
-func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
+func (c *TokensCommand) Add(ctx context.Context, client *auth.Client) error {
 	// Parse string to see if it's a type of role that Teleport supports.
 	roles, err := types.ParseTeleportRoles(c.tokenType)
 	if err != nil {
@@ -357,7 +357,7 @@ func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
 }
 
 // Del is called to execute "tokens del ..." command.
-func (c *TokensCommand) Del(ctx context.Context, client auth.ClientI) error {
+func (c *TokensCommand) Del(ctx context.Context, client *auth.Client) error {
 	if c.value == "" {
 		return trace.Errorf("Need an argument: token")
 	}
@@ -369,7 +369,7 @@ func (c *TokensCommand) Del(ctx context.Context, client auth.ClientI) error {
 }
 
 // List is called to execute "tokens ls" command.
-func (c *TokensCommand) List(ctx context.Context, client auth.ClientI) error {
+func (c *TokensCommand) List(ctx context.Context, client *auth.Client) error {
 	tokens, err := client.GetTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/top_command.go
+++ b/tool/tctl/common/top_command.go
@@ -63,7 +63,7 @@ func (c *TopCommand) Initialize(app *kingpin.Application, config *servicecfg.Con
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TopCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (c *TopCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case c.top.FullCommand():
 		diagClient, err := roundtrip.NewClient(*c.diagURL, "")

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -149,7 +149,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 }
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
-func (u *UserCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+func (u *UserCommand) TryRun(ctx context.Context, cmd string, client *auth.Client) (match bool, err error) {
 	switch cmd {
 	case u.userAdd.FullCommand():
 		err = u.Add(ctx, client)
@@ -168,7 +168,7 @@ func (u *UserCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 }
 
 // ResetPassword resets user password and generates a token to setup new password
-func (u *UserCommand) ResetPassword(ctx context.Context, client auth.ClientI) error {
+func (u *UserCommand) ResetPassword(ctx context.Context, client *auth.Client) error {
 	req := auth.CreateUserTokenRequest{
 		Name: u.login,
 		TTL:  u.ttl,
@@ -232,7 +232,7 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, format stri
 
 // Add implements `tctl users add` for the enterprise edition. Unlike the OSS
 // version, this one requires --roles flag to be set
-func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
+func (u *UserCommand) Add(ctx context.Context, client *auth.Client) error {
 	u.allowedRoles = flattenSlice(u.allowedRoles)
 	u.allowedLogins = flattenSlice(u.allowedLogins)
 	u.allowedWindowsLogins = flattenSlice(u.allowedWindowsLogins)
@@ -354,7 +354,7 @@ func printTokenAsText(token types.UserToken, messageFormat string) error {
 }
 
 // Update updates existing user
-func (u *UserCommand) Update(ctx context.Context, client auth.ClientI) error {
+func (u *UserCommand) Update(ctx context.Context, client *auth.Client) error {
 	user, err := client.GetUser(u.login, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -476,7 +476,7 @@ func (u *UserCommand) Update(ctx context.Context, client auth.ClientI) error {
 }
 
 // List prints all existing user accounts
-func (u *UserCommand) List(ctx context.Context, client auth.ClientI) error {
+func (u *UserCommand) List(ctx context.Context, client *auth.Client) error {
 	users, err := client.GetUsers(false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -505,7 +505,7 @@ func (u *UserCommand) List(ctx context.Context, client auth.ClientI) error {
 
 // Delete deletes teleport user(s). User IDs are passed as a comma-separated
 // list in UserCommand.login
-func (u *UserCommand) Delete(ctx context.Context, client auth.ClientI) error {
+func (u *UserCommand) Delete(ctx context.Context, client *auth.Client) error {
 	for _, l := range strings.Split(u.login, ",") {
 		if err := client.DeleteUser(ctx, l); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -38,7 +38,7 @@ type SSOConfigureCommand struct {
 
 type AuthKindCommand struct {
 	Parsed bool
-	Run    func(ctx context.Context, clt auth.ClientI) error
+	Run    func(ctx context.Context, clt *auth.Client) error
 }
 
 // Initialize allows a caller-defined command to plug itself into CLI
@@ -54,7 +54,7 @@ func (cmd *SSOConfigureCommand) Initialize(app *kingpin.Application, cfg *servic
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand string, clt auth.ClientI) (match bool, err error) {
+func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand string, clt *auth.Client) (match bool, err error) {
 	for _, subCommand := range cmd.AuthCommands {
 		if subCommand.Parsed {
 			// the default tctl logging behavior is to ignore all logs, unless --debug is present.

--- a/tool/tctl/sso/configure/github.go
+++ b/tool/tctl/sso/configure/github.go
@@ -83,7 +83,7 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`)
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt auth.ClientI) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
+		Run: func(ctx context.Context, clt *auth.Client) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -94,7 +94,7 @@ Examples:
 	return preset
 }
 
-func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt auth.ClientI) error {
+func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt *auth.Client) error {
 	if err := specCheckRoles(ctx, cmd.Logger, spec, flags.ignoreMissingRoles, clt); err != nil {
 		return trace.Wrap(err)
 	}
@@ -111,7 +111,7 @@ func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.Github
 }
 
 // ResolveCallbackURL deals with common pattern of resolving callback URL for IdP to use.
-func ResolveCallbackURL(logger *logrus.Entry, clt auth.ClientI, fieldName string, callbackPattern string) string {
+func ResolveCallbackURL(logger *logrus.Entry, clt *auth.Client, fieldName string, callbackPattern string) string {
 	var callbackURL string
 
 	logger.Infof("%v empty, resolving automatically.", fieldName)
@@ -138,7 +138,7 @@ func ResolveCallbackURL(logger *logrus.Entry, clt auth.ClientI, fieldName string
 	return callbackURL
 }
 
-func specCheckRoles(ctx context.Context, logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt auth.ClientI) error {
+func specCheckRoles(ctx context.Context, logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt *auth.Client) error {
 	allRoles, err := clt.GetRoles(ctx)
 	if err != nil {
 		logger.WithError(err).Warn("Unable to get roles list. Skipping teams-to-roles sanity checks.")

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -45,7 +45,7 @@ type SSOTestCommand struct {
 	connectorFileName string
 
 	// Handlers is a mapping between auth kind and appropriate handling function
-	Handlers map[string]func(c auth.ClientI, connBytes []byte) (*AuthRequestInfo, error)
+	Handlers map[string]func(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error)
 	// GetDiagInfoFields provides auth kind-specific diagnostic info fields.
 	GetDiagInfoFields map[string]func(diag *types.SSODiagnosticInfo, debug bool) []string
 	// Browser to use in login flow.
@@ -76,7 +76,7 @@ Examples:
 
   > tctl sso configure github ... | tee connector.yaml | tctl sso test`)
 
-	cmd.Handlers = map[string]func(c auth.ClientI, connBytes []byte) (*AuthRequestInfo, error){
+	cmd.Handlers = map[string]func(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error){
 		types.KindGithubConnector: handleGithubConnector,
 	}
 
@@ -95,7 +95,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 	return kinds
 }
 
-func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) error {
+func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c *auth.Client) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
 		f, err := utils.OpenFileAllowingUnsafeLinks(cmd.connectorFileName)
@@ -145,7 +145,7 @@ func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) e
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOTestCommand) TryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error) {
+func (cmd *SSOTestCommand) TryRun(ctx context.Context, selectedCommand string, c *auth.Client) (match bool, err error) {
 	if selectedCommand == cmd.ssoTestCmd.FullCommand() {
 		return true, cmd.ssoTestCommand(ctx, c)
 	}
@@ -162,7 +162,7 @@ type AuthRequestInfo struct {
 	RequestCreateErr error
 }
 
-func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, protocol string, c auth.ClientI, config *client.RedirectorConfig) (*auth.SSHLoginResponse, error) {
+func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, protocol string, c *auth.Client, config *client.RedirectorConfig) (*auth.SSHLoginResponse, error) {
 	key, err := client.GenerateRSAKey()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tctl/sso/tester/github.go
+++ b/tool/tctl/sso/tester/github.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func githubTest(c auth.ClientI, connector types.GithubConnector) (*AuthRequestInfo, error) {
+func githubTest(c *auth.Client, connector types.GithubConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.GithubConnectorSpecV3
@@ -71,7 +71,7 @@ func githubTest(c auth.ClientI, connector types.GithubConnector) (*AuthRequestIn
 	return requestInfo, nil
 }
 
-func handleGithubConnector(c auth.ClientI, connBytes []byte) (*AuthRequestInfo, error) {
+func handleGithubConnector(c *auth.Client, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalGithubConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load GitHub connector. Correct the definition and try again.")


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/39059 to branch/v14

Paired with https://github.com/gravitational/teleport.e/pull/3643