### PR TITLE
AWS OIDC: Require S3 for configure IdP Script

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -659,7 +659,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/ping/:connector", h.WithUnauthenticatedHighLimiter(h.pingWithConnector))
 
 	// Unauthenticated access to JWT public keys.
-	h.GET("/.well-known/jwks.json", h.WithUnauthenticatedHighLimiter(h.jwks))
+	h.GET("/.well-known/jwks.json", h.WithUnauthenticatedHighLimiter(h.wellKnownJWKS))
 
 	// Unauthenticated access to the message of the day
 	h.GET("/webapi/motd", h.WithHighLimiter(h.motd))
@@ -1710,35 +1710,8 @@ func (h *Handler) getUIConfig(ctx context.Context) webclient.UIConfig {
 }
 
 // jwks returns all public keys used to sign JWT tokens for this cluster.
-func (h *Handler) jwks(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	clusterName, err := h.cfg.ProxyClient.GetDomainName(r.Context())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Fetch the JWT public keys only.
-	ca, err := h.cfg.ProxyClient.GetCertAuthority(r.Context(), types.CertAuthID{
-		Type:       types.JWTSigner,
-		DomainName: clusterName,
-	}, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	pairs := ca.GetTrustedJWTKeyPairs()
-
-	// Create response and allocate space for the keys.
-	var resp JWKSResponse
-	resp.Keys = make([]jwt.JWK, 0, len(pairs))
-
-	// Loop over and all add public keys in JWK format.
-	for _, pair := range pairs {
-		jwk, err := jwt.MarshalJWK(pair.PublicKey)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		resp.Keys = append(resp.Keys, jwk)
-	}
-	return &resp, nil
+func (h *Handler) wellKnownJWKS(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
+	return h.jwks(r.Context(), types.JWTSigner)
 }
 
 func (h *Handler) motd(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -20,8 +20,11 @@ package web
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -42,7 +45,6 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils/oidc"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -857,7 +859,18 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
-	proxyAddr, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr)
+	s3Bucket := queryParams.Get("s3Bucket")
+	s3Prefix := queryParams.Get("s3Prefix")
+	if s3Bucket == "" || s3Prefix == "" {
+		return nil, trace.BadParameter("s3Bucket and s3Prefix query params are required")
+	}
+	s3URI := url.URL{Scheme: "s3", Host: s3Bucket, Path: s3Prefix}
+
+	jwksContents, err := h.jwks(r.Context(), types.OIDCIdPCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	jwksJSON, err := json.Marshal(jwksContents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -869,7 +882,8 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--name=%s", integrationName),
 		fmt.Sprintf("--role=%s", role),
-		fmt.Sprintf("--proxy-public-url=%s", proxyAddr),
+		fmt.Sprintf("--s3-bucket-uri=%s", s3URI.String()),
+		fmt.Sprintf("--s3-jwks-base64=%s", base64.StdEncoding.EncodeToString(jwksJSON)),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs:   strings.Join(argsList, " "),

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"testing"
@@ -353,9 +354,12 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 		"configure",
 		"awsoidc-idp.sh",
 	}
-	endpoint := publicClt.Endpoint(pathVars...)
+	scriptEndpoint := publicClt.Endpoint(pathVars...)
 
-	proxyPublicURL := env.proxies[0].webURL
+	jwksEndpoint := publicClt.Endpoint(".well-known", "jwks-oidc")
+	resp, err := publicClt.Get(ctx, jwksEndpoint, nil)
+	require.NoError(t, err)
+	jwksBase64 := base64.StdEncoding.EncodeToString(resp.Bytes())
 
 	tests := []struct {
 		name                 string
@@ -370,13 +374,16 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"myRole"},
 				"integrationName": []string{"myintegration"},
+				"s3Bucket":        []string{"my-bucket"},
+				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure awsoidc-idp " +
 				"--cluster=localhost " +
 				"--name=myintegration " +
 				"--role=myRole " +
-				"--proxy-public-url=" + proxyPublicURL.String(),
+				`--s3-bucket-uri=s3://my-bucket/prefix ` +
+				"--s3-jwks-base64=" + jwksBase64,
 		},
 		{
 			name: "valid with symbols in role",
@@ -384,25 +391,50 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"Test+1=2,3.4@5-6_7"},
 				"integrationName": []string{"myintegration"},
+				"s3Bucket":        []string{"my-bucket"},
+				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure awsoidc-idp " +
 				"--cluster=localhost " +
 				"--name=myintegration " +
 				"--role=Test+1=2,3.4@5-6_7 " +
-				"--proxy-public-url=" + proxyPublicURL.String(),
+				`--s3-bucket-uri=s3://my-bucket/prefix ` +
+				"--s3-jwks-base64=" + jwksBase64,
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
 				"integrationName": []string{"myintegration"},
+				"s3Bucket":        []string{"my-bucket"},
+				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing integration name",
 			reqQuery: url.Values{
-				"role": []string{"role"},
+				"role":     []string{"role"},
+				"s3Bucket": []string{"my-bucket"},
+				"s3Prefix": []string{"prefix"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing s3 bucket",
+			reqQuery: url.Values{
+				"integrationName": []string{"myintegration"},
+				"role":            []string{"role"},
+				"s3Prefix":        []string{"prefix"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing s3 prefix",
+			reqQuery: url.Values{
+				"integrationName": []string{"myintegration"},
+				"role":            []string{"role"},
+				"s3Bucket":        []string{"my-bucket"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -412,6 +444,8 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"role"},
 				"integrationName": []string{"'; rm -rf /tmp/dir; echo '"},
+				"s3Bucket":        []string{"my-bucket"},
+				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -420,7 +454,7 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			resp, err := publicClt.Get(ctx, scriptEndpoint, tc.reqQuery)
 			tc.errCheck(t, err)
 			if err != nil {
 				return

--- a/lib/web/oidcidp.go
+++ b/lib/web/oidcidp.go
@@ -19,6 +19,7 @@
 package web
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gravitational/trace"
@@ -47,14 +48,18 @@ func (h *Handler) openidConfiguration(_ http.ResponseWriter, _ *http.Request, _ 
 
 // jwksOIDC returns all public keys used to sign JWT tokens for this cluster.
 func (h *Handler) jwksOIDC(_ http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
-	clusterName, err := h.GetProxyClient().GetDomainName(r.Context())
+	return h.jwks(r.Context(), types.OIDCIdPCA)
+}
+
+func (h *Handler) jwks(ctx context.Context, caType types.CertAuthType) (*JWKSResponse, error) {
+	clusterName, err := h.GetProxyClient().GetDomainName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Fetch the JWT public keys only.
-	ca, err := h.GetProxyClient().GetCertAuthority(r.Context(), types.CertAuthID{
-		Type:       types.OIDCIdPCA,
+	ca, err := h.GetProxyClient().GetCertAuthority(ctx, types.CertAuthID{
+		Type:       caType,
 		DomainName: clusterName,
 	}, false /* loadKeys */)
 	if err != nil {


### PR DESCRIPTION
There are two new required fields for generating the configure IdP script:
- s3Bucket
- s3Prefix

This must form a valid URI when joining them:
`s3://<s3Bucket>/<s3Prefix>`

Context: https://github.com/gravitational/teleport/issues/38782