### PR TITLE
Remove `lib/service` usage of `auth.ClientI`

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -1460,7 +1460,7 @@ func (w *OktaWrapper) Close() error {
 
 // NewRemoteProxyCachingAccessPoint returns new caching access point using
 // access point policy
-type NewRemoteProxyCachingAccessPoint func(clt ClientI, cacheName []string) (RemoteProxyAccessPoint, error)
+type NewRemoteProxyCachingAccessPoint func(clt *Client, cacheName []string) (RemoteProxyAccessPoint, error)
 
 // notImplementedMessage is the message to return for endpoints that are not
 // implemented. This is due to how service interfaces are used with Teleport.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -101,7 +101,7 @@ type AgentPool struct {
 type AgentPoolConfig struct {
 	// Client is client to the auth server this agent connects to receive
 	// a list of pools
-	Client auth.ClientI
+	Client *auth.Client
 	// AccessPoint is a lightweight access point
 	// that can optionally cache some values
 	AccessPoint auth.AccessCache

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -59,7 +59,7 @@ func (m *mockAgent) GetProxyID() (string, bool) {
 }
 
 type mockClient struct {
-	auth.ClientI
+	*auth.Client
 	ssh.Signer
 	mockGetClusterNetworkingConfig func(context.Context) (types.ClusterNetworkingConfig, error)
 }

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -41,12 +41,12 @@ type certificateCache struct {
 	mu sync.Mutex
 
 	cache      *ttlmap.TTLMap
-	authClient auth.ClientI
+	authClient *auth.Client
 }
 
 // newHostCertificateCache creates a shared host certificate cache that is
 // used by the forwarding server.
-func newHostCertificateCache(authClient auth.ClientI) (*certificateCache, error) {
+func newHostCertificateCache(authClient *auth.Client) (*certificateCache, error) {
 	native.PrecomputeKeys() // ensure native package is set to precompute keys
 	cache, err := ttlmap.New(defaults.HostCertCacheSize)
 	if err != nil {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -147,7 +147,7 @@ type localSite struct {
 	srv         *server
 
 	// client provides access to the Auth Server API of the local cluster.
-	client auth.ClientI
+	client *auth.Client
 	// accessPoint provides access to a cached subset of the Auth Server API of
 	// the local cluster.
 	accessPoint auth.RemoteProxyAccessPoint
@@ -198,7 +198,7 @@ func (s *localSite) NodeWatcher() (*services.NodeWatcher, error) {
 }
 
 // GetClient returns a client to the full Auth Server API.
-func (s *localSite) GetClient() (auth.ClientI, error) {
+func (s *localSite) GetClient() (*auth.Client, error) {
 	return s.client, nil
 }
 

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -98,7 +98,7 @@ func (p *clusterPeers) NodeWatcher() (*services.NodeWatcher, error) {
 	return peer.NodeWatcher()
 }
 
-func (p *clusterPeers) GetClient() (auth.ClientI, error) {
+func (p *clusterPeers) GetClient() (*auth.Client, error) {
 	peer, err := p.pickPeer()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -206,7 +206,7 @@ func (s *clusterPeer) NodeWatcher() (*services.NodeWatcher, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch node watcher, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) GetClient() (auth.ClientI, error) {
+func (s *clusterPeer) GetClient() (*auth.Client, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch client, this proxy %v has not been discovered yet, try again later", s)
 }
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -62,7 +62,7 @@ type remoteClusterKey struct {
 // RemoteClusterTunnelManager.
 type RemoteClusterTunnelManagerConfig struct {
 	// AuthClient is client to the auth server.
-	AuthClient auth.ClientI
+	AuthClient *auth.Client
 	// AccessPoint is a lightweight access point that can optionally cache some
 	// values.
 	AccessPoint auth.ProxyAccessPoint

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -183,7 +183,7 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 }
 
 type mockAuthClient struct {
-	auth.ClientI
+	*auth.Client
 
 	reverseTunnels    []types.ReverseTunnel
 	reverseTunnelsErr error

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -71,10 +71,10 @@ type remoteSite struct {
 
 	// localClient provides access to the Auth Server API of the cluster
 	// within which reversetunnelclient.Server is running.
-	localClient auth.ClientI
+	localClient *auth.Client
 	// remoteClient provides access to the Auth Server API of the remote cluster that
 	// this site belongs to.
-	remoteClient auth.ClientI
+	remoteClient *auth.Client
 	// localAccessPoint provides access to a cached subset of the Auth Server API of
 	// the local cluster.
 	localAccessPoint auth.ProxyAccessPoint
@@ -100,7 +100,7 @@ type remoteSite struct {
 	proxySyncInterval time.Duration
 }
 
-func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
+func (s *remoteSite) getRemoteClient() (*auth.Client, bool, error) {
 	// check if all cert authorities are initiated and if everything is OK
 	ca, err := s.srv.localAccessPoint.GetCertAuthority(s.ctx, types.CertAuthID{Type: types.HostCA, DomainName: s.domainName}, false)
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *remoteSite) NodeWatcher() (*services.NodeWatcher, error) {
 	return s.nodeWatcher, nil
 }
 
-func (s *remoteSite) GetClient() (auth.ClientI, error) {
+func (s *remoteSite) GetClient() (*auth.Client, error) {
 	return s.remoteClient, nil
 }
 

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -85,7 +85,7 @@ type server struct {
 
 	// localAuthClient provides access to the full Auth Server API for the
 	// local cluster.
-	localAuthClient auth.ClientI
+	localAuthClient *auth.Client
 	// localAccessPoint provides access to a cached subset of the Auth
 	// Server API.
 	localAccessPoint auth.ProxyAccessPoint
@@ -142,7 +142,7 @@ type Config struct {
 	// Limiter is optional request limiter
 	Limiter *limiter.Limiter
 	// LocalAuthClient provides access to a full AuthClient for the local cluster.
-	LocalAuthClient auth.ClientI
+	LocalAuthClient *auth.Client
 	// AccessPoint provides access to a subset of AuthClient of the cluster.
 	// AccessPoint caches values and can still return results during connection
 	// problems.
@@ -1289,7 +1289,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 // **WARNING**: Ensure that the version below matches the version in which backward incompatible
 // changes were introduced so that the cache is created successfully. Otherwise, the remote cache may
 // never become healthy due to unknown resources.
-func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
+func createRemoteAccessPoint(srv *server, clt *auth.Client, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
 	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("13.0.0"))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -216,7 +216,7 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			newProxyFn := func(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+			newProxyFn := func(clt *auth.Client, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 				if tt.oldRemoteProxy {
 					return nil, errors.New("expected to create an old remote proxy")
 				}
@@ -224,7 +224,7 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 				return nil, nil
 			}
 
-			oldProxyFn := func(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+			oldProxyFn := func(clt *auth.Client, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 				if !tt.oldRemoteProxy {
 					return nil, errors.New("expected to create an new remote proxy")
 				}
@@ -232,7 +232,6 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 				return nil, nil
 			}
 
-			clt := &mockAuthClient{}
 			srv := &server{
 				log: utils.NewLoggerForTests(),
 				Config: Config{
@@ -240,7 +239,7 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 					NewCachingAccessPointOldProxy: oldProxyFn,
 				},
 			}
-			_, err := createRemoteAccessPoint(srv, clt, tt.version, "test")
+			_, err := createRemoteAccessPoint(srv, &auth.Client{}, tt.version, "test")
 			tt.assertion(t, err)
 		})
 	}

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -118,7 +118,7 @@ type RemoteSite interface {
 	// GetStatus returns status of this site (either offline or connected)
 	GetStatus() string
 	// GetClient returns client connected to remote auth server
-	GetClient() (auth.ClientI, error)
+	GetClient() (*auth.Client, error)
 	// CachingAccessPoint returns access point that is lightweight
 	// but is resilient to auth server crashes
 	CachingAccessPoint() (auth.RemoteProxyAccessPoint, error)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -599,7 +599,7 @@ func (process *TeleportProcess) syncOpenSSHRotationState() error {
 	return nil
 }
 
-func registerServer(a *servicecfg.Config, ctx context.Context, client auth.ClientI, lastRotation time.Time) error {
+func registerServer(a *servicecfg.Config, ctx context.Context, client *auth.Client, lastRotation time.Time) error {
 	server, err := types.NewServerWithLabels(
 		a.HostUUID,
 		types.KindNode,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2273,7 +2273,7 @@ func (process *TeleportProcess) newAccessCache(cfg accesspoint.AccessCacheConfig
 }
 
 // newLocalCacheForNode returns new instance of access point configured for a local proxy.
-func (process *TeleportProcess) newLocalCacheForNode(clt auth.ClientI, cacheName []string) (auth.NodeAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForNode(clt *auth.Client, cacheName []string) (auth.NodeAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2288,7 +2288,7 @@ func (process *TeleportProcess) newLocalCacheForNode(clt auth.ClientI, cacheName
 }
 
 // newLocalCacheForKubernetes returns new instance of access point configured for a kubernetes service.
-func (process *TeleportProcess) newLocalCacheForKubernetes(clt auth.ClientI, cacheName []string) (auth.KubernetesAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForKubernetes(clt *auth.Client, cacheName []string) (auth.KubernetesAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2303,7 +2303,7 @@ func (process *TeleportProcess) newLocalCacheForKubernetes(clt auth.ClientI, cac
 }
 
 // newLocalCacheForDatabase returns new instance of access point configured for a database service.
-func (process *TeleportProcess) newLocalCacheForDatabase(clt auth.ClientI, cacheName []string) (auth.DatabaseAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForDatabase(clt *auth.Client, cacheName []string) (auth.DatabaseAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2323,15 +2323,15 @@ type eksClustersEnroller interface {
 
 // combinedDiscoveryClient is an auth.Client client with other, specific, services added to it.
 type combinedDiscoveryClient struct {
-	auth.ClientI
+	*auth.Client
 	services.DiscoveryConfigsGetter
 	eksClustersEnroller
 }
 
 // newLocalCacheForDiscovery returns a new instance of access point for a discovery service.
-func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cacheName []string) (auth.DiscoveryAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForDiscovery(clt *auth.Client, cacheName []string) (auth.DiscoveryAccessPoint, error) {
 	client := combinedDiscoveryClient{
-		ClientI:                clt,
+		Client:                 clt,
 		DiscoveryConfigsGetter: clt.DiscoveryConfigClient(),
 		eksClustersEnroller:    clt.IntegrationAWSOIDCClient(),
 	}
@@ -2348,7 +2348,7 @@ func (process *TeleportProcess) newLocalCacheForDiscovery(clt auth.ClientI, cach
 }
 
 // newLocalCacheForProxy returns new instance of access point configured for a local proxy.
-func (process *TeleportProcess) newLocalCacheForProxy(clt auth.ClientI, cacheName []string) (auth.ProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForProxy(clt *auth.Client, cacheName []string) (auth.ProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2363,7 +2363,7 @@ func (process *TeleportProcess) newLocalCacheForProxy(clt auth.ClientI, cacheNam
 }
 
 // newLocalCacheForRemoteProxy returns new instance of access point configured for a remote proxy.
-func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt *auth.Client, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2381,7 +2381,7 @@ func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt auth.ClientI, ca
 //
 // newLocalCacheForOldRemoteProxy returns new instance of access point
 // configured for an old remote proxy.
-func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt *auth.Client, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2396,7 +2396,7 @@ func (process *TeleportProcess) newLocalCacheForOldRemoteProxy(clt auth.ClientI,
 }
 
 // newLocalCacheForApps returns new instance of access point configured for a remote proxy.
-func (process *TeleportProcess) newLocalCacheForApps(clt auth.ClientI, cacheName []string) (auth.AppsAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForApps(clt *auth.Client, cacheName []string) (auth.AppsAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2411,7 +2411,7 @@ func (process *TeleportProcess) newLocalCacheForApps(clt auth.ClientI, cacheName
 }
 
 // newLocalCacheForWindowsDesktop returns new instance of access point configured for a windows desktop service.
-func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt auth.ClientI, cacheName []string) (auth.WindowsDesktopAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt *auth.Client, cacheName []string) (auth.WindowsDesktopAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -2426,7 +2426,7 @@ func (process *TeleportProcess) newLocalCacheForWindowsDesktop(clt auth.ClientI,
 }
 
 // NewLocalCache returns new instance of access point
-func (process *TeleportProcess) NewLocalCache(clt auth.ClientI, setupConfig cache.SetupConfigFn, cacheName []string) (*cache.Cache, error) {
+func (process *TeleportProcess) NewLocalCache(clt *auth.Client, setupConfig cache.SetupConfigFn, cacheName []string) (*cache.Cache, error) {
 	return process.newAccessCache(accesspoint.AccessCacheConfig{
 		Services:  clt,
 		Setup:     setupConfig,


### PR DESCRIPTION
Replaces references to auth.ClientI with either the concrete type or a more specific interface.

Paired with https://github.com/gravitational/teleport.e/pull/3645