### PR TITLE
Add License File guide link from Installation page

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -77,6 +77,10 @@ in [Deploying a High-Availability Teleport
 Cluster](./deploy-a-cluster/introduction.mdx), which provides full requirements
 and Terraform modules for deploying Teleport Enterprise on your infrastructure.
 
+Self-hosted Teleport Enterprise clusters require a license file. Read [Teleport
+Enterprise License File](./choose-an-edition/teleport-enterprise/license.mdx)
+for how to manage this.
+
 ### One-line installation script
 
 You can run a one-line command to install Teleport binaries on a Linux server.


### PR DESCRIPTION
Closes #37226

The Installation page currently has no link to the License File page. However, users who visit the Installation page are sometimes looking for license file information. Add a link to the License File page at the most appropriate place in the "Linux" section of the page.