### PR TITLE
[v13] chore: Bump Buf and shellcheck to latest releases

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -236,7 +236,7 @@ RUN git clone --depth=1 https://github.com/bats-core/bats-core.git -b v1.2.1 && 
     rm -r bats-core
 
 # Install shellcheck.
-RUN scversion='v0.9.0' && \
+RUN scversion='v0.10.0' && \
     curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/$scversion/shellcheck-$scversion.linux.$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch64"; fi).tar.xz" | \
         tar -xJv && \
     cp "shellcheck-$scversion/shellcheck" /usr/local/bin/ && \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -14,7 +14,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.29.0
+BUF_VERSION ?= v1.30.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #39120 to branch/v13

* https://github.com/bufbuild/buf/releases/tag/v1.30.0
* https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v0100---2024-03-07