### PR TITLE
update SAML service provider preset constant  `gcp` to `gcp-workforce`

### DIFF
--- a/api/types/saml_idp_service_provider.go
+++ b/api/types/saml_idp_service_provider.go
@@ -340,7 +340,7 @@ func (am *SAMLAttributeMapping) CheckAndSetDefaults() error {
 // preset can be either empty or one of the supported type.
 func validatePreset(preset string) bool {
 	switch preset {
-	case "", samlsp.GCP:
+	case "", samlsp.GCPWorkforce:
 		return true
 	default:
 		return false

--- a/api/types/saml_idp_service_provider_test.go
+++ b/api/types/saml_idp_service_provider_test.go
@@ -181,7 +181,7 @@ func TestNewSAMLIdPServiceProvider(t *testing.T) {
 			acsURL:           "https:/test.com/acs",
 			expectedEntityID: "IAMShowcase",
 			errAssertion:     require.NoError,
-			preset:           samlsp.GCP,
+			preset:           samlsp.GCPWorkforce,
 		},
 		{
 			name:             "unsupported preset value",

--- a/api/types/samlsp/samlsp.go
+++ b/api/types/samlsp/samlsp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package samlsp
 
 const (
-	// GCP is a SAML service provider preset name for Google Cloud.
-	GCP = "gcp"
+	// GCPWorkforce is a SAML service provider preset name for Google Cloud Platform
+	// Workforce Identity Federation.
+	GCPWorkforce = "gcp-workforce"
 )


### PR DESCRIPTION
This PR just updates the preset name `gcp` to `gcp-workforce`. `gcp` was added to refer to Workforce identity federation based configuration. But a plan is underway where we may manage GCP policy with Workload Identity based integration. 

While the feature isn't released yet, it's right time to update the name and so to avoid confusion in the future. The names such as `gcp-workforce`, `gcp-workload` are more meaningful than plain `gcp`.