### PR TITLE
Init discover resources inside the discover component

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -38,12 +38,13 @@ import {
   ResourceKind,
 } from 'teleport/Discover/Shared';
 import {
+  BASE_RESOURCES,
   getResourcePretitle,
-  RESOURCES,
 } from 'teleport/Discover/SelectResource/resources';
 import AddApp from 'teleport/Apps/AddApp';
 import { useUser } from 'teleport/User/UserContext';
 import { storageService } from 'teleport/services/storageService';
+import cfg from 'teleport/config';
 
 import { resourceKindToPreferredResource } from 'teleport/Discover/Shared/ResourceKind';
 
@@ -51,6 +52,7 @@ import { getMarketingTermMatches } from './getMarketingTermMatches';
 import { DiscoverIcon } from './icons';
 
 import { PrioritizedResources, SearchResource } from './types';
+import { SAML_APPLICATIONS } from './resourcesE';
 
 import type { ResourceSpec } from './types';
 
@@ -73,6 +75,9 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
   const [resources, setResources] = useState<ResourceSpec[]>([]);
   const [defaultResources, setDefaultResources] = useState<ResourceSpec[]>([]);
   const [showApp, setShowApp] = useState(false);
+  const RESOURCES = !cfg.isEnterprise
+    ? BASE_RESOURCES
+    : [...BASE_RESOURCES, ...SAML_APPLICATIONS];
 
   function onSearch(s: string, customList?: ResourceSpec[]) {
     const list = customList || defaultResources;

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -21,7 +21,6 @@ import { Platform } from 'design/platform';
 import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
 import { DiscoverEventResource } from 'teleport/services/userEvent';
-import cfg from 'teleport/config';
 
 import { ResourceKind } from '../Shared/ResourceKind';
 
@@ -37,7 +36,6 @@ import {
   ResourceSpec,
   ServerLocation,
 } from './types';
-import { SAML_APPLICATIONS } from './resourcesE';
 
 const baseServerKeywords = 'server node';
 const awsKeywords = 'aws amazon ';
@@ -151,7 +149,7 @@ export const KUBERNETES: ResourceSpec[] = [
   },
 ];
 
-const BASE_RESOURCES: ResourceSpec[] = [
+export const BASE_RESOURCES: ResourceSpec[] = [
   ...APPLICATIONS,
   ...KUBERNETES,
   ...WINDOWS_DESKTOPS,
@@ -160,10 +158,6 @@ const BASE_RESOURCES: ResourceSpec[] = [
   ...DATABASES_UNGUIDED,
   ...DATABASES_UNGUIDED_DOC,
 ];
-
-export const RESOURCES = !cfg.isEnterprise
-  ? BASE_RESOURCES
-  : [...BASE_RESOURCES, ...SAML_APPLICATIONS];
 
 export function getResourcePretitle(r: ResourceSpec) {
   if (!r) {


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/39163

This PR will make the `RESOURCES` value initialized inside the component. Before, it was initialized at a global level which would get a falsy value for `cfg.isEnterprise`.

I checked around to see other global instances of `cfg` used and didn't find any (yet) but I'll still keep looking around. So far, it seems most references are held within functions which is good since none of them are called until after the app is initialized.

This PR fixes the issue above, but if any other instances of a global cfg use pop up, i'll open a separate PR with all of them