### PR TITLE
Lock AWS Sync into a single discovery service

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4753,6 +4753,9 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if a.hasBuiltinRole(types.RoleDiscovery) && params.SemaphoreKind != types.KindAccessGraph {
+		return nil, trace.AccessDenied("discovery service can not create other semaphores")
+	}
 	return a.authServer.AcquireSemaphore(ctx, params)
 }
 
@@ -4760,6 +4763,9 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 func (a *ServerWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
+	}
+	if a.hasBuiltinRole(types.RoleDiscovery) && lease.SemaphoreKind != types.KindAccessGraph {
+		return trace.AccessDenied("discovery service can not create other semaphores")
 	}
 	return a.authServer.KeepAliveSemaphoreLease(ctx, lease)
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1118,6 +1118,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindApp, services.RW()),
 						types.NewRule(types.KindDiscoveryConfig, services.RO()),
 						types.NewRule(types.KindIntegration, append(services.RO(), types.VerbUse)),
+						types.NewRule(types.KindSemaphore, services.RW()),
 					},
 					// Discovery service should only access kubes/apps/dbs that originated from discovery.
 					KubernetesLabels: types.Labels{types.OriginLabel: []string{types.OriginCloud}},

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -77,6 +77,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		DiscoveryGroup:    process.Config.Discovery.DiscoveryGroup,
 		Emitter:           asyncEmitter,
 		AccessPoint:       accessPoint,
+		ServerID:          process.Config.HostUUID,
 		Log:               process.log,
 		ClusterName:       conn.ClientIdentity.ClusterName,
 		ClusterFeatures:   process.getClusterFeatures,

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -116,6 +116,8 @@ type Config struct {
 	AccessPoint auth.DiscoveryAccessPoint
 	// Log is the logger.
 	Log logrus.FieldLogger
+	// ServerID identifies the Teleport instance where this service runs.
+	ServerID string
 	// onDatabaseReconcile is called after each database resource reconciliation.
 	onDatabaseReconcile func()
 	// protocolChecker is used by Kubernetes fetchers to check port's protocol if needed.

--- a/lib/srv/discovery/fetchers/aws-sync/features.go
+++ b/lib/srv/discovery/fetchers/aws-sync/features.go
@@ -1,0 +1,73 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+const (
+	awsNamespace = "aws"
+	awsUsers     = awsNamespace + "/" + "users"
+	awsGroups    = awsNamespace + "/" + "groups"
+	awsEC2       = awsNamespace + "/" + "ec2"
+	awsEKS       = awsNamespace + "/" + "eks"
+	awsRDS       = awsNamespace + "/" + "rds"
+	awsS3        = awsNamespace + "/" + "s3"
+	awsRoles     = awsNamespace + "/" + "roles"
+)
+
+// Features is the list of supported resources by the server.
+type Features struct {
+	// Groups enables AWS groups sync.
+	Groups bool
+	// Roles enables AWS roles sync.
+	Roles bool
+	// Users enables AWS Users sync.
+	Users bool
+	// EC2 enables AWS EC2 sync.
+	EC2 bool
+	// RDS enables AWS RDS sync.
+	RDS bool
+	// EKS enables AWS EKS sync.
+	EKS bool
+	// S3 enables AWS S3 sync.
+	S3 bool
+}
+
+// BuildFeatures builds the feature flags based on supported types returned by Access Graph
+// AWS endpoints.
+func BuildFeatures(values ...string) Features {
+	features := Features{}
+	for _, value := range values {
+		switch value {
+		case awsGroups:
+			features.Groups = true
+		case awsUsers:
+			features.Users = true
+		case awsEC2:
+			features.EC2 = true
+		case awsEKS:
+			features.EKS = true
+		case awsRDS:
+			features.RDS = true
+		case awsS3:
+			features.S3 = true
+		case awsRoles:
+			features.Roles = true
+		}
+	}
+	return features
+}


### PR DESCRIPTION
This pull request addresses the issue of multiple instances of `discovery_services` running concurrently with identical configurations, preventing them from competing and pushing new resources to the Access Graph service.

Additionally, this pull request introduces the concept of features to identify the supported resource list that the Access Graph service to which `discovery_service` is connected to supports.

Paired with https://github.com/gravitational/access-graph/pull/591