### PR TITLE
feat: add "SAML Application" title to discovery tile

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -204,6 +204,8 @@ export function getResourcePretitle(r: ResourceSpec) {
         return 'Amazon Web Services (AWS)';
       }
       return 'Server';
+    case ResourceKind.SamlApplication:
+      return 'SAML Application';
   }
 
   return '';

--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -31,7 +31,7 @@ export const SAML_APPLICATIONS: ResourceSpec[] = [
     event: DiscoverEventResource.SamlApplication,
   },
   {
-    name: 'SAML Application (Grafana)',
+    name: 'Grafana',
     kind: ResourceKind.SamlApplication,
     keywords: 'saml sso application idp grafana',
     icon: 'Grafana',


### PR DESCRIPTION
- Adds "SAML Application" title to discovery tile.
- Updates Grafana app name from "SAML Application (Grafana)"  to "Grafana" as mention of SAML application is redundant when title is displayed. 