### PR TITLE
feat: add `samlMeta` field with `SAMLServiceProviderPresets` to `ResourceSpec`

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -20,13 +20,13 @@ import { DiscoverEventResource } from 'teleport/services/userEvent';
 
 import { ResourceKind } from '../Shared';
 
-import { ResourceSpec, SAMLServiceProviderPresets } from './types';
+import { ResourceSpec, SamlServiceProviderPreset } from './types';
 
 export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
     name: 'SAML Application',
     kind: ResourceKind.SamlApplication,
-    samlMeta: { preset: SAMLServiceProviderPresets.Unspecified },
+    samlMeta: { preset: SamlServiceProviderPreset.Unspecified },
     keywords: 'saml sso application idp',
     icon: 'Application',
     event: DiscoverEventResource.SamlApplication,
@@ -34,7 +34,7 @@ export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
     name: 'Grafana',
     kind: ResourceKind.SamlApplication,
-    samlMeta: { preset: SAMLServiceProviderPresets.Grafana },
+    samlMeta: { preset: SamlServiceProviderPreset.Grafana },
     keywords: 'saml sso application idp grafana',
     icon: 'Grafana',
     event: DiscoverEventResource.SamlApplication,

--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -20,12 +20,13 @@ import { DiscoverEventResource } from 'teleport/services/userEvent';
 
 import { ResourceKind } from '../Shared';
 
-import { ResourceSpec } from './types';
+import { ResourceSpec, SAMLServiceProviderPresets } from './types';
 
 export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
     name: 'SAML Application',
     kind: ResourceKind.SamlApplication,
+    samlMeta: { preset: SAMLServiceProviderPresets.Unspecified },
     keywords: 'saml sso application idp',
     icon: 'Application',
     event: DiscoverEventResource.SamlApplication,
@@ -33,6 +34,7 @@ export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
     name: 'Grafana',
     kind: ResourceKind.SamlApplication,
+    samlMeta: { preset: SAMLServiceProviderPresets.Grafana },
     keywords: 'saml sso application idp grafana',
     icon: 'Grafana',
     event: DiscoverEventResource.SamlApplication,

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -66,10 +66,10 @@ export enum KubeLocation {
   Aws,
 }
 
-/** SAMLServiceProviderPresets defines SAML service provider preset types.
+/** SamlServiceProviderPreset defines SAML service provider preset types.
  * Used to define custom or pre-defined configuration flow.
-*/
-export enum SAMLServiceProviderPresets {
+ */
+export enum SamlServiceProviderPreset {
   Unspecified = 'unspecified',
   Grafana = 'grafana',
 }
@@ -78,7 +78,7 @@ export interface ResourceSpec {
   dbMeta?: { location: DatabaseLocation; engine: DatabaseEngine };
   nodeMeta?: { location: ServerLocation };
   kubeMeta?: { location: KubeLocation };
-  samlMeta?: { preset: SAMLServiceProviderPresets };
+  samlMeta?: { preset: SamlServiceProviderPreset };
   name: string;
   popular?: boolean;
   kind: ResourceKind;

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -66,10 +66,19 @@ export enum KubeLocation {
   Aws,
 }
 
+/** SAMLServiceProviderPresets defines SAML service provider preset types.
+ * Used to define custom or pre-defined configuration flow.
+*/
+export enum SAMLServiceProviderPresets {
+  Unspecified = 'unspecified',
+  Grafana = 'grafana',
+}
+
 export interface ResourceSpec {
   dbMeta?: { location: DatabaseLocation; engine: DatabaseEngine };
   nodeMeta?: { location: ServerLocation };
   kubeMeta?: { location: KubeLocation };
+  samlMeta?: { preset: SAMLServiceProviderPresets };
   name: string;
   popular?: boolean;
   kind: ResourceKind;


### PR DESCRIPTION
- Adds `samlMeta` field to `ResourceSpec`. The `samlMeta` object defines one `preset` subfield.
- Adds `SAMLServiceProviderPresets` enum to define SAML app type. The values will be used in `samlMeta.preset`.

The goal is to define preset SAML application profiles, which will then be passed to the SAML application discovery flow for custom configuration. 