### PR TITLE
web: fix label in MFA dialog

### DIFF
--- a/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AddAuthDeviceWizard/AddAuthDeviceWizard.tsx
@@ -449,6 +449,9 @@ export function SaveDeviceStep({
     setAuthCode(e.target.value);
   };
 
+  const label =
+    usage === 'passwordless' ? 'Passkey Nickname' : 'MFA Method Name';
+
   return (
     <div ref={refCallback} data-testid="save-step">
       <DialogHeader
@@ -466,12 +469,8 @@ export function SaveDeviceStep({
         {({ validator }) => (
           <form onSubmit={e => onSave(e, validator)}>
             <FieldInput
-              label={
-                usage === 'passwordless'
-                  ? 'Passkey Nickname'
-                  : 'MFA Method Name'
-              }
-              rule={requiredField('Passkey nickname is required')}
+              label={label}
+              rule={requiredField(`${label} is required`)}
               value={deviceName}
               placeholder="ex. my-macbookpro"
               autoFocus


### PR DESCRIPTION
This prevents the text box from saying "Passkey nickname required" when attempting to add an OTP app (which is not a passkey)