### PR TITLE
Access request promotions use the cache.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4846,7 +4846,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 // the error and return whatever it has. The caller is expected to deal with the possibility of a nil promotions object.
 func (a *Server) generateAccessRequestPromotions(ctx context.Context, req types.AccessRequest) (types.AccessRequest, *types.AccessRequestAllowedPromotions) {
 	reqCopy := req.Copy()
-	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Services, reqCopy)
+	promotions, err := modules.GetModules().GenerateAccessRequestPromotions(ctx, a.Cache, reqCopy)
 	if err != nil {
 		// Do not fail the request if the promotions failed to generate.
 		// The request promotion will be blocked, but the request can still be approved.


### PR DESCRIPTION
The access request promotion call now uses the cache instead of hitting the backend directly.

Testing:

This is deployed to our okta-demo cluster, where it significantly speeds up the access request checkout page.