### PR TITLE
Convert api to use slog instead of logrus

### DIFF
--- a/api/client/alpn_conn_upgrade.go
+++ b/api/client/alpn_conn_upgrade.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -29,7 +30,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -71,20 +71,21 @@ func IsALPNConnUpgradeRequired(ctx context.Context, addr string, insecure bool, 
 		InsecureSkipVerify: insecure,
 	}
 	testConn, err := tlsutils.TLSDial(ctx, baseDialer, "tcp", addr, tlsConfig)
+	logger := slog.With("address", addr)
 	if err != nil {
 		if isRemoteNoALPNError(err) {
-			logrus.Debugf("ALPN connection upgrade required for %q: %v. No ALPN protocol is negotiated by the server.", addr, true)
+			logger.DebugContext(ctx, "No ALPN protocol is negotiated by the server.", "upgrade_required", true)
 			return true
 		}
 		if isUnadvertisedALPNError(err) {
-			logrus.Debugf("ALPN connection upgrade required for %q: %v.", addr, err)
+			logger.DebugContext(ctx, "ALPN connection upgrade received an unadvertised ALPN protocol.", "error", err)
 			return true
 		}
 
 		// If dialing TLS fails for any other reason, we assume connection
 		// upgrade is not required so it will fallback to original connection
 		// method.
-		logrus.Infof("ALPN connection upgrade test failed for %q: %v.", addr, err)
+		logger.InfoContext(ctx, "ALPN connection upgrade test failed.", "error", err)
 		return false
 	}
 	defer testConn.Close()
@@ -92,7 +93,7 @@ func IsALPNConnUpgradeRequired(ctx context.Context, addr string, insecure bool, 
 	// Upgrade required when ALPN is not supported on the remote side so
 	// NegotiatedProtocol comes back as empty.
 	result := testConn.ConnectionState().NegotiatedProtocol == ""
-	logrus.Debugf("ALPN connection upgrade required for %q: %v.", addr, result)
+	logger.DebugContext(ctx, "ALPN connection upgrade test complete", "upgrade_required", result)
 	return result
 }
 
@@ -124,7 +125,7 @@ func OverwriteALPNConnUpgradeRequirementByEnv(addr string) (bool, bool) {
 		return false, false
 	}
 	result := isALPNConnUpgradeRequiredByEnv(addr, envValue)
-	logrus.WithField(defaults.TLSRoutingConnUpgradeEnvVar, envValue).Debugf("ALPN connection upgrade required for %q: %v.", addr, result)
+	slog.DebugContext(context.TODO(), "Determining if ALPN connection upgrade is explicitly forced due to environment variables.", defaults.TLSRoutingConnUpgradeEnvVar, envValue, "address", addr, "upgrade_required", result)
 	return result, true
 }
 
@@ -153,14 +154,14 @@ func isALPNConnUpgradeRequiredByEnv(addr, envValue string) bool {
 			if _, boolText, ok := strings.Cut(token, addr+"="); ok {
 				upgradeRequiredForAddr, err := utils.ParseBool(boolText)
 				if err != nil {
-					logrus.Debugf("Failed to parse %v: %v", envValue, err)
+					slog.DebugContext(context.TODO(), "Failed to parse ALPN connection upgrade environment variable", "value", envValue, "error", err)
 				}
 				return upgradeRequiredForAddr
 			}
 
 		default:
 			if boolValue, err := utils.ParseBool(token); err != nil {
-				logrus.Debugf("Failed to parse %v: %v", envValue, err)
+				slog.DebugContext(context.TODO(), "Failed to parse ALPN connection upgrade environment variable", "value", envValue, "error", err)
 			} else {
 				upgradeRequiredForAll = boolValue
 			}
@@ -270,18 +271,19 @@ func upgradeConnThroughWebAPI(conn net.Conn, api url.URL, alpnUpgradeType string
 	}
 
 	// Handle WebSocket.
+	logger := slog.With("hostname", api.Host)
 	if resp.Header.Get(constants.WebAPIConnUpgradeHeader) == constants.WebAPIConnUpgradeTypeWebSocket {
 		if err := checkWebSocketUpgradeResponse(resp, alpnUpgradeType, challengeKey); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		logrus.WithField("hostname", api.Host).Debug("Performing ALPN WebSocket connection upgrade.")
+		logger.DebugContext(req.Context(), "Performing ALPN WebSocket connection upgrade.")
 		return newWebSocketALPNClientConn(conn), nil
 	}
 
 	// Handle "legacy".
 	// TODO(greedy52) DELETE in 17.0.
-	logrus.WithField("hostname", api.Host).Debug("Performing ALPN legacy connection upgrade.")
+	logger.DebugContext(req.Context(), "Performing ALPN legacy connection upgrade.")
 	if alpnUpgradeType == constants.WebAPIConnUpgradeTypeALPNPing {
 		return pingconn.New(conn), nil
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"slices"
 	"sync"
@@ -32,7 +33,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
@@ -290,9 +290,7 @@ func connect(ctx context.Context, cfg Config) (*Client, error) {
 						sendError(trace.Wrap(err))
 						continue
 					}
-					log.WithField("address", addrs).Debug(
-						"No addresses were configured explicitly, falling back to addresses specified by credential. Consider explicitly configuring an address.",
-					)
+					slog.DebugContext(ctx, "No addresses were configured explicitly, falling back to addresses specified by credential. Consider explicitly configuring an address.", "address", addrs)
 				}
 			}
 
@@ -2522,7 +2520,7 @@ func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, nam
 		event, err := events.FromOneOf(*rawEvent)
 		if err != nil {
 			if trace.IsBadParameter(err) {
-				log.Warnf("skipping unknown event: %v", err)
+				slog.WarnContext(ctx, "skipping unknown event", "error", err)
 				continue
 			}
 			return nil, "", trace.Wrap(err)

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,9 +42,6 @@ import (
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	if testing.Verbose() {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
 	os.Exit(m.Run())
 }
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gravitational/trace v1.4.0
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/russellhaering/gosaml2 v0.9.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -869,8 +869,6 @@ github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYz
 github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -1173,7 +1171,6 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -18,15 +18,16 @@ package types
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -298,7 +299,7 @@ func (c *AuthPreferenceV2) GetPreferredLocalMFA() constants.SecondFactorType {
 		}
 		return constants.SecondFactorOTP
 	default:
-		log.Warnf("Unexpected second_factor setting: %v", sf)
+		slog.WarnContext(context.Background(), "Found unknown second_factor setting", "second_factor", sf)
 		return "" // Unsure, say nothing.
 	}
 }
@@ -323,7 +324,7 @@ func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
 	case trace.IsNotFound(err): // OK, expected to happen in some cases.
 		return false
 	case err != nil:
-		log.WithError(err).Warnf("Got unexpected error when reading Webauthn config")
+		slog.WarnContext(context.Background(), "Got unexpected error when reading Webauthn config", "error", err)
 		return false
 	}
 
@@ -568,10 +569,11 @@ func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
 	}
 
 	if c.Spec.SecondFactor == constants.SecondFactorU2F {
-		log.Warnf(`` +
+		const deprecationMessage = `` +
 			`Second Factor "u2f" is deprecated and marked for removal, using "webauthn" instead. ` +
 			`Please update your configuration to use WebAuthn. ` +
-			`Refer to https://goteleport.com/docs/access-controls/guides/webauthn/`)
+			`Refer to https://goteleport.com/docs/access-controls/guides/webauthn/`
+		slog.WarnContext(context.Background(), deprecationMessage)
 		c.Spec.SecondFactor = constants.SecondFactorWebauthn
 	}
 
@@ -775,7 +777,7 @@ func (w *Webauthn) CheckAndSetDefaults(u *U2F) error {
 		default:
 			return trace.BadParameter("failed to infer webauthn RPID from U2F App ID (%q)", u.AppID)
 		}
-		log.Infof("WebAuthn: RPID inferred from U2F configuration: %q", rpID)
+		slog.InfoContext(context.Background(), "WebAuthn: RPID inferred from U2F configuration", "rpid", rpID)
 		w.RPID = rpID
 	default:
 		return trace.BadParameter("webauthn configuration missing rp_id")
@@ -784,7 +786,7 @@ func (w *Webauthn) CheckAndSetDefaults(u *U2F) error {
 	// AttestationAllowedCAs.
 	switch {
 	case u != nil && len(u.DeviceAttestationCAs) > 0 && len(w.AttestationAllowedCAs) == 0 && len(w.AttestationDeniedCAs) == 0:
-		log.Infof("WebAuthn: using U2F device attestation CAs as allowed CAs")
+		slog.InfoContext(context.Background(), "WebAuthn: using U2F device attestation CAs as allowed CAs")
 		w.AttestationAllowedCAs = u.DeviceAttestationCAs
 	default:
 		for _, pem := range w.AttestationAllowedCAs {

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -17,14 +17,15 @@ limitations under the License.
 package types
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/utils"
 	atlasutils "github.com/gravitational/teleport/api/utils/atlas"
@@ -692,7 +693,7 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 	case awsutils.IsRDSEndpoint(d.Spec.URI):
 		details, err := awsutils.ParseRDSEndpoint(d.Spec.URI)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to parse RDS endpoint %v.", d.Spec.URI)
+			slog.WarnContext(context.Background(), "Failed to parse RDS endpoint.", "uri", d.Spec.URI, "error", err)
 			break
 		}
 		if d.Spec.AWS.RDS.InstanceID == "" {
@@ -728,7 +729,7 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 	case awsutils.IsRedshiftServerlessEndpoint(d.Spec.URI):
 		details, err := awsutils.ParseRedshiftServerlessEndpoint(d.Spec.URI)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to parse Redshift Serverless endpoint %v.", d.Spec.URI)
+			slog.WarnContext(context.Background(), "Failed to parse Redshift Serverless endpoint.", "uri", d.Spec.URI, "error", err)
 			break
 		}
 		if d.Spec.AWS.RedshiftServerless.WorkgroupName == "" {
@@ -746,7 +747,7 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 	case awsutils.IsElastiCacheEndpoint(d.Spec.URI):
 		endpointInfo, err := awsutils.ParseElastiCacheEndpoint(d.Spec.URI)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to parse %v as ElastiCache endpoint", d.Spec.URI)
+			slog.WarnContext(context.Background(), "Failed to parse ElastiCache endpoint", "uri", d.Spec.URI, "error", err)
 			break
 		}
 		if d.Spec.AWS.ElastiCache.ReplicationGroupID == "" {
@@ -760,7 +761,7 @@ func (d *DatabaseV3) CheckAndSetDefaults() error {
 	case awsutils.IsMemoryDBEndpoint(d.Spec.URI):
 		endpointInfo, err := awsutils.ParseMemoryDBEndpoint(d.Spec.URI)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to parse %v as MemoryDB endpoint", d.Spec.URI)
+			slog.WarnContext(context.Background(), "Failed to parse MemoryDB endpoint", "uri", d.Spec.URI, "error", err)
 			break
 		}
 		if d.Spec.AWS.MemoryDB.ClusterName == "" {

--- a/api/types/events/oneof.go
+++ b/api/types/events/oneof.go
@@ -17,11 +17,12 @@ limitations under the License.
 package events
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"reflect"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // MustToOneOf converts audit event to OneOf
@@ -653,7 +654,7 @@ func ToOneOf(in AuditEvent) (*OneOf, error) {
 		}
 
 	default:
-		log.Errorf("Attempted to convert dynamic event of unknown type \"%v\" into protobuf event.", in.GetType())
+		slog.ErrorContext(context.Background(), "Attempted to convert dynamic event of unknown type into protobuf event.", "event_type", in.GetType())
 		unknown := &Unknown{}
 		unknown.Type = UnknownEvent
 		unknown.Code = UnknownCode

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -17,10 +17,11 @@ limitations under the License.
 package types
 
 import (
+	"context"
+	"log/slog"
 	"time"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/defaults"
@@ -191,7 +192,7 @@ func (c *GithubConnectorV3) CheckAndSetDefaults() error {
 
 	// DELETE IN 11.0.0
 	if len(c.Spec.TeamsToLogins) > 0 {
-		log.Warn("GitHub connector field teams_to_logins is deprecated and will be removed in the next version. Please use teams_to_roles instead.")
+		slog.WarnContext(context.Background(), "GitHub connector field teams_to_logins is deprecated and will be removed in the next version. Please use teams_to_roles instead.")
 	}
 
 	// make sure claim mappings have either roles or a role template

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -17,11 +17,11 @@ package interceptors
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport/api/mfa"
@@ -53,7 +53,7 @@ func WithMFAUnaryInterceptor(mfaCeremony mfa.MFACeremony) grpc.UnaryClientInterc
 		// we just want the method name.
 		splitMethod := strings.Split(method, "/")
 		readableMethodName := splitMethod[len(splitMethod)-1]
-		logrus.Debugf("Retrying API request %q with Admin MFA", readableMethodName)
+		slog.DebugContext(ctx, "Retrying API request with Admin MFA", "method", readableMethodName)
 
 		// Start an MFA prompt that shares what API request caused MFA to be prompted.
 		// ex: MFA is required for admin-level API request: "CreateUser"

--- a/api/utils/prompt/context_reader.go
+++ b/api/utils/prompt/context_reader.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"sync"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
 
@@ -177,7 +177,7 @@ func (cr *ContextReader) processReads() {
 
 		select {
 		case <-cr.closed:
-			log.Warnf("ContextReader closed during ongoing read, dropping %v bytes", len(value))
+			slog.WarnContext(context.Background(), "ContextReader closed during ongoing read,", "dropped_bytes", len(value))
 			return
 		case cr.reads <- readOutcome{value: value, err: err}:
 		}
@@ -199,7 +199,7 @@ func (cr *ContextReader) handleInterrupt() {
 	for {
 		select {
 		case sig := <-c:
-			log.Debugf("Captured signal %s, attempting to restore terminal state", sig)
+			slog.DebugContext(context.Background(), "Captured signal attempting to restore terminal state", "signal", sig)
 			cr.mu.Lock()
 			_ = cr.maybeRestoreTerm(iAmHoldingTheLock{})
 			cr.mu.Unlock()
@@ -276,14 +276,14 @@ func (cr *ContextReader) ReadPassword(ctx context.Context) ([]byte, error) {
 	if cr.fd == -1 {
 		return nil, ErrNotTerminal
 	}
-	if err := cr.firePasswordRead(); err != nil {
+	if err := cr.firePasswordRead(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return cr.waitForRead(ctx)
 }
 
-func (cr *ContextReader) firePasswordRead() error {
+func (cr *ContextReader) firePasswordRead(ctx context.Context) error {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
 
@@ -300,7 +300,7 @@ func (cr *ContextReader) firePasswordRead() error {
 		cr.cond.Broadcast()
 	case readerStateClean: // OK, ongoing clean read.
 		// TODO(codingllama): Transition the terminal to password read?
-		log.Warn("prompt: Clean read reused by password read")
+		slog.WarnContext(ctx, "prompt: Clean read reused by password read")
 	case readerStatePassword: // OK, ongoing password read.
 	case readerStateClosed:
 		return ErrReaderClosed

--- a/api/utils/retryutils/retry.go
+++ b/api/utils/retryutils/retry.go
@@ -21,11 +21,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 )
 
 // Retry is an interface that provides retry logic
@@ -190,7 +190,7 @@ func (r *Linear) For(ctx context.Context, retryFn func() error) error {
 		if errors.As(trace.Unwrap(err), &permanentRetryError) {
 			return trace.Wrap(err)
 		}
-		log.Debugf("Will retry in %v: %v.", r.Duration(), err)
+		slog.DebugContext(ctx, "Waiting to retry operation again", "wait", r.Duration(), "error", err)
 		select {
 		case <-r.After():
 			r.Inc()

--- a/api/utils/sshutils/callback.go
+++ b/api/utils/sshutils/callback.go
@@ -17,9 +17,11 @@ limitations under the License.
 package sshutils
 
 import (
+	"context"
+	"log/slog"
+
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -72,7 +74,7 @@ func makeIsHostAuthorityFunc(getCheckers CheckersGetter) func(key ssh.PublicKey,
 	return func(key ssh.PublicKey, host string) bool {
 		checkers, err := getCheckers()
 		if err != nil {
-			logrus.WithError(err).Errorf("Failed to get checkers for %v.", host)
+			slog.ErrorContext(context.Background(), "Failed to get checkers.", "host", host, "error", err)
 			return false
 		}
 		for _, checker := range checkers {
@@ -87,7 +89,7 @@ func makeIsHostAuthorityFunc(getCheckers CheckersGetter) func(key ssh.PublicKey,
 				}
 			}
 		}
-		logrus.Debugf("No CA for host %v.", host)
+		slog.DebugContext(context.Background(), "No CA found for target host.", "host", host)
 		return false
 	}
 }


### PR DESCRIPTION
The use of slog now allows logrus to be removed from the api module entirely.