### PR TITLE
Don't count mfa-verifeid Private Key Policy as MFA for Admin Actions

### DIFF
--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -116,6 +116,10 @@ func (p PrivateKeyPolicy) IsHardwareKeyPolicy() bool {
 
 // MFAVerified checks that private keys with this key policy count as MFA verified.
 // Both Hardware key touch and pin are count as MFA verification.
+//
+// Note: MFA checks with private key policies are only performed during the establishment
+// of the connection, during the TLS/SSH handshake. For long term connections, MFA should
+// be re-verified through other methods (e.g. webauthn).
 func (p PrivateKeyPolicy) MFAVerified() bool {
 	return p.isHardwareKeyTouchVerified() || p.isHardwareKeyPINVerified()
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -490,12 +490,6 @@ func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, aut
 }
 
 func (a *authorizer) authorizeAdminAction(ctx context.Context, authContext *Context) error {
-	// Certain hardware-key based private key policies require MFA for each request.
-	if authContext.Identity.GetIdentity().PrivateKeyPolicy.MFAVerified() {
-		authContext.AdminActionAuthState = AdminActionAuthMFAVerified
-		return nil
-	}
-
 	// MFA is required to be passed through the request context.
 	mfaResp, err := mfa.CredentialsFromContext(ctx)
 	if err != nil {

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -562,6 +562,16 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			},
 			wantAdminActionAuthorized: false,
 		}, {
+			name: "NOK local user mfa verified private key policy",
+			user: LocalUser{
+				Username: localUser.GetName(),
+				Identity: tlsca.Identity{
+					Username:         localUser.GetName(),
+					PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+				},
+			},
+			wantAdminActionAuthorized: false,
+		}, {
 			// edge case for the admin role check.
 			name: "NOK local user with host-like username",
 			user: LocalUser{
@@ -612,16 +622,6 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			},
 			withMFA:                   validMFAWithReuse,
 			allowedReusedMFA:          true,
-			wantAdminActionAuthorized: true,
-		}, {
-			name: "OK local user mfa verified private key policy",
-			user: LocalUser{
-				Username: localUser.GetName(),
-				Identity: tlsca.Identity{
-					Username:         localUser.GetName(),
-					PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
-				},
-			},
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK admin",

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1119,7 +1119,10 @@ func (id Identity) GetSessionMetadata(sid string) events.SessionMetadata {
 	}
 }
 
-// IsMFAVerified returns whether this identity is MFA verified.
+// IsMFAVerified returns whether this identity is MFA verified. This MFA
+// verification may or may not have taken place recently, so it should not
+// be treated as blanket MFA verification uncritically. For example, MFA
+// should be re-verified for login procedures or admin actions.
 func (id *Identity) IsMFAVerified() bool {
 	return id.MFAVerified != "" || id.PrivateKeyPolicy.MFAVerified()
 }


### PR DESCRIPTION
Changelog: Improve the security for MFA for Admin Actions when used alongside Hardware Key support.

Removes a check that allowed certificates backed by a hardware key with MFA verification to count towards Admin Actions. hardware key based mfa verification only occurs during the client connection setup and therefore should not count as a blanket MFA verification for the full length of the client connection. 

Users will now be prompted for MFA for Admin Actions in addition to the initial Hardware Key Touch/PIN check, if applicable.

In the future, we can consider solutions involving accepting hardware key based MFA verification for a short duration after the connection was established (1m?), and then only requiring webauthn verification after that time elapses. This would improve the UX for the majority of Teleport client connections for admin actions, which are short lived.

Credit to Edoardo for noticing this issue :+1: 