### PR TITLE
Fix `TestIntegration/X11Forwarding`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4851,12 +4851,12 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 						// Reading the display may fail if the session is not fully initialized
 						// and the write to stdin is swallowed.
 						var display string
-						require.EventuallyWithT(t, func(collect *assert.CollectT) {
+						require.EventuallyWithT(t, func(t *assert.CollectT) {
 							// enter 'printenv DISPLAY > /path/to/tmp/file' into the session (dumping the value of DISPLAY into the temp file)
 							_, err = keyboard.Write([]byte(fmt.Sprintf("printenv %v > %s\n\r", x11.DisplayEnv, tmpFile.Name())))
-							assert.NoError(collect, err)
+							assert.NoError(t, err)
 
-							assert.Eventually(collect, func() bool {
+							assert.Eventually(t, func() bool {
 								output, err := os.ReadFile(tmpFile.Name())
 								if err == nil && len(output) != 0 {
 									display = strings.TrimSpace(string(output))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4854,9 +4854,9 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 						require.EventuallyWithT(t, func(collect *assert.CollectT) {
 							// enter 'printenv DISPLAY > /path/to/tmp/file' into the session (dumping the value of DISPLAY into the temp file)
 							_, err = keyboard.Write([]byte(fmt.Sprintf("printenv %v > %s\n\r", x11.DisplayEnv, tmpFile.Name())))
-							assert.NoError(t, err)
+							assert.NoError(collect, err)
 
-							assert.Eventually(t, func() bool {
+							assert.Eventually(collect, func() bool {
 								output, err := os.ReadFile(tmpFile.Name())
 								if err == nil && len(output) != 0 {
 									display = strings.TrimSpace(string(output))


### PR DESCRIPTION
Fix improper usage of `EventuallyWithT` introduced in https://github.com/gravitational/teleport/pull/39271.

Already backported in https://github.com/gravitational/teleport/pull/39281 and https://github.com/gravitational/teleport/pull/39280