### PR TITLE
Update Node.js, Electron and node-pty

### DIFF
--- a/.github/workflows/check-devbox.yaml
+++ b/.github/workflows/check-devbox.yaml
@@ -48,4 +48,4 @@ jobs:
         with:
           enable-cache: true
           devbox-version: 0.9.1
-          sha256-sum: a4f66cacf6091530f3d51148df83a08353906496c8ada001b0edd7ac29226dc5
+          sha256-checksum: f58202279237b9e0e7d69ef9334c7ca0628db31e5575f105dad6f41a171ebb6a

--- a/.github/workflows/check-devbox.yaml
+++ b/.github/workflows/check-devbox.yaml
@@ -47,5 +47,5 @@ jobs:
         uses: jetpack-io/devbox-install-action@4a7f1d5332cc72057d5e8080edebfcdf652e642e # v0.8.0
         with:
           enable-cache: true
-          devbox-version: 0.9.0
+          devbox-version: 0.9.1
           sha256-sum: a4f66cacf6091530f3d51148df83a08353906496c8ada001b0edd7ac29226dc5

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.22.1
 GOLANGCI_LINT_VERSION ?= v1.56.2
 
-NODE_VERSION ?= 18.19.1
+NODE_VERSION ?= 20.11.1
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1

--- a/devbox.json
+++ b/devbox.json
@@ -23,7 +23,7 @@
     "golangci-lint@1.55.2",
     "libfido2@1.13.0",
     "llvmPackages_14.clangUseLLVM@14.0.6",
-    "nodejs@18.16.1",
+    "nodejs@20.11.1",
     "protobuf3_20@3.20.3",
     "yarn@1.22.19",
 

--- a/devbox.lock
+++ b/devbox.lock
@@ -120,11 +120,25 @@
       "source": "devbox-search",
       "version": "14.0.6"
     },
-    "nodejs@18.16.1": {
-      "last_modified": "2023-06-30T04:44:22Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+    "nodejs@20.11.1": {
+      "last_modified": "2024-02-24T23:06:34Z",
+      "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#nodejs_20",
       "source": "devbox-search",
-      "version": "18.16.1"
+      "version": "20.11.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xr7qgwzvymigkn4lhz8hzdky765m32r4-nodejs-20.11.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/gdjc5gacmfpj6warfxhfkjj3i8vhaxq9-nodejs-20.11.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/vz13mi0w75q96sfjxz2ylnv8812hvf34-nodejs-20.11.1"
+        }
+      }
     },
     "openssl@latest": {
       "last_modified": "2023-08-30T00:25:28Z",

--- a/devbox.lock
+++ b/devbox.lock
@@ -121,22 +121,22 @@
       "version": "14.0.6"
     },
     "nodejs@20.11.1": {
-      "last_modified": "2024-02-24T23:06:34Z",
-      "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#nodejs_20",
+      "last_modified": "2024-03-08T13:51:52Z",
+      "resolved": "github:NixOS/nixpkgs/a343533bccc62400e8a9560423486a3b6c11a23b#nodejs_20",
       "source": "devbox-search",
       "version": "20.11.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/xr7qgwzvymigkn4lhz8hzdky765m32r4-nodejs-20.11.1"
+          "store_path": "/nix/store/5c0nzhy641v5hqnpb056vvdgg3pl9hgc-nodejs-20.11.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/gdjc5gacmfpj6warfxhfkjj3i8vhaxq9-nodejs-20.11.1"
+          "store_path": "/nix/store/mx6ji5alyrzm731x3nxpah9ag66dak0h-nodejs-20.11.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1"
+          "store_path": "/nix/store/sx7h48g69jlq5dhxmi3bwyw5qpd9lp9h-nodejs-20.11.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/vz13mi0w75q96sfjxz2ylnv8812hvf34-nodejs-20.11.1"
+          "store_path": "/nix/store/rxpjn1vzbpv0a2i5lx887wka8054gpwj-nodejs-20.11.1"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start-teleport-e": "yarn workspace @gravitational/teleport.e start",
     "build-term": "yarn workspace @gravitational/teleterm build",
     "start-term": "yarn workspace @gravitational/teleterm start",
-    "start-term-skip-native-deps": "yarn workspace @gravitational/teleterm start-skip-native-deps",
     "package-term": "yarn workspace @gravitational/teleterm package",
     "storybook": "start-storybook -p 9002 -c web/.storybook -s web/.storybook/public",
     "storybook-smoke-test": "yarn storybook --ci --smoke-test",

--- a/web/README.md
+++ b/web/README.md
@@ -16,13 +16,14 @@ You can make production builds locally or you can use Docker to do that.
 
 ### Local Build
 
-Make sure that [you have yarn installed](https://yarnpkg.com/lang/en/docs/install/#debian-stable)
-on your system since this monorepo uses the yarn package manager.
+Make sure that you have [Yarn 1](https://classic.yarnpkg.com/en/docs/install/) installed. The
+Node.js version should match the one reported by executing `make -C build.assets print-node-version`
+from the root directory.
 
-Then you need download and initialize these repository dependencies.
+Then you need to download and initialize JavaScript dependencies.
 
 ```
-$ yarn install
+yarn install
 ```
 
 You will also need the following tools installed:
@@ -35,7 +36,7 @@ You will also need the following tools installed:
 To build the Teleport open source version
 
 ```
-$ yarn build-ui-oss
+yarn build-ui-oss
 ```
 
 The resulting output will be in the `webassets` folder.
@@ -45,7 +46,7 @@ The resulting output will be in the `webassets` folder.
 To build the Teleport community version
 
 ```
-$ make docker-ui
+make docker-ui
 ```
 
 ## Getting Started with Teleport Connect
@@ -139,13 +140,13 @@ We use [jest](https://jestjs.io/) as our testing framework.
 To run all jest unit-tests:
 
 ```
-$ yarn run test
+yarn run test
 ```
 
 To run jest in watch-mode
 
 ```
-$ yarn run tdd
+yarn run tdd
 ```
 
 ### Interactive Testing
@@ -157,7 +158,7 @@ each component, and interactively develop and test components.
 To start a storybook:
 
 ```
-$ yarn run storybook
+yarn run storybook
 ```
 
 This command will open a new browser window with storybook in it. There
@@ -169,7 +170,7 @@ and iterate on shared functionality.
 We are targeting last 2 versions of all major browsers. To quickly find out which ones exactly, use the following command:
 
 ```
-$ yarn browserslist 'last 2 chrome version, last 2 edge version, last 2 firefox version, last 2 safari version'
+yarn browserslist 'last 2 chrome version, last 2 edge version, last 2 firefox version, last 2 safari version'
 ```
 
 ### Setup Prettier on VSCode

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -48,7 +48,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.10",
     "@types/jsdom": "^21.1.6",
-    "@types/node": "^18.19.17",
+    "@types/node": "^20.11.26",
     "@types/react": "^18.2.39",
     "@types/react-dom": "^18.2.17",
     "@types/react-router-dom": "^5.1.1",

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -24,7 +24,7 @@ make build/tsh
 The build output can be found in the `build` directory. The tsh binary will be packed together with
 the Electron app.
 
-Next, we're going to build the Electron app. **This project uses Node.js v20 and Yarn v1.**
+Next, we're going to build the Electron app.
 
 ```bash
 cd teleport

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -24,7 +24,7 @@ make build/tsh
 The build output can be found in the `build` directory. The tsh binary will be packed together with
 the Electron app.
 
-Next, we're going to build the Electron app. **This project uses Node.js v16 and Yarn v1.**
+Next, we're going to build the Electron app. **This project uses Node.js v20 and Yarn v1.**
 
 ```bash
 cd teleport

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -70,15 +70,7 @@ module.exports = {
       fs.writeFileSync(path, tshAppPlist);
     }
   },
-  files: [
-    'build/app',
-    // node-pty creates some files that differ across architecture builds causing
-    // the error "can't reconcile the non-macho files" as they cant be combined
-    // with lipo for a universal build. They aren't needed so skip them.
-    '!node_modules/node-pty/build/*/.forge-meta',
-    '!node_modules/node-pty/build/Debug/.deps/**',
-    '!node_modules/node-pty/bin',
-  ],
+  files: ['build/app'],
   protocols: [
     {
       // name ultimately becomes CFBundleURLName which is the URL identifier. [1] Apple recommends

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -46,7 +46,7 @@
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
     "clean-webpack-plugin": "4.0.0",
-    "electron": "28.2.3",
+    "electron": "29.1.1",
     "electron-notarize": "^1.2.1",
     "electron-vite": "^2.0.0",
     "eslint-import-resolver-webpack": "0.13.2",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -44,7 +44,7 @@
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
     "clean-webpack-plugin": "4.0.0",
-    "electron": "29.1.1",
+    "electron": "29.1.4",
     "electron-notarize": "^1.2.1",
     "electron-vite": "^2.0.0",
     "eslint-import-resolver-webpack": "0.13.2",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.8.8",
     "node-forge": "^1.3.1",
-    "node-pty": "1.1.0-beta5",
+    "node-pty": "1.1.0-beta12",
     "ring-buffer-ts": "^1.2.0",
     "split2": "4.1.0",
     "strip-ansi": "^7.1.0",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -10,11 +10,9 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "start": "yarn build-native-deps && yarn start-skip-native-deps",
-    "start-skip-native-deps": "electron-vite dev",
+    "start": "electron-vite dev",
     "start-electron": "electron build/app/dist/main/main.js",
     "build": "electron-vite build",
-    "build-native-deps": "electron-builder install-app-deps",
     "package": "electron-builder build --config electron-builder-config.js --publish never -c.extraMetadata.name=teleport-connect",
     "generate-grpc-shared": "npx -y --target_arch=x64 --package=@protobuf-ts/plugin@2.9.3 -- protoc -I=src/sharedProcess/api/proto --ts_opt long_type_number,eslint_disable,add_pb_suffix,client_grpc1,server_grpc1,ts_nocheck --ts_out=src/sharedProcess/api/protogen src/sharedProcess/api/proto/*.proto"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,10 +4127,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.11.18", "@types/node@^18.19.17":
-  version "18.19.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.17.tgz#a581a9fb4b2cfdbc61f008804f4436b2d5c40354"
-  integrity sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.26", "@types/node@^20.9.0":
+  version "20.11.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.26.tgz#3fbda536e51d5c79281e1d9657dcb0131baabd2d"
+  integrity sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==
   dependencies:
     undici-types "~5.26.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7447,10 +7447,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@29.1.1:
-  version "29.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.1.tgz#e9cb11311324e4b43a3e73667cd2b65a30e8fa34"
-  integrity sha512-cXN15NgCi7MkzGo5/23ZQbii+0UfhmUiDjACunmzcUofYCjF42XhFbL7JZnwgI0qtBCCeJU8qZNZt9lU91gUFw==
+electron@29.1.4:
+  version "29.1.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.4.tgz#6c47467ba50be5dd60b99b8737f69cd12fc0733f"
+  integrity sha512-IWXys0SqgmIfrqXusUGQC0gGG7CCqA5vfmNsUMj8dFkAnK3lisKyjSESStWlrsste/OX/AAC5wsVlf23reUNnw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11926,11 +11926,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.17.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
-  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
-
 nanoid@^3.3.1, nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
@@ -11996,6 +11991,11 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+node-addon-api@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.0.tgz#71f609369379c08e251c558527a107107b5e0fdb"
+  integrity sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -12036,12 +12036,12 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-pty@1.1.0-beta5:
-  version "1.1.0-beta5"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta5.tgz#364386b7058a93070234064f13164ec1ef914993"
-  integrity sha512-j3QdgFHnLY0JWxztrvM3g67RaQLOGvytv+C6mFu0PqD+JILlzqfwuoyqRqVxdZZjoOTUXPfSRj1qPVCaCH+eOw==
+node-pty@1.1.0-beta12:
+  version "1.1.0-beta12"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta12.tgz#702f8c05ac1d175dcbc17901f1c66ee5d67b27cd"
+  integrity sha512-xhWrczF9AN+TnIZoHcSiclt4dkD1IcncUOzcdgx3by0jwctt54ZgWEp68O0lE0D8ydxa/bk3nA9sWEDhDNJuwg==
   dependencies:
-    nan "^2.17.0"
+    node-addon-api "^7.1.0"
 
 node-releases@^2.0.13:
   version "2.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7447,13 +7447,13 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@28.2.3:
-  version "28.2.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.3.tgz#d26821bcfda7ee445b4b75231da4b057a7ce6e7b"
-  integrity sha512-he9nGphZo03ejDjYBXpmFVw0KBKogXvR2tYxE4dyYvnfw42uaFIBFrwGeenvqoEOfheJfcI0u4rFG6h3QxDwnA==
+electron@29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.1.tgz#e9cb11311324e4b43a3e73667cd2b65a30e8fa34"
+  integrity sha512-cXN15NgCi7MkzGo5/23ZQbii+0UfhmUiDjACunmzcUofYCjF42XhFbL7JZnwgI0qtBCCeJU8qZNZt9lU91gUFw==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^18.11.18"
+    "@types/node" "^20.9.0"
     extract-zip "^2.0.1"
 
 emittery@^0.13.1:


### PR DESCRIPTION
This time we have a bigger update :)

* Electron 28.2.3 -> 29.1.1. No breaking changes that would affect us https://www.electronjs.org/blog/electron-29-0.
However, they upgraded Node.js to v20, so I did the same for us. 
* Node.js 18.19.1 -> 20.11.1. No breaking changes as well https://nodejs.org/en/blog/announcements/v20-release-announce.
 I checked if the supported systems requirements haven't changed, the only difference I see is for [macOS](https://github.com/nodejs/node/blob/v20.x-staging/BUILDING.md); now 10.15 is required for x64. This aligns with Electron compatibility, starting from v28 they require v10.15 too.
* node-pty 1.1.0-beta5 -> 1.1.0-beta12 - this one is the most interesting.
Recently, the library has been ported to use [Node-API](https://github.com/microsoft/node-pty/pull/644). If I'm correct, this means that we no longer need to rebuild it manually, but instead the native code is compiled in `[4/4] 🔨  Building fresh packages...` phase. I verified that on macOS and Windows, the app starts without a manual deps rebuild. 
I looked at the `yarn install` time on CI, it doesn't seem that there is any significant difference.
Additionally, the package no longer depends on `nan` (it is predecessor of NAPI), which in the past we had to update along with Electron.
I removed all commands that we used to build deps natively and the code related to `node-pty` that we had in `electron-builder-config.js` - it seems that these files doesn't exist anyway.

Note: `electron-builder` stills rebuilds `node-pty` when packaging the app, I don't know if this is necessary now, but AFAIK we can't turn it off. I hope I'm not wrong about that Node-API stuff :) I learned more about it from [here](https://nodejs.github.io/node-addon-examples/about/what).

Tag build: 15.0.0-dev.gzdunek.12, tested on macOS, Windows, Ubuntu.

Changelog: Updated Electron to v29 in Teleport Connect 
 
