### PR TITLE
[v15] Remove redirects added in 2021

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2183,123 +2183,13 @@
       "permanent": true
     },
     {
-      "source": "/production/",
-      "destination": "/deploy-a-cluster/deployments/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guide/",
-      "destination": "/management/admin/",
-      "permanent": true
-    },
-    {
-      "source": "/trustedclusters/",
-      "destination": "/management/admin/trustedclusters/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/api/architecture/",
-      "destination": "/api/architecture/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/api/getting-started/",
-      "destination": "/api/getting-started/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/api/introduction/",
-      "destination": "/api/introduction/",
-      "permanent": true
-    },
-    {
-      "source": "/metrics-logs-reference/",
-      "destination": "/management/diagnostics/metrics/",
-      "permanent": true
-    },
-    {
-      "source": "/config-reference/",
-      "destination": "/reference/config/",
-      "permanent": true
-    },
-    {
-      "source": "/cli-docs/",
-      "destination": "/reference/cli/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/ssh-kubernetes-fedramp/",
-      "destination": "/access-controls/compliance-frameworks/fedramp/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-one-login/",
-      "destination": "/access-controls/sso/one-login/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-okta/",
-      "destination": "/access-controls/sso/okta/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-google-workspace/",
-      "destination": "/access-controls/sso/google-workspace/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-azuread/",
-      "destination": "/access-controls/sso/azuread/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-adfs/",
-      "destination": "/access-controls/sso/adfs/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/sso/ssh-sso/",
-      "destination": "/access-controls/sso/",
-      "permanent": true
-    },
-    {
       "source": "/enterprise/ssh_sso/",
       "destination": "/access-controls/sso/",
       "permanent": true
     },
     {
-      "source": "/enterprise/quickstart-enterprise/",
-      "destination": "/choose-an-edition/teleport-enterprise/introduction/",
-      "permanent": true
-    },
-    {
-      "source": "/gcp-guide/",
-      "destination": "/deploy-a-cluster/deployments/gcp/",
-      "permanent": true
-    },
-    {
-      "source": "/ibm-cloud-guide/",
-      "destination": "/deploy-a-cluster/deployments/ibm/",
-      "permanent": true
-    },
-    {
-      "source": "/aws-terraform-guide/",
-      "destination": "/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform/",
-      "permanent": true
-    },
-    {
       "source": "/aws-terraform/",
       "destination": "/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform/",
-      "permanent": true
-    },
-    {
-      "source": "/setup/guides/docker-compose/",
-      "destination": "/installation/",
-      "permanent": true
-    },
-    {
-      "source": "/cloud/",
-      "destination": "/choose-an-edition/teleport-cloud/introduction/",
       "permanent": true
     },
     {
@@ -2320,61 +2210,6 @@
     {
       "source": "/kubernetes-access/",
       "destination": "/kubernetes-access/introduction/",
-      "permanent": true
-    },
-    {
-      "source": "/enterprise/ssh-rbac/",
-      "destination": "/access-controls/introduction/",
-      "permanent": true
-    },
-    {
-      "source": "/quickstart/",
-      "destination": "/",
-      "permanent": true
-    },
-    {
-      "source": "/preview/database-access/",
-      "destination": "/database-access/",
-      "permanent": true
-    },
-    {
-      "source": "/preview/cloud/",
-      "destination": "/choose-an-edition/teleport-cloud/introduction/",
-      "permanent": true
-    },
-    {
-      "source": "/kubernetes-ssh/",
-      "destination": "/kubernetes-access/",
-      "permanent": true
-    },
-    {
-      "source": "/features/ssh-pam/",
-      "destination": "/server-access/guides/ssh-pam/",
-      "permanent": true
-    },
-    {
-      "source": "/openssh-teleport/",
-      "destination": "/server-access/openssh/",
-      "permanent": true
-    },
-    {
-      "source": "/features/enhanced-session-recording/",
-      "destination": "/server-access/guides/bpf-session-recording/",
-      "permanent": true
-    },
-    {
-      "source": "/quickstart-docker/",
-      "destination": "/installation/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/postgres-aws/",
-      "destination": "/database-access/guides/rds/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/guides/mysql-aws/",
-      "destination": "/database-access/guides/rds/",
       "permanent": true
     },
     {


### PR DESCRIPTION
As these redirects are 2-3 years old, they are unlikely to impact users. The exceptions are redirects added from the roots of docs sections like `application-access` and `database-access` to the introduction pages of these sections.

Used the following command to identify redirects from 2021:

```
git blame -L 2179,2473 -- docs/config.json | \
awk 'BEGIN{FS="[()]"} $2 ~ /2021/ && /source":/{print $3}'
```