### PR TITLE
Replace constants from trace with equivalents defined in teleport

### DIFF
--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -132,8 +131,6 @@ type Config struct {
 	OnStandBy func()
 	// IsSuccessful is used by the CircuitBreaker to determine if the executed function was successful or not
 	IsSuccessful func(v interface{}, err error) bool
-	// Logger is the logger
-	Logger logrus.FieldLogger
 	// TrippedErrorMessage is an optional message to use as the error message when the CircuitBreaker
 	// is tripped. Defaults to ErrStateTripped if not provided.
 	TrippedErrorMessage string
@@ -260,12 +257,6 @@ func (c *Config) CheckAndSetDefaults() error {
 		c.IsSuccessful = NonNilErrorIsSuccess
 	}
 
-	if c.Logger == nil {
-		c.Logger = logrus.New().WithFields(logrus.Fields{
-			trace.Component: "breaker",
-		})
-	}
-
 	c.TrippedPeriod = retryutils.NewSeventhJitter()(c.TrippedPeriod)
 
 	return nil
@@ -359,10 +350,8 @@ func (c *CircuitBreaker) afterExecution(prior uint64, v interface{}, err error) 
 	}
 
 	if c.cfg.IsSuccessful(v, err) {
-		c.cfg.Logger.Debugf("successful execution, %s", c.metrics.String())
 		c.success(state, now)
 	} else {
-		c.cfg.Logger.Debugf("failed execution, %s", c.metrics.String())
 		c.failure(state, now)
 	}
 }
@@ -406,8 +395,6 @@ func (c *CircuitBreaker) setState(s State, t time.Time) {
 	if c.state == s {
 		return
 	}
-
-	c.cfg.Logger.Debugf("state is transition from %s -> %s", c.state, s)
 
 	c.state = s
 	c.nextGeneration(t)

--- a/constants.go
+++ b/constants.go
@@ -69,6 +69,12 @@ const (
 )
 
 const (
+	// ComponentKey is a field that represents a component - e.g. service or
+	// function
+	ComponentKey = "teleport.ComponentKey"
+	// ComponentFields is a fields component
+	ComponentFields = "trace.fields"
+
 	// ComponentMemory is a memory backend
 	ComponentMemory = "memory"
 

--- a/lib/auth/assist/assistv1/service.go
+++ b/lib/auth/assist/assistv1/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -90,7 +91,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 	case cfg.ResourceGetter == nil:
 		return nil, trace.BadParameter("resource getter is required")
 	case cfg.Logger == nil:
-		cfg.Logger = logrus.WithField(trace.Component, "assist.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "assist.service")
 	}
 	// Embedder can be nil is the OpenAI API key is not set.
 

--- a/lib/auth/dbobjectimportrule/dbobjectimportrulev1/service.go
+++ b/lib/auth/dbobjectimportrule/dbobjectimportrulev1/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/databaseobjectimportrule"
@@ -54,7 +55,7 @@ func NewDatabaseObjectImportRuleService(cfg DatabaseObjectImportRuleServiceConfi
 		return nil, trace.BadParameter("backend service is required")
 	}
 	if cfg.Logger == nil {
-		cfg.Logger = logrus.WithField(trace.Component, "db_obj_import_rule")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "db_obj_import_rule")
 	}
 	return &DatabaseObjectImportRuleService{
 		logger:     cfg.Logger,

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	conv "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
@@ -60,7 +61,7 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 	}
 
 	if s.Logger == nil {
-		s.Logger = logrus.New().WithField(trace.Component, "discoveryconfig_crud_service")
+		s.Logger = logrus.New().WithField(teleport.ComponentKey, "discoveryconfig_crud_service")
 	}
 
 	if s.Clock == nil {

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -141,7 +141,7 @@ func (a *Server) CreateGithubAuthRequest(ctx context.Context, req types.GithubAu
 		return nil, trace.Wrap(err)
 	}
 	req.RedirectURL = client.AuthCodeURL(req.StateToken, "", "")
-	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
+	log.WithFields(logrus.Fields{teleport.ComponentKey: "github"}).Debugf(
 		"Redirect URL: %v.", req.RedirectURL)
 	req.SetExpiry(a.GetClock().Now().UTC().Add(defaults.GithubAuthRequestTTL))
 	err = a.Services.CreateGithubAuthRequest(ctx, req)
@@ -578,7 +578,7 @@ func (a *Server) getGithubOAuth2Client(connector types.GithubConnector) (*oauth2
 
 // ValidateGithubAuthCallback validates Github auth callback redirect
 func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*GithubAuthResponse, error) {
-	logger := log.WithFields(logrus.Fields{trace.Component: "github"})
+	logger := log.WithFields(logrus.Fields{teleport.ComponentKey: "github"})
 
 	if errParam := q.Get("error"); errParam != "" {
 		// try to find request so the error gets logged against it.
@@ -860,7 +860,7 @@ func (a *Server) calculateGithubUser(ctx context.Context, diagCtx *SSODiagContex
 }
 
 func (a *Server) createGithubUser(ctx context.Context, p *CreateUserParams, dryRun bool) (types.User, error) {
-	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
+	log.WithFields(logrus.Fields{teleport.ComponentKey: "github"}).Debugf(
 		"Generating dynamic GitHub identity %v/%v with roles: %v. Dry run: %v.",
 		p.ConnectorName, p.Username, p.Roles, dryRun)
 
@@ -941,7 +941,7 @@ func populateGithubClaims(user *userResponse, teams []teamResponse) (*types.Gith
 		OrganizationToTeams: orgToTeams,
 		Teams:               teamList,
 	}
-	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
+	log.WithFields(logrus.Fields{teleport.ComponentKey: "github"}).Debugf(
 		"Claims: %#v.", claims)
 	return claims, nil
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5278,7 +5278,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,
 		Entry: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.Component(teleport.ComponentAuth, teleport.ComponentGRPC),
+			teleport.ComponentKey: teleport.Component(teleport.ComponentAuth, teleport.ComponentGRPC),
 		}),
 		server:       server,
 		usersService: usersService,

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -70,7 +70,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentAuth,
+	teleport.ComponentKey: teleport.ComponentAuth,
 })
 
 // InitConfig is auth server init config

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -138,7 +139,7 @@ func (s *AWSOIDCServiceConfig) CheckAndSetDefaults() error {
 	}
 
 	if s.Logger == nil {
-		s.Logger = logrus.WithField(trace.Component, "integrations.awsoidc.service")
+		s.Logger = logrus.WithField(teleport.ComponentKey, "integrations.awsoidc.service")
 	}
 
 	return nil

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -87,7 +88,7 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 	}
 
 	if s.Logger == nil {
-		s.Logger = logrus.WithField(trace.Component, "integrations.service")
+		s.Logger = logrus.WithField(teleport.ComponentKey, "integrations.service")
 	}
 
 	if s.Clock == nil {

--- a/lib/auth/keystore/gcp_kms.go
+++ b/lib/auth/keystore/gcp_kms.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/keystore/internal/faketime"
 )
@@ -122,7 +123,7 @@ func newGCPKMSKeyStore(ctx context.Context, cfg *GCPKMSConfig, logger logrus.Fie
 		clock = cfg.clockOverride
 	}
 
-	logger = logger.WithFields(logrus.Fields{trace.Component: "GCPKMSKeyStore"})
+	logger = logger.WithFields(logrus.Fields{teleport.ComponentKey: "GCPKMSKeyStore"})
 
 	return &gcpKMSKeyStore{
 		hostUUID:        cfg.HostUUID,

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -33,6 +33,7 @@ import (
 	"github.com/miekg/pkcs11"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 )
@@ -91,7 +92,7 @@ func newPKCS11KeyStore(config *PKCS11Config, logger logrus.FieldLogger) (*pkcs11
 		return nil, trace.Wrap(err, "getting PKCS#11 module info")
 	}
 
-	logger = logger.WithFields(logrus.Fields{trace.Component: "PKCS11KeyStore"})
+	logger = logger.WithFields(logrus.Fields{teleport.ComponentKey: "PKCS11KeyStore"})
 
 	return &pkcs11KeyStore{
 		ctx:       ctx,

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -125,7 +126,7 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 	}
 
 	if cfg.Logger == nil {
-		cfg.Logger = logrus.WithField(trace.Component, "bot.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "bot.service")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -86,7 +87,7 @@ func NewWorkloadIdentityService(
 	}
 
 	if cfg.Logger == nil {
-		cfg.Logger = logrus.WithField(trace.Component, "workload-identity.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "workload-identity.service")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -210,7 +210,7 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 			},
 		},
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: cfg.Component,
+			teleport.ComponentKey: cfg.Component,
 		}),
 	}
 	server.cfg.TLS.GetConfigForClient = server.GetConfigForClient

--- a/lib/auth/migration/migration.go
+++ b/lib/auth/migration/migration.go
@@ -52,7 +52,7 @@ func withMigrations(m []migration) func(c *applyConfig) {
 }
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentAuth,
+	teleport.ComponentKey: teleport.ComponentAuth,
 })
 
 var tracer = tracing.NewTracer("migrations")

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -39,7 +39,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentKeyGen,
+	teleport.ComponentKey: teleport.ComponentKeyGen,
 })
 
 // precomputedKeys is a queue of cached keys ready for usage.

--- a/lib/auth/okta/service.go
+++ b/lib/auth/okta/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -57,7 +58,7 @@ func (c *ServiceConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = logrus.New().WithField(trace.Component, "okta_crud_service")
+		c.Logger = logrus.New().WithField(teleport.ComponentKey, "okta_crud_service")
 	}
 
 	if c.Authorizer == nil {

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -77,7 +78,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 	case cfg.AuthServer == nil:
 		return nil, trace.BadParameter("authServer is required")
 	case cfg.Logger == nil:
-		cfg.Logger = logrus.WithField(trace.Component, "trust.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "trust.service")
 	}
 
 	return &Service{

--- a/lib/auth/userloginstate/service.go
+++ b/lib/auth/userloginstate/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	"github.com/gravitational/teleport/api/types"
 	conv "github.com/gravitational/teleport/api/types/userloginstate/convert/v1"
@@ -58,7 +59,7 @@ func (c *ServiceConfig) checkAndSetDefaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = logrus.WithField(trace.Component, "user_login_state_crud_service")
+		c.Logger = logrus.WithField(teleport.ComponentKey, "user_login_state_crud_service")
 	}
 
 	if c.Clock == nil {

--- a/lib/auth/userpreferences/userpreferencesv1/service.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	userpreferences "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/services"
@@ -54,7 +55,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
 	case cfg.Logger == nil:
-		cfg.Logger = logrus.WithField(trace.Component, "userpreferences.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "userpreferences.service")
 	}
 
 	return &Service{

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
@@ -103,7 +104,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	if cfg.Logger == nil {
-		cfg.Logger = logrus.WithField(trace.Component, "users.service")
+		cfg.Logger = logrus.WithField(teleport.ComponentKey, "users.service")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -98,7 +98,7 @@ func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
 	}
 	logger := opts.Logger
 	if logger == nil {
-		logger = logrus.WithFields(logrus.Fields{trace.Component: "authorizer"})
+		logger = logrus.WithFields(logrus.Fields{teleport.ComponentKey: "authorizer"})
 	}
 
 	return &authorizer{

--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -92,7 +92,7 @@ func NewCircularBuffer(opts ...BufferOption) *CircularBuffer {
 	}
 	return &CircularBuffer{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentBuffer,
+			teleport.ComponentKey: teleport.ComponentBuffer,
 		}),
 		cfg:      cfg,
 		watchers: newWatcherTree(),

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -44,6 +44,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -220,7 +221,7 @@ var _ backend.Backend = &Backend{}
 // New returns new instance of DynamoDB backend.
 // It's an implementation of backend API's NewFunc
 func New(ctx context.Context, params backend.Params) (*Backend, error) {
-	l := log.WithFields(log.Fields{trace.Component: BackendName})
+	l := log.WithFields(log.Fields{teleport.ComponentKey: BackendName})
 
 	var cfg *Config
 	err := utils.ObjectToStruct(params, &cfg)

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -279,7 +279,7 @@ func New(ctx context.Context, params backend.Params, opts ...Option) (*EtcdBacke
 	}
 
 	b := &EtcdBackend{
-		Entry:       log.WithFields(log.Fields{trace.Component: GetName()}),
+		Entry:       log.WithFields(log.Fields{teleport.ComponentKey: GetName()}),
 		cfg:         cfg,
 		nodes:       cfg.Nodes,
 		cancelC:     make(chan bool, 1),

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -328,7 +329,7 @@ func (opts *Options) checkAndSetDefaults() error {
 // New returns new instance of Firestore backend.
 // It's an implementation of backend API's NewFunc
 func New(ctx context.Context, params backend.Params, options Options) (*Backend, error) {
-	l := log.WithFields(log.Fields{trace.Component: BackendName})
+	l := log.WithFields(log.Fields{teleport.ComponentKey: BackendName})
 	var cfg *backendConfig
 	err := apiutils.ObjectToStruct(params, &cfg)
 	if err != nil {
@@ -1083,7 +1084,7 @@ type indexTask struct {
 // EnsureIndexes is a function used by Firestore events and backend to generate indexes and will block until
 // indexes are reported as created
 func EnsureIndexes(ctx context.Context, adminSvc *apiv1.FirestoreAdminClient, tuples IndexList, indexParent string) error {
-	l := log.WithFields(log.Fields{trace.Component: BackendName})
+	l := log.WithFields(log.Fields{teleport.ComponentKey: BackendName})
 	var tasks []indexTask
 
 	// create the indexes

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -47,6 +47,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
@@ -328,7 +329,7 @@ func TestDeleteDocuments(t *testing.T) {
 
 			b := &Backend{
 				svc:           client,
-				Entry:         utils.NewLoggerForTests().WithFields(logrus.Fields{trace.Component: BackendName}),
+				Entry:         utils.NewLoggerForTests().WithFields(logrus.Fields{teleport.ComponentKey: BackendName}),
 				clock:         clockwork.NewFakeClock(),
 				clientContext: ctx,
 				clientCancel:  cancel,

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -249,7 +250,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	l := &Backend{
 		Config: cfg,
 		db:     db,
-		Entry:  log.WithFields(log.Fields{trace.Component: BackendName}),
+		Entry:  log.WithFields(log.Fields{teleport.ComponentKey: BackendName}),
 		clock:  cfg.Clock,
 		buf:    buf,
 		ctx:    closeCtx,

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -101,7 +101,7 @@ func New(cfg Config) (*Memory, error) {
 	m := &Memory{
 		Mutex: &sync.Mutex{},
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentMemory,
+			teleport.ComponentKey: teleport.ComponentMemory,
 		}),
 		Config: cfg,
 		tree: btree.NewG(cfg.BTreeDegree, func(a, b *btreeItem) bool {

--- a/lib/backend/pgbk/pgbk.go
+++ b/lib/backend/pgbk/pgbk.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -171,7 +172,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	log := logrus.WithField(trace.Component, componentName)
+	log := logrus.WithField(teleport.ComponentKey, componentName)
 
 	if cfg.AuthMode == AzureADAuth {
 		bc, err := pgcommon.AzureBeforeConnect(log)

--- a/lib/bpf/helper.go
+++ b/lib/bpf/helper.go
@@ -36,7 +36,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentBPF,
+	teleport.ComponentKey: teleport.ComponentBPF,
 })
 
 const (

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -942,7 +942,7 @@ func New(config Config) (*Cache, error) {
 		eventsFanout:                 fanout,
 		lowVolumeEventsFanout:        utils.NewRoundRobin(lowVolumeFanouts),
 		Logger: log.WithFields(log.Fields{
-			trace.Component: config.Component,
+			teleport.ComponentKey: config.Component,
 		}),
 	}
 	collections, err := setupCollections(cs, config.Watches)

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -47,7 +47,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentCgroup,
+	teleport.ComponentKey: teleport.ComponentCgroup,
 })
 
 // Config holds configuration for the cgroup service.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -129,7 +129,7 @@ const (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentClient,
+	teleport.ComponentKey: teleport.ComponentClient,
 })
 
 // ForwardedPort specifies local tunnel to remote

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -53,7 +53,7 @@ type Store struct {
 func NewFSClientStore(dirPath string) *Store {
 	dirPath = profile.FullProfilePath(dirPath)
 	return &Store{
-		log:               logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+		log:               logrus.WithField(teleport.ComponentKey, teleport.ComponentKeyStore),
 		KeyStore:          NewFSKeyStore(dirPath),
 		TrustedCertsStore: NewFSTrustedCertsStore(dirPath),
 		ProfileStore:      NewFSProfileStore(dirPath),
@@ -63,7 +63,7 @@ func NewFSClientStore(dirPath string) *Store {
 // NewMemClientStore initializes a new in-memory client store.
 func NewMemClientStore() *Store {
 	return &Store{
-		log:               logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+		log:               logrus.WithField(teleport.ComponentKey, teleport.ComponentKeyStore),
 		KeyStore:          NewMemKeyStore(),
 		TrustedCertsStore: NewMemTrustedCertsStore(),
 		ProfileStore:      NewMemProfileStore(),

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -121,7 +121,7 @@ func NewLocalAgent(conf LocalAgentConfig) (a *LocalKeyAgent, err error) {
 	}
 	a = &LocalKeyAgent{
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentKeyAgent,
+			teleport.ComponentKey: teleport.ComponentKeyAgent,
 		}),
 		ExtendedAgent: conf.Agent,
 		clientStore:   conf.ClientStore,

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -97,7 +97,7 @@ type FSKeyStore struct {
 func NewFSKeyStore(dirPath string) *FSKeyStore {
 	dirPath = profile.FullProfilePath(dirPath)
 	return &FSKeyStore{
-		log:    logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+		log:    logrus.WithField(teleport.ComponentKey, teleport.ComponentKeyStore),
 		KeyDir: dirPath,
 	}
 }

--- a/lib/client/known_hosts_migrate.go
+++ b/lib/client/known_hosts_migrate.go
@@ -117,7 +117,7 @@ func canPruneOldHostsEntry(oldEntry *knownHostEntry, newEntries []*knownHostEntr
 // duplicate entry exists. This may modify order of host keys, but will not
 // change their content.
 func pruneOldHostKeys(output []string) []string {
-	log := logrus.WithField(trace.Component, teleport.ComponentMigrate)
+	log := logrus.WithField(teleport.ComponentKey, teleport.ComponentMigrate)
 
 	var (
 		oldEntries   = make([]*knownHostEntry, 0)

--- a/lib/client/kube/kube.go
+++ b/lib/client/kube/kube.go
@@ -26,7 +26,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentKubeClient,
+	teleport.ComponentKey: teleport.ComponentKubeClient,
 })
 
 // CheckIfCertsAreAllowedToAccessCluster evaluates if the new cert created by the user

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -121,7 +121,7 @@ type FSProfileStore struct {
 func NewFSProfileStore(dirPath string) *FSProfileStore {
 	dirPath = profile.FullProfilePath(dirPath)
 	return &FSProfileStore{
-		log: logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+		log: logrus.WithField(teleport.ComponentKey, teleport.ComponentKeyStore),
 		Dir: dirPath,
 	}
 }

--- a/lib/client/terminal/terminal_common.go
+++ b/lib/client/terminal/terminal_common.go
@@ -29,7 +29,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentClient,
+	teleport.ComponentKey: teleport.ComponentClient,
 })
 
 // ResizeEvent is emitted when a terminal window is resized.

--- a/lib/client/trusted_certs_store.go
+++ b/lib/client/trusted_certs_store.go
@@ -171,7 +171,7 @@ type FSTrustedCertsStore struct {
 func NewFSTrustedCertsStore(dirPath string) *FSTrustedCertsStore {
 	dirPath = profile.FullProfilePath(dirPath)
 	return &FSTrustedCertsStore{
-		log: logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+		log: logrus.WithField(teleport.ComponentKey, teleport.ComponentKeyStore),
 		Dir: dirPath,
 	}
 }

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -341,7 +341,7 @@ type TOTPRegisterChallenge struct {
 // initClient creates a new client to the HTTPS web proxy.
 func initClient(proxyAddr string, insecure bool, pool *x509.CertPool, extraHeaders map[string]string, opts ...roundtrip.ClientParam) (*WebClient, *url.URL, error) {
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.ComponentClient,
+		teleport.ComponentKey: teleport.ComponentClient,
 	})
 	log.Debugf("HTTPS client init(proxyAddr=%v, insecure=%v, extraHeaders=%v)", proxyAddr, insecure, extraHeaders)
 

--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -267,7 +267,7 @@ func (cfg *Config) CheckAndSetDefaults(ctx context.Context) error {
 
 	if cfg.LogEntry == nil {
 		cfg.LogEntry = log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentAthena,
+			teleport.ComponentKey: teleport.ComponentAthena,
 		})
 	}
 

--- a/lib/events/athena/consumer.go
+++ b/lib/events/athena/consumer.go
@@ -391,7 +391,7 @@ func (cfg *sqsCollectConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.logger == nil {
 		cfg.logger = log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentAthena,
+			teleport.ComponentKey: teleport.ComponentAthena,
 		})
 	}
 	if cfg.errHandlingFn == nil {

--- a/lib/events/athena/consumer_test.go
+++ b/lib/events/athena/consumer_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/segmentio/parquet-go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events"
@@ -576,7 +577,7 @@ func TestErrHandlingFnFromSQS(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		LogEntry: log.WithField(trace.Component, "test"),
+		LogEntry: log.WithField(teleport.ComponentKey, "test"),
 		metrics:  metrics,
 	}
 

--- a/lib/events/athena/querier.go
+++ b/lib/events/athena/querier.go
@@ -113,7 +113,7 @@ func (cfg *querierConfig) CheckAndSetDefaults() error {
 
 	if cfg.logger == nil {
 		cfg.logger = log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentAthena,
+			teleport.ComponentKey: teleport.ComponentAthena,
 		})
 	}
 	if cfg.clock == nil {

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -302,7 +302,7 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 		playbackDir:    filepath.Join(cfg.DataDir, PlaybackDir, SessionLogsDir, apidefaults.Namespace),
 		AuditLogConfig: cfg,
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentAuditLog,
+			teleport.ComponentKey: teleport.ComponentAuditLog,
 		}),
 		activeDownloads: make(map[string]context.Context),
 		ctx:             ctx,

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -160,7 +160,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "azblob")
+		c.Log = logrus.WithField(teleport.ComponentKey, "azblob")
 	}
 
 	return nil

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -97,7 +97,7 @@ func NewUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {
 	u := &UploadCompleter{
 		cfg: cfg,
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(cfg.Component, "completer"),
+			teleport.ComponentKey: teleport.Component(cfg.Component, "completer"),
 		}),
 		closeC: make(chan struct{}),
 	}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -251,7 +251,7 @@ const (
 // It's an implementation of backend API's NewFunc
 func New(ctx context.Context, cfg Config) (*Log, error) {
 	l := log.WithFields(log.Fields{
-		trace.Component: teleport.Component(teleport.ComponentDynamoDB),
+		teleport.ComponentKey: teleport.Component(teleport.ComponentDynamoDB),
 	})
 	l.Info("Initializing event backend.")
 

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -273,7 +273,7 @@ func (*LoggingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Audit
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fields[trace.Component] = teleport.Component(teleport.ComponentAuditLog)
+	fields[teleport.ComponentKey] = teleport.Component(teleport.ComponentAuditLog)
 
 	log.WithFields(fields).Infof(event.GetType())
 	return nil

--- a/lib/events/eventstest/channel.go
+++ b/lib/events/eventstest/channel.go
@@ -21,9 +21,9 @@ package eventstest
 import (
 	"context"
 
-	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/session"
 )
@@ -37,7 +37,7 @@ type ChannelEmitter struct {
 // NewChannelEmitter returns a new instance of test emitter.
 func NewChannelEmitter(capacity int) *ChannelEmitter {
 	return &ChannelEmitter{
-		log:    logrus.WithField(trace.Component, "channel_emitter"),
+		log:    logrus.WithField(teleport.ComponentKey, "channel_emitter"),
 		events: make(chan apievents.AuditEvent, capacity),
 	}
 }
@@ -65,7 +65,7 @@ type ChannelRecorder struct {
 // NewChannelRecorder returns a new instance of test recorder.
 func NewChannelRecorder(capacity int) *ChannelRecorder {
 	return &ChannelRecorder{
-		log:    logrus.WithField(trace.Component, "channel_recorder"),
+		log:    logrus.WithField(teleport.ComponentKey, "channel_recorder"),
 		events: make(chan apievents.AuditEvent, capacity),
 	}
 }

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -102,7 +102,7 @@ func NewFileLog(cfg FileLogConfig) (*FileLog, error) {
 	f := &FileLog{
 		FileLogConfig: cfg,
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentAuditLog,
+			teleport.ComponentKey: teleport.ComponentAuditLog,
 		}),
 	}
 	return f, nil

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -105,7 +105,7 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 	uploader := &Uploader{
 		cfg: cfg,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: cfg.Component,
+			teleport.ComponentKey: cfg.Component,
 		}),
 		closeC:        make(chan struct{}),
 		semaphore:     make(chan struct{}, cfg.ConcurrentUploads),

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -74,7 +74,7 @@ func NewHandler(cfg Config) (*Handler, error) {
 
 	h := &Handler{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.SchemeFile),
+			teleport.ComponentKey: teleport.Component(teleport.SchemeFile),
 		}),
 		Config: cfg,
 	}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -275,7 +275,7 @@ func New(cfg EventsConfig) (*Log, error) {
 	}
 
 	l := log.WithFields(log.Fields{
-		trace.Component: teleport.Component(teleport.ComponentFirestore),
+		teleport.ComponentKey: teleport.Component(teleport.ComponentFirestore),
 	})
 	l.Info("Initializing event backend.")
 	closeCtx, cancel := context.WithCancel(context.Background())

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -200,7 +200,7 @@ func NewHandler(ctx context.Context, cancelFunc context.CancelFunc, cfg Config, 
 	}
 	h := &Handler{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.SchemeGCS),
+			teleport.ComponentKey: teleport.Component(teleport.SchemeGCS),
 		}),
 		Config:        cfg,
 		gcsClient:     client,

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
@@ -175,7 +176,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, componentName)
+		c.Log = logrus.WithField(teleport.ComponentKey, componentName)
 	}
 
 	return nil

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -210,7 +210,7 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 
 	h := &Handler{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.SchemeS3),
+			teleport.ComponentKey: teleport.Component(teleport.SchemeS3),
 		}),
 		Config:     cfg,
 		uploader:   uploader,

--- a/lib/events/session_writer.go
+++ b/lib/events/session_writer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	logrus "github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/session"
@@ -51,7 +52,7 @@ func NewSessionWriter(cfg SessionWriterConfig) (*SessionWriter, error) {
 		cfg:    cfg,
 		stream: stream,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: cfg.Component,
+			teleport.ComponentKey: cfg.Component,
 		}),
 		cancel:   cancel,
 		closeCtx: ctx,

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -21,7 +21,6 @@ package usageevents
 import (
 	"context"
 
-	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
@@ -84,7 +83,7 @@ func New(reporter usagereporter.UsageReporter, log logrus.FieldLogger, inner api
 
 	return &UsageLogger{
 		Entry: log.WithField(
-			trace.Component,
+			teleport.ComponentKey,
 			teleport.Component(teleport.ComponentUsageReporting),
 		),
 		reporter: reporter,

--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/lib/modules"
@@ -322,7 +323,7 @@ func newCredentialsCache(ctx context.Context, region, roleARN string, options *O
 	gotFirstCredsOrErr := make(chan struct{})
 	return &credentialsCache{
 		roleARN:                 roleARN,
-		log:                     logrus.WithField(trace.Component, "ExternalAuditStorage.CredentialsCache"),
+		log:                     logrus.WithField(teleport.ComponentKey, "ExternalAuditStorage.CredentialsCache"),
 		initialized:             initialized,
 		closeInitialized:        sync.OnceFunc(func() { close(initialized) }),
 		gotFirstCredsOrErr:      gotFirstCredsOrErr,

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -50,7 +51,7 @@ const (
 	syncInterval = 30 * time.Second
 )
 
-var log = logrus.WithField(trace.Component, "ExternalAuditStorage")
+var log = logrus.WithField(teleport.ComponentKey, "ExternalAuditStorage")
 
 // ClusterAlertService abstracts a service providing Upsert and Delete
 // operations for cluster alerts.

--- a/lib/kube/grpc/grpc.go
+++ b/lib/kube/grpc/grpc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	proto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -118,7 +119,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Log == nil {
 		c.Log = logrus.New()
 	}
-	c.Log = c.Log.WithFields(logrus.Fields{trace.Component: c.Component})
+	c.Log = c.Log.WithFields(logrus.Fields{teleport.ComponentKey: c.Component})
 	return nil
 }
 

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -39,7 +39,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentKubeClient,
+	teleport.ComponentKey: teleport.ComponentKubeClient,
 })
 
 const (

--- a/lib/kube/proxy/portforward_spdy.go
+++ b/lib/kube/proxy/portforward_spdy.go
@@ -92,8 +92,8 @@ func runPortForwardingHTTPStreams(req portForwardRequest) error {
 
 	h := &portForwardProxy{
 		Entry: log.WithFields(log.Fields{
-			trace.Component:   teleport.Component(teleport.ComponentProxyKube),
-			events.RemoteAddr: req.httpRequest.RemoteAddr,
+			teleport.ComponentKey: teleport.Component(teleport.ComponentProxyKube),
+			events.RemoteAddr:     req.httpRequest.RemoteAddr,
 		}),
 		portForwardRequest:    req,
 		sourceConn:            conn,

--- a/lib/kube/proxy/portforward_websocket.go
+++ b/lib/kube/proxy/portforward_websocket.go
@@ -144,8 +144,8 @@ func runPortForwardingWebSocket(req portForwardRequest) error {
 		targetConn:    targetConn,
 		onPortForward: req.onPortForward,
 		FieldLogger: logrus.WithFields(logrus.Fields{
-			trace.Component:   teleport.Component(teleport.ComponentProxyKube),
-			events.RemoteAddr: req.httpRequest.RemoteAddr,
+			teleport.ComponentKey: teleport.Component(teleport.ComponentProxyKube),
+			events.RemoteAddr:     req.httpRequest.RemoteAddr,
 		}),
 		context: req.context,
 	}

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -192,7 +192,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	log := cfg.Log.WithFields(logrus.Fields{
-		trace.Component: cfg.Component,
+		teleport.ComponentKey: cfg.Component,
 	})
 	// limiter limits requests by frequency and amount of simultaneous
 	// connections per client

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/remotecommand"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
@@ -242,7 +243,7 @@ func Test_session_trackSession(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sess := &session{
-				log: logrus.New().WithField(trace.Component, "test"),
+				log: logrus.New().WithField(teleport.ComponentKey, "test"),
 				id:  uuid.New(),
 				req: &http.Request{
 					URL: &url.URL{},

--- a/lib/labels/cloud.go
+++ b/lib/labels/cloud.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 )
@@ -66,7 +67,7 @@ func (conf *CloudConfig) checkAndSetDefaults() error {
 		conf.Clock = clockwork.NewRealClock()
 	}
 	if conf.Log == nil {
-		conf.Log = logrus.WithField(trace.Component, "cloudlabels")
+		conf.Log = logrus.WithField(teleport.ComponentKey, "cloudlabels")
 	}
 	return nil
 }

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -155,7 +155,7 @@ func New(cfg Config) (*Mux, error) {
 	waitContext, waitCancel := context.WithCancel(context.TODO())
 	return &Mux{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component("mx", cfg.ID),
+			teleport.ComponentKey: teleport.Component("mx", cfg.ID),
 		}),
 		Config:      cfg,
 		context:     ctx,

--- a/lib/multiplexer/testproxy.go
+++ b/lib/multiplexer/testproxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -49,7 +50,7 @@ func NewTestProxy(target string, v2 bool) (*TestProxy, error) {
 		listener: listener,
 		target:   target,
 		closeCh:  make(chan struct{}),
-		log:      logrus.WithField(trace.Component, "test:proxy"),
+		log:      logrus.WithField(teleport.ComponentKey, "test:proxy"),
 		v2:       v2,
 	}, nil
 }

--- a/lib/multiplexer/tls.go
+++ b/lib/multiplexer/tls.go
@@ -74,7 +74,7 @@ func NewTLSListener(cfg TLSListenerConfig) (*TLSListener, error) {
 	context, cancel := context.WithCancel(context.TODO())
 	return &TLSListener{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.Component("mxtls", cfg.ID),
+			teleport.ComponentKey: teleport.Component("mxtls", cfg.ID),
 		}),
 		cfg:           cfg,
 		http2Listener: newListener(context, cfg.Listener.Addr()),

--- a/lib/multiplexer/web.go
+++ b/lib/multiplexer/web.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	dbcommon "github.com/gravitational/teleport/lib/srv/db/dbutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -66,7 +67,7 @@ func NewWebListener(cfg WebListenerConfig) (*WebListener, error) {
 	}
 	context, cancel := context.WithCancel(context.Background())
 	return &WebListener{
-		log:         logrus.WithField(trace.Component, "mxweb"),
+		log:         logrus.WithField(teleport.ComponentKey, "mxweb"),
 		cfg:         cfg,
 		webListener: newListener(context, cfg.Listener.Addr()),
 		dbListener:  newListener(context, cfg.Listener.Addr()),

--- a/lib/observability/tracing/tracing.go
+++ b/lib/observability/tracing/tracing.go
@@ -99,7 +99,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = logrus.WithField(trace.Component, teleport.ComponentTracing)
+		c.Logger = logrus.WithField(teleport.ComponentKey, teleport.ComponentTracing)
 	}
 
 	if c.Client != nil {

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -102,7 +102,7 @@ func init() {
 }
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentPAM,
+	teleport.ComponentKey: teleport.ComponentPAM,
 })
 
 const (

--- a/lib/player/player.go
+++ b/lib/player/player.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/session"
 )
@@ -108,7 +109,7 @@ func New(cfg *Config) (*Player, error) {
 
 	var log logrus.FieldLogger = cfg.Log
 	if log == nil {
-		log = logrus.New().WithField(trace.Component, "player")
+		log = logrus.New().WithField(teleport.ComponentKey, "player")
 	}
 
 	p := &Player{

--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -103,7 +103,7 @@ func (c *ClientConfig) checkAndSetDefaults() error {
 	}
 
 	c.Log = c.Log.WithField(
-		trace.Component,
+		teleport.ComponentKey,
 		teleport.Component(teleport.ComponentProxyPeer),
 	)
 

--- a/lib/proxy/peer/server.go
+++ b/lib/proxy/peer/server.go
@@ -68,7 +68,7 @@ func (c *ServerConfig) checkAndSetDefaults() error {
 		c.Log = logrus.New()
 	}
 	c.Log = c.Log.WithField(
-		trace.Component,
+		teleport.ComponentKey,
 		teleport.Component(teleport.ComponentProxy, "peer"),
 	)
 

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -136,7 +136,7 @@ type RouterConfig struct {
 // CheckAndSetDefaults ensures the required items were populated
 func (c *RouterConfig) CheckAndSetDefaults() error {
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "Router")
+		c.Log = logrus.WithField(teleport.ComponentKey, "Router")
 	}
 
 	if c.ClusterName == "" {

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -480,7 +480,7 @@ type fakeConn struct {
 func TestRouter_DialHost(t *testing.T) {
 	t.Parallel()
 
-	logger := utils.NewLoggerForTests().WithField(trace.Component, "test")
+	logger := utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test")
 
 	srv := &types.ServerV2{
 		Kind:    types.KindNode,
@@ -654,7 +654,7 @@ func TestRouter_DialSite(t *testing.T) {
 	t.Parallel()
 
 	const cluster = "test"
-	logger := utils.NewLoggerForTests().WithField(trace.Component, cluster)
+	logger := utils.NewLoggerForTests().WithField(teleport.ComponentKey, cluster)
 
 	cases := []struct {
 		name      string

--- a/lib/resumption/server_detect.go
+++ b/lib/resumption/server_detect.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -79,7 +80,7 @@ type SSHServerWrapperConfig struct {
 // NewSSHServerWrapper creates a [SSHServerWrapper].
 func NewSSHServerWrapper(cfg SSHServerWrapperConfig) *SSHServerWrapper {
 	if cfg.Log == nil {
-		cfg.Log = logrus.WithField(trace.Component, Component)
+		cfg.Log = logrus.WithField(teleport.ComponentKey, Component)
 	}
 
 	return &SSHServerWrapper{

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -203,7 +203,7 @@ func NewAgentPool(ctx context.Context, config AgentPoolConfig) (*AgentPool, erro
 		backoff:         retry,
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: teleport.ComponentReverseTunnelAgent,
-			trace.ComponentFields: logrus.Fields{
+			teleport.ComponentFields: logrus.Fields{
 				"targetCluster": config.Cluster,
 				"localCluster":  config.LocalCluster,
 			},

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -202,7 +202,7 @@ func NewAgentPool(ctx context.Context, config AgentPoolConfig) (*AgentPool, erro
 		events:          make(chan Agent),
 		backoff:         retry,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentReverseTunnelAgent,
+			teleport.ComponentKey: teleport.ComponentReverseTunnelAgent,
 			teleport.ComponentFields: logrus.Fields{
 				"targetCluster": config.Cluster,
 				"localCluster":  config.LocalCluster,

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 )
@@ -109,7 +110,7 @@ type connConfig struct {
 func newRemoteConn(cfg *connConfig) *remoteConn {
 	c := &remoteConn{
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: "discovery",
+			teleport.ComponentKey: "discovery",
 		}),
 		connConfig:  cfg,
 		clock:       clockwork.NewRealClock(),

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -102,7 +102,7 @@ func newLocalSite(srv *server, domainName string, authServers []string, opts ...
 		remoteConns: make(map[connKey][]*remoteConn),
 		clock:       srv.Clock,
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentReverseTunnelServer,
+			teleport.ComponentKey: teleport.ComponentReverseTunnelServer,
 			teleport.ComponentFields: map[string]string{
 				"cluster": domainName,
 			},

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -103,7 +103,7 @@ func newLocalSite(srv *server, domainName string, authServers []string, opts ...
 		clock:       srv.Clock,
 		log: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentReverseTunnelServer,
-			trace.ComponentFields: map[string]string{
+			teleport.ComponentFields: map[string]string{
 				"cluster": domainName,
 			},
 		}),

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -158,7 +158,7 @@ func newClusterPeer(srv *server, connInfo types.TunnelConnection, offlineThresho
 		connInfo: connInfo,
 		log: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentReverseTunnelServer,
-			trace.ComponentFields: map[string]string{
+			teleport.ComponentFields: map[string]string{
 				"cluster": connInfo.GetClusterName(),
 			},
 		}),

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -157,7 +157,7 @@ func newClusterPeer(srv *server, connInfo types.TunnelConnection, offlineThresho
 		srv:      srv,
 		connInfo: connInfo,
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentReverseTunnelServer,
+			teleport.ComponentKey: teleport.ComponentReverseTunnelServer,
 			teleport.ComponentFields: map[string]string{
 				"cluster": connInfo.GetClusterName(),
 			},

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -269,7 +269,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		logger = log.StandardLogger()
 	}
 	cfg.Log = logger.WithFields(log.Fields{
-		trace.Component: cfg.Component,
+		teleport.ComponentKey: cfg.Component,
 	})
 	if cfg.LockWatcher == nil {
 		return trace.BadParameter("missing parameter LockWatcher")
@@ -1181,7 +1181,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		domainName: domainName,
 		connInfo:   connInfo,
 		logger: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentReverseTunnelServer,
+			teleport.ComponentKey: teleport.ComponentReverseTunnelServer,
 			teleport.ComponentFields: log.Fields{
 				"cluster": domainName,
 			},

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1182,7 +1182,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		connInfo:   connInfo,
 		logger: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentReverseTunnelServer,
-			trace.ComponentFields: log.Fields{
+			teleport.ComponentFields: log.Fields{
 				"cluster": domainName,
 			},
 		}),

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -83,7 +83,7 @@ func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater() error {
 	}
 
 	updater, err := NewDeployServiceUpdater(AWSOIDCDeployServiceUpdaterConfig{
-		Log:                    process.log.WithField(trace.Component, teleport.Component(teleport.ComponentProxy, "aws_oidc_deploy_service_updater")),
+		Log:                    process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentProxy, "aws_oidc_deploy_service_updater")),
 		AuthClient:             authClient,
 		Clock:                  process.Clock,
 		TeleportClusterName:    clusterNameConfig.GetClusterName(),
@@ -129,7 +129,7 @@ func (cfg *AWSOIDCDeployServiceUpdaterConfig) CheckAndSetDefaults() error {
 	}
 
 	if cfg.Log == nil {
-		cfg.Log = logrus.WithField(trace.Component, teleport.Component(teleport.ComponentProxy, "aws_oidc_deploy_service_updater"))
+		cfg.Log = logrus.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentProxy, "aws_oidc_deploy_service_updater"))
 	}
 
 	if cfg.Clock == nil {

--- a/lib/service/certreloader.go
+++ b/lib/service/certreloader.go
@@ -58,7 +58,7 @@ type CertReloader struct {
 func NewCertReloader(cfg CertReloaderConfig) *CertReloader {
 	return &CertReloader{
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.ComponentProxy, "certreloader"),
+			teleport.ComponentKey: teleport.Component(teleport.ComponentProxy, "certreloader"),
 		}),
 		cfg: cfg,
 	}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -47,7 +47,7 @@ func (process *TeleportProcess) initDatabases() {
 }
 
 func (process *TeleportProcess) initDatabaseService() (retErr error) {
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentDatabase, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase, process.id))
 
 	conn, err := process.WaitForConnector(DatabasesIdentityEvent, logger)
 	if conn == nil {
@@ -87,7 +87,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentDatabase,
-			Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentDatabase, process.id)),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase, process.id)),
 			Client:    conn.Client,
 		},
 	})
@@ -100,7 +100,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
-		Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentDatabase, process.id)),
+		Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase, process.id)),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -45,7 +45,7 @@ import (
 )
 
 func (process *TeleportProcess) initWindowsDesktopService() {
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentWindowsDesktop, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id))
 	process.RegisterWithAuthServer(types.RoleWindowsDesktop, WindowsDesktopIdentityEvent)
 	process.RegisterCriticalFunc("windows_desktop.init", func() error {
 		conn, err := process.WaitForConnector(WindowsDesktopIdentityEvent, logger)
@@ -144,7 +144,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentWindowsDesktop,
-			Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
 			Clock:     cfg.Clock,
 			Client:    conn.Client,
 		},
@@ -159,7 +159,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
-		Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+		Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
 		// Device authorization breaks browser-based access.
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			DisableGlobalMode: true,
@@ -212,7 +212,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 
 	srv, err := desktop.NewWindowsService(desktop.WindowsServiceConfig{
 		DataDir:      process.Config.DataDir,
-		Log:          process.log.WithField(trace.Component, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+		Log:          process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
 		Clock:        process.Clock,
 		Authorizer:   authorizer,
 		Emitter:      conn.Client,

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -37,7 +37,7 @@ func (process *TeleportProcess) initDiscovery() {
 }
 
 func (process *TeleportProcess) initDiscoveryService() error {
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentDiscovery, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiscovery, process.id))
 
 	conn, err := process.WaitForConnector(DiscoveryIdentityEvent, logger)
 	if conn == nil {

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -39,7 +39,7 @@ import (
 )
 
 func (process *TeleportProcess) initKubernetes() {
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentKube, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id))
 
 	process.RegisterWithAuthServer(types.RoleKube, KubeIdentityEvent)
 	process.RegisterCriticalFunc("kube.init", func() error {
@@ -152,7 +152,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 	if len(cfg.Kube.DynamicLabels) != 0 {
 		dynLabels, err = labels.NewDynamic(process.ExitContext(), &labels.DynamicConfig{
 			Labels: cfg.Kube.DynamicLabels,
-			Log:    process.log.WithField(trace.Component, teleport.Component(teleport.ComponentKube, process.id)),
+			Log:    process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -169,7 +169,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentKube,
-			Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentKube, process.id)),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 			Client:    conn.Client,
 		},
 	})
@@ -182,7 +182,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		ClusterName: teleportClusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
-		Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentKube, process.id)),
+		Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -236,7 +236,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		StaticLabels:         cfg.Kube.StaticLabels,
 		DynamicLabels:        dynLabels,
 		CloudLabels:          process.cloudLabels,
-		Log:                  process.log.WithField(trace.Component, teleport.Component(teleport.ComponentKube, process.id)),
+		Log:                  process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 		PROXYProtocolMode:    multiplexer.PROXYProtocolOff, // Kube service doesn't need to process unsigned PROXY headers.
 	})
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -830,11 +830,11 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	processID := fmt.Sprintf("%v", nextProcessID())
 	cfg.Log = utils.WrapLogger(cfg.Log.WithFields(logrus.Fields{
-		trace.Component: teleport.Component(teleport.ComponentProcess, processID),
-		"pid":           fmt.Sprintf("%v.%v", os.Getpid(), processID),
+		teleport.ComponentKey: teleport.Component(teleport.ComponentProcess, processID),
+		"pid":                 fmt.Sprintf("%v.%v", os.Getpid(), processID),
 	}))
 	cfg.Logger = cfg.Logger.With(
-		trace.Component, teleport.Component(teleport.ComponentProcess, processID),
+		teleport.ComponentKey, teleport.Component(teleport.ComponentProcess, processID),
 		"pid", fmt.Sprintf("%v.%v", os.Getpid(), processID),
 	)
 
@@ -1792,7 +1792,7 @@ func (process *TeleportProcess) initAuthService() error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		traceConf.Logger = process.log.WithField(trace.Component, teleport.ComponentTracing)
+		traceConf.Logger = process.log.WithField(teleport.ComponentKey, teleport.ComponentTracing)
 
 		clt, err := tracing.NewStartedClient(process.ExitContext(), *traceConf)
 		if err != nil {
@@ -1895,12 +1895,12 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentAuth, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id))
 
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentAuth,
-			Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentAuth, process.id)),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id)),
 			Client:    authServer.Services,
 		},
 	})
@@ -1917,7 +1917,7 @@ func (process *TeleportProcess) initAuthService() error {
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			QueueSize:    defaults.UnifiedResourcesQueueSize,
 			Component:    teleport.ComponentUnifiedResource,
-			Log:          process.log.WithField(trace.Component, teleport.ComponentUnifiedResource),
+			Log:          process.log.WithField(teleport.ComponentKey, teleport.ComponentUnifiedResource),
 			Client:       authServer,
 			MaxStaleness: time.Minute,
 		},
@@ -1946,7 +1946,7 @@ func (process *TeleportProcess) initAuthService() error {
 			EmbeddingsRetriever: embeddingsRetriever,
 			EmbeddingSrv:        authServer,
 			NodeSrv:             authServer.UnifiedResourceCache,
-			Log:                 process.log.WithField(trace.Component, teleport.Component(teleport.ComponentAuth, process.id)),
+			Log:                 process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id)),
 			Jitter:              retryutils.NewFullJitter(),
 		})
 
@@ -2013,7 +2013,7 @@ func (process *TeleportProcess) initAuthService() error {
 		AccessPoint:      authServer,
 		MFAAuthenticator: authServer,
 		LockWatcher:      lockWatcher,
-		Logger:           process.log.WithField(trace.Component, teleport.Component(teleport.ComponentAuth, process.id)),
+		Logger:           process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id)),
 		// Auth Server does explicit device authorization.
 		// Various Auth APIs must allow access to unauthorized devices, otherwise it
 		// is not possible to acquire device-aware certificates in the first place.
@@ -2488,7 +2488,7 @@ func (process *TeleportProcess) initInstance() error {
 	}
 	process.RegisterWithAuthServer(types.RoleInstance, InstanceIdentityEvent)
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentInstance, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentInstance, process.id))
 
 	process.RegisterCriticalFunc("instance.init", func() error {
 		conn, err := process.WaitForConnector(InstanceIdentityEvent, logger)
@@ -2509,7 +2509,7 @@ func (process *TeleportProcess) initInstance() error {
 func (process *TeleportProcess) initSSH() error {
 	process.RegisterWithAuthServer(types.RoleNode, SSHIdentityEvent)
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentNode, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentNode, process.id))
 
 	proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
@@ -2618,7 +2618,7 @@ func (process *TeleportProcess) initSSH() error {
 		lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 			ResourceWatcherConfig: services.ResourceWatcherConfig{
 				Component: teleport.ComponentNode,
-				Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentNode, process.id)),
+				Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentNode, process.id)),
 				Client:    conn.Client,
 			},
 		})
@@ -2640,7 +2640,7 @@ func (process *TeleportProcess) initSSH() error {
 			LockEnforcer:   lockWatcher,
 			Emitter:        &events.StreamerAndEmitter{Emitter: asyncEmitter, Streamer: conn.Client},
 			Component:      teleport.ComponentNode,
-			Logger:         process.log.WithField(trace.Component, teleport.Component(teleport.ComponentNode, process.id)).WithField(trace.Component, "sessionctrl"),
+			Logger:         process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentNode, process.id)).WithField(teleport.ComponentKey, "sessionctrl"),
 			TracerProvider: process.TracingProvider,
 			ServerID:       serverID,
 		})
@@ -2694,7 +2694,7 @@ func (process *TeleportProcess) initSSH() error {
 		var resumableServer *resumption.SSHServerWrapper
 		if os.Getenv("TELEPORT_UNSTABLE_DISABLE_SSH_RESUMPTION") == "" {
 			resumableServer = resumption.NewSSHServerWrapper(resumption.SSHServerWrapperConfig{
-				Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentNode, resumption.Component)),
+				Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentNode, resumption.Component)),
 				SSHServer: s.HandleConnection,
 
 				HostID:  serverID,
@@ -2875,7 +2875,7 @@ func waitForInstanceConnector(process *TeleportProcess, log *slog.Logger) (*Conn
 func (process *TeleportProcess) initUploaderService() error {
 	component := teleport.Component(teleport.ComponentUpload, process.id)
 
-	logger := process.logger.With(trace.Component, component)
+	logger := process.logger.With(teleport.ComponentKey, component)
 
 	var clusterName string
 
@@ -3017,7 +3017,7 @@ func (process *TeleportProcess) initMetricsService() error {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentMetrics, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentMetrics, process.id))
 
 	listener, err := process.importOrCreateListener(ListenerMetrics, process.Config.Metrics.ListenAddr.Addr)
 	if err != nil {
@@ -3126,7 +3126,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 		roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{"status": "ok"})
 	})
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentDiagnostic, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnostic, process.id))
 
 	// Create a state machine that will process and update the internal state of
 	// Teleport based off Events. Use this state machine to return return the
@@ -3219,7 +3219,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 }
 
 func (process *TeleportProcess) initTracingService() error {
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentTracing, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentTracing, process.id))
 	logger.InfoContext(process.ExitContext(), "Initializing tracing provider and exporter.")
 
 	attrs := []attribute.KeyValue{
@@ -3232,7 +3232,7 @@ func (process *TeleportProcess) initTracingService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	traceConf.Logger = process.log.WithField(trace.Component, teleport.Component(teleport.ComponentTracing, process.id))
+	traceConf.Logger = process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentTracing, process.id))
 
 	provider, err := tracing.NewTraceProvider(process.ExitContext(), *traceConf)
 	if err != nil {
@@ -3840,7 +3840,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		proxySSHAddr.Addr = listeners.ssh.Addr().String()
 	}
 
-	logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id))
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id))
 
 	// asyncEmitter makes sure that sessions do not block
 	// in case if connections are slow
@@ -3856,7 +3856,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentProxy,
-			Log:       process.log.WithField(trace.Component, teleport.ComponentProxy),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.ComponentProxy),
 			Client:    conn.Client,
 		},
 	})
@@ -3867,7 +3867,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	nodeWatcher, err := services.NewNodeWatcher(process.ExitContext(), services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component:    teleport.ComponentProxy,
-			Log:          process.log.WithField(trace.Component, teleport.ComponentProxy),
+			Log:          process.log.WithField(teleport.ComponentKey, teleport.ComponentProxy),
 			Client:       accessPoint,
 			MaxStaleness: time.Minute,
 		},
@@ -3880,7 +3880,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	caWatcher, err := services.NewCertAuthorityWatcher(process.ExitContext(), services.CertAuthorityWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentProxy,
-			Log:       process.log.WithField(trace.Component, teleport.ComponentProxy),
+			Log:       process.log.WithField(teleport.ComponentKey, teleport.ComponentProxy),
 			Client:    accessPoint,
 		},
 		AuthorityGetter: accessPoint,
@@ -3996,7 +3996,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if !process.Config.Proxy.DisableReverseTunnel {
 		router, err := proxy.NewRouter(proxy.RouterConfig{
 			ClusterName:         clusterName,
-			Log:                 process.log.WithField(trace.Component, "router"),
+			Log:                 process.log.WithField(teleport.ComponentKey, "router"),
 			RemoteClusterGetter: accessPoint,
 			SiteGetter:          tsrv,
 			TracerProvider:      process.TracingProvider,
@@ -4020,7 +4020,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		LockEnforcer:   lockWatcher,
 		Emitter:        asyncEmitter,
 		Component:      teleport.ComponentProxy,
-		Logger:         process.log.WithField(trace.Component, "sessionctrl"),
+		Logger:         process.log.WithField(teleport.ComponentKey, "sessionctrl"),
 		TracerProvider: process.TracingProvider,
 		ServerID:       serverID,
 	})
@@ -4059,7 +4059,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			traceConf.Logger = process.log.WithField(trace.Component, teleport.ComponentTracing)
+			traceConf.Logger = process.log.WithField(teleport.ComponentKey, teleport.ComponentTracing)
 
 			clt, err := tracing.NewStartedClient(process.ExitContext(), *traceConf)
 			if err != nil {
@@ -4157,7 +4157,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				},
 			},
 			Handler: webHandler,
-			Log:     process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			Log:     process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4175,7 +4175,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		})
 
 		if listeners.reverseTunnelMux != nil {
-			if minimalWebServer, err = process.initMinimalReverseTunnel(listeners, tlsConfigWeb, cfg, webConfig, process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id))); err != nil {
+			if minimalWebServer, err = process.initMinimalReverseTunnel(listeners, tlsConfigWeb, cfg, webConfig, process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id))); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -4205,7 +4205,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Listener:      listeners.proxyPeer,
 			TLSConfig:     serverTLSConfig,
 			ClusterDialer: clusterdial.NewClusterDialer(tsrv),
-			Log:           process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			Log:           process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 			ClusterName:   clusterName,
 		})
 		if err != nil {
@@ -4280,7 +4280,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
-		Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+		Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -4299,7 +4299,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		tlscfg.InsecureSkipVerify = true
 		tlscfg.ClientAuth = tls.RequireAnyClientCert
 	}
-	tlscfg.GetConfigForClient = auth.WithClusterCAs(tlscfg, accessPoint, clusterName, process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)))
+	tlscfg.GetConfigForClient = auth.WithClusterCAs(tlscfg, accessPoint, clusterName, process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)))
 
 	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
 		TransportCredentials: credentials.NewTLS(tlscfg),
@@ -4342,7 +4342,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	transportService, err := transportv1.NewService(transportv1.ServerConfig{
 		FIPS:   cfg.FIPS,
-		Logger: process.log.WithField(trace.Component, "transport"),
+		Logger: process.log.WithField(teleport.ComponentKey, "transport"),
 		Dialer: proxyRouter,
 		SignerFn: func(authzCtx *authz.Context, clusterName string) agentless.SignerCreator {
 			return agentless.SignerFromAuthzContext(authzCtx, accessPoint, clusterName)
@@ -4382,7 +4382,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	})
 
 	rcWatchLog := logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.Component(teleport.ComponentReverseTunnelAgent, process.id),
+		teleport.ComponentKey: teleport.Component(teleport.ComponentReverseTunnelAgent, process.id),
 	})
 
 	// Create and register reverse tunnel AgentPool.
@@ -4421,7 +4421,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
-			Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4443,7 +4443,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		kubeServerWatcher, err := services.NewKubeServerWatcher(process.ExitContext(), services.KubeServerWatcherConfig{
 			ResourceWatcherConfig: services.ResourceWatcherConfig{
 				Component: component,
-				Log:       process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+				Log:       process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 				Client:    accessPoint,
 			},
 		})
@@ -4483,7 +4483,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			AccessPoint:              accessPoint,
 			GetRotation:              process.GetRotation,
 			OnHeartbeat:              process.OnHeartbeat(component),
-			Log:                      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			Log:                      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 			IngressReporter:          ingressReporter,
 			KubernetesServersWatcher: kubeServerWatcher,
 			PROXYProtocolMode:        cfg.Proxy.PROXYProtocolMode,
@@ -4492,7 +4492,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 		process.RegisterCriticalFunc("proxy.kube", func() error {
-			logger := process.logger.With(trace.Component, component)
+			logger := process.logger.With(teleport.ComponentKey, component)
 
 			kubeListenAddr := listeners.kube.Addr().String()
 			if cfg.Proxy.Kube.ListenAddr.Addr != "" {
@@ -4522,7 +4522,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
-			Logger:      process.log.WithField(trace.Component, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			Logger:      process.log.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4592,7 +4592,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			})
 		}
 
-		logger := process.logger.With(trace.Component, teleport.Component(teleport.ComponentDatabase))
+		logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase))
 		if listeners.db.postgres != nil {
 			process.RegisterCriticalFunc("proxy.db.postgres", func() error {
 				logger.InfoContext(process.ExitContext(), "Starting Database Postgres proxy server.", "listen_address", listeners.db.postgres.Addr())
@@ -5204,7 +5204,7 @@ func (process *TeleportProcess) initApps() {
 
 	// Define logger to prefix log lines with the name of the component and PID.
 	component := teleport.Component(teleport.ComponentApp, process.id)
-	logger := process.logger.With(trace.Component, component)
+	logger := process.logger.With(teleport.ComponentKey, component)
 
 	process.RegisterCriticalFunc("apps.start", func() error {
 		conn, err := process.WaitForConnector(AppsIdentityEvent, logger)
@@ -5327,7 +5327,7 @@ func (process *TeleportProcess) initApps() {
 		lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
 			ResourceWatcherConfig: services.ResourceWatcherConfig{
 				Component: teleport.ComponentApp,
-				Log:       process.log.WithField(trace.Component, component),
+				Log:       process.log.WithField(teleport.ComponentKey, component),
 				Client:    conn.Client,
 			},
 		})
@@ -5338,7 +5338,7 @@ func (process *TeleportProcess) initApps() {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
-			Logger:      process.log.WithField(trace.Component, component),
+			Logger:      process.log.WithField(teleport.ComponentKey, component),
 			DeviceAuthorization: authz.DeviceAuthorizationOpts{
 				// Ignore the global device_trust.mode toggle, but allow role-based
 				// settings to be applied.
@@ -5992,7 +5992,7 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 		AccessPoint: cfg.accessPoint,
 		LockWatcher: cfg.lockWatcher,
 		Logger: process.log.WithFields(logrus.Fields{
-			trace.Component: teleport.Component(teleport.ComponentProxySecureGRPC, process.id),
+			teleport.ComponentKey: teleport.Component(teleport.ComponentProxySecureGRPC, process.id),
 		}),
 	})
 	if err != nil {

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -203,7 +203,7 @@ func NewSupervisor(id string, parentLog logrus.FieldLogger) Supervisor {
 
 		reloadContext: reloadContext,
 		signalReload:  signalReload,
-		log:           parentLog.WithField(trace.Component, teleport.Component(teleport.ComponentProcess, id)),
+		log:           parentLog.WithField(teleport.ComponentKey, teleport.Component(teleport.ComponentProcess, id)),
 	}
 	go srv.fanOut()
 	return srv

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -44,7 +45,7 @@ type AccessService struct {
 func NewAccessService(backend backend.Backend) *AccessService {
 	return &AccessService{
 		Backend: backend,
-		log:     logrus.WithFields(logrus.Fields{trace.Component: "AccessService"}),
+		log:     logrus.WithFields(logrus.Fields{teleport.ComponentKey: "AccessService"}),
 	}
 }
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -110,7 +111,7 @@ func NewAccessListService(backend backend.Backend, clock clockwork.Clock) (*Acce
 	}
 
 	return &AccessListService{
-		log:           logrus.WithFields(logrus.Fields{trace.Component: "access-list:local-service"}),
+		log:           logrus.WithFields(logrus.Fields{teleport.ComponentKey: "access-list:local-service"}),
 		clock:         clock,
 		service:       service,
 		memberService: memberService,

--- a/lib/services/local/assistant.go
+++ b/lib/services/local/assistant.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	"github.com/gravitational/teleport/lib/backend"
 )
@@ -50,7 +51,7 @@ type AssistService struct {
 func NewAssistService(backend backend.Backend) *AssistService {
 	return &AssistService{
 		Backend: backend,
-		log:     logrus.WithField(trace.Component, "assist"),
+		log:     logrus.WithField(teleport.ComponentKey, "assist"),
 	}
 }
 

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -45,7 +46,7 @@ type DynamicAccessService struct {
 func NewDynamicAccessService(backend backend.Backend) *DynamicAccessService {
 	return &DynamicAccessService{
 		Backend: backend,
-		log:     logrus.WithFields(logrus.Fields{trace.Component: "DynamicAccess"}),
+		log:     logrus.WithFields(logrus.Fields{teleport.ComponentKey: "DynamicAccess"}),
 	}
 }
 

--- a/lib/services/local/embeddings.go
+++ b/lib/services/local/embeddings.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/ai"
@@ -103,7 +104,7 @@ func (e EmbeddingsService) UpsertEmbedding(ctx context.Context, embedding *embed
 // NewEmbeddingsService is a constructor for the EmbeddingsService.
 func NewEmbeddingsService(b backend.Backend) *EmbeddingsService {
 	return &EmbeddingsService{
-		log:     logrus.WithFields(logrus.Fields{trace.Component: "Embeddings"}),
+		log:     logrus.WithFields(logrus.Fields{teleport.ComponentKey: "Embeddings"}),
 		jitter:  retryutils.NewFullJitter(),
 		Backend: b,
 		clock:   clockwork.NewRealClock(),

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -42,7 +43,7 @@ type EventsService struct {
 // NewEventsService returns new events service instance
 func NewEventsService(b backend.Backend) *EventsService {
 	return &EventsService{
-		Entry:   logrus.WithFields(logrus.Fields{trace.Component: "Events"}),
+		Entry:   logrus.WithFields(logrus.Fields{teleport.ComponentKey: "Events"}),
 		backend: b,
 	}
 }

--- a/lib/services/local/externalauditstorage.go
+++ b/lib/services/local/externalauditstorage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/backend"
@@ -53,7 +54,7 @@ type ExternalAuditStorageService struct {
 func NewExternalAuditStorageService(backend backend.Backend) *ExternalAuditStorageService {
 	return &ExternalAuditStorageService{
 		backend: backend,
-		logger:  logrus.WithField(trace.Component, "ExternalAuditStorage.backend"),
+		logger:  logrus.WithField(teleport.ComponentKey, "ExternalAuditStorage.backend"),
 	}
 }
 

--- a/lib/services/local/externalauditstorage_watcher.go
+++ b/lib/services/local/externalauditstorage_watcher.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -52,7 +53,7 @@ func (cfg *ClusterExternalAuditStorageWatcherConfig) CheckAndSetDefaults() error
 		return trace.BadParameter("missing parameter Backend")
 	}
 	if cfg.Log == nil {
-		cfg.Log = logrus.StandardLogger().WithField(trace.Component, "ExternalAuditStorage.watcher")
+		cfg.Log = logrus.StandardLogger().WithField(teleport.ComponentKey, "ExternalAuditStorage.watcher")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = cfg.Backend.Clock()

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -75,7 +76,7 @@ func NewOktaService(backend backend.Backend, clock clockwork.Clock) (*OktaServic
 	}
 
 	return &OktaService{
-		log:           logrus.WithFields(logrus.Fields{trace.Component: "okta:local-service"}),
+		log:           logrus.WithFields(logrus.Fields{teleport.ComponentKey: "okta:local-service"}),
 		clock:         clock,
 		importRuleSvc: importRuleSvc,
 		assignmentSvc: assignmentSvc,

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -55,7 +56,7 @@ type backendItemToResourceFunc func(item backend.Item) (types.ResourceWithLabels
 // NewPresenceService returns new presence service instance
 func NewPresenceService(b backend.Backend) *PresenceService {
 	return &PresenceService{
-		log:     logrus.WithFields(logrus.Fields{trace.Component: "Presence"}),
+		log:     logrus.WithFields(logrus.Fields{teleport.ComponentKey: "Presence"}),
 		jitter:  retryutils.NewFullJitter(),
 		Backend: b,
 	}

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -80,7 +80,7 @@ func NewSAMLIdPServiceProviderService(backend backend.Backend, opts ...SAMLIdPOp
 
 	samlSPService := &SAMLIdPServiceProviderService{
 		svc: *svc,
-		log: logrus.WithFields(logrus.Fields{trace.Component: "saml-idp"}),
+		log: logrus.WithFields(logrus.Fields{teleport.ComponentKey: "saml-idp"}),
 	}
 
 	for _, opt := range opts {

--- a/lib/services/local/secreports.go
+++ b/lib/services/local/secreports.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/lib/backend"
@@ -98,7 +99,7 @@ func NewSecReportsService(backend backend.Backend, clock clockwork.Clock) (*SecR
 	}
 
 	return &SecReportsService{
-		log:                              logrus.WithFields(logrus.Fields{trace.Component: "secreports:local-service"}),
+		log:                              logrus.WithFields(logrus.Fields{teleport.ComponentKey: "secreports:local-service"}),
 		clock:                            clock,
 		auditQuerySvc:                    auditQuerySvc,
 		securityReportSvc:                securityReportSvc,

--- a/lib/services/local/status.go
+++ b/lib/services/local/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -40,7 +41,7 @@ type StatusService struct {
 func NewStatusService(bk backend.Backend) *StatusService {
 	return &StatusService{
 		Backend: bk,
-		log:     logrus.WithField(trace.Component, "status"),
+		log:     logrus.WithField(teleport.ComponentKey, "status"),
 	}
 }
 

--- a/lib/services/local/user_login_state.go
+++ b/lib/services/local/user_login_state.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/backend"
@@ -55,7 +56,7 @@ func NewUserLoginStateService(backend backend.Backend) (*UserLoginStateService, 
 	}
 
 	return &UserLoginStateService{
-		log: logrus.WithFields(logrus.Fields{trace.Component: "user-login-state:local-service"}),
+		log: logrus.WithFields(logrus.Fields{teleport.ComponentKey: "user-login-state:local-service"}),
 		svc: svc,
 	}, nil
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
@@ -67,7 +68,7 @@ type IdentityService struct {
 func NewIdentityService(backend backend.Backend) *IdentityService {
 	return &IdentityService{
 		Backend: backend,
-		log:     logrus.WithField(trace.Component, "identity"),
+		log:     logrus.WithField(teleport.ComponentKey, "identity"),
 	}
 }
 

--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -74,7 +75,7 @@ func (c *ReconcilerConfig[T]) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing reconciler OnDelete")
 	}
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "reconciler")
+		c.Log = logrus.WithField(teleport.ComponentKey, "reconciler")
 	}
 	return nil
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2423,7 +2423,7 @@ type AccessCheckable interface {
 // allowing the RBAC system to generate more verbose errors in debug mode.
 func rbacDebugLogger() (debugEnabled bool, debugf func(format string, args ...interface{})) {
 	isDebugEnabled := log.IsLevelEnabled(log.TraceLevel)
-	log := log.WithField(trace.Component, teleport.ComponentRBAC)
+	log := log.WithField(teleport.ComponentKey, teleport.ComponentRBAC)
 	return isDebugEnabled, log.Tracef
 }
 
@@ -3015,7 +3015,7 @@ func (set RoleSet) checkAccessToRuleImpl(p checkAccessParams) (err error) {
 			}
 			if matched {
 				log.WithFields(log.Fields{
-					trace.Component: teleport.ComponentRBAC,
+					teleport.ComponentKey: teleport.ComponentRBAC,
 				}).Tracef("Access to %v %v in namespace %v denied to %v: deny rule matched.",
 					p.verb, p.resource, p.namespace, role.GetName())
 				return trace.AccessDenied("access denied to perform action %q on %q", p.verb, p.resource)
@@ -3038,7 +3038,7 @@ func (set RoleSet) checkAccessToRuleImpl(p checkAccessParams) (err error) {
 	}
 
 	log.WithFields(log.Fields{
-		trace.Component: teleport.ComponentRBAC,
+		teleport.ComponentKey: teleport.ComponentRBAC,
 	}).Tracef("Access to %v %v in namespace %v denied to %v: no allow rule matched.",
 		p.verb, p.resource, p.namespace, set)
 

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -260,7 +260,7 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 	switch sc.GetProvider() {
 	case teleport.ADFS, teleport.JumpCloud:
 		log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentSAML,
+			teleport.ComponentKey: teleport.ComponentSAML,
 		}).Debug("Setting ADFS/JumpCloud values.")
 		if sp.SignAuthnRequests {
 			sp.SignAuthnRequestsCanonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList(dsig.DefaultPrefix)

--- a/lib/services/simple/access_list.go
+++ b/lib/services/simple/access_list.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/backend"
@@ -92,7 +93,7 @@ func NewAccessListService(backend backend.Backend) (*AccessListService, error) {
 	}
 
 	return &AccessListService{
-		log:           logrus.WithFields(logrus.Fields{trace.Component: "access-list:simple-service"}),
+		log:           logrus.WithFields(logrus.Fields{teleport.ComponentKey: "access-list:simple-service"}),
 		service:       service,
 		memberService: memberService,
 		reviewService: reviewService,

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -97,7 +97,7 @@ func NewUnifiedResourceCache(ctx context.Context, cfg UnifiedResourceCacheConfig
 
 	m := &UnifiedResourceCache{
 		log: log.WithFields(log.Fields{
-			trace.Component: cfg.Component,
+			teleport.ComponentKey: cfg.Component,
 		}),
 		cfg: cfg,
 		nameTree: btree.NewG(cfg.BTreeDegree, func(a, b *item) bool {

--- a/lib/srv/alpnproxy/auth_checker_middleware.go
+++ b/lib/srv/alpnproxy/auth_checker_middleware.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
 // AuthorizationCheckerMiddleware is a middleware that checks `Authorization` header of incoming requests.
@@ -43,7 +45,7 @@ var _ LocalProxyHTTPMiddleware = (*AuthorizationCheckerMiddleware)(nil)
 // CheckAndSetDefaults checks configuration validity and sets defaults.
 func (m *AuthorizationCheckerMiddleware) CheckAndSetDefaults() error {
 	if m.Log == nil {
-		m.Log = logrus.WithField(trace.Component, "gcp")
+		m.Log = logrus.WithField(teleport.ComponentKey, "gcp")
 	}
 
 	if m.Secret == "" {

--- a/lib/srv/alpnproxy/aws_local_proxy.go
+++ b/lib/srv/alpnproxy/aws_local_proxy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	appcommon "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -50,7 +51,7 @@ var _ LocalProxyHTTPMiddleware = &AWSAccessMiddleware{}
 
 func (m *AWSAccessMiddleware) CheckAndSetDefaults() error {
 	if m.Log == nil {
-		m.Log = logrus.WithField(trace.Component, "aws_access")
+		m.Log = logrus.WithField(teleport.ComponentKey, "aws_access")
 	}
 
 	if m.AWSCredentials == nil {

--- a/lib/srv/alpnproxy/azure_msi_middleware.go
+++ b/lib/srv/alpnproxy/azure_msi_middleware.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -63,7 +64,7 @@ func (m *AzureMSIMiddleware) CheckAndSetDefaults() error {
 		m.Clock = clockwork.NewRealClock()
 	}
 	if m.Log == nil {
-		m.Log = logrus.WithField(trace.Component, "azure_msi")
+		m.Log = logrus.WithField(teleport.ComponentKey, "azure_msi")
 	}
 
 	if m.Key == nil {

--- a/lib/srv/alpnproxy/azure_msi_middleware_test.go
+++ b/lib/srv/alpnproxy/azure_msi_middleware_test.go
@@ -28,11 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -52,7 +52,7 @@ func TestAzureMSIMiddlewareHandleRequest(t *testing.T) {
 		Identity: "azureTestIdentity",
 		TenantID: "cafecafe-cafe-4aaa-cafe-cafecafecafe",
 		ClientID: "decaffff-cafe-4aaa-cafe-cafecafecafe",
-		Log:      logrus.WithField(trace.Component, "msi"),
+		Log:      logrus.WithField(teleport.ComponentKey, "msi"),
 		Clock:    clockwork.NewFakeClockAt(time.Date(2022, 1, 1, 9, 0, 0, 0, time.UTC)),
 		Key:      newPrivateKey(),
 		Secret:   "my-secret",

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -40,6 +40,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -118,7 +119,7 @@ func (m *KubeMiddleware) CheckAndSetDefaults() error {
 		m.clock = clockwork.NewRealClock()
 	}
 	if m.logger == nil {
-		m.logger = logrus.WithField(trace.Component, "local_proxy_kube")
+		m.logger = logrus.WithField(teleport.ComponentKey, "local_proxy_kube")
 	}
 	return nil
 }

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/utils/pingconn"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -119,7 +120,7 @@ func (cfg *LocalProxyConfig) CheckAndSetDefaults() error {
 		cfg.Clock = clockwork.NewRealClock()
 	}
 	if cfg.Log == nil {
-		cfg.Log = logrus.WithField(trace.Component, "localproxy")
+		cfg.Log = logrus.WithField(teleport.ComponentKey, "localproxy")
 	}
 	// copy the cert slice to avoid races when the proxy is running.
 	cfg.Certs = slices.Clone(cfg.Certs)

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/pingconn"
 	"github.com/gravitational/teleport/lib/auth"
@@ -250,7 +251,7 @@ func (c *ProxyConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("listener missing")
 	}
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "alpn:proxy")
+		c.Log = logrus.WithField(teleport.ComponentKey, "alpn:proxy")
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -76,7 +76,7 @@ func (cfg *SignerHandlerConfig) CheckAndSetDefaults() error {
 		cfg.RoundTripper = tr
 	}
 	if cfg.Log == nil {
-		cfg.Log = logrus.WithField(trace.Component, "aws:signer")
+		cfg.Log = logrus.WithField(teleport.ComponentKey, "aws:signer")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -70,7 +71,7 @@ func (s *HandlerConfig) CheckAndSetDefaults() error {
 		s.Clock = clockwork.NewRealClock()
 	}
 	if s.Log == nil {
-		s.Log = logrus.WithField(trace.Component, "azure:fwd")
+		s.Log = logrus.WithField(teleport.ComponentKey, "azure:fwd")
 	}
 	if s.getAccessToken == nil {
 		s.getAccessToken = getAccessTokenManagedIdentity

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -131,7 +132,7 @@ func NewCloud(cfg CloudConfig) (Cloud, error) {
 	}
 	return &cloud{
 		cfg: cfg,
-		log: logrus.WithField(trace.Component, "cloud"),
+		log: logrus.WithField(teleport.ComponentKey, "cloud"),
 	}, nil
 }
 

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -84,7 +85,7 @@ func NewAudit(config AuditConfig) (Audit, error) {
 	}
 	return &audit{
 		cfg: config,
-		log: logrus.WithField(trace.Component, "app:audit"),
+		log: logrus.WithField(teleport.ComponentKey, "app:audit"),
 	}, nil
 }
 

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/gcp"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -88,7 +89,7 @@ func (s *HandlerConfig) CheckAndSetDefaults() error {
 		s.Clock = clockwork.NewRealClock()
 	}
 	if s.Log == nil {
-		s.Log = logrus.WithField(trace.Component, "gcp:fwd")
+		s.Log = logrus.WithField(teleport.ComponentKey, "gcp:fwd")
 	}
 	if s.cloudClientGCP == nil {
 		clients, err := cloud.NewClients()

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -302,7 +302,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 	s := &Server{
 		c: c,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentApp,
+			teleport.ComponentKey: teleport.ComponentApp,
 		}),
 		heartbeats:    make(map[string]*srv.Heartbeat),
 		dynamicLabels: make(map[string]*labels.Dynamic),

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -62,7 +62,7 @@ func (c *transportConfig) Check() error {
 		return trace.BadParameter("jwt missing")
 	}
 	if c.log == nil {
-		c.log = logrus.WithField(trace.Component, "transport")
+		c.log = logrus.WithField(teleport.ComponentKey, "transport")
 	}
 
 	return nil

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -300,7 +300,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 	fingerprint := fmt.Sprintf("%v %v", key.Type(), sshutils.Fingerprint(key))
 
 	// create a new logging entry with info specific to this login attempt
-	log := h.log.WithField(trace.ComponentFields, log.Fields{
+	log := h.log.WithField(teleport.ComponentFields, log.Fields{
 		"local":       conn.LocalAddr(),
 		"remote":      conn.RemoteAddr(),
 		"user":        conn.User(),

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -140,7 +140,7 @@ func NewAuthHandlers(config *AuthHandlerConfig) (*AuthHandlers, error) {
 
 	ah := &AuthHandlers{
 		c:   config,
-		log: log.WithField(trace.Component, config.Component),
+		log: log.WithField(teleport.ComponentKey, config.Component),
 	}
 	ah.loginChecker = &ahLoginChecker{
 		log: ah.log,

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -498,8 +498,8 @@ func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, s
 		"id":           child.id,
 	}
 	child.Entry = log.WithFields(log.Fields{
-		trace.Component:       child.srv.Component(),
-		trace.ComponentFields: fields,
+		trace.Component:          child.srv.Component(),
+		teleport.ComponentFields: fields,
 	})
 
 	if identityContext.Login == teleport.SSHSessionJoinPrincipal {
@@ -524,8 +524,8 @@ func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, s
 		fields["idle"] = child.clientIdleTimeout
 	}
 	child.Entry = log.WithFields(log.Fields{
-		trace.Component:       srv.Component(),
-		trace.ComponentFields: fields,
+		trace.Component:          srv.Component(),
+		teleport.ComponentFields: fields,
 	})
 
 	clusterName, err := srv.GetAccessPoint().GetClusterName()

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -498,7 +498,7 @@ func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, s
 		"id":           child.id,
 	}
 	child.Entry = log.WithFields(log.Fields{
-		trace.Component:          child.srv.Component(),
+		teleport.ComponentKey:    child.srv.Component(),
 		teleport.ComponentFields: fields,
 	})
 
@@ -524,7 +524,7 @@ func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, s
 		fields["idle"] = child.clientIdleTimeout
 	}
 	child.Entry = log.WithFields(log.Fields{
-		trace.Component:          srv.Component(),
+		teleport.ComponentKey:    srv.Component(),
 		teleport.ComponentFields: fields,
 	})
 

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -240,7 +241,7 @@ func newTestAuth(ac common.AuthConfig) (*testAuth, error) {
 	}
 	return &testAuth{
 		Auth:        auth,
-		FieldLogger: logrus.WithField(trace.Component, "auth:test"),
+		FieldLogger: logrus.WithField(teleport.ComponentKey, "auth:test"),
 	}, nil
 }
 

--- a/lib/srv/db/cassandra/test.go
+++ b/lib/srv/db/cassandra/test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
@@ -142,8 +143,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 		tlsConfig: tlsConfig,
 		server:    server,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolCassandra,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolCassandra,
+			"name":                config.Name,
 		}),
 	}
 	for _, opt := range opts {

--- a/lib/srv/db/clickhouse/test.go
+++ b/lib/srv/db/clickhouse/test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
@@ -93,8 +94,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 		port:      port,
 		tlsConfig: tlsConfig,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolClickHouse,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolClickHouse,
+			"name":                config.Name,
 		}),
 	}
 

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
@@ -71,8 +72,8 @@ func newAWS(ctx context.Context, config awsConfig) (*awsClient, error) {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		trace.Component: "aws",
-		"db":            config.database.GetName(),
+		teleport.ComponentKey: "aws",
+		"db":                  config.database.GetName(),
 	})
 	dbConfigurator, err := getDBConfigurator(ctx, logger, config.clients, config.database)
 	if err != nil {

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -112,7 +113,7 @@ func NewIAM(ctx context.Context, config IAMConfig) (*IAM, error) {
 	}
 	return &IAM{
 		cfg:             config,
-		log:             logrus.WithField(trace.Component, "iam"),
+		log:             logrus.WithField(teleport.ComponentKey, "iam"),
 		tasks:           make(chan iamTask, defaultIAMTaskQueueSize),
 		iamPolicyStatus: sync.Map{},
 	}, nil

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
@@ -73,7 +74,7 @@ func NewMetadata(config MetadataConfig) (*Metadata, error) {
 	}
 	return &Metadata{
 		cfg: config,
-		log: logrus.WithField(trace.Component, "meta"),
+		log: logrus.WithField(teleport.ComponentKey, "meta"),
 	}, nil
 }
 

--- a/lib/srv/db/cloud/resource_checker.go
+++ b/lib/srv/db/cloud/resource_checker.go
@@ -63,7 +63,7 @@ func (c *DiscoveryResourceCheckerConfig) CheckAndSetDefaults() error {
 		c.Context = context.Background()
 	}
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, teleport.ComponentDatabase)
+		c.Log = logrus.WithField(teleport.ComponentKey, teleport.ComponentDatabase)
 	}
 	return nil
 }

--- a/lib/srv/db/cloud/users/user.go
+++ b/lib/srv/db/cloud/users/user.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/srv/db/secrets"
 )
 
@@ -100,7 +101,7 @@ func (u *baseUser) CheckAndSetDefaults() error {
 		u.clock = clockwork.NewRealClock()
 	}
 	if u.log == nil {
-		u.log = logrus.WithField(trace.Component, "clouduser")
+		u.log = logrus.WithField(teleport.ComponentKey, "clouduser")
 	}
 	return nil
 }

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -75,7 +76,7 @@ func (c *Config) CheckAndSetDefaults() error {
 		c.Interval = 15 * time.Minute
 	}
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "clouduser")
+		c.Log = logrus.WithField(teleport.ComponentKey, "clouduser")
 	}
 	return nil
 }

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
@@ -100,7 +101,7 @@ func NewAudit(config AuditConfig) (Audit, error) {
 	}
 	return &audit{
 		cfg: config,
-		log: logrus.WithField(trace.Component, config.Component),
+		log: logrus.WithField(teleport.ComponentKey, config.Component),
 	}, nil
 }
 

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -46,6 +46,7 @@ import (
 	"github.com/sirupsen/logrus"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
@@ -139,7 +140,7 @@ func (c *AuthConfig) CheckAndSetDefaults() error {
 		c.Clock = clockwork.NewRealClock()
 	}
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "db:auth")
+		c.Log = logrus.WithField(teleport.ComponentKey, "db:auth")
 	}
 	return nil
 }

--- a/lib/srv/db/dynamodb/test.go
+++ b/lib/srv/db/dynamodb/test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -90,8 +91,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: defaults.ProtocolDynamoDB,
-		"name":          config.Name,
+		teleport.ComponentKey: defaults.ProtocolDynamoDB,
+		"name":                config.Name,
 	})
 	tlsConfig, err := common.MakeTestServerTLSConfig(config)
 	if err != nil {

--- a/lib/srv/db/elasticsearch/test.go
+++ b/lib/srv/db/elasticsearch/test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
@@ -71,8 +72,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 		port:      port,
 		tlsConfig: tlsConfig,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolElasticsearch,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolElasticsearch,
+			"name":                config.Name,
 		}),
 	}
 

--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -37,6 +37,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/mongodb/protocol"
@@ -131,8 +132,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 		return nil, trace.Wrap(err)
 	}
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: defaults.ProtocolMongoDB,
-		"name":          config.Name,
+		teleport.ComponentKey: defaults.ProtocolMongoDB,
+		"name":                config.Name,
 	})
 	server := &TestServer{
 		cfg: config,

--- a/lib/srv/db/mysql/test.go
+++ b/lib/srv/db/mysql/test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -135,8 +136,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: defaults.ProtocolMySQL,
-		"name":          config.Name,
+		teleport.ComponentKey: defaults.ProtocolMySQL,
+		"name":                config.Name,
 	})
 	server := &TestServer{
 		cfg:      config,

--- a/lib/srv/db/opensearch/test.go
+++ b/lib/srv/db/opensearch/test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
@@ -70,8 +71,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 		port:      port,
 		tlsConfig: tlsConfig,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolOpenSearch,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolOpenSearch,
+			"name":                config.Name,
 		}),
 	}
 

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jackc/pgtype"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -160,8 +161,8 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 		port:      port,
 		tlsConfig: tlsConfig,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolPostgres,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolPostgres,
+			"name":                config.Name,
 		}),
 		parametersCh:           make(chan map[string]string, 100),
 		pids:                   make(map[uint32]*pidHandle),

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -196,7 +196,7 @@ func NewProxyServer(ctx context.Context, config ProxyServerConfig) (*ProxyServer
 			AcceptedUsage: []string{teleport.UsageDatabaseOnly},
 		},
 		closeCtx: ctx,
-		log:      logrus.WithField(trace.Component, proxyServerComponent),
+		log:      logrus.WithField(teleport.ComponentKey, proxyServerComponent),
 	}
 	server.cfg.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	server.cfg.TLSConfig.GetConfigForClient = getConfigForClient(

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -548,6 +549,6 @@ func (l *driverLogger) Printf(_ context.Context, format string, v ...any) {
 
 func init() {
 	redis.SetLogger(&driverLogger{
-		Entry: logrus.WithField(trace.Component, "go-redis"),
+		Entry: logrus.WithField(teleport.ComponentKey, "go-redis"),
 	})
 }

--- a/lib/srv/db/redis/test.go
+++ b/lib/srv/db/redis/test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )
@@ -128,8 +129,8 @@ func NewTestServer(t testing.TB, config common.TestServerConfig, opts ...TestSer
 		return nil, trace.Wrap(err)
 	}
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: defaults.ProtocolRedis,
-		"name":          config.Name,
+		teleport.ComponentKey: defaults.ProtocolRedis,
+		"name":                config.Name,
 	})
 	server := &TestServer{
 		cfg: config,

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -383,7 +383,7 @@ func New(ctx context.Context, config Config) (*Server, error) {
 	connCtx, connCancelFunc := context.WithCancel(ctx)
 	server := &Server{
 		cfg:              config,
-		log:              logrus.WithField(trace.Component, teleport.ComponentDatabase),
+		log:              logrus.WithField(teleport.ComponentKey, teleport.ComponentDatabase),
 		closeContext:     closeCtx,
 		closeFunc:        closeCancelFunc,
 		dynamicLabels:    make(map[string]*labels.Dynamic),

--- a/lib/srv/db/snowflake/test.go
+++ b/lib/srv/db/snowflake/test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -86,8 +87,8 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 		port:      port,
 		tlsConfig: tlsConfig,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: defaults.ProtocolSnowflake,
-			"name":          config.Name,
+			teleport.ComponentKey: defaults.ProtocolSnowflake,
+			"name":                config.Name,
 		}),
 		authorizationToken: "test-token-123",
 	}

--- a/lib/srv/db/sqlserver/test.go
+++ b/lib/srv/db/sqlserver/test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver/protocol"
@@ -133,8 +134,8 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 		return nil, trace.Wrap(err)
 	}
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: defaults.ProtocolSQLServer,
-		"name":          config.Name,
+		teleport.ComponentKey: defaults.ProtocolSQLServer,
+		"name":                config.Name,
 	})
 	server := &TestServer{
 		cfg:      config,

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -125,7 +125,7 @@ func (s *Server) startCloudWatcher(ctx context.Context) error {
 
 	watcher, err := discovery.NewWatcher(ctx, discovery.WatcherConfig{
 		FetchersFn: discovery.StaticFetchers(allFetchers),
-		Log:        logrus.WithField(trace.Component, "watcher:cloud"),
+		Log:        logrus.WithField(teleport.ComponentKey, "watcher:cloud"),
 		Origin:     types.OriginCloud,
 	})
 	if err != nil {

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -233,7 +233,7 @@ func (cfg *WindowsServiceConfig) checkAndSetDiscoveryDefaults() error {
 
 func (cfg *WindowsServiceConfig) CheckAndSetDefaults() error {
 	if cfg.Log == nil {
-		cfg.Log = logrus.New().WithField(trace.Component, teleport.ComponentWindowsDesktop)
+		cfg.Log = logrus.New().WithField(teleport.ComponentKey, teleport.ComponentWindowsDesktop)
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -219,7 +219,7 @@ kubernetes matchers are present.`)
 		return trace.BadParameter("cluster features are required")
 	}
 
-	c.Log = c.Log.WithField(trace.Component, teleport.ComponentDiscovery)
+	c.Log = c.Log.WithField(teleport.ComponentKey, teleport.ComponentDiscovery)
 
 	if c.DiscoveryGroup == "" {
 		c.Log.Warn("discovery_service.discovery_group is not set. This field is required for the discovery service to work properly.\n" +

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
@@ -64,7 +65,7 @@ func (c *AKSFetcherConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "fetcher:aks")
+		c.Log = logrus.WithField(teleport.ComponentKey, "fetcher:aks")
 	}
 	return nil
 }

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -82,11 +83,11 @@ func (cfg *awsFetcherConfig) CheckAndSetDefaults(component string) error {
 			credentialsSource = fmt.Sprintf("integration:%s", cfg.Integration)
 		}
 		cfg.Log = logrus.WithFields(logrus.Fields{
-			trace.Component: "watch:" + component,
-			"labels":        cfg.Labels,
-			"region":        cfg.Region,
-			"role":          cfg.AssumeRole,
-			"credentials":   credentialsSource,
+			teleport.ComponentKey: "watch:" + component,
+			"labels":              cfg.Labels,
+			"region":              cfg.Region,
+			"role":                cfg.AssumeRole,
+			"credentials":         credentialsSource,
 		})
 	}
 	return nil

--- a/lib/srv/discovery/fetchers/db/azure.go
+++ b/lib/srv/discovery/fetchers/db/azure.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -61,12 +62,12 @@ func newAzureFetcher[DBType comparable, ListClient azureListClient[DBType]](conf
 	fetcher := &azureFetcher[DBType, ListClient]{
 		cfg: config,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: "watch:azure",
-			"labels":        config.Labels,
-			"regions":       config.Regions,
-			"group":         config.ResourceGroup,
-			"subscription":  config.Subscription,
-			"type":          config.Type,
+			teleport.ComponentKey: "watch:azure",
+			"labels":              config.Labels,
+			"regions":             config.Regions,
+			"group":               config.ResourceGroup,
+			"subscription":        config.Subscription,
+			"type":                config.Type,
 		}),
 		azureFetcherPlugin: plugin,
 	}

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
@@ -89,7 +90,7 @@ func (c *EKSFetcherConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "fetcher:eks")
+		c.Log = logrus.WithField(teleport.ComponentKey, "fetcher:eks")
 	}
 	return nil
 }

--- a/lib/srv/discovery/fetchers/gke.go
+++ b/lib/srv/discovery/fetchers/gke.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/services"
@@ -61,7 +62,7 @@ func (c *GKEFetcherConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "fetcher:gke")
+		c.Log = logrus.WithField(teleport.ComponentKey, "fetcher:gke")
 	}
 	return nil
 }

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -328,7 +328,7 @@ func New(c ServerConfig) (*Server, error) {
 
 	s := &Server{
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentForwardingNode,
+			teleport.ComponentKey: teleport.ComponentForwardingNode,
 			teleport.ComponentFields: map[string]string{
 				"src-addr": c.SrcAddr.String(),
 				"dst-addr": c.DstAddr.String(),

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -329,7 +329,7 @@ func New(c ServerConfig) (*Server, error) {
 	s := &Server{
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: teleport.ComponentForwardingNode,
-			trace.ComponentFields: map[string]string{
+			teleport.ComponentFields: map[string]string{
 				"src-addr": c.SrcAddr.String(),
 				"dst-addr": c.DstAddr.String(),
 			},

--- a/lib/srv/forward/sshserver_test.go
+++ b/lib/srv/forward/sshserver_test.go
@@ -26,7 +26,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -185,7 +184,7 @@ func TestDirectTCPIP(t *testing.T) {
 			t.Parallel()
 
 			s := Server{
-				log:             utils.NewLoggerForTests().WithField(trace.Component, "test"),
+				log:             utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 				identityContext: srv.IdentityContext{Login: tt.login},
 			}
 
@@ -221,7 +220,7 @@ func TestCheckTCPIPForward(t *testing.T) {
 			t.Parallel()
 
 			s := Server{
-				log:             utils.NewLoggerForTests().WithField(trace.Component, "test"),
+				log:             utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 				identityContext: srv.IdentityContext{Login: tt.login},
 			}
 			err := s.checkTCPIPForwardRequest(&ssh.Request{

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -49,7 +49,7 @@ func parseRemoteSubsystem(ctx context.Context, subsytemName string, serverContex
 	return &remoteSubsystem{
 		log: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentRemoteSubsystem,
-			trace.ComponentFields: map[string]string{
+			teleport.ComponentFields: map[string]string{
 				"name": subsytemName,
 			},
 		}),

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -48,7 +48,7 @@ type remoteSubsystem struct {
 func parseRemoteSubsystem(ctx context.Context, subsytemName string, serverContext *srv.ServerContext) *remoteSubsystem {
 	return &remoteSubsystem{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentRemoteSubsystem,
+			teleport.ComponentKey: teleport.ComponentRemoteSubsystem,
 			teleport.ComponentFields: map[string]string{
 				"name": subsytemName,
 			},

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -157,7 +157,7 @@ func NewHeartbeat(cfg HeartbeatConfig) (*Heartbeat, error) {
 		cancel:          cancel,
 		HeartbeatConfig: cfg,
 		Entry: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(cfg.Component, "beat"),
+			teleport.ComponentKey: teleport.Component(cfg.Component, "beat"),
 		}),
 		checkTicker: cfg.Clock.NewTicker(cfg.CheckPeriod),
 		announceC:   make(chan struct{}, 1),

--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
@@ -61,7 +60,7 @@ func StartKeepAliveLoop(p KeepAliveParams) {
 	var missedCount int64
 
 	log := logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.ComponentKeepAlive,
+		teleport.ComponentKey: teleport.ComponentKeepAlive,
 	})
 	log.Debugf("Starting keep-alive loop with interval %v and max count %v.", p.Interval, p.MaxCount)
 

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -186,8 +186,8 @@ func newProxySubsys(ctx *srv.ServerContext, srv *Server, req proxySubsysRequest)
 		proxySubsysRequest: req,
 		ctx:                ctx,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component:       teleport.ComponentSubsystemProxy,
-			trace.ComponentFields: map[string]string{},
+			trace.Component:          teleport.ComponentSubsystemProxy,
+			teleport.ComponentFields: map[string]string{},
 		}),
 		closeC:       make(chan error),
 		router:       srv.router,
@@ -207,7 +207,7 @@ func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.C
 	// once we start the connection, update logger to include component fields
 	t.log = logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentSubsystemProxy,
-		trace.ComponentFields: map[string]string{
+		teleport.ComponentFields: map[string]string{
 			"src":       sconn.RemoteAddr().String(),
 			"dst":       sconn.LocalAddr().String(),
 			"subsystem": t.String(),

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -186,7 +186,7 @@ func newProxySubsys(ctx *srv.ServerContext, srv *Server, req proxySubsysRequest)
 		proxySubsysRequest: req,
 		ctx:                ctx,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component:          teleport.ComponentSubsystemProxy,
+			teleport.ComponentKey:    teleport.ComponentSubsystemProxy,
 			teleport.ComponentFields: map[string]string{},
 		}),
 		closeC:       make(chan error),
@@ -206,7 +206,7 @@ func (t *proxySubsys) String() string {
 func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	// once we start the connection, update logger to include component fields
 	t.log = logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.ComponentSubsystemProxy,
+		teleport.ComponentKey: teleport.ComponentSubsystemProxy,
 		teleport.ComponentFields: map[string]string{
 			"src":       sconn.RemoteAddr().String(),
 			"dst":       sconn.LocalAddr().String(),

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -56,7 +56,7 @@ type sftpSubsys struct {
 func newSFTPSubsys(fileTransferReq *srv.FileTransferRequest) (*sftpSubsys, error) {
 	return &sftpSubsys{
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentSubsystemSFTP,
+			teleport.ComponentKey: teleport.ComponentSubsystemSFTP,
 		}),
 		fileTransferReq: fileTransferReq,
 	}, nil

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -75,7 +75,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentNode,
+	teleport.ComponentKey: teleport.ComponentNode,
 })
 
 // Server implements SSH server that uses configuration backend and
@@ -803,7 +803,7 @@ func New(
 	}
 
 	s.Entry = logrus.WithFields(logrus.Fields{
-		trace.Component:          component,
+		teleport.ComponentKey:    component,
 		teleport.ComponentFields: logrus.Fields{},
 	})
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -803,8 +803,8 @@ func New(
 	}
 
 	s.Entry = logrus.WithFields(logrus.Fields{
-		trace.Component:       component,
-		trace.ComponentFields: logrus.Fields{},
+		trace.Component:          component,
+		teleport.ComponentFields: logrus.Fields{},
 	})
 
 	if s.GetCreateHostUser() {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1465,7 +1465,7 @@ func TestProxyRoundRobin(t *testing.T) {
 
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
-		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Log:                 utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -1605,7 +1605,7 @@ func TestProxyDirectAccess(t *testing.T) {
 
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
-		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Log:                 utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -2323,7 +2323,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 
 		router, err := libproxy.NewRouter(libproxy.RouterConfig{
 			ClusterName:         f.testSrv.ClusterName(),
-			Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+			Log:                 utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 			RemoteClusterGetter: proxyClient,
 			SiteGetter:          reverseTunnelServer,
 			TracerProvider:      tracing.NoopProvider(),
@@ -2584,7 +2584,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
-		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Log:                 utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -173,7 +173,7 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 	return &SessionRegistry{
 		SessionRegistryConfig: cfg,
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.ComponentSession, cfg.Srv.Component()),
+			teleport.ComponentKey: teleport.Component(teleport.ComponentSession, cfg.Srv.Component()),
 		}),
 		sessions: make(map[rsession.ID]*session),
 		users:    cfg.Srv.GetHostUsers(),
@@ -764,8 +764,8 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 	access := auth.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, scx.Identity.TeleportUser)
 	sess := &session{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.ComponentSession, r.Srv.Component()),
-			"session_id":    id,
+			teleport.ComponentKey: teleport.Component(teleport.ComponentSession, r.Srv.Component()),
+			"session_id":          id,
 		}),
 		id:                             id,
 		registry:                       r,
@@ -2044,7 +2044,7 @@ type party struct {
 func newParty(s *session, mode types.SessionParticipantMode, ch ssh.Channel, ctx *ServerContext) *party {
 	return &party{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.Component(teleport.ComponentSession, ctx.srv.Component()),
+			teleport.ComponentKey: teleport.Component(teleport.ComponentSession, ctx.srv.Component()),
 		}),
 		user:     ctx.Identity.TeleportUser,
 		login:    ctx.Identity.Login,

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -231,7 +231,7 @@ func TestSession_newRecorder(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.ComponentAuth,
+		teleport.ComponentKey: teleport.ComponentAuth,
 	})
 
 	isNotSessionWriter := func(t require.TestingT, i interface{}, i2 ...interface{}) {
@@ -412,7 +412,7 @@ func TestSession_emitAuditEvent(t *testing.T) {
 	t.Parallel()
 
 	logger := logrus.WithFields(logrus.Fields{
-		trace.Component: teleport.ComponentAuth,
+		teleport.ComponentKey: teleport.ComponentAuth,
 	})
 
 	t.Run("FallbackConcurrency", func(t *testing.T) {
@@ -869,7 +869,7 @@ func TestTrackingSession(t *testing.T) {
 
 			sess := &session{
 				id:  rsession.NewID(),
-				log: utils.NewLoggerForTests().WithField(trace.Component, "test-session"),
+				log: utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test-session"),
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv:                   srv,

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -114,7 +114,7 @@ func (c *SessionControllerConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = logrus.WithField(trace.Component, "SessionCtrl")
+		c.Logger = logrus.WithField(teleport.ComponentKey, "SessionCtrl")
 	}
 
 	if c.Clock == nil {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -155,7 +155,7 @@ func newLocalTerminal(ctx *ServerContext) (*terminal, error) {
 
 	t := &terminal{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentLocalTerm,
+			teleport.ComponentKey: teleport.ComponentLocalTerm,
 		}),
 		serverContext: ctx,
 		terminateFD:   ctx.killShellw,
@@ -511,7 +511,7 @@ func newRemoteTerminal(ctx *ServerContext) (*remoteTerminal, error) {
 
 	t := &remoteTerminal{
 		log: log.WithFields(log.Fields{
-			trace.Component: teleport.ComponentRemoteTerm,
+			teleport.ComponentKey: teleport.ComponentRemoteTerm,
 		}),
 		ctx:       ctx,
 		session:   ctx.RemoteSession,

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 
+	"github.com/gravitational/teleport"
 	transportv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	streamutils "github.com/gravitational/teleport/api/utils/grpc/stream"
 	"github.com/gravitational/teleport/lib/agentless"
@@ -90,7 +91,7 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = utils.NewLogger().WithField(trace.Component, "transport")
+		c.Logger = utils.NewLogger().WithField(teleport.ComponentKey, "transport")
 	}
 
 	if c.agentGetterFn == nil {

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -177,7 +177,7 @@ func (c *Config) CheckAndSetDefaults() error {
 		logger = log.StandardLogger()
 	}
 	c.Log = logger.WithFields(log.Fields{
-		trace.Component: "SCP",
+		teleport.ComponentKey: "SCP",
 		teleport.ComponentFields: log.Fields{
 			"LocalAddr":      c.Flags.LocalAddr,
 			"RemoteAddr":     c.Flags.RemoteAddr,

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -177,7 +178,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	c.Log = logger.WithFields(log.Fields{
 		trace.Component: "SCP",
-		trace.ComponentFields: log.Fields{
+		teleport.ComponentFields: log.Fields{
 			"LocalAddr":      c.Flags.LocalAddr,
 			"RemoteAddr":     c.Flags.RemoteAddr,
 			"Target":         c.Flags.Target,

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -47,7 +48,7 @@ func TestSend(t *testing.T) {
 	atime := testNow.Add(1 * time.Second)
 	dirModtime := testNow.Add(2 * time.Second)
 	dirAtime := testNow.Add(3 * time.Second)
-	logger := logrus.WithField(trace.Component, "t:send")
+	logger := logrus.WithField(teleport.ComponentKey, "t:send")
 	testCases := []struct {
 		desc   string
 		config Config
@@ -111,7 +112,7 @@ func TestReceive(t *testing.T) {
 	atime := testNow.Add(1 * time.Second)
 	dirModtime := testNow.Add(2 * time.Second)
 	dirAtime := testNow.Add(3 * time.Second)
-	logger := logrus.WithField(trace.Component, "t:recv")
+	logger := logrus.WithField(teleport.ComponentKey, "t:recv")
 	testCases := []struct {
 		desc       string
 		config     Config

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -137,7 +137,7 @@ func SetIngressReporter(service string, r *ingress.Reporter) ServerOption {
 // SetLogger sets the logger for the server
 func SetLogger(logger logrus.FieldLogger) ServerOption {
 	return func(s *Server) error {
-		s.log = logger.WithField(trace.Component, "ssh:"+s.component)
+		s.log = logger.WithField(teleport.ComponentKey, "ssh:"+s.component)
 		return nil
 	}
 }
@@ -205,7 +205,7 @@ func NewServer(
 	closeContext, cancel := context.WithCancel(context.TODO())
 	s := &Server{
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: "ssh:" + component,
+			teleport.ComponentKey: "ssh:" + component,
 		}),
 		addr:           a,
 		newChanHandler: h,

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -220,7 +220,7 @@ func (c *Config) setDefaults() {
 		logger = log.StandardLogger()
 	}
 	c.Log = logger.WithFields(log.Fields{
-		trace.Component: "SFTP",
+		teleport.ComponentKey: "SFTP",
 		teleport.ComponentFields: log.Fields{
 			"SrcPaths":      c.srcPaths,
 			"DstPath":       c.dstPath,

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -221,7 +221,7 @@ func (c *Config) setDefaults() {
 	}
 	c.Log = logger.WithFields(log.Fields{
 		trace.Component: "SFTP",
-		trace.ComponentFields: log.Fields{
+		teleport.ComponentFields: log.Fields{
 			"SrcPaths":      c.srcPaths,
 			"DstPath":       c.dstPath,
 			"Recursive":     c.opts.Recursive,

--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -34,7 +34,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTBot,
+	teleport.ComponentKey: teleport.ComponentTBot,
 })
 
 // SymlinksMode is an enum type listing various symlink behavior modes.

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -60,7 +60,7 @@ var SupportedJoinMethods = []string{
 }
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTBot,
+	teleport.ComponentKey: teleport.ComponentTBot,
 })
 
 // RemainingArgsList is a custom kingpin parser that consumes all remaining

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -66,7 +66,7 @@ const (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTBot,
+	teleport.ComponentKey: teleport.ComponentTBot,
 })
 
 // Identity is collection of raw key and certificate data as well as the

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -176,7 +176,7 @@ func (b *Bot) Run(ctx context.Context) error {
 		reloadBroadcaster: reloadBroadcaster,
 		resolver:          resolver,
 		log: b.log.WithField(
-			trace.Component, teleport.Component(componentTBot, "identity"),
+			teleport.ComponentKey, teleport.Component(componentTBot, "identity"),
 		),
 	}
 	// Initialize bot's own identity. This will load from disk, or fetch a new
@@ -197,7 +197,7 @@ func (b *Bot) Run(ctx context.Context) error {
 			diagAddr:     b.cfg.DiagAddr,
 			pprofEnabled: b.cfg.Debug,
 			log: b.log.WithField(
-				trace.Component, teleport.Component(componentTBot, "diagnostics"),
+				teleport.ComponentKey, teleport.Component(componentTBot, "diagnostics"),
 			),
 		})
 	}
@@ -207,7 +207,7 @@ func (b *Bot) Run(ctx context.Context) error {
 		cfg:            b.cfg,
 		resolver:       resolver,
 		log: b.log.WithField(
-			trace.Component, teleport.Component(componentTBot, "outputs"),
+			teleport.ComponentKey, teleport.Component(componentTBot, "outputs"),
 		),
 		reloadBroadcaster: reloadBroadcaster,
 	})
@@ -215,7 +215,7 @@ func (b *Bot) Run(ctx context.Context) error {
 		getBotIdentity: b.botIdentitySvc.GetIdentity,
 		botClient:      b.botIdentitySvc.GetClient(),
 		log: b.log.WithField(
-			trace.Component, teleport.Component(componentTBot, "ca-rotation"),
+			teleport.ComponentKey, teleport.Component(componentTBot, "ca-rotation"),
 		),
 		reloadBroadcaster: reloadBroadcaster,
 	})
@@ -242,7 +242,7 @@ func (b *Bot) Run(ctx context.Context) error {
 				},
 			}
 			svc.log = b.log.WithField(
-				trace.Component, teleport.Component(componentTBot, "svc", svc.String()),
+				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
 			)
 			services = append(services, svc)
 		case *config.ExampleService:

--- a/lib/tbot/tshwrap/wrap.go
+++ b/lib/tbot/tshwrap/wrap.go
@@ -50,7 +50,7 @@ const (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTBot,
+	teleport.ComponentKey: teleport.ComponentTBot,
 })
 
 // capture runs a command (presumably tsh) with the given arguments and

--- a/lib/teleterm/apiserver/config.go
+++ b/lib/teleterm/apiserver/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -60,7 +61,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "conn:apiserver")
+		c.Log = logrus.WithField(teleport.ComponentKey, "conn:apiserver")
 	}
 
 	return nil

--- a/lib/teleterm/clusters/cluster_auth_test.go
+++ b/lib/teleterm/clusters/cluster_auth_test.go
@@ -27,11 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/gravitational/teleport"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
-var log = logrus.WithField(trace.Component, "cluster_auth_test")
+var log = logrus.WithField(teleport.ComponentKey, "cluster_auth_test")
 
 func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 	stream := &mockLoginPwdlessStream{}

--- a/lib/teleterm/clusters/config.go
+++ b/lib/teleterm/clusters/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 )
 
@@ -52,7 +53,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "conn:storage")
+		c.Log = logrus.WithField(teleport.ComponentKey, "conn:storage")
 	}
 
 	return nil

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
@@ -112,7 +113,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.NewEntry(logrus.StandardLogger()).WithField(trace.Component, "daemon")
+		c.Log = logrus.NewEntry(logrus.StandardLogger()).WithField(teleport.ComponentKey, "daemon")
 	}
 
 	if c.ConnectMyComputerRoleSetup == nil {

--- a/lib/teleterm/gateway/db_middleware_test.go
+++ b/lib/teleterm/gateway/db_middleware_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/defaults"
 	alpn "github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -112,7 +112,7 @@ func TestDBMiddleware_OnNewConnection(t *testing.T) {
 					hasCalledOnExpiredCert = true
 					return nil
 				},
-				log:     logrus.WithField(trace.Component, "middleware"),
+				log:     logrus.WithField(teleport.ComponentKey, "middleware"),
 				dbRoute: tt.dbRoute,
 			}
 

--- a/lib/teleterm/services/clientcache/clientcache.go
+++ b/lib/teleterm/services/clientcache/clientcache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
@@ -51,7 +52,7 @@ type Config struct {
 
 func (c *Config) checkAndSetDefaults() {
 	if c.Log == nil {
-		c.Log = logrus.WithField(trace.Component, "clientcache")
+		c.Log = logrus.WithField(teleport.ComponentKey, "clientcache")
 	}
 }
 

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
@@ -276,7 +277,7 @@ type RoleSetupConfig struct {
 
 func (c *RoleSetupConfig) CheckAndSetDefaults() error {
 	if c.Log == nil {
-		c.Log = logrus.NewEntry(logrus.StandardLogger()).WithField(trace.Component, "CMC role")
+		c.Log = logrus.NewEntry(logrus.StandardLogger()).WithField(teleport.ComponentKey, "CMC role")
 	}
 
 	return nil

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -45,7 +45,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentAuthority,
+	teleport.ComponentKey: teleport.ComponentAuthority,
 })
 
 // FromCertAndSigner returns a CertAuthority with the given raw certificate and signer.

--- a/lib/usagereporter/usagereporter.go
+++ b/lib/usagereporter/usagereporter.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -422,7 +421,7 @@ func NewUsageReporter[T any](options *Options[T]) *UsageReporter[T] {
 
 	reporter := &UsageReporter[T]{
 		Entry: options.Log.WithField(
-			trace.Component,
+			teleport.ComponentKey,
 			teleport.Component(teleport.ComponentUsageReporting),
 		),
 		events:          make(chan []*SubmittedEvent[T], 1),

--- a/lib/utils/diagnostics/latency/monitor.go
+++ b/lib/utils/diagnostics/latency/monitor.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 )
 
-var log = logrus.WithField(trace.Component, "latency")
+var log = logrus.WithField(teleport.ComponentKey, "latency")
 
 // Statistics contain latency measurements for both
 // legs of a proxied connection.

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
 // NewLoadBalancer returns new load balancer listening on frontend
@@ -58,7 +60,7 @@ func newLoadBalancer(ctx context.Context, frontend NetAddr, policy loadBalancerP
 		waitCancel: waitCancel,
 		Entry: log.WithFields(log.Fields{
 			trace.Component: "loadbalancer",
-			trace.ComponentFields: log.Fields{
+			teleport.ComponentFields: log.Fields{
 				"listen": frontend.String(),
 			},
 		}),

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -59,7 +59,7 @@ func newLoadBalancer(ctx context.Context, frontend NetAddr, policy loadBalancerP
 		waitCtx:    waitCtx,
 		waitCancel: waitCancel,
 		Entry: log.WithFields(log.Fields{
-			trace.Component: "loadbalancer",
+			teleport.ComponentKey: "loadbalancer",
 			teleport.ComponentFields: log.Fields{
 				"listen": frontend.String(),
 			},

--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -41,6 +41,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
 )
 
 const message = "Adding diagnostic debugging handlers.\t To connect with profiler, use `go tool pprof diag_addr`."
@@ -138,7 +140,7 @@ func TestOutput(t *testing.T) {
 				logrusLogger.SetOutput(&logrusOutput)
 				logrusLogger.ReplaceHooks(logrus.LevelHooks{})
 				logrusLogger.SetLevel(test.logrusLevel)
-				entry := logrusLogger.WithField(trace.Component, "test").WithTime(clock.Now().UTC())
+				entry := logrusLogger.WithField(teleport.ComponentKey, "test").WithTime(clock.Now().UTC())
 
 				// Create a slog logger using the custom handler which outputs to a local buffer.
 				var slogOutput bytes.Buffer
@@ -152,7 +154,7 @@ func TestOutput(t *testing.T) {
 						return a
 					},
 				}
-				slogLogger := slog.New(NewSlogTextHandler(&slogOutput, slogConfig)).With(trace.Component, "test")
+				slogLogger := slog.New(NewSlogTextHandler(&slogOutput, slogConfig)).With(teleport.ComponentKey, "test")
 
 				// Add some fields and output the message at the desired log level via logrus.
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
@@ -267,11 +269,11 @@ func TestOutput(t *testing.T) {
 				logrusLogger.SetOutput(&logrusOut)
 				logrusLogger.ReplaceHooks(logrus.LevelHooks{})
 				logrusLogger.SetLevel(test.logrusLevel)
-				entry := logrusLogger.WithField(trace.Component, "test")
+				entry := logrusLogger.WithField(teleport.ComponentKey, "test")
 
 				// Create a slog logger using the custom formatter which outputs to a local buffer.
 				var slogOutput bytes.Buffer
-				slogLogger := slog.New(NewSlogJSONHandler(&slogOutput, SlogJSONHandlerConfig{Level: test.slogLevel})).With(trace.Component, "test")
+				slogLogger := slog.New(NewSlogJSONHandler(&slogOutput, SlogJSONHandlerConfig{Level: test.slogLevel})).With(teleport.ComponentKey, "test")
 
 				// Add some fields and output the message at the desired log level via logrus.
 				l := entry.WithField("test", 123).WithField("animal", "llama").WithField("error", logErr)
@@ -355,7 +357,7 @@ func BenchmarkFormatter(b *testing.B) {
 			logger.SetOutput(io.Discard)
 			b.ResetTimer()
 
-			entry := logger.WithField(trace.Component, "test")
+			entry := logger.WithField(teleport.ComponentKey, "test")
 			for i := 0; i < b.N; i++ {
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
 				l.WithField("diag_addr", &addr).WithField(teleport.ComponentFields, fields).Info(message)
@@ -371,7 +373,7 @@ func BenchmarkFormatter(b *testing.B) {
 			logger.ReplaceHooks(logrus.LevelHooks{})
 			b.ResetTimer()
 
-			entry := logger.WithField(trace.Component, "test")
+			entry := logger.WithField(teleport.ComponentKey, "test")
 			for i := 0; i < b.N; i++ {
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
 				l.WithField("diag_addr", &addr).WithField(teleport.ComponentFields, fields).Info(message)
@@ -384,7 +386,7 @@ func BenchmarkFormatter(b *testing.B) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
 				AddSource: true,
 				Level:     slog.LevelDebug,
-			})).With(trace.Component, "test")
+			})).With(teleport.ComponentKey, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -394,7 +396,7 @@ func BenchmarkFormatter(b *testing.B) {
 		})
 
 		b.Run("text", func(b *testing.B) {
-			logger := slog.New(NewSlogTextHandler(io.Discard, SlogTextHandlerConfig{Level: slog.LevelDebug, EnableColors: true})).With(trace.Component, "test")
+			logger := slog.New(NewSlogTextHandler(io.Discard, SlogTextHandlerConfig{Level: slog.LevelDebug, EnableColors: true})).With(teleport.ComponentKey, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -407,7 +409,7 @@ func BenchmarkFormatter(b *testing.B) {
 			logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{
 				AddSource: true,
 				Level:     slog.LevelDebug,
-			})).With(trace.Component, "test")
+			})).With(teleport.ComponentKey, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -417,7 +419,7 @@ func BenchmarkFormatter(b *testing.B) {
 		})
 
 		b.Run("json", func(b *testing.B) {
-			logger := slog.New(NewSlogJSONHandler(io.Discard, SlogJSONHandlerConfig{Level: slog.LevelDebug})).With(trace.Component, "test")
+			logger := slog.New(NewSlogJSONHandler(io.Discard, SlogJSONHandlerConfig{Level: slog.LevelDebug})).With(teleport.ComponentKey, "test")
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -435,7 +437,7 @@ func TestConcurrentOutput(t *testing.T) {
 		logrus.SetFormatter(debugFormatter)
 		logrus.SetOutput(os.Stdout)
 
-		logger := logrus.WithField(trace.Component, "test")
+		logger := logrus.WithField(teleport.ComponentKey, "test")
 
 		var wg sync.WaitGroup
 		for i := 0; i < 1000; i++ {
@@ -451,7 +453,7 @@ func TestConcurrentOutput(t *testing.T) {
 	t.Run("slog", func(t *testing.T) {
 		logger := slog.New(NewSlogTextHandler(os.Stdout, SlogTextHandlerConfig{
 			EnableColors: true,
-		})).With(trace.Component, "test")
+		})).With(teleport.ComponentKey, "test")
 
 		var wg sync.WaitGroup
 		ctx := context.Background()
@@ -529,7 +531,7 @@ func TestExtraFields(t *testing.T) {
 				var slogHandler slog.Handler = NewSlogTextHandler(&slogOutput, SlogTextHandlerConfig{ConfiguredFields: configuredFields})
 
 				entry := &logrus.Entry{
-					Data:    logrus.Fields{"animal": "llama", "vegetable": "carrot", trace.Component: "test"},
+					Data:    logrus.Fields{"animal": "llama", "vegetable": "carrot", teleport.ComponentKey: "test"},
 					Time:    now,
 					Level:   logrus.DebugLevel,
 					Caller:  &f,
@@ -546,7 +548,7 @@ func TestExtraFields(t *testing.T) {
 					PC:      pc,
 				}
 
-				record.AddAttrs(slog.String(trace.Component, "test"), slog.String("animal", "llama"), slog.String("vegetable", "carrot"))
+				record.AddAttrs(slog.String(teleport.ComponentKey, "test"), slog.String("animal", "llama"), slog.String("vegetable", "carrot"))
 
 				require.NoError(t, slogHandler.Handle(context.Background(), record))
 
@@ -576,7 +578,7 @@ func TestExtraFields(t *testing.T) {
 				var slogHandler slog.Handler = NewSlogJSONHandler(&slogOutput, SlogJSONHandlerConfig{ConfiguredFields: configuredFields})
 
 				entry := &logrus.Entry{
-					Data:    logrus.Fields{"animal": "llama", "vegetable": "carrot", trace.Component: "test"},
+					Data:    logrus.Fields{"animal": "llama", "vegetable": "carrot", teleport.ComponentKey: "test"},
 					Time:    now,
 					Level:   logrus.DebugLevel,
 					Caller:  &f,
@@ -593,7 +595,7 @@ func TestExtraFields(t *testing.T) {
 					PC:      pc,
 				}
 
-				record.AddAttrs(slog.String(trace.Component, "test"), slog.String("animal", "llama"), slog.String("vegetable", "carrot"))
+				record.AddAttrs(slog.String(teleport.ComponentKey, "test"), slog.String("animal", "llama"), slog.String("vegetable", "carrot"))
 
 				require.NoError(t, slogHandler.Handle(context.Background(), record))
 

--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -157,14 +157,14 @@ func TestOutput(t *testing.T) {
 				// Add some fields and output the message at the desired log level via logrus.
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
 				logrusTestLogLineNumber := func() int {
-					l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Log(test.logrusLevel, message)
+					l.WithField("diag_addr", &addr).WithField(teleport.ComponentFields, fields).Log(test.logrusLevel, message)
 					return getCallerLineNumber() - 1 // Get the line number of this call, and assume the log call is right above it
 				}()
 
 				// Add some fields and output the message at the desired log level via slog.
 				l2 := slogLogger.With("test", 123).With("animal", "llama\n").With("error", logErr)
 				slogTestLogLineNumber := func() int {
-					l2.With(trace.ComponentFields, fields).Log(context.Background(), test.slogLevel, message, "diag_addr", &addr)
+					l2.With(teleport.ComponentFields, fields).Log(context.Background(), test.slogLevel, message, "diag_addr", &addr)
 					return getCallerLineNumber() - 1 // Get the line number of this call, and assume the log call is right above it
 				}()
 
@@ -358,7 +358,7 @@ func BenchmarkFormatter(b *testing.B) {
 			entry := logger.WithField(trace.Component, "test")
 			for i := 0; i < b.N; i++ {
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
-				l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Info(message)
+				l.WithField("diag_addr", &addr).WithField(teleport.ComponentFields, fields).Info(message)
 			}
 		})
 
@@ -374,7 +374,7 @@ func BenchmarkFormatter(b *testing.B) {
 			entry := logger.WithField(trace.Component, "test")
 			for i := 0; i < b.N; i++ {
 				l := entry.WithField("test", 123).WithField("animal", "llama\n").WithField("error", logErr)
-				l.WithField("diag_addr", &addr).WithField(trace.ComponentFields, fields).Info(message)
+				l.WithField("diag_addr", &addr).WithField(teleport.ComponentFields, fields).Info(message)
 			}
 		})
 	})
@@ -389,7 +389,7 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
+				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
@@ -399,7 +399,7 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
+				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
@@ -412,7 +412,7 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
+				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 
@@ -422,7 +422,7 @@ func BenchmarkFormatter(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
-				l.With(trace.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
+				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
 		})
 	})

--- a/lib/utils/log/logrus_formatter.go
+++ b/lib/utils/log/logrus_formatter.go
@@ -87,13 +87,17 @@ const (
 	callerField    = "caller"
 	timestampField = "timestamp"
 	messageField   = "message"
+	// defaultComponentPadding is a default padding for component field
+	defaultComponentPadding = 11
+	// defaultLevelPadding is a default padding for level field
+	defaultLevelPadding = 4
 )
 
 // NewDefaultTextFormatter creates a TextFormatter with
 // the default options set.
 func NewDefaultTextFormatter(enableColors bool) *TextFormatter {
 	return &TextFormatter{
-		ComponentPadding: trace.DefaultComponentPadding,
+		ComponentPadding: defaultComponentPadding,
 		FormatCaller:     formatCallerWithPathAndLine,
 		ExtraFields:      defaultFormatFields,
 		EnableColors:     enableColors,
@@ -106,7 +110,7 @@ func NewDefaultTextFormatter(enableColors bool) *TextFormatter {
 func (tf *TextFormatter) CheckAndSetDefaults() error {
 	// set padding
 	if tf.ComponentPadding == 0 {
-		tf.ComponentPadding = trace.DefaultComponentPadding
+		tf.ComponentPadding = defaultComponentPadding
 	}
 	// set caller
 	tf.FormatCaller = formatCallerWithPathAndLine
@@ -173,9 +177,9 @@ func (tf *TextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 				color = noColor
 			}
 
-			w.writeField(padMax(level, trace.DefaultLevelPadding), color)
+			w.writeField(padMax(level, defaultLevelPadding), color)
 		case componentField:
-			padding := trace.DefaultComponentPadding
+			padding := defaultComponentPadding
 			if tf.ComponentPadding != 0 {
 				padding = tf.ComponentPadding
 			}

--- a/lib/utils/log/logrus_formatter.go
+++ b/lib/utils/log/logrus_formatter.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
 // TextFormatter is a [logrus.Formatter] that outputs messages in
@@ -180,7 +182,7 @@ func (tf *TextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 			if w.Len() > 0 {
 				w.WriteByte(' ')
 			}
-			component, ok := e.Data[trace.Component].(string)
+			component, ok := e.Data[teleport.ComponentKey].(string)
 			if ok && component != "" {
 				component = fmt.Sprintf("[%v]", component)
 			}
@@ -267,10 +269,10 @@ func (j *JSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	}
 
 	if j.componentEnabled {
-		e.Data[componentField] = e.Data[trace.Component]
+		e.Data[componentField] = e.Data[teleport.ComponentKey]
 	}
 
-	delete(e.Data, trace.Component)
+	delete(e.Data, teleport.ComponentKey)
 
 	return j.JSONFormatter.Format(e)
 }
@@ -359,7 +361,7 @@ func (w *writer) writeMap(m map[string]any) {
 	}
 	slices.Sort(keys)
 	for _, key := range keys {
-		if key == trace.Component {
+		if key == teleport.ComponentKey {
 			continue
 		}
 		switch value := m[key].(type) {

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
 // TraceLevel is the logging level when set to Trace verbosity.
@@ -144,7 +146,7 @@ func (s *SlogTextHandler) appendAttr(buf []byte, a slog.Attr) []byte {
 			break
 		}
 
-		if a.Key == trace.ComponentFields {
+		if a.Key == teleport.ComponentFields {
 			switch fields := a.Value.Any().(type) {
 			case map[string]any:
 				for k, v := range fields {
@@ -416,7 +418,7 @@ func (s *SlogTextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 			if component[len(component)-1] != ' ' {
 				component = component[:len(component)-1] + "]"
 			}
-		case trace.ComponentFields:
+		case teleport.ComponentFields:
 			switch fields := a.Value.Any().(type) {
 			case map[string]any:
 				for k, v := range fields {

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -160,7 +160,7 @@ func (s *SlogTextHandler) appendAttr(buf []byte, a slog.Attr) []byte {
 		}
 
 		if needsQuoting(value) {
-			if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
+			if a.Key == teleport.ComponentKey || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
 				if len(buf) > 0 {
 					buf = fmt.Append(buf, " ")
 				}
@@ -174,7 +174,7 @@ func (s *SlogTextHandler) appendAttr(buf []byte, a slog.Attr) []byte {
 			break
 		}
 
-		if a.Key == trace.Component || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
+		if a.Key == teleport.ComponentKey || a.Key == slog.LevelKey || a.Key == callerField || a.Key == slog.MessageKey {
 			if len(buf) > 0 {
 				buf = fmt.Append(buf, " ")
 			}
@@ -314,11 +314,11 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 			// specified in the arguments, the one with the lowest index is used and the others are ignored.
 			// In the example below, the resulting component in the message output would be "alpaca".
 			//
-			//	logger := logger.With(trace.Component, "fish")
-			//	logger.InfoContext(ctx, "llama llama llama", trace.Component, "alpaca", "foo", 123, trace.Component, "shark")
+			//	logger := logger.With(teleport.ComponentKey, "fish")
+			//	logger.InfoContext(ctx, "llama llama llama", teleport.ComponentKey, "alpaca", "foo", 123, teleport.ComponentKey, "shark")
 			component := s.component
 			r.Attrs(func(attr slog.Attr) bool {
-				if attr.Key == trace.Component {
+				if attr.Key == teleport.ComponentKey {
 					component = fmt.Sprintf("[%v]", attr.Value)
 					component = strings.ToUpper(padMax(component, s.cfg.Padding))
 					if component[len(component)-1] != ' ' {
@@ -331,7 +331,7 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 				return true
 			})
 
-			*buf = s.appendAttr(*buf, slog.String(trace.Component, component))
+			*buf = s.appendAttr(*buf, slog.String(teleport.ComponentKey, component))
 		default:
 			if _, ok := knownFormatFields[field]; !ok {
 				return trace.BadParameter("invalid log format key: %v", field)
@@ -353,7 +353,7 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 
 		r.Attrs(func(a slog.Attr) bool {
 			// Skip adding any component attrs since they are processed above.
-			if a.Key == trace.Component {
+			if a.Key == teleport.ComponentKey {
 				return true
 			}
 
@@ -412,7 +412,7 @@ func (s *SlogTextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	// Pre-format the attributes.
 	for _, a := range attrs {
 		switch a.Key {
-		case trace.Component:
+		case teleport.ComponentKey:
 			component = fmt.Sprintf("[%v]", a.Value.String())
 			component = strings.ToUpper(padMax(component, s.cfg.Padding))
 			if component[len(component)-1] != ' ' {
@@ -484,7 +484,7 @@ func NewSlogJSONHandler(w io.Writer, cfg SlogJSONHandlerConfig) *SlogJSONHandler
 			Level:     cfg.Level,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				switch a.Key {
-				case trace.Component:
+				case teleport.ComponentKey:
 					if !withComponent {
 						return slog.Attr{}
 					}

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -93,7 +93,7 @@ type SlogTextHandlerConfig struct {
 // NewSlogTextHandler creates a SlogTextHandler that writes messages to w.
 func NewSlogTextHandler(w io.Writer, cfg SlogTextHandlerConfig) *SlogTextHandler {
 	if cfg.Padding == 0 {
-		cfg.Padding = trace.DefaultComponentPadding
+		cfg.Padding = defaultComponentPadding
 	}
 
 	handler := SlogTextHandler{
@@ -302,7 +302,7 @@ func (s *SlogTextHandler) Handle(ctx context.Context, r slog.Record) error {
 				color = noColor
 			}
 
-			level = padMax(level, trace.DefaultLevelPadding)
+			level = padMax(level, defaultLevelPadding)
 			if color == noColor {
 				*buf = s.appendAttr(*buf, slog.String(slog.LevelKey, level))
 			} else {

--- a/lib/utils/proxy/proxy.go
+++ b/lib/utils/proxy/proxy.go
@@ -35,7 +35,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentConnectProxy,
+	teleport.ComponentKey: teleport.ComponentConnectProxy,
 })
 
 // A Dialer is a means for a client to establish a SSH connection.

--- a/lib/utils/proxyconn_test.go
+++ b/lib/utils/proxyconn_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
 )
 
 // TestProxyConn tests proxying the connection between client and server.
@@ -123,7 +125,7 @@ func newEchoServer() (*echoServer, error) {
 	}
 	return &echoServer{
 		listener: listener,
-		log:      logrus.WithField(trace.Component, "echo"),
+		log:      logrus.WithField(teleport.ComponentKey, "echo"),
 	}, nil
 }
 

--- a/lib/utils/socks/socks.go
+++ b/lib/utils/socks/socks.go
@@ -33,7 +33,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentSOCKS,
+	teleport.ComponentKey: teleport.ComponentSOCKS,
 })
 
 const (

--- a/lib/versioncontrol/github/github.go
+++ b/lib/versioncontrol/github/github.go
@@ -39,7 +39,7 @@ import (
 // run as part of normal CI.
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentVersionControl,
+	teleport.ComponentKey: teleport.ComponentVersionControl,
 })
 
 // Visit uses the supplied visitor to aggregate release info from the github releases api.

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -410,7 +410,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:         s.server.ClusterName(),
-		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Log:                 utils.NewLoggerForTests().WithField(teleport.ComponentKey, "test"),
 		RemoteClusterGetter: s.proxyClient,
 		SiteGetter:          revTunServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -7676,7 +7676,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	clustername := authServer.ClusterName()
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:         clustername,
-		Log:                 log.WithField(trace.Component, "router"),
+		Log:                 log.WithField(teleport.ComponentKey, "router"),
 		RemoteClusterGetter: client,
 		SiteGetter:          revTunServer,
 		TracerProvider:      tracing.NoopProvider(),

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -110,7 +110,7 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		c:            c,
 		closeContext: ctx,
 		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentAppProxy,
+			teleport.ComponentKey: teleport.ComponentAppProxy,
 		}),
 	}
 

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -458,8 +458,8 @@ func newCommandHandler(ctx context.Context, cfg CommandHandlerConfig) (*commandH
 	return &commandHandler{
 		sshBaseHandler: sshBaseHandler{
 			log: logrus.WithFields(logrus.Fields{
-				trace.Component: teleport.ComponentWebsocket,
-				"session_id":    cfg.SessionData.ID.String(),
+				teleport.ComponentKey: teleport.ComponentWebsocket,
+				"session_id":          cfg.SessionData.ID.String(),
 			}),
 			ctx:                cfg.SessionCtx,
 			userAuthClient:     cfg.UserAuthClient,

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -60,7 +60,7 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = utils.NewLogger().WithField(trace.Component, teleport.ComponentProxy)
+		c.Log = utils.NewLogger().WithField(teleport.ComponentKey, teleport.ComponentProxy)
 	}
 
 	return nil

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -951,8 +952,8 @@ func (s *sessionCache) upsertSessionContext(user string) *sessionResources {
 	}
 	ctx := &sessionResources{
 		log: s.log.WithFields(logrus.Fields{
-			trace.Component: "user-session",
-			"user":          user,
+			teleport.ComponentKey: "user-session",
+			"user":                user,
 		}),
 	}
 	s.resources[user] = ctx

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -122,8 +122,8 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 	return &TerminalHandler{
 		sshBaseHandler: sshBaseHandler{
 			log: logrus.WithFields(logrus.Fields{
-				trace.Component: teleport.ComponentWebsocket,
-				"session_id":    cfg.SessionData.ID.String(),
+				teleport.ComponentKey: teleport.ComponentWebsocket,
+				"session_id":          cfg.SessionData.ID.String(),
 			}),
 			ctx:                cfg.SessionCtx,
 			userAuthClient:     cfg.UserAuthClient,

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -19,7 +19,6 @@
 package web
 
 import (
-	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
@@ -30,6 +29,6 @@ var log = newPackageLogger()
 // newPackageLogger returns a new instance of the logger
 // configured for the package
 func newPackageLogger(subcomponents ...string) logrus.FieldLogger {
-	return logrus.WithField(trace.Component,
+	return logrus.WithField(teleport.ComponentKey,
 		teleport.Component(append([]string{teleport.ComponentWeb}, subcomponents...)...))
 }

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -43,7 +43,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTBot,
+	teleport.ComponentKey: teleport.ComponentTBot,
 })
 
 const (

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -49,7 +49,7 @@ type AuthKindCommand struct {
 // argument parsing
 func (cmd *SSOConfigureCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Config) {
 	cmd.Config = cfg
-	cmd.Logger = cfg.Log.WithField(trace.Component, teleport.ComponentClient)
+	cmd.Logger = cfg.Log.WithField(teleport.ComponentKey, teleport.ComponentClient)
 
 	sso := app.Command("sso", "A family of commands for configuring and testing auth connectors (SSO).")
 	cmd.ConfigureCmd = sso.Command("configure", "Create auth connector configuration.")

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -591,7 +591,7 @@ func onSFTP() error {
 
 	// Ensure the parent process will receive log messages from us
 	l := utils.NewLogger()
-	logger := l.WithField(trace.Component, teleport.ComponentSubsystemSFTP)
+	logger := l.WithField(teleport.ComponentKey, teleport.ComponentSubsystemSFTP)
 
 	currentUser, err := user.Current()
 	if err != nil {

--- a/tool/tsh/common/resolve_default_addr_test.go
+++ b/tool/tsh/common/resolve_default_addr_test.go
@@ -29,14 +29,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	apihelpers "github.com/gravitational/teleport/api/testhelpers"
 	"github.com/gravitational/teleport/integration/helpers"
 )
 
-var testLog = log.WithField(trace.Component, "test")
+var testLog = log.WithField(teleport.ComponentKey, "test")
 
 func newWaitForeverHandler() (http.Handler, chan struct{}) {
 	doneChannel := make(chan struct{})

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -91,7 +91,7 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-	trace.Component: teleport.ComponentTSH,
+	teleport.ComponentKey: teleport.ComponentTSH,
 })
 
 const (


### PR DESCRIPTION
Adds teleport.ComponentKey and teleport.ComponentFields to replace trace.Component and trace.ComponentFields so that we can upgrade to trace v1.4.0. The logging formatters were also updated to define default padding inline instead of using the constants from trace.