### PR TITLE
fix: incorrectly placed provision token name

### DIFF
--- a/examples/agent-pool-terraform/teleport/token.tf
+++ b/examples/agent-pool-terraform/teleport/token.tf
@@ -9,7 +9,7 @@ resource "teleport_provision_token" "agent" {
     roles = var.agent_roles
   }
   metadata = {
-    name  = random_string.token[count.index].result
+    name    = random_string.token[count.index].result
     expires = timeadd(timestamp(), "1h")
   }
 }

--- a/examples/agent-pool-terraform/teleport/token.tf
+++ b/examples/agent-pool-terraform/teleport/token.tf
@@ -7,9 +7,9 @@ resource "teleport_provision_token" "agent" {
   count = var.agent_count
   spec = {
     roles = var.agent_roles
-    name  = random_string.token[count.index].result
   }
   metadata = {
+    name  = random_string.token[count.index].result
     expires = timeadd(timestamp(), "1h")
   }
 }


### PR DESCRIPTION
name is part of metadata not spec