### PR TITLE
Disable disk-based recording in TestAppLoginLeaf

### DIFF
--- a/tool/tsh/common/app_test.go
+++ b/tool/tsh/common/app_test.go
@@ -82,10 +82,15 @@ func TestAppLoginLeaf(t *testing.T) {
 
 	// TODO(tener): consider making this default for tests.
 	configStorage := func(cfg *servicecfg.Config) {
+		cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 		cfg.Auth.StorageConfig.Params["poll_stream_period"] = 50 * time.Millisecond
 	}
 
-	rootAuth, rootProxy := makeTestServers(t, withClusterName(t, "root"), withBootstrap(connector, alice), withConfig(configStorage))
+	rootAuth, rootProxy := makeTestServers(t,
+		withClusterName(t, "root"),
+		withBootstrap(connector, alice),
+		withConfig(configStorage),
+	)
 	event, err := rootAuth.WaitForEventTimeout(time.Second, service.ProxyReverseTunnelReady)
 	require.NoError(t, err)
 	tunnel, ok := event.Payload.(reversetunnelclient.Server)


### PR DESCRIPTION
This resolves occasinal flakiness as observed in
https://github.com/gravitational/teleport/actions/runs/8266855866/job/22615883726