### PR TITLE
Fix integrations tests

### DIFF
--- a/integrations/lib/testing/integration/authservice.go
+++ b/integrations/lib/testing/integration/authservice.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/logger"
 )
 
-var regexpAuthStarting = regexp.MustCompile(`Auth service [^ ]+ is starting on [^ ]+:(\d+)`)
+var regexpAuthStarting = regexp.MustCompile(`listen_address:[^ ]+:(\d+)`)
 
 type AuthService struct {
 	mu           sync.Mutex

--- a/integrations/lib/testing/integration/proxyservice.go
+++ b/integrations/lib/testing/integration/proxyservice.go
@@ -37,9 +37,9 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/logger"
 )
 
-var regexpWebProxyStarting = regexp.MustCompile(`Web proxy service [^ ]+ is starting on [^ ]+:(\d+)`)
-var regexpSSHProxyStarting = regexp.MustCompile(`SSH proxy service [^ ]+ is starting on [^ ]+:(\d+)`)
-var regexpReverseTunnelStarting = regexp.MustCompile(`Reverse tunnel service [^ ]+ is starting on [^ ]+:(\d+)`)
+var regexpWebProxyStarting = regexp.MustCompile(`Starting web proxy service.*listen_address:[^ ]+:(\d+)`)
+var regexpSSHProxyStarting = regexp.MustCompile(`Starting SSH proxy service.*listen_address:[^ ]+:(\d+)`)
+var regexpReverseTunnelStarting = regexp.MustCompile(`Starting reverse tunnel server.*listen_address:[^ ]+:(\d+)`)
 
 type ProxyService struct {
 	mu                sync.Mutex


### PR DESCRIPTION
The change to migrate the TeleportProcess to use slog in https://github.com/gravitational/teleport/pull/38551 was preventing the regular expressions used by the plugin tests to determine when auth and proxy were ready. This lead to the tests hanging indefinitely until the go test framework timed out. To remediate, the regular expressions have been updated to match the output when using slog.

For example, the test was expecting the output in the format of:

```
Auth service 15.0.0:v15.0.0-0-ge126e8cd is starting on 192.168.50.108:3025. pid:61933.1 service/service.go:2072
```

#38551 moved the listen address to a field instead of being formatted in the message:

```
Auth service is starting. pid:54159.1 version:16.0.0-dev git_ref:api/v13.4.16-31-g2b9ae35e31 listen_address:127.0.0.1:63152 service/service.go:2107
```