### PR TITLE
Add missing option to the tbot config reference

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -79,6 +79,7 @@ onboarding:
   # - `github`
   # - `gitlab`
   # - `iam`
+  # - `kubernetes`
   join_method: "token"
 
   # ca_pins are used to validate the identity of the Teleport Auth Service on


### PR DESCRIPTION
Adds `kubernetes` to the list of supported join methods since it is indeed supported 😄 