### PR TITLE
docs: advise cockroachdb storage backend requires enterprise

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1433,7 +1433,7 @@ teleport:
 ## CockroachDB
 
 <Admonition type="warning" title="Enterprise">
-  CockroachDB storage backend requires Teleport Enterprise.
+  Use of the CockroachDB storage backend requires Teleport Enterprise.
 </Admonition>
 
 Teleport can use [CockroachDB](https://www.cockroachlabs.com/) as a storage backend

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1432,6 +1432,10 @@ teleport:
 
 ## CockroachDB
 
+<Admonition type="warning" title="Enterprise">
+  CockroachDB storage backend requires Teleport Enterprise.
+</Admonition>
+
 Teleport can use [CockroachDB](https://www.cockroachlabs.com/) as a storage backend
 to achieve high availability and survive regional failures. You must take steps to 
 protect access to CockroachDB in this configuration because that is where Teleport


### PR DESCRIPTION
This is only available in enterprise, not community.