### PR TITLE
Edit recording playback instructions in tsh guide

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -898,15 +898,19 @@ DEBU [TSH]       Self re-exec command: tsh [status --format=json]. tsh/aliases.g
 ...
 ```
 
-## Interactive Recording
+## Examining recorded sessions
 
-Within the Teleport cluster, server and Kubernetes recorded sessions are available for listing and replay for authorized users via `tsh`.
-The same listings, including Windows desktop sessions, are available in the Web Console under Session Recordings in the Activity section.
+You can use `tsh` to examine sessions that users have completed in resources
+protected by Teleport. This section explains how to list and play Teleport
+session recordings with `tsh`.
 
-### List and Play Recordings
+Note that you can also play session recordings in the Teleport Web UI. To do so,
+navigate to the **Access Management** tab on the top sidebar and view the
+**Session Recordings** tab on the left sidebar.
 
-Get the list of recorded sessions. By default, recordings for the past 24 hours are shown.
-The time range can be customized with the `--last`, `--from-utc`, and `--to-utc` flags.
+### Listing recordings
+
+Run the following command to review recorded sessions:
 
 ```code
 $ tsh recordings ls
@@ -917,23 +921,42 @@ c0a02222-70dc-4be8-9308-7b7901d2d600 kube alice                  Nov 26 20:36:16
 d0a04442-70dc-4be8-9308-7b7901d2d600 ssh  navin        test      Nov 26 16:36:16 UTC
 ```
 
-To play sessions, use the `tsh play <sessionid>` command. The screen will reset playing the interactive session with the timestamp in the upper right.
+### Playing recordings
+
+To play a session recording, run the `tsh play` command with the ID of a session
+as returned by `tsh recordings ls`: 
 
 ```code
 $ tsh play c0a02222-70dc-4be8-9308-7b7901d2d600
-root@ubuntu:/# df                                                                     2022-11-26T21:20:52.715Z
-Filesystem     1K-blocks    Used Available Use% Mounted on
-overlay         20959212 4387284  16571928  21% /
-tmpfs              65536       0     65536   0% /dev
-tmpfs            1982720       0   1982720   0% /sys/fs/cgroup
-/dev/nvme0n1p1  20959212 4387284  16571928  21% /etc/hosts
-shm                65536       0     65536   0% /dev/shm
-tmpfs            3410436      12   3410424   1% /run/secrets/kubernetes.io/serviceaccount
-tmpfs            1982720       0   1982720   0% /proc/acpi
-tmpfs            1982720       0   1982720   0% /sys/firmware
-root@ubuntu:/# exit
-exit
 ```
+
+Users of self-hosted Teleport clusters can also run `tsh play` with the path to
+a TAR file that contains a session recording (this requires access to the
+session recording backend):
+
+```code
+$ tsh play ./my-recording.tar
+```
+
+The `tsh play` command can print recordings in three formats, depending on the
+kind of resource the recorded session interacts with. To choose a format, use
+the `--format` flag of `tsh play`:
+
+| `--format` value | Supported resources | Description |
+|------------------|---------------------|-------------|
+| `pty` (default)  | Servers, Kubernetes clusters | `tsh` opens a pseudo-terminal to play each command executed in the session. |
+| `json` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a JSON-serialized list of audit events, separated by newlines. |
+| `yaml` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a YAML-serialized list of audit events, separated by `---` characters. |
+
+To view recordings of Windows desktop sessions, you must run the following
+command:
+
+```code
+$ tsh recordings export <session-id>
+```
+
+This command downloads a file containing a recording of the desktop session that
+you can play from your workstation.
 
 ## tsh configuration files
 
@@ -1134,4 +1157,6 @@ To remove `tsh` and associated user data see
 [Uninstalling Teleport](../management/admin/uninstall-teleport.mdx).
 
 ## Further reading
-- [CLI Reference](../reference/cli.mdx).
+
+Read the [`tsh` CLI Reference](../reference/cli/tsh.mdx) for all `tsh` commands
+and their options.

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -930,13 +930,17 @@ as returned by `tsh recordings ls`:
 $ tsh play c0a02222-70dc-4be8-9308-7b7901d2d600
 ```
 
-Users of self-hosted Teleport clusters can also run `tsh play` with the path to
-a TAR file that contains a session recording (this requires access to the
-session recording backend):
+You can also run `tsh play` with the path to a TAR file that contains a session
+recording:
 
 ```code
 $ tsh play ./my-recording.tar
 ```
+
+To retrieve a TAR file containing a session recording, you must have access to
+the session recording backend. This requires either a self-hosted Teleport
+cluster or [external audit
+storage](../choose-an-edition/teleport-cloud/external-audit-storage.mdx).
 
 The `tsh play` command can print recordings in three formats, depending on the
 kind of resource the recorded session interacts with. To choose a format, use
@@ -947,16 +951,6 @@ the `--format` flag of `tsh play`:
 | `pty` (default)  | Servers, Kubernetes clusters | `tsh` opens a pseudo-terminal to play each command executed in the session. |
 | `json` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a JSON-serialized list of audit events, separated by newlines. |
 | `yaml` | Servers, Kubernetes clusters, applications, databases | `tsh` prints a YAML-serialized list of audit events, separated by `---` characters. |
-
-To view recordings of Windows desktop sessions, you must run the following
-command:
-
-```code
-$ tsh recordings export <session-id>
-```
-
-This command downloads a file containing a recording of the desktop session that
-you can play from your workstation.
 
 ## tsh configuration files
 


### PR DESCRIPTION
Closes #26521

Add `tsh play` instructions for databases by editing the `tsh` guide in the "Connect your Client" section. The section currently assumes that the user is playing sessions via PTY, so this change includes the possibility of using the `yaml` and `json` values of the `--format` flag.

This change also restructures the section of the `tsh` guide related to session playback to accommodate the new instructions. It also mentions Windows desktops for completeness.

Finally, the current version of the guide includes a brief note about `tsh recordings ls` flags that is not complete enough to be useful. This change removes the note and links to the `tsh` CLI reference at the end of the guide for further information about flags and arguments.