### PR TITLE
[v15] docs: add missing token types to machine id config reference 

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -80,7 +80,9 @@ onboarding:
   # - `github`
   # - `gitlab`
   # - `iam`
+  # - `ec2`
   # - `kubernetes`
+  # - `spacelift`
   join_method: "token"
 
   # ca_pins are used to validate the identity of the Teleport Auth Service on

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -75,6 +75,7 @@ onboarding:
   # Support values include:
   # - `token`
   # - `azure`
+  # - `gcp`
   # - `circleci`
   # - `github`
   # - `gitlab`

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -80,6 +80,7 @@ onboarding:
   # - `github`
   # - `gitlab`
   # - `iam`
+  # - `kubernetes`
   join_method: "token"
 
   # ca_pins are used to validate the identity of the Teleport Auth Service on


### PR DESCRIPTION
Backport #39318 to branch/v15