### PR TITLE
[v15] Re-enable AWS IMDSv1 fallback

### DIFF
--- a/examples/teleport-usage/main.go
+++ b/examples/teleport-usage/main.go
@@ -81,7 +81,6 @@ func main() {
 			Retryer:                       limiter,
 			Region:                        aws.String(params.awsRegion),
 			CredentialsChainVerboseErrors: aws.Bool(true),
-			EC2MetadataEnableFallback:     aws.Bool(false),
 			UseFIPSEndpoint:               useFIPSEndpoint,
 		},
 	})

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
@@ -144,9 +143,6 @@ func getIID(ctx context.Context, t *testing.T) imds.InstanceIdentityDocument {
 func getCallerIdentity(t *testing.T) *sts.GetCallerIdentityOutput {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-		Config: aws.Config{
-			EC2MetadataEnableFallback: aws.Bool(false),
-		},
 	})
 	require.NoError(t, err)
 	stsService := sts.New(sess)

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -437,9 +437,8 @@ func createSignedSTSIdentityRequest(ctx context.Context, challenge string, opts 
 
 func newSTSClient(ctx context.Context, cfg *stsIdentityRequestConfig) (*sts.STS, error) {
 	awsConfig := awssdk.Config{
-		EC2MetadataEnableFallback: awssdk.Bool(false),
-		UseFIPSEndpoint:           cfg.fipsEndpointOption,
-		STSRegionalEndpoint:       cfg.regionalEndpointOption,
+		UseFIPSEndpoint:     cfg.fipsEndpointOption,
+		STSRegionalEndpoint: cfg.regionalEndpointOption,
 	}
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -251,9 +251,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		useFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
-	awsConfig := aws.Config{
-		EC2MetadataEnableFallback: aws.Bool(false),
-	}
+	awsConfig := aws.Config{}
 	if cfg.Region != "" {
 		awsConfig.Region = aws.String(cfg.Region)
 	}

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -1023,9 +1023,8 @@ func (c *TestCloudClients) getAWSSessionForRegion(region string) (*awssession.Se
 			AccessKeyID:     "fakeClientKeyID",
 			SecretAccessKey: "fakeClientSecret",
 		}}),
-		Region:                    aws.String(region),
-		EC2MetadataEnableFallback: aws.Bool(false),
-		UseFIPSEndpoint:           useFIPSEndpoint,
+		Region:          aws.String(region),
+		UseFIPSEndpoint: useFIPSEndpoint,
 	})
 }
 
@@ -1296,10 +1295,9 @@ func buildAWSSessionOptions(region string, cred *credentials.Credentials) awsses
 	return awssession.Options{
 		SharedConfigState: awssession.SharedConfigEnable,
 		Config: aws.Config{
-			Region:                    aws.String(region),
-			Credentials:               cred,
-			EC2MetadataEnableFallback: aws.Bool(false),
-			UseFIPSEndpoint:           useFIPSEndpoint,
+			Region:          aws.String(region),
+			Credentials:     cred,
+			UseFIPSEndpoint: useFIPSEndpoint,
 		},
 	}
 }

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -336,8 +336,7 @@ func (c *ConfiguratorConfig) CheckAndSetDefaults() error {
 			c.AWSSession, err = awssession.NewSessionWithOptions(awssession.Options{
 				SharedConfigState: awssession.SharedConfigEnable,
 				Config: aws.Config{
-					EC2MetadataEnableFallback: aws.Bool(false),
-					UseFIPSEndpoint:           useFIPSEndpoint,
+					UseFIPSEndpoint: useFIPSEndpoint,
 				},
 			})
 			if err != nil {
@@ -369,9 +368,8 @@ func (c *ConfiguratorConfig) CheckAndSetDefaults() error {
 					}
 					session, err := awssession.NewSessionWithOptions(awssession.Options{
 						Config: aws.Config{
-							Region:                    &region,
-							EC2MetadataEnableFallback: aws.Bool(false),
-							UseFIPSEndpoint:           useFIPSEndpoint,
+							Region:          &region,
+							UseFIPSEndpoint: useFIPSEndpoint,
 						},
 						SharedConfigState: awssession.SharedConfigEnable,
 					})

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -264,9 +264,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 		Config: cfg,
 	}
 
-	awsConfig := aws.Config{
-		EC2MetadataEnableFallback: aws.Bool(false),
-	}
+	awsConfig := aws.Config{}
 
 	// Override the default environment's region if value set in YAML file:
 	if cfg.Region != "" {

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -157,8 +157,7 @@ func (s *Config) CheckAndSetDefaults() error {
 	}
 	if s.Session == nil {
 		awsConfig := aws.Config{
-			EC2MetadataEnableFallback: aws.Bool(false),
-			UseFIPSEndpoint:           events.FIPSProtoStateToAWSState(s.UseFIPSEndpoint),
+			UseFIPSEndpoint: events.FIPSProtoStateToAWSState(s.UseFIPSEndpoint),
 		}
 		if s.Region != "" {
 			awsConfig.Region = aws.String(s.Region)

--- a/lib/integrations/awsoidc/clientsv1.go
+++ b/lib/integrations/awsoidc/clientsv1.go
@@ -71,8 +71,7 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigDisable,
 		Config: aws.Config{
-			EC2MetadataEnableFallback: aws.Bool(false),
-			UseFIPSEndpoint:           useFIPSEndpoint,
+			UseFIPSEndpoint: useFIPSEndpoint,
 		},
 	})
 	if err != nil {
@@ -99,10 +98,9 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 	session, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigDisable,
 		Config: aws.Config{
-			Region:                    aws.String(region),
-			Credentials:               awsCredentials,
-			EC2MetadataEnableFallback: aws.Bool(false),
-			UseFIPSEndpoint:           useFIPSEndpoint,
+			Region:          aws.String(region),
+			Credentials:     awsCredentials,
+			UseFIPSEndpoint: useFIPSEndpoint,
 		},
 	})
 	if err != nil {

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -104,8 +104,7 @@ func (c *CloudConfig) CheckAndSetDefaults() error {
 		session, err := awssession.NewSessionWithOptions(awssession.Options{
 			SharedConfigState: awssession.SharedConfigEnable,
 			Config: aws.Config{
-				EC2MetadataEnableFallback: aws.Bool(false),
-				UseFIPSEndpoint:           useFIPSEndpoint,
+				UseFIPSEndpoint: useFIPSEndpoint,
 			},
 		})
 		if err != nil {

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -75,8 +75,7 @@ func (s *SigningServiceConfig) CheckAndSetDefaults() error {
 		ses, err := awssession.NewSessionWithOptions(awssession.Options{
 			SharedConfigState: awssession.SharedConfigEnable,
 			Config: aws.Config{
-				EC2MetadataEnableFallback: aws.Bool(false),
-				UseFIPSEndpoint:           useFIPSEndpoint,
+				UseFIPSEndpoint: useFIPSEndpoint,
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Backport #39363 to branch/v15

changelog: Re-enable AWS IMDSv1 fallback due to some EKS clusters having their IMDSv2 hop limit set to `1`, leading to IMDSv2 requests failing. Users who wish to keep IMDSv1 fallback disabled can set the `AWS_EC2_METADATA_V1_DISABLED` environmental variable.
