### PR TITLE
[v14] docs: add missing token types to machine id config reference

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -75,10 +75,14 @@ onboarding:
   # Support values include:
   # - `token`
   # - `azure`
+  # - `gcp`
   # - `circleci`
   # - `github`
   # - `gitlab`
   # - `iam`
+  # - `ec2`
+  # - `kubernetes`
+  # - `spacelift`
   join_method: "token"
 
   # ca_pins are used to validate the identity of the Teleport Auth Service on


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/39318 to branch/v14