### PR TITLE
[v15] Support `tsh login -i`

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -106,6 +106,10 @@ type Profile struct {
 
 	// PIVSlot is a specific piv slot that Teleport clients should use for hardware key support.
 	PIVSlot keys.PIVSlot `yaml:"piv_slot"`
+
+	// MissingClusterDetails means this profile was created with limited cluster details.
+	// Missing cluster details should be loaded into the profile by pinging the proxy.
+	MissingClusterDetails bool
 }
 
 // Copy returns a shallow copy of p, or nil if p is nil.

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -835,7 +835,12 @@ func LoadIdentityFileIntoClientStore(store *client.Store, identityFile, proxyAdd
 		return trace.Wrap(err)
 	}
 
-	// Load the client key from the agent.
+	// This key may already exist in a tsh profile, delete it before overwriting
+	// it with the identity key to avoid leaving app/db/kube certs from the old key.
+	if err := store.DeleteKey(key.KeyIndex); err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
 	if err := store.AddKey(key); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -448,10 +448,11 @@ func TestNewClientStoreFromIdentityFile(t *testing.T) {
 	retrievedProfile, err := clientStore.GetProfile(currentProfile)
 	require.NoError(t, err)
 	require.Equal(t, &profile.Profile{
-		WebProxyAddr:     key.ProxyHost + ":3080",
-		SiteName:         key.ClusterName,
-		Username:         key.Username,
-		PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+		WebProxyAddr:          key.ProxyHost + ":3080",
+		SiteName:              key.ClusterName,
+		Username:              key.Username,
+		PrivateKeyPolicy:      keys.PrivateKeyPolicyNone,
+		MissingClusterDetails: true,
 	}, retrievedProfile)
 
 	retrievedKey, err := clientStore.GetKey(key.KeyIndex, client.WithAllCerts...)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4146,9 +4146,6 @@ func refuseArgs(command string, args []string) error {
 func onFlatten(cf *CLIConf) error {
 	// Save the identity file path for later
 	identityFile := cf.IdentityFileIn
-	if cf.Proxy == "" {
-		return trace.BadParameter("--proxy must be specified")
-	}
 
 	// We clear the identity flag so that the client store will be backed
 	// by the filesystem instead (in ~/.tsh or TELEPORT_HOME).
@@ -4158,6 +4155,11 @@ func onFlatten(cf *CLIConf) error {
 	c, err := loadClientConfigFromCLIConf(cf, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	// Proxy address may be loaded from existing tsh profile or from --proxy flag.
+	if c.WebProxyAddr == "" {
+		return trace.BadParameter("No proxy address specified, missed --proxy flag?")
 	}
 
 	// Load the identity file key and partial profile into the client store.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1122,9 +1122,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// MFA subcommands.
 	mfa := newMFACommand(app)
 
-	flatten := app.Command("flatten", "Flattens an identity file into a profile stored in ~/.tsh or TELEPORT_HOME.")
-	flatten.Arg("identity", "Identity file").StringVar(&cf.IdentityFileIn)
-
 	config := app.Command("config", "Print OpenSSH configuration details.")
 	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 
@@ -1374,8 +1371,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onListSessions(&cf)
 	case login.FullCommand():
 		err = onLogin(&cf)
-	case flatten.FullCommand():
-		err = onFlatten(&cf)
 	case logout.FullCommand():
 		if err := refuseArgs(logout.FullCommand(), args); err != nil {
 			return trace.Wrap(err)
@@ -1758,7 +1753,7 @@ func onLogin(cf *CLIConf) error {
 	}
 
 	if cf.IdentityFileIn != "" {
-		return trace.BadParameter("-i flag cannot be used here")
+		return trace.Wrap(flattenIdentity(cf), "converting identity file into a local profile")
 	}
 
 	switch cf.IdentityFormat {
@@ -4142,8 +4137,8 @@ func refuseArgs(command string, args []string) error {
 	return nil
 }
 
-// onFlatten reads an identity file and flattens it into a tsh profile on disk.
-func onFlatten(cf *CLIConf) error {
+// flattenIdentity reads an identity file and flattens it into a tsh profile on disk.
+func flattenIdentity(cf *CLIConf) error {
 	// Save the identity file path for later
 	identityFile := cf.IdentityFileIn
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1122,6 +1122,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// MFA subcommands.
 	mfa := newMFACommand(app)
 
+	flatten := app.Command("flatten", "Flattens an identity file into a profile stored in ~/.tsh or TELEPORT_HOME.")
+
 	config := app.Command("config", "Print OpenSSH configuration details.")
 	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 
@@ -1371,6 +1373,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onListSessions(&cf)
 	case login.FullCommand():
 		err = onLogin(&cf)
+	case flatten.FullCommand():
+		err = onFlatten(&cf)
 	case logout.FullCommand():
 		if err := refuseArgs(logout.FullCommand(), args); err != nil {
 			return trace.Wrap(err)
@@ -3101,9 +3105,7 @@ func onListSessions(cf *CLIConf) error {
 
 func sortAndFilterSessions(sessions []types.SessionTracker, kinds []types.SessionKind) []types.SessionTracker {
 	filtered := slices.DeleteFunc(sessions, func(st types.SessionTracker) bool {
-		return !slices.Contains(kinds, st.GetSessionKind()) ||
-			(st.GetState() != types.SessionState_SessionStateRunning &&
-				st.GetState() != types.SessionState_SessionStatePending)
+		return !slices.Contains(kinds, st.GetSessionKind())
 	})
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].GetCreated().Before(filtered[j].GetCreated())
@@ -4133,6 +4135,51 @@ func refuseArgs(command string, args []string) error {
 			return trace.BadParameter("unexpected argument: %s", arg)
 		}
 	}
+	return nil
+}
+
+// onFlatten reads an identity file and flattens it into a tsh profile on disk.
+func onFlatten(cf *CLIConf) error {
+	// Save the identity file path for later
+	identityFile := cf.IdentityFileIn
+	if identityFile == "" {
+		return trace.BadParameter("-i must be specified")
+	}
+	if cf.Proxy == "" {
+		return trace.BadParameter("--proxy must be specified")
+	}
+
+	// Making a client validates the connection and builds a valid profile for us
+	tc, err := makeClientForProxy(cf, cf.Proxy)
+	if err != nil {
+		return trace.Wrap(err, "making client for proxy")
+	}
+	profile := tc.Profile()
+
+	// We clear the identity flag and create a new client store.
+	// Because the identity flag is unset, it will be backed by the filesystem (in ~/.tsh or TELEPORT_HOME).
+	cf.IdentityFileIn = ""
+	store, err := initClientStore(cf, cf.Proxy)
+	if err != nil {
+		return trace.Wrap(err, "initializing client store")
+	}
+
+	// Now we extract the key from the identity file and load it into our new store.
+	key, err := identityfile.KeyFromIdentityFile(identityFile, cf.Proxy, cf.SiteName)
+	if err != nil {
+		return trace.Wrap(err, "loading key from identity file")
+	}
+
+	if err = store.AddKey(key); err != nil {
+		return trace.Wrap(err, "adding key into the client store")
+	}
+
+	// Finally we also save the profile built by the client into our new store.
+	if err := store.SaveProfile(profile, true); err != nil {
+		return trace.Wrap(err, "saving profile")
+	}
+
+	fmt.Printf("Identity file %q flattented into a tsh profile.", identityFile)
 	return nil
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3105,7 +3105,9 @@ func onListSessions(cf *CLIConf) error {
 
 func sortAndFilterSessions(sessions []types.SessionTracker, kinds []types.SessionKind) []types.SessionTracker {
 	filtered := slices.DeleteFunc(sessions, func(st types.SessionTracker) bool {
-		return !slices.Contains(kinds, st.GetSessionKind())
+		return !slices.Contains(kinds, st.GetSessionKind()) ||
+			(st.GetState() != types.SessionState_SessionStateRunning &&
+				st.GetState() != types.SessionState_SessionStatePending)
 	})
 	sort.Slice(filtered, func(i, j int) bool {
 		return filtered[i].GetCreated().Before(filtered[j].GetCreated())

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1753,7 +1753,11 @@ func onLogin(cf *CLIConf) error {
 	}
 
 	if cf.IdentityFileIn != "" {
-		return trace.Wrap(flattenIdentity(cf), "converting identity file into a local profile")
+		err := flattenIdentity(cf)
+		if err != nil {
+			return trace.Wrap(err, "converting identity file into a local profile")
+		}
+		return nil
 	}
 
 	switch cf.IdentityFormat {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1123,6 +1123,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	mfa := newMFACommand(app)
 
 	flatten := app.Command("flatten", "Flattens an identity file into a profile stored in ~/.tsh or TELEPORT_HOME.")
+	flatten.Arg("identity", "Identity file").StringVar(&cf.IdentityFileIn)
 
 	config := app.Command("config", "Print OpenSSH configuration details.")
 	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
@@ -4145,9 +4146,6 @@ func refuseArgs(command string, args []string) error {
 func onFlatten(cf *CLIConf) error {
 	// Save the identity file path for later
 	identityFile := cf.IdentityFileIn
-	if identityFile == "" {
-		return trace.BadParameter("-i must be specified")
-	}
 	if cf.Proxy == "" {
 		return trace.BadParameter("--proxy must be specified")
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3553,15 +3553,16 @@ func makeClientForProxy(cf *CLIConf, proxy string) (*client.TeleportClient, erro
 
 	// If we are missing client profile information, ping the webproxy
 	// for proxy info and load it into the client config.
-	if profileError != nil || cf.IdentityFileIn != "" {
+	if profileError != nil || profile.MissingClusterDetails {
 		log.Debug("Pinging the proxy to fetch listening addresses for non-web ports.")
 		_, err := tc.Ping(cf.Context)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		// Identityfile uses a placeholder profile. Save missing profile info.
-		if cf.IdentityFileIn != "" {
+		// This is a placeholder profile created from limited cluster details.
+		// Save missing cluster details gathererd during Ping.
+		if profileError == nil && profile.MissingClusterDetails {
 			if err := tc.SaveProfile(true); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -4149,38 +4150,26 @@ func onFlatten(cf *CLIConf) error {
 		return trace.BadParameter("--proxy must be specified")
 	}
 
-	// Making a client validates the connection and builds a valid profile for us
-	tc, err := makeClientForProxy(cf, cf.Proxy)
-	if err != nil {
-		return trace.Wrap(err, "making client for proxy")
-	}
-	profile := tc.Profile()
-
-	// We clear the identity flag and create a new client store.
-	// Because the identity flag is unset, it will be backed by the filesystem (in ~/.tsh or TELEPORT_HOME).
+	// We clear the identity flag so that the client store will be backed
+	// by the filesystem instead (in ~/.tsh or TELEPORT_HOME).
 	cf.IdentityFileIn = ""
-	store, err := initClientStore(cf, cf.Proxy)
+
+	// Load client config as normal to parse client inputs and add defaults.
+	c, err := loadClientConfigFromCLIConf(cf, cf.Proxy)
 	if err != nil {
-		return trace.Wrap(err, "initializing client store")
+		return trace.Wrap(err)
 	}
 
-	// Now we extract the key from the identity file and load it into our new store.
-	key, err := identityfile.KeyFromIdentityFile(identityFile, cf.Proxy, cf.SiteName)
-	if err != nil {
-		return trace.Wrap(err, "loading key from identity file")
+	// Load the identity file key and partial profile into the client store.
+	if err := identityfile.LoadIdentityFileIntoClientStore(c.ClientStore, identityFile, c.WebProxyAddr, c.SiteName); err != nil {
+		return trace.Wrap(err)
 	}
 
-	if err = store.AddKey(key); err != nil {
-		return trace.Wrap(err, "adding key into the client store")
-	}
+	fmt.Printf("Successfully flattened Identity file %q into a tsh profile.\n", identityFile)
 
-	// Finally we also save the profile built by the client into our new store.
-	if err := store.SaveProfile(profile, true); err != nil {
-		return trace.Wrap(err, "saving profile")
-	}
-
-	fmt.Printf("Identity file %q flattented into a tsh profile.", identityFile)
-	return nil
+	// onStatus will ping the proxy to fill in cluster profile information missing in the
+	// client store, then print the login status.
+	return trace.Wrap(onStatus(cf))
 }
 
 // onShow reads an identity file (a public SSH key or a cert) and dumps it to stdout

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5422,3 +5422,61 @@ func Test_formatActiveDB(t *testing.T) {
 		})
 	}
 }
+
+func TestFlatten(t *testing.T) {
+	// Test setup: create a server and a user
+	home := t.TempDir()
+	identityPath := filepath.Join(t.TempDir(), "identity.pem")
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"access"})
+
+	connector := mockConnector(t)
+
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Test setup: log in and obtain a valid identity for the user
+	conf := CLIConf{
+		Username:           alice.GetName(),
+		Proxy:              proxyAddr.String(),
+		InsecureSkipVerify: true,
+		IdentityFileOut:    identityPath,
+		IdentityFormat:     identityfile.FormatFile,
+		HomePath:           home,
+		AuthConnector:      connector.GetName(),
+		MockSSOLogin:       mockSSOLogin(t, authServer, alice),
+		Context:            context.Background(),
+	}
+	require.NoError(t, onLogin(&conf))
+
+	// Test setup: validate we got a valid identity
+	_, err = identityfile.KeyFromIdentityFile(identityPath, "proxy.example.com", "")
+	require.NoError(t, err)
+
+	// Test execution: flatten the identity previously obtained in a new home.
+	freshHome := t.TempDir()
+	conf = CLIConf{
+		Proxy:              proxyAddr.String(),
+		InsecureSkipVerify: true,
+		IdentityFileIn:     identityPath,
+		HomePath:           freshHome,
+		Context:            context.Background(),
+	}
+	require.NoError(t, onFlatten(&conf))
+
+	// Test execution: validate that the newly created profile can be used to build a valid client.
+	clt, err := makeClient(&conf)
+	require.NoError(t, err)
+
+	_, err = clt.Ping(context.Background())
+	require.NoError(t, err)
+
+	// Test execution: validate that flattening fails if a profile already exists.
+	require.Error(t, onFlatten(&conf), "expecting an error when overwriting an existing profile")
+}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5450,7 +5450,7 @@ func TestFlatten(t *testing.T) {
 		IdentityFormat:     identityfile.FormatFile,
 		HomePath:           home,
 		AuthConnector:      connector.GetName(),
-		MockSSOLogin:       mockSSOLogin(t, authServer, alice),
+		MockSSOLogin:       mockSSOLogin(authServer, alice),
 		Context:            context.Background(),
 	}
 	require.NoError(t, onLogin(&conf))

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5477,6 +5477,7 @@ func TestFlatten(t *testing.T) {
 	_, err = clt.Ping(context.Background())
 	require.NoError(t, err)
 
-	// Test execution: validate that flattening fails if a profile already exists.
-	require.Error(t, onFlatten(&conf), "expecting an error when overwriting an existing profile")
+	// Test execution: validate that flattening succeeds if a profile already exists.
+	conf.IdentityFileIn = identityPath
+	require.NoError(t, onFlatten(&conf), "unexpected error when overwriting a tsh profile with tsh flatten")
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5450,7 +5450,7 @@ func TestFlatten(t *testing.T) {
 		IdentityFormat:     identityfile.FormatFile,
 		HomePath:           home,
 		AuthConnector:      connector.GetName(),
-		MockSSOLogin:       mockSSOLogin(authServer, alice),
+		MockSSOLogin:       mockSSOLogin(t, authServer, alice),
 		Context:            context.Background(),
 	}
 	require.NoError(t, onLogin(&conf))

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5468,7 +5468,7 @@ func TestFlatten(t *testing.T) {
 		HomePath:           freshHome,
 		Context:            context.Background(),
 	}
-	require.NoError(t, onFlatten(&conf))
+	require.NoError(t, flattenIdentity(&conf))
 
 	// Test execution: validate that the newly created profile can be used to build a valid client.
 	clt, err := makeClient(&conf)
@@ -5479,5 +5479,5 @@ func TestFlatten(t *testing.T) {
 
 	// Test execution: validate that flattening succeeds if a profile already exists.
 	conf.IdentityFileIn = identityPath
-	require.NoError(t, onFlatten(&conf), "unexpected error when overwriting a tsh profile with tsh flatten")
+	require.NoError(t, flattenIdentity(&conf), "unexpected error when overwriting a tsh profile")
 }


### PR DESCRIPTION
Backport #39024 to branch/v15

changelog: Support logging in with an identity file with `tsh login -i identity.pem`. This allows running `tsh app login` in CI environments where MachineID is impossible.
