### PR TITLE
Improve error messaging when creating or updating resources fails

### DIFF
--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -90,6 +90,10 @@ func (s *AppService) CreateApp(ctx context.Context, app types.Application) error
 		ID:      app.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("app %q already exists", app.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,10 @@ func (s *AppService) UpdateApp(ctx context.Context, app types.Application) error
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("app %q doesn't exist", app.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -90,6 +90,10 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, database types.Dat
 		ID:      database.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("database %q already exists", database.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,10 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, database types.Dat
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("database %q doesn't exist", database.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -82,6 +82,10 @@ func (s *WindowsDesktopService) CreateWindowsDesktop(ctx context.Context, deskto
 		ID:      desktop.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("windows desktop %q %q doesn't exist", desktop.GetHostID(), desktop.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -106,6 +110,10 @@ func (s *WindowsDesktopService) UpdateWindowsDesktop(ctx context.Context, deskto
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("windows desktop %q %q  doesn't exist", desktop.GetHostID(), desktop.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -90,6 +90,10 @@ func (s *KubernetesService) CreateKubernetesCluster(ctx context.Context, cluster
 		ID:      cluster.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("kubernetes cluster %q already exists", cluster.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,9 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("kubernetes cluster %q doesn't exist", cluster.GetName())
+	}
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
There have been a few support questions raised recently about very confusing error messages similar to the following:

```
RespMetadata: {
   StatusCode: 400,
    RequestID: &#34;FVRLJR89DF3H16H4NS9I2SM6R7VV4KQNSO5AEMVJF66Q9ASUAAJG&#34;
  },
Message_: &#34;The conditional request failed&#34;
}, failed to create db <db>
ConditionalCheckFailedException: The conditional request failed
```

This error is returned because a resource that already exists is trying to be created again, and when DynamoDB detects this it returns a ConditionalCheckFailedException. Instead of returning these confusing error messages directly to users we can intercept them and provide a clearer message.

Apps, Databases, Desktops and KubernetesClusters have all been updated to catch AlreadyExists errors on Create and NotFound errors on Update and alter the message returned to something similar to `resource "foo" does not exist` or `resource "foo" already exists`.


Changelog: improve error messaging when creating resources fails because they already exist or updating resources fails because they were removed