### PR TITLE
Web: add another date config

### DIFF
--- a/web/packages/shared/config.js
+++ b/web/packages/shared/config.js
@@ -20,6 +20,8 @@ const cfg = {
   dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
   dateFormat: 'yyyy-MM-dd',
   shortFormat: 'MMM dd, yyyy',
+  // Displays time as 12/25/2024 at 12:00AM
+  dateWithPrefixedTime: `LL/dd/yyyy 'at' h:mma`,
 };
 
 export default cfg;


### PR DESCRIPTION
from a figma design, to be used with `assume start time`.

I know we are adding yet another date style, i created an issue: https://github.com/gravitational/teleport/issues/39326, and planning to ask on coming tuesday UX design meeting about unifying date styles.

