### PR TITLE
[v15] Improve error messaging when creating or updating resources fails

### DIFF
--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -90,6 +90,10 @@ func (s *AppService) CreateApp(ctx context.Context, app types.Application) error
 		ID:      app.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("app %q already exists", app.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,10 @@ func (s *AppService) UpdateApp(ctx context.Context, app types.Application) error
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("app %q doesn't exist", app.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -90,6 +90,10 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, database types.Dat
 		ID:      database.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("database %q already exists", database.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,10 @@ func (s *DatabaseService) UpdateDatabase(ctx context.Context, database types.Dat
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("database %q doesn't exist", database.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -82,6 +82,10 @@ func (s *WindowsDesktopService) CreateWindowsDesktop(ctx context.Context, deskto
 		ID:      desktop.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("windows desktop %q %q doesn't exist", desktop.GetHostID(), desktop.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -106,6 +110,10 @@ func (s *WindowsDesktopService) UpdateWindowsDesktop(ctx context.Context, deskto
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("windows desktop %q %q  doesn't exist", desktop.GetHostID(), desktop.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -90,6 +90,10 @@ func (s *KubernetesService) CreateKubernetesCluster(ctx context.Context, cluster
 		ID:      cluster.GetResourceID(),
 	}
 	_, err = s.Create(ctx, item)
+	if trace.IsAlreadyExists(err) {
+		return trace.AlreadyExists("kubernetes cluster %q already exists", cluster.GetName())
+	}
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,6 +118,9 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 		Revision: rev,
 	}
 	_, err = s.Update(ctx, item)
+	if trace.IsNotFound(err) {
+		return trace.NotFound("kubernetes cluster %q doesn't exist", cluster.GetName())
+	}
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #39379 to branch/v15

changelog: improve error messaging when creating resources fails because they already exist or updating resources fails because they were removed
