### PR TITLE
[v15] Cluster config service

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -124,7 +124,7 @@ type ReadNodeAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
@@ -182,7 +182,7 @@ type ReadProxyAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetUIConfig returns configuration for the UI served by the proxy service
 	GetUIConfig(ctx context.Context) (types.UIConfig, error)
@@ -339,7 +339,7 @@ type ReadRemoteProxyAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
@@ -430,7 +430,7 @@ type ReadKubernetesAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
@@ -496,7 +496,7 @@ type ReadAppsAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
@@ -563,7 +563,7 @@ type ReadDatabaseAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
@@ -630,7 +630,7 @@ type ReadWindowsDesktopAccessPoint interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
@@ -896,7 +896,7 @@ type AccessCache interface {
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -927,7 +927,7 @@ type Cache interface {
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetNamespaces returns a list of namespaces
 	GetNamespaces() ([]types.Namespace, error)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -118,7 +118,7 @@ type ReadNodeAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -176,7 +176,7 @@ type ReadProxyAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -333,7 +333,7 @@ type ReadRemoteProxyAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -424,7 +424,7 @@ type ReadKubernetesAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -490,7 +490,7 @@ type ReadAppsAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -557,7 +557,7 @@ type ReadDatabaseAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -624,7 +624,7 @@ type ReadWindowsDesktopAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -893,7 +893,7 @@ type AccessCache interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
@@ -921,7 +921,7 @@ type Cache interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4465,13 +4465,13 @@ func (a *ServerWithRoles) ResetClusterNetworkingConfig(ctx context.Context) erro
 }
 
 // GetSessionRecordingConfig gets session recording configuration.
-func (a *ServerWithRoles) GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error) {
+func (a *ServerWithRoles) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
 	if err := a.action(apidefaults.Namespace, types.KindSessionRecordingConfig, types.VerbRead); err != nil {
 		if err2 := a.action(apidefaults.Namespace, types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetSessionRecordingConfig(ctx, opts...)
+	return a.authServer.GetSessionRecordingConfig(ctx)
 }
 
 // SetSessionRecordingConfig sets session recording configuration.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4402,13 +4402,13 @@ func (a *ServerWithRoles) GetClusterAuditConfig(ctx context.Context, opts ...ser
 }
 
 // GetClusterNetworkingConfig gets cluster networking configuration.
-func (a *ServerWithRoles) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (a *ServerWithRoles) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	if err := a.action(apidefaults.Namespace, types.KindClusterNetworkingConfig, types.VerbRead); err != nil {
 		if err2 := a.action(apidefaults.Namespace, types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetClusterNetworkingConfig(ctx, opts...)
+	return a.authServer.GetClusterNetworkingConfig(ctx)
 }
 
 // SetClusterNetworkingConfig sets cluster networking configuration.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -431,7 +431,7 @@ func (c *Client) GetClusterAuditConfig(ctx context.Context, opts ...services.Mar
 }
 
 // GetClusterNetworkingConfig gets cluster networking configuration.
-func (c *Client) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (c *Client) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	return c.APIClient.GetClusterNetworkingConfig(ctx)
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -436,7 +436,7 @@ func (c *Client) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterN
 }
 
 // GetSessionRecordingConfig gets session recording configuration.
-func (c *Client) GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error) {
+func (c *Client) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
 	return c.APIClient.GetSessionRecordingConfig(ctx)
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -154,6 +154,54 @@ func (c *Client) Close() error {
 	return c.APIClient.Close()
 }
 
+func (c *Client) CreateAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertAuthPreference(context.Context, types.AuthPreference) (types.AuthPreference, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertSessionRecordingConfig(context.Context, types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertClusterAuditConfig(context.Context, types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) CreateClusterNetworkingConfig(context.Context, types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpdateClusterNetworkingConfig(ctx context.Context, preference types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+func (c *Client) UpsertClusterNetworkingConfig(ctx context.Context, preference types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
 // CreateCertAuthority not implemented: can only be called locally.
 func (c *Client) CreateCertAuthority(ctx context.Context, ca types.CertAuthority) error {
 	return trace.NotImplemented(notImplementedMessage)

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -1,0 +1,260 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/modules"
+)
+
+// Cache is used by the [Service] to query cluster config resources.
+type Cache interface {
+	GetAuthPreference(context.Context) (types.AuthPreference, error)
+}
+
+// Backend is used by the [Service] to mutate cluster config resources.
+type Backend interface {
+	CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+}
+
+// ServiceConfig contain dependencies required to create a [Service].
+type ServiceConfig struct {
+	Cache      Cache
+	Backend    Backend
+	Authorizer authz.Authorizer
+}
+
+// Service implements the teleport.clusterconfig.v1.ClusterConfigService RPC service.
+type Service struct {
+	clusterconfigpb.UnimplementedClusterConfigServiceServer
+
+	cache      Cache
+	backend    Backend
+	authorizer authz.Authorizer
+}
+
+// NewService validates the provided configuration and returns a [Service].
+func NewService(cfg ServiceConfig) (*Service, error) {
+	switch {
+	case cfg.Cache == nil:
+		return nil, trace.BadParameter("cache service is required")
+	case cfg.Backend == nil:
+		return nil, trace.BadParameter("backend service is required")
+	case cfg.Authorizer == nil:
+		return nil, trace.BadParameter("authorizer is required")
+	}
+
+	return &Service{cache: cfg.Cache, backend: cfg.Backend, authorizer: cfg.Authorizer}, nil
+}
+
+// GetAuthPreference returns the locally cached auth preference.
+func (s Service) GetAuthPreference(ctx context.Context, _ *clusterconfigpb.GetAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pref, err := s.cache.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := pref.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", pref, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// CreateAuthPreference creates a new auth preference if one does not exist. This
+// is an internal API and is not exposed via [clusterconfigv1.ClusterConfigServiceServer]. It
+// is only meant to be called directly from the first time an Auth instance is started.
+func (s Service) CreateAuthPreference(ctx context.Context, p types.AuthPreference) (types.AuthPreference, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzCtx, string(types.RoleAuth)) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if p.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(p.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := s.backend.CreateAuthPreference(ctx, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := created.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", created, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// UpdateAuthPreference conditional updates an existing auth preference if the value
+// wasn't concurrently modified.
+func (s Service) UpdateAuthPreference(ctx context.Context, req *clusterconfigpb.UpdateAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if req.AuthPreference.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req.AuthPreference.SetOrigin(types.OriginDynamic)
+
+	updated, err := s.backend.UpdateAuthPreference(ctx, req.AuthPreference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := updated.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", updated, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+func (s Service) UpsertAuthPreference(ctx context.Context, req *clusterconfigpb.UpsertAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Support reused MFA for bulk tctl create requests.
+	if err := authzCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// check that the given RequireMFAType is supported in this build.
+	if req.AuthPreference.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
+	}
+
+	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req.AuthPreference.SetOrigin(types.OriginDynamic)
+
+	updated, err := s.backend.UpsertAuthPreference(ctx, req.AuthPreference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPrefV2, ok := updated.(*types.AuthPreferenceV2)
+	if !ok {
+		return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", updated, authPrefV2))
+	}
+
+	return authPrefV2, nil
+}
+
+// ResetAuthPreference restores the auth preferences to the default value.
+func (s Service) ResetAuthPreference(ctx context.Context, req *clusterconfigpb.ResetAuthPreferenceRequest) (*types.AuthPreferenceV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	defaultPreference := types.DefaultAuthPreference()
+	const iterationLimit = 3
+	// Attempt a few iterations in case the conditional update fails
+	// due to spurious networking conditions.
+	for i := 0; i < iterationLimit; i++ {
+		pref, err := s.cache.GetAuthPreference(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if pref.Origin() == types.OriginConfigFile {
+			return nil, trace.BadParameter("auth preference has been defined via the config file and cannot be reset back to defaults dynamically.")
+		}
+
+		defaultPreference.SetRevision(pref.GetRevision())
+
+		reset, err := s.backend.UpdateAuthPreference(ctx, defaultPreference)
+		if err != nil {
+			if trace.IsCompareFailed(err) {
+				continue
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		authPrefV2, ok := reset.(*types.AuthPreferenceV2)
+		if !ok {
+			return nil, trace.Wrap(trace.BadParameter("unexpected auth preference type %T (expected %T)", reset, authPrefV2))
+		}
+
+		return authPrefV2, nil
+	}
+
+	return nil, trace.LimitExceeded("failed to reset networking config within %v iterations", iterationLimit)
+}

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -1,0 +1,580 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestCreateAuthPreference(t *testing.T) {
+	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+		Role:     types.RoleAuth,
+		Username: string(types.RoleAuth),
+	}, nil)
+	require.NoError(t, err, "creating auth role context")
+
+	cases := []struct {
+		name       string
+		modules    modules.Modules
+		authorizer authz.Authorizer
+		preference func(p types.AuthPreference)
+		assertion  func(t *testing.T, created types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized built in role",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authz.ContextForBuiltinRole(authz.BuiltinRole{
+					Role:     types.RoleProxy,
+					Username: string(types.RoleProxy),
+				}, nil)
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating auth preferences", err)
+			},
+		},
+		{
+			name: "authorized built in auth",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected hardware key policy to be rejected in OSS", err)
+			},
+		},
+		{
+			name: "creation allowed when hardware key policy is set in enterprise",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.SetDeviceTrust(&types.DeviceTrust{
+					Mode: constants.DeviceTrustModeRequired,
+				})
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected device trust mode conflict to prevent creation", err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.modules != nil {
+				modules.SetTestModules(t, test.modules)
+			}
+
+			var opts []serviceOpt
+			if test.authorizer != nil {
+				opts = append(opts, withAuthorizer(test.authorizer))
+			}
+
+			env, err := newTestEnv(opts...)
+			require.NoError(t, err, "creating test service")
+
+			pref := types.DefaultAuthPreference()
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			created, err := env.CreateAuthPreference(context.Background(), pref)
+			test.assertion(t, created, err)
+		})
+	}
+}
+
+func TestGetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), unauthorized user to be prevented from getting auth preferences", err)
+			},
+		}, {
+			name: "authorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetAuthPreference(context.Background(), &clusterconfigpb.GetAuthPreferenceRequest{})
+			test.assertion(t, err)
+			if err == nil {
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			}
+		})
+	}
+}
+
+func TestUpdateAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "updated",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpdateAuthPreference(context.Background(), &clusterconfigpb.UpdateAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestUpsertAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "access prevented",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "upserted",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpsertAuthPreference(context.Background(), &clusterconfigpb.UpsertAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestResetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		modules    modules.Modules
+		preference types.AuthPreference
+		assertion  func(t *testing.T, reset types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "config file origin prevents reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func() types.AuthPreference {
+				p := types.DefaultAuthPreference()
+				p.SetOrigin(types.OriginConfigFile)
+				return p
+			}(),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			p := types.DefaultAuthPreference()
+			if test.preference != nil {
+				p = test.preference
+			}
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(p))
+			require.NoError(t, err, "creating test service")
+
+			reset, err := env.ResetAuthPreference(context.Background(), &clusterconfigpb.ResetAuthPreferenceRequest{})
+			test.assertion(t, reset, err)
+		})
+	}
+}
+
+type fakeChecker struct {
+	services.AccessChecker
+	rules map[string][]string
+}
+
+func (f fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string) error {
+	verbs, ok := f.rules[kind]
+	if !ok {
+		return trace.AccessDenied("no allow rules for kind")
+	}
+
+	if !slices.Contains(verbs, verb) {
+		return trace.AccessDenied("verb %s not allowed", verb)
+	}
+
+	return nil
+}
+
+type envConfig struct {
+	authorizer            authz.Authorizer
+	defaultAuthPreference types.AuthPreference
+}
+type serviceOpt = func(config *envConfig)
+
+func withAuthorizer(authz authz.Authorizer) serviceOpt {
+	return func(config *envConfig) {
+		config.authorizer = authz
+	}
+}
+
+func withDefaultAuthPreference(p types.AuthPreference) serviceOpt {
+	return func(config *envConfig) {
+		config.defaultAuthPreference = p
+	}
+}
+
+type env struct {
+	*clusterconfigv1.Service
+	backend           clusterconfigv1.Backend
+	defaultPreference types.AuthPreference
+}
+
+func newTestEnv(opts ...serviceOpt) (*env, error) {
+	bk, err := memory.New(memory.Config{})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating memory backend")
+	}
+
+	storage, err := local.NewClusterConfigurationService(bk)
+	if err != nil {
+		return nil, trace.Wrap(err, "created cluster configuration storage service")
+	}
+
+	var cfg envConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	service := struct{ services.ClusterConfiguration }{ClusterConfiguration: storage}
+	svc, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
+		Cache:      service,
+		Backend:    service,
+		Authorizer: cfg.authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating users service")
+	}
+
+	var defaultPreference types.AuthPreference
+	if cfg.defaultAuthPreference != nil {
+		defaultPreference, err = service.CreateAuthPreference(context.Background(), cfg.defaultAuthPreference)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating default auth preference")
+		}
+	}
+
+	return &env{
+		Service:           svc,
+		backend:           service,
+		defaultPreference: defaultPreference,
+	}, nil
+}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev12 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
@@ -68,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/assist/assistv1"
+	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/auth/dbobjectimportrule/dbobjectimportrulev1"
 	"github.com/gravitational/teleport/lib/auth/discoveryconfig/discoveryconfigv1"
 	integrationService "github.com/gravitational/teleport/lib/auth/integration/integrationv1"
@@ -5687,6 +5689,8 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	userspb.RegisterUsersServiceServer(server, usersService)
+
 	botService, err := machineidv1.NewBotService(machineidv1.BotServiceConfig{
 		Authorizer: cfg.Authorizer,
 		Cache:      cfg.AuthServer.Cache,
@@ -5837,7 +5841,16 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	userloginstatev1.RegisterUserLoginStateServiceServer(server, userLoginStateServer)
 
-	userspb.RegisterUsersServiceServer(server, usersService)
+	clusterConfigService, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
+		Cache:      cfg.AuthServer.Cache,
+		Backend:    cfg.AuthServer.Services,
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clusterconfigpb.RegisterClusterConfigServiceServer(server, clusterConfigService)
 
 	// Only register the service if this is an open source build. Enterprise builds
 	// register the actual service via an auth plugin, if we register here then all

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1221,10 +1221,23 @@ func TestAuthPreferenceSettings(t *testing.T) {
 	clt, err := testSrv.NewClient(TestAdmin())
 	require.NoError(t, err)
 
-	suite := &suite.ServicesTestSuite{
-		ConfigS: clt,
-	}
-	suite.AuthPreference(t)
+	ctx := context.Background()
+	ap, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
+		Type:                  "local",
+		SecondFactor:          "otp",
+		DisconnectExpiredCert: types.NewBoolOption(true),
+	})
+	require.NoError(t, err)
+
+	err = clt.SetAuthPreference(ctx, ap)
+	require.NoError(t, err)
+
+	gotAP, err := clt.GetAuthPreference(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "local", gotAP.GetType())
+	require.Equal(t, constants.SecondFactorOTP, gotAP.GetSecondFactor())
+	require.True(t, gotAP.GetDisconnectExpiredCert())
 }
 
 func TestTunnelConnectionsCRUD(t *testing.T) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -150,7 +150,7 @@ type AuthorizerAccessPoint interface {
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -153,7 +153,7 @@ type AuthorizerAccessPoint interface {
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 }
 
 // MFAAuthenticator authenticates MFA responses.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1786,7 +1786,7 @@ func (c *Cache) GetClusterAuditConfig(ctx context.Context, opts ...services.Mars
 }
 
 // GetClusterNetworkingConfig gets ClusterNetworkingConfig from the backend.
-func (c *Cache) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (c *Cache) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetClusterNetworkingConfig")
 	defer span.End()
 
@@ -1797,7 +1797,7 @@ func (c *Cache) GetClusterNetworkingConfig(ctx context.Context, opts ...services
 	defer rg.Release()
 	if !rg.IsCacheRead() {
 		cachedCfg, err := utils.FnCacheGet(ctx, c.fnCache, clusterConfigCacheKey{"networking"}, func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
-			cfg, err := rg.reader.GetClusterNetworkingConfig(ctx, opts...)
+			cfg, err := rg.reader.GetClusterNetworkingConfig(ctx)
 			return cfg, err
 		})
 		if err != nil {
@@ -1805,7 +1805,7 @@ func (c *Cache) GetClusterNetworkingConfig(ctx context.Context, opts ...services
 		}
 		return cachedCfg.Clone(), nil
 	}
-	return rg.reader.GetClusterNetworkingConfig(ctx, opts...)
+	return rg.reader.GetClusterNetworkingConfig(ctx)
 }
 
 // GetClusterName gets the name of the cluster from the backend.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2462,7 +2462,7 @@ func (c *Cache) GetAuthPreference(ctx context.Context) (types.AuthPreference, er
 }
 
 // GetSessionRecordingConfig gets session recording configuration.
-func (c *Cache) GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error) {
+func (c *Cache) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetSessionRecordingConfig")
 	defer span.End()
 
@@ -2471,7 +2471,7 @@ func (c *Cache) GetSessionRecordingConfig(ctx context.Context, opts ...services.
 		return nil, trace.Wrap(err)
 	}
 	defer rg.Release()
-	return rg.reader.GetSessionRecordingConfig(ctx, opts...)
+	return rg.reader.GetSessionRecordingConfig(ctx)
 }
 
 // GetNetworkRestrictions gets the network restrictions.

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1774,7 +1774,7 @@ func (clusterNetworkingConfigExecutor) getReader(cache *Cache, cacheOK bool) clu
 }
 
 type clusterNetworkingConfigGetter interface {
-	GetClusterNetworkingConfig(context.Context, ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error)
 }
 
 var _ executor[types.ClusterNetworkingConfig, clusterNetworkingConfigGetter] = clusterNetworkingConfigExecutor{}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1848,7 +1848,7 @@ func (sessionRecordingConfigExecutor) getReader(cache *Cache, cacheOK bool) sess
 }
 
 type sessionRecordingConfigGetter interface {
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 }
 
 var _ executor[types.SessionRecordingConfig, sessionRecordingConfigGetter] = sessionRecordingConfigExecutor{}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1209,7 +1209,7 @@ type mockAccessPoint struct {
 	cas             map[string]types.CertAuthority
 }
 
-func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context, ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error) {
 	return ap.netConfig, nil
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1213,7 +1213,7 @@ func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context) (types.Clu
 	return ap.netConfig, nil
 }
 
-func (ap mockAccessPoint) GetSessionRecordingConfig(context.Context, ...services.MarshalOption) (types.SessionRecordingConfig, error) {
+func (ap mockAccessPoint) GetSessionRecordingConfig(context.Context) (types.SessionRecordingConfig, error) {
 	return ap.recordingConfig, nil
 }
 

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -384,7 +384,7 @@ func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, check
 // for a reversetunnelclient.RemoteSite. It makes testing easier.
 type site interface {
 	GetNodes(ctx context.Context, fn func(n services.Node) bool) ([]types.Server, error)
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 }
 
 // remoteSite is a site implementation that wraps
@@ -404,13 +404,13 @@ func (r remoteSite) GetNodes(ctx context.Context, fn func(n services.Node) bool)
 }
 
 // GetClusterNetworkingConfig uses the wrapped sites cache to retrieve the ClusterNetworkingConfig
-func (r remoteSite) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (r remoteSite) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	ap, err := r.site.CachingAccessPoint()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := ap.GetClusterNetworkingConfig(ctx, opts...)
+	cfg, err := ap.GetClusterNetworkingConfig(ctx)
 	return cfg, trace.Wrap(err)
 }
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -47,7 +47,7 @@ type testSite struct {
 	nodes []types.Server
 }
 
-func (t testSite) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (t testSite) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	return t.cfg, nil
 }
 

--- a/lib/reversetunnel/agent_dialer_test.go
+++ b/lib/reversetunnel/agent_dialer_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -124,6 +123,6 @@ func (fc *fakeClient) GetCertAuthorities(ctx context.Context, caType types.CertA
 	return []types.CertAuthority{ca}, nil
 }
 
-func (fc *fakeClient) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (fc *fakeClient) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	return types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{})
 }

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -65,7 +64,7 @@ type mockClient struct {
 	mockGetClusterNetworkingConfig func(context.Context) (types.ClusterNetworkingConfig, error)
 }
 
-func (c *mockClient) GetClusterNetworkingConfig(ctx context.Context, _ ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (c *mockClient) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	if c.mockGetClusterNetworkingConfig != nil {
 		return c.mockGetClusterNetworkingConfig(ctx)
 	}

--- a/lib/service/proxy_settings.go
+++ b/lib/service/proxy_settings.go
@@ -28,13 +28,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 // networkConfigGetter is a helper interface that allows to fetch the current proxy configuration.
 type networkConfigGetter interface {
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 }
 
 // proxySettings is a helper type that allows to fetch the current proxy configuration.

--- a/lib/service/proxy_settings_test.go
+++ b/lib/service/proxy_settings_test.go
@@ -27,14 +27,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 type accessPointMock struct{}
 
 // GetClusterNetworkingConfig returns a cluster config.
-func (a *accessPointMock) GetClusterNetworkingConfig(_ context.Context, _ ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (a *accessPointMock) GetClusterNetworkingConfig(_ context.Context) (types.ClusterNetworkingConfig, error) {
 	return &types.ClusterNetworkingConfigV2{
 		Spec: types.ClusterNetworkingConfigSpecV2{
 			RoutingStrategy: types.RoutingStrategy_MOST_RECENT,

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -95,7 +95,7 @@ type ClusterConfiguration interface {
 	DeleteClusterAuditConfig(ctx context.Context) error
 
 	// GetClusterNetworkingConfig gets ClusterNetworkingConfig from the backend.
-	GetClusterNetworkingConfig(context.Context, ...MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error)
 	// CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.
 	CreateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
 	// UpdateClusterNetworkingConfig updates an existing cluster networking config.

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -28,7 +28,7 @@ import (
 // the resources modified by this interface can only have a single instance
 // in the backend.
 type ClusterConfiguration interface {
-	// SetClusterName gets services.ClusterName from the backend.
+	// GetClusterName gets types.ClusterName from the backend.
 	GetClusterName(opts ...MarshalOption) (types.ClusterName, error)
 	// SetClusterName sets services.ClusterName on the backend.
 	SetClusterName(types.ClusterName) error
@@ -54,28 +54,56 @@ type ClusterConfiguration interface {
 
 	// GetAuthPreference gets types.AuthPreference from the backend.
 	GetAuthPreference(context.Context) (types.AuthPreference, error)
+	// CreateAuthPreference creates an auth preference if once does not already exist.
+	CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	// UpdateAuthPreference updates an existing auth preference.
+	UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
+	// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+	UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error)
 	// SetAuthPreference sets types.AuthPreference from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetAuthPreference(context.Context, types.AuthPreference) error
 	// DeleteAuthPreference deletes types.AuthPreference from the backend.
 	DeleteAuthPreference(ctx context.Context) error
 
 	// GetSessionRecordingConfig gets SessionRecordingConfig from the backend.
 	GetSessionRecordingConfig(context.Context, ...MarshalOption) (types.SessionRecordingConfig, error)
+	// CreateSessionRecordingConfig creates a session recording config if once does not already exist.
+	CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
+	// UpdateSessionRecordingConfig updates an existing session recording config.
+	UpdateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
+	// UpsertSessionRecordingConfig creates a new session recording config or overwrites the existing session recording.
+	UpsertSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
 	// SetSessionRecordingConfig sets SessionRecordingConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetSessionRecordingConfig(context.Context, types.SessionRecordingConfig) error
 	// DeleteSessionRecordingConfig deletes SessionRecordingConfig from the backend.
 	DeleteSessionRecordingConfig(ctx context.Context) error
 
 	// GetClusterAuditConfig gets ClusterAuditConfig from the backend.
 	GetClusterAuditConfig(context.Context, ...MarshalOption) (types.ClusterAuditConfig, error)
+	// CreateClusterAuditConfig creates a cluster audit config if once does not already exist.
+	CreateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
+	// UpdateClusterAuditConfig updates an existing cluster audit config.
+	UpdateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
+	// UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
+	UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error)
 	// SetClusterAuditConfig sets ClusterAuditConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetClusterAuditConfig(context.Context, types.ClusterAuditConfig) error
 	// DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
 	DeleteClusterAuditConfig(ctx context.Context) error
 
 	// GetClusterNetworkingConfig gets ClusterNetworkingConfig from the backend.
 	GetClusterNetworkingConfig(context.Context, ...MarshalOption) (types.ClusterNetworkingConfig, error)
+	// CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.
+	CreateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
+	// UpdateClusterNetworkingConfig updates an existing cluster networking config.
+	UpdateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
+	// UpsertClusterNetworkingConfig creates a new cluster networking config or overwrites the existing cluster networking config.
+	UpsertClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error)
 	// SetClusterNetworkingConfig sets ClusterNetworkingConfig from the backend.
+	// TODO(tross): Deprecate/Remove this once everything is converted to use the new methods.
 	SetClusterNetworkingConfig(context.Context, types.ClusterNetworkingConfig) error
 	// DeleteClusterNetworkingConfig deletes ClusterNetworkingConfig from the backend.
 	DeleteClusterNetworkingConfig(ctx context.Context) error

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -67,7 +67,7 @@ type ClusterConfiguration interface {
 	DeleteAuthPreference(ctx context.Context) error
 
 	// GetSessionRecordingConfig gets SessionRecordingConfig from the backend.
-	GetSessionRecordingConfig(context.Context, ...MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(context.Context) (types.SessionRecordingConfig, error)
 	// CreateSessionRecordingConfig creates a session recording config if once does not already exist.
 	CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error)
 	// UpdateSessionRecordingConfig updates an existing session recording config.

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -494,7 +494,7 @@ func (s *ClusterConfigurationService) DeleteClusterNetworkingConfig(ctx context.
 }
 
 // GetSessionRecordingConfig gets session recording config from the backend.
-func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error) {
+func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
 	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, sessionRecordingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -502,7 +502,7 @@ func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Cont
 		}
 		return nil, trace.Wrap(err)
 	}
-	return services.UnmarshalSessionRecordingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
+	return services.UnmarshalSessionRecordingConfig(item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))
 }
 
 // CreateSessionRecordingConfig creates a session recording config if once does not already exist.

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -258,14 +258,16 @@ func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, 
 		return nil, trace.Wrap(err)
 	}
 
+	rev := preference.GetRevision()
 	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
-		Value: value,
+		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value:    value,
+		Revision: rev,
 	}
 
 	lease, err := s.Put(ctx, item)
@@ -352,14 +354,16 @@ func (s *ClusterConfigurationService) UpdateClusterAuditConfig(ctx context.Conte
 
 // UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
 func (s *ClusterConfigurationService) UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	rev := cfg.GetRevision()
 	value, err := services.MarshalClusterAuditConfig(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
-		Value: value,
+		Key:      backend.Key(clusterConfigPrefix, auditPrefix),
+		Value:    value,
+		Revision: rev,
 	}
 
 	lease, err := s.Backend.Put(ctx, item)
@@ -455,14 +459,16 @@ func (s *ClusterConfigurationService) UpsertClusterNetworkingConfig(ctx context.
 		return nil, trace.Wrap(err)
 	}
 
+	rev := cfg.GetRevision()
 	value, err := services.MarshalClusterNetworkingConfig(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
-		Value: value,
+		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value:    value,
+		Revision: rev,
 	}
 
 	lease, err := s.Backend.Put(ctx, item)
@@ -566,14 +572,16 @@ func (s *ClusterConfigurationService) UpsertSessionRecordingConfig(ctx context.C
 		return nil, trace.Wrap(err)
 	}
 
+	rev := cfg.GetRevision()
 	value, err := services.MarshalSessionRecordingConfig(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
-		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
-		Value: value,
+		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value:    value,
+		Revision: rev,
 	}
 
 	lease, err := s.Backend.Put(ctx, item)

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -191,31 +191,90 @@ func (s *ClusterConfigurationService) GetAuthPreference(ctx context.Context) (ty
 
 // SetAuthPreference sets the cluster authentication preferences
 // on the backend.
-func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, preferences types.AuthPreference) error {
+func (s *ClusterConfigurationService) SetAuthPreference(ctx context.Context, preference types.AuthPreference) error {
+	_, err := s.UpsertAuthPreference(ctx, preference)
+	return trace.Wrap(err)
+}
+
+// CreateAuthPreference creates an auth preference if once does not already exist.
+func (s *ClusterConfigurationService) CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
 	// Perform the modules-provided checks.
-	rev := preferences.GetRevision()
-	if err := modules.ValidateResource(preferences); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	value, err := services.MarshalAuthPreference(preferences)
+	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	preference.SetRevision(lease.Revision)
+	return preference, nil
+}
+
+// UpdateAuthPreference updates an existing auth preference.
+func (s *ClusterConfigurationService) UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
+	// Perform the modules-provided checks.
+	rev := preference.GetRevision()
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalAuthPreference(preference)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(authPrefix, preferencePrefix, generalPrefix),
 		Value:    value,
-		ID:       preferences.GetResourceID(),
+		ID:       preference.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return nil
+	preference.SetRevision(lease.Revision)
+	return preference, nil
+}
+
+// UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
+func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(preference); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalAuthPreference(preference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(authPrefix, preferencePrefix, generalPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	preference.SetRevision(lease.Revision)
+	return preference, nil
 }
 
 // DeleteAuthPreference deletes types.AuthPreference from the backend.
@@ -243,25 +302,73 @@ func (s *ClusterConfigurationService) GetClusterAuditConfig(ctx context.Context,
 }
 
 // SetClusterAuditConfig sets the cluster audit config on the backend.
-func (s *ClusterConfigurationService) SetClusterAuditConfig(ctx context.Context, auditConfig types.ClusterAuditConfig) error {
-	rev := auditConfig.GetRevision()
-	value, err := services.MarshalClusterAuditConfig(auditConfig)
+func (s *ClusterConfigurationService) SetClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) error {
+	_, err := s.UpsertClusterAuditConfig(ctx, cfg)
+	return trace.Wrap(err)
+}
+
+// CreateClusterAuditConfig creates a cluster audit config if once does not already exist.
+func (s *ClusterConfigurationService) CreateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	value, err := services.MarshalClusterAuditConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateClusterAuditConfig updates an existing cluster audit config.
+func (s *ClusterConfigurationService) UpdateClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	rev := cfg.GetRevision()
+	value, err := services.MarshalClusterAuditConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, auditPrefix),
 		Value:    value,
-		ID:       auditConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertClusterAuditConfig creates a new cluster audit config or overwrites the existing cluster audit config.
+func (s *ClusterConfigurationService) UpsertClusterAuditConfig(ctx context.Context, cfg types.ClusterAuditConfig) (types.ClusterAuditConfig, error) {
+	value, err := services.MarshalClusterAuditConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, auditPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
 }
 
 // DeleteClusterAuditConfig deletes ClusterAuditConfig from the backend.
@@ -288,32 +395,90 @@ func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Con
 	return services.UnmarshalClusterNetworkingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
 }
 
-// SetClusterNetworkingConfig sets the cluster networking config
-// on the backend.
-func (s *ClusterConfigurationService) SetClusterNetworkingConfig(ctx context.Context, netConfig types.ClusterNetworkingConfig) error {
+// CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.
+func (s *ClusterConfigurationService) CreateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
 	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(netConfig); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	rev := netConfig.GetRevision()
-	value, err := services.MarshalClusterNetworkingConfig(netConfig)
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateClusterNetworkingConfig updates an existing cluster networking config.
+func (s *ClusterConfigurationService) UpdateClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rev := cfg.GetRevision()
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, networkingPrefix),
 		Value:    value,
-		ID:       netConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertClusterNetworkingConfig creates a new cluster networking config or overwrites the existing cluster networking config.
+func (s *ClusterConfigurationService) UpsertClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) (types.ClusterNetworkingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalClusterNetworkingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, networkingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// SetClusterNetworkingConfig sets the cluster networking config
+// on the backend.
+func (s *ClusterConfigurationService) SetClusterNetworkingConfig(ctx context.Context, cfg types.ClusterNetworkingConfig) error {
+	_, err := s.UpsertClusterNetworkingConfig(ctx, cfg)
+	return trace.Wrap(err)
 }
 
 // DeleteClusterNetworkingConfig deletes ClusterNetworkingConfig from the backend.
@@ -340,31 +505,90 @@ func (s *ClusterConfigurationService) GetSessionRecordingConfig(ctx context.Cont
 	return services.UnmarshalSessionRecordingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
 }
 
-// SetSessionRecordingConfig sets session recording config on the backend.
-func (s *ClusterConfigurationService) SetSessionRecordingConfig(ctx context.Context, recConfig types.SessionRecordingConfig) error {
+// CreateSessionRecordingConfig creates a session recording config if once does not already exist.
+func (s *ClusterConfigurationService) CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
 	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(recConfig); err != nil {
-		return trace.Wrap(err)
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	rev := recConfig.GetRevision()
-	value, err := services.MarshalSessionRecordingConfig(recConfig)
+	value, err := services.MarshalSessionRecordingConfig(cfg)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Create(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpdateSessionRecordingConfig updates an existing session recording config.
+func (s *ClusterConfigurationService) UpdateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rev := cfg.GetRevision()
+	value, err := services.MarshalSessionRecordingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	item := backend.Item{
 		Key:      backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
 		Value:    value,
-		ID:       recConfig.GetResourceID(),
 		Revision: rev,
 	}
 
-	_, err = s.Put(ctx, item)
+	lease, err := s.Backend.ConditionalUpdate(ctx, item)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// UpsertSessionRecordingConfig creates a new session recording or overwrites the existing session recording.
+func (s *ClusterConfigurationService) UpsertSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (types.SessionRecordingConfig, error) {
+	// Perform the modules-provided checks.
+	if err := modules.ValidateResource(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalSessionRecordingConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := backend.Item{
+		Key:   backend.Key(clusterConfigPrefix, sessionRecordingPrefix),
+		Value: value,
+	}
+
+	lease, err := s.Backend.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg.SetRevision(lease.Revision)
+	return cfg, nil
+}
+
+// SetSessionRecordingConfig sets session recording config on the backend.
+func (s *ClusterConfigurationService) SetSessionRecordingConfig(ctx context.Context, recConfig types.SessionRecordingConfig) error {
+	_, err := s.UpsertSessionRecordingConfig(ctx, recConfig)
+	return trace.Wrap(err)
 }
 
 // DeleteSessionRecordingConfig deletes SessionRecordingConfig from the backend.

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -384,7 +384,7 @@ func (s *ClusterConfigurationService) DeleteClusterAuditConfig(ctx context.Conte
 }
 
 // GetClusterNetworkingConfig gets cluster networking config from the backend.
-func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	item, err := s.Get(ctx, backend.Key(clusterConfigPrefix, networkingPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -392,7 +392,7 @@ func (s *ClusterConfigurationService) GetClusterNetworkingConfig(ctx context.Con
 		}
 		return nil, trace.Wrap(err)
 	}
-	return services.UnmarshalClusterNetworkingConfig(item.Value, append(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))...)
+	return services.UnmarshalClusterNetworkingConfig(item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))
 }
 
 // CreateClusterNetworkingConfig creates a cluster networking config if once does not already exist.

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -94,6 +94,18 @@ func TestClusterNetworkingConfig(t *testing.T) {
 	suite.ClusterNetworkingConfig(t)
 }
 
+func TestClusterAuditConfig(t *testing.T) {
+	tt := setupConfigContext(context.Background(), t)
+
+	clusterConfig, err := NewClusterConfigurationService(tt.bk)
+	require.NoError(t, err)
+
+	suite := &suite.ServicesTestSuite{
+		ConfigS: clusterConfig,
+	}
+	suite.ClusterNetworkingConfig(t)
+}
+
 func TestSessionRecordingConfig(t *testing.T) {
 	tt := setupConfigContext(context.Background(), t)
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1136,21 +1136,36 @@ func (s *ServicesTestSuite) RemoteClustersCRUD(t *testing.T) {
 func (s *ServicesTestSuite) AuthPreference(t *testing.T) {
 	ctx := context.Background()
 	ap, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
-		Type:                  "local",
-		SecondFactor:          "otp",
+		Type:                  constants.Local,
+		SecondFactor:          constants.SecondFactorOTP,
 		DisconnectExpiredCert: types.NewBoolOption(true),
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetAuthPreference(ctx, ap)
+	// Create a preference when one does not exist.
+	created, err := s.ConfigS.CreateAuthPreference(ctx, ap)
 	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
 
+	// Validate the created preference matches the retrieve preference.
 	gotAP, err := s.ConfigS.GetAuthPreference(ctx)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(ap, gotAP), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"))
 
-	require.Equal(t, "local", gotAP.GetType())
-	require.Equal(t, constants.SecondFactorOTP, gotAP.GetSecondFactor())
-	require.True(t, gotAP.GetDisconnectExpiredCert())
+	// Validate that update only works if the revision matches.
+	gotAP.SetRevision("123")
+	_, err = s.ConfigS.UpdateAuthPreference(ctx, gotAP)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetSecondFactor(constants.SecondFactorOff)
+	updated, err := s.ConfigS.UpdateAuthPreference(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, constants.SecondFactorOff, updated.GetSecondFactor())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertAuthPreference(ctx, gotAP)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotAP), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"))
 }
 
 // SessionRecordingConfig tests session recording configuration.
@@ -1161,13 +1176,36 @@ func (s *ServicesTestSuite) SessionRecordingConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetSessionRecordingConfig(ctx, recConfig)
-	require.NoError(t, err)
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateSessionRecordingConfig(ctx, recConfig)
+	require.True(t, trace.IsCompareFailed(err))
 
-	gotrecConfig, err := s.ConfigS.GetSessionRecordingConfig(ctx)
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateSessionRecordingConfig(ctx, recConfig)
 	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
 
-	require.Equal(t, types.RecordAtProxy, gotrecConfig.GetMode())
+	// Validate the created config matches the retrieve config.
+	gotRecConfig, err := s.ConfigS.GetSessionRecordingConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(recConfig, gotRecConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Validate that update only works if the revision matches.
+	gotRecConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateSessionRecordingConfig(ctx, gotRecConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetMode(types.RecordAtNode)
+
+	updated, err := s.ConfigS.UpdateSessionRecordingConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, types.RecordAtNode, updated.GetMode())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertSessionRecordingConfig(ctx, gotRecConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotRecConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
 }
 
 func (s *ServicesTestSuite) StaticTokens(t *testing.T) {
@@ -1259,14 +1297,75 @@ func (s *ServicesTestSuite) ClusterNetworkingConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.ConfigS.SetClusterNetworkingConfig(ctx, netConfig)
-	require.NoError(t, err)
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateClusterNetworkingConfig(ctx, netConfig)
+	require.True(t, trace.IsCompareFailed(err))
 
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateClusterNetworkingConfig(ctx, netConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
+
+	// Validate the created config matches the retrieve config.
 	gotNetConfig, err := s.ConfigS.GetClusterNetworkingConfig(ctx)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(netConfig, gotNetConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 
-	require.Equal(t, 17*time.Second, gotNetConfig.GetClientIdleTimeout())
-	require.Equal(t, int64(3000), gotNetConfig.GetKeepAliveCountMax())
+	// Validate that update only works if the revision matches.
+	gotNetConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateClusterNetworkingConfig(ctx, gotNetConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetKeepAliveCountMax(10)
+
+	updated, err := s.ConfigS.UpdateClusterNetworkingConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), updated.GetKeepAliveCountMax())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertClusterNetworkingConfig(ctx, gotNetConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotNetConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+}
+
+// ClusterAuditConfig tests cluster audit configuration.
+func (s *ServicesTestSuite) ClusterAuditConfig(t *testing.T) {
+	ctx := context.Background()
+	auditConfig, err := types.NewClusterAuditConfig(types.ClusterAuditConfigSpecV2{
+		Region:                  "us-east-1",
+		EnableContinuousBackups: true,
+	})
+	require.NoError(t, err)
+
+	// Validate updating a non-existent config fails.
+	_, err = s.ConfigS.UpdateClusterAuditConfig(ctx, auditConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	// Create a config when one does not exist.
+	created, err := s.ConfigS.CreateClusterAuditConfig(ctx, auditConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.GetRevision())
+
+	// Validate the created config matches the retrieve config.
+	gotAuditConfig, err := s.ConfigS.GetClusterAuditConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(auditConfig, gotAuditConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// Validate that update only works if the revision matches.
+	gotAuditConfig.SetRevision("123")
+	_, err = s.ConfigS.UpdateClusterAuditConfig(ctx, gotAuditConfig)
+	require.True(t, trace.IsCompareFailed(err))
+
+	created.SetRegion("us-west-2")
+
+	updated, err := s.ConfigS.UpdateClusterAuditConfig(ctx, created)
+	require.NoError(t, err)
+	require.Equal(t, "us-west-2", updated.Region())
+
+	// Validate that upserting overwrites the value regardless of the revision.
+	upserted, err := s.ConfigS.UpsertClusterAuditConfig(ctx, gotAuditConfig)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(upserted, gotAuditConfig, cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
 }
 
 // sem wrapper is a helper for overriding the keepalive

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -99,7 +99,7 @@ type AccessPoint interface {
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
-	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -96,7 +96,7 @@ type AccessPoint interface {
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
 
 	// GetClusterNetworkingConfig returns cluster networking configuration.
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context, opts ...services.MarshalOption) (types.SessionRecordingConfig, error)

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -64,7 +64,7 @@ func (m mockAccessPoint) GetClusterName(opts ...services.MarshalOption) (types.C
 	return m.clusterName, nil
 }
 
-func (m mockAccessPoint) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (m mockAccessPoint) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	return m.netConfig, nil
 }
 

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -280,7 +280,7 @@ type certificateSigner interface {
 	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error)
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
-	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 	GetDatabaseServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.DatabaseServer, error)
 	GetProxies() ([]types.Server, error)
 	GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error)

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -404,7 +404,7 @@ func (c *mockClient) GetClusterName(...services.MarshalOption) (types.ClusterNam
 	return c.clusterName, nil
 }
 
-func (c *mockClient) GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error) {
+func (c *mockClient) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 	if c.networkConfig == nil {
 		return &types.ClusterNetworkingConfigV2{}, nil
 	}


### PR DESCRIPTION
Backports all backend changes and the implementation of teleport.clusterconfig.v1.ClusterConfigService to branch/v15

- #38349
- #38523 
- #38590
- #38591