### PR TITLE
Fix RBAC issues in the host user creation guide

### DIFF
--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -15,10 +15,11 @@ end of an SSH session.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport server. See the [Server Access Getting Started
-  Guide](../getting-started.mdx) for how to add a server to your Teleport
-  cluster. We recommend enrolling a server that runs in a demo environment for
-  the purpose of this guide until you are familiar with the instructions.
+- A running Linux server registered with Teleport. See the [Server Access
+  Getting Started Guide](../getting-started.mdx) for how to add a server to your
+  Teleport cluster. We recommend enrolling a server that runs in a demo
+  environment for the purpose of this guide until you are familiar with the
+  instructions.
 - The following utilities should be available in the PATH for the Teleport SSH
   Service, since it must execute these commands in order to create transient
   users:
@@ -59,7 +60,7 @@ To enable host user creation, you will:
 
    ```diff
      labels:
-   +   host_user_creation: "enabled"
+   +   app: "nginx"
    ```
 
 1. Restart Teleport on the server.
@@ -92,24 +93,18 @@ spec:
        "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
     ]
     node_labels:
-      "host_user_creation": "enabled"
+      "app": "nginx"
 ```
 
 The `create_host_user_mode` field enables host user creation when the value is
 `keep`.  When a user with the `auto-users` role logs in to a server that matches
-the `host_user_creation:enabled` label, the Teleport SSH Service creates a host
-user, adds it to the groups listed in `host_groups`, and gives it the sudoer
-permissions specified in the `host_sudoers` field. In this case, the new user
-receives permission to restart the Nginx service as root.
+the `app:nginx` label, the Teleport SSH Service creates a host user, adds it to
+the groups listed in `host_groups`, and gives it the sudoer permissions
+specified in the `host_sudoers` field. In this case, the new user receives
+permission to restart the Nginx service as root.
 
 {/*TODO (ptgott): We should move the information below into a reference guide*/}
 <Details title="Customizing host user creation">
-
-`create_host_user_mode` can also be set to `insecure_drop`, which deletes users
-once the session ends. However, in this mode it is possible for a created user
-to get the same UID as a previously deleted user, which would give the new user
-access to all of the old user's files if they are not deleted. Use `keep` mode
-unless you really need users to be removed.
 
 Each value of the `logins` field must conform to the username requirements of
 the Linux distribution being used. See [User/Group Name
@@ -137,7 +132,7 @@ spec:
        "ALL=(ALL) NOPASSWD: ALL" # host_sudoers entries matching this are filtered out
     ]
     node_labels:
-      'host_user_creation': 'enabled'
+      "app": "nginx"
 ```
 
 If a server must never allow the automatic creation of transient Unix users you
@@ -152,6 +147,13 @@ ssh_service:
   # Disable automatic host user creation on this Node, regardless of role permissions.
   disable_create_host_user: true
 ```
+
+In low-security environments, you can also set `create_host_user_mode` to
+`insecure_drop`, which deletes users once the session ends. However, in this
+mode it is possible for a created user to get the same UID as a previously
+deleted user, which would give the new user access to all of the old user's
+files if they are not deleted. Use `keep` mode unless you really need users to
+be removed.
 
 </Details>
 

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -15,9 +15,13 @@ end of an SSH session.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport Node. See the [Server Access Getting Started Guide](../getting-started.mdx) for  how to add a Node to your Teleport cluster.
-- The following utilities should be available in the PATH for the Teleport SSH Service,
-since it must execute these commands in order to create transient users:
+- A running Teleport server. See the [Server Access Getting Started
+  Guide](../getting-started.mdx) for how to add a server to your Teleport
+  cluster. We recommend enrolling a server that runs in a demo environment for
+  the purpose of this guide until you are familiar with the instructions.
+- The following utilities should be available in the PATH for the Teleport SSH
+  Service, since it must execute these commands in order to create transient
+  users:
   - `useradd`
   - `userdel`
   - `usermod`
@@ -26,23 +30,44 @@ since it must execute these commands in order to create transient users:
   - `visudo`
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/3. Configure a role
+## Step 1/3. Configure RBAC
 
-First, create a role with `create_host_user_mode` set to `keep`. 
-The following role specification will allow users to log in as `nginxrestarter` on
-any matching Node. The host user will be created and added to the groups listed in
-`host_groups`. They will also be given permission to restart the Nginx service as
-root.
+In this section, you will configure a Teleport role that enables host user
+creation.  
 
-<Admonition type="note">
-  `create_host_user_mode` can also be set to `insecure_drop`, which deletes users
-  once the session ends. However, in this mode it is possible for a created user 
-  to get the same UID as a previously deleted user, which would give the new user access
-  to all of the old user's files if they are not deleted. Use `keep` mode
-  unless you really need users to be removed.
-</Admonition>
+When a Teleport user accesses an SSH Service instance, Teleport checks each of
+the user's roles that match the instance. If at least one role matches the
+instance but does not set `create_host_user_mode`, automatic user creation will
+be disabled. Roles that do not match the server will not be checked.
 
-Save the file below as `auto-users.yaml`
+To enable host user creation, you will:
+
+- Label your server so you can match it with a Teleport role that enables host
+  user creation.
+- Create a role that enables host user creation for servers with the label you
+  added.
+- For the purpose of this guide, create a Teleport user with only the role you
+  created.
+
+### Label your server
+
+1. Access the server you enrolled with Teleport before beginning this guide and
+   open the Teleport configuration file, which is `/etc/teleport.yaml` by
+   default.
+
+1. Make the following change to the configuration file:
+
+   ```diff
+     labels:
+   +   host_user_creation: "enabled"
+   ```
+
+1. Restart Teleport on the server.
+
+### Define a Teleport role
+
+The following role specification allows users to log in as `nginxrestarter` on
+any matching server. Add this content to a file called `auto-users.yaml`:
 
 ```yaml
 kind: role
@@ -67,32 +92,32 @@ spec:
        "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
     ]
     node_labels:
-      'env': 'devel'
-```
-Create the role:
-```code
-$ tctl create -f auto-users.yaml
-# role 'auto-users' has been created
+      "host_user_creation": "enabled"
 ```
 
-Each value of the `logins` field must conform to the username requirements
-of the Linux distribution being used. See [User/Group Name Syntax](https://systemd.io/USER_NAMES/) for requirements in common distributions.
+The `create_host_user_mode` field enables host user creation when the value is
+`keep`.  When a user with the `auto-users` role logs in to a server that matches
+the `host_user_creation:enabled` label, the Teleport SSH Service creates a host
+user, adds it to the groups listed in `host_groups`, and gives it the sudoer
+permissions specified in the `host_sudoers` field. In this case, the new user
+receives permission to restart the Nginx service as root.
 
-<Admonition type="warning">
+{/*TODO (ptgott): We should move the information below into a reference guide*/}
+<Details title="Customizing host user creation">
 
-When a Teleport user accesses an SSH Service instance, Teleport checks each of the
-user's roles that match the instance. If at least one role matches the instance
-but does not set `create_host_user_mode`, automatic user creation will be disabled.
-Roles that do not match the server will not be checked.
+`create_host_user_mode` can also be set to `insecure_drop`, which deletes users
+once the session ends. However, in this mode it is possible for a created user
+to get the same UID as a previously deleted user, which would give the new user
+access to all of the old user's files if they are not deleted. Use `keep` mode
+unless you really need users to be removed.
 
-</Admonition>
-
-<Admonition type="warning">
+Each value of the `logins` field must conform to the username requirements of
+the Linux distribution being used. See [User/Group Name
+Syntax](https://systemd.io/USER_NAMES/) for requirements in common
+distributions.
 
 When multiple roles contain `host_sudoers` entries, the sudoers file
 will have the entries written to it ordered by role name
-
-</Admonition>
 
 If a role includes a `deny` rule that sets `host_sudoers` to `'*'`, the user will
 have all sudoers entries removed when accessing matching Nodes, otherwise `deny`
@@ -112,11 +137,11 @@ spec:
        "ALL=(ALL) NOPASSWD: ALL" # host_sudoers entries matching this are filtered out
     ]
     node_labels:
-      'env': 'devel'
+      'host_user_creation': 'enabled'
 ```
 
-If an SSH Node must never allow the automatic creation of transient Unix users
-you can set `disable_create_host_user` to `true` in the Node's configuration:
+If a server must never allow the automatic creation of transient Unix users you
+can set `disable_create_host_user` to `true` in the Node's configuration:
 
 ```yaml
 # teleport.yaml
@@ -128,7 +153,26 @@ ssh_service:
   disable_create_host_user: true
 ```
 
-(!docs/pages/includes/add-role-to-user.mdx role="auto-users"!)
+</Details>
+
+Create the role:
+
+```code
+$ tctl create -f auto-users.yaml
+# role 'auto-users' has been created
+```
+
+### Create a Teleport user
+
+1. Run the following command to create a Teleport user with the `auto-users`
+   role:
+
+   ```code
+   $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
+   ```
+
+1. Follow the instructions in your terminal to visit the Teleport Web UI and
+   create the user.
 
 ## Step 2/3. [Optional] Configure the UID and GID for the created users
 
@@ -146,13 +190,12 @@ be created with the same login name as the user being created.
 ```yaml
 kind: user
 metadata:
-  name: some_teleport_user
+  name: demo-user
 spec:
   ...
   traits:
     logins:
-    - root
-    - alex
+    - nginxrestarter
     host_user_gid:
     # gid and uid values must be quoted.
     - "1234"


### PR DESCRIPTION
Closes #38801

Edit the Teleport RBAC section of the guide to ensure a working setup:

- Add a label to the node to enable host user creation.
- Edit the role we tell the reader to create in order to allow access to nodes with the host user creation label.
- Add a new user with only the role we tell the reader to create.

To clean up the role-related section, this guide also moves information about host user creation role fields into a `Details` box if they are not required to complete the guide.