### PR TITLE
Implement client-side device web authentication

### DIFF
--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -91,30 +91,115 @@ func TestRunCeremony(t *testing.T) {
 			}
 
 			// We need to enroll the device before we can test device auth
-			require.NoError(
-				t,
-				enrollDevice(ctx, devices, test.dev),
-				"enrollDevice failed",
-			)
+			_, err := enrollDevice(ctx, devices, test.dev)
+			require.NoError(t, err, "enrollDevice failed")
 
-			_, err := ceremony.Run(ctx, devices, test.certs)
+			_, err = ceremony.Run(ctx, devices, test.certs)
 			// A nil error is good enough for this test.
 			assert.NoError(t, err, "RunCeremony failed")
 		})
 	}
 }
 
-func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient, dev testenv.FakeDevice) error {
+func TestCeremony_RunWeb(t *testing.T) {
+	t.Parallel()
+
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
+	t.Cleanup(func() { env.Close() })
+
+	devicesClient := env.DevicesClient
+	fakeService := env.Service
+	ctx := context.Background()
+
+	macOSFakeDev1, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+
+	// Enroll the fake device before authentication.
+	macOSDev1, err := enrollDevice(ctx, devicesClient, macOSFakeDev1)
+	require.NoError(t, err, "EnrollDevice failed")
+
+	runError := func(t *testing.T, wantErr string, dev testenv.FakeDevice, webToken *devicepb.DeviceWebToken) {
+		t.Helper()
+
+		err := newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
+		assert.ErrorContains(t, err, wantErr, "RunWeb expected to fail")
+	}
+
+	// Verify that fake validations are working.
+	t.Run("sanity checks", func(t *testing.T) {
+		t.Parallel()
+
+		devID := macOSDev1.Id
+		dev := macOSFakeDev1
+
+		webToken1, err := fakeService.CreateDeviceWebTokenForTesting(devID)
+		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
+
+		invalidDeviceToken, err := fakeService.CreateDeviceWebTokenForTesting("I'm a llama not a device ID")
+		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
+
+		const wantErr = "invalid device web token"
+
+		// Unknown token fails.
+		runError(t, wantErr, dev, &devicepb.DeviceWebToken{
+			Id:    "I'm a llama not a token",
+			Token: webToken1.Token,
+		})
+
+		// Incorrect token fails (spends webToken1 regardless).
+		runError(t, wantErr, dev, &devicepb.DeviceWebToken{
+			Id:    webToken1.Id,
+			Token: webToken1.Token + "BAD",
+		})
+
+		// Spent token fails (spent above).
+		runError(t, wantErr, dev, webToken1)
+
+		// Mismatched device fails.
+		runError(t, wantErr, dev, invalidDeviceToken)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		devID := macOSDev1.Id
+		dev := macOSFakeDev1
+
+		// Create a fake DeviceWebToken. This and a previous enrollment is all the
+		// fake service requires.
+		webToken, err := fakeService.CreateDeviceWebTokenForTesting(devID)
+		require.NoError(t, err, "CreateDeviceWebTokenForTesting failed")
+
+		err = newAuthnCeremony(dev).RunWeb(ctx, devicesClient, webToken)
+
+		// Absence of errors is good enough here.
+		assert.NoError(t, err, "RunWeb failed")
+	})
+}
+
+func newAuthnCeremony(dev testenv.FakeDevice) *authn.Ceremony {
+	return &authn.Ceremony{
+		GetDeviceCredential: func() (*devicepb.DeviceCredential, error) {
+			return dev.GetDeviceCredential(), nil
+		},
+		CollectDeviceData:            dev.CollectDeviceData,
+		SignChallenge:                dev.SignChallenge,
+		SolveTPMAuthnDeviceChallenge: dev.SolveTPMAuthnDeviceChallenge,
+		GetDeviceOSType:              dev.GetDeviceOSType,
+	}
+}
+
+func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient, dev testenv.FakeDevice) (*devicepb.Device, error) {
 	stream, err := devices.EnrollDevice(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer stream.CloseSend()
 
 	// 1. Init.
 	enrollDeviceInit, err := dev.EnrollDeviceInit()
 	if err != nil {
-		return fmt.Errorf("enroll device init: %w", err)
+		return nil, fmt.Errorf("enroll device init: %w", err)
 	}
 	enrollDeviceInit.Token = testenv.FakeEnrollmentToken
 	if err := stream.Send(&devicepb.EnrollDeviceRequest{
@@ -122,19 +207,19 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 			Init: enrollDeviceInit,
 		},
 	}); err != nil {
-		return err
+		return nil, err
 	}
 
 	// 2. Challenge.
 	resp, err := stream.Recv()
 	if err != nil {
-		return fmt.Errorf("challenge Recv: %w", err)
+		return nil, fmt.Errorf("challenge Recv: %w", err)
 	}
 	switch osType := dev.GetDeviceOSType(); osType {
 	case devicepb.OSType_OS_TYPE_MACOS:
 		sig, err := dev.SignChallenge(resp.GetMacosChallenge().Challenge)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := stream.Send(&devicepb.EnrollDeviceRequest{
 			Payload: &devicepb.EnrollDeviceRequest_MacosChallengeResponse{
@@ -143,31 +228,32 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 				},
 			},
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	case devicepb.OSType_OS_TYPE_LINUX, devicepb.OSType_OS_TYPE_WINDOWS:
 		solution, err := dev.SolveTPMEnrollChallenge(resp.GetTpmChallenge(), false /* debug */)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := stream.Send(&devicepb.EnrollDeviceRequest{
 			Payload: &devicepb.EnrollDeviceRequest_TpmChallengeResponse{
 				TpmChallengeResponse: solution,
 			},
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	default:
-		return fmt.Errorf("unrecognized device os type %q", osType)
+		return nil, fmt.Errorf("unrecognized device os type %q", osType)
 	}
 
 	// 3. Success.
 	resp, err = stream.Recv()
-	switch {
-	case err != nil:
-		return fmt.Errorf("challenge response Recv: %w", err)
-	case resp.GetSuccess() == nil:
-		return fmt.Errorf("success response is nil, got %T instead", resp.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("challenge response Recv: %w", err)
 	}
-	return nil
+	success := resp.GetSuccess()
+	if success == nil {
+		return nil, fmt.Errorf("success response is nil, got %T instead", resp.Payload)
+	}
+	return success.Device, nil
 }


### PR DESCRIPTION
This is the basis for the [TerminalService.AuthenticateDeviceWeb RPC][1], implemented under lib/devicetrust for consistency and clean separation of responsibility. (The lib/devicetrust package is small and client-focused.)

In real-world use the DeviceWebToken is passed from the Web UI, during user login, to Connect.

https://github.com/gravitational/teleport.e/issues/3236

[1]: https://github.com/gravitational/teleport/blob/a0068878dea1b924bbe7c7259891e2892f13cfd2/proto/teleport/lib/teleterm/v1/service.proto#L174