### PR TITLE
[v15] Disable client cache in teleterm local proxy integration tests

### DIFF
--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
+	"github.com/gravitational/teleport/lib/teleterm/services/clientcache"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -196,6 +197,7 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 		CreateTshdEventsClientCredsFunc: func() (grpc.DialOption, error) {
 			return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
 		},
+		ClientCache:    clientcache.NewNoCache(storage),
 		KubeconfigsDir: t.TempDir(),
 		AgentsDir:      t.TempDir(),
 	})

--- a/lib/teleterm/services/clientcache/clientcache.go
+++ b/lib/teleterm/services/clientcache/clientcache.go
@@ -88,9 +88,7 @@ func (c *Cache) Get(ctx context.Context, clusterURI uri.ResourceURI) (*client.Pr
 		// We'll save the client in the cache, so we don't have to
 		// build a new connection next time.
 		// All cached clients will be closed when the daemon exits.
-		if err := c.addToCache(clusterURI, newProxyClient); err != nil {
-			return nil, trace.NewAggregate(err, newProxyClient.Close())
-		}
+		c.addToCache(clusterURI, newProxyClient)
 
 		c.cfg.Log.WithField("cluster", clusterURI.String()).Info("Added client to cache.")
 
@@ -154,14 +152,10 @@ func (c *Cache) Clear() error {
 	return trace.NewAggregate(errors...)
 }
 
-func (c *Cache) addToCache(clusterURI uri.ResourceURI, proxyClient *client.ProxyClient) error {
+func (c *Cache) addToCache(clusterURI uri.ResourceURI, proxyClient *client.ProxyClient) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var err error
-	if c.clients[clusterURI] != nil {
-		err = c.clients[clusterURI].Close()
-	}
 	c.clients[clusterURI] = proxyClient
 
 	// This goroutine removes the connection from the cache when
@@ -180,7 +174,6 @@ func (c *Cache) addToCache(clusterURI uri.ResourceURI, proxyClient *client.Proxy
 		c.cfg.Log.WithField("cluster", clusterURI.String()).WithError(err).
 			Info("Connection has been closed, removed client from cache.")
 	}()
-	return trace.Wrap(err)
 }
 
 func (c *Cache) getFromCache(clusterURI uri.ResourceURI) *client.ProxyClient {


### PR DESCRIPTION
This PR aims to address flakiness of lib/teleterm integration tests (#39268, https://github.com/gravitational/teleport/issues/20906#issuecomment-1992137366).

I realize that this is not the best solution as we still don't understand what the exact problem is (#39268 includes attempts at figuring this out). However, we are not able to reproduce the issue locally and the client cache (#15603) is the only recent big change that I can think of which could cause flakiness.

Included in this PR are also fixes to logging and removing an unnecessary client.Close(). Best reviewed commit-by-commit.

Backports #39417