### PR TITLE
[v14] Prevent possible panic caused missing cluster features when TAG is enabled

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -81,6 +81,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		PollInterval:      process.Config.Discovery.PollInterval,
 		ServerCredentials: tlsConfig,
 		AccessGraphConfig: process.Config.AccessGraph,
+		ClusterFeatures:   process.getClusterFeatures,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -164,6 +164,10 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("no AccessPoint configured for discovery")
 	}
 
+	if c.ClusterFeatures == nil {
+		return trace.BadParameter("no ClusterFeatures configured for discovery")
+	}
+
 	if len(c.Matchers.Kubernetes) > 0 && c.DiscoveryGroup == "" {
 		return trace.BadParameter(`the DiscoveryGroup name should be set for discovery server if
 kubernetes matchers are present.`)


### PR DESCRIPTION
This PR prevents a possible panic caused by a nil pointer de-reference of cluster features.

Changelog: Prevents a possible panic when discovery service is enabled with Access Graph config