### PR TITLE
Change macOS runners to use macos-14-xlarge image

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-13-xl-arm64
+    runs-on: macos-14-xlarge
 
     permissions:
       contents: read


### PR DESCRIPTION
We continue to have problems with the `macos-13-xl-arm64` image, so swap to a different macOS runner type to see if reliability is improved.

https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners