### PR TITLE
fix AWS database access

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4938,9 +4938,6 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if a.hasBuiltinRole(types.RoleDiscovery) && params.SemaphoreKind != types.KindAccessGraph {
-		return nil, trace.AccessDenied("discovery service can not create other semaphores")
-	}
 	return a.authServer.AcquireSemaphore(ctx, params)
 }
 
@@ -4948,9 +4945,6 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 func (a *ServerWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
-	}
-	if a.hasBuiltinRole(types.RoleDiscovery) && lease.SemaphoreKind != types.KindAccessGraph {
-		return trace.AccessDenied("discovery service can not create other semaphores")
 	}
 	return a.authServer.KeepAliveSemaphoreLease(ctx, lease)
 }


### PR DESCRIPTION
changelog: Fix an issue with AWS IAM permissions that may prevent AWS database access when discovery_service is enabled in the same Teleport config as the db_service, namely AWS RDS, Redshift, Elasticache, and MemoryDB.

This PR removes the restriction on semaphore kind added in #39171 last week.

That restriction prevents the database service from acquiring a semaphore to configure its IAM permissions for various AWS databases (namely, RDS) here: https://github.com/gravitational/teleport/blob/31a4a01fdf2751dc79dbbb2430480e2456d1c152/lib/srv/db/cloud/iam.go#L301-L320

The e2e tests did not catch this, because they did not clean up IAM permissions after each run. However, the e2e test infra (including iam roles/policies) are re-created each week, and now the tests are failing because the tests can't configure the `rds-db:connect` permissions they need in AWS.

This will get the e2e tests to start passing again.

I will update the e2e tests in a separate PR to make them cleanup IAM after each run so we don't have this week-long delay in catching a breaking change to the AWS IAM auto-configuration.