### PR TITLE
[v14] fix AWS database access

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4768,9 +4768,6 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if a.hasBuiltinRole(types.RoleDiscovery) && params.SemaphoreKind != types.KindAccessGraph {
-		return nil, trace.AccessDenied("discovery service can not create other semaphores")
-	}
 	return a.authServer.AcquireSemaphore(ctx, params)
 }
 
@@ -4778,9 +4775,6 @@ func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.Acq
 func (a *ServerWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
 	if err := a.action(apidefaults.Namespace, types.KindSemaphore, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
-	}
-	if a.hasBuiltinRole(types.RoleDiscovery) && lease.SemaphoreKind != types.KindAccessGraph {
-		return trace.AccessDenied("discovery service can not create other semaphores")
 	}
 	return a.authServer.KeepAliveSemaphoreLease(ctx, lease)
 }


### PR DESCRIPTION
Backport #39486 to branch/v14

changelog: Fixed an issue with AWS IAM permissions that may prevent AWS database access when discovery_service is enabled in the same Teleport config as the db_service, namely AWS RDS, Redshift, Elasticache, and MemoryDB.
