### PR TITLE
Wrap diag service listener with multiplexer so it can work behind PROXY enabled loadbalancer/proxy.

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -97,6 +97,9 @@ type Config struct {
 	Clock clockwork.Clock
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode PROXYProtocolMode
+	// SuppressUnexpectedPROXYWarning makes multiplexer to not issue warnings if it receives PROXY
+	// line when running in PROXYProtocolMode=PROXYProtocolUnspecified
+	SuppressUnexpectedPROXYWarning bool
 	// ID is an identifier used for debugging purposes
 	ID string
 	// CertAuthorityGetter is used to get CA to verify singed PROXY headers sent internally by teleport
@@ -171,13 +174,14 @@ type Mux struct {
 	sync.RWMutex
 	*log.Entry
 	Config
-	sshListener *Listener
-	tlsListener *Listener
-	dbListener  *Listener
-	context     context.Context
-	cancel      context.CancelFunc
-	waitContext context.Context
-	waitCancel  context.CancelFunc
+	sshListener  *Listener
+	tlsListener  *Listener
+	dbListener   *Listener
+	httpListener *Listener
+	context      context.Context
+	cancel       context.CancelFunc
+	waitContext  context.Context
+	waitCancel   context.CancelFunc
 	// logLimiter is a goroutine responsible for deduplicating multiplexer errors
 	// (over a 1min window) that occur when detecting the types of new connections.
 	// This ensures that health checkers / malicious actors cannot overpower /
@@ -214,6 +218,16 @@ func (m *Mux) DB() net.Listener {
 		m.dbListener = newListener(m.context, m.Config.Listener.Addr())
 	}
 	return m.dbListener
+}
+
+// HTTP returns listener that receives plain HTTP connections
+func (m *Mux) HTTP() net.Listener {
+	m.Lock()
+	defer m.Unlock()
+	if m.httpListener == nil {
+		m.httpListener = newListener(m.context, m.Config.Listener.Addr())
+	}
+	return m.httpListener
 }
 
 func (m *Mux) closeListener() {
@@ -287,6 +301,9 @@ func (m *Mux) protocolListener(proto Protocol) *Listener {
 		return m.sshListener
 	case ProtoPostgres:
 		return m.dbListener
+	case ProtoHTTP:
+		return m.httpListener
+
 	}
 	return nil
 }
@@ -511,7 +528,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			}
 			unsignedPROXYLineReceived = true
 
-			if m.PROXYProtocolMode == PROXYProtocolUnspecified {
+			if m.PROXYProtocolMode == PROXYProtocolUnspecified && !m.SuppressUnexpectedPROXYWarning {
 				m.logLimiter.Log(m.WithFields(log.Fields{
 					"direct_src_addr": conn.RemoteAddr(),
 					"direct_dst_addr": conn.LocalAddr(),
@@ -589,7 +606,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			}
 			unsignedPROXYLineReceived = true
 
-			if m.PROXYProtocolMode == PROXYProtocolUnspecified {
+			if m.PROXYProtocolMode == PROXYProtocolUnspecified && !m.SuppressUnexpectedPROXYWarning {
 				m.logLimiter.Log(m.WithFields(log.Fields{
 					"direct_src_addr": conn.RemoteAddr(),
 					"direct_dst_addr": conn.LocalAddr(),

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -97,7 +97,7 @@ type Config struct {
 	Clock clockwork.Clock
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode PROXYProtocolMode
-	// SuppressUnexpectedPROXYWarning makes multiplexer to not issue warnings if it receives PROXY
+	// SuppressUnexpectedPROXYWarning makes multiplexer not issue warnings if it receives PROXY
 	// line when running in PROXYProtocolMode=PROXYProtocolUnspecified
 	SuppressUnexpectedPROXYWarning bool
 	// ID is an identifier used for debugging purposes

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3203,8 +3203,25 @@ func (process *TeleportProcess) initDiagnosticService() error {
 	logger.InfoContext(process.ExitContext(), "Starting diagnostic service.", "listen_address", process.Config.DiagnosticAddr.Addr)
 
 	process.RegisterFunc("diagnostic.service", func() error {
-		err := server.Serve(listener)
-		if err != nil && err != http.ErrServerClosed {
+		muxListener, err := multiplexer.New(multiplexer.Config{
+			Context:                        process.GracefulExitContext(),
+			Listener:                       listener,
+			PROXYProtocolMode:              multiplexer.PROXYProtocolUnspecified,
+			SuppressUnexpectedPROXYWarning: true,
+			ID:                             teleport.Component(teleport.ComponentDiagnostic),
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		listenerHTTP := muxListener.HTTP()
+		go func() {
+			if err := muxListener.Serve(); err != nil && !utils.IsOKNetworkError(err) {
+				muxListener.Entry.WithError(err).Error("Mux encountered err serving")
+			}
+		}()
+
+		err = server.Serve(listenerHTTP)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.WarnContext(process.ExitContext(), "Diagnostic server exited with error.", "error", err)
 		}
 		return nil

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3204,7 +3204,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 
 	process.RegisterFunc("diagnostic.service", func() error {
 		muxListener, err := multiplexer.New(multiplexer.Config{
-			Context:                        process.GracefulExitContext(),
+			Context:                        process.ExitContext(),
 			Listener:                       listener,
 			PROXYProtocolMode:              multiplexer.PROXYProtocolUnspecified,
 			SuppressUnexpectedPROXYWarning: true,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3202,8 +3202,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 
 	logger.InfoContext(process.ExitContext(), "Starting diagnostic service.", "listen_address", process.Config.DiagnosticAddr.Addr)
 
-	var muxListener *multiplexer.Mux
-	muxListener, err = multiplexer.New(multiplexer.Config{
+	muxListener, err := multiplexer.New(multiplexer.Config{
 		Context:                        process.ExitContext(),
 		Listener:                       listener,
 		PROXYProtocolMode:              multiplexer.PROXYProtocolUnspecified,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3221,8 +3221,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 			}
 		}()
 
-		err = server.Serve(listenerHTTP)
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(listenerHTTP); !errors.Is(err, http.ErrServerClosed) {
 			logger.WarnContext(process.ExitContext(), "Diagnostic server exited with error.", "error", err)
 		}
 		return nil

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3203,17 +3203,18 @@ func (process *TeleportProcess) initDiagnosticService() error {
 	logger.InfoContext(process.ExitContext(), "Starting diagnostic service.", "listen_address", process.Config.DiagnosticAddr.Addr)
 
 	var muxListener *multiplexer.Mux
+	muxListener, err = multiplexer.New(multiplexer.Config{
+		Context:                        process.ExitContext(),
+		Listener:                       listener,
+		PROXYProtocolMode:              multiplexer.PROXYProtocolUnspecified,
+		SuppressUnexpectedPROXYWarning: true,
+		ID:                             teleport.Component(teleport.ComponentDiagnostic),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	process.RegisterFunc("diagnostic.service", func() error {
-		muxListener, err = multiplexer.New(multiplexer.Config{
-			Context:                        process.ExitContext(),
-			Listener:                       listener,
-			PROXYProtocolMode:              multiplexer.PROXYProtocolUnspecified,
-			SuppressUnexpectedPROXYWarning: true,
-			ID:                             teleport.Component(teleport.ComponentDiagnostic),
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		listenerHTTP := muxListener.HTTP()
 		go func() {
 			if err := muxListener.Serve(); err != nil && !utils.IsOKNetworkError(err) {


### PR DESCRIPTION
This PR wraps diag service listener with multiplexer. It now can accept simultaneously connections that are prepended with PROXY line or not. We also add `HTTP()` protocol listener to multiplexer and a flag that controls whether we should issue warnings about unspecified PROXY protocol mode for this listener - diag service will always run in unspecified mode to support both local access and access from behind a proxy/loadbalancer.

Fixes #39327 

Changelog: Allow diagnostic endpoints to be accessed behind a PROXY protocol enabled loadbalancer/proxy.