### PR TITLE
Add DeviceWebTokenCreateEvent to the dynamic events list

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -241,9 +241,13 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		e = &events.MFADeviceDelete{}
 	case DeviceEvent: // Kept for backwards compatibility.
 		e = &events.DeviceEvent{}
-	case DeviceCreateEvent, DeviceDeleteEvent, DeviceUpdateEvent,
-		DeviceEnrollEvent, DeviceAuthenticateEvent,
-		DeviceEnrollTokenCreateEvent:
+	case DeviceCreateEvent,
+		DeviceDeleteEvent,
+		DeviceUpdateEvent,
+		DeviceEnrollEvent,
+		DeviceAuthenticateEvent,
+		DeviceEnrollTokenCreateEvent,
+		DeviceWebTokenCreateEvent:
 		e = &events.DeviceEvent2{}
 	case LockCreatedEvent:
 		e = &events.LockCreate{}


### PR DESCRIPTION
Add the DeviceWebTokenCreateEvent event to the FromEventFields switch.

Fixes errors like:

> 2024-03-18T14:52:12-03:00 ERRO             Attempted to convert dynamic event of unknown type "device.webtoken.create" into protobuf event. events/dynamic.go:384

(Only possible to trigger in modified branches, so not an actual production error.)

https://github.com/gravitational/teleport.e/issues/3236