### PR TITLE
Tweak device trust event descriptions

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -574,7 +574,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Web Token Create
+            Device Web Token Created
           </div>
         </td>
         <td
@@ -3189,7 +3189,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Update
+            Device Updated
           </div>
         </td>
         <td
@@ -3243,7 +3243,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enrollment
+            Device Enrolled
           </div>
         </td>
         <td
@@ -3297,7 +3297,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enrollment
+            Device Enrolled
           </div>
         </td>
         <td
@@ -3459,7 +3459,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Delete
+            Device Deleted
           </div>
         </td>
         <td
@@ -3513,7 +3513,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Delete
+            Device Deleted
           </div>
         </td>
         <td
@@ -3567,7 +3567,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enroll Token Create
+            Device Enroll Token Created
           </div>
         </td>
         <td
@@ -3621,7 +3621,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enroll Token Create
+            Device Enroll Token Created
           </div>
         </td>
         <td
@@ -3675,7 +3675,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Authenticate
+            Device Authenticated
           </div>
         </td>
         <td
@@ -3729,7 +3729,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Authenticate
+            Device Authenticated
           </div>
         </td>
         <td
@@ -3783,7 +3783,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Register
+            Device Registered
           </div>
         </td>
         <td
@@ -3837,7 +3837,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Register
+            Device Registered
           </div>
         </td>
         <td
@@ -3891,7 +3891,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enrollment
+            Device Enrolled
           </div>
         </td>
         <td
@@ -3945,7 +3945,7 @@ exports[`list of all events 1`] = `
                 />
               </svg>
             </span>
-            Device Enrollment
+            Device Enrolled
           </div>
         </td>
         <td

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1305,7 +1305,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_CREATE]: {
     type: 'device.create',
-    desc: 'Device Register',
+    desc: 'Device Registered',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has registered a device`
@@ -1313,7 +1313,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_DELETE]: {
     type: 'device.delete',
-    desc: 'Device Delete',
+    desc: 'Device Deleted',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has deleted a device`
@@ -1321,7 +1321,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_AUTHENTICATE]: {
     type: 'device.authenticate',
-    desc: 'Device Authenticate',
+    desc: 'Device Authenticated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully authenticated their device`
@@ -1329,7 +1329,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL]: {
     type: 'device.enroll',
-    desc: 'Device Enrollment',
+    desc: 'Device Enrolled',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully enrolled their device`
@@ -1337,7 +1337,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL_TOKEN_CREATE]: {
     type: 'device.token.create',
-    desc: 'Device Enroll Token Create',
+    desc: 'Device Enroll Token Created',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] created a device enroll token`
@@ -1353,7 +1353,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_UPDATE]: {
     type: 'device.update',
-    desc: 'Device Update',
+    desc: 'Device Updated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has updated a device`
@@ -1361,7 +1361,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_WEB_TOKEN_CREATE]: {
     type: 'device.webtoken.create',
-    desc: 'Device Web Token Create',
+    desc: 'Device Web Token Created',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has issued a device web token`


### PR DESCRIPTION
Change event descriptions to use past tense, similarly to "user" events (and a few others).

Related to https://github.com/gravitational/teleport.e/issues/3236.