### PR TITLE
Fix hosted snow Teleport client building

### DIFF
--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -140,7 +140,7 @@ func (a *App) init(ctx context.Context) error {
 	log := logger.Get(ctx)
 
 	var err error
-	a.teleport, err = a.Conf.GetTeleportClient(ctx)
+	a.teleport, err = a.conf.GetTeleportClient(ctx)
 	if err != nil {
 		return trace.Wrap(err, "getting teleport client")
 	}

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -140,10 +140,9 @@ func (a *App) init(ctx context.Context) error {
 	log := logger.Get(ctx)
 
 	var err error
-	if a.teleport == nil {
-		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
-			return trace.Wrap(err)
-		}
+	a.teleport, err = a.Conf.GetTeleportClient(ctx)
+	if err != nil {
+		return trace.Wrap(err, "getting teleport client")
 	}
 
 	pong, err := a.checkTeleportVersion(ctx)

--- a/integrations/access/servicenow/config.go
+++ b/integrations/access/servicenow/config.go
@@ -19,6 +19,7 @@
 package servicenow
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/gravitational/trace"
@@ -67,6 +68,13 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	c.PluginType = types.PluginTypeServiceNow
 	return nil
+}
+
+func (c *Config) GetTeleportClient(ctx context.Context) (teleport.Client, error) {
+	if c.Client != nil {
+		return c.Client, nil
+	}
+	return c.BaseConfig.GetTeleportClient(ctx)
 }
 
 // NewBot initializes the new Servicenow message generator (ServicenowBot)


### PR DESCRIPTION
Fix the client not being propagated properly to the plugin by its configuration when running in hosted mode (since https://github.com/gravitational/teleport.e/pull/2503).

Changelog: fix a bug in Teleport Cloud causing the hosted ServiceNow plugin to crash when setting up the integration.