### PR TITLE
Document enum possible values in protobuf messages

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -541,9 +541,12 @@ type Recurrence struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// frequency is the frequency of reviews.
+	// frequency is the frequency of reviews. This represents the period in months
+	// between two reviews.
+	// Supported values are 0, 1, 3, 6, and 12.
 	Frequency ReviewFrequency `protobuf:"varint,1,opt,name=frequency,proto3,enum=teleport.accesslist.v1.ReviewFrequency" json:"frequency,omitempty"`
 	// day_of_month is the day of month that reviews will be scheduled on.
+	// Supported values are 0, 1, 15, and 31.
 	DayOfMonth ReviewDayOfMonth `protobuf:"varint,2,opt,name=day_of_month,json=dayOfMonth,proto3,enum=teleport.accesslist.v1.ReviewDayOfMonth" json:"day_of_month,omitempty"`
 }
 

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -121,10 +121,13 @@ enum ReviewDayOfMonth {
 
 // Recurrence is the definition for when reviews will be scheduled.
 message Recurrence {
-  // frequency is the frequency of reviews.
+  // frequency is the frequency of reviews. This represents the period in months
+  // between two reviews.
+  // Supported values are 0, 1, 3, 6, and 12.
   ReviewFrequency frequency = 1;
 
   // day_of_month is the day of month that reviews will be scheduled on.
+  // Supported values are 0, 1, 15, and 31.
   ReviewDayOfMonth day_of_month = 2;
 }
 

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -612,7 +612,8 @@ enum DatabaseTLSMode {
 
 // DatabaseTLS contains TLS configuration options.
 message DatabaseTLS {
-  // Mode is a TLS connection mode. See DatabaseTLSMode for details.
+  // Mode is a TLS connection mode.
+  // 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
   DatabaseTLSMode Mode = 1 [(gogoproto.jsontag) = "mode"];
   // CACert is an optional user provided CA certificate used for verifying
   // database TLS connection.
@@ -1715,9 +1716,11 @@ message ClusterNetworkingConfigSpecV2 {
   ];
 
   // ProxyListenerMode is proxy listener mode used by Teleport Proxies.
+  // 0 is "separate"; 1 is "multiplex".
   ProxyListenerMode ProxyListenerMode = 7 [(gogoproto.jsontag) = "proxy_listener_mode,omitempty"];
 
   // RoutingStrategy determines the strategy used to route to nodes.
+  // 0 is "unambiguous_match"; 1 is "most_recent".
   RoutingStrategy RoutingStrategy = 8 [(gogoproto.jsontag) = "routing_strategy,omitempty"];
 
   // TunnelStrategyV1 determines the tunnel strategy used in the cluster.
@@ -1895,6 +1898,8 @@ message AuthPreferenceSpecV2 {
   ];
 
   // RequireMFAType is the type of MFA requirement enforced for this cluster.
+  // 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+  // 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
   RequireMFAType RequireMFAType = 12 [(gogoproto.jsontag) = "require_session_mfa,omitempty"];
 
   // DeviceTrust holds settings related to trusted device verification.
@@ -2783,6 +2788,8 @@ message RoleOptions {
   ];
 
   // RequireMFAType is the type of MFA requirement enforced for this user.
+  // 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+  // 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
   RequireMFAType RequireMFAType = 23 [(gogoproto.jsontag) = "require_session_mfa,omitempty"];
 
   // DeviceTrustMode is the device authorization mode used for the resources
@@ -2810,11 +2817,14 @@ message RoleOptions {
   ];
 
   // CreateHostUserMode allows users to be automatically created on a
-  // host when not set to off
+  // host when not set to off.
+  // 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above),
+  // 3 is "keep"; 4 is "insecure-drop".
   CreateHostUserMode CreateHostUserMode = 28 [(gogoproto.jsontag) = "create_host_user_mode,omitempty"];
 
   // CreateDatabaseUserMode allows users to be automatically created on a
   // database when not set to off.
+  // 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
   CreateDatabaseUserMode CreateDatabaseUserMode = 29 [(gogoproto.jsontag) = "create_db_user_mode,omitempty"];
 }
 
@@ -2858,9 +2868,11 @@ enum CertExtensionType {
 message CertExtension {
   // Type represents the certificate type being extended, only ssh
   // is supported at this time.
+  // 0 is "ssh".
   CertExtensionType Type = 1 [(gogoproto.jsontag) = "type"];
   // Mode is the type of extension to be used -- currently
-  // critical-option is not supported
+  // critical-option is not supported.
+  // 0 is "extension".
   CertExtensionMode Mode = 2 [(gogoproto.jsontag) = "mode"];
   // Name specifies the key to be used in the cert extension.
   string Name = 3 [(gogoproto.jsontag) = "name"];

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -2243,7 +2243,8 @@ var xxx_messageInfo_AD proto.InternalMessageInfo
 
 // DatabaseTLS contains TLS configuration options.
 type DatabaseTLS struct {
-	// Mode is a TLS connection mode. See DatabaseTLSMode for details.
+	// Mode is a TLS connection mode.
+	// 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
 	Mode DatabaseTLSMode `protobuf:"varint,1,opt,name=Mode,proto3,enum=types.DatabaseTLSMode" json:"mode"`
 	// CACert is an optional user provided CA certificate used for verifying
 	// database TLS connection.
@@ -5114,8 +5115,10 @@ type ClusterNetworkingConfigSpecV2 struct {
 	// timeouts.
 	WebIdleTimeout Duration `protobuf:"varint,6,opt,name=WebIdleTimeout,proto3,casttype=Duration" json:"web_idle_timeout"`
 	// ProxyListenerMode is proxy listener mode used by Teleport Proxies.
+	// 0 is "separate"; 1 is "multiplex".
 	ProxyListenerMode ProxyListenerMode `protobuf:"varint,7,opt,name=ProxyListenerMode,proto3,enum=types.ProxyListenerMode" json:"proxy_listener_mode,omitempty"`
 	// RoutingStrategy determines the strategy used to route to nodes.
+	// 0 is "unambiguous_match"; 1 is "most_recent".
 	RoutingStrategy RoutingStrategy `protobuf:"varint,8,opt,name=RoutingStrategy,proto3,enum=types.RoutingStrategy" json:"routing_strategy,omitempty"`
 	// TunnelStrategyV1 determines the tunnel strategy used in the cluster.
 	TunnelStrategy *TunnelStrategyV1 `protobuf:"bytes,9,opt,name=TunnelStrategy,proto3" json:"tunnel_strategy,omitempty"`
@@ -5511,6 +5514,8 @@ type AuthPreferenceSpecV2 struct {
 	// otherwise.
 	AllowPasswordless *BoolOption `protobuf:"bytes,11,opt,name=AllowPasswordless,proto3,customtype=BoolOption" json:"allow_passwordless,omitempty"`
 	// RequireMFAType is the type of MFA requirement enforced for this cluster.
+	// 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+	// 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 	RequireMFAType RequireMFAType `protobuf:"varint,12,opt,name=RequireMFAType,proto3,enum=types.RequireMFAType" json:"require_session_mfa,omitempty"`
 	// DeviceTrust holds settings related to trusted device verification.
 	// Requires Teleport Enterprise.
@@ -7183,6 +7188,8 @@ type RoleOptions struct {
 	// over an SSH session. It defaults to true unless explicitly set to false.
 	SSHFileCopy *BoolOption `protobuf:"bytes,22,opt,name=SSHFileCopy,proto3,customtype=BoolOption" json:"ssh_file_copy"`
 	// RequireMFAType is the type of MFA requirement enforced for this user.
+	// 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH",
+	// 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 	RequireMFAType RequireMFAType `protobuf:"varint,23,opt,name=RequireMFAType,proto3,enum=types.RequireMFAType" json:"require_session_mfa,omitempty"`
 	// DeviceTrustMode is the device authorization mode used for the resources
 	// associated with the role.
@@ -7197,10 +7204,13 @@ type RoleOptions struct {
 	// CreateDatabaseUser enabled automatic database user creation.
 	CreateDatabaseUser *BoolOption `protobuf:"bytes,27,opt,name=CreateDatabaseUser,proto3,customtype=BoolOption" json:"create_db_user"`
 	// CreateHostUserMode allows users to be automatically created on a
-	// host when not set to off
+	// host when not set to off.
+	// 0 is "unspecified"; 1 is "off"; 2 is "drop" (removed for v15 and above),
+	// 3 is "keep"; 4 is "insecure-drop".
 	CreateHostUserMode CreateHostUserMode `protobuf:"varint,28,opt,name=CreateHostUserMode,proto3,enum=types.CreateHostUserMode" json:"create_host_user_mode,omitempty"`
 	// CreateDatabaseUserMode allows users to be automatically created on a
 	// database when not set to off.
+	// 0 is "unspecified", 1 is "off", 2 is "keep", 3 is "best_effort_drop".
 	CreateDatabaseUserMode CreateDatabaseUserMode `protobuf:"varint,29,opt,name=CreateDatabaseUserMode,proto3,enum=types.CreateDatabaseUserMode" json:"create_db_user_mode,omitempty"`
 	XXX_NoUnkeyedLiteral   struct{}               `json:"-"`
 	XXX_unrecognized       []byte                 `json:"-"`
@@ -7290,9 +7300,11 @@ var xxx_messageInfo_RecordSession proto.InternalMessageInfo
 type CertExtension struct {
 	// Type represents the certificate type being extended, only ssh
 	// is supported at this time.
+	// 0 is "ssh".
 	Type CertExtensionType `protobuf:"varint,1,opt,name=Type,proto3,enum=types.CertExtensionType" json:"type"`
 	// Mode is the type of extension to be used -- currently
-	// critical-option is not supported
+	// critical-option is not supported.
+	// 0 is "extension".
 	Mode CertExtensionMode `protobuf:"varint,2,opt,name=Mode,proto3,enum=types.CertExtensionMode" json:"mode"`
 	// Name specifies the key to be used in the cert extension.
 	Name string `protobuf:"bytes,3,opt,name=Name,proto3" json:"name"`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_accesslists.yaml
@@ -62,10 +62,13 @@ spec:
                     properties:
                       day_of_month:
                         description: day_of_month is the day of month that reviews
-                          will be scheduled on.
+                          will be scheduled on. Supported values are 0, 1, 15, and
+                          31.
                         x-kubernetes-int-or-string: true
                       frequency:
-                        description: frequency is the frequency of reviews.
+                        description: frequency is the frequency of reviews. This represents
+                          the period in months between two reviews. Supported values
+                          are 0, 1, 3, 6, and 12.
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
@@ -1116,7 +1116,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1124,7 +1124,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1149,7 +1149,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1161,7 +1162,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1272,7 +1275,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations
@@ -2468,7 +2472,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -2476,7 +2480,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -2501,7 +2505,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -2513,7 +2518,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -2624,7 +2631,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_rolesv6.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_rolesv6.yaml
@@ -1119,7 +1119,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1127,7 +1127,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1152,7 +1152,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1164,7 +1165,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1275,7 +1278,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_rolesv7.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_rolesv7.yaml
@@ -1119,7 +1119,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1127,7 +1127,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1152,7 +1152,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1164,7 +1165,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1275,7 +1278,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -178,13 +178,16 @@ export interface AccessListAudit {
  */
 export interface Recurrence {
     /**
-     * frequency is the frequency of reviews.
+     * frequency is the frequency of reviews. This represents the period in months
+     * between two reviews.
+     * Supported values are 0, 1, 3, 6, and 12.
      *
      * @generated from protobuf field: teleport.accesslist.v1.ReviewFrequency frequency = 1;
      */
     frequency: ReviewFrequency;
     /**
      * day_of_month is the day of month that reviews will be scheduled on.
+     * Supported values are 0, 1, 15, and 31.
      *
      * @generated from protobuf field: teleport.accesslist.v1.ReviewDayOfMonth day_of_month = 2;
      */

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -62,10 +62,13 @@ spec:
                     properties:
                       day_of_month:
                         description: day_of_month is the day of month that reviews
-                          will be scheduled on.
+                          will be scheduled on. Supported values are 0, 1, 15, and
+                          31.
                         x-kubernetes-int-or-string: true
                       frequency:
-                        description: frequency is the frequency of reviews.
+                        description: frequency is the frequency of reviews. This represents
+                          the period in months between two reviews. Supported values
+                          are 0, 1, 3, 6, and 12.
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1116,7 +1116,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1124,7 +1124,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1149,7 +1149,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1161,7 +1162,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1272,7 +1275,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations
@@ -2468,7 +2472,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -2476,7 +2480,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -2501,7 +2505,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -2513,7 +2518,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -2624,7 +2631,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
@@ -1119,7 +1119,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1127,7 +1127,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1152,7 +1152,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1164,7 +1165,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1275,7 +1278,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
@@ -1119,7 +1119,7 @@ spec:
                       properties:
                         mode:
                           description: Mode is the type of extension to be used --
-                            currently critical-option is not supported
+                            currently critical-option is not supported. 0 is "extension".
                           x-kubernetes-int-or-string: true
                         name:
                           description: Name specifies the key to be used in the cert
@@ -1127,7 +1127,7 @@ spec:
                           type: string
                         type:
                           description: Type represents the certificate type being
-                            extended, only ssh is supported at this time.
+                            extended, only ssh is supported at this time. 0 is "ssh".
                           x-kubernetes-int-or-string: true
                         value:
                           description: Value specifies the value to be used in the
@@ -1152,7 +1152,8 @@ spec:
                     type: boolean
                   create_db_user_mode:
                     description: CreateDatabaseUserMode allows users to be automatically
-                      created on a database when not set to off.
+                      created on a database when not set to off. 0 is "unspecified",
+                      1 is "off", 2 is "keep", 3 is "best_effort_drop".
                     x-kubernetes-int-or-string: true
                   create_desktop_user:
                     description: CreateDesktopUser allows users to be automatically
@@ -1164,7 +1165,9 @@ spec:
                     type: boolean
                   create_host_user_mode:
                     description: CreateHostUserMode allows users to be automatically
-                      created on a host when not set to off
+                      created on a host when not set to off. 0 is "unspecified"; 1
+                      is "off"; 2 is "drop" (removed for v15 and above), 3 is "keep";
+                      4 is "insecure-drop".
                     x-kubernetes-int-or-string: true
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
@@ -1275,7 +1278,8 @@ spec:
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
-                      for this user.
+                      for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY",
+                      3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
                     x-kubernetes-int-or-string: true
                   ssh_file_copy:
                     description: SSHFileCopy indicates whether remote file operations


### PR DESCRIPTION
Document enum values in the proto messages. This is a workaround to cope with the generators not being able to understand the relation between the enum ID, messages, and the user pretty names.

Note: the terraform reference was not re-rendered because recent RPC changes broke the TF provider. I cannot run the generators without re-writing the whole Terraform Bot resource. I will manually trigger the render in the v15 backport.

We will have to fix Terraform for v16, and re-render the reference, so the v16 docs will be up to date before the v16 release.