### PR TITLE
Fix integrations ssh service tests

### DIFF
--- a/integrations/lib/testing/integration/sshservice.go
+++ b/integrations/lib/testing/integration/sshservice.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/logger"
 )
 
-var regexpSSHStarting = regexp.MustCompile(`Service [^ ]+ is starting on [^ ]+:(\d+)`)
+var regexpSSHStarting = regexp.MustCompile(`SSH Service is starting.*listen_address:[^ ]+:(\d+)`)
 
 type SSHService struct {
 	mu           sync.Mutex


### PR DESCRIPTION
Similar to https://github.com/gravitational/teleport/pull/39315, this updates the integrations test suite to use a regular expression that will match output to know when the ssh_service is ready now that Teleport is using slog instead of logrus.