### PR TITLE
[v15] configure entity descriptor based on preset value

### DIFF
--- a/api/types/saml_idp_service_provider.go
+++ b/api/types/saml_idp_service_provider.go
@@ -133,6 +133,8 @@ type SAMLIdPServiceProvider interface {
 	GetAttributeMapping() []*SAMLAttributeMapping
 	// SetAttributeMapping sets Attribute Mapping.
 	SetAttributeMapping([]*SAMLAttributeMapping)
+	// GetPreset returns the Preset.
+	GetPreset() string
 	// GetRelayState returns Relay State.
 	GetRelayState() string
 	// SetRelayState sets Relay State.
@@ -197,6 +199,11 @@ func (s *SAMLIdPServiceProviderV1) GetAttributeMapping() []*SAMLAttributeMapping
 // SetAttributeMapping sets Attribute Mapping.
 func (s *SAMLIdPServiceProviderV1) SetAttributeMapping(attrMaps []*SAMLAttributeMapping) {
 	s.Spec.AttributeMapping = attrMaps
+}
+
+// GetPreset returns the Preset.
+func (s *SAMLIdPServiceProviderV1) GetPreset() string {
+	return s.Spec.Preset
 }
 
 // GetRelayState returns Relay State.


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/39385 to `Branch/v15`

If entity descriptor is not provided when creating a SAML IdP service provider, we used to first try and fetch the entity descriptor from given Entity ID endpoint. If that would fail, we would generate it ourselves. Now, with the `preset` types, we consider preset value to decide whether to go through fetch and gen process or directly generate entity descriptor. As part of this PR, we now directly generate the entity descriptor for the configured `gcp-workforce` preset type. 


This PR also adds the following:
- `Get` func for for the `Preset` field of `SAMLIdPServiceProviderV1` type. 
- Emit error log for the failed entity descriptor generator. 

