### PR TITLE
docs: expand internal/external trait reference

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -395,6 +395,9 @@ const (
 	// allowed GCP service accounts.
 	TraitGCPServiceAccounts = "gcp_service_accounts"
 
+	// TraitJWT is the name of the trait containing JWT header for app access.
+	TraitJWT = "jwt"
+
 	// TraitHostUserUID is the name of the variable used to specify
 	// the UID to create host user account with.
 	TraitHostUserUID = "host_user_uid"

--- a/constants.go
+++ b/constants.go
@@ -581,9 +581,6 @@ const (
 	// membership information
 	TraitTeams = "github_teams"
 
-	// TraitJWT is the name of the trait containing JWT header for app access.
-	TraitJWT = "jwt"
-
 	// TraitInternalLoginsVariable is the variable used to store allowed
 	// logins for local accounts.
 	TraitInternalLoginsVariable = "{{internal.logins}}"

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -434,7 +434,7 @@ spec:
 ##### Local user traits
 
 For local users, you can specify arbitrary key-value data in the `spec.traits`
-field of a `user` resource, then use the `{{internal.*}}` template variable in a
+field of a `user` resource, then use the `{{external.*}}` template variable in a
 role to refer to those traits.
 
 For example, this role fills in `kubernetes_users` and `kubernetes_groups` with
@@ -447,8 +447,8 @@ metadata:
   name: group-member
 spec:
   allow:
-    kubernetes_groups: ["{{internal.groups}}"]
-    kubernetes_users: ["{{internal.kube_username}}"]
+    kubernetes_groups: ["{{external.groups}}"]
+    kubernetes_users: ["{{external.kube_username}}"]
     # ...
 ```
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -482,9 +482,10 @@ sign-on provider.
 |`{{internal.aws_role_arns}}`|List of allowed AWS role ARNS for the user.|
 |`{{internal.azure_identities}}`| Returns the Azure identities defined in Teleport available to the user. Azure identities can be set for a specific user or defined in a role.|
 |`{{internal.db_names}}`|List of all allowed database names for the user.|
+|`{{internal.db_roles}}`|List of all allowed database roles for the user.|
 |`{{internal.db_users}}`|List of all allowed database users for the user.|
 |`{{internal.gcp_service_accounts}}`|List of GCP service accounts for the user.|
-|`{{internal.kube_username}}`|Kubernetes usernames available to the user.|
+|`{{internal.jwt}}`|JWT header used for app access.|
 |`{{internal.kubernetes_groups}}`|List of allowed Kubernetes groups for the user.|
 |`{{internal.kubernetes_users}}`|List of allowed Kubernetes users for the user.|
 |`{{internal.logins}}` | Substituted with a value stored in Teleport's local user database and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the "allowed logins" parameter used in the `tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [trusted cluster](../../admin-guides/management/admin/trustedclusters.mdx), Teleport will substitute the logins from the root cluster whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root cluster, then `ubuntu` will be substituted in the leaf cluster with this variable. |
@@ -495,17 +496,15 @@ sign-on provider.
 
 The `internal` trait namespace includes only the exact internal trait names
 included in the above table.
-They can be set in the `spec.traits` field of the
-[user resource](../reference/resources.mdx#user), or passed from an external
-IdP.
+For local Teleport users, these traits can be set in the `spec.traits` field of the
+[user resource](../reference/resources.mdx#user).
+These trait names can also be set for SSO users if they are included in an
+attribute or claim from your IdP.
 
-Internal traits may be referenced in built-in roles such as the `access` role,
-and they may be different when a user is accessing a leaf cluster vs a root
-cluster.
-For example, when accessing a leaf cluster, the `logins` trait will be set to
-the complete list of SSH logins allowed for the user, which may include values
-from the user's `logins` trait in the root cluster as well as logins hardcoded
-in roles the user holds in the root cluster.
+Internal traits are referenced in the [preset roles](#preset-roles) `access` and
+`require-trusted-device` to allow access to resources based on user traits.
+External traits are never referenced in preset roles (unless you manually edit
+said preset roles).
 
 You can use the following format in your role to reference an internal trait:
 
@@ -514,14 +513,32 @@ logins:
   - '{{internal.logins}}'
 ```
 
+<Admonition type="warning">
+For backward compatibility, some internal traits will differ when expanded
+in a leaf cluster vs a root cluster.
+In a leaf cluster the `logins`, `kubernetes_groups`, `kubernetes_users`,
+`db_names`, `db_users`, and `aws_role_arns` traits will all be set to the
+complete set of values that are encoded into the user's certificate when they
+sign in to Teleport.
+For example, when accessing a leaf cluster, the `internal.logins` trait will be set to
+the complete list of SSH logins allowed for the user, which may include values
+from the user's `internal.logins` trait in the root cluster as well as logins only
+included in the `spec.allow.logins` field of roles the user holds in the root cluster.
+</Admonition>
+
 #### Referring to external traits in Teleport roles
 
 For local Teleport users, the `external` trait namespace includes all values
 from the `spec.traits` field of the [user resource](../reference/resources.mdx#user).
+This includes any custom traits names, as well as names matching the `internal`
+traits listed above.
+For example, `{{internal.logins}}` and `{{external.logins}}` are both valid ways
+to refer to the `logins` traits, but a custom trait called `groups` can only be
+refenced by `{{external.groups}}`.
+
 When a user authenticates to Teleport through a single sign-on identity provider
 (IdP), Teleport populates `external` traits using attributes it receives from the
 IdP.
-
 For example, assuming you have the following SAML assertion attribute in your
 response:
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -497,7 +497,7 @@ sign-on provider.
 The `internal` trait namespace includes only the exact internal trait names
 included in the above table.
 For local Teleport users, these traits can be set in the `spec.traits` field of the
-[user resource](../reference/resources.mdx#user).
+[user resource](../resources.mdx#user).
 These trait names can also be set for SSO users if they are included in an
 attribute or claim from your IdP.
 
@@ -529,7 +529,7 @@ included in the `spec.allow.logins` field of roles the user holds in the root cl
 #### Referring to external traits in Teleport roles
 
 For local Teleport users, the `external` trait namespace includes all values
-from the `spec.traits` field of the [user resource](../reference/resources.mdx#user).
+from the `spec.traits` field of the [user resource](../resources.mdx#user).
 This includes any custom trait names, as well as names matching the `internal`
 traits listed above.
 For example, `{{internal.logins}}` and `{{external.logins}}` are both valid ways

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -491,16 +491,41 @@ sign-on provider.
 |`{{internal.windows_logins}}`|List of allowed Windows logins for the user.|
 |`{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, the variable is expanded to the value of the "xyz" claim. See the next section for more information on referring to the `external` variable in Teleport roles. |
 
-#### Accessing external traits in Teleport roles
+#### Referring to internal traits in Teleport roles
 
+The `internal` trait namespace includes only the exact internal trait names
+included in the above table.
+They can be set in the `spec.traits` field of the
+[user resource](../reference/resources.mdx#user), or passed from an external
+IdP.
+
+Internal traits may be referenced in built-in roles such as the `access` role,
+and they may be different when a user is accessing a leaf cluster vs a root
+cluster.
+For example, when accessing a leaf cluster, the `logins` trait will be set to
+the complete list of SSH logins allowed for the user, which may include values
+from the user's `logins` trait in the root cluster as well as logins hardcoded
+in roles the user holds in the root cluster.
+
+You can use the following format in your role to reference an internal trait:
+
+```yaml
+logins:
+  - '{{internal.logins}}'
+```
+
+#### Referring to external traits in Teleport roles
+
+For local Teleport users, the `external` trait namespace includes all values
+from the `spec.traits` field of the [user resource](../reference/resources.mdx#user).
 When a user authenticates to Teleport through a single sign-on identity provider
-(IdP), Teleport populates external variables using traits it receives from the
+(IdP), Teleport populates `external` traits using attributes it receives from the
 IdP.
 
 For example, assuming you have the following SAML assertion attribute in your
 response:
 
-```
+```xml
 <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname">
         <AttributeValue>firstname.lastname</AttributeValue>
 </Attribute>
@@ -508,7 +533,7 @@ response:
 
 ... you can use the following format in your role:
 
-```
+```yaml
 logins:
    - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
@@ -592,4 +617,3 @@ within this guide:
 Read the [predicate
 language](../predicate-language.mdx)
 guide for a more in depth explanation of the language.
-

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -530,11 +530,11 @@ included in the `spec.allow.logins` field of roles the user holds in the root cl
 
 For local Teleport users, the `external` trait namespace includes all values
 from the `spec.traits` field of the [user resource](../reference/resources.mdx#user).
-This includes any custom traits names, as well as names matching the `internal`
+This includes any custom trait names, as well as names matching the `internal`
 traits listed above.
 For example, `{{internal.logins}}` and `{{external.logins}}` are both valid ways
-to refer to the `logins` traits, but a custom trait called `groups` can only be
-refenced by `{{external.groups}}`.
+to refer to the `logins` trait, but a custom trait called `groups` can only be
+referenced by `{{external.groups}}`.
 
 When a user authenticates to Teleport through a single sign-on identity provider
 (IdP), Teleport populates `external` traits using attributes it receives from the

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -627,7 +627,7 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 				constants.TraitKubeGroups, constants.TraitKubeUsers,
 				constants.TraitDBNames, constants.TraitDBUsers, constants.TraitDBRoles,
 				constants.TraitAWSRoleARNs, constants.TraitAzureIdentities,
-				constants.TraitGCPServiceAccounts, teleport.TraitJWT:
+				constants.TraitGCPServiceAccounts, constants.TraitJWT:
 			default:
 				return trace.BadParameter("unsupported variable %q", name)
 			}
@@ -638,11 +638,13 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 		// - IdPs are allowed to set those trait names so it wouldn't make
 		//   sense to block them when referenced via "external"
 		// - The user resource spec.traits can include the "internal" trait
-		//   names listed above as well as any other trait name but it must be
-		//   referenced in the "external" namespace. It wouldn't make a lot of
-		//   sense to change the reference namespace based only on the trait
-		//   name, especially given that we tend to expand the list of
-		//   "internal" traits fairly often.
+		//   names listed above, as well as any other trait name - but other
+		//   trait names must be referenced in the "external" namespace. It
+		//   wouldn't make a lot of sense to change the namespace
+		//   based only on the trait name, especially given that we tend to
+		//   expand the list of "internal" traits, and that would be a breaking
+		//   change if someone already referred to one of the "new" internal
+		//   traits in the "external" namespace.
 		return nil
 	}
 	interpolated, err := expr.Interpolate(varValidation, traits)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -632,14 +632,17 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 				return trace.BadParameter("unsupported variable %q", name)
 			}
 		}
-		// TODO: return a not found error if the variable namespace is not
-		// the namespace of `traits`.
-		// If e.g. the `traits` belong to the "internal" namespace (as the
-		// validation above suggests), and "foo" is a key in `traits`, then
-		// "external.foo" will return the value of "internal.foo". This is
-		// incorrect, and a not found error should be returned instead.
-		// This would be similar to the var validation done in getPAMConfig
-		// (lib/srv/ctx.go).
+		// The "external" trait namespace is explicitly allowed to reference
+		// "internal" traits listed above. This is for multiple reasons:
+		// - back compat, it's always been this way
+		// - IdPs are allowed to set those trait names so it wouldn't make
+		//   sense to block them when referenced via "external"
+		// - The user resource spec.traits can include the "internal" trait
+		//   names listed above as well as any other trait name but it must be
+		//   referenced in the "external" namespace. It wouldn't make a lot of
+		//   sense to change the reference namespace based only on the trait
+		//   name, especially given that we tend to expand the list of
+		//   "internal" traits fairly often.
 		return nil
 	}
 	interpolated, err := expr.Interpolate(varValidation, traits)

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3302,6 +3302,51 @@ func TestApplyTraits(t *testing.T) {
 				},
 			},
 		},
+		{
+			// See comment in ApplyValueTraits for why we allow this.
+			comment: "explicitly allow internal traits referenced via external namespace",
+			inTraits: map[string][]string{
+				constants.TraitLogins:             {"logins"},
+				constants.TraitWindowsLogins:      {"windowsLogins"},
+				constants.TraitKubeGroups:         {"kubeGroups"},
+				constants.TraitKubeUsers:          {"kubeUsers"},
+				constants.TraitDBNames:            {"dBNames"},
+				constants.TraitDBUsers:            {"dBUsers"},
+				constants.TraitDBRoles:            {"dBRoles"},
+				constants.TraitAWSRoleARNs:        {"aWSRoleARNs"},
+				constants.TraitAzureIdentities:    {"azureIdentities"},
+				constants.TraitGCPServiceAccounts: {"gCPServiceAccounts"},
+				constants.TraitJWT:                {"jwt"},
+			},
+			allow: rule{
+				inLogins: []string{
+					"{{external.logins}}",
+					"{{external.windows_logins}}",
+					"{{external.kubernetes_groups}}",
+					"{{external.kubernetes_users}}",
+					"{{external.db_names}}",
+					"{{external.db_users}}",
+					"{{external.db_roles}}",
+					"{{external.aws_role_arns}}",
+					"{{external.azure_identities}}",
+					"{{external.gcp_service_accounts}}",
+					"{{external.jwt}}",
+				},
+				outLogins: []string{
+					"logins",
+					"windowsLogins",
+					"kubeGroups",
+					"kubeUsers",
+					"dBNames",
+					"dBUsers",
+					"dBRoles",
+					"aWSRoleARNs",
+					"azureIdentities",
+					"gCPServiceAccounts",
+					"jwt",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -177,7 +178,7 @@ func (c *ConnectionsHandler) withJWTTokenForwarder(ctx context.Context, sess *se
 	if traits == nil {
 		traits = make(wrappers.Traits)
 	}
-	traits[teleport.TraitJWT] = []string{jwt}
+	traits[constants.TraitJWT] = []string{jwt}
 
 	// Create a rewriting transport that will be used to forward requests.
 	transport, err := newTransport(c.closeContext,


### PR DESCRIPTION
It's not always obvious when to use the `internal` vs `external` trait namespace, this change attempts to clear that up.

Closes https://github.com/gravitational/teleport/issues/17994