### PR TITLE
Do not replace `AccessDenied` error messages with generic "access denied"

### DIFF
--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -278,6 +278,8 @@ type RpcStatusCode =
 
 /**
  * Checks if the given value is a `TshdRpcError`.
+ * It's meant to be used to check errors received from a gRPC client
+ * that was produced with `cloneClient()`.
  * @param error - Error to check.
  * @param statusCode - Optionally, a gRPC status code to compare.
  */

--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -254,9 +254,45 @@ export type TshdRpcError = Pick<
   isResolvableWithRelogin: boolean;
 };
 
-/** Checks if the given value is a `TshdRpcError`. */
-export function isTshdRpcError(error: unknown): error is TshdRpcError {
-  return error['name'] === 'TshdRpcError';
+/**
+ * Subset of gRPC status codes.
+ * It doesn't contain UNAUTHENTICATED and ABORTED values, which could be
+ * mistakenly used as PERMISSION_DENIED and CANCELLED.
+ * @see https://grpc.io/docs/guides/status-codes
+ */
+type RpcStatusCode =
+  | 'CANCELLED'
+  | 'UNKNOWN'
+  | 'INVALID_ARGUMENT'
+  | 'DEADLINE_EXCEEDED'
+  | 'NOT_FOUND'
+  | 'ALREADY_EXISTS'
+  | 'PERMISSION_DENIED'
+  | 'RESOURCE_EXHAUSTED'
+  | 'FAILED_PRECONDITION'
+  | 'OUT_OF_RANGE'
+  | 'UNIMPLEMENTED'
+  | 'INTERNAL'
+  | 'UNAVAILABLE'
+  | 'DATA_LOSS';
+
+/**
+ * Checks if the given value is a `TshdRpcError`.
+ * @param error - Error to check.
+ * @param statusCode - Optionally, a gRPC status code to compare.
+ */
+export function isTshdRpcError(
+  error: unknown,
+  statusCode?: RpcStatusCode
+): error is TshdRpcError {
+  const isTshdRpcError = error['name'] === 'TshdRpcError';
+  if (!isTshdRpcError) {
+    return false;
+  }
+  if (statusCode) {
+    return (error as TshdRpcError).code === statusCode;
+  }
+  return true;
 }
 
 function cloneError(error: unknown): TshdRpcError | Error | unknown {

--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -255,9 +255,7 @@ export type TshdRpcError = Pick<
 };
 
 /**
- * Subset of gRPC status codes.
- * It doesn't contain UNAUTHENTICATED and ABORTED values, which could be
- * mistakenly used as PERMISSION_DENIED and CANCELLED.
+ * gRPC status codes.
  * @see https://grpc.io/docs/guides/status-codes
  */
 type RpcStatusCode =
@@ -270,11 +268,13 @@ type RpcStatusCode =
   | 'PERMISSION_DENIED'
   | 'RESOURCE_EXHAUSTED'
   | 'FAILED_PRECONDITION'
+  | 'ABORTED'
   | 'OUT_OF_RANGE'
   | 'UNIMPLEMENTED'
   | 'INTERNAL'
   | 'UNAVAILABLE'
-  | 'DATA_LOSS';
+  | 'DATA_LOSS'
+  | 'UNAUTHENTICATED';
 
 /**
  * Checks if the given value is a `TshdRpcError`.

--- a/web/packages/teleterm/src/services/tshd/errors.ts
+++ b/web/packages/teleterm/src/services/tshd/errors.ts
@@ -18,24 +18,7 @@
 
 import { isTshdRpcError } from './cloneableClient';
 
-export function isAccessDeniedError(error: unknown): boolean {
-  // TODO(gzdunek): Replace it with check on the code field.
-  if (isTshdRpcError(error)) {
-    return error.message.includes('access denied');
-  }
-  return false;
-}
-
-export function isNotFoundError(error: unknown): boolean {
-  if (isTshdRpcError(error)) {
-    return error.code === 'NOT_FOUND';
-  }
-  return false;
-}
-
+/** @deprecated Use `isTshdRpcError(error, 'UNIMPLEMENTED')`. */
 export function isUnimplementedError(error: unknown): boolean {
-  if (isTshdRpcError(error)) {
-    return error.code === 'UNIMPLEMENTED';
-  }
-  return false;
+  return isTshdRpcError(error, 'UNIMPLEMENTED');
 }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -238,9 +238,12 @@ function AgentSetup() {
                 await ctx.connectMyComputerService.createRole(rootClusterUri);
               certsReloaded = response.certsReloaded;
             } catch (error) {
-              if (isTshdRpcError(error, 'PERMISSION_DENIED')) {
+              if (
+                isTshdRpcError(error, 'PERMISSION_DENIED') &&
+                !error.isResolvableWithRelogin
+              ) {
                 throw new Error(
-                  'Access denied. Contact your administrator for permissions to manage users and roles.'
+                  `Cannot set up the role: ${error.message}. Contact your administrator for permissions to manage users and roles.`
                 );
               }
               throw error;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -32,7 +32,7 @@ import {
   useConnectMyComputerContext,
 } from 'teleterm/ui/ConnectMyComputer';
 import { codeOrSignal } from 'teleterm/ui/utils/process';
-import { isAccessDeniedError } from 'teleterm/services/tshd/errors';
+import { isTshdRpcError } from 'teleterm/services/tshd/cloneableClient';
 import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { DocumentConnectMyComputer } from 'teleterm/ui/services/workspacesService';
 
@@ -238,7 +238,7 @@ function AgentSetup() {
                 await ctx.connectMyComputerService.createRole(rootClusterUri);
               certsReloaded = response.certsReloaded;
             } catch (error) {
-              if (isAccessDeniedError(error)) {
+              if (isTshdRpcError(error, 'PERMISSION_DENIED')) {
                 throw new Error(
                   'Access denied. Contact your administrator for permissions to manage users and roles.'
                 );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -37,8 +37,10 @@ import { wait } from 'shared/utils/wait';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { Server } from 'teleterm/services/tshd/types';
-import { cloneAbortSignal } from 'teleterm/services/tshd/cloneableClient';
-import { isNotFoundError } from 'teleterm/services/tshd/errors';
+import {
+  cloneAbortSignal,
+  isTshdRpcError,
+} from 'teleterm/services/tshd/cloneableClient';
 import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { useLogger } from 'teleterm/ui/hooks/useLogger';
 
@@ -281,7 +283,7 @@ export const ConnectMyComputerContextProvider: FC<
           rootClusterUri
         );
     } catch (error) {
-      if (isNotFoundError(error)) {
+      if (isTshdRpcError(error, 'NOT_FOUND')) {
         return;
       }
       throw error;


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/32550

After merging https://github.com/gravitational/teleport/pull/39229 we no longer compare the error message on the Electron side to check if the error is retryable. Because of that, we don't need to convert all access denied errors to generic "access denied".
I went through all the remote calls in tshd, I didn't see any place without `AddMetadataToRetryableError`, so showing the error modal should work as before.

I also removed `isAccessDeniedError` that was doing the check on error message (I cleaned up the other functions as well).

Changelog: Teleport Connect now shows specific error messages instead of generic "access denied"