### PR TITLE
teleport config retrieval from configmap example

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -485,7 +485,7 @@ $ kubectl exec -i my-pod -- tctl status
 # sending local files via stdin
 $ kubectl exec -i my-pod -- tctl create -f < my-local-file.yaml
 
-# retrieving the teleport service config file from a pod
+# retrieving the teleport service config file from the configmap
 $ kubectl -n <namespace> get configmap teleport-cluster-auth -o jsonpath="{.data['teleport\.yaml']}"
 
 # retrieving output via stdout and tar

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -485,6 +485,9 @@ $ kubectl exec -i my-pod -- tctl status
 # sending local files via stdin
 $ kubectl exec -i my-pod -- tctl create -f < my-local-file.yaml
 
+# retrieving the teleport service config file from a pod
+$ kubectl -n <namespace> get configmap teleport-cluster-auth -o jsonpath="{.data['teleport\.yaml']}"
+
 # retrieving output via stdout and tar
 $ kubectl exec -i my-pod -- tctl auth sign --user admin --format tls --ttl 10m --tar -o admin| tar xv -C local
 $ ls -l local

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -486,7 +486,7 @@ $ kubectl exec -i my-pod -- tctl status
 $ kubectl exec -i my-pod -- tctl create -f < my-local-file.yaml
 
 # retrieving the teleport service config file from the configmap
-$ kubectl -n <namespace> get configmap teleport-cluster-auth -o jsonpath="{.data['teleport\.yaml']}"
+$ kubectl get configmap teleport-cluster-auth -o jsonpath="{.data['teleport\.yaml']}"
 
 # retrieving output via stdout and tar
 $ kubectl exec -i my-pod -- tctl auth sign --user admin --format tls --ttl 10m --tar -o admin| tar xv -C local


### PR DESCRIPTION
This example shows users how to retrieve the teleport.yaml file from distroless pods. 