### PR TITLE
Expose `GetClusterAccessGraphConfig` to auth.ClientI

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1066,6 +1066,6 @@ type ClientI interface {
 	// an MFA challenge response for the user.
 	PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
 
-	// GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
+	// GetClusterAccessGraphConfig retrieves the cluster Access Graph configuration from Auth server.
 	GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error)
 }

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1065,4 +1065,7 @@ type ClientI interface {
 	// and prompts the user to answer the challenge with the given promptOpts, and ultimately returning
 	// an MFA challenge response for the user.
 	PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
+
+	// GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
+	GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error)
 }


### PR DESCRIPTION
Expose `GetClusterAccessGraphConfig` in `auth.ClientI`