### PR TITLE
Discovery: Fallback AccessGraph settings to `GetClusterAccessGraphConfig` data

### DIFF
--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -19,12 +19,17 @@
 package service
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/srv/discovery"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTeleportProcessIntegrationsOnly(t *testing.T) {
@@ -69,4 +74,105 @@ func TestTeleportProcessIntegrationsOnly(t *testing.T) {
 			require.Equal(t, tt.integrationOnly, p.integrationOnlyCredentials())
 		})
 	}
+}
+
+func TestTeleportProcess_initDiscoveryService(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		cfg       servicecfg.AccessGraphConfig
+		rsp       *clusterconfigpb.AccessGraphConfig
+		err       error
+		want      discovery.AccessGraphConfig
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "local access graph",
+			cfg: servicecfg.AccessGraphConfig{
+				Enabled:  true,
+				Addr:     "localhost:5000",
+				Insecure: true,
+			},
+			rsp: nil,
+			err: nil,
+			want: discovery.AccessGraphConfig{
+				Enabled:  true,
+				Addr:     "localhost:5000",
+				Insecure: true,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "access graph disabled locally but enabled in auth",
+			cfg: servicecfg.AccessGraphConfig{
+				Enabled: false,
+			},
+			rsp: &clusterconfigpb.AccessGraphConfig{
+				Enabled:  true,
+				Address:  "localhost:5000",
+				Insecure: true,
+			},
+			err: nil,
+			want: discovery.AccessGraphConfig{
+				Enabled:  true,
+				Addr:     "localhost:5000",
+				Insecure: true,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "access graph disabled locally and auth doesn't implement GetClusterAccessGraphConfig",
+			cfg: servicecfg.AccessGraphConfig{
+				Enabled: false,
+			},
+			rsp: nil,
+			err: trace.NotImplemented("err"),
+			want: discovery.AccessGraphConfig{
+				Enabled: false,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "access graph disabled locally and auth call fails",
+			cfg: servicecfg.AccessGraphConfig{
+				Enabled: false,
+			},
+			rsp: nil,
+			err: trace.BadParameter("err"),
+			want: discovery.AccessGraphConfig{
+				Enabled: false,
+			},
+			assertErr: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
+				context.Background(),
+				&servicecfg.Config{
+					AccessGraph: tt.cfg,
+				},
+				&fakeClient{
+					rsp: tt.rsp,
+					err: tt.err,
+				},
+				slog.Default(),
+			)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.want, accessGraphCfg)
+		})
+	}
+}
+
+type fakeClient struct {
+	auth.ClientI
+	rsp *clusterconfigpb.AccessGraphConfig
+	err error
+}
+
+func (f *fakeClient) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rsp, nil
 }

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -23,13 +23,14 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
-	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTeleportProcessIntegrationsOnly(t *testing.T) {

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -43,8 +43,8 @@ const (
 )
 
 var (
-	// errNoTAGFetchers is returned when there are no TAG fetchers.
-	errNoTAGFetchers = errors.New("no TAG fetchers")
+	// errNoAccessGraphFetchers is returned when there are no TAG fetchers.
+	errNoAccessGraphFetchers = errors.New("no Access Graph fetchers")
 )
 
 func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *aws_sync.Resources, stream accessgraphv1alpha.AccessGraphService_AWSEventsStreamClient, features aws_sync.Features) error {
@@ -62,7 +62,7 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 		if err != nil {
 			s.Log.WithError(err).Error("Error pushing TAGs")
 		}
-		return trace.Wrap(errNoTAGFetchers)
+		return trace.Wrap(errNoAccessGraphFetchers)
 	}
 	resultsC := make(chan fetcherResult, len(allFetchers))
 	// Use a channel to limit the number of concurrent fetchers.
@@ -316,7 +316,7 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	defer ticker.Stop()
 	for {
 		err := s.reconcileAccessGraph(ctx, currentTAGResources, stream, features)
-		if errors.Is(err, errNoTAGFetchers) {
+		if errors.Is(err, errNoAccessGraphFetchers) {
 			// no fetchers, no need to continue.
 			// we will wait for the config to change and re-evaluate the fetchers
 			// before starting the sync.

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"os"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -33,7 +32,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 )
@@ -44,14 +42,28 @@ const (
 	batchSize = 500
 )
 
-func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *aws_sync.Resources, stream accessgraphv1alpha.AccessGraphService_AWSEventsStreamClient, features aws_sync.Features) {
+var (
+	// errNoTAGFetchers is returned when there are no TAG fetchers.
+	errNoTAGFetchers = errors.New("no TAG fetchers")
+)
+
+func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *aws_sync.Resources, stream accessgraphv1alpha.AccessGraphService_AWSEventsStreamClient, features aws_sync.Features) error {
 	type fetcherResult struct {
 		result *aws_sync.Resources
 		err    error
 	}
 
 	allFetchers := s.getAllAWSSyncFetchers()
-
+	if len(allFetchers) == 0 {
+		// If there are no fetchers, we don't need to continue.
+		// We will send a delete request for all resources and return.
+		upsert, toDel := aws_sync.ReconcileResults(currentTAGResources, &aws_sync.Resources{})
+		err := push(stream, upsert, toDel)
+		if err != nil {
+			s.Log.WithError(err).Error("Error pushing TAGs")
+		}
+		return trace.Wrap(errNoTAGFetchers)
+	}
 	resultsC := make(chan fetcherResult, len(allFetchers))
 	// Use a channel to limit the number of concurrent fetchers.
 	tokens := make(chan struct{}, 3)
@@ -91,10 +103,11 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 	err = push(stream, upsert, toDel)
 	if err != nil {
 		s.Log.WithError(err).Error("Error pushing TAGs")
-		return
+		return nil
 	}
 	// Update the currentTAGResources with the result of the reconciliation.
 	*currentTAGResources = *result
+	return nil
 }
 
 // getAllAWSSyncFetchers returns all AWS sync fetchers.
@@ -184,7 +197,7 @@ func push(
 }
 
 // NewAccessGraphClient returns a new access graph service client.
-func newAccessGraphClient(ctx context.Context, certs []tls.Certificate, config servicecfg.AccessGraphConfig, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func newAccessGraphClient(ctx context.Context, certs []tls.Certificate, config AccessGraphConfig, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	opt, err := grpcCredentials(config, certs)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -302,7 +315,13 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	ticker := time.NewTicker(15 * time.Minute)
 	defer ticker.Stop()
 	for {
-		s.reconcileAccessGraph(ctx, currentTAGResources, stream, features)
+		err := s.reconcileAccessGraph(ctx, currentTAGResources, stream, features)
+		if errors.Is(err, errNoTAGFetchers) {
+			// no fetchers, no need to continue.
+			// we will wait for the config to change and re-evaluate the fetchers
+			// before starting the sync.
+			return nil
+		}
 		select {
 		case <-ctx.Done():
 			return trace.Wrap(ctx.Err())
@@ -313,15 +332,11 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 }
 
 // grpcCredentials returns a grpc.DialOption configured with TLS credentials.
-func grpcCredentials(config servicecfg.AccessGraphConfig, certs []tls.Certificate) (grpc.DialOption, error) {
+func grpcCredentials(config AccessGraphConfig, certs []tls.Certificate) (grpc.DialOption, error) {
 	var pool *x509.CertPool
-	if config.CA != "" {
+	if len(config.CA) > 0 {
 		pool = x509.NewCertPool()
-		caBytes, err := os.ReadFile(config.CA)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !pool.AppendCertsFromPEM(caBytes) {
+		if !pool.AppendCertsFromPEM(config.CA) {
 			return nil, trace.BadParameter("failed to append CA certificate to pool")
 		}
 	}
@@ -346,6 +361,20 @@ func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error
 		go func() {
 			reloadCh := s.newDiscoveryConfigChangedSub()
 			for {
+				allFetchers := s.getAllAWSSyncFetchers()
+				// If there are no fetchers, we don't need to start the access graph sync.
+				// We will wait for the config to change and re-evaluate the fetchers
+				// before starting the sync.
+				if len(allFetchers) == 0 {
+					s.Log.Debug("No AWS sync fetchers configured. Access graph sync will not be enabled.")
+					select {
+					case <-ctx.Done():
+						return
+					case <-reloadCh:
+						// if the config changes, we need to re-evaluate the fetchers.
+					}
+					continue
+				}
 				// reset the currentTAGResources to force a full sync
 				if err := s.initializeAndWatchAccessGraph(ctx, reloadCh); errors.Is(err, errTAGFeatureNotEnabled) {
 					s.Log.Warn("Access Graph specified in config, but the license does not include Teleport Policy. Access graph sync will not be enabled.")

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -58,9 +58,9 @@ func (s *Server) reconcileAccessGraph(ctx context.Context, currentTAGResources *
 		// If there are no fetchers, we don't need to continue.
 		// We will send a delete request for all resources and return.
 		upsert, toDel := aws_sync.ReconcileResults(currentTAGResources, &aws_sync.Resources{})
-		err := push(stream, upsert, toDel)
-		if err != nil {
-			s.Log.WithError(err).Error("Error pushing TAGs")
+
+		if err := push(stream, upsert, toDel); err != nil {
+			s.Log.WithError(err).Error("Error pushing empty resources to TAGs")
 		}
 		return trace.Wrap(errNoAccessGraphFetchers)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -49,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
@@ -140,7 +139,7 @@ type Config struct {
 	// to the Access Graph service.
 	ServerCredentials *tls.Config
 	// AccessGraphConfig is the configuration for the Access Graph client
-	AccessGraphConfig servicecfg.AccessGraphConfig
+	AccessGraphConfig AccessGraphConfig
 
 	// ClusterFeatures returns flags for supported/unsupported features.
 	// Used as a function because cluster features might change on Auth restarts.
@@ -154,6 +153,21 @@ type Config struct {
 	// clock is passed to watchers to handle poll intervals.
 	// Mostly used in tests.
 	clock clockwork.Clock
+}
+
+// AccessGraphConfig represents TAG server config
+type AccessGraphConfig struct {
+	// Enabled Access Graph reporting enabled
+	Enabled bool
+
+	// Addr of the Access Graph service addr
+	Addr string
+
+	// CA is the CA in PEM format used by the Access Graph service.
+	CA []byte
+
+	// Insecure is true if the connection to the Access Graph service should be insecure
+	Insecure bool
 }
 
 func (c *Config) CheckAndSetDefaults() error {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -155,18 +155,18 @@ type Config struct {
 	clock clockwork.Clock
 }
 
-// AccessGraphConfig represents TAG server config
+// AccessGraphConfig represents TAG server config.
 type AccessGraphConfig struct {
-	// Enabled Access Graph reporting enabled
+	// Enabled indicates if Access Graph reporting is enabled.
 	Enabled bool
 
-	// Addr of the Access Graph service addr
+	// Addr of the Access Graph service.
 	Addr string
 
 	// CA is the CA in PEM format used by the Access Graph service.
 	CA []byte
 
-	// Insecure is true if the connection to the Access Graph service should be insecure
+	// Insecure is true if the connection to the Access Graph service should be insecure.
 	Insecure bool
 }
 


### PR DESCRIPTION

When Access Graph is configured in cluster but it's not configured at the `teleport.yaml` of the discovery_service, fallback to `GetClusterAccessGraphConfig` settings served by auth.