### PR TITLE
Make TestProxySSHJumpHost less flaky

### DIFF
--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -572,9 +572,11 @@ func TestProxySSHJumpHost(t *testing.T) {
 			opts: []testSuiteOptionFunc{
 				withRootConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 				withLeafConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 			},
 		},
@@ -583,9 +585,11 @@ func TestProxySSHJumpHost(t *testing.T) {
 			opts: []testSuiteOptionFunc{
 				withRootConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 				withLeafConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 			},
 		},
@@ -594,9 +598,11 @@ func TestProxySSHJumpHost(t *testing.T) {
 			opts: []testSuiteOptionFunc{
 				withRootConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 				withLeafConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 			},
 		},
@@ -605,9 +611,11 @@ func TestProxySSHJumpHost(t *testing.T) {
 			opts: []testSuiteOptionFunc{
 				withRootConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 				withLeafConfigFunc(func(cfg *servicecfg.Config) {
 					cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Separate)
+					cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 				}),
 			},
 		},


### PR DESCRIPTION
Disables disk-based session recording mode for all subtests to prevent writing to disk after the test concludes.

```
testing.go:1225: TempDir RemoveAll cleanup: unlinkat /tmp/TestProxySSHJumpHostTLS_routing_enabled_for_root_and_disabled_for_leaf132326872/002: directory not empty
```

Fixes #39578