### PR TITLE
Add optional datakey in useKeybasedPagination hook

### DIFF
--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -35,6 +35,7 @@ import { isAbortError } from 'shared/utils/abortError';
  */
 export function useKeyBasedPagination<T>({
   fetchFunc,
+  dataKey = 'agents',
   initialFetchSize = 30,
   fetchMoreSize = 20,
 }: KeyBasedPaginationOptions<T>): KeyBasedPagination<T> {
@@ -110,7 +111,7 @@ export function useKeyBasedPagination<T>({
         abortController.current = null;
 
         setState({
-          resources: [...resources, ...res.agents],
+          resources: [...resources, ...res[dataKey]],
           startKey: res.startKey,
           finished: !res.startKey,
           attempt: { status: 'success' },
@@ -171,6 +172,7 @@ export type KeyBasedPaginationOptions<T> = {
   ) => Promise<ResourcesResponse<T>>;
   initialFetchSize?: number;
   fetchMoreSize?: number;
+  dataKey?: string;
 };
 
 type KeyBasedPagination<T> = {


### PR DESCRIPTION
In support of https://github.com/gravitational/teleport.e/issues/3263

The web UI is moving Access Requests (and other resources) to a paginated api. `useKeybasedPagination` works very well for our pagination needs but not every api returns "agents" anymore as the default key. For example, an upcoming PR for paginating through access requests uses this update to name the datakey as `requests`. I have an upcoming PR that will update our access requests api to use this new datakey as well as the `startKey` props already existing in this hook