### PR TITLE
[v15] Make reconciler use map keys as resource identity

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -27,18 +27,16 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-// Reconciled holds the common information required by any subject of the Reconciler.
-type Reconciled interface {
-	GetName() string
-}
-
 // ReconcilerConfig is the resource reconciler configuration.
-type ReconcilerConfig[T Reconciled] struct {
+type ReconcilerConfig[T any] struct {
 	// Matcher is used to match resources.
 	Matcher Matcher[T]
-	// GetCurrentResources returns currently registered resources.
+	// GetCurrentResources returns currently registered resources. Note that the
+	// map keys must be consistent across the current and new resources.
 	GetCurrentResources func() map[string]T
 	// GetNewResources returns resources to compare current resources against.
+	// Note that the map keys must be consistent across the current and new
+	// resources.
 	GetNewResources func() map[string]T
 	// OnCreate is called when a new resource is detected.
 	OnCreate func(context.Context, T) error
@@ -80,7 +78,7 @@ func (c *ReconcilerConfig[T]) CheckAndSetDefaults() error {
 }
 
 // NewReconciler creates a new reconciler with provided configuration.
-func NewReconciler[T Reconciled](cfg ReconcilerConfig[T]) (*Reconciler[T], error) {
+func NewReconciler[T any](cfg ReconcilerConfig[T]) (*Reconciler[T], error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -100,7 +98,7 @@ func NewReconciler[T Reconciled](cfg ReconcilerConfig[T]) (*Reconciler[T], error
 //
 // It's used in combination with watchers by agents (app, database, desktop)
 // to enable dynamically registered resources.
-type Reconciler[T Reconciled] struct {
+type Reconciler[T any] struct {
 	cfg ReconcilerConfig[T]
 	log *logrus.Entry
 }
@@ -117,15 +115,15 @@ func (r *Reconciler[T]) Reconcile(ctx context.Context) error {
 	var errs []error
 
 	// Process already registered resources to see if any of them were removed.
-	for _, current := range currentResources {
-		if err := r.processRegisteredResource(ctx, newResources, current); err != nil {
+	for key, current := range currentResources {
+		if err := r.processRegisteredResource(ctx, newResources, key, current); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
 	}
 
 	// Add new resources if there are any or refresh those that were updated.
-	for _, newResource := range newResources {
-		if err := r.processNewResource(ctx, currentResources, newResource); err != nil {
+	for key, newResource := range newResources {
+		if err := r.processNewResource(ctx, currentResources, key, newResource); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
 	}
@@ -135,8 +133,7 @@ func (r *Reconciler[T]) Reconcile(ctx context.Context) error {
 
 // processRegisteredResource checks the specified registered resource against the
 // new list of resources.
-func (r *Reconciler[T]) processRegisteredResource(ctx context.Context, newResources map[string]T, registered T) error {
-	name := registered.GetName()
+func (r *Reconciler[T]) processRegisteredResource(ctx context.Context, newResources map[string]T, name string, registered T) error {
 	// See if this registered resource is still present among "new" resources.
 	if _, ok := newResources[name]; ok {
 		return nil
@@ -156,8 +153,7 @@ func (r *Reconciler[T]) processRegisteredResource(ctx context.Context, newResour
 
 // processNewResource checks the provided new resource agsinst currently
 // registered resources.
-func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources map[string]T, newT T) error {
-	name := newT.GetName()
+func (r *Reconciler[T]) processNewResource(ctx context.Context, currentResources map[string]T, name string, newT T) error {
 	// First see if the resource is already registered and if not, whether it
 	// matches the selector labels and should be registered.
 	registered, ok := currentResources[name]


### PR DESCRIPTION
Cherry-pick backport of #39547

Prior to this change, the reconciler required that the input map keys be equal to the value returned by calling GetName() on the map value.

This patch removes this requirement, and uses the map key directly as the identity of a resource. This allows the reconciler to be used more flexibly in situatons where the resource name may not be a suitable identity.

The motivating context is the AccessListMember reconciler. Using the AccessListMember (i.e. the member username) is fine for reconciling the users for a single AccessList, as the map key and resource name are the same. This falls apart when the reconciler is managing reconciliation across multiple access lists at once. In this case, the map keys are typically a generated string like `${ACCESS_LIST}/${MEMBER_USER_NAME}`.

In this case, the reconciler will attempt to match existing and updated resources using the `AccessListMember` name (i.e. the member username) as the `AccessListMember` identity. This identity is obviously not present in the updated resources map, which expects the AccessList+Username pair and so the reconciler promptly deletes the associated resource (which is then promptly re-created by the reconciler while it processes processing any new resources).

This patch sidesteps all that by only using the input map keys as the resource identity.