### PR TITLE
[v13] [buddy]  Fix: jq has been missing in the installer scripts

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -139,7 +139,7 @@ install_teleport() {
       fi
     else
       # no automatic upgrades
-      sudo apt-get install -y "$TELEPORT_PACKAGE"
+      sudo apt-get install -y "$TELEPORT_PACKAGE" jq
     fi
 
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
@@ -165,7 +165,7 @@ install_teleport() {
       fi
     else
       # no automatic upgrades
-      sudo yum install -y "$TELEPORT_PACKAGE"
+      sudo yum install -y "$TELEPORT_PACKAGE" jq
     fi
 
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
@@ -192,7 +192,7 @@ install_teleport() {
       fi
     else
       # no automatic upgrades
-      sudo zypper --non-interactive install -y "$TELEPORT_PACKAGE"
+      sudo zypper --non-interactive install -y "$TELEPORT_PACKAGE" jq
     fi
   else
     echo "Unsupported distro: $ID"

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -86,7 +86,7 @@ on_gcp() {
       fi
     else
       # no automatic upgrades
-      sudo apt-get install -y "$TELEPORT_PACKAGE"
+      sudo apt-get install -y "$TELEPORT_PACKAGE" jq
     fi
 
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
@@ -112,7 +112,7 @@ on_gcp() {
       fi
     else
       # no automatic upgrades
-      sudo yum install -y "$TELEPORT_PACKAGE"
+      sudo yum install -y "$TELEPORT_PACKAGE" jq
     fi
 
   elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
@@ -124,7 +124,6 @@ on_gcp() {
     sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
     sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo zypper --gpg-auto-import-keys refresh
-    sudo zypper --non-interactive install ${PACKAGE_LIST}
 
     # shellcheck disable=SC2050
     if [ "{{ .AutomaticUpgrades }}" = "true" ]; then
@@ -141,7 +140,7 @@ on_gcp() {
       fi
     else
       # no automatic upgrades
-      sudo zypper --non-interactive install -y "$TELEPORT_PACKAGE"
+      sudo zypper --non-interactive install -y "$TELEPORT_PACKAGE" jq
     fi
   else
     echo "Unsupported distro: $ID"


### PR DESCRIPTION
Backport #39594 to branch/v13

changelog: fix a bug of the discovery script failing when `jq` was not installed
