### PR TITLE
Release 14.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 14.3.12 (03/20/24)
+
+* Fixed the discovery script failing when `jq` was not installed. [#39600](https://github.com/gravitational/teleport/pull/39600)
+* Improve performance when listing nodes with tsh or tctl. [#39568](https://github.com/gravitational/teleport/pull/39568)
+* Require AWS S3 bucket fields when creating/editing AWS OIDC integration in the web UI. [#39513](https://github.com/gravitational/teleport/pull/39513)
+* Removed implicit AccessList membership and ownership modes. All AccessList owners and members must be explicitly specified. [#39388](https://github.com/gravitational/teleport/pull/39388)
+
 ## 14.3.11 (03/18/24)
 
 * Fixed an issue with AWS IAM permissions that may prevent AWS database access when discovery_service is enabled in the same Teleport config as the db_service, namely AWS RDS, Redshift, Elasticache, and MemoryDB. [#39487](https://github.com/gravitational/teleport/pull/39487)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=14.3.11
+VERSION=14.3.12
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "14.3.11"
+const Version = "14.3.12"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>14.3.11</string>
+		<string>14.3.12</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>14.3.11</string>
+		<string>14.3.12</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>14.3.11</string>
+		<string>14.3.12</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>14.3.11</string>
+		<string>14.3.12</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "14.3.11"
+.version: &version "14.3.12"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "14.3.11"
+.version: &version "14.3.12"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -1,6 +1,6 @@
 should add an operator side-car when operator is enabled:
   1: |
-    image: public.ecr.aws/gravitational/teleport-operator:14.3.11
+    image: public.ecr.aws/gravitational/teleport-operator:14.3.12
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:
@@ -41,7 +41,7 @@ should add an operator side-car when operator is enabled:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -174,7 +174,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -271,7 +271,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -357,7 +357,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -5,7 +5,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v13.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       name: wait-auth-update
     - args:
       - echo test
@@ -62,7 +62,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -123,7 +123,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v13.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -174,7 +174,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -242,7 +242,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v13.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       name: wait-auth-update
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
@@ -275,7 +275,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -343,7 +343,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v13.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -383,7 +383,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -451,7 +451,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v13.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "14.3.11"
+.version: &version "14.3.12"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -30,7 +30,7 @@ sets Deployment annotations when specified if action is Upgrade:
             env:
             - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+            image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -103,7 +103,7 @@ sets Deployment labels when specified if action is Upgrade:
           env:
           - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
             value: "true"
-          image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+          image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -163,7 +163,7 @@ sets Pod annotations when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -223,7 +223,7 @@ sets Pod labels when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -300,7 +300,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -361,7 +361,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -421,7 +421,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -479,7 +479,7 @@ should expose diag port if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -551,7 +551,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -623,7 +623,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -683,7 +683,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -743,7 +743,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -810,7 +810,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -880,7 +880,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -946,7 +946,7 @@ should provision initContainer correctly when set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1042,7 +1042,7 @@ should set SecurityContext if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1122,7 +1122,7 @@ should set affinity when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1182,7 +1182,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1255,7 +1255,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: "true"
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1375,7 +1375,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1435,7 +1435,7 @@ should set nodeSelector if set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1497,7 +1497,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1569,7 +1569,7 @@ should set preferred affinity when more than one replica is used if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1629,7 +1629,7 @@ should set priorityClassName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1690,7 +1690,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1760,7 +1760,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1820,7 +1820,7 @@ should set resources when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1887,7 +1887,7 @@ should set serviceAccountName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1947,7 +1947,7 @@ should set tolerations when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -104,7 +104,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+            image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -132,7 +132,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -160,7 +160,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -190,7 +190,7 @@ should set securityContext in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -16,7 +16,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -84,7 +84,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -176,7 +176,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+            image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -272,7 +272,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -340,7 +340,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -428,7 +428,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+            image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -506,7 +506,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -574,7 +574,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -642,7 +642,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -724,7 +724,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -804,7 +804,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -872,7 +872,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -940,7 +940,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1010,7 +1010,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1085,7 +1085,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1165,7 +1165,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1241,7 +1241,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1309,7 +1309,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1413,7 +1413,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1501,7 +1501,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1569,7 +1569,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1650,7 +1650,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1786,7 +1786,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1854,7 +1854,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1936,7 +1936,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2004,7 +2004,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2082,7 +2082,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2150,7 +2150,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2225,7 +2225,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2293,7 +2293,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2361,7 +2361,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2429,7 +2429,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:14.3.11
+      image: public.ecr.aws/gravitational/teleport-distroless:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.3.11
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -71,7 +71,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.3.11
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.3.12
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
* Fixed the discovery script failing when `jq` was not installed. [#39600](https://github.com/gravitational/teleport/pull/39600)
* Improve performance when listing nodes with tsh or tctl. [#39568](https://github.com/gravitational/teleport/pull/39568)
* Require AWS S3 bucket fields when creating/editing AWS OIDC integration in the web UI. [#39513](https://github.com/gravitational/teleport/pull/39513)
* Removed implicit AccessList membership and ownership modes. All AccessList owners and members must be explicitly specified. [#39388](https://github.com/gravitational/teleport/pull/39388)