### PR TITLE
[v14] Implement `GetClusterAccessGraphConfig` method

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -55,6 +55,8 @@ type APIConfig struct {
 	// MetadataGetter retrieves additional metadata about session uploads.
 	// Will be nil if audit logging is not enabled.
 	MetadataGetter events.UploadMetadataGetter
+	// AccessGraph contains the configuration about the access graph service
+	AccessGraph AccessGraphConfig
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -69,6 +71,21 @@ func (a *APIConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("authorizer is missing")
 	}
 	return nil
+}
+
+// AccessGraphConfig contains the configuration about the access graph service
+// and whether it is enabled or not.
+type AccessGraphConfig struct {
+	// Enabled is a flag that indicates whether the access graph service is enabled.
+	Enabled bool
+	// Address is the address of the access graph service. The address is in the
+	// form of "host:port".
+	Address string
+	// CA is the PEM-encoded CA certificate of the access graph service.
+	CA []byte
+	// Insecure is a flag that indicates whether the access graph service should
+	// skip verifying the server's certificate chain and host name.
+	Insecure bool
 }
 
 // APIServer implements http API server for AuthServer interface

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -17,22 +17,43 @@
 package clusterconfigv1
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 // ServiceConfig contain dependencies required to create a [Service].
 type ServiceConfig struct {
-	Authorizer authz.Authorizer
+	Authorizer  authz.Authorizer
+	AccessGraph AccessGraphConfig
+}
+
+// AccessGraphConfig contains the configuration about the access graph service
+// and whether it is enabled or not.
+type AccessGraphConfig struct {
+	// Enabled is a flag that indicates whether the access graph service is enabled.
+	Enabled bool
+	// Address is the address of the access graph service. The address is in the
+	// form of "host:port".
+	Address string
+	// CA is the PEM-encoded CA certificate of the access graph service.
+	CA []byte
+	// Insecure is a flag that indicates whether the access graph service should
+	// skip verifying the server's certificate chain and host name.
+	Insecure bool
 }
 
 // Service implements the teleport.clusterconfig.v1.ClusterConfigService RPC service.
 type Service struct {
 	clusterconfigpb.UnimplementedClusterConfigServiceServer
 
-	authorizer authz.Authorizer
+	authorizer  authz.Authorizer
+	accessGraph AccessGraphConfig
 }
 
 // NewService validates the provided configuration and returns a [Service].
@@ -41,5 +62,34 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("authorizer is required")
 	}
 
-	return &Service{authorizer: cfg.Authorizer}, nil
+	return &Service{authorizer: cfg.Authorizer, accessGraph: cfg.AccessGraph}, nil
+}
+
+func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clusterconfigpb.GetClusterAccessGraphConfigRequest) (*clusterconfigpb.GetClusterAccessGraphConfigResponse, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzCtx, string(types.RoleProxy)) && !authz.HasBuiltinRole(*authzCtx, string(types.RoleDiscovery)) {
+		return nil, trace.AccessDenied("this request can be only executed by proxy or discovery services")
+	}
+
+	// If the policy feature is disabled in the license, return a disabled response.
+	if !modules.GetModules().Features().Policy.Enabled && !modules.GetModules().Features().AccessGraph {
+		return &clusterconfigpb.GetClusterAccessGraphConfigResponse{
+			AccessGraph: &clusterconfigpb.AccessGraphConfig{
+				Enabled: false,
+			},
+		}, nil
+	}
+
+	return &clusterconfigpb.GetClusterAccessGraphConfigResponse{
+		AccessGraph: &clusterconfigpb.AccessGraphConfig{
+			Enabled:  s.accessGraph.Enabled,
+			Address:  s.accessGraph.Address,
+			Ca:       s.accessGraph.CA,
+			Insecure: s.accessGraph.Insecure,
+		},
+	}, nil
 }

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -1,0 +1,45 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1
+
+import (
+	"github.com/gravitational/trace"
+
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+// ServiceConfig contain dependencies required to create a [Service].
+type ServiceConfig struct {
+	Authorizer authz.Authorizer
+}
+
+// Service implements the teleport.clusterconfig.v1.ClusterConfigService RPC service.
+type Service struct {
+	clusterconfigpb.UnimplementedClusterConfigServiceServer
+
+	authorizer authz.Authorizer
+}
+
+// NewService validates the provided configuration and returns a [Service].
+func NewService(cfg ServiceConfig) (*Service, error) {
+	if cfg.Authorizer == nil {
+		return nil, trace.BadParameter("authorizer is required")
+	}
+
+	return &Service{authorizer: cfg.Authorizer}, nil
+}

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -1,0 +1,1390 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusterconfigv1_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestCreateAuthPreference(t *testing.T) {
+	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+		Role:     types.RoleAuth,
+		Username: string(types.RoleAuth),
+	}, nil)
+	require.NoError(t, err, "creating auth role context")
+
+	cases := []struct {
+		name       string
+		modules    modules.Modules
+		authorizer authz.Authorizer
+		preference func(p types.AuthPreference)
+		assertion  func(t *testing.T, created types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized built in role",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authz.ContextForBuiltinRole(authz.BuiltinRole{
+					Role:     types.RoleProxy,
+					Username: string(types.RoleProxy),
+				}, nil)
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating auth preferences", err)
+			},
+		},
+		{
+			name: "authorized built in auth",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected hardware key policy to be rejected in OSS", err)
+			},
+		},
+		{
+			name: "creation allowed when hardware key policy is set in enterprise",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			preference: func(p types.AuthPreference) {
+				pp := p.(*types.AuthPreferenceV2)
+				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when hardware key policy is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.SetDeviceTrust(&types.DeviceTrust{
+					Mode: constants.DeviceTrustModeRequired,
+				})
+			},
+			assertion: func(t *testing.T, created types.AuthPreference, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected device trust mode conflict to prevent creation", err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.modules != nil {
+				modules.SetTestModules(t, test.modules)
+			}
+
+			var opts []serviceOpt
+			if test.authorizer != nil {
+				opts = append(opts, withAuthorizer(test.authorizer))
+			}
+
+			env, err := newTestEnv(opts...)
+			require.NoError(t, err, "creating test service")
+
+			pref := types.DefaultAuthPreference()
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			created, err := env.CreateAuthPreference(context.Background(), pref)
+			test.assertion(t, created, err)
+		})
+	}
+}
+
+func TestGetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
+			},
+		}, {
+			name: "authorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetAuthPreference(context.Background(), &clusterconfigpb.GetAuthPreferenceRequest{})
+			test.assertion(t, err)
+			if err == nil {
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			}
+		})
+	}
+}
+
+func TestUpdateAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent updating auth preferences", err)
+			},
+		},
+		{
+			name: "updated",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpdateAuthPreference(context.Background(), &clusterconfigpb.UpdateAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestUpsertAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		preference func(p types.AuthPreference)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "access prevented",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "oss hardware key policy",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "invalid device trust settings",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent upserting auth preferences", err)
+			},
+		},
+		{
+			name: "upserted",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func(p types.AuthPreference) {
+				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			pref := env.defaultPreference
+			if test.preference != nil {
+				test.preference(pref)
+			}
+
+			updated, err := env.UpsertAuthPreference(context.Background(), &clusterconfigpb.UpsertAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestResetAuthPreference(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		modules    modules.Modules
+		preference types.AuthPreference
+		assertion  func(t *testing.T, reset types.AuthPreference, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "config file origin prevents reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			preference: func() types.AuthPreference {
+				p := types.DefaultAuthPreference()
+				p.SetOrigin(types.OriginConfigFile)
+				return p
+			}(),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting auth preferences", err)
+			},
+		},
+		{
+			name: "reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			p := types.DefaultAuthPreference()
+			if test.preference != nil {
+				p = test.preference
+			}
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(p))
+			require.NoError(t, err, "creating test service")
+
+			reset, err := env.ResetAuthPreference(context.Background(), &clusterconfigpb.ResetAuthPreferenceRequest{})
+			test.assertion(t, reset, err)
+		})
+	}
+}
+
+func TestCreateClusterNetworkingConfig(t *testing.T) {
+	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+		Role:     types.RoleAuth,
+		Username: string(types.RoleAuth),
+	}, nil)
+	require.NoError(t, err, "creating auth role context")
+
+	cases := []struct {
+		name       string
+		modules    modules.Modules
+		authorizer authz.Authorizer
+		config     func(p types.ClusterNetworkingConfig)
+		assertion  func(t *testing.T, created types.ClusterNetworkingConfig, err error)
+	}{
+		{
+			name: "unauthorized built in role",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authz.ContextForBuiltinRole(authz.BuiltinRole{
+					Role:     types.RoleProxy,
+					Username: string(types.RoleProxy),
+				}, nil)
+			}),
+			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating networking config", err)
+			},
+		},
+		{
+			name: "authorized built in auth",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create networking config", err)
+				require.NotNil(t, created)
+			},
+		},
+		{
+			name: "creation prevented when proxy peering is set in open source",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetTunnelStrategy(&types.TunnelStrategyV1{
+					Strategy: &types.TunnelStrategyV1_ProxyPeering{
+						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
+					},
+				})
+			},
+			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy peering to be rejected in OSS", err)
+			},
+		},
+		{
+			name: "creation allowed when proxy peering is set in enterprise",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetTunnelStrategy(&types.TunnelStrategyV1{
+					Strategy: &types.TunnelStrategyV1_ProxyPeering{
+						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
+					},
+				})
+			},
+			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create networking config", err)
+				require.NotNil(t, created)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.modules != nil {
+				modules.SetTestModules(t, test.modules)
+			}
+
+			var opts []serviceOpt
+			if test.authorizer != nil {
+				opts = append(opts, withAuthorizer(test.authorizer))
+			}
+
+			env, err := newTestEnv(opts...)
+			require.NoError(t, err, "creating test service")
+
+			cfg := types.DefaultClusterNetworkingConfig()
+			if test.config != nil {
+				test.config(cfg)
+			}
+
+			created, err := env.CreateClusterNetworkingConfig(context.Background(), cfg)
+			test.assertion(t, created, err)
+		})
+	}
+}
+
+func TestGetClusterNetworkingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
+			},
+		}, {
+			name: "authorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetClusterNetworkingConfig(context.Background(), &clusterconfigpb.GetClusterNetworkingConfigRequest{})
+			test.assertion(t, err)
+			if err == nil {
+				require.Empty(t, cmp.Diff(types.DefaultClusterNetworkingConfig(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			}
+		})
+	}
+}
+
+func TestUpdateClusterNetworkingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		config     func(p types.ClusterNetworkingConfig)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.ClusterNetworkingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating networking config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating networking config", err)
+			},
+		},
+		{
+			name: "oss proxy peering",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetTunnelStrategy(&types.TunnelStrategyV1{
+					Strategy: &types.TunnelStrategyV1_ProxyPeering{
+						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
+					},
+				})
+			},
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating networking config", err)
+			},
+		},
+		{
+			name: "updated",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetRoutingStrategy(types.RoutingStrategy_MOST_RECENT)
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.NoError(t, err)
+				require.Equal(t, types.RoutingStrategy_MOST_RECENT, updated.GetRoutingStrategy())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			cfg := env.defaultNetworkingConfig
+			if test.config != nil {
+				test.config(cfg)
+			}
+
+			updated, err := env.UpdateClusterNetworkingConfig(context.Background(), &clusterconfigpb.UpdateClusterNetworkingConfigRequest{ClusterNetworkConfig: cfg.(*types.ClusterNetworkingConfigV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestUpsertClusterNetworkingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		config     func(p types.ClusterNetworkingConfig)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.ClusterNetworkingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting network config", err)
+			},
+		},
+		{
+			name: "access prevented",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting network config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting network config", err)
+			},
+		},
+		{
+			name: "oss proxy peering",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetTunnelStrategy(&types.TunnelStrategyV1{
+					Strategy: &types.TunnelStrategyV1_ProxyPeering{
+						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
+					},
+				})
+			},
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting network config", err)
+			},
+		},
+		{
+			name: "upserted",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.ClusterNetworkingConfig) {
+				p.SetRoutingStrategy(types.RoutingStrategy_MOST_RECENT)
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
+				require.NoError(t, err)
+				require.Equal(t, types.RoutingStrategy_MOST_RECENT, updated.GetRoutingStrategy())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			cfg := env.defaultNetworkingConfig
+			if test.config != nil {
+				test.config(cfg)
+			}
+
+			updated, err := env.UpsertClusterNetworkingConfig(context.Background(), &clusterconfigpb.UpsertClusterNetworkingConfigRequest{ClusterNetworkConfig: cfg.(*types.ClusterNetworkingConfigV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestResetClusterNetworkingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		modules    modules.Modules
+		config     types.ClusterNetworkingConfig
+		assertion  func(t *testing.T, reset types.ClusterNetworkingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting network config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting network config", err)
+			},
+		},
+		{
+			name: "config file origin prevents reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func() types.ClusterNetworkingConfig {
+				cfg := types.DefaultClusterNetworkingConfig()
+				cfg.SetOrigin(types.OriginConfigFile)
+				return cfg
+			}(),
+			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting network config", err)
+			},
+		},
+		{
+			name: "reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(types.DefaultClusterNetworkingConfig(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := types.DefaultClusterNetworkingConfig()
+			if test.config != nil {
+				cfg = test.config
+			}
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(cfg))
+			require.NoError(t, err, "creating test service")
+
+			reset, err := env.ResetClusterNetworkingConfig(context.Background(), &clusterconfigpb.ResetClusterNetworkingConfigRequest{})
+			test.assertion(t, reset, err)
+		})
+	}
+}
+
+func TestCreateSessionRecordingConfig(t *testing.T) {
+	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+		Role:     types.RoleAuth,
+		Username: string(types.RoleAuth),
+	}, nil)
+	require.NoError(t, err, "creating auth role context")
+
+	cases := []struct {
+		name       string
+		modules    modules.Modules
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, created types.SessionRecordingConfig, err error)
+	}{
+		{
+			name: "unauthorized built in role",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authz.ContextForBuiltinRole(authz.BuiltinRole{
+					Role:     types.RoleProxy,
+					Username: string(types.RoleProxy),
+				}, nil)
+			}),
+			assertion: func(t *testing.T, created types.SessionRecordingConfig, err error) {
+				assert.Nil(t, created)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating recording config", err)
+			},
+		},
+		{
+			name: "authorized built in auth",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			}),
+			assertion: func(t *testing.T, created types.SessionRecordingConfig, err error) {
+				require.NoError(t, err, "got (%v), expected auth role to create recording config", err)
+				require.NotNil(t, created)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.modules != nil {
+				modules.SetTestModules(t, test.modules)
+			}
+
+			var opts []serviceOpt
+			if test.authorizer != nil {
+				opts = append(opts, withAuthorizer(test.authorizer))
+			}
+
+			env, err := newTestEnv(opts...)
+			require.NoError(t, err, "creating test service")
+
+			created, err := env.CreateSessionRecordingConfig(context.Background(), types.DefaultSessionRecordingConfig())
+			test.assertion(t, created, err)
+		})
+	}
+}
+
+func TestGetSessionRecordingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting recording config", err)
+			},
+		}, {
+			name: "authorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetSessionRecordingConfig(context.Background(), &clusterconfigpb.GetSessionRecordingConfigRequest{})
+			test.assertion(t, err)
+			if err == nil {
+				require.Empty(t, cmp.Diff(types.DefaultSessionRecordingConfig(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			}
+		})
+	}
+}
+
+func TestUpdateSessionRecordingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		config     func(p types.SessionRecordingConfig)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.SessionRecordingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating recording config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating recording config", err)
+			},
+		},
+		{
+			name: "updated",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.SessionRecordingConfig) {
+				p.SetProxyChecksHostKeys(false)
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.NoError(t, err)
+				require.False(t, updated.GetProxyChecksHostKeys())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			cfg := env.defaultRecordingConfig
+			if test.config != nil {
+				test.config(cfg)
+			}
+
+			updated, err := env.UpdateSessionRecordingConfig(context.Background(), &clusterconfigpb.UpdateSessionRecordingConfigRequest{SessionRecordingConfig: cfg.(*types.SessionRecordingConfigV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestUpsertSessionRecordingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		config     func(p types.SessionRecordingConfig)
+		authorizer authz.Authorizer
+		assertion  func(t *testing.T, updated types.SessionRecordingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting recording config", err)
+			},
+		},
+		{
+			name: "access prevented",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting recording config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbCreate, types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
+				}, nil
+			}),
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting recording config", err)
+			},
+		},
+		{
+			name: "upserted",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func(p types.SessionRecordingConfig) {
+				p.SetProxyChecksHostKeys(false)
+				p.SetOrigin("test-origin")
+			},
+			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
+				require.NoError(t, err)
+				require.False(t, updated.GetProxyChecksHostKeys())
+				require.Equal(t, types.OriginDynamic, updated.Origin())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
+			require.NoError(t, err, "creating test service")
+
+			// Set revisions to allow the update to succeed.
+			cfg := env.defaultRecordingConfig
+			if test.config != nil {
+				test.config(cfg)
+			}
+
+			updated, err := env.UpsertSessionRecordingConfig(context.Background(), &clusterconfigpb.UpsertSessionRecordingConfigRequest{SessionRecordingConfig: cfg.(*types.SessionRecordingConfigV2)})
+			test.assertion(t, updated, err)
+		})
+	}
+}
+
+func TestResetSessionRecordingConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		authorizer authz.Authorizer
+		modules    modules.Modules
+		config     types.SessionRecordingConfig
+		assertion  func(t *testing.T, reset types.SessionRecordingConfig, err error)
+	}{
+		{
+			name: "unauthorized",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting recording config", err)
+			},
+		},
+		{
+			name: "no admin action",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting recording config", err)
+			},
+		},
+		{
+			name: "config file origin prevents reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			config: func() types.SessionRecordingConfig {
+				cfg := types.DefaultSessionRecordingConfig()
+				cfg.SetOrigin(types.OriginConfigFile)
+				return cfg
+			}(),
+			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
+				assert.Nil(t, reset)
+				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting recording config", err)
+			},
+		},
+		{
+			name: "reset",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate, types.VerbCreate}},
+					},
+					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
+				}, nil
+			}),
+			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(types.DefaultSessionRecordingConfig(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := types.DefaultSessionRecordingConfig()
+			if test.config != nil {
+				cfg = test.config
+			}
+			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(cfg))
+			require.NoError(t, err, "creating test service")
+
+			reset, err := env.ResetSessionRecordingConfig(context.Background(), &clusterconfigpb.ResetSessionRecordingConfigRequest{})
+			test.assertion(t, reset, err)
+		})
+	}
+}
+
+type fakeChecker struct {
+	services.AccessChecker
+	rules map[string][]string
+}
+
+func (f fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string) error {
+	verbs, ok := f.rules[kind]
+	if !ok {
+		return trace.AccessDenied("no allow rules for kind")
+	}
+
+	if !slices.Contains(verbs, verb) {
+		return trace.AccessDenied("verb %s not allowed", verb)
+	}
+
+	return nil
+}
+
+type envConfig struct {
+	authorizer              authz.Authorizer
+	defaultAuthPreference   types.AuthPreference
+	defaultNetworkingConfig types.ClusterNetworkingConfig
+	defaultRecordingConfig  types.SessionRecordingConfig
+}
+type serviceOpt = func(config *envConfig)
+
+func withAuthorizer(authz authz.Authorizer) serviceOpt {
+	return func(config *envConfig) {
+		config.authorizer = authz
+	}
+}
+
+func withDefaultAuthPreference(p types.AuthPreference) serviceOpt {
+	return func(config *envConfig) {
+		config.defaultAuthPreference = p
+	}
+}
+
+func withDefaultClusterNetworkingConfig(c types.ClusterNetworkingConfig) serviceOpt {
+	return func(config *envConfig) {
+		config.defaultNetworkingConfig = c
+	}
+}
+
+func withDefaultRecordingConfig(c types.SessionRecordingConfig) serviceOpt {
+	return func(config *envConfig) {
+		config.defaultRecordingConfig = c
+	}
+}
+
+type env struct {
+	*clusterconfigv1.Service
+	backend                 clusterconfigv1.Backend
+	defaultPreference       types.AuthPreference
+	defaultNetworkingConfig types.ClusterNetworkingConfig
+	defaultRecordingConfig  types.SessionRecordingConfig
+}
+
+func newTestEnv(opts ...serviceOpt) (*env, error) {
+	bk, err := memory.New(memory.Config{})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating memory backend")
+	}
+
+	storage, err := local.NewClusterConfigurationService(bk)
+	if err != nil {
+		return nil, trace.Wrap(err, "created cluster configuration storage service")
+	}
+
+	var cfg envConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	service := struct{ services.ClusterConfiguration }{ClusterConfiguration: storage}
+	svc, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
+		Cache:      service,
+		Backend:    service,
+		Authorizer: cfg.authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating users service")
+	}
+
+	ctx := context.Background()
+	var defaultPreference types.AuthPreference
+	if cfg.defaultAuthPreference != nil {
+		defaultPreference, err = service.CreateAuthPreference(ctx, cfg.defaultAuthPreference)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating default auth preference")
+		}
+	}
+
+	var defaultNetworkingConfig types.ClusterNetworkingConfig
+	if cfg.defaultNetworkingConfig != nil {
+		defaultNetworkingConfig, err = service.CreateClusterNetworkingConfig(ctx, cfg.defaultNetworkingConfig)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating default networking config")
+		}
+	}
+
+	var defaultSessionRecordingConfig types.SessionRecordingConfig
+	if cfg.defaultRecordingConfig != nil {
+		defaultSessionRecordingConfig, err = service.CreateSessionRecordingConfig(ctx, cfg.defaultRecordingConfig)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating session recording config")
+		}
+	}
+
+	return &env{
+		Service:                 svc,
+		backend:                 service,
+		defaultPreference:       defaultPreference,
+		defaultNetworkingConfig: defaultNetworkingConfig,
+		defaultRecordingConfig:  defaultSessionRecordingConfig,
+	}, nil
+}

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -18,1282 +18,23 @@ package clusterconfigv1_test
 
 import (
 	"context"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/gravitational/teleport/api/constants"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 )
 
-func TestCreateAuthPreference(t *testing.T) {
-	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
-		Role:     types.RoleAuth,
-		Username: string(types.RoleAuth),
-	}, nil)
-	require.NoError(t, err, "creating auth role context")
-
-	cases := []struct {
-		name       string
-		modules    modules.Modules
-		authorizer authz.Authorizer
-		preference func(p types.AuthPreference)
-		assertion  func(t *testing.T, created types.AuthPreference, err error)
-	}{
-		{
-			name: "unauthorized built in role",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authz.ContextForBuiltinRole(authz.BuiltinRole{
-					Role:     types.RoleProxy,
-					Username: string(types.RoleProxy),
-				}, nil)
-			}),
-			assertion: func(t *testing.T, created types.AuthPreference, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating auth preferences", err)
-			},
-		},
-		{
-			name: "authorized built in auth",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			assertion: func(t *testing.T, created types.AuthPreference, err error) {
-				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
-				require.NotNil(t, created)
-			},
-		},
-		{
-			name: "creation prevented when hardware key policy is set in open source",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				pp := p.(*types.AuthPreferenceV2)
-				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
-			},
-			assertion: func(t *testing.T, created types.AuthPreference, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected hardware key policy to be rejected in OSS", err)
-			},
-		},
-		{
-			name: "creation allowed when hardware key policy is set in enterprise",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
-			preference: func(p types.AuthPreference) {
-				pp := p.(*types.AuthPreferenceV2)
-				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
-			},
-			assertion: func(t *testing.T, created types.AuthPreference, err error) {
-				require.NoError(t, err, "got (%v), expected auth role to create auth preference", err)
-				require.NotNil(t, created)
-			},
-		},
-		{
-			name: "creation prevented when hardware key policy is set in open source",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.SetDeviceTrust(&types.DeviceTrust{
-					Mode: constants.DeviceTrustModeRequired,
-				})
-			},
-			assertion: func(t *testing.T, created types.AuthPreference, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected device trust mode conflict to prevent creation", err)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
-			}
-
-			var opts []serviceOpt
-			if test.authorizer != nil {
-				opts = append(opts, withAuthorizer(test.authorizer))
-			}
-
-			env, err := newTestEnv(opts...)
-			require.NoError(t, err, "creating test service")
-
-			pref := types.DefaultAuthPreference()
-			if test.preference != nil {
-				test.preference(pref)
-			}
-
-			created, err := env.CreateAuthPreference(context.Background(), pref)
-			test.assertion(t, created, err)
-		})
-	}
-}
-
-func TestGetAuthPreference(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
-			},
-		}, {
-			name: "authorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbRead}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.NoError(t, err)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
-			require.NoError(t, err, "creating test service")
-
-			got, err := env.GetAuthPreference(context.Background(), &clusterconfigpb.GetAuthPreferenceRequest{})
-			test.assertion(t, err)
-			if err == nil {
-				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			}
-		})
-	}
-}
-
-func TestUpdateAuthPreference(t *testing.T) {
-	cases := []struct {
-		name       string
-		preference func(p types.AuthPreference)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.AuthPreference, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating auth preferences", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating auth preferences", err)
-			},
-		},
-		{
-			name: "oss hardware key policy",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating auth preferences", err)
-			},
-		},
-		{
-			name: "invalid device trust settings",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent updating auth preferences", err)
-			},
-		},
-		{
-			name: "updated",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.NoError(t, err)
-				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			pref := env.defaultPreference
-			if test.preference != nil {
-				test.preference(pref)
-			}
-
-			updated, err := env.UpdateAuthPreference(context.Background(), &clusterconfigpb.UpdateAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestUpsertAuthPreference(t *testing.T) {
-	cases := []struct {
-		name       string
-		preference func(p types.AuthPreference)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.AuthPreference, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting auth preferences", err)
-			},
-		},
-		{
-			name: "access prevented",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting auth preferences", err)
-			},
-		},
-		{
-			name: "oss hardware key policy",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting auth preferences", err)
-			},
-		},
-		{
-			name: "invalid device trust settings",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.DeviceTrust = &types.DeviceTrust{Mode: constants.DeviceTrustModeRequired}
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected conflicting device trust settings to prevent upserting auth preferences", err)
-			},
-		},
-		{
-			name: "upserted",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func(p types.AuthPreference) {
-				p.(*types.AuthPreferenceV2).Spec.LockingMode = constants.LockingModeStrict
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.AuthPreference, err error) {
-				require.NoError(t, err)
-				require.Equal(t, constants.LockingModeStrict, updated.GetLockingMode())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(types.DefaultAuthPreference()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			pref := env.defaultPreference
-			if test.preference != nil {
-				test.preference(pref)
-			}
-
-			updated, err := env.UpsertAuthPreference(context.Background(), &clusterconfigpb.UpsertAuthPreferenceRequest{AuthPreference: pref.(*types.AuthPreferenceV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestResetAuthPreference(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		modules    modules.Modules
-		preference types.AuthPreference
-		assertion  func(t *testing.T, reset types.AuthPreference, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting auth preferences", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting auth preferences", err)
-			},
-		},
-		{
-			name: "config file origin prevents reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			preference: func() types.AuthPreference {
-				p := types.DefaultAuthPreference()
-				p.SetOrigin(types.OriginConfigFile)
-				return p
-			}(),
-			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting auth preferences", err)
-			},
-		},
-		{
-			name: "reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterAuthPreference: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.AuthPreference, err error) {
-				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(types.DefaultAuthPreference(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			p := types.DefaultAuthPreference()
-			if test.preference != nil {
-				p = test.preference
-			}
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultAuthPreference(p))
-			require.NoError(t, err, "creating test service")
-
-			reset, err := env.ResetAuthPreference(context.Background(), &clusterconfigpb.ResetAuthPreferenceRequest{})
-			test.assertion(t, reset, err)
-		})
-	}
-}
-
-func TestCreateClusterNetworkingConfig(t *testing.T) {
-	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
-		Role:     types.RoleAuth,
-		Username: string(types.RoleAuth),
-	}, nil)
-	require.NoError(t, err, "creating auth role context")
-
-	cases := []struct {
-		name       string
-		modules    modules.Modules
-		authorizer authz.Authorizer
-		config     func(p types.ClusterNetworkingConfig)
-		assertion  func(t *testing.T, created types.ClusterNetworkingConfig, err error)
-	}{
-		{
-			name: "unauthorized built in role",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authz.ContextForBuiltinRole(authz.BuiltinRole{
-					Role:     types.RoleProxy,
-					Username: string(types.RoleProxy),
-				}, nil)
-			}),
-			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating networking config", err)
-			},
-		},
-		{
-			name: "authorized built in auth",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
-				require.NoError(t, err, "got (%v), expected auth role to create networking config", err)
-				require.NotNil(t, created)
-			},
-		},
-		{
-			name: "creation prevented when proxy peering is set in open source",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetTunnelStrategy(&types.TunnelStrategyV1{
-					Strategy: &types.TunnelStrategyV1_ProxyPeering{
-						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
-					},
-				})
-			},
-			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy peering to be rejected in OSS", err)
-			},
-		},
-		{
-			name: "creation allowed when proxy peering is set in enterprise",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetTunnelStrategy(&types.TunnelStrategyV1{
-					Strategy: &types.TunnelStrategyV1_ProxyPeering{
-						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
-					},
-				})
-			},
-			assertion: func(t *testing.T, created types.ClusterNetworkingConfig, err error) {
-				require.NoError(t, err, "got (%v), expected auth role to create networking config", err)
-				require.NotNil(t, created)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
-			}
-
-			var opts []serviceOpt
-			if test.authorizer != nil {
-				opts = append(opts, withAuthorizer(test.authorizer))
-			}
-
-			env, err := newTestEnv(opts...)
-			require.NoError(t, err, "creating test service")
-
-			cfg := types.DefaultClusterNetworkingConfig()
-			if test.config != nil {
-				test.config(cfg)
-			}
-
-			created, err := env.CreateClusterNetworkingConfig(context.Background(), cfg)
-			test.assertion(t, created, err)
-		})
-	}
-}
-
-func TestGetClusterNetworkingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
-			},
-		}, {
-			name: "authorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbRead}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.NoError(t, err)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			got, err := env.GetClusterNetworkingConfig(context.Background(), &clusterconfigpb.GetClusterNetworkingConfigRequest{})
-			test.assertion(t, err)
-			if err == nil {
-				require.Empty(t, cmp.Diff(types.DefaultClusterNetworkingConfig(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			}
-		})
-	}
-}
-
-func TestUpdateClusterNetworkingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		config     func(p types.ClusterNetworkingConfig)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.ClusterNetworkingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating networking config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating networking config", err)
-			},
-		},
-		{
-			name: "oss proxy peering",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetTunnelStrategy(&types.TunnelStrategyV1{
-					Strategy: &types.TunnelStrategyV1_ProxyPeering{
-						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
-					},
-				})
-			},
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent updating networking config", err)
-			},
-		},
-		{
-			name: "updated",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetRoutingStrategy(types.RoutingStrategy_MOST_RECENT)
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.NoError(t, err)
-				require.Equal(t, types.RoutingStrategy_MOST_RECENT, updated.GetRoutingStrategy())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			cfg := env.defaultNetworkingConfig
-			if test.config != nil {
-				test.config(cfg)
-			}
-
-			updated, err := env.UpdateClusterNetworkingConfig(context.Background(), &clusterconfigpb.UpdateClusterNetworkingConfigRequest{ClusterNetworkConfig: cfg.(*types.ClusterNetworkingConfigV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestUpsertClusterNetworkingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		config     func(p types.ClusterNetworkingConfig)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.ClusterNetworkingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting network config", err)
-			},
-		},
-		{
-			name: "access prevented",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting network config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting network config", err)
-			},
-		},
-		{
-			name: "oss proxy peering",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetTunnelStrategy(&types.TunnelStrategyV1{
-					Strategy: &types.TunnelStrategyV1_ProxyPeering{
-						ProxyPeering: types.DefaultProxyPeeringTunnelStrategy(),
-					},
-				})
-			},
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected enterprise only features to prevent upserting network config", err)
-			},
-		},
-		{
-			name: "upserted",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.ClusterNetworkingConfig) {
-				p.SetRoutingStrategy(types.RoutingStrategy_MOST_RECENT)
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.ClusterNetworkingConfig, err error) {
-				require.NoError(t, err)
-				require.Equal(t, types.RoutingStrategy_MOST_RECENT, updated.GetRoutingStrategy())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(types.DefaultClusterNetworkingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			cfg := env.defaultNetworkingConfig
-			if test.config != nil {
-				test.config(cfg)
-			}
-
-			updated, err := env.UpsertClusterNetworkingConfig(context.Background(), &clusterconfigpb.UpsertClusterNetworkingConfigRequest{ClusterNetworkConfig: cfg.(*types.ClusterNetworkingConfigV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestResetClusterNetworkingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		modules    modules.Modules
-		config     types.ClusterNetworkingConfig
-		assertion  func(t *testing.T, reset types.ClusterNetworkingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting network config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting network config", err)
-			},
-		},
-		{
-			name: "config file origin prevents reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func() types.ClusterNetworkingConfig {
-				cfg := types.DefaultClusterNetworkingConfig()
-				cfg.SetOrigin(types.OriginConfigFile)
-				return cfg
-			}(),
-			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting network config", err)
-			},
-		},
-		{
-			name: "reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindClusterNetworkingConfig: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.ClusterNetworkingConfig, err error) {
-				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(types.DefaultClusterNetworkingConfig(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := types.DefaultClusterNetworkingConfig()
-			if test.config != nil {
-				cfg = test.config
-			}
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultClusterNetworkingConfig(cfg))
-			require.NoError(t, err, "creating test service")
-
-			reset, err := env.ResetClusterNetworkingConfig(context.Background(), &clusterconfigpb.ResetClusterNetworkingConfigRequest{})
-			test.assertion(t, reset, err)
-		})
-	}
-}
-
-func TestCreateSessionRecordingConfig(t *testing.T) {
-	authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
-		Role:     types.RoleAuth,
-		Username: string(types.RoleAuth),
-	}, nil)
-	require.NoError(t, err, "creating auth role context")
-
-	cases := []struct {
-		name       string
-		modules    modules.Modules
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, created types.SessionRecordingConfig, err error)
-	}{
-		{
-			name: "unauthorized built in role",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authz.ContextForBuiltinRole(authz.BuiltinRole{
-					Role:     types.RoleProxy,
-					Username: string(types.RoleProxy),
-				}, nil)
-			}),
-			assertion: func(t *testing.T, created types.SessionRecordingConfig, err error) {
-				assert.Nil(t, created)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected proxy role to be prevented from creating recording config", err)
-			},
-		},
-		{
-			name: "authorized built in auth",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return authRoleContext, nil
-			}),
-			assertion: func(t *testing.T, created types.SessionRecordingConfig, err error) {
-				require.NoError(t, err, "got (%v), expected auth role to create recording config", err)
-				require.NotNil(t, created)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
-			}
-
-			var opts []serviceOpt
-			if test.authorizer != nil {
-				opts = append(opts, withAuthorizer(test.authorizer))
-			}
-
-			env, err := newTestEnv(opts...)
-			require.NoError(t, err, "creating test service")
-
-			created, err := env.CreateSessionRecordingConfig(context.Background(), types.DefaultSessionRecordingConfig())
-			test.assertion(t, created, err)
-		})
-	}
-}
-
-func TestGetSessionRecordingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting recording config", err)
-			},
-		}, {
-			name: "authorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbRead}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, err error) {
-				require.NoError(t, err)
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			got, err := env.GetSessionRecordingConfig(context.Background(), &clusterconfigpb.GetSessionRecordingConfigRequest{})
-			test.assertion(t, err)
-			if err == nil {
-				require.Empty(t, cmp.Diff(types.DefaultSessionRecordingConfig(), got, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			}
-		})
-	}
-}
-
-func TestUpdateSessionRecordingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		config     func(p types.SessionRecordingConfig)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.SessionRecordingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent updating recording config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent updating recording config", err)
-			},
-		},
-		{
-			name: "updated",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.SessionRecordingConfig) {
-				p.SetProxyChecksHostKeys(false)
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.NoError(t, err)
-				require.False(t, updated.GetProxyChecksHostKeys())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			cfg := env.defaultRecordingConfig
-			if test.config != nil {
-				test.config(cfg)
-			}
-
-			updated, err := env.UpdateSessionRecordingConfig(context.Background(), &clusterconfigpb.UpdateSessionRecordingConfigRequest{SessionRecordingConfig: cfg.(*types.SessionRecordingConfigV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestUpsertSessionRecordingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		config     func(p types.SessionRecordingConfig)
-		authorizer authz.Authorizer
-		assertion  func(t *testing.T, updated types.SessionRecordingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent upserting recording config", err)
-			},
-		},
-		{
-			name: "access prevented",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting recording config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbCreate, types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthUnauthorized,
-				}, nil
-			}),
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent upserting recording config", err)
-			},
-		},
-		{
-			name: "upserted",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func(p types.SessionRecordingConfig) {
-				p.SetProxyChecksHostKeys(false)
-				p.SetOrigin("test-origin")
-			},
-			assertion: func(t *testing.T, updated types.SessionRecordingConfig, err error) {
-				require.NoError(t, err)
-				require.False(t, updated.GetProxyChecksHostKeys())
-				require.Equal(t, types.OriginDynamic, updated.Origin())
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(types.DefaultSessionRecordingConfig()))
-			require.NoError(t, err, "creating test service")
-
-			// Set revisions to allow the update to succeed.
-			cfg := env.defaultRecordingConfig
-			if test.config != nil {
-				test.config(cfg)
-			}
-
-			updated, err := env.UpsertSessionRecordingConfig(context.Background(), &clusterconfigpb.UpsertSessionRecordingConfigRequest{SessionRecordingConfig: cfg.(*types.SessionRecordingConfigV2)})
-			test.assertion(t, updated, err)
-		})
-	}
-}
-
-func TestResetSessionRecordingConfig(t *testing.T) {
-	cases := []struct {
-		name       string
-		authorizer authz.Authorizer
-		modules    modules.Modules
-		config     types.SessionRecordingConfig
-		assertion  func(t *testing.T, reset types.SessionRecordingConfig, err error)
-	}{
-		{
-			name: "unauthorized",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting recording config", err)
-			},
-		},
-		{
-			name: "no admin action",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
-					},
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsAccessDenied(err), "got (%v), expected lack of admin action to prevent resetting recording config", err)
-			},
-		},
-		{
-			name: "config file origin prevents reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			config: func() types.SessionRecordingConfig {
-				cfg := types.DefaultSessionRecordingConfig()
-				cfg.SetOrigin(types.OriginConfigFile)
-				return cfg
-			}(),
-			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
-				assert.Nil(t, reset)
-				require.True(t, trace.IsBadParameter(err), "got (%v), expected config file origin to prevent resetting recording config", err)
-			},
-		},
-		{
-			name: "reset",
-			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-				return &authz.Context{
-					Checker: fakeChecker{
-						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbUpdate, types.VerbCreate}},
-					},
-					AdminActionAuthState: authz.AdminActionAuthMFAVerified,
-				}, nil
-			}),
-			assertion: func(t *testing.T, reset types.SessionRecordingConfig, err error) {
-				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(types.DefaultSessionRecordingConfig(), reset, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-			},
-		},
-	}
-
-	for _, test := range cases {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := types.DefaultSessionRecordingConfig()
-			if test.config != nil {
-				cfg = test.config
-			}
-			env, err := newTestEnv(withAuthorizer(test.authorizer), withDefaultRecordingConfig(cfg))
-			require.NoError(t, err, "creating test service")
-
-			reset, err := env.ResetSessionRecordingConfig(context.Background(), &clusterconfigpb.ResetSessionRecordingConfigRequest{})
-			test.assertion(t, reset, err)
-		})
-	}
-}
-
-type fakeChecker struct {
-	services.AccessChecker
-	rules map[string][]string
-}
-
-func (f fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, kind string, verb string) error {
-	verbs, ok := f.rules[kind]
-	if !ok {
-		return trace.AccessDenied("no allow rules for kind")
-	}
-
-	if !slices.Contains(verbs, verb) {
-		return trace.AccessDenied("verb %s not allowed", verb)
-	}
-
-	return nil
-}
-
 type envConfig struct {
-	authorizer              authz.Authorizer
-	defaultAuthPreference   types.AuthPreference
-	defaultNetworkingConfig types.ClusterNetworkingConfig
-	defaultRecordingConfig  types.SessionRecordingConfig
+	authorizer        authz.Authorizer
+	accessGraphConfig clusterconfigv1.AccessGraphConfig
 }
 type serviceOpt = func(config *envConfig)
 
@@ -1303,88 +44,139 @@ func withAuthorizer(authz authz.Authorizer) serviceOpt {
 	}
 }
 
-func withDefaultAuthPreference(p types.AuthPreference) serviceOpt {
+func withAccessGraphConfig(cfg clusterconfigv1.AccessGraphConfig) serviceOpt {
 	return func(config *envConfig) {
-		config.defaultAuthPreference = p
-	}
-}
-
-func withDefaultClusterNetworkingConfig(c types.ClusterNetworkingConfig) serviceOpt {
-	return func(config *envConfig) {
-		config.defaultNetworkingConfig = c
-	}
-}
-
-func withDefaultRecordingConfig(c types.SessionRecordingConfig) serviceOpt {
-	return func(config *envConfig) {
-		config.defaultRecordingConfig = c
+		config.accessGraphConfig = cfg
 	}
 }
 
 type env struct {
 	*clusterconfigv1.Service
-	backend                 clusterconfigv1.Backend
-	defaultPreference       types.AuthPreference
-	defaultNetworkingConfig types.ClusterNetworkingConfig
-	defaultRecordingConfig  types.SessionRecordingConfig
 }
 
 func newTestEnv(opts ...serviceOpt) (*env, error) {
-	bk, err := memory.New(memory.Config{})
-	if err != nil {
-		return nil, trace.Wrap(err, "creating memory backend")
-	}
-
-	storage, err := local.NewClusterConfigurationService(bk)
-	if err != nil {
-		return nil, trace.Wrap(err, "created cluster configuration storage service")
-	}
-
 	var cfg envConfig
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	service := struct{ services.ClusterConfiguration }{ClusterConfiguration: storage}
 	svc, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
-		Cache:      service,
-		Backend:    service,
-		Authorizer: cfg.authorizer,
+		Authorizer:  cfg.authorizer,
+		AccessGraph: cfg.accessGraphConfig,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating users service")
 	}
 
-	ctx := context.Background()
-	var defaultPreference types.AuthPreference
-	if cfg.defaultAuthPreference != nil {
-		defaultPreference, err = service.CreateAuthPreference(ctx, cfg.defaultAuthPreference)
-		if err != nil {
-			return nil, trace.Wrap(err, "creating default auth preference")
-		}
-	}
-
-	var defaultNetworkingConfig types.ClusterNetworkingConfig
-	if cfg.defaultNetworkingConfig != nil {
-		defaultNetworkingConfig, err = service.CreateClusterNetworkingConfig(ctx, cfg.defaultNetworkingConfig)
-		if err != nil {
-			return nil, trace.Wrap(err, "creating default networking config")
-		}
-	}
-
-	var defaultSessionRecordingConfig types.SessionRecordingConfig
-	if cfg.defaultRecordingConfig != nil {
-		defaultSessionRecordingConfig, err = service.CreateSessionRecordingConfig(ctx, cfg.defaultRecordingConfig)
-		if err != nil {
-			return nil, trace.Wrap(err, "creating session recording config")
-		}
-	}
-
 	return &env{
-		Service:                 svc,
-		backend:                 service,
-		defaultPreference:       defaultPreference,
-		defaultNetworkingConfig: defaultNetworkingConfig,
-		defaultRecordingConfig:  defaultSessionRecordingConfig,
+		Service: svc,
 	}, nil
+}
+
+func TestGetAccessGraphConfig(t *testing.T) {
+	cfgEnabled := clusterconfigv1.AccessGraphConfig{
+		Enabled:  true,
+		Address:  "address",
+		CA:       []byte("ca"),
+		Insecure: true,
+	}
+	cases := []struct {
+		name              string
+		accessGraphConfig clusterconfigv1.AccessGraphConfig
+		role              types.SystemRole
+		testSetup         func(*testing.T)
+		errorAssertion    require.ErrorAssertionFunc
+		responseAssertion *clusterconfigpb.GetClusterAccessGraphConfigResponse
+	}{
+		{
+			name: "unauthorized",
+			role: types.RoleKube,
+			errorAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to be prevented from getting auth preferences", err)
+			},
+		},
+		{
+			name:              "authorized proxy with non empty access graph config; Policy module is disabled",
+			role:              types.RoleProxy,
+			accessGraphConfig: cfgEnabled,
+			errorAssertion:    require.NoError,
+			responseAssertion: &clusterconfigpb.GetClusterAccessGraphConfigResponse{
+				AccessGraph: &clusterconfigpb.AccessGraphConfig{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			name: "authorized proxy with non empty access graph config; Policy module is enabled",
+			role: types.RoleProxy,
+			testSetup: func(t *testing.T) {
+				m := modules.TestModules{
+					TestFeatures: modules.Features{
+						Policy: modules.PolicyFeature{
+							Enabled: true,
+						},
+					},
+				}
+				modules.SetTestModules(t, &m)
+			},
+			accessGraphConfig: cfgEnabled,
+			errorAssertion:    require.NoError,
+			responseAssertion: &clusterconfigpb.GetClusterAccessGraphConfigResponse{
+				AccessGraph: &clusterconfigpb.AccessGraphConfig{
+					Enabled:  true,
+					Insecure: true,
+					Address:  "address",
+					Ca:       []byte("ca"),
+				},
+			},
+		},
+		{
+			name: "authorized discovery with non empty access graph config; Policy module is enabled",
+			role: types.RoleDiscovery,
+			testSetup: func(t *testing.T) {
+				m := modules.TestModules{
+					TestFeatures: modules.Features{
+						Policy: modules.PolicyFeature{
+							Enabled: true,
+						},
+					},
+				}
+				modules.SetTestModules(t, &m)
+			},
+			accessGraphConfig: cfgEnabled,
+			errorAssertion:    require.NoError,
+			responseAssertion: &clusterconfigpb.GetClusterAccessGraphConfigResponse{
+				AccessGraph: &clusterconfigpb.AccessGraphConfig{
+					Enabled:  true,
+					Insecure: true,
+					Address:  "address",
+					Ca:       []byte("ca"),
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.testSetup != nil {
+				test.testSetup(t)
+			}
+			authRoleContext, err := authz.ContextForBuiltinRole(authz.BuiltinRole{
+				Role:     test.role,
+				Username: string(test.role),
+			}, nil)
+			require.NoError(t, err, "creating auth role context")
+			authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return authRoleContext, nil
+			})
+			env, err := newTestEnv(withAuthorizer(authorizer), withAccessGraphConfig(test.accessGraphConfig))
+			require.NoError(t, err, "creating test service")
+
+			got, err := env.GetClusterAccessGraphConfig(context.Background(), &clusterconfigpb.GetClusterAccessGraphConfigRequest{})
+			test.errorAssertion(t, err)
+
+			require.Empty(t, cmp.Diff(test.responseAssertion, got, protocmp.Transform()))
+
+		})
+	}
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5648,6 +5648,12 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 
 	clusterConfigService, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
 		Authorizer: cfg.Authorizer,
+		AccessGraph: clusterconfigv1.AccessGraphConfig{
+			Enabled:  cfg.APIConfig.AccessGraph.Enabled,
+			CA:       cfg.APIConfig.AccessGraph.CA,
+			Address:  cfg.APIConfig.AccessGraph.Address,
+			Insecure: cfg.APIConfig.AccessGraph.Insecure,
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
@@ -62,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/assist/assistv1"
+	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/auth/discoveryconfig/discoveryconfigv1"
 	integrationService "github.com/gravitational/teleport/lib/auth/integration/integrationv1"
 	"github.com/gravitational/teleport/lib/auth/loginrule"
@@ -5643,6 +5645,14 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	userloginstatev1.RegisterUserLoginStateServiceServer(server, userLoginStateServer)
+
+	clusterConfigService, err := clusterconfigv1.NewService(clusterconfigv1.ServiceConfig{
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	clusterconfigpb.RegisterClusterConfigServiceServer(server, clusterConfigService)
 
 	// Only register the service if this is an open source build. Enterprise builds
 	// register the actual service via an auth plugin, if we register here then all

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4717,6 +4717,7 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 
 type testTLSServerOptions struct {
 	cacheEnabled bool
+	accessGraph  *AccessGraphConfig
 }
 
 type testTLSServerOption func(*testTLSServerOptions)
@@ -4724,6 +4725,12 @@ type testTLSServerOption func(*testTLSServerOptions)
 func withCacheEnabled(enabled bool) testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.cacheEnabled = enabled
+	}
+}
+
+func withAccessGraphConfig(cfg AccessGraphConfig) testTLSServerOption {
+	return func(options *testTLSServerOptions) {
+		options.accessGraph = &cfg
 	}
 }
 
@@ -4741,10 +4748,14 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *TestTLSServer 
 		Dir:          t.TempDir(),
 		Clock:        clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
 		CacheEnabled: options.cacheEnabled,
+		//AccessGraphConfig: options.accessGraph,
 	})
 	require.NoError(t, err)
-
-	srv, err := as.NewTestTLSServer()
+	var tlsServerOpts []TestTLSServerOption
+	if options.accessGraph != nil {
+		tlsServerOpts = append(tlsServerOpts, WithAccessGraphConfig(*options.accessGraph))
+	}
+	srv, err := as.NewTestTLSServer(tlsServerOpts...)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1991,6 +1991,13 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	var accessGraphCAData []byte
+	if cfg.AccessGraph.Enabled && cfg.AccessGraph.CA != "" {
+		accessGraphCAData, err = os.ReadFile(cfg.AccessGraph.CA)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	apiConf := &auth.APIConfig{
 		AuthServer:     authServer,
 		Authorizer:     authorizer,
@@ -1998,6 +2005,12 @@ func (process *TeleportProcess) initAuthService() error {
 		PluginRegistry: process.PluginRegistry,
 		Emitter:        authServer,
 		MetadataGetter: uploadHandler,
+		AccessGraph: auth.AccessGraphConfig{
+			Enabled:  cfg.AccessGraph.Enabled,
+			Address:  cfg.AccessGraph.Addr,
+			CA:       accessGraphCAData,
+			Insecure: cfg.AccessGraph.Insecure,
+		},
 	}
 
 	// Auth initialization is done (including creation/updating of all singleton


### PR DESCRIPTION
Backport #39560 to branch/v14

This also partially backports https://github.com/gravitational/teleport/pull/38523