### PR TITLE
[v15] Tweak device trust event descriptions

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3033,7 +3033,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Update
+              Device Updated
             </div>
           </td>
           <td
@@ -3087,7 +3087,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -3141,7 +3141,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -3303,7 +3303,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -3357,7 +3357,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -3411,7 +3411,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -3465,7 +3465,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -3519,7 +3519,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3573,7 +3573,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3627,7 +3627,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td
@@ -3681,7 +3681,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td
@@ -3735,7 +3735,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Update
+              Device Updated
             </div>
           </td>
           <td
@@ -3789,7 +3789,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3843,7 +3843,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -3951,7 +3951,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -4005,7 +4005,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -4059,7 +4059,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1305,7 +1305,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_CREATE]: {
     type: 'device.create',
-    desc: 'Device Register',
+    desc: 'Device Registered',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has registered a device`
@@ -1313,7 +1313,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_DELETE]: {
     type: 'device.delete',
-    desc: 'Device Delete',
+    desc: 'Device Deleted',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has deleted a device`
@@ -1321,7 +1321,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_AUTHENTICATE]: {
     type: 'device.authenticate',
-    desc: 'Device Authenticate',
+    desc: 'Device Authenticated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully authenticated their device`
@@ -1329,7 +1329,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL]: {
     type: 'device.enroll',
-    desc: 'Device Enrollment',
+    desc: 'Device Enrolled',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully enrolled their device`
@@ -1337,7 +1337,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL_TOKEN_CREATE]: {
     type: 'device.token.create',
-    desc: 'Device Enroll Token Create',
+    desc: 'Device Enroll Token Created',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] created a device enroll token`
@@ -1353,7 +1353,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_UPDATE]: {
     type: 'device.update',
-    desc: 'Device Update',
+    desc: 'Device Updated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has updated a device`


### PR DESCRIPTION
Change event descriptions to use past tense, similarly to "user" events (and a few others).

Related to https://github.com/gravitational/teleport.e/issues/3236.
