### PR TITLE
[v14] Tweak device trust event descriptions

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -2776,7 +2776,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Update
+              Device Updated
             </div>
           </td>
           <td
@@ -2830,7 +2830,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -2884,7 +2884,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -3046,7 +3046,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -3100,7 +3100,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -3154,7 +3154,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -3208,7 +3208,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -3262,7 +3262,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3316,7 +3316,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3370,7 +3370,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td
@@ -3424,7 +3424,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td
@@ -3478,7 +3478,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Update
+              Device Updated
             </div>
           </td>
           <td
@@ -3532,7 +3532,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Authenticate
+              Device Authenticated
             </div>
           </td>
           <td
@@ -3586,7 +3586,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enrollment
+              Device Enrolled
             </div>
           </td>
           <td
@@ -3694,7 +3694,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Enroll Token Create
+              Device Enroll Token Created
             </div>
           </td>
           <td
@@ -3748,7 +3748,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Delete
+              Device Deleted
             </div>
           </td>
           <td
@@ -3802,7 +3802,7 @@ exports[`list of all events 1`] = `
                   />
                 </svg>
               </span>
-              Device Register
+              Device Registered
             </div>
           </td>
           <td

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1226,7 +1226,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_CREATE]: {
     type: 'device.create',
-    desc: 'Device Register',
+    desc: 'Device Registered',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has registered a device`
@@ -1234,7 +1234,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_DELETE]: {
     type: 'device.delete',
-    desc: 'Device Delete',
+    desc: 'Device Deleted',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has deleted a device`
@@ -1242,7 +1242,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_AUTHENTICATE]: {
     type: 'device.authenticate',
-    desc: 'Device Authenticate',
+    desc: 'Device Authenticated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully authenticated their device`
@@ -1250,7 +1250,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL]: {
     type: 'device.enroll',
-    desc: 'Device Enrollment',
+    desc: 'Device Enrolled',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has successfully enrolled their device`
@@ -1258,7 +1258,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_ENROLL_TOKEN_CREATE]: {
     type: 'device.token.create',
-    desc: 'Device Enroll Token Create',
+    desc: 'Device Enroll Token Created',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] created a device enroll token`
@@ -1274,7 +1274,7 @@ export const formatters: Formatters = {
   },
   [eventCodes.DEVICE_UPDATE]: {
     type: 'device.update',
-    desc: 'Device Update',
+    desc: 'Device Updated',
     format: ({ user, status, success }) =>
       success || (status && status.success)
         ? `User [${user}] has updated a device`


### PR DESCRIPTION
Change event descriptions to use past tense, similarly to "user" events (and a few others).

Related to https://github.com/gravitational/teleport.e/issues/3236.
