### PR TITLE
Fix comment for AWS OIDC IdP set up

### DIFF
--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -319,7 +319,8 @@ func NewIdPIAMConfigureClient(ctx context.Context) (IdPIAMConfigureClient, error
 //   - s3:CreateBucket
 //   - s3:GetBucketPolicy
 //   - s3:PutBucketPolicy
-//   - s3:DeletePublicAccessBlock
+//   - s3:PutBucketPublicAccessBlock (used for s3:DeletePublicAccessBlock)
+//   - s3:ListBuckets (used for s3:HeadBucket)
 //   - s3:PutObject
 func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMConfigureRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {


### PR DESCRIPTION
The method's godoc wrongly mentions the required actions. We referenced API Calls and not the actual required IAM Policy Actions.