### PR TITLE
Use new access request filters in webUI

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -20,6 +20,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
@@ -548,7 +549,11 @@ func (r *AccessRequestV3) GetAllLabels() map[string]string {
 // MatchSearch goes through select field values and tries to
 // match against the list of search values.
 func (r *AccessRequestV3) MatchSearch(values []string) bool {
-	fieldVals := append(utils.MapToStrings(r.GetAllLabels()), r.GetName())
+	fieldVals := append(utils.MapToStrings(r.GetAllLabels()), r.GetName(), r.GetUser())
+	fieldVals = append(fieldVals, r.GetRoles()...)
+	for _, resource := range r.GetRequestedResourceIDs() {
+		fieldVals = append(fieldVals, resource.Name)
+	}
 	return MatchSearch(fieldVals, values, nil)
 }
 
@@ -774,8 +779,46 @@ func (f *AccessRequestFilter) FromMap(m map[string]string) error {
 	return nil
 }
 
+func hasReviewed(req AccessRequest, author string) bool {
+	reviews := req.GetReviews()
+	var reviewers []string
+	for _, review := range reviews {
+		reviewers = append(reviewers, review.Author)
+	}
+	return slices.Contains(reviewers, author)
+}
+
 // Match checks if a given access request matches this filter.
 func (f *AccessRequestFilter) Match(req AccessRequest) bool {
+	// only return if the request was made by the api requester
+	if f.Scope == AccessRequestScope_MY_REQUESTS && req.GetUser() != f.Requester {
+		return false
+	}
+	// a user cannot review their own requests
+	if f.Scope == AccessRequestScope_NEEDS_REVIEW {
+		if req.GetUser() == f.Requester {
+			return false
+		}
+		if req.GetState() != RequestState_PENDING {
+			return false
+		}
+		if hasReviewed(req, f.Requester) {
+			return false
+		}
+	}
+	// only match if the api requester has submit a review
+	if f.Scope == AccessRequestScope_REVIEWED {
+		// users cant review their own requests so we can early return
+		if req.GetUser() == f.Requester {
+			return false
+		}
+		if !hasReviewed(req, f.Requester) {
+			return false
+		}
+	}
+	if !req.MatchSearch(f.SearchKeywords) {
+		return false
+	}
 	if f.ID != "" && req.GetName() != f.ID {
 		return false
 	}

--- a/api/types/sortby.go
+++ b/api/types/sortby.go
@@ -31,7 +31,7 @@ func GetSortByFromString(sortStr string) SortBy {
 	vals := strings.Split(sortStr, ":")
 	if vals[0] != "" {
 		sortBy.Field = vals[0]
-		if len(vals) > 1 && vals[1] == "desc" {
+		if len(vals) > 1 && strings.ToLower(vals[1]) == "desc" {
 			sortBy.IsDesc = true
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2482,6 +2482,9 @@ func (a *ServerWithRoles) ListAccessRequests(ctx context.Context, req *proto.Lis
 	if req.Filter == nil {
 		req.Filter = &types.AccessRequestFilter{}
 	}
+	// set the requesting user to be used in the filter match. This is only meant to be set here
+	// and will be overwritten if set elsewhere
+	req.Filter.Requester = a.context.User.GetName()
 
 	if err := a.action(apidefaults.Namespace, types.KindAccessRequest, types.VerbList, types.VerbRead); err != nil {
 		// Users are allowed to read + list their own access requests and

--- a/lib/services/access_request_cache.go
+++ b/lib/services/access_request_cache.go
@@ -43,6 +43,8 @@ const (
 	accessRequestCreated = "Created"
 	// accessRequestState is the name of the sort index used for sorting requests by their current state (pending, approved, etc).
 	accessRequestState = "State"
+	// accessRequestUser is the name of the sort index used for sorting requests by the person who created the request.
+	accessRequestUser = "User"
 )
 
 // AccessRequestCacheConfig holds the configuration parameters for an [AccessRequestCache].
@@ -186,6 +188,8 @@ func (c *AccessRequestCache) ListMatchingAccessRequests(ctx context.Context, req
 		index = accessRequestCreated
 	case proto.AccessRequestSort_STATE:
 		index = accessRequestState
+	case proto.AccessRequestSort_USER:
+		index = accessRequestUser
 	default:
 		return nil, trace.BadParameter("unsupported access request sort index '%v'", req.Sort)
 	}
@@ -249,6 +253,9 @@ func (c *AccessRequestCache) fetch(ctx context.Context) (*sortcache.SortCache[*t
 			},
 			accessRequestState: func(req *types.AccessRequestV3) string {
 				return fmt.Sprintf("%s/%s", req.GetState().String(), req.GetName())
+			},
+			accessRequestUser: func(req *types.AccessRequestV3) string {
+				return fmt.Sprintf("%s/%s", req.GetUser(), req.GetName())
 			},
 		},
 	})

--- a/lib/services/access_request_cache_test.go
+++ b/lib/services/access_request_cache_test.go
@@ -70,28 +70,34 @@ func TestAccessRequestCacheBasics(t *testing.T) {
 	// creation times 1 second apart, according to the order in
 	// which they are defined).
 	rrs := []struct {
+		name  string
 		id    string
 		state types.RequestState
 	}{
 		{
 			id:    "00000000-0000-0000-0000-000000000005",
 			state: types.RequestState_PENDING,
+			name:  "bob",
 		},
 		{
 			id:    "00000000-0000-0000-0000-000000000004",
 			state: types.RequestState_APPROVED,
+			name:  "bob",
 		},
 		{
 			id:    "00000000-0000-0000-0000-000000000003",
 			state: types.RequestState_DENIED,
+			name:  "alice",
 		},
 		{
 			id:    "00000000-0000-0000-0000-000000000002",
 			state: types.RequestState_APPROVED,
+			name:  "alice",
 		},
 		{
 			id:    "00000000-0000-0000-0000-000000000001",
 			state: types.RequestState_PENDING,
+			name:  "jan",
 		},
 	}
 
@@ -166,11 +172,33 @@ func TestAccessRequestCacheBasics(t *testing.T) {
 				"00000000-0000-0000-0000-000000000002", // approved
 			},
 		},
+		{
+			Sort:       proto.AccessRequestSort_USER,
+			Descending: true,
+			Expect: []string{
+				"00000000-0000-0000-0000-000000000001", // jan
+				"00000000-0000-0000-0000-000000000005", // bob
+				"00000000-0000-0000-0000-000000000004", // bob
+				"00000000-0000-0000-0000-000000000003", // alice
+				"00000000-0000-0000-0000-000000000002", // alice
+			},
+		},
+		{
+			Sort:       proto.AccessRequestSort_USER,
+			Descending: false,
+			Expect: []string{
+				"00000000-0000-0000-0000-000000000002", // alice
+				"00000000-0000-0000-0000-000000000003", // alice
+				"00000000-0000-0000-0000-000000000004", // bob
+				"00000000-0000-0000-0000-000000000005", // bob
+				"00000000-0000-0000-0000-000000000001", // jan
+			},
+		},
 	}
 
 	created := time.Now()
 	for _, rr := range rrs {
-		r, err := types.NewAccessRequest(rr.id, "alice@example.com", "some-role")
+		r, err := types.NewAccessRequest(rr.id, rr.name, "some-role")
 		require.NoError(t, err)
 		require.NoError(t, r.SetState(rr.state))
 		r.SetCreationTime(created.UTC())

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2620,7 +2620,7 @@ func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ ht
 func makeUnifiedResourceRequest(r *http.Request) (*proto.ListUnifiedResourcesRequest, error) {
 	values := r.URL.Query()
 
-	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3562,7 +3562,7 @@ func queryLimit(query url.Values, name string, def int) (int, error) {
 // query string. Similar to function 'queryLimit' except it returns as type int32.
 //
 // If there's no such parameter, specified default limit is returned.
-func queryLimitAsInt32(query url.Values, name string, def int32) (int32, error) {
+func QueryLimitAsInt32(query url.Values, name string, def int32) (int32, error) {
 	str := query.Get(name)
 	if str == "" {
 		return def, nil

--- a/lib/web/discoveryconfig.go
+++ b/lib/web/discoveryconfig.go
@@ -163,7 +163,7 @@ func (h *Handler) discoveryconfigList(w http.ResponseWriter, r *http.Request, p 
 	}
 
 	values := r.URL.Query()
-	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -194,7 +194,7 @@ func (h *Handler) integrationsList(w http.ResponseWriter, r *http.Request, p htt
 	}
 
 	values := r.URL.Query()
-	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -442,7 +442,7 @@ func ExtractResourceAndValidate(yaml string) (*services.UnknownResource, error) 
 func convertListResourcesRequest(r *http.Request, kind string) (*proto.ListResourcesRequest, error) {
 	values := r.URL.Query()
 
-	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -472,7 +472,7 @@ func listKubeResources(ctx context.Context, kubeClient kubeproto.KubeServiceClie
 
 // newKubeListRequest parses the request parameters into a ListKubernetesResourcesRequest.
 func newKubeListRequest(values url.Values, site, resourceKind string) (*kubeproto.ListKubernetesResourcesRequest, error) {
-	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -110,8 +110,16 @@ export function useKeyBasedPagination<T>({
         pendingPromise.current = null;
         abortController.current = null;
 
+        // this will handle backward compatibility with access requests.
+        // The old access requests API returns only an array of resources while
+        // the new one sends the paginated object with startKey/requests
+        // If this webclient requests an older proxy, this should allow the
+        // old request to not break the webui
+        // TODO (avatus): DELETE in 17
+        const newResources = res[dataKey] || res;
+
         setState({
-          resources: [...resources, ...res[dataKey]],
+          resources: [...resources, ...newResources],
           startKey: res.startKey,
           finished: !res.startKey,
           attempt: { status: 'success' },

--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -85,6 +85,12 @@ export type ResourceIdKind =
   | 'user_group'
   | 'windows_desktop';
 
+export type AccessRequestScope =
+  | 'my_requests'
+  | 'needs_review'
+  | 'reviewed'
+  | '';
+
 export type ConnectionDiagnostic = {
   /** id is the identifier of the connection diagnostic. */
   id: string;


### PR DESCRIPTION
In support of https://github.com/gravitational/teleport.e/issues/3263

Requires and `e` PR as the web UI for access requests lives there.

This PR adds new field values to use during `MatchSearch`, as well as new scopes