### PR TITLE
rework ListUsers API

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1000,60 +1000,59 @@ func (c *Client) GetCurrentUserRoles(ctx context.Context) ([]types.Role, error) 
 // GetUsers returns all currently registered users.
 // withSecrets controls whether authentication details are returned.
 func (c *Client) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error) {
-	users, next, err := c.ListUsers(ctx, defaults.DefaultChunkSize, "", withSecrets)
-	if err != nil {
-		// TODO(tross): DELETE IN 16.0.0
-		if trace.IsNotImplemented(err) {
-			//nolint:staticcheck // SA1019. Kept for backward compatibility.
-			stream, err := c.grpc.GetUsers(ctx, &proto.GetUsersRequest{
-				WithSecrets: withSecrets,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			var users []types.User
-			for user, err := stream.Recv(); !errors.Is(err, io.EOF); user, err = stream.Recv() {
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				users = append(users, user)
-			}
-			return users, nil
-		}
-
-		return nil, trace.Wrap(err)
+	req := userspb.ListUsersRequest{
+		WithSecrets: withSecrets,
 	}
 
-	out := users
-	for next != "" {
-		users, next, err = c.ListUsers(ctx, defaults.DefaultChunkSize, next, withSecrets)
+	var out []types.User
+	for {
+		rsp, err := c.ListUsers(ctx, &req)
 		if err != nil {
+			// TODO(tross): DELETE IN 16.0.0
+			if trace.IsNotImplemented(err) {
+				return c.getUsersCompat(ctx, withSecrets)
+			}
+
 			return nil, trace.Wrap(err)
 		}
 
-		out = append(out, users...)
+		for _, user := range rsp.Users {
+			out = append(out, user)
+		}
+
+		req.PageToken = rsp.NextPageToken
+		if req.PageToken == "" {
+			break
+		}
 	}
 
 	return out, nil
 }
 
-// ListUsers returns a page of users.
-func (c *Client) ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error) {
-	resp, err := userspb.NewUsersServiceClient(c.conn).ListUsers(ctx, &userspb.ListUsersRequest{
-		PageSize:    int32(pageSize),
-		PageToken:   nextToken,
+// getUsersCompat is a fallback used to load users when talking to older auth servers that
+// don't implement the newer ListUsers method.
+func (c *Client) getUsersCompat(ctx context.Context, withSecrets bool) ([]types.User, error) {
+	//nolint:staticcheck // SA1019. Kept for backward compatibility.
+	stream, err := c.grpc.GetUsers(ctx, &proto.GetUsersRequest{
 		WithSecrets: withSecrets,
 	})
 	if err != nil {
-		return nil, "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	out := make([]types.User, 0, len(resp.Users))
-	for _, u := range resp.Users {
-		out = append(out, u)
+	var users []types.User
+	for user, err := stream.Recv(); !errors.Is(err, io.EOF); user, err = stream.Recv() {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		users = append(users, user)
 	}
+	return users, nil
+}
 
-	return out, resp.NextPageToken, nil
+// ListUsers returns a page of users.
+func (c *Client) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error) {
+	resp, err := userspb.NewUsersServiceClient(c.conn).ListUsers(ctx, req)
+	return resp, trace.Wrap(err)
 }
 
 // DeleteUser deletes a user by name.

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -978,7 +979,7 @@ type Cache interface {
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
 	// ListUsers returns a page of users.
-	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
+	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
 
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -44,6 +44,7 @@ import (
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -695,7 +696,7 @@ type IdentityService interface {
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
 
 	// ListUsers returns a page of users.
-	ListUsers(ctx context.Context, pageSize int, pageToken string, withSecrets bool) ([]types.User, string, error)
+	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
 
 	// ChangePassword changes user password
 	ChangePassword(ctx context.Context, req *proto.ChangePasswordRequest) error

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -44,7 +44,7 @@ type Cache interface {
 	// GetUser returns a user by name.
 	GetUser(ctx context.Context, user string, withSecrets bool) (types.User, error)
 	// ListUsers returns a page of users.
-	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
+	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
 	// GetRole returns a role by name.
 	GetRole(ctx context.Context, name string) (types.Role, error)
 }
@@ -562,25 +562,6 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 		}
 	}
 
-	users, next, err := s.cache.ListUsers(ctx, int(req.PageSize), req.PageToken, req.WithSecrets)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	resp := &userspb.ListUsersResponse{
-		Users:         make([]*types.UserV2, 0, len(users)),
-		NextPageToken: next,
-	}
-
-	for _, user := range users {
-		v2, ok := user.(*types.UserV2)
-		if !ok {
-			s.logger.Warnf("expected type UserV2, got %T", user)
-		}
-
-		resp.Users = append(resp.Users, v2)
-
-	}
-
-	return resp, nil
+	rsp, err := s.cache.ListUsers(ctx, req)
+	return rsp, trace.Wrap(err)
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -1212,7 +1213,7 @@ func (userExecutor) getReader(cache *Cache, cacheOK bool) userGetter {
 type userGetter interface {
 	GetUser(ctx context.Context, user string, withSecrets bool) (types.User, error)
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
-	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
+	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
 }
 
 var _ executor[types.User, userGetter] = userExecutor{}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -63,7 +64,7 @@ type UsersService interface {
 	// GetUsers returns a list of users registered with the local auth server
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
 	// ListUsers returns a page of users.
-	ListUsers(ctx context.Context, pageSize int, nextToken string, withSecrets bool) ([]types.User, string, error)
+	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
 	// DeleteAllUsers deletes all users
 	DeleteAllUsers(ctx context.Context) error
 }

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -185,7 +185,7 @@ func itemFromUser(user types.User) (*backend.Item, error) {
 
 // itemToUser attempts to decode the supplied `backend.Item` as
 // a user resource.
-func itemToUser(item backend.Item) (types.User, error) {
+func itemToUser(item backend.Item) (*types.UserV2, error) {
 	user, err := services.UnmarshalUser(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -346,7 +346,7 @@ func itemFromSAMLConnector(connector types.SAMLConnector) (*backend.Item, error)
 // userFromUserItems is an extended variant of itemToUser which can be used
 // with the `userItems` collector to include additional backend.Item values
 // such as password hash or MFA devices.
-func userFromUserItems(name string, items userItems) (types.User, error) {
+func userFromUserItems(name string, items userItems) (*types.UserV2, error) {
 	if items.params == nil {
 		return nil, trace.BadParameter("cannot itemTo user %q without primary item %q", name, paramsPrefix)
 	}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -40,6 +41,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
@@ -78,9 +80,11 @@ func (s *IdentityService) DeleteAllUsers(ctx context.Context) error {
 	return trace.Wrap(s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
-func (s *IdentityService) listUsersWithSecrets(ctx context.Context, pageSize int, pageToken string) ([]types.User, string, error) {
-	rangeStart := backend.Key(webPrefix, usersPrefix, pageToken)
+// ListUsers returns a page of users.
+func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error) {
+	rangeStart := backend.Key(webPrefix, usersPrefix, req.PageToken)
 	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
+	pageSize := req.PageSize
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > apidefaults.DefaultChunkSize {
@@ -89,65 +93,32 @@ func (s *IdentityService) listUsersWithSecrets(ctx context.Context, pageSize int
 
 	// Artificially inflate the limit to account for user secrets
 	// which have the same prefix.
-	limit := pageSize * 4
+	limit := int(pageSize) * 4
 
-	rangeStream := backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit)
+	itemStream := backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit)
 
-	var (
-		out []types.User
-
-		name  string
-		items userItems
-	)
-	for rangeStream.Next() {
-		item := rangeStream.Item()
-
-		itemName, suffix, err := splitUsernameAndSuffix(string(item.Key))
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-
-		if itemName == name {
-			items.Set(suffix, item)
-			continue
-		}
-
-		// we exclude user item sets that don't have a /params subitem because
-		// SSO users have an expiration time on /params but their /mfa devices
-		// are persistent
-		if items.complete() {
-			user, err := userFromUserItems(name, items)
-			if err != nil {
-				return nil, "", trace.Wrap(err)
-			}
-			out = append(out, user)
-
-			if len(out) >= pageSize {
-				if err := rangeStream.Done(); err != nil {
-					return nil, "", trace.Wrap(err)
-				}
-
-				return out, nextUserToken(user), nil
-			}
-		}
-
-		name = itemName
-		items = userItems{}
-		items.Set(suffix, item)
-	}
-	if err := rangeStream.Done(); err != nil {
-		return nil, "", trace.Wrap(err)
+	var userStream stream.Stream[*types.UserV2]
+	if req.WithSecrets {
+		userStream = s.streamUsersWithSecrets(itemStream)
+	} else {
+		userStream = s.streamUsersWithoutSecrets(itemStream)
 	}
 
-	if items.complete() {
-		user, err := userFromUserItems(name, items)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		out = append(out, user)
+	users, full := stream.Take(userStream, int(pageSize))
+
+	var nextToken string
+	if full && userStream.Next() {
+		nextToken = nextUserToken(users[len(users)-1])
 	}
 
-	return out, "", nil
+	if err := userStream.Done(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &userspb.ListUsersResponse{
+		Users:         users,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 // nextUserToken returns the last token for the given user. This
@@ -158,45 +129,89 @@ func nextUserToken(user types.User) string {
 	return string(backend.RangeEnd(backend.ExactKey(user.GetName())))[utf8.RuneLen(backend.Separator):]
 }
 
-// ListUsers returns a page of users.
-func (s *IdentityService) ListUsers(ctx context.Context, pageSize int, pageToken string, withSecrets bool) ([]types.User, string, error) {
-	if withSecrets {
-		users, next, err := s.listUsersWithSecrets(ctx, pageSize, pageToken)
-		return users, next, trace.Wrap(err)
+// streamUsersWithSecrets is a helper that converts a stream of backend items over the user key range into a stream
+// of users along with their associated secrets.
+func (s *IdentityService) streamUsersWithSecrets(itemStream stream.Stream[backend.Item]) stream.Stream[*types.UserV2] {
+	type collector struct {
+		items userItems
+		name  string
 	}
 
-	rangeStart := backend.Key(webPrefix, usersPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(webPrefix, usersPrefix))
+	var current collector
 
-	// Adjust page size, so it can't be too large.
-	if pageSize <= 0 || pageSize > apidefaults.DefaultChunkSize {
-		pageSize = apidefaults.DefaultChunkSize
-	}
+	collectorStream := stream.FilterMap(itemStream, func(item backend.Item) (collector, bool) {
+		name, suffix, err := splitUsernameAndSuffix(string(item.Key))
+		if err != nil {
+			s.log.Warnf("Failed to extract name/suffix for user item at %q: %v", item.Key, err)
+			return collector{}, false
+		}
 
-	// Artificially inflate the limit to account for user secrets
-	// which have the same prefix.
-	limit := pageSize * 4
+		if name == current.name {
+			// we're already in the process of aggregating the items for this user, so just
+			// store this item and continue on to the next one.
+			current.items.Set(suffix, item)
+			return collector{}, false
+		}
 
-	rangeStream := stream.FilterMap(
-		backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit),
-		func(item backend.Item) (backend.Item, bool) {
-			return item, bytes.HasSuffix(item.Key, []byte(paramsPrefix))
-		})
+		// we've reached a new user range, so take local ownership of the previous aggregator and
+		// set up a new one to aggregate this new range.
+		prev := current
+		current = collector{
+			name: name,
+		}
+		current.items.Set(suffix, item)
 
-	var err error
-	userStream := stream.MapWhile(rangeStream, func(item backend.Item) (types.User, bool) {
-		var user types.User
-		user, err = services.UnmarshalUser(item.Value, services.WithRevision(item.Revision))
-		return user, err == nil
+		if !prev.items.complete() {
+			// previous aggregator was empty or malformed and can be discarded.
+			return collector{}, false
+		}
+
+		return prev, true
+
 	})
 
-	users, more := stream.Take(userStream, pageSize)
-	var nextToken string
-	if more && userStream.Next() {
-		nextToken = nextUserToken(users[len(users)-1])
-	}
+	// since a collector for a given user isn't yielded until the above stream reaches the *next*
+	// user, that means the last user's collector is never yielded. we need to append a single
+	// additional check to the stream that decides if it should yield the final collector.
+	collectorStream = stream.Chain(collectorStream, stream.OnceFunc(func() (collector, error) {
+		if !current.items.complete() {
+			return collector{}, io.EOF
+		}
+		return current, nil
+	}))
 
-	return users, nextToken, trace.NewAggregate(err, userStream.Done())
+	userStream := stream.FilterMap(collectorStream, func(c collector) (*types.UserV2, bool) {
+		user, err := userFromUserItems(c.name, c.items)
+		if err != nil {
+			s.log.Warnf("Failed to build user %q from user item aggregator: %v", c.name, err)
+			return nil, false
+		}
+
+		return user, true
+	})
+
+	return userStream
+}
+
+// streamUsersWithoutSecrets is a helper that converts a stream of backend items over the user range into a stream of
+// user resources without any included secrets.
+func (s *IdentityService) streamUsersWithoutSecrets(itemStream stream.Stream[backend.Item]) stream.Stream[*types.UserV2] {
+	suffix := []byte(paramsPrefix)
+	userStream := stream.FilterMap(itemStream, func(item backend.Item) (*types.UserV2, bool) {
+		if !bytes.HasSuffix(item.Key, suffix) {
+			return nil, false
+		}
+
+		user, err := services.UnmarshalUser(item.Value, services.WithRevision(item.Revision))
+		if err != nil {
+			s.log.Warnf("Failed to unmarshal user at %q: %v", item.Key, err)
+			return nil, false
+		}
+
+		return user, true
+	})
+
+	return userStream
 }
 
 // GetUsers returns a list of users registered with the local auth server

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -1012,15 +1013,17 @@ func TestIdentityService_ListUsers(t *testing.T) {
 	require.NoError(t, err, "creating otp device failed")
 
 	// Validate that no users returns an empty page.
-	users, next, err := identity.ListUsers(ctx, 0, "", false)
+	rsp, err := identity.ListUsers(ctx, &userspb.ListUsersRequest{})
 	assert.NoError(t, err, "no error returned when no users exist")
-	assert.Empty(t, users, "users returned from listing when no users exist")
-	assert.Empty(t, next, "next page token returned from listing when no users exist")
+	assert.Empty(t, rsp.Users, "users returned from listing when no users exist")
+	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no users exist")
 
-	users, next, err = identity.ListUsers(ctx, 0, "", true)
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{
+		WithSecrets: true,
+	})
 	assert.NoError(t, err, "no error returned when no users exist")
-	assert.Empty(t, users, "users returned from listing when no users exist")
-	assert.Empty(t, next, "next page token returned from listing when no users exist")
+	assert.Empty(t, rsp.Users, "users returned from listing when no users exist")
+	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no users exist")
 
 	// Validate that listing works when there is only a single user
 	user, err := types.NewUser("fish0")
@@ -1028,17 +1031,17 @@ func TestIdentityService_ListUsers(t *testing.T) {
 
 	user, err = identity.CreateUser(ctx, user)
 	require.NoError(t, err, "creating user %s failed", user)
-	expectedUsers := []types.User{user}
+	expectedUsers := []*types.UserV2{user.(*types.UserV2)}
 
-	users, next, err = identity.ListUsers(ctx, 0, "", false)
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{})
 	assert.NoError(t, err, "no error returned when no users exist")
-	assert.Empty(t, next, "next page token returned from listing when no more users exist")
-	assert.Empty(t, cmp.Diff(expectedUsers, users, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
+	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no more users exist")
+	assert.Empty(t, cmp.Diff(expectedUsers, rsp.Users, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
 
-	users, next, err = identity.ListUsers(ctx, 0, "", true)
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{})
 	assert.NoError(t, err, "no error returned when no users exist")
-	assert.Empty(t, next, "next page token returned from listing when no users exist")
-	assert.Empty(t, cmp.Diff(expectedUsers, users), "not all users returned from listing operation")
+	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no users exist")
+	assert.Empty(t, cmp.Diff(expectedUsers, rsp.Users), "not all users returned from listing operation")
 
 	// Create a number of users.
 	usernames := []string{"llama", "alpaca", "fox", "fish", "fish+", "fish2"}
@@ -1070,25 +1073,29 @@ func TestIdentityService_ListUsers(t *testing.T) {
 
 		created, err := identity.CreateUser(ctx, user)
 		require.NoError(t, err, "creating user %s failed", user)
-		expectedUsers = append(expectedUsers, created)
+		expectedUsers = append(expectedUsers, created.(*types.UserV2))
 	}
-	slices.SortFunc(expectedUsers, func(a, b types.User) int {
+	slices.SortFunc(expectedUsers, func(a, b *types.UserV2) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 
 	// List a few users at a time and validate that all users are eventually returned.
-	var retrieved []types.User
-	for next := ""; ; {
-		users, nextToken, err := identity.ListUsers(ctx, 2, next, false)
+	var retrieved []*types.UserV2
+	req := userspb.ListUsersRequest{
+		PageSize: 2,
+	}
+	for {
+		rsp, err := identity.ListUsers(ctx, &req)
 		require.NoError(t, err, "no error returned when no users exist")
 
-		for _, user := range users {
+		for _, user := range rsp.Users {
 			assert.Empty(t, user.GetLocalAuth(), "expected no secrets to be returned with user %s", user.GetName())
 		}
 
-		retrieved = append(retrieved, users...)
-		next = nextToken
-		if next == "" {
+		retrieved = append(retrieved, rsp.Users...)
+
+		req.PageToken = rsp.NextPageToken
+		if req.PageToken == "" {
 			break
 		}
 
@@ -1097,16 +1104,22 @@ func TestIdentityService_ListUsers(t *testing.T) {
 		}
 	}
 
-	slices.SortFunc(retrieved, func(a, b types.User) int {
+	slices.SortFunc(retrieved, func(a, b *types.UserV2) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 	assert.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
 
 	// Validate that listing all users at once returns all expected users with secrets.
-	users, next, err = identity.ListUsers(ctx, 200, "", true)
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{
+		PageSize:    200,
+		WithSecrets: true,
+	})
 	require.NoError(t, err, "unexpected error listing users")
-	assert.Empty(t, next, "got a next page token when page size was greater than number of items")
-	slices.SortFunc(users, func(a, b types.User) int {
+	assert.Empty(t, rsp.NextPageToken, "got a next page token when page size was greater than number of items")
+
+	users := rsp.Users
+
+	slices.SortFunc(users, func(a, b *types.UserV2) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 
@@ -1115,14 +1128,19 @@ func TestIdentityService_ListUsers(t *testing.T) {
 	require.Empty(t, cmp.Diff(expectedUsers, users, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")
 
 	// List a few users at a time and validate that all users are eventually returned with their secrets.
-	retrieved = []types.User{}
-	for next := ""; ; {
-		users, nextToken, err := identity.ListUsers(ctx, 2, next, true)
+	retrieved = nil
+	req = userspb.ListUsersRequest{
+		PageSize:    2,
+		WithSecrets: true,
+	}
+	for {
+		rsp, err := identity.ListUsers(ctx, &req)
 		require.NoError(t, err, "no error returned when no users exist")
 
-		retrieved = append(retrieved, users...)
-		next = nextToken
-		if next == "" {
+		retrieved = append(retrieved, rsp.Users...)
+
+		req.PageToken = rsp.NextPageToken
+		if req.PageToken == "" {
 			break
 		}
 
@@ -1131,7 +1149,7 @@ func TestIdentityService_ListUsers(t *testing.T) {
 		}
 	}
 
-	slices.SortFunc(retrieved, func(a, b types.User) int {
+	slices.SortFunc(retrieved, func(a, b *types.UserV2) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 	require.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")
@@ -1145,10 +1163,15 @@ func TestIdentityService_ListUsers(t *testing.T) {
 
 	clock.Advance(time.Hour)
 
-	retrieved, next, err = identity.ListUsers(ctx, 0, "", true)
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{
+		WithSecrets: true,
+	})
 	assert.NoError(t, err, "got an error while listing over an expired user")
-	assert.Empty(t, next, "next page token returned from listing all users")
-	slices.SortFunc(retrieved, func(a, b types.User) int {
+	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing all users")
+
+	retrieved = rsp.Users
+
+	slices.SortFunc(retrieved, func(a, b *types.UserV2) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 	require.Empty(t, cmp.Diff(expectedUsers, retrieved, cmpopts.SortSlices(devicesSort)), "not all users returned from listing operation")

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -84,7 +84,7 @@ func (la *LoginAttempt) Check() error {
 }
 
 // UnmarshalUser unmarshals the User resource from JSON.
-func UnmarshalUser(bytes []byte, opts ...MarshalOption) (types.User, error) {
+func UnmarshalUser(bytes []byte, opts ...MarshalOption) (*types.UserV2, error) {
 	var h types.ResourceHeader
 	err := json.Unmarshal(bytes, &h)
 	if err != nil {


### PR DESCRIPTION
This PR reworks the `ListUsers` api in preparation for the upcoming addition of filtering/sorting options.  It switches the interface to operate on request/response structs rather than tuples of bare values in order to make it easier to add new parameters, and mostly unifies the underlying backend implementation's with/without secrets variants so that future higher-level changes (including filtering) can have a single source of truth for both request variants.

In order to support the above changes, two new stream combinators have been added to `api/internalutils/stream`.  The `Chain` operator enables joining multiple streams sequentially into a single stream, and the `OnceFunc` operator enables creation of zero or one element streams based on a lazily evaluated closure.