### PR TITLE
Dependabot - Temporary removal of groups config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,11 +22,6 @@ updates:
       - dependency-name: github.com/redis/go-redis/v9
       - dependency-name: github.com/vulcand/predicate
     open-pull-requests-limit: 10
-    groups:
-      go:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - jentfoo
@@ -44,11 +39,6 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
-    groups:
-      go:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - jentfoo
@@ -69,11 +59,6 @@ updates:
       # Forked/replaced dependencies
       - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
-    groups:
-      go:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - jentfoo
@@ -92,11 +77,6 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
-    groups:
-      go:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - jentfoo
@@ -117,11 +97,6 @@ updates:
       # Forked/replaced dependencies
       - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
-    groups:
-      go:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - fheinecke
@@ -140,11 +115,6 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
-    groups:
-      rust:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - ibeckermayer
@@ -163,11 +133,6 @@ updates:
       day: "sunday"
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
-    groups:
-      rust:
-        update-types:
-          - "minor"
-          - "patch"
     reviewers:
       - codingllama
       - ibeckermayer


### PR DESCRIPTION
We currently are failing to get Dependabot updates for `/`.  After discussing with GitHub support, they suggested for debugging we temporarily remove the `groups` config, apply updated, then re-apply the `groups` configuration.

This is a temporary disable of the beta feature to hope to get Dependabot into a working state again.