### PR TITLE
Use GracefulExitContext for Proxy Web Endpoint service

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4113,7 +4113,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Emitter:          asyncEmitter,
 			PluginRegistry:   process.PluginRegistry,
 			HostUUID:         process.Config.HostUUID,
-			Context:          process.ExitContext(),
+			Context:          process.GracefulExitContext(),
 			StaticFS:         fs,
 			ClusterFeatures:  process.getClusterFeatures(),
 			GetProxyIdentity: func() (*auth.Identity, error) {


### PR DESCRIPTION
GracefulExitContext is usually the context that should be used to be notified of process shutdown.

ExitContext only notifies on immediate shutdowns, and gives no time to do clean ups.