### PR TITLE
Fix Access Graph config error message

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -401,7 +401,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.AccessGraph.Enabled {
 		cfg.AccessGraph.Enabled = true
 		if fc.AccessGraph.Endpoint == "" {
-			return trace.Errorf("access_graph.endpoint is required when access graph integration is enabled")
+			return trace.BadParameter("access_graph.endpoint is required when access graph integration is enabled")
 		}
 		cfg.AccessGraph.Addr = fc.AccessGraph.Endpoint
 		cfg.AccessGraph.CA = fc.AccessGraph.CA

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -401,7 +401,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.AccessGraph.Enabled {
 		cfg.AccessGraph.Enabled = true
 		if fc.AccessGraph.Endpoint == "" {
-			return trace.Errorf("Please, provide access_graph_service.addr configuration variable")
+			return trace.Errorf("Please provide access_graph.endpoint configuration variable")
 		}
 		cfg.AccessGraph.Addr = fc.AccessGraph.Endpoint
 		cfg.AccessGraph.CA = fc.AccessGraph.CA

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -401,7 +401,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.AccessGraph.Enabled {
 		cfg.AccessGraph.Enabled = true
 		if fc.AccessGraph.Endpoint == "" {
-			return trace.Errorf("Please provide access_graph.endpoint configuration variable")
+			return trace.Errorf("access_graph.endpoint is required when access graph integration is enabled")
 		}
 		cfg.AccessGraph.Addr = fc.AccessGraph.Endpoint
 		cfg.AccessGraph.CA = fc.AccessGraph.CA


### PR DESCRIPTION
The message mistakenly refers to the unset option as `access_graph_service.addr`, while the YAML option is `access_graph.endpoint`.