### PR TITLE
chore: Bump golangci-lint to v1.57.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,12 @@
 issues:
+  exclude-dirs:
+    - (^|/)node_modules/
+    - ^api/gen/
+    - ^docs/
+    - ^gen/
+    - ^rfd/
+    - ^web/
+  exclude-dirs-use-default: false
   exclude-rules:
     - linters:
       - gosimple
@@ -104,12 +112,4 @@ output:
 run:
   go: '1.21'
   build-tags: []
-  skip-dirs:
-    - (^|/)node_modules/
-    - ^api/gen/
-    - ^docs/
-    - ^gen/
-    - ^rfd/
-    - ^web/
-  skip-dirs-use-default: false
   timeout: 15m

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.1
-GOLANGCI_LINT_VERSION ?= v1.56.2
+GOLANGCI_LINT_VERSION ?= v1.57.1
 
 NODE_VERSION ?= 20.11.1
 


### PR DESCRIPTION
Update to the latest version.

The `run.skip-dirs` and `run.skip-dirs-use-default` keys moved under `issues`, but other than that no noteworthy changes for us.

* https://golangci-lint.run/product/changelog/#v1570
* https://golangci-lint.run/product/changelog/#v1571