### PR TITLE
fix a few bugs with kube waiting container backend

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -113,6 +113,7 @@ type testPack struct {
 	userLoginStates         services.UserLoginStates
 	secReports              services.SecReports
 	accessLists             services.AccessLists
+	kubeWaitingContainers   services.KubeWaitingContainer
 }
 
 // testFuncs are functions to support testing an object in a cache.
@@ -288,6 +289,12 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.accessLists = accessListsSvc
 
+	kubeWaitingContSvc, err := local.NewKubeWaitingContainerService(p.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p.kubeWaitingContainers = kubeWaitingContSvc
+
 	return p, nil
 }
 
@@ -329,6 +336,7 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 		UserLoginStates:         p.userLoginStates,
 		SecReports:              p.secReports,
 		AccessLists:             p.accessLists,
+		KubeWaitingContainers:   p.kubeWaitingContainers,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))
@@ -727,6 +735,7 @@ func TestCompletenessInit(t *testing.T) {
 			UserLoginStates:         p.userLoginStates,
 			SecReports:              p.secReports,
 			AccessLists:             p.accessLists,
+			KubeWaitingContainers:   p.kubeWaitingContainers,
 			MaxRetryPeriod:          200 * time.Millisecond,
 			EventsC:                 p.eventsC,
 		}))
@@ -799,6 +808,7 @@ func TestCompletenessReset(t *testing.T) {
 		UserLoginStates:         p.userLoginStates,
 		SecReports:              p.secReports,
 		AccessLists:             p.accessLists,
+		KubeWaitingContainers:   p.kubeWaitingContainers,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))
@@ -983,6 +993,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		UserLoginStates:         p.userLoginStates,
 		SecReports:              p.secReports,
 		AccessLists:             p.accessLists,
+		KubeWaitingContainers:   p.kubeWaitingContainers,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 		neverOK:                 true, // ensure reads are never healthy
@@ -1066,6 +1077,7 @@ func initStrategy(t *testing.T) {
 		UserLoginStates:         p.userLoginStates,
 		SecReports:              p.secReports,
 		AccessLists:             p.accessLists,
+		KubeWaitingContainers:   p.kubeWaitingContainers,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/39317. Found these bugs while testing the service implementation more with code that used it: https://github.com/gravitational/teleport-private/pull/1362.

Fixes include:
- Some cache tests failing due to kube waiting cont service not getting added to the cache used in tests
- When the cache received put events of kube waiting cont resources an error would sometimes occur due to an unexpected resource type being received
- The cache's `executor.getAll` method listed from the cache instead of Auth