### PR TITLE
[v13] Use GracefulExitContext for Proxy Web Endpoint service

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3987,7 +3987,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Emitter:                   streamEmitter,
 			PluginRegistry:            process.PluginRegistry,
 			HostUUID:                  process.Config.HostUUID,
-			Context:                   process.ExitContext(),
+			Context:                   process.GracefulExitContext(),
 			StaticFS:                  fs,
 			ClusterFeatures:           process.getClusterFeatures(),
 			UI:                        cfg.Proxy.UI,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/39664 to branch/v13