### PR TITLE
Add CORS headers to the `tsh login` callback

### DIFF
--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -268,13 +268,14 @@ func (rd *Redirector) callback(w http.ResponseWriter, r *http.Request) (*auth.SS
 		return nil, trace.NotFound("path not found")
 	}
 
-	if r.URL.Query().Has("err") {
-		err := r.URL.Query().Get("err")
+	r.ParseForm()
+	if r.Form.Has("err") {
+		err := r.Form.Get("err")
 		return nil, trace.Errorf("identity provider callback failed with error: %v", err)
 	}
 
 	// Decrypt ciphertext to get login response.
-	plaintext, err := rd.key.Open([]byte(r.URL.Query().Get("response")))
+	plaintext, err := rd.key.Open([]byte(r.Form.Get("response")))
 	if err != nil {
 		return nil, trace.BadParameter("failed to decrypt response: in %v, err: %v", r.URL.String(), err)
 	}
@@ -301,12 +302,27 @@ func (rd *Redirector) Close() error {
 // and sends a result to the channel and redirect users to error page
 func (rd *Redirector) wrapCallback(fn func(http.ResponseWriter, *http.Request) (*auth.SSHLoginResponse, error)) http.Handler {
 	clone := *rd.proxyURL
+	origin := clone.String()
 	clone.Path = LoginFailedRedirectURL
 	errorURL := clone.String()
 	clone.Path = LoginSuccessRedirectURL
 	successURL := clone.String()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Access-Control-Allow-Origin", origin)
+		w.Header().Add("Access-Control-Allow-Methods", "GET, POST")
+		w.Header().Add("Access-Control-Allow-Private-Network", "true")
+		w.Header().Add("Allow", "GET, OPTIONS, POST")
+		switch r.Method {
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		case http.MethodOptions:
+			w.WriteHeader(http.StatusOK)
+			return
+		case http.MethodGet, http.MethodPost:
+		}
+
 		response, err := fn(w, r)
 		if err != nil {
 			if trace.IsNotFound(err) {
@@ -316,18 +332,15 @@ func (rd *Redirector) wrapCallback(fn func(http.ResponseWriter, *http.Request) (
 			select {
 			case rd.errorC <- err:
 			case <-rd.context.Done():
-				http.Redirect(w, r, errorURL, http.StatusFound)
-				return
 			}
 			http.Redirect(w, r, errorURL, http.StatusFound)
 			return
 		}
 		select {
 		case rd.responseC <- response:
+			http.Redirect(w, r, successURL, http.StatusFound)
 		case <-rd.context.Done():
 			http.Redirect(w, r, errorURL, http.StatusFound)
-			return
 		}
-		http.Redirect(w, r, successURL, http.StatusFound)
 	})
 }

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -302,17 +302,20 @@ func (rd *Redirector) Close() error {
 // and sends a result to the channel and redirect users to error page
 func (rd *Redirector) wrapCallback(fn func(http.ResponseWriter, *http.Request) (*auth.SSHLoginResponse, error)) http.Handler {
 	clone := *rd.proxyURL
-	origin := clone.String()
 	clone.Path = LoginFailedRedirectURL
 	errorURL := clone.String()
 	clone.Path = LoginSuccessRedirectURL
 	successURL := clone.String()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Access-Control-Allow-Origin", origin)
-		w.Header().Add("Access-Control-Allow-Methods", "GET, POST")
-		w.Header().Add("Access-Control-Allow-Private-Network", "true")
 		w.Header().Add("Allow", "GET, OPTIONS, POST")
+		// CORS protects the _response_, and our response is always just a
+		// redirect to info/login_success or error/login so it's fine to share
+		// with the world; we could use the proxy URL as the origin, but that
+		// would break setups where the proxy public address that tsh is using
+		// is not the "main" one that ends up being used for the redirect after
+		// the IdP login
+		w.Header().Add("Access-Control-Allow-Origin", "*")
 		switch r.Method {
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
This PR adds CORS response headers for preflight requests on `/callback` during the `tsh login` SSO login flow, which might become necessary in the future since it's a requirement that has been added and removed several times to Google Chrome (most recently discussed in https://issues.chromium.org/issues/330364341).

Before this PR, launching Chrome with `--enable-features=PrivateNetworkAccessForNavigations` and going through `tsh login` results in a successful `tsh login` but a broken page in the browser; after this PR, the browser is successfully redirected to the "Login successful" page.

In addition, this PR makes it so that in the future (v17) we can have the proxy POST the callback data to `tsh` rather than relying on a redirect.

changelog: fix broken SSO login landing page on certain versions of Google Chrome