### PR TITLE
Update docs to call out acme is not for HA

### DIFF
--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -128,6 +128,8 @@ proxy_service:
     # 'teleport configure --acme --acme-email=email@example.com \
     # --cluster-name=tele.example.com -o file'
     # This should NOT be enabled in a highly available Teleport deployment
+    # Using in HA can lead to too many failed authorizations and a lock-up
+    # of the ACME process (https://letsencrypt.org/docs/failed-validation-limit/)
     #acme:
     #  enabled: yes
     #  email: user@example.com

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -127,6 +127,7 @@ proxy_service:
     # Also set using the CLI command:
     # 'teleport configure --acme --acme-email=email@example.com \
     # --cluster-name=tele.example.com -o file'
+    # This should NOT be enabled in a highly available Teleport deployment
     #acme:
     #  enabled: yes
     #  email: user@example.com


### PR DESCRIPTION
based on user issues, until https://github.com/gravitational/teleport/issues/27613#issue-1746989232 is implemented we should call out that using ACME is not for HA deployments