### PR TITLE
Move DownloadConnect to shared

### DIFF
--- a/web/packages/shared/components/DownloadConnect/DownloadConnect.story.tsx
+++ b/web/packages/shared/components/DownloadConnect/DownloadConnect.story.tsx
@@ -1,0 +1,50 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Box, Text } from 'design';
+import { Platform } from 'design/platform';
+
+import { DownloadConnect, getConnectDownloadLinks } from './DownloadConnect';
+
+export default {
+  title: 'Shared/DownloadConnect',
+};
+
+const links = getConnectDownloadLinks(Platform.Windows, '15.1.2');
+const macLinks = getConnectDownloadLinks(Platform.macOS, '15.1.2');
+const linuxLinks = getConnectDownloadLinks(Platform.Linux, '15.1.2');
+
+export const Story = () => {
+  return (
+    <Box>
+      <Box mb={4}>
+        <Text>Single Link (Windows)</Text>
+        <DownloadConnect downloadLinks={links} />
+      </Box>
+      <Box mb={4}>
+        <Text>Single Link (Macos)</Text>
+        <DownloadConnect downloadLinks={macLinks} />
+      </Box>
+      <Box mb={4}>
+        <Text>Multiple Links (Linux)</Text>
+        <DownloadConnect downloadLinks={linuxLinks} />
+      </Box>
+    </Box>
+  );
+};

--- a/web/packages/shared/components/DownloadConnect/DownloadConnect.tsx
+++ b/web/packages/shared/components/DownloadConnect/DownloadConnect.tsx
@@ -17,6 +17,7 @@
  */
 
 import { ButtonSecondary } from 'design/Button';
+import { Platform } from 'design/platform';
 
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 
@@ -44,3 +45,41 @@ export const DownloadConnect = (props: {
     </MenuButton>
   );
 };
+
+export function getConnectDownloadLinks(
+  platform: Platform,
+  proxyVersion: string
+): Array<DownloadLink> {
+  switch (platform) {
+    case Platform.Windows:
+      return [
+        {
+          text: 'Teleport Connect',
+          url: `https://cdn.teleport.dev/Teleport Connect Setup-${proxyVersion}.exe`,
+        },
+      ];
+    case Platform.macOS:
+      return [
+        {
+          text: 'Teleport Connect',
+          url: `https://cdn.teleport.dev/Teleport Connect-${proxyVersion}.dmg`,
+        },
+      ];
+    case Platform.Linux:
+      return [
+        {
+          text: 'DEB',
+          url: `https://cdn.teleport.dev/teleport-connect_${proxyVersion}_amd64.deb`,
+        },
+        {
+          text: 'RPM',
+          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}.x86_64.rpm`,
+        },
+
+        {
+          text: 'tar.gz',
+          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}-x64.tar.gz`,
+        },
+      ];
+  }
+}

--- a/web/packages/shared/components/DownloadConnect/DownloadConnect.tsx
+++ b/web/packages/shared/components/DownloadConnect/DownloadConnect.tsx
@@ -1,0 +1,46 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ButtonSecondary } from 'design/Button';
+
+import { MenuButton, MenuItem } from 'shared/components/MenuAction';
+
+export type DownloadLink = { text: string; url: string };
+
+export const DownloadConnect = (props: {
+  downloadLinks: Array<DownloadLink>;
+}) => {
+  if (props.downloadLinks.length === 1) {
+    const downloadLink = props.downloadLinks[0];
+    return (
+      <ButtonSecondary as="a" href={downloadLink.url}>
+        Download Teleport Connect
+      </ButtonSecondary>
+    );
+  }
+
+  return (
+    <MenuButton buttonText="Download Teleport Connect">
+      {props.downloadLinks.map(link => (
+        <MenuItem key={link.url} as="a" href={link.url}>
+          {link.text}
+        </MenuItem>
+      ))}
+    </MenuButton>
+  );
+};

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -23,9 +23,12 @@ import { ButtonSecondary } from 'design/Button';
 import { Platform, getPlatform } from 'design/platform';
 import { Text, Flex } from 'design';
 import * as Icons from 'design/Icon';
-import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 import * as connectMyComputer from 'shared/connectMyComputer';
+import {
+  DownloadLink,
+  DownloadConnect,
+} from 'shared/components/DownloadConnect/DownloadConnect';
 
 import cfg from 'teleport/config';
 import useTeleport from 'teleport/useTeleport';
@@ -318,29 +321,6 @@ export const usePollForConnectMyComputerNode = (args: {
   );
 
   return { node, isPolling };
-};
-
-type DownloadLink = { text: string; url: string };
-
-const DownloadConnect = (props: { downloadLinks: Array<DownloadLink> }) => {
-  if (props.downloadLinks.length === 1) {
-    const downloadLink = props.downloadLinks[0];
-    return (
-      <ButtonSecondary as="a" href={downloadLink.url}>
-        Download Teleport Connect
-      </ButtonSecondary>
-    );
-  }
-
-  return (
-    <MenuButton buttonText="Download Teleport Connect">
-      {props.downloadLinks.map(link => (
-        <MenuItem key={link.url} as="a" href={link.url}>
-          {link.text}
-        </MenuItem>
-      ))}
-    </MenuButton>
-  );
 };
 
 function getConnectDownloadLinks(

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -20,14 +20,14 @@ import React, { useEffect, useCallback, useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ButtonSecondary } from 'design/Button';
-import { Platform, getPlatform } from 'design/platform';
+import { getPlatform } from 'design/platform';
 import { Text, Flex } from 'design';
 import * as Icons from 'design/Icon';
 import { Path, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
 import * as connectMyComputer from 'shared/connectMyComputer';
 import {
-  DownloadLink,
   DownloadConnect,
+  getConnectDownloadLinks,
 } from 'shared/components/DownloadConnect/DownloadConnect';
 
 import cfg from 'teleport/config';
@@ -322,41 +322,3 @@ export const usePollForConnectMyComputerNode = (args: {
 
   return { node, isPolling };
 };
-
-function getConnectDownloadLinks(
-  platform: Platform,
-  proxyVersion: string
-): Array<DownloadLink> {
-  switch (platform) {
-    case Platform.Windows:
-      return [
-        {
-          text: 'Teleport Connect',
-          url: `https://cdn.teleport.dev/Teleport Connect Setup-${proxyVersion}.exe`,
-        },
-      ];
-    case Platform.macOS:
-      return [
-        {
-          text: 'Teleport Connect',
-          url: `https://cdn.teleport.dev/Teleport Connect-${proxyVersion}.dmg`,
-        },
-      ];
-    case Platform.Linux:
-      return [
-        {
-          text: 'DEB',
-          url: `https://cdn.teleport.dev/teleport-connect_${proxyVersion}_amd64.deb`,
-        },
-        {
-          text: 'RPM',
-          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}.x86_64.rpm`,
-        },
-
-        {
-          text: 'tar.gz',
-          url: `https://cdn.teleport.dev/teleport-connect-${proxyVersion}-x64.tar.gz`,
-        },
-      ];
-  }
-}


### PR DESCRIPTION
This PR moves the `DownloadConnect` component to the `shared` package. It is going to be reused in the device trust webUI as well so I figured I could take it out of Discover