### PR TITLE
add "tsh ping" command for debugging purposes

### DIFF
--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -176,9 +176,20 @@ func TestAWS(t *testing.T) {
 	})
 }
 
-func makeUserWithAWSRole(t *testing.T) (types.User, types.Role) {
+func makeUserAlice(t *testing.T) types.User {
+	t.Helper()
+
 	alice, err := types.NewUser("alice@example.com")
 	require.NoError(t, err)
+
+	alice.AddRole("access")
+	return alice
+}
+
+func makeUserWithAWSRole(t *testing.T) (types.User, types.Role) {
+	t.Helper()
+
+	alice := makeUserAlice(t)
 
 	awsRole, err := types.NewRole("aws", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -192,7 +203,7 @@ func makeUserWithAWSRole(t *testing.T) (types.User, types.Role) {
 	})
 	require.NoError(t, err)
 
-	alice.SetRoles([]string{"access", awsRole.GetName()})
+	alice.AddRole(awsRole.GetName())
 	return alice, awsRole
 }
 

--- a/tool/tsh/common/ping.go
+++ b/tool/tsh/common/ping.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gravitational/trace"
+)
+
+// onPing does a ping test against the Proxy.
+//
+// Some notes on this command:
+// - user profiles will NOT be updated after the test.
+// - set "--proxy" flag to test a different Teleport Proxy.
+// - use "--debug" flag to see ALPN handshake test, port resolver, etc.
+// - the command can run without being logged in as long as `--proxy` is set.
+// - newer fields in webapi/ping may not show up if `tsh` is old.
+func onPing(cf *CLIConf) error {
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	resp, err := tc.Ping(cf.Context)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	json, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintln(cf.Stdout(), string(json))
+	return nil
+}

--- a/tool/tsh/common/ping_test.go
+++ b/tool/tsh/common/ping_test.go
@@ -1,0 +1,66 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPingCommand(t *testing.T) {
+	t.Parallel()
+
+	tmpHomePath := t.TempDir()
+	connector := mockConnector(t)
+	alice := makeUserAlice(t)
+
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	expectOutputContains := fmt.Sprintf(`"web_listen_addr": "%s"`, proxyAddr)
+
+	// Test ping without logging in
+	pingCommandArgs := []string{"ping", "--insecure", "--debug", "--proxy", proxyAddr.String()}
+	mustRunAndContainsOutput(t, pingCommandArgs, tmpHomePath, expectOutputContains)
+
+	// Test ping while logged in (--proxy is not required after login).
+	err = Run(context.Background(), []string{
+		"login", "--insecure", "--debug", "--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, alice, connector.GetName()))
+	require.NoError(t, err)
+
+	pingCommandArgs = []string{"ping", "--insecure", "--debug"}
+	mustRunAndContainsOutput(t, pingCommandArgs, tmpHomePath, expectOutputContains)
+}
+
+func mustRunAndContainsOutput(t *testing.T, args []string, tmpHomePath, expectOutputContains string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	err := Run(context.Background(), args, setHomePath(tmpHomePath), setCopyStdout(&buf))
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), expectOutputContains)
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1134,6 +1134,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		puttyConfig.Hidden()
 	}
 
+	ping := app.Command("ping", "Test ping against Teleport Proxy.").Hidden()
+
 	// FIDO2, TouchID and WebAuthnWin commands.
 	f2 := newFIDO2Command(app)
 	tid := newTouchIDCommand(app)
@@ -1502,6 +1504,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onHeadlessApprove(&cf)
 	case workloadIdentityCmd.issue.FullCommand():
 		err = workloadIdentityCmd.issue.run(&cf)
+	case ping.FullCommand():
+		err = onPing(&cf)
 	default:
 		// Handle commands that might not be available.
 		switch {


### PR DESCRIPTION
This new command provides a quick way to see the ping result when debugging a connection issue.

It replaces the following "manual" commands:
- `curl https://<proxy-addr>/webapi/ping | jq .`
- `openssl s_client -connect <proxy-addr>:443 -alpn teleport-reversetunnel -servername <proxy-addr> -showcerts`

It can be used to test the currently logged-in cluster or any other cluster with `--proxy <another-proxy-addr>`.

Sample output:
```
$ tsh login --proxy teleport.dev.aws.stevexin.me --user STeve
...

$ tsh ping
{
  "auth": {
    "type": "local",
    "second_factor": "on",
    "preferred_local_mfa": "webauthn",
    "allow_passwordless": true,
    "allow_headless": true,
    "local": {
      "name": ""
    },
    "webauthn": {
      "rp_id": "teleport.dev.aws.stevexin.me"
    },
    "private_key_policy": "none",
    "piv_slot": "",
    "device_trust": {},
    "has_motd": false,
    "default_session_ttl": "12h0m0s"
  },
  "proxy": {
    "kube": {
      "enabled": true,
      "listen_addr": "0.0.0.0:443"
    },
    "ssh": {
      "listen_addr": "0.0.0.0:443",
      "tunnel_listen_addr": "0.0.0.0:443",
      "web_listen_addr": "0.0.0.0:443",
      "public_addr": "teleport.dev.aws.stevexin.me:443",
      "ssh_tunnel_public_addr": "localhost:3023"
    },
    "db": {
      "postgres_listen_addr": "0.0.0.0:443",
      "mysql_listen_addr": "0.0.0.0:443"
    },
    "tls_routing_enabled": true,
    "assist_enabled": false
  },
  "server_version": "16.0.0-dev",
  "min_client_version": "15.0.0",
  "cluster_name": "teleport.dev.aws.stevexin.me",
  "automatic_upgrades": false
}

$ tsh ping --proxy platform.teleport.sh --debug
2024-03-21T16:48:32-04:00 DEBU [TSH]       Web proxy port was not set. Attempting to detect port number to use. common/tsh.go:4107
2024-03-21T16:48:32-04:00 DEBU [TSH]       Resolving default proxy port (insecure: false) common/resolve_default_addr.go:113
2024-03-21T16:48:32-04:00 DEBU [TSH]       Trying platform.teleport.sh:3080... common/resolve_default_addr.go:101
2024-03-21T16:48:32-04:00 DEBU [TSH]       Trying platform.teleport.sh:443... common/resolve_default_addr.go:101
2024-03-21T16:48:32-04:00 DEBU [TSH]       Address platform.teleport.sh:443 succeeded. Selected as canonical proxy address common/resolve_default_addr.go:193
2024-03-21T16:48:32-04:00 DEBU [TSH]       Waiting for all in-flight proxy address tests to finish common/resolve_default_addr.go:141
2024-03-21T16:48:32-04:00 DEBU [TSH]       Proxy address test failed error:[Get "https://platform.teleport.sh:3080/webapi/ping": context canceled] common/resolve_default_addr.go:65
2024-03-21T16:48:32-04:00 INFO [CLIENT]    No teleport login given. defaulting to stevehuang client/api.go:1109
2024-03-21T16:48:32-04:00 INFO [CLIENT]    no host login given. defaulting to stevehuang client/api.go:1119
2024-03-21T16:48:32-04:00 INFO [CLIENT]    [KEY AGENT] Connected to the system agent: "/private/tmp/com.apple.launchd.nxRCpwNs8w/Listeners" client/api.go:4804
2024-03-21T16:48:32-04:00 DEBU [TSH]       Pinging the proxy to fetch listening addresses for non-web ports. common/tsh.go:3570
2024-03-21T16:48:32-04:00 DEBU [CLIENT]    not using loopback pool for remote proxy addr: platform.teleport.sh:443 client/api.go:4759
2024-03-21T16:48:32-04:00 DEBU             Attempting GET platform.teleport.sh:443/webapi/ping webclient/webclient.go:129
2024-03-21T16:48:33-04:00 DEBU             ALPN connection upgrade required for "platform.teleport.sh:443": false. client/alpn_conn_upgrade.go:95
{
  "auth": {
    "type": "saml",
    "second_factor": "otp",
    "preferred_local_mfa": "otp",
    "saml": {
      "name": "okta",
      "display": "Okta"
    },
    "private_key_policy": "none",
    "piv_slot": "",
    "device_trust": {},
    "has_motd": false,
    "default_session_ttl": "12h0m0s"
  },
  "proxy": {
    "kube": {
      "enabled": true,
      "listen_addr": "0.0.0.0:3080"
    },
    "ssh": {
      "listen_addr": "0.0.0.0:3080",
      "tunnel_listen_addr": "0.0.0.0:3080",
      "web_listen_addr": "0.0.0.0:3080",
      "public_addr": "platform.teleport.sh:443"
    },
    "db": {
      "postgres_listen_addr": "0.0.0.0:3080",
      "mysql_listen_addr": "0.0.0.0:3080"
    },
    "tls_routing_enabled": true,
    "assist_enabled": false
  },
  "server_version": "15.1.9",
  "min_client_version": "14.0.0",
  "cluster_name": "platform.teleport.sh",
  "automatic_upgrades": true
}
```