### PR TITLE
Improve performance of resource filtering

### DIFF
--- a/api/types/appserver_or_saml_idp_sp.go
+++ b/api/types/appserver_or_saml_idp_sp.go
@@ -195,7 +195,9 @@ func (a *AppServerOrSAMLIdPServiceProviderV1) GetLabel(key string) (value string
 		v, ok := appServer.Spec.App.Metadata.Labels[key]
 		return v, ok
 	} else {
-		return "", true
+		sp := a.GetSAMLIdPServiceProvider()
+		v, ok := sp.Metadata.Labels[key]
+		return v, ok
 	}
 }
 

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -544,15 +544,21 @@ func IsValidLabelKey(s string) bool {
 // Returns true if all search vals were matched (or if nil search vals).
 // Returns false if no or partial match (or nil field values).
 func MatchSearch(fieldVals []string, searchVals []string, customMatch func(val string) bool) bool {
-	// Case fold all values to avoid repeated case folding while matching.
-	caseFoldedSearchVals := utils.ToLowerStrings(searchVals)
-	caseFoldedFieldVals := utils.ToLowerStrings(fieldVals)
+	caseFoldedFieldVals := make(map[string]string, len(fieldVals))
 
 Outer:
-	for _, searchV := range caseFoldedSearchVals {
+	for _, searchV := range searchVals {
+		searchV = strings.ToLower(searchV)
+
 		// Iterate through field values to look for a match.
-		for _, fieldV := range caseFoldedFieldVals {
-			if strings.Contains(fieldV, searchV) {
+		for _, fieldV := range fieldVals {
+			f, ok := caseFoldedFieldVals[fieldV]
+			if !ok {
+				f = strings.ToLower(fieldV)
+				caseFoldedFieldVals[fieldV] = f
+			}
+
+			if strings.Contains(f, searchV) {
 				continue Outer
 			}
 		}

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -504,13 +504,8 @@ func (m *Metadata) CheckAndSetDefaults() error {
 // MatchLabels takes a map of labels and returns `true` if the resource has ALL
 // of them.
 func MatchLabels(resource ResourceWithLabels, labels map[string]string) bool {
-	if len(labels) == 0 {
-		return true
-	}
-
-	resourceLabels := resource.GetAllLabels()
-	for name, value := range labels {
-		if resourceLabels[name] != value {
+	for key, value := range labels {
+		if v, ok := resource.GetLabel(key); !ok || v != value {
 			return false
 		}
 	}

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -559,6 +559,7 @@ Outer:
 	return true
 }
 
+// containsFold is a case-insensitive alternative to strings.Contains, used to help avoid excess allocations during searches.
 func containsFold(s, substr string) bool {
 	if len(s) < len(substr) {
 		return false

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -544,21 +544,11 @@ func IsValidLabelKey(s string) bool {
 // Returns true if all search vals were matched (or if nil search vals).
 // Returns false if no or partial match (or nil field values).
 func MatchSearch(fieldVals []string, searchVals []string, customMatch func(val string) bool) bool {
-	caseFoldedFieldVals := make(map[string]string, len(fieldVals))
-
 Outer:
 	for _, searchV := range searchVals {
-		searchV = strings.ToLower(searchV)
-
 		// Iterate through field values to look for a match.
 		for _, fieldV := range fieldVals {
-			f, ok := caseFoldedFieldVals[fieldV]
-			if !ok {
-				f = strings.ToLower(fieldV)
-				caseFoldedFieldVals[fieldV] = f
-			}
-
-			if strings.Contains(f, searchV) {
+			if containsFold(fieldV, searchV) {
 				continue Outer
 			}
 		}
@@ -572,6 +562,22 @@ Outer:
 	}
 
 	return true
+}
+
+func containsFold(s, substr string) bool {
+	if len(s) < len(substr) {
+		return false
+	}
+
+	n := len(s) - len(substr)
+
+	for i := 0; i <= n; i++ {
+		if strings.EqualFold(s[i:i+len(substr)], substr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func stringCompare(a string, b string, isDesc bool) bool {

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -496,19 +496,23 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 // MatchSearch goes through select field values and tries to
 // match against the list of search values.
 func (s *ServerV2) MatchSearch(values []string) bool {
-	var fieldVals []string
-	var custom func(val string) bool
-
-	if s.GetKind() == KindNode {
-		fieldVals = append(utils.MapToStrings(s.GetAllLabels()), s.GetName(), s.GetHostname(), s.GetAddr())
-		fieldVals = append(fieldVals, s.GetPublicAddrs()...)
-
-		if s.GetUseTunnel() {
-			custom = func(val string) bool {
-				return strings.EqualFold(val, "tunnel")
-			}
-		}
+	if s.GetKind() != KindNode {
+		return false
 	}
+
+	custom := func(val string) bool {
+		return s.GetUseTunnel() && strings.EqualFold(val, "tunnel")
+	}
+
+	fieldVals := make([]string, 0, (len(s.Metadata.Labels)*2)+(len(s.Spec.CmdLabels)*2)+len(s.Spec.PublicAddrs)+3)
+
+	labels := CombineLabels(s.Metadata.Labels, s.Spec.CmdLabels)
+	for key, value := range labels {
+		fieldVals = append(fieldVals, key, value)
+	}
+
+	fieldVals = append(fieldVals, s.Metadata.Name, s.Spec.Hostname, s.Spec.Addr)
+	fieldVals = append(fieldVals, s.Spec.PublicAddrs...)
 
 	return MatchSearch(fieldVals, values, custom)
 }

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -350,7 +350,11 @@ func (s *ServerV2) GetAllLabels() map[string]string {
 
 // CombineLabels combines the passed in static and dynamic labels.
 func CombineLabels(static map[string]string, dynamic map[string]CommandLabelV2) map[string]string {
-	lmap := make(map[string]string)
+	if len(dynamic) == 0 {
+		return static
+	}
+
+	lmap := make(map[string]string, len(static)+len(dynamic))
 	for key, value := range static {
 		lmap[key] = value
 	}

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -500,8 +500,11 @@ func (s *ServerV2) MatchSearch(values []string) bool {
 		return false
 	}
 
-	custom := func(val string) bool {
-		return s.GetUseTunnel() && strings.EqualFold(val, "tunnel")
+	var custom func(val string) bool
+	if s.GetUseTunnel() {
+		custom = func(val string) bool {
+			return strings.EqualFold(val, "tunnel")
+		}
 	}
 
 	fieldVals := make([]string, 0, (len(s.Metadata.Labels)*2)+(len(s.Spec.CmdLabels)*2)+len(s.Spec.PublicAddrs)+3)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1328,8 +1328,18 @@ func (a *ServerWithRoles) checkUnifiedAccess(resource types.ResourceWithLabels, 
 
 	// Filter first and only check RBAC if there is a match to improve perf.
 	match, err := services.MatchResourceByFilters(resource, filter, nil)
-	if !match || err != nil {
-		return false, trace.Wrap(err)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"resource_name": resource.GetName(),
+			"resource_kind": resourceKind,
+			"error":         err,
+		}).
+			Warn("Unable to determine access to resource, matching with filter failed")
+		return false, nil
+	}
+
+	if !match {
+		return false, nil
 	}
 
 	if resourceKind == types.KindSAMLIdPServiceProvider {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2422,9 +2422,14 @@ type AccessCheckable interface {
 // It also returns a flag indicating whether debug logging is enabled,
 // allowing the RBAC system to generate more verbose errors in debug mode.
 func rbacDebugLogger() (debugEnabled bool, debugf func(format string, args ...interface{})) {
-	isDebugEnabled := log.IsLevelEnabled(log.TraceLevel)
-	log := log.WithField(teleport.ComponentKey, teleport.ComponentRBAC)
-	return isDebugEnabled, log.Tracef
+	debugEnabled = log.IsLevelEnabled(log.TraceLevel)
+	debugf = func(format string, args ...interface{}) {}
+
+	if debugEnabled {
+		debugf = log.WithField(teleport.ComponentKey, teleport.ComponentRBAC).Tracef
+	}
+
+	return
 }
 
 func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state AccessState, matchers ...RoleMatcher) error {

--- a/lib/services/suite/presence_test.go
+++ b/lib/services/suite/presence_test.go
@@ -32,7 +32,6 @@ func TestServerLabels(t *testing.T) {
 	emptyLabels := make(map[string]string)
 	// empty
 	server := &types.ServerV2{}
-	require.Empty(t, cmp.Diff(server.GetAllLabels(), emptyLabels))
 	require.Empty(t, server.GetAllLabels())
 	require.True(t, types.MatchLabels(server, emptyLabels))
 	require.False(t, types.MatchLabels(server, map[string]string{"a": "b"}))


### PR DESCRIPTION
There are three main ways that performance was increased

1) Switch the order of operations for ListUnifiedResources such that RBAC happens after filtering. This reduces the amount of time processing roles for each resource to just the ones that would be returned.
2) Prevent creating a logrus entry during RBAC evaluation if debug logging is disabled
3) Reduce the number of allocations performed in searching and filtering code


### Benchmarks


The output below is comparing the benchmark run on the first commit with the last commit. The changes result in a 60% reduction in test time and 91% reduction of allocations.

```bash

$ benchstat 309068ff441efbc6cf6c9638b0548562e376c66a.txt b6fc568d95ade92b61737b55b19cfceeb8d7f099.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/auth
                                        │ 309068ff441efbc6cf6c9638b0548562e376c66a.txt │ b6fc568d95ade92b61737b55b19cfceeb8d7f099.txt │
                                        │                    sec/op                    │        sec/op         vs base                │
ListUnifiedResourcesFilter/labels-12                                            267.26m ± 1%            67.75m ± 6%  -74.65% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                     500.1m ± 1%            281.3m ± 2%  -43.75% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                    533.8m ± 8%            290.0m ± 1%  -45.68% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                       365.0m ± 4%            122.8m ± 6%  -66.35% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_upper-12                                       337.5m ± 1%            137.2m ± 1%  -59.35% (p=0.000 n=10)
geomean                                                                    388.0m                 156.3m       -59.73%

                                        │ 309068ff441efbc6cf6c9638b0548562e376c66a.txt │ b6fc568d95ade92b61737b55b19cfceeb8d7f099.txt │
                                        │                     B/op                     │         B/op          vs base                │
ListUnifiedResourcesFilter/labels-12                                         162555.6Ki ± 0%           728.3Ki ± 1%  -99.55% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                    396.9Mi ± 0%           238.9Mi ± 0%  -39.81% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                   396.9Mi ± 0%           238.9Mi ± 0%  -39.82% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                     158.62Mi ± 0%           16.76Mi ± 0%  -89.44% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_upper-12                                     159.59Mi ± 0%           16.76Mi ± 0%  -89.50% (p=0.000 n=10)
geomean                                                                   229.2Mi                25.79Mi       -88.75%

                                        │ 309068ff441efbc6cf6c9638b0548562e376c66a.txt │ b6fc568d95ade92b61737b55b19cfceeb8d7f099.txt │
                                        │                  allocs/op                   │      allocs/op        vs base                │
ListUnifiedResourcesFilter/labels-12                                           2411.98k ± 0%            11.42k ± 0%  -99.53% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_path-12                                     7.362M ± 0%            4.962M ± 0%  -32.60% (p=0.000 n=10)
ListUnifiedResourcesFilter/predicate_index-12                                    7.213M ± 0%            4.812M ± 0%  -33.28% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_lower-12                                      3162.2k ± 0%            161.6k ± 0%  -94.89% (p=0.000 n=10)
ListUnifiedResourcesFilter/search_upper-12                                      3312.2k ± 0%            161.6k ± 0%  -95.12% (p=0.000 n=10)
geomean                                                                    4.222M                 371.9k       -91.19%

```


### Real world tests

The changes were tested in a cluster with 150,002 static nodes. 150,000 had varying and overlapping labels and the final two nodes had unique labels to allow finding a needle in the haystack. The overall time of listing the entire set was not improved, though searching for one item out of the whole lot was improved by several hundred milliseconds. 

```bash

#### 15.1.9

time ./releases/15.1.9/tsh ls --format=json | jq .[].metadata.name | wc -l
  150002

________________________________________________________
Executed in   20.40 secs    fish           external
   usr time    3.95 secs    0.21 millis    3.95 secs
   sys time    0.60 secs    2.22 millis    0.60 secs


time ./releases/15.1.9/tsh ls --search="10.20.30.40" --format=json | jq .[].metadata.name | wc -l
      1

________________________________________________________
Executed in    1.08 secs      fish           external
  usr time   88.14 millis    0.23 millis   87.92 millis
  sys time   38.26 millis    2.54 millis   35.72 millis



#### tross/listing_performance


time ./releases/15.1.9/tsh ls --format=json | jq .[].metadata.name | wc -l
  150002

________________________________________________________
Executed in   20.84 secs    fish           external
   usr time    4.05 secs    0.19 millis    4.05 secs
   sys time    0.59 secs    2.57 millis    0.59 secs

time ./releases/15.1.9/tsh ls --search="10.20.30.40" --format=json | jq .[].metadata.name | wc -l
       1

________________________________________________________
Executed in  704.20 millis    fish           external
   usr time   75.38 millis    0.24 millis   75.14 millis
   sys time   49.23 millis    2.77 millis   46.46 millis

```




Changelog: Improve resource filtering performance for tsh ls and the web ui.