### PR TITLE
[v13] chore: Bump golangci-lint to v1.57.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,12 @@
 issues:
+  exclude-dirs:
+    - (^|/)node_modules/
+    - ^api/gen/
+    - ^docs/
+    - ^gen/
+    - ^rfd/
+    - ^web/
+  exclude-dirs-use-default: false
   exclude-rules:
     - linters:
       - gosimple
@@ -74,12 +82,4 @@ output:
 run:
   go: '1.21'
   build-tags: []
-  skip-dirs:
-    - (^|/)node_modules/
-    - ^api/gen/
-    - ^docs/
-    - ^gen/
-    - ^rfd/
-    - ^web/
-  skip-dirs-use-default: false
   timeout: 15m

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -2,7 +2,7 @@
 # This file can be included in other Makefiles to avoid duplication.
 
 GOLANG_VERSION ?= go1.21.8
-GOLANGCI_LINT_VERSION ?= v1.56.2
+GOLANGCI_LINT_VERSION ?= v1.57.1
 
 NODE_VERSION ?= 20.11.1
 


### PR DESCRIPTION
Backport ##39669 to branch/v13.