### PR TITLE
add GCP Workforce Identity Federation tile to discovery ui

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -39,4 +39,12 @@ export const SAML_APPLICATIONS: ResourceSpec[] = [
     icon: 'Grafana',
     event: DiscoverEventResource.SamlApplication,
   },
+  {
+    name: 'Workforce Identity Federation',
+    kind: ResourceKind.SamlApplication,
+    samlMeta: {preset: SamlServiceProviderPreset.GcpWorkforce},
+    keywords: 'saml sso application idp gcp workforce federation',
+    icon: 'Gcp',
+    event: DiscoverEventResource.SamlApplication,
+  },
 ];

--- a/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resourcesE.tsx
@@ -42,7 +42,7 @@ export const SAML_APPLICATIONS: ResourceSpec[] = [
   {
     name: 'Workforce Identity Federation',
     kind: ResourceKind.SamlApplication,
-    samlMeta: {preset: SamlServiceProviderPreset.GcpWorkforce},
+    samlMeta: { preset: SamlServiceProviderPreset.GcpWorkforce },
     keywords: 'saml sso application idp gcp workforce federation',
     icon: 'Gcp',
     event: DiscoverEventResource.SamlApplication,

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -72,6 +72,7 @@ export enum KubeLocation {
 export enum SamlServiceProviderPreset {
   Unspecified = 'unspecified',
   Grafana = 'grafana',
+  GcpWorkforce = 'gcp-workforce',
 }
 
 export interface ResourceSpec {

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -528,15 +528,20 @@ export type EksMeta = BaseMeta & {
   kube: Kube;
 };
 
-// SamlIdPSpMeta describes the fields for SAML IdP
+// SamlMeta describes the fields for SAML IdP
 // service provider resource that needs to be
 // preserved throughout the flow.
-export type SamlIdPSpMeta = BaseMeta & {
-  isAutoConfig: boolean;
-  samlAppName: string;
+export type SamlMeta = BaseMeta & {
+  samlPresetMeta: GcpWorkforceMeta;
 };
 
+export type GcpWorkforceMeta = {
+  isAutoConfig: boolean;
+  orgId: string;
+  poolName: string;
+  poolProviderName: string;
+};
 
-export type AgentMeta = DbMeta | NodeMeta | KubeMeta | EksMeta | SamlIdPSpMeta;
+export type AgentMeta = DbMeta | NodeMeta | KubeMeta | EksMeta | SamlMeta;
 
 export type State = ReturnType<typeof useDiscover>;

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -535,6 +535,9 @@ export type SamlMeta = BaseMeta & {
   samlPresetMeta: GcpWorkforceMeta;
 };
 
+// GcpWorkforceMeta describes the fields for SAML
+// GCP workforce pool resource that needs to be
+// preserved throughout the flow.
 export type GcpWorkforceMeta = {
   isAutoConfig: boolean;
   orgId: string;

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -528,6 +528,15 @@ export type EksMeta = BaseMeta & {
   kube: Kube;
 };
 
-export type AgentMeta = DbMeta | NodeMeta | KubeMeta | EksMeta;
+// SamlIdPSpMeta describes the fields for SAML IdP
+// service provider resource that needs to be
+// preserved throughout the flow.
+export type SamlIdPSpMeta = BaseMeta & {
+  isAutoConfig: boolean;
+  samlAppName: string;
+};
+
+
+export type AgentMeta = DbMeta | NodeMeta | KubeMeta | EksMeta | SamlIdPSpMeta;
 
 export type State = ReturnType<typeof useDiscover>;

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -531,14 +531,12 @@ export type EksMeta = BaseMeta & {
 // SamlMeta describes the fields for SAML IdP
 // service provider resource that needs to be
 // preserved throughout the flow.
-export type SamlMeta = BaseMeta & {
-  samlPresetMeta: GcpWorkforceMeta;
-};
+export type SamlMeta = BaseMeta & SamlGcpWorkforceMeta;
 
 // GcpWorkforceMeta describes the fields for SAML
 // GCP workforce pool resource that needs to be
 // preserved throughout the flow.
-export type GcpWorkforceMeta = {
+export type SamlGcpWorkforceMeta = {
   isAutoConfig: boolean;
   orgId: string;
   poolName: string;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -329,7 +329,7 @@ const cfg = {
     botsTokenPath: '/v1/webapi/sites/:clusterId/machine-id/token',
 
     gcpWorkforceConfigurePath:
-    '/webapi/scripts/integrations/configure/gcp-workforce-saml.sh?orgId=:orgId&poolName=:poolName&poolProviderName=:poolProviderName',
+      '/webapi/scripts/integrations/configure/gcp-workforce-saml.sh?orgId=:orgId&poolName=:poolName&poolProviderName=:poolProviderName',
   },
 
   getUserClusterPreferencesUrl(clusterId: string) {
@@ -1047,10 +1047,9 @@ const cfg = {
     return generatePath(cfg.api.botsPath, { clusterId, name });
   },
 
-  getGcpWorkforceConfigScriptUrl( p: UrlGcpWorkforceConfigParam) {
+  getGcpWorkforceConfigScriptUrl(p: UrlGcpWorkforceConfigParam) {
     return (
-      cfg.baseUrl +
-      generatePath(cfg.api.gcpWorkforceConfigurePath, { ...p })
+      cfg.baseUrl + generatePath(cfg.api.gcpWorkforceConfigurePath, { ...p })
     );
   },
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -327,6 +327,9 @@ const cfg = {
 
     botsPath: '/v1/webapi/sites/:clusterId/machine-id/bot/:name?',
     botsTokenPath: '/v1/webapi/sites/:clusterId/machine-id/token',
+
+    gcpWorkforceConfigurePath:
+    '/webapi/scripts/integrations/configure/gcp-workforce-saml.sh?orgId=:orgId&poolName=:poolName&poolProviderName=:poolProviderName',
   },
 
   getUserClusterPreferencesUrl(clusterId: string) {
@@ -1044,6 +1047,13 @@ const cfg = {
     return generatePath(cfg.api.botsPath, { clusterId, name });
   },
 
+  getGcpWorkforceConfigScriptUrl( p: UrlGcpWorkforceConfigParam) {
+    return (
+      cfg.baseUrl +
+      generatePath(cfg.api.gcpWorkforceConfigurePath, { ...p })
+    );
+  },
+
   init(backendConfig = {}) {
     mergeDeep(this, backendConfig);
   },
@@ -1158,6 +1168,12 @@ export interface UrlAwsOidcConfigureIdp {
 export interface UrlAwsConfigureIamScriptParams {
   region: Regions;
   iamRoleName: string;
+}
+
+export interface UrlGcpWorkforceConfigParam {
+  orgId: string;
+  poolName: string;
+  poolProviderName: string;
 }
 
 export default cfg;


### PR DESCRIPTION
This PR:
- Adds GCP workforce identity federation tile to the discovery UI.
- Updates `useDiscover` `AgentMeta` type with `SamlMeta`  type which in turn uses `GcpWorkforceMeta`.  
- Adds script serving URL path generating function, which is used to generate config script. 

see https://github.com/gravitational/teleport.e/issues/3538