### PR TITLE
Refactor `NewWebSessionRequest` into lib/auth

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -616,6 +616,8 @@ func (r *NewWebSessionRequest) CheckAndSetDefaults() error {
 
 // NewWebSessionRequest defines a request to create a new user
 // web session
+// TODO (Joerger): Remove this and replace it with lib/auth.NewWebSessionRequest
+// once /e is no longer dependent on this.
 type NewWebSessionRequest struct {
 	// User specifies the user this session is bound to
 	User string

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3947,7 +3947,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 	}
 
 	sessionTTL := utils.ToTTL(a.clock, expiresAt)
-	sess, err := a.NewWebSession(ctx, types.NewWebSessionRequest{
+	sess, err := a.NewWebSession(ctx, NewWebSessionRequest{
 		User:                 req.User,
 		LoginIP:              identity.LoginIP,
 		Roles:                roles,
@@ -4044,7 +4044,7 @@ func (a *Server) CreateWebSession(ctx context.Context, user string) (types.WebSe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	session, err := a.CreateWebSessionFromReq(ctx, types.NewWebSessionRequest{
+	session, err := a.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
 		User:      user,
 		Roles:     u.GetRoles(),
 		Traits:    u.GetTraits(),
@@ -4559,7 +4559,7 @@ func (a *Server) GetTokens(ctx context.Context, opts ...services.MarshalOption) 
 }
 
 // NewWebSession creates and returns a new web session for the specified request
-func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionRequest) (types.WebSession, error) {
+func (a *Server) NewWebSession(ctx context.Context, req NewWebSessionRequest) (types.WebSession, error) {
 	userState, err := a.GetUserOrLoginState(ctx, req.User)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2807,7 +2807,7 @@ func TestNewWebSession(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new web session.
-	req := types.NewWebSessionRequest{
+	req := NewWebSessionRequest{
 		User:       user.GetName(),
 		Roles:      user.GetRoles(),
 		Traits:     user.GetTraits(),

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -727,7 +727,7 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODia
 
 	// If the request is coming from a browser, create a web session.
 	if req.CreateWebSession {
-		session, err := a.CreateWebSessionFromReq(ctx, types.NewWebSessionRequest{
+		session, err := a.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
 			User:             userState.GetName(),
 			Roles:            userState.GetRoles(),
 			Traits:           userState.GetTraits(),

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -678,7 +678,7 @@ func (a *Server) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRe
 		userAgent = cm.UserAgent
 	}
 
-	sess, err := a.CreateWebSessionFromReq(ctx, types.NewWebSessionRequest{
+	sess, err := a.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
 		User:             user.GetName(),
 		LoginIP:          loginIP,
 		Roles:            user.GetRoles(),
@@ -911,7 +911,7 @@ func (a *Server) emitNoLocalAuthEvent(username string) {
 func (a *Server) createUserWebSession(ctx context.Context, user services.UserState, loginIP string) (types.WebSession, error) {
 	// It's safe to extract the roles and traits directly from services.User as this method
 	// is only used for local accounts.
-	return a.CreateWebSessionFromReq(ctx, types.NewWebSessionRequest{
+	return a.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
 		User:      user.GetName(),
 		LoginIP:   loginIP,
 		Roles:     user.GetRoles(),

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -41,6 +41,10 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// TODO (Joerger): Replace this alias with the definition of types.NewWebSessionRequest
+// once /e is no longer dependent on types.NewWebSessionRequest.
+type NewWebSessionRequest = types.NewWebSessionRequest
+
 // CreateAppSession creates and inserts a services.WebSession into the
 // backend with the identity of the caller used to generate the certificate.
 // The certificate is used for all access requests, which is where access
@@ -265,7 +269,7 @@ func (a *Server) generateAppToken(ctx context.Context, username string, roles []
 	return token, nil
 }
 
-func (a *Server) CreateWebSessionFromReq(ctx context.Context, req types.NewWebSessionRequest) (types.WebSession, error) {
+func (a *Server) CreateWebSessionFromReq(ctx context.Context, req NewWebSessionRequest) (types.WebSession, error) {
 	session, err := a.NewWebSession(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Small refactor.

For the MFA for App Access implementation, I'm reusing `NewWebSessionRequest`. I need to expand it to hold `*proto.RouteToApp` and other fields not available from the types package. This struct should have always been in lib/auth.

Note: I'm handling this in its own PR due to the complications with e.

e PR: https://github.com/gravitational/teleport.e/pull/3764

Follow up PR: https://github.com/gravitational/teleport/pull/39742