### PR TITLE
yaml lint fix on agent roles

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/role.yaml
@@ -11,4 +11,4 @@ rules:
 - apiGroups: [""]
   # objects is "secrets"
   resources: ["secrets"]
-  verbs: ["create", "get", "update","patch"]
+  verbs: ["create", "get", "update", "patch"]


### PR DESCRIPTION
Tiny little fix to allow yaml lint to pass the roles file, our lint errors on "warning  too few spaces after comma  (commas)"