### PR TITLE
Fix missing fields in KubeContainer cache propagation for delete ops

### DIFF
--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1922,6 +1922,8 @@ func (p *kubeWaitingContainerParser) parse(event backend.Event) (types.Resource,
 				Namespace:     parts[3],
 				PodName:       parts[4],
 				ContainerName: parts[5],
+				Patch:         []byte("{}"),                       // default to empty patch. It doesn't matter for delete ops.
+				PatchType:     kubewaitingcontainer.JSONPatchType, // default to JSON patch. It doesn't matter for delete ops.
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
This PR fixes an error thrown by
`kubewaitingcontainer.NewKubeWaitingContainer` because `kubewaitingcontainerpb.KubernetesWaitingContainerSpec` missed the `Patch` and `PatchType` fields when propgating delete events through cache.