### PR TITLE
Fix `tctl apply` reference in docs

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -407,4 +407,4 @@ the access that is granted to a Bot.
 (!docs/pages/includes/machine-id/bot-spec.mdx!)
 
 You can apply a file containing YAML that defines a `bot` resource using
-`tctl apply -f ./bot.yaml`.
+`tctl create -f ./bot.yaml`.


### PR DESCRIPTION
Tiny fix - I must have been using kubectl shortly before writing these docs.