### PR TITLE
Allow typical parsers to optionally support dynamic values

### DIFF
--- a/lib/expression/parser.go
+++ b/lib/expression/parser.go
@@ -31,8 +31,8 @@ type evaluationEnvVar map[string]typical.Variable
 
 // DefaultParserSpec is the default parser specification.
 // Contains useful functions for manipulating and comparing strings.
-func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec {
-	return typical.ParserSpec{
+func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
+	return typical.ParserSpec[evaluationEnv]{
 		Functions: map[string]typical.Function{
 			"set": typical.UnaryVariadicFunction[evaluationEnv](
 				func(args ...string) (Set, error) {

--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -56,7 +56,7 @@ func mustNewLabelExpressionParser() *typical.CachedParser[labelExpressionEnv, bo
 }
 
 func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool], error) {
-	parser, err := typical.NewCachedParser[labelExpressionEnv, bool](typical.ParserSpec{
+	parser, err := typical.NewCachedParser[labelExpressionEnv, bool](typical.ParserSpec[labelExpressionEnv]{
 		Variables: map[string]typical.Variable{
 			"user.spec.traits": typical.DynamicVariable(
 				func(env labelExpressionEnv) (map[string][]string, error) {

--- a/lib/srv/db/common/databaseobjectimportrule/apply.go
+++ b/lib/srv/db/common/databaseobjectimportrule/apply.go
@@ -148,7 +148,7 @@ func (e expression) eval(spec *dbobjectv1.DatabaseObjectSpec) (string, error) {
 		}),
 	}
 
-	parser, err := typical.NewParser[evaluationEnv, string](typical.ParserSpec{Variables: envVar})
+	parser, err := typical.NewParser[evaluationEnv, string](typical.ParserSpec[evaluationEnv]{Variables: envVar})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -163,7 +163,7 @@ func newTraitsTemplateParser() (*typical.CachedParser[traitsTemplateEnv, []strin
 		})
 	}
 
-	parser, err := typical.NewCachedParser[traitsTemplateEnv, []string](typical.ParserSpec{
+	parser, err := typical.NewCachedParser[traitsTemplateEnv, []string](typical.ParserSpec[traitsTemplateEnv]{
 		Variables: map[string]typical.Variable{
 			"external": traitsVariable("external"),
 			"internal": traitsVariable("internal"),
@@ -342,7 +342,7 @@ func mustNewMatcherParser() *typical.CachedParser[matcherEnv, Matcher] {
 }
 
 func newMatcherParser() (*typical.CachedParser[matcherEnv, Matcher], error) {
-	parser, err := typical.NewCachedParser[matcherEnv, Matcher](typical.ParserSpec{
+	parser, err := typical.NewCachedParser[matcherEnv, Matcher](typical.ParserSpec[matcherEnv]{
 		Functions: map[string]typical.Function{
 			RegexpMatchFnName:    typical.UnaryFunction[matcherEnv](regexpMatch),
 			RegexpNotMatchFnName: typical.UnaryFunction[matcherEnv](regexpNotMatch),

--- a/lib/utils/typical/cached_parser.go
+++ b/lib/utils/typical/cached_parser.go
@@ -60,7 +60,7 @@ type CachedParser[TEnv, TResult any] struct {
 }
 
 // NewCachedParser creates a cached predicate expression parser with the given specification.
-func NewCachedParser[TEnv, TResult any](spec ParserSpec, opts ...ParserOption) (*CachedParser[TEnv, TResult], error) {
+func NewCachedParser[TEnv, TResult any](spec ParserSpec[TEnv], opts ...ParserOption) (*CachedParser[TEnv, TResult], error) {
 	parser, err := NewParser[TEnv, TResult](spec, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/utils/typical/cached_parser_test.go
+++ b/lib/utils/typical/cached_parser_test.go
@@ -35,7 +35,7 @@ func (t *testLogger) Infof(msg string, args ...any) {
 
 func TestCachedParser(t *testing.T) {
 	// A simple cached parser with no environment that always returns an int.
-	p, err := NewCachedParser[struct{}, int](ParserSpec{
+	p, err := NewCachedParser[struct{}, int](ParserSpec[struct{}]{
 		Functions: map[string]Function{
 			"inc": UnaryFunction[struct{}](func(i int) (int, error) {
 				return i + 1, nil

--- a/lib/utils/typical/example_test.go
+++ b/lib/utils/typical/example_test.go
@@ -31,7 +31,7 @@ type expressionEnv struct {
 }
 
 func Example() {
-	parser, err := typical.NewParser[expressionEnv, bool](typical.ParserSpec{
+	parser, err := typical.NewParser[expressionEnv, bool](typical.ParserSpec[expressionEnv]{
 		Variables: map[string]typical.Variable{
 			"traits": typical.DynamicVariable(func(e expressionEnv) (map[string][]string, error) {
 				return e.traits, nil

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// typical (TYPed predICAte Library) is a library for building better predicate
+// Package typical (TYPed predICAte Library) is a library for building better predicate
 // expression parsers faster. It is built on top of
 // [predicate](github.com/gravitational/predicate).
 //
@@ -56,20 +56,31 @@ type Expression[TEnv, TResult any] interface {
 }
 
 // ParserSpec defines a predicate language.
-type ParserSpec struct {
-	// Variables defines all of the literals and variables available to
+type ParserSpec[TEnv any] struct {
+	// Variables define the literals and variables available to
 	// expressions in the predicate language. It is a map from variable name to
 	// definition.
 	Variables map[string]Variable
 
-	// Functions defines all of the functions available to expressions in the
+	// Functions define the functions available to expressions in the
 	// predicate language.
 	Functions map[string]Function
 
-	// Methods defines all of the methods available to expressions in the
+	// Methods define the methods available to expressions in the
 	// predicate language. Methods are just functions that take their receiver
 	// as their first argument.
 	Methods map[string]Function
+
+	// GetUnknownIdentifier is used to retrieve any identifiers that cannot
+	// be determined statically. If not defined, any unknown identifiers result
+	// in a [UnknownIdentifierError].
+	//
+	// Useful in situations where a parser may allow specifying nested paths
+	// to variables without requiring users to enumerate all paths in [ParserSpec.Variables].
+	// Caution should be used when using this method as it shifts type safety
+	// guarantees from parse time to evaluation time.
+	// Typos in identifier names will also be caught at evaluation time instead of parse time.
+	GetUnknownIdentifier func(env TEnv, fields []string) (any, error)
 }
 
 // Variable holds the definition of a literal or variable. It is expected to be
@@ -86,7 +97,7 @@ type Function interface {
 // Parser is a predicate expression parser configured to parse expressions of a
 // specific expression language.
 type Parser[TEnv, TResult any] struct {
-	spec    ParserSpec
+	spec    ParserSpec[TEnv]
 	pred    predicate.Parser
 	options parserOptions
 }
@@ -109,7 +120,7 @@ func WithInvalidNamespaceHack() ParserOption {
 }
 
 // NewParser creates a predicate expression parser with the given specification.
-func NewParser[TEnv, TResult any](spec ParserSpec, opts ...ParserOption) (*Parser[TEnv, TResult], error) {
+func NewParser[TEnv, TResult any](spec ParserSpec[TEnv], opts ...ParserOption) (*Parser[TEnv, TResult], error) {
 	var options parserOptions
 	for _, opt := range opts {
 		opt(&options)
@@ -121,7 +132,7 @@ func NewParser[TEnv, TResult any](spec ParserSpec, opts ...ParserOption) (*Parse
 	}
 	def := predicate.Def{
 		GetIdentifier: p.getIdentifier,
-		GetProperty:   getProperty[TEnv],
+		GetProperty:   p.getProperty,
 		Functions:     make(map[string]any, len(spec.Functions)),
 		Methods:       make(map[string]any, len(spec.Methods)),
 		Operators: predicate.Operators{
@@ -191,7 +202,7 @@ func (p *Parser[TEnv, TResult]) getIdentifier(selector []string) (any, error) {
 		}
 		// Allow map lookups with map.key instead of map["key"]
 		if len(remaining) == 1 {
-			expr, err := getProperty[TEnv](v, remaining[0])
+			expr, err := p.getProperty(v, remaining[0])
 			if err == nil {
 				return expr, nil
 			}
@@ -212,9 +223,19 @@ func (p *Parser[TEnv, TResult]) getIdentifier(selector []string) (any, error) {
 		case 1:
 			return external, nil
 		case 2:
-			expr, err := getProperty[TEnv](external, selector[1])
+			expr, err := p.getProperty(external, selector[1])
 			return expr, trace.Wrap(err)
 		}
+	}
+
+	// Return a dynamic variable if and only if the parser was
+	// constructed to opt in to the dangerous behavior.
+	if p.spec.GetUnknownIdentifier != nil {
+		return dynamicVariable[TEnv, any]{
+			accessor: func(env TEnv) (any, error) {
+				return p.spec.GetUnknownIdentifier(env, selector)
+			},
+		}, nil
 	}
 
 	return nil, UnknownIdentifierError(joined)
@@ -234,7 +255,7 @@ func (u UnknownIdentifierError) Identifier() string {
 
 // getProperty is a helper for parsing map[key] expressions and returns either a
 // propertyExpr or a dynamicMapExpr.
-func getProperty[TEnv any](mapVal, keyVal any) (any, error) {
+func (p *Parser[TEnv, TResult]) getProperty(mapVal, keyVal any) (any, error) {
 	keyExpr, err := coerce[TEnv, string](keyVal)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing key of index expression")
@@ -249,6 +270,17 @@ func getProperty[TEnv any](mapVal, keyVal any) (any, error) {
 	if dynamicMap, ok := mapVal.(indexExpressionBuilder[TEnv]); ok {
 		return dynamicMap.buildIndexExpression(keyExpr), nil
 	}
+
+	// Only allow falling back to an untyped expression if the parser was constructed
+	// to allow unknown identifiers. This ensures compile time type safety for all
+	// parsers that don't explicitly opt in to the more dangerous behavior required to
+	// support dynamic fields.
+	if p.spec.GetUnknownIdentifier != nil {
+		if mapExpr, ok := mapVal.(Expression[TEnv, any]); ok {
+			return untypedPropertyExpr[TEnv]{mapExpr, keyExpr}, nil
+		}
+	}
+
 	return nil, trace.Wrap(unexpectedTypeError[map[string]string](mapVal), "cannot take index of unexpected type")
 }
 
@@ -268,6 +300,32 @@ func (p propertyExpr[TEnv, TValues]) Evaluate(env TEnv) (TValues, error) {
 		return nul, trace.Wrap(err, "evaluating key of index expression")
 	}
 	return m[k], nil
+}
+
+type untypedPropertyExpr[TEnv any] struct {
+	mapExpr Expression[TEnv, any]
+	keyExpr Expression[TEnv, string]
+}
+
+func (u untypedPropertyExpr[TEnv]) Evaluate(env TEnv) (any, error) {
+	k, err := u.keyExpr.Evaluate(env)
+	if err != nil {
+		return nil, trace.Wrap(err, "evaluating key of index expression")
+	}
+	m, err := u.mapExpr.Evaluate(env)
+	if err != nil {
+		return nil, trace.Wrap(err, "evaluating base of index expression")
+	}
+	switch typedMap := m.(type) {
+	case map[string]string:
+		return typedMap[k], nil
+	case map[string][]string:
+		return typedMap[k], nil
+	case map[string]any:
+		return typedMap[k], nil
+	default:
+		return nil, trace.Wrap(unexpectedTypeError[map[string]any](u.mapExpr), "cannot take index of unexpected type")
+	}
 }
 
 type indexExpressionBuilder[TEnv any] interface {


### PR DESCRIPTION
Provides an opt-in mechanism to allow parsers to support dynamically resolving variables at runtime. While this defeats some of the static compile type benefits that typical guarantees, it is required to allow existing parsers to be converted to use typical.

The existing resource parsers allow searching for variables by their fully qualified path. For example, the hostname of a server may be queried via `resource.spec.hostname`. In order to support this typical could use some reflection to automatically add variables to every nested field but that would be complicated and expensive.

Instead the ParserSpec can now be configured with `GetUnknownIdentifier`, which allows creators of the parsers to have full control over how a dynamic variable is resolved. The parser prevents any dynamic resolution if the value is not configured to limit the unsafe behavior to only parsers that explicitly opt in.