### PR TITLE
[v14] Fix incorrect expiry when using `resource153ToLegacyAdapter`

### DIFF
--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -152,7 +152,13 @@ func (r *resource153ToLegacyAdapter) CheckAndSetDefaults() error {
 }
 
 func (r *resource153ToLegacyAdapter) Expiry() time.Time {
-	return r.inner.GetMetadata().Expires.AsTime()
+	expires := r.inner.GetMetadata().Expires
+	// return zero time.time{} for zero *timestamppb.Timestamp, instead of 01/01/1970.
+	if expires == nil {
+		return time.Time{}
+	}
+
+	return expires.AsTime()
 }
 
 func (r *resource153ToLegacyAdapter) GetKind() string {
@@ -161,7 +167,13 @@ func (r *resource153ToLegacyAdapter) GetKind() string {
 
 func (r *resource153ToLegacyAdapter) GetMetadata() Metadata {
 	md := r.inner.GetMetadata()
+
+	// use zero time.time{} for zero *timestamppb.Timestamp, instead of 01/01/1970.
 	expires := md.Expires.AsTime()
+	if md.Expires == nil {
+		expires = time.Time{}
+	}
+
 	return Metadata{
 		Name:        md.Name,
 		Namespace:   md.Namespace,

--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -281,13 +281,10 @@ func TestExpiryConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bot := &machineidv1.Bot{
+			bot := &fake153Resource{
 				Kind:     "bot",
 				SubKind:  "robot",
 				Metadata: &headerv1.Metadata{Name: "Bernard", Expires: tt.expiryTimestamp},
-				Spec: &machineidv1.BotSpec{
-					Roles: []string{"robot", "human"},
-				},
 			}
 
 			legacyResource := types.Resource153ToLegacy(bot)

--- a/api/types/resource_153_test.go
+++ b/api/types/resource_153_test.go
@@ -202,3 +202,65 @@ func TestResourceMethods(t *testing.T) {
 		require.Equal(t, "mars", types.GetOrigin(bot))
 	})
 }
+
+// Tests that expiry is consistent across the different types and transformations.
+func TestExpiryConsistency(t *testing.T) {
+	tests := []struct {
+		name            string
+		expiryTimestamp *timestamppb.Timestamp
+		expectedExpiry  time.Time
+	}{
+		{
+			name:            "nil expiry",
+			expiryTimestamp: nil,
+			expectedExpiry:  time.Time{},
+		},
+		{
+			name:            "zero expiry",
+			expiryTimestamp: timestamppb.New(time.Time{}),
+			expectedExpiry:  time.Time{},
+		},
+		{
+			name:            "set expiry",
+			expiryTimestamp: timestamppb.New(time.Date(2024, 11, 11, 11, 11, 11, 00, time.UTC)),
+			expectedExpiry:  time.Date(2024, 11, 11, 11, 11, 11, 00, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bot := &machineidv1.Bot{
+				Kind:     "bot",
+				SubKind:  "robot",
+				Metadata: &headerv1.Metadata{Name: "Bernard", Expires: tt.expiryTimestamp},
+				Spec: &machineidv1.BotSpec{
+					Roles: []string{"robot", "human"},
+				},
+			}
+
+			legacyResource := types.Resource153ToLegacy(bot)
+
+			// verify expiry time in different ways
+			t.Run("GetExpiry() resource", func(t *testing.T) {
+				expiry, err := types.GetExpiry(bot)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedExpiry, expiry)
+			})
+
+			t.Run("GetExpiry() wrapper", func(t *testing.T) {
+				expiry, err := types.GetExpiry(legacyResource)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedExpiry, expiry)
+			})
+
+			t.Run("wrapper .Expiry()", func(t *testing.T) {
+				require.Equal(t, tt.expectedExpiry, legacyResource.Expiry())
+			})
+
+			t.Run("wrapper metadata .Expiry()", func(t *testing.T) {
+				md := legacyResource.GetMetadata()
+				require.Equal(t, tt.expectedExpiry, md.Expiry())
+			})
+		})
+	}
+}


### PR DESCRIPTION
Backport #39761 to branch/v14

changelog: Fix potential issue with some resources expiry being set to 01/01/1970 instead of never.
