### PR TITLE
Fix incorrect naming of AWS RDS instances

### DIFF
--- a/lib/srv/discovery/fetchers/aws-sync/rds.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds.go
@@ -129,7 +129,7 @@ func awsRDSInstanceToRDS(instance *rds.DBInstance, region, accountID string) *ac
 	}
 
 	return &accessgraphv1alpha.AWSRDSDatabaseV1{
-		Name:      aws.StringValue(instance.DBName),
+		Name:      aws.StringValue(instance.DBInstanceIdentifier),
 		Arn:       aws.StringValue(instance.DBInstanceArn),
 		CreatedAt: awsTimeToProtoTime(instance.InstanceCreateTime),
 		Status:    aws.StringValue(instance.DBInstanceStatus),
@@ -156,7 +156,7 @@ func awsRDSClusterToRDS(instance *rds.DBCluster, region, accountID string) *acce
 	}
 
 	return &accessgraphv1alpha.AWSRDSDatabaseV1{
-		Name:      aws.StringValue(instance.DatabaseName),
+		Name:      aws.StringValue(instance.DBClusterIdentifier),
 		Arn:       aws.StringValue(instance.DBClusterArn),
 		CreatedAt: awsTimeToProtoTime(instance.ClusterCreateTime),
 		Status:    aws.StringValue(instance.Status),

--- a/lib/srv/discovery/fetchers/aws-sync/rds_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds_test.go
@@ -144,12 +144,12 @@ func TestPollAWSRDS(t *testing.T) {
 func dbInstances() []*rds.DBInstance {
 	return []*rds.DBInstance{
 		{
-			DBName:             aws.String("db1"),
-			DBInstanceArn:      aws.String("arn:us-west1:rds:instance1"),
-			InstanceCreateTime: aws.Time(date),
-			Engine:             aws.String(rds.EngineFamilyMysql),
-			DBInstanceStatus:   aws.String(rds.DBProxyStatusAvailable),
-			EngineVersion:      aws.String("v1.1"),
+			DBInstanceIdentifier: aws.String("db1"),
+			DBInstanceArn:        aws.String("arn:us-west1:rds:instance1"),
+			InstanceCreateTime:   aws.Time(date),
+			Engine:               aws.String(rds.EngineFamilyMysql),
+			DBInstanceStatus:     aws.String(rds.DBProxyStatusAvailable),
+			EngineVersion:        aws.String("v1.1"),
 			TagList: []*rds.Tag{
 				{
 					Key:   aws.String("tag"),
@@ -163,12 +163,12 @@ func dbInstances() []*rds.DBInstance {
 func dbClusters() []*rds.DBCluster {
 	return []*rds.DBCluster{
 		{
-			DatabaseName:      aws.String("cluster1"),
-			DBClusterArn:      aws.String("arn:us-west1:rds:cluster1"),
-			ClusterCreateTime: aws.Time(date),
-			Engine:            aws.String(rds.EngineFamilyMysql),
-			Status:            aws.String(rds.DBProxyStatusAvailable),
-			EngineVersion:     aws.String("v1.1"),
+			DBClusterIdentifier: aws.String("cluster1"),
+			DBClusterArn:        aws.String("arn:us-west1:rds:cluster1"),
+			ClusterCreateTime:   aws.Time(date),
+			Engine:              aws.String(rds.EngineFamilyMysql),
+			Status:              aws.String(rds.DBProxyStatusAvailable),
+			EngineVersion:       aws.String("v1.1"),
 			TagList: []*rds.Tag{
 				{
 					Key:   aws.String("tag"),


### PR DESCRIPTION
This PR fixes the collection of the name based on database name to use the instance/cluster identifier.