### PR TITLE
[v15] Ensure watcherjob always returns an error

### DIFF
--- a/integrations/lib/testing/integration/accessrequestsuite.go
+++ b/integrations/lib/testing/integration/accessrequestsuite.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib"
-	"github.com/gravitational/teleport/integrations/lib/logger"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -351,8 +350,7 @@ func (s *AccessRequestSuite) RunAndWaitReady(t *testing.T, app AppI) {
 	go func() {
 		ctx := appCtx
 		if err := app.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Get(ctx).WithError(err).Error("Application failed")
-			assert.Fail(t, "Application failed")
+			assert.ErrorContains(t, err, context.Canceled.Error(), "if a non-nil error is returned, it should be canceled context")
 		}
 	}()
 

--- a/integrations/lib/testing/integration/accessrequestsuite.go
+++ b/integrations/lib/testing/integration/accessrequestsuite.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -349,7 +350,7 @@ func (s *AccessRequestSuite) RunAndWaitReady(t *testing.T, app AppI) {
 
 	go func() {
 		ctx := appCtx
-		if err := app.Run(ctx); err != nil {
+		if err := app.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Get(ctx).WithError(err).Error("Application failed")
 			assert.Fail(t, "Application failed")
 		}
@@ -358,7 +359,10 @@ func (s *AccessRequestSuite) RunAndWaitReady(t *testing.T, app AppI) {
 	t.Cleanup(func() {
 		err := app.Shutdown(appCtx)
 		assert.NoError(t, err)
-		assert.NoError(t, app.Err())
+		err = app.Err()
+		if err != nil {
+			assert.ErrorContains(t, err, context.Canceled.Error(), "if a non-nil error is returned, it should be canceled context")
+		}
 	})
 
 	waitCtx, cancel := context.WithTimeout(appCtx, 20*time.Second)

--- a/integrations/lib/watcherjob/helpers_test.go
+++ b/integrations/lib/watcherjob/helpers_test.go
@@ -120,7 +120,8 @@ func NewMockEventsProcess(ctx context.Context, t *testing.T, config Config, fn E
 	}
 	t.Cleanup(func() {
 		process.Terminate()
-		assert.NoError(t, process.Shutdown(ctx))
+		err := process.Shutdown(ctx)
+		assert.ErrorContains(t, err, context.Canceled.Error(), "if a non-nil error is returned, it should be canceled context")
 		process.Close()
 	})
 	var err error

--- a/integrations/lib/watcherjob/watcherjob.go
+++ b/integrations/lib/watcherjob/watcherjob.go
@@ -110,6 +110,8 @@ func NewJobWithEvents(events types.Events, config Config, fn EventFunc) (lib.Ser
 			// We are not supporting liveness/readiness yet, but if we do it would make sense to use job's readiness
 			job.SetReady(false)
 
+			// Note: we must always return an error, even if everything went great and we're doing a graceful shutdown.
+			// The process library will trigger a complete shutdown only if the critical job exist with an error.
 			switch {
 			case trace.IsConnectionProblem(err):
 				if config.FailFast {
@@ -123,8 +125,7 @@ func NewJobWithEvents(events types.Events, config Config, fn EventFunc) (lib.Ser
 				log.WithError(err).Error("Watcher stream closed. Attempting to reconnect.")
 			case lib.IsCanceled(err):
 				log.Debug("Watcher context is canceled")
-				// Context cancellation is not an error
-				return nil
+				return trace.Wrap(err)
 			default:
 				log.WithError(err).Error("Watcher event loop failed")
 				return trace.Wrap(err)
@@ -133,7 +134,7 @@ func NewJobWithEvents(events types.Events, config Config, fn EventFunc) (lib.Ser
 			// To mitigate a potentially aggressive retry loop, we wait
 			if err := bk.Do(ctx); err != nil {
 				log.Debug("Watcher context was canceled while waiting before a reconnection")
-				return nil
+				return trace.Wrap(err)
 			}
 		}
 	})
@@ -172,7 +173,11 @@ func (job job) watchEvents(ctx context.Context) error {
 					return trace.Wrap(ctx.Err())
 				}
 			}
-			return trace.Wrap(watcher.Error())
+			err := watcher.Error()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Errorf("watcher closed without error")
 		}
 	}
 }

--- a/integrations/lib/watcherjob/watcherjob.go
+++ b/integrations/lib/watcherjob/watcherjob.go
@@ -111,7 +111,7 @@ func NewJobWithEvents(events types.Events, config Config, fn EventFunc) (lib.Ser
 			job.SetReady(false)
 
 			// Note: we must always return an error, even if everything went great and we're doing a graceful shutdown.
-			// The process library will trigger a complete shutdown only if the critical job exist with an error.
+			// The process library will trigger a complete shutdown only if the critical job exits with an error.
 			switch {
 			case trace.IsConnectionProblem(err):
 				if config.FailFast {
@@ -173,8 +173,7 @@ func (job job) watchEvents(ctx context.Context) error {
 					return trace.Wrap(ctx.Err())
 				}
 			}
-			err := watcher.Error()
-			if err != nil {
+			if err := watcher.Error(); err != nil {
 				return trace.Wrap(err)
 			}
 			return trace.Errorf("watcher closed without error")


### PR DESCRIPTION
Backport #39581 to branch/v15

changelog: Fix a bug in the teleport plugins causing the plugin not to exit even if it stopped watching events.
