### PR TITLE
[docs] add troubleshooting for app access request size limit

### DIFF
--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -443,6 +443,28 @@ instance and attach an IAM role to it.
 
 (!docs/pages/includes/aws-no-credential-provider.mdx service="Application"!)
 
+### `the read limit is reached` error when updating AWS lambda function
+
+Teleport enforces a 10MB size limit for each HTTP request's body.
+You may encounter this error when updating an AWS lambda function using
+`tsh aws update-function-code --function-name myfunction --zip-file ./file.zip`
+if `file.zip` is larger than 10MB.
+
+AWS also limits zip file size to 50MB.
+You can workaround this issue in the same way you would work around AWS's direct
+upload size limit: upload your lambda function archive to an s3 bucket,
+and then update your lambda function by referencing the s3 bucket instead of
+uploading an archive directly:
+
+```code
+# create an s3 bucket
+$ tsh aws s3 mb s3://mybucket
+# upload function to the bucket
+$ tsh aws s3 cp ./file.zip s3://mybucket/path/to/file.zip
+# update your lambda function by using the s3 bucket
+$ tsh aws lambda update-function-code --function-name myfunction --s3-bucket mybucket --s3-key path/to/file.zip
+```
+
 ## Next steps
 
 - Take a closer look at [role-based access controls](../controls.mdx).

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -153,3 +153,17 @@ This configuration is available under the `jwt_claims` property of the
 application's `rewrite` configuration. See
 [Web Application Access](./guides/connecting-apps.mdx#configuring-the-jwt-token)
 for details.
+
+## Request too large
+
+Teleport enforces a 10MB size limit for the body of each HTTP request.
+
+### Symptom
+
+When attempting to connect to an HTTP app behind Teleport, you see an error
+that states *the read limit is reached*.
+
+### Solution
+
+If your application supports sending requests with chunked encoding, use that
+to break up large requests into smaller chunks.


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport/issues/23784

This PR adds troubleshooting for when a user runs into Teleport's 10MB http body request size limit.

Related: https://github.com/gravitational/teleport/pull/40242