### PR TITLE
Reconnect sessionCache watcher on close

### DIFF
--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -48,12 +48,10 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/retryutils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -62,7 +60,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/interval"
 )
 
 // SessionContext is a context associated with a user's
@@ -626,6 +623,8 @@ type sessionCacheOptions struct {
 	sessionLingeringThreshold time.Duration
 	// proxySigner is used to sign PROXY header and securely propagate client's real IP
 	proxySigner multiplexer.PROXYHeaderSigner
+	// See [sessionCache.startWebSessionWatcherImmediately]. Used for testing.
+	startWebSessionWatcherImmediately bool
 }
 
 // newSessionCache creates a [sessionCache] from the provided [config] and
@@ -642,18 +641,19 @@ func newSessionCache(ctx context.Context, config sessionCacheOptions) (*sessionC
 	}
 
 	cache := &sessionCache{
-		clusterName:               clusterName.GetClusterName(),
-		proxyClient:               config.proxyClient,
-		accessPoint:               config.accessPoint,
-		sessions:                  make(map[string]*SessionContext),
-		resources:                 make(map[string]*sessionResources),
-		authServers:               config.servers,
-		closer:                    utils.NewCloseBroadcaster(),
-		cipherSuites:              config.cipherSuites,
-		log:                       newPackageLogger(),
-		clock:                     config.clock,
-		sessionLingeringThreshold: config.sessionLingeringThreshold,
-		proxySigner:               config.proxySigner,
+		clusterName:                       clusterName.GetClusterName(),
+		proxyClient:                       config.proxyClient,
+		accessPoint:                       config.accessPoint,
+		sessions:                          make(map[string]*SessionContext),
+		resources:                         make(map[string]*sessionResources),
+		authServers:                       config.servers,
+		closer:                            utils.NewCloseBroadcaster(),
+		cipherSuites:                      config.cipherSuites,
+		log:                               newPackageLogger(),
+		clock:                             config.clock,
+		sessionLingeringThreshold:         config.sessionLingeringThreshold,
+		proxySigner:                       config.proxySigner,
+		startWebSessionWatcherImmediately: config.startWebSessionWatcherImmediately,
 	}
 
 	// periodically close expired and unused sessions
@@ -699,6 +699,11 @@ type sessionCache struct {
 
 	// proxySigner is used to sign PROXY header and securely propagate client's real IP
 	proxySigner multiplexer.PROXYHeaderSigner
+
+	// startWebSessionWatcherImmediately removes the First component of the linear
+	// backoff used to start the WebSession watcher.
+	// Used for testing.
+	startWebSessionWatcherImmediately bool
 }
 
 // Close closes all allocated resources and stops goroutines
@@ -749,29 +754,29 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 		return
 	}
 
-	ticker := interval.New(interval.Config{
-		Duration: defaults.HighResPollingPeriod,
-		Jitter:   retryutils.NewHalfJitter(),
-	})
-	defer ticker.Stop()
+	linear := utils.NewDefaultLinear()
+	if s.startWebSessionWatcherImmediately {
+		linear.First = 0
+	}
 
 	s.log.Debug("Starting sessionCache WebSession watcher")
 	for {
-		if err := s.watchWebSessionsOnce(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			const msg = "" +
-				"sessionCache WebSession watcher aborted, re-connecting. " +
-				"This may have an impact in device trust web sessions."
-			s.log.WithError(err).Warn(msg)
-		}
-
 		select {
 		// Stop when the context tells us to.
 		case <-ctx.Done():
 			s.log.Debug("Stopping sessionCache WebSession watcher")
 			return
 
-		case <-ticker.Next():
+		case <-linear.After():
+			linear.Inc()
 			// continue
+		}
+
+		if err := s.watchWebSessionsOnce(ctx, linear.Reset); err != nil && !errors.Is(err, context.Canceled) {
+			const msg = "" +
+				"sessionCache WebSession watcher aborted, re-connecting. " +
+				"This may have an impact in device trust web sessions."
+			s.log.WithError(err).Warn(msg)
 		}
 	}
 }
@@ -783,7 +788,7 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 // is that an updated session got its certificates augmented with device trust
 // extensions, so it is evicted in order for the new certificates to be loaded
 // by the Proxy.
-func (s *sessionCache) watchWebSessionsOnce(ctx context.Context) error {
+func (s *sessionCache) watchWebSessionsOnce(ctx context.Context, reset func()) error {
 	watcher, err := s.proxyClient.NewWatcher(ctx, types.Watch{
 		Name: teleport.ComponentWebProxy + ".sessionCache." + types.KindWebSession,
 		Kinds: []types.WatchKind{
@@ -809,6 +814,8 @@ func (s *sessionCache) watchWebSessionsOnce(ctx context.Context) error {
 			return errors.New("watcher closed")
 
 		case event := <-watcher.Events():
+			reset() // Reset linear backoff attempts.
+
 			s.log.
 				WithField("event", event).
 				Debug("Received sessionCache watcher event")

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -769,7 +769,6 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 
 		case <-linear.After():
 			linear.Inc()
-			// continue
 		}
 
 		if err := s.watchWebSessionsOnce(ctx, linear.Reset); err != nil && !errors.Is(err, context.Canceled) {

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -749,11 +749,9 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 		return
 	}
 
-	const period = defaults.HighResPollingPeriod
 	ticker := interval.New(interval.Config{
-		Duration:      period,
-		FirstDuration: period,
-		Jitter:        retryutils.NewSeventhJitter(),
+		Duration: defaults.HighResPollingPeriod,
+		Jitter:   retryutils.NewHalfJitter(),
 	})
 	defer ticker.Stop()
 

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/mailgun/holster/v3/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -198,6 +197,7 @@ func TestSessionCache_watcher(t *testing.T) {
 	webSuite := newWebSuite(t)
 	authServer := webSuite.server.AuthServer.AuthServer
 	authClient := webSuite.proxyClient
+	clock := webSuite.clock
 
 	// cancel is used to make sure the sessionCache stops cleanly.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -209,8 +209,9 @@ func TestSessionCache_watcher(t *testing.T) {
 		servers: []utils.NetAddr{
 			// An addr is required but unused.
 			{Addr: "localhost:12345", AddrNetwork: "tcp"}},
-		clock:                     webSuite.clock,
-		sessionLingeringThreshold: 1 * time.Minute,
+		clock:                             clock,
+		sessionLingeringThreshold:         1 * time.Minute,
+		startWebSessionWatcherImmediately: true,
 	})
 	require.NoError(t, err, "newSessionCache() failed")
 	defer sessionCache.Close()


### PR DESCRIPTION
Handler watcher.Done() and loop over watcher creation until told to stop. Used [periodicSyncRotationState][1] as a reference for the watcher loop.

Follow up from #39712.

https://github.com/gravitational/teleport.e/issues/3236

[1]: https://github.com/gravitational/teleport/blob/efc8c498c82cb04a0272c67a0ba1b97e457efca4/lib/service/connect.go#L629