### PR TITLE
[v14] always require MFA when joining a session if at least one role requires session MFA

### DIFF
--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -531,9 +531,9 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 			t.Parallel()
 
 			resp, err := test.userClient.IsMFARequired(ctx, test.req)
-			require.NoError(t, err, "CreateAuthenticateChallenge")
+			require.NoError(t, err, "IsMFARequired")
 
-			assert.Equal(t, test.wantMFARequired, resp.Required, "resp.MFARequired mismatch")
+			assert.Equal(t, test.wantMFARequired, resp.Required, "resp.Required mismatch")
 		})
 	}
 }

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -644,7 +644,7 @@ func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAu
 		auth.RoleSupportsModeratedSessions(accessChecker.Roles()) {
 
 		// allow joining if cluster wide MFA is not required
-		if state.MFARequired != services.MFARequiredAlways {
+		if state.MFARequired == services.MFARequiredNever {
 			return nil
 		}
 

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -317,7 +317,7 @@ func TestRBACJoinMFA(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	_, err = server.auth.CreateRole(ctx, joinMFARole)
+	err = server.auth.CreateRole(ctx, joinMFARole)
 	require.NoError(t, err)
 
 	joinRole, err := types.NewRole("join", types.RoleSpecV6{
@@ -328,7 +328,7 @@ func TestRBACJoinMFA(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	_, err = server.auth.CreateRole(ctx, joinRole)
+	err = server.auth.CreateRole(ctx, joinRole)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -26,7 +26,9 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -34,13 +36,18 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-type mockCAGetter struct {
+type mockCAandAuthPrefGetter struct {
 	AccessPoint
 
-	cas map[types.CertAuthType]types.CertAuthority
+	authPref types.AuthPreference
+	cas      map[types.CertAuthType]types.CertAuthority
 }
 
-func (m mockCAGetter) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error) {
+func (m mockCAandAuthPrefGetter) GetAuthPreference(s_12345678 context.Context) (types.AuthPreference, error) {
+	return m.authPref, nil
+}
+
+func (m mockCAandAuthPrefGetter) GetCertAuthorities(_ context.Context, caType types.CertAuthType, _ bool) ([]types.CertAuthority, error) {
 	ca, ok := m.cas[caType]
 	if !ok {
 		return nil, trace.NotFound("CA not found")
@@ -158,8 +165,9 @@ func TestRBAC(t *testing.T) {
 	err = server.auth.SetClusterName(clusterName)
 	require.NoError(t, err)
 
-	accessPoint := mockCAGetter{
+	accessPoint := mockCAandAuthPrefGetter{
 		AccessPoint: server.auth,
+		authPref:    types.DefaultAuthPreference(),
 		cas: map[types.CertAuthType]types.CertAuthority{
 			types.UserCA: userCA,
 		},
@@ -220,6 +228,181 @@ func TestRBAC(t *testing.T) {
 			require.NoError(t, err)
 
 			tt.assertRBACCheck(t, lc.rbacChecked)
+		})
+	}
+}
+
+// TestRBACJoinMFA tests that MFA is enforced correctly when joining
+// sessions depending on the cluster auth preference and roles presented.
+func TestRBACJoinMFA(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "localhost"
+	const username = "testuser"
+
+	// create User CA
+	userTA := testauthority.New()
+	userCAPriv, err := userTA.GeneratePrivateKey()
+	require.NoError(t, err)
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{
+				{
+					PublicKey:      userCAPriv.MarshalSSHPublicKey(),
+					PrivateKey:     userCAPriv.PrivateKeyPEM(),
+					PrivateKeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// create mock SSH server and add a cluster name
+	server := newMockServer(t)
+	cn, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: clusterName,
+		ClusterID:   "cluster_id",
+	})
+	require.NoError(t, err)
+	err = server.auth.SetClusterName(cn)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	accessPoint := &mockCAandAuthPrefGetter{
+		AccessPoint: server.auth,
+		cas: map[types.CertAuthType]types.CertAuthority{
+			types.UserCA: userCA,
+		},
+	}
+
+	// create auth handler and dummy node
+	config := &AuthHandlerConfig{
+		Server:      server,
+		Emitter:     &eventstest.MockRecorderEmitter{},
+		AccessPoint: accessPoint,
+	}
+	ah, err := NewAuthHandlers(config)
+	require.NoError(t, err)
+
+	node, err := types.NewServer("testie_node", types.KindNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "testie",
+		Version:  types.V2,
+	})
+	require.NoError(t, err)
+
+	mfaAuthPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+		SecondFactor:   constants.SecondFactorOTP,
+		RequireMFAType: types.RequireMFAType_HARDWARE_KEY_TOUCH,
+	})
+	require.NoError(t, err)
+
+	noMFAAuthPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+		SecondFactor:   constants.SecondFactorOTP,
+		RequireMFAType: types.RequireMFAType_OFF,
+	})
+	require.NoError(t, err)
+
+	// create roles
+	joinMFARole, err := types.NewRole("joinMFA", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			RequireMFAType: types.RequireMFAType_SESSION,
+		},
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = server.auth.CreateRole(ctx, joinMFARole)
+	require.NoError(t, err)
+
+	joinRole, err := types.NewRole("join", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = server.auth.CreateRole(ctx, joinRole)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		authPref  types.AuthPreference
+		role      string
+		testError func(t *testing.T, err error)
+	}{
+		{
+			name:     "MFA cluster auth, MFA role",
+			authPref: mfaAuthPref,
+			role:     joinMFARole.GetName(),
+			testError: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:     "MFA cluster auth, no MFA role",
+			authPref: mfaAuthPref,
+			role:     joinRole.GetName(),
+			testError: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:     "no MFA cluster auth, MFA role",
+			authPref: noMFAAuthPref,
+			role:     joinMFARole.GetName(),
+			testError: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name:     "no MFA cluster auth, no MFA role",
+			authPref: noMFAAuthPref,
+			role:     joinRole.GetName(),
+			testError: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessPoint.authPref = tt.authPref
+
+			// create SSH certificate
+			caSigner, err := ssh.NewSignerFromKey(userCAPriv)
+			require.NoError(t, err)
+			keygen := testauthority.New()
+			privateKey, err := native.GeneratePrivateKey()
+			require.NoError(t, err)
+
+			c, err := keygen.GenerateUserCert(services.UserCertParams{
+				CASigner:      caSigner,
+				PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+				Username:      username,
+				AllowedLogins: []string{username},
+				Traits: wrappers.Traits{
+					teleport.TraitInternalPrefix: []string{""},
+				},
+				Roles:             []string{tt.role},
+				CertificateFormat: constants.CertificateFormatStandard,
+			})
+			require.NoError(t, err)
+
+			cert, err := sshutils.ParseCertificate(c)
+			require.NoError(t, err)
+
+			err = ah.canLoginWithRBAC(cert, userCA, clusterName, node, username, teleport.SSHSessionJoinPrincipal)
+			tt.testError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/39602.

Note that the unit test had to be reworked a bit to call `IsMFARequired` instead of `CreateAuthenticateChallenge`, because in v14 `CreateAuthenticateChallengeRequest` doesn't have a `MFARequiredCheck` field. 

changelog: fix MFA checks not being prompted when joining a session