### PR TITLE
Ignore access list status in CompareResources.

### DIFF
--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -26,6 +26,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
 // IsEqual[T] will be used instead of cmp.Equal if a resource implements it.
@@ -44,6 +45,7 @@ func CompareResources[T any](resA, resB T) int {
 			cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
 			cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
 			cmpopts.IgnoreFields(types.UserSpecV2{}, "Status"),
+			cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"),
 			cmpopts.IgnoreUnexported(headerv1.Metadata{}),
 			cmpopts.EquateEmpty(),
 		)


### PR DESCRIPTION
CompareResources will now ignore the access list status field, which will ensure that the reconciler ignores it for the purposes of determining if an access list needs to be updated by the access list sync.

Fixes https://github.com/gravitational/teleport.e/issues/3785