### PR TITLE
Keep any TAG related local storage values on logout

### DIFF
--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -48,7 +48,9 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
 export const storageService = {
   clear() {
     Object.keys(window.localStorage).forEach(key => {
-      if (!KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT.includes(key)) {
+      const isAccessGraph = key.startsWith('tag_');
+
+      if (!isAccessGraph && !KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT.includes(key)) {
         window.localStorage.removeItem(key);
       }
     });


### PR DESCRIPTION
In TAG we set a few local storage values beginning with `tag_` and it's annoying that they get cleared on logout. This adds a check to avoid that, without having to add each TAG local storage key going forward to the `KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT`