### PR TITLE
port core CA ops to use revisions/atomics

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -375,7 +375,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	services := &Services{
-		Trust:                     cfg.Trust,
+		TrustInternal:             cfg.Trust,
 		PresenceInternal:          cfg.Presence,
 		Provisioner:               cfg.Provisioner,
 		Identity:                  cfg.Identity,
@@ -531,7 +531,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 }
 
 type Services struct {
-	services.Trust
+	services.TrustInternal
 	services.PresenceInternal
 	services.Provisioner
 	services.Identity
@@ -6414,50 +6414,36 @@ func mergeKeySets(a, b types.CAKeySet) types.CAKeySet {
 	return newKeySet
 }
 
-// addAdditionalTrustedKeysAtomic performs an atomic CompareAndSwap to update
+// addAdditionalTrustedKeysAtomic performs an atomic update to
 // the given CA with newKeys added to the AdditionalTrustedKeys
-func (a *Server) addAdditionalTrustedKeysAtomic(
-	ctx context.Context,
-	currentCA types.CertAuthority,
-	newKeys types.CAKeySet,
-	needsUpdate func(types.CertAuthority) (bool, error),
-) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return trace.Wrap(ctx.Err())
-		default:
+func (a *Server) addAdditionalTrustedKeysAtomic(ctx context.Context, ca types.CertAuthority, newKeys types.CAKeySet, needsUpdate func(types.CertAuthority) (bool, error)) error {
+	const maxIterations = 64
+
+	for i := 0; i < maxIterations; i++ {
+		if update, err := needsUpdate(ca); err != nil || !update {
+			return trace.Wrap(err)
 		}
-		updateRequired, err := needsUpdate(currentCA)
+
+		err := ca.SetAdditionalTrustedKeys(mergeKeySets(
+			ca.GetAdditionalTrustedKeys(),
+			newKeys,
+		))
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if !updateRequired {
-			return nil
-		}
 
-		newCA := currentCA.Clone()
-		currentKeySet := newCA.GetAdditionalTrustedKeys()
-		mergedKeySet := mergeKeySets(currentKeySet, newKeys)
-		if err := newCA.SetAdditionalTrustedKeys(mergedKeySet); err != nil {
+		if _, err := a.UpdateCertAuthority(ctx, ca); err == nil {
+			return nil
+		} else if !errors.Is(err, backend.ErrIncorrectRevision) {
 			return trace.Wrap(err)
 		}
 
-		err = a.CompareAndSwapCertAuthority(newCA, currentCA)
-		if err != nil && !trace.IsCompareFailed(err) {
-			return trace.Wrap(err)
-		}
-		if err == nil {
-			// success!
-			return nil
-		}
-		// else trace.IsCompareFailed(err) == true (CA was concurrently updated)
-
-		currentCA, err = a.Services.GetCertAuthority(ctx, currentCA.GetID(), true)
+		ca, err = a.Services.GetCertAuthority(ctx, ca.GetID(), true)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
+	return trace.Errorf("too many conflicts attempting to set additional trusted keys for ca %q of type %q", ca.GetClusterName(), ca.GetType())
 }
 
 // newKeySet generates a new sets of keys for a given CA type.

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3611,7 +3611,7 @@ func newTestServices(t *testing.T) Services {
 	require.NoError(t, err)
 
 	return Services{
-		Trust:                   local.NewCAService(bk),
+		TrustInternal:           local.NewCAService(bk),
 		PresenceInternal:        local.NewPresenceService(bk),
 		Provisioner:             local.NewProvisioningService(bk),
 		Identity:                local.NewTestIdentityService(bk),

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -123,7 +123,7 @@ type InitConfig struct {
 	OIDCConnectors []types.OIDCConnector
 
 	// Trust is a service that manages users and credentials
-	Trust services.Trust
+	Trust services.TrustInternal
 
 	// Presence service is a discovery and heartbeat tracker
 	Presence services.PresenceInternal
@@ -499,7 +499,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		return trace.Wrap(err, "applying migrations")
 	}
 	span.AddEvent("migrating db_client_authority")
-	err = migrateDBClientAuthority(ctx, asrv.Trust, cfg.ClusterName.GetClusterName())
+	err = migrateDBClientAuthority(ctx, asrv.Services, cfg.ClusterName.GetClusterName())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4093,7 +4093,7 @@ func TestEvents(t *testing.T) {
 		LocalConfigS:  testSrv.Auth(),
 		EventsS:       clt,
 		PresenceS:     testSrv.Auth(),
-		CAS:           clt,
+		CAS:           testSrv.Auth(),
 		ProvisioningS: clt,
 		Access:        clt,
 		UsersS:        clt,

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -51,7 +51,7 @@ type authServer interface {
 type ServiceConfig struct {
 	Authorizer authz.Authorizer
 	Cache      services.AuthorityGetter
-	Backend    services.Trust
+	Backend    services.TrustInternal
 	Logger     *logrus.Entry
 	AuthServer authServer
 }
@@ -61,7 +61,7 @@ type Service struct {
 	trustpb.UnimplementedTrustServiceServer
 	authorizer authz.Authorizer
 	cache      services.AuthorityGetter
-	backend    services.Trust
+	backend    services.TrustInternal
 	authServer authServer
 	logger     *logrus.Entry
 }
@@ -349,7 +349,7 @@ func (s *Service) RotateExternalCertAuthority(ctx context.Context, req *trustpb.
 
 	// use compare and swap to protect from concurrent updates
 	// by trusted cluster API
-	if err := s.backend.CompareAndSwapCertAuthority(updated, existing); err != nil {
+	if _, err := s.backend.UpdateCertAuthority(ctx, updated); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -653,7 +653,12 @@ func TestDeleteCertAuthority(t *testing.T) {
 				Domain: "unknown",
 			},
 			assertion: func(t *testing.T, err error) {
-				require.True(t, trace.IsNotFound(err))
+				// ca deletion doesn't generate not found errors. this is a quirk of
+				// the fact that deleting active and inactive CAs simultanesouly
+				// is difficult to do conditionally without introducing odd edge
+				// cases (e.g. having a delete fail while appearing to succeed if it
+				// races with a concurrent activation/deactivation).
+				require.NoError(t, err)
 			},
 		},
 		{

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -100,7 +100,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 		}
 		log.Debugf("Enabling existing Trusted Cluster relationship.")
 
-		if err := a.activateCertAuthority(trustedCluster); err != nil {
+		if err := a.activateCertAuthority(ctx, trustedCluster); err != nil {
 			if trace.IsNotFound(err) {
 				return nil, trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
 			}
@@ -116,7 +116,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 		}
 		log.Debugf("Disabling existing Trusted Cluster relationship.")
 
-		if err := a.deactivateCertAuthority(trustedCluster); err != nil {
+		if err := a.deactivateCertAuthority(ctx, trustedCluster); err != nil {
 			if trace.IsNotFound(err) {
 				return nil, trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
 			}
@@ -161,7 +161,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 			return nil, trace.Wrap(err)
 		}
 
-		if err := a.deactivateCertAuthority(trustedCluster); err != nil {
+		if err := a.deactivateCertAuthority(ctx, trustedCluster); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -221,13 +221,17 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 		return trace.BadParameter("trusted cluster %q is the name of this root cluster and cannot be removed.", name)
 	}
 
-	// Remove all CAs
-	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA, types.OpenSSHCA} {
-		if err := a.DeleteCertAuthority(ctx, types.CertAuthID{Type: caType, DomainName: name}); err != nil {
-			if !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-		}
+	// err on the safe side and delete all possible CA types.
+	var ids []types.CertAuthID
+	for _, caType := range types.CertAuthTypes {
+		ids = append(ids, types.CertAuthID{
+			Type:       caType,
+			DomainName: name,
+		})
+	}
+
+	if err := a.DeleteCertAuthorities(ctx, ids...); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if err := a.DeleteReverseTunnel(name); err != nil {
@@ -336,16 +340,12 @@ func (a *Server) addCertAuthorities(ctx context.Context, trustedCluster types.Tr
 			}
 			remoteCertAuthority.SetRoleMap(trustedCluster.GetRoleMap())
 		}
-
-		// we use create here instead of upsert to prevent people from wiping out
-		// their own ca if it has the same name as the remote ca
-		err := a.CreateCertAuthority(ctx, remoteCertAuthority)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
-	return nil
+	// we use create here instead of upsert to prevent people from wiping out
+	// their own ca if it has the same name as the remote ca
+	_, err := a.CreateCertAuthorities(ctx, remoteCAs...)
+	return trace.Wrap(err)
 }
 
 // DeleteRemoteCluster deletes remote cluster resource, all certificate authorities
@@ -353,35 +353,26 @@ func (a *Server) addCertAuthorities(ctx context.Context, trustedCluster types.Tr
 func (a *Server) DeleteRemoteCluster(ctx context.Context, clusterName string) error {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	_, err := a.GetRemoteCluster(ctx, clusterName)
-	if err != nil {
+	if _, err := a.GetRemoteCluster(ctx, clusterName); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// we only expect host CAs to be present for remote clusters, but it doesn't hurt
+	// to err on the side of paranoia and delete all CA types.
+	var ids []types.CertAuthID
+	for _, caType := range types.CertAuthTypes {
+		ids = append(ids, types.CertAuthID{
+			Type:       caType,
+			DomainName: clusterName,
+		})
+	}
+
 	// delete cert authorities associated with the cluster
-	err = a.DeleteCertAuthority(ctx, types.CertAuthID{
-		Type:       types.HostCA,
-		DomainName: clusterName,
-	})
-	if err != nil {
-		// this method could have succeeded on the first call,
-		// but then if the remote cluster resource could not be deleted
-		// it would be impossible to delete the cluster after then
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
+	if err := a.DeleteCertAuthorities(ctx, ids...); err != nil {
+		return trace.Wrap(err)
 	}
-	// there should be no User CA in trusted clusters on the main cluster side
-	// per standard automation but clean up just in case
-	err = a.DeleteCertAuthority(ctx, types.CertAuthID{
-		Type:       types.UserCA,
-		DomainName: clusterName,
-	})
-	if err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-	}
-	return a.Services.DeleteRemoteCluster(ctx, clusterName)
+
+	return trace.Wrap(a.Services.DeleteRemoteCluster(ctx, clusterName))
 }
 
 // GetRemoteCluster returns remote cluster by name
@@ -768,24 +759,32 @@ func (v *ValidateTrustedClusterResponseRaw) ToNative() (*ValidateTrustedClusterR
 
 // activateCertAuthority will activate both the user and host certificate
 // authority given in the services.TrustedCluster resource.
-func (a *Server) activateCertAuthority(t types.TrustedCluster) error {
-	err := a.ActivateCertAuthority(types.CertAuthID{Type: types.UserCA, DomainName: t.GetName()})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(a.ActivateCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: t.GetName()}))
+func (a *Server) activateCertAuthority(ctx context.Context, t types.TrustedCluster) error {
+	return trace.Wrap(a.ActivateCertAuthorities(ctx, []types.CertAuthID{
+		{
+			Type:       types.UserCA,
+			DomainName: t.GetName(),
+		},
+		{
+			Type:       types.HostCA,
+			DomainName: t.GetName(),
+		},
+	}...))
 }
 
 // deactivateCertAuthority will deactivate both the user and host certificate
 // authority given in the services.TrustedCluster resource.
-func (a *Server) deactivateCertAuthority(t types.TrustedCluster) error {
-	err := a.DeactivateCertAuthority(types.CertAuthID{Type: types.UserCA, DomainName: t.GetName()})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(a.DeactivateCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: t.GetName()}))
+func (a *Server) deactivateCertAuthority(ctx context.Context, t types.TrustedCluster) error {
+	return trace.Wrap(a.DeactivateCertAuthorities(ctx, []types.CertAuthID{
+		{
+			Type:       types.UserCA,
+			DomainName: t.GetName(),
+		},
+		{
+			Type:       types.HostCA,
+			DomainName: t.GetName(),
+		},
+	}...))
 }
 
 // createReverseTunnel will create a services.ReverseTunnel givenin the

--- a/lib/backend/memory/atomicwrite.go
+++ b/lib/backend/memory/atomicwrite.go
@@ -36,9 +36,6 @@ func (m *Memory) AtomicWrite(ctx context.Context, condacts []backend.Conditional
 
 	m.Lock()
 	defer m.Unlock()
-	if m.Mirror {
-		return "", trace.Errorf("atomic write not supported by mirror-mode memory backend")
-	}
 
 	m.removeExpired()
 

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -145,7 +145,7 @@ type Config struct {
 	PIDFile string
 
 	// Trust is a service that manages certificate authorities
-	Trust services.Trust
+	Trust services.TrustInternal
 
 	// Presence service is a discovery and heartbeat tracker
 	Presence services.PresenceInternal

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -20,6 +20,10 @@ package local
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -54,27 +58,50 @@ func (s *CA) DeleteAllCertAuthorities(caType types.CertAuthType) error {
 
 // CreateCertAuthority updates or inserts a new certificate authority
 func (s *CA) CreateCertAuthority(ctx context.Context, ca types.CertAuthority) error {
-	if err := services.ValidateCertAuthority(ca); err != nil {
-		return trace.Wrap(err)
-	}
-	value, err := services.MarshalCertAuthority(ca)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:     backend.Key(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
-		Value:   value,
-		Expires: ca.Expiry(),
+	_, err := s.CreateCertAuthorities(ctx, ca)
+	return trace.Wrap(err)
+}
+
+// CreateCertAuthorities creates multiple cert authorities atomically.
+func (s *CA) CreateCertAuthorities(ctx context.Context, cas ...types.CertAuthority) (revision string, err error) {
+	var condacts []backend.ConditionalAction
+	var clusterNames []string
+	for _, ca := range cas {
+		if !slices.Contains(clusterNames, ca.GetName()) {
+			clusterNames = append(clusterNames, ca.GetName())
+		}
+		if err := services.ValidateCertAuthority(ca); err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		item, err := caToItem(nil, ca)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		condacts = append(condacts, []backend.ConditionalAction{
+			{
+				Key:       activeCAKey(ca.GetID()),
+				Condition: backend.NotExists(),
+				Action:    backend.Put(item),
+			},
+			{
+				Key:       inactiveCAKey(ca.GetID()),
+				Condition: backend.Whatever(),
+				Action:    backend.Delete(),
+			},
+		}...)
 	}
 
-	_, err = s.Create(ctx, item)
+	rev, err := s.AtomicWrite(ctx, condacts)
 	if err != nil {
-		if trace.IsAlreadyExists(err) {
-			return trace.AlreadyExists("cluster %q already exists", ca.GetName())
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return "", trace.AlreadyExists("one or more CAs from cluster(s) %q already exist", strings.Join(clusterNames, ","))
 		}
-		return trace.Wrap(err)
+		return "", trace.Wrap(err)
 	}
-	return nil
+
+	return rev, nil
 }
 
 // UpsertCertAuthority updates or inserts a new certificate authority
@@ -84,26 +111,15 @@ func (s *CA) UpsertCertAuthority(ctx context.Context, ca types.CertAuthority) er
 	}
 
 	// try to skip writes that would have no effect
-	if existing, err := s.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       ca.GetType(),
-		DomainName: ca.GetClusterName(),
-	}, true); err == nil {
+	if existing, err := s.GetCertAuthority(ctx, ca.GetID(), true); err == nil {
 		if services.CertAuthoritiesEquivalent(existing, ca) {
 			return nil
 		}
 	}
 
-	rev := ca.GetRevision()
-	value, err := services.MarshalCertAuthority(ca)
+	item, err := caToItem(activeCAKey(ca.GetID()), ca)
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:      backend.Key(authoritiesPrefix, string(ca.GetType()), ca.GetName()),
-		Value:    value,
-		Expires:  ca.Expiry(),
-		ID:       ca.GetResourceID(),
-		Revision: rev,
 	}
 
 	_, err = s.Put(ctx, item)
@@ -111,6 +127,28 @@ func (s *CA) UpsertCertAuthority(ctx context.Context, ca types.CertAuthority) er
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// UpdateCertAuthority updates an existing cert authority if the revisions match.
+func (s *CA) UpdateCertAuthority(ctx context.Context, ca types.CertAuthority) (types.CertAuthority, error) {
+	if err := services.ValidateCertAuthority(ca); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item, err := caToItem(activeCAKey(ca.GetID()), ca)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	lease, err := s.ConditionalUpdate(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ca = ca.Clone()
+	ca.SetRevision(lease.Revision)
+	ca.SetResourceID(lease.ID)
+	return ca, nil
 }
 
 // CompareAndSwapCertAuthority updates the cert authority value
@@ -136,16 +174,9 @@ func (s *CA) CompareAndSwapCertAuthority(new, expected types.CertAuthority) erro
 		return trace.CompareFailed("cluster %v settings have been updated, try again", new.GetName())
 	}
 
-	rev := new.GetRevision()
-	newValue, err := services.MarshalCertAuthority(new)
+	newItem, err := caToItem(key, new)
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	newItem := backend.Item{
-		Key:      key,
-		Value:    newValue,
-		Expires:  new.Expiry(),
-		Revision: rev,
 	}
 
 	_, err = s.CompareAndSwap(context.TODO(), *actualItem, newItem)
@@ -160,48 +191,76 @@ func (s *CA) CompareAndSwapCertAuthority(new, expected types.CertAuthority) erro
 
 // DeleteCertAuthority deletes particular certificate authority
 func (s *CA) DeleteCertAuthority(ctx context.Context, id types.CertAuthID) error {
-	if err := id.Check(); err != nil {
-		return trace.Wrap(err)
-	}
-	// when removing a types.CertAuthority also remove any deactivated
-	// types.CertAuthority as well if they exist.
-	err := s.Delete(ctx, backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName))
-	if err != nil {
-		if !trace.IsNotFound(err) {
+	return s.DeleteCertAuthorities(ctx, id)
+}
+
+// DeleteCertAuthorities deletes multiple cert authorities atomically.
+func (s *CA) DeleteCertAuthorities(ctx context.Context, ids ...types.CertAuthID) error {
+	var condacts []backend.ConditionalAction
+	for _, id := range ids {
+		if err := id.Check(); err != nil {
 			return trace.Wrap(err)
 		}
+		for _, key := range [][]byte{activeCAKey(id), inactiveCAKey(id)} {
+			condacts = append(condacts, backend.ConditionalAction{
+				Key:       key,
+				Condition: backend.Whatever(),
+				Action:    backend.Delete(),
+			})
+		}
 	}
-	err = s.Delete(ctx, backend.Key(authoritiesPrefix, string(id.Type), id.DomainName))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+
+	_, err := s.AtomicWrite(ctx, condacts)
+	return trace.Wrap(err)
 }
 
 // ActivateCertAuthority moves a CertAuthority from the deactivated list to
 // the normal list.
 func (s *CA) ActivateCertAuthority(id types.CertAuthID) error {
-	item, err := s.Get(context.TODO(), backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName))
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return trace.BadParameter("can not activate cert authority %q which has not been deactivated", id.DomainName)
+	return s.ActivateCertAuthorities(context.TODO(), id)
+}
+
+// ActivateCertAuthorities activates multiple cert authorities atomically.
+func (s *CA) ActivateCertAuthorities(ctx context.Context, ids ...types.CertAuthID) error {
+	var condacts []backend.ConditionalAction
+	var domainNames []string
+	for _, id := range ids {
+		if err := id.Check(); err != nil {
+			return trace.Wrap(err)
 		}
-		return trace.Wrap(err)
+
+		if !slices.Contains(domainNames, id.DomainName) {
+			domainNames = append(domainNames, id.DomainName)
+		}
+
+		item, err := s.Get(ctx, inactiveCAKey(id))
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return trace.Errorf("can not activate cert authority %q of type %q (not a currently inactive ca)", id.DomainName, id.Type)
+			}
+			return trace.Wrap(err)
+		}
+
+		condacts = append(condacts, []backend.ConditionalAction{
+			{
+				Key:       inactiveCAKey(id),
+				Condition: backend.Revision(item.Revision),
+				Action:    backend.Delete(),
+			},
+			{
+				Key: activeCAKey(id),
+				// active CAs take priority over inactive CAs, so never overwrite an
+				// active CA with an inactive CA.
+				Condition: backend.NotExists(),
+				Action:    backend.Put(*item),
+			},
+		}...)
 	}
 
-	certAuthority, err := services.UnmarshalCertAuthority(
-		item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = s.UpsertCertAuthority(context.TODO(), certAuthority)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = s.Delete(context.TODO(), backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName))
-	if err != nil {
+	if _, err := s.AtomicWrite(ctx, condacts); err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return trace.Errorf("failed to activate one or more cert authorities for cluster(s) %q due to concurrent modification", strings.Join(domainNames, ","))
+		}
 		return trace.Wrap(err)
 	}
 
@@ -211,34 +270,50 @@ func (s *CA) ActivateCertAuthority(id types.CertAuthID) error {
 // DeactivateCertAuthority moves a CertAuthority from the normal list to
 // the deactivated list.
 func (s *CA) DeactivateCertAuthority(id types.CertAuthID) error {
-	certAuthority, err := s.GetCertAuthority(context.TODO(), id, true)
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return trace.NotFound("can not deactivate cert authority %q which does not exist", id.DomainName)
+	return s.DeactivateCertAuthorities(context.TODO(), id)
+}
+
+// DeactivateCertAuthorities deactivates multiple cert authorities atomically.
+func (s *CA) DeactivateCertAuthorities(ctx context.Context, ids ...types.CertAuthID) error {
+	var condacts []backend.ConditionalAction
+	var domainNames []string
+	for _, id := range ids {
+		if err := id.Check(); err != nil {
+			return trace.Wrap(err)
 		}
-		return trace.Wrap(err)
+
+		if !slices.Contains(domainNames, id.DomainName) {
+			domainNames = append(domainNames, id.DomainName)
+		}
+
+		item, err := s.Get(ctx, activeCAKey(id))
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return trace.Errorf("can not deactivate cert authority %q of type %q (not a currently active ca)", id.DomainName, id.Type)
+			}
+			return trace.Wrap(err)
+		}
+
+		condacts = append(condacts, []backend.ConditionalAction{
+			{
+				Key:       activeCAKey(id),
+				Condition: backend.Revision(item.Revision),
+				Action:    backend.Delete(),
+			},
+			{
+				Key: inactiveCAKey(id),
+				// active CAs always take priority over inactive CAs, so deactivating
+				// an active CA should overwrite any dangling inactive CAs.
+				Condition: backend.Whatever(),
+				Action:    backend.Put(*item),
+			},
+		}...)
 	}
 
-	err = s.DeleteCertAuthority(context.TODO(), id)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	rev := certAuthority.GetRevision()
-	value, err := services.MarshalCertAuthority(certAuthority)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:      backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName),
-		Value:    value,
-		Expires:  certAuthority.Expiry(),
-		ID:       certAuthority.GetResourceID(),
-		Revision: rev,
-	}
-
-	_, err = s.Put(context.TODO(), item)
-	if err != nil {
+	if _, err := s.AtomicWrite(ctx, condacts); err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return trace.Errorf("failed to deactivate one or more cert authorities for cluster(s) %q due to concurrent modification", strings.Join(domainNames, ","))
+		}
 		return trace.Wrap(err)
 	}
 
@@ -251,7 +326,7 @@ func (s *CA) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSign
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	item, err := s.Get(ctx, backend.Key(authoritiesPrefix, string(id.Type), id.DomainName))
+	item, err := s.Get(ctx, activeCAKey(id))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -297,10 +372,12 @@ func (s *CA) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, 
 	for i, item := range result.Items {
 		ca, err := services.UnmarshalCertAuthority(item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires), services.WithRevision(item.Revision))
 		if err != nil {
-			return nil, trace.Wrap(err)
+			slog.WarnContext(ctx, "Failed to unmarshal cert authority", "key", item.Key, "error", err)
+			continue
 		}
 		if err := services.ValidateCertAuthority(ca); err != nil {
-			return nil, trace.Wrap(err)
+			slog.WarnContext(ctx, "Failed to validate cert authority", "key", item.Key, "error", err)
+			continue
 		}
 		setSigningKeys(ca, loadSigningKeys)
 		cas[i] = ca
@@ -311,9 +388,13 @@ func (s *CA) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, 
 
 // UpdateUserCARoleMap updates the role map of the userCA of the specified existing cluster.
 func (s *CA) UpdateUserCARoleMap(ctx context.Context, name string, roleMap types.RoleMap, activated bool) error {
-	key := backend.Key(authoritiesPrefix, string(types.UserCA), name)
+	id := types.CertAuthID{
+		Type:       types.UserCA,
+		DomainName: name,
+	}
+	key := activeCAKey(id)
 	if !activated {
-		key = backend.Key(authoritiesPrefix, deactivatedPrefix, string(types.UserCA), name)
+		key = inactiveCAKey(id)
 	}
 
 	actualItem, err := s.Get(ctx, key)
@@ -327,17 +408,11 @@ func (s *CA) UpdateUserCARoleMap(ctx context.Context, name string, roleMap types
 
 	actual.SetRoleMap(roleMap)
 
-	rev := actual.GetRevision()
-	newValue, err := services.MarshalCertAuthority(actual)
+	newItem, err := caToItem(key, actual)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	newItem := backend.Item{
-		Key:      key,
-		Value:    newValue,
-		Expires:  actual.Expiry(),
-		Revision: rev,
-	}
+
 	_, err = s.CompareAndSwap(ctx, *actualItem, newItem)
 	if err != nil {
 		if trace.IsCompareFailed(err) {
@@ -346,6 +421,32 @@ func (s *CA) UpdateUserCARoleMap(ctx context.Context, name string, roleMap types
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// catToItem builds a backend.Item corresponding to the supplied CA.
+func caToItem(key []byte, ca types.CertAuthority) (backend.Item, error) {
+	value, err := services.MarshalCertAuthority(ca)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
+	return backend.Item{
+		Key:      key,
+		Value:    value,
+		Expires:  ca.Expiry(),
+		ID:       ca.GetResourceID(),
+		Revision: ca.GetRevision(),
+	}, nil
+}
+
+// activeCAKey builds the active key variant for the supplied ca id.
+func activeCAKey(id types.CertAuthID) []byte {
+	return backend.Key(authoritiesPrefix, string(id.Type), id.DomainName)
+}
+
+// inactiveCAKey builds the inactive key variant for the supplied ca id.
+func inactiveCAKey(id types.CertAuthID) []byte {
+	return backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName)
 }
 
 const (

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -181,7 +181,7 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 // using gRPC to guarantee consistency between local and remote services
 type ServicesTestSuite struct {
 	Access        services.Access
-	CAS           services.Trust
+	CAS           services.TrustInternal
 	PresenceS     services.Presence
 	ProvisioningS services.Provisioner
 	WebS          services.Identity
@@ -389,6 +389,72 @@ func (s *ServicesTestSuite) CertAuthCRUD(t *testing.T) {
 	out, err = s.CAS.GetCertAuthority(ctx, ca.GetID(), true)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(&newCA, out, cmpopts.EquateApproxTime(time.Second), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// test conditional update
+	ca = NewTestCA(types.UserCA, "update.example.com")
+	rev, err := s.CAS.CreateCertAuthorities(ctx, ca)
+	require.NoError(t, err)
+
+	newCA = *ca
+	rotation = types.Rotation{
+		State:       types.RotationStateInProgress,
+		CurrentID:   "id1",
+		GracePeriod: types.NewDuration(time.Hour),
+		Started:     clock.Now(),
+	}
+	newCA.SetRotation(rotation)
+
+	// verify that mismatched revision does not work
+	_, err = s.CAS.UpdateCertAuthority(ctx, &newCA)
+	require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+
+	// verify that revision returned by create causes update to succeed
+	newCA.SetRevision(rev)
+	_, err = s.CAS.UpdateCertAuthority(ctx, &newCA)
+	require.NoError(t, err)
+
+	out, err = s.CAS.GetCertAuthority(ctx, ca.GetID(), true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(&newCA, out, cmpopts.EquateApproxTime(time.Second), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+
+	// verify 'bulk' ca operations
+
+	clusterNames := []string{
+		"foo.example.com",
+		"bar.example.com",
+		"bin.example.com",
+		"baz.example.com",
+	}
+
+	cas = nil
+	for _, cn := range clusterNames {
+		cas = append(cas, NewTestCA(types.UserCA, cn))
+	}
+
+	rev, err = s.CAS.CreateCertAuthorities(ctx, cas...)
+	require.NoError(t, err)
+
+	// verify that all CAs were created and that they all have the expected revision
+	for _, original := range cas {
+		ca, err := s.CAS.GetCertAuthority(ctx, original.GetID(), true)
+		require.NoError(t, err)
+		require.Equal(t, rev, ca.GetRevision())
+		require.Empty(t, cmp.Diff(original, ca, cmpopts.EquateApproxTime(time.Second), cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision")))
+	}
+
+	// set up bulk delete
+	var ids []types.CertAuthID
+	for _, ca := range cas {
+		ids = append(ids, ca.GetID())
+	}
+
+	require.NoError(t, s.CAS.DeleteCertAuthorities(ctx, ids...))
+
+	// verify that bulk deletion succeeded
+	for _, ca := range cas {
+		_, err := s.CAS.GetCertAuthority(ctx, ca.GetID(), true)
+		require.True(t, trace.IsNotFound(err), "err: %v", err)
+	}
 }
 
 // NewServer creates a new server resource

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -74,3 +74,23 @@ type Trust interface {
 	// UpdateUserCARoleMap updates the role map of the userCA of the specified existing cluster.
 	UpdateUserCARoleMap(ctx context.Context, name string, roleMap types.RoleMap, activated bool) error
 }
+
+// TrustInternal extends the Trust interface with local-only methods used by the
+// auth server for some local operations.
+type TrustInternal interface {
+	Trust
+	// CreateCertAuthorities creates multiple cert authorities atomically.
+	CreateCertAuthorities(context.Context, ...types.CertAuthority) (revision string, err error)
+
+	// UpdateCertAuthority updates an existing cert authority if the revisions match.
+	UpdateCertAuthority(context.Context, types.CertAuthority) (types.CertAuthority, error)
+
+	// DeleteCertAuthorities deletes multiple cert authorities atomically.
+	DeleteCertAuthorities(context.Context, ...types.CertAuthID) error
+
+	// ActivateCertAuthorities activates multiple cert authorities atomically.
+	ActivateCertAuthorities(context.Context, ...types.CertAuthID) error
+
+	// DeactivateCertAuthorities deactivates multiple cert authorities atomically.
+	DeactivateCertAuthorities(context.Context, ...types.CertAuthID) error
+}


### PR DESCRIPTION
This PR ports various cert authority operations over to using revision and/or atomic writes.  The most notable change is the addition of bulk methods that allow us to create/delete/activate/deactivate multiple CAs atomically, ensuring that we can't end up with partially applied state-changes for groups of related CAs.

This PR addresses some low-hanging fruit, but there still needs to be additional work done in the higher level remote cluster/ca logic to improve its atomicity/resilience.