### PR TITLE
[v14] Ignore access list status in CompareResources.

### DIFF
--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -24,6 +24,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
 // CompareResources compares two resources by all significant fields.
@@ -33,6 +34,7 @@ func CompareResources[T any](resA, resB T) int {
 		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Revision"),
 		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
 		cmpopts.IgnoreFields(types.UserSpecV2{}, "Status"),
+		cmpopts.IgnoreFields(accesslist.AccessList{}, "Status"),
 		cmpopts.IgnoreUnexported(headerv1.Metadata{}),
 		cmpopts.EquateEmpty(),
 	)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/39832 to branch/v14.

Note: This backport was manual due to the differences in `compare.go`.