### PR TITLE
Access Graph AWS sync docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -493,6 +493,13 @@
               "forScopes": [
                 "enterprise"
               ]
+            },
+            {
+              "title": "Setup AWS sync with Access Graph",
+              "slug": "/access-controls/access-graph/aws-sync/",
+              "forScopes": [
+                "enterprise"
+              ]
             }
           ]
         },

--- a/docs/config.json
+++ b/docs/config.json
@@ -498,6 +498,7 @@
               "title": "Setup AWS sync with Access Graph",
               "slug": "/access-controls/access-graph/aws-sync/",
               "forScopes": [
+                "cloud",
                 "enterprise"
               ]
             }

--- a/docs/config.json
+++ b/docs/config.json
@@ -495,7 +495,7 @@
               ]
             },
             {
-              "title": "Setup AWS sync with Access Graph",
+              "title": "Analyze AWS IAM policies",
               "slug": "/access-controls/access-graph/aws-sync/",
               "forScopes": [
                 "cloud",

--- a/docs/pages/access-controls/access-graph/aws-sync.mdx
+++ b/docs/pages/access-controls/access-graph/aws-sync.mdx
@@ -1,9 +1,9 @@
 ---
-title: Discover AWS access patterns with Teleport Access Graph
+title: Discover AWS Access Patterns with Teleport Access Graph
 description: Describes how to import and visualize AWS accounts access patterns using Teleport Access Graph.
 ---
 
-The Teleport Access Graph offers insights into access patterns within
+Teleport Access Graph offers insights into access patterns within
 your AWS account. By scanning IAM permissions, users, groups, resources, and 
 identities, it provides a visual representation and aids in enhancing the 
 permission model within your AWS environment. This functionality enables you
@@ -24,9 +24,9 @@ to Teleport Enterprise customers.
 After logging in to the Teleport UI, go to the Management tab. If enabled, 
 Access Graph options can be found under the Permission Management section.
 
-## How AWS Sync Process works
+## How TAG discovers AWS access patterns
 
-Teleport Access Graph seamlessly synchronizes various AWS resources,
+Teleport Access Graph synchronizes various AWS resources,
 including IAM Policies, Groups, Users, User Groups, EC2 instances, 
 EKS clusters, and RDS databases. These resources are then visualized
 using the graph representation detailed in the
@@ -36,8 +36,7 @@ The importing process involves two primary steps:
 
 ### Polling Cloud APIs
 
-The Teleport Discovery Service plays a pivotal role in this process
-by continuously scanning the configured AWS accounts. 
+The Teleport Discovery Service continuously scans the configured AWS accounts. 
 At intervals of 15 minutes, it retrieves the following resources from your
 AWS account:
 
@@ -76,7 +75,7 @@ from Teleport Auth Service and Discovery Service.
 
 <Notice type="warning">
 
-If you have a Teleport Cloud cluster, please disregard
+If you have a Teleport Cloud cluster, you can disregard
 this step, as Teleport Cloud already operates a properly configured 
 Discovery Service within your cluster.
 </Notice>
@@ -88,7 +87,7 @@ that are set up with the `discovery_group` matching
 <Var name="access-graph-disc" />.
 
 
-```code
+```yaml
 discovery_service:
   enabled: true
   discovery_group: <Var name="access-graph-disc" />

--- a/docs/pages/access-controls/access-graph/aws-sync.mdx
+++ b/docs/pages/access-controls/access-graph/aws-sync.mdx
@@ -3,7 +3,7 @@ title: Discover AWS access patterns with Teleport Access Graph
 description: Describes how to import and visualize AWS accounts access patterns using Teleport Access Graph.
 ---
 
-The Teleport Access Graph offers invaluable insights into access patterns within
+The Teleport Access Graph offers insights into access patterns within
 your AWS account. By scanning IAM permissions, users, groups, resources, and 
 identities, it provides a visual representation and aids in enhancing the 
 permission model within your AWS environment. This functionality enables you
@@ -21,7 +21,7 @@ Teleport Access Graph is a feature of the [Teleport
 Policy](https://goteleport.com/platform/policy/) product that is only available
 to Teleport Enterprise customers.
 
-After logging into the Teleport UI, go to the Management tab. If enabled, 
+After logging in to the Teleport UI, go to the Management tab. If enabled, 
 Access Graph options can be found under the Permission Management section.
 
 ## How AWS Sync Process works
@@ -80,7 +80,7 @@ from Teleport Auth Service and Discovery Service. Check
 [Access Graph page](../access-graph.mdx) for details on
 how to setup Teleport Access Graph.
 
-## Step 1/2. Configure Discovery Service (On-Prem only)
+## Step 1/2. Configure Discovery Service (Self-hosted only)
 
 <Notice type="warning">
 
@@ -89,7 +89,7 @@ this step, as Teleport Cloud already operates a properly configured
 Discovery Service within your cluster.
 </Notice>
 
-To activate the Teleport Discovery Service, it's necessary to
+To activate the Teleport Discovery Service,
 add the provided snippet to your Auth Service configuration. 
 This service monitors dynamic `discovery_config` resources
 that are set up with the `discovery_group` matching 
@@ -117,10 +117,10 @@ navigate to the Management tab, and choose the Access Graph option within the
 Permission Management section.
 
 If both Teleport and Access Graph support AWS sync, you'll notice a new button
-adjacent to the Access Graph navigation bar labeled `Setup AWS sync with
+adjacent to the Access Graph navigation bar labeled `Set up AWS sync with
 Access Graph`.
 
-The setup process is intuitive, guiding you through the steps. You'll be
+You'll be
 prompted to create a new Teleport AWS integration if you haven't configured
 one already. Alternatively, you can opt for a previously established integration.
 
@@ -213,7 +213,7 @@ which Teleport should import resources. This selection solely pertains
 to regional resources and does not impact global resources such as S3
 Buckets, IAM Policies, or IAM Users.
 
-If you're operating an on-premises cluster, you'll additionally need to
+If you're operating a self-hosted cluster, you'll additionally need to
 provide input for the `discovery_group` configured during Step 1.
 
 

--- a/docs/pages/access-controls/access-graph/aws-sync.mdx
+++ b/docs/pages/access-controls/access-graph/aws-sync.mdx
@@ -1,0 +1,219 @@
+---
+title: Discover AWS access patterns with Teleport Access Graph
+description: Describes how to import and visualize AWS accounts access patterns using Teleport Access Graph.
+---
+
+The Teleport Access Graph offers invaluable insights into access patterns within
+your AWS account. By scanning IAM permissions, users, groups, resources, and 
+identities, it provides a visual representation and aids in enhancing the 
+permission model within your AWS environment. This functionality enables you
+to address queries such as:
+
+- What resources are accessible to AWS users and roles?
+- Which resources can be reached via identities associated with EC2 instances?
+- What AWS resources can Teleport users access when connecting to EC2 nodes?
+
+Utilizing the Access Graph to analyze IAM permissions within an AWS
+account necessitates the setup of the Teleport Access Graph (TAG)
+service, a Discovery Service, and integration with your AWS account.
+
+Teleport Access Graph is a feature of the [Teleport
+Policy](https://goteleport.com/platform/policy/) product that is only available
+to Teleport Enterprise customers.
+
+After logging into the Teleport UI, go to the Management tab. If enabled, 
+Access Graph options can be found under the Permission Management section.
+
+## How AWS Sync Process works
+
+Teleport Access Graph seamlessly synchronizes various AWS resources,
+including IAM Policies, Groups, Users, User Groups, EC2 instances, 
+EKS clusters, and RDS databases. These resources are then visualized
+using the graph representation detailed in the
+[Access Graph page](../access-graph.mdx).
+
+The importing process involves two primary steps:
+
+### Polling Cloud APIs
+
+The Teleport Discovery Service plays a pivotal role in this process
+by continuously scanning the configured AWS accounts. 
+At intervals of 15 minutes, it retrieves the following resources from your
+AWS account:
+
+- AWS Users
+- AWS Groups
+- AWS User Groups
+- AWS IAM Roles
+- AWS IAM Policies
+- AWS EKS Clusters
+- AWS RDS Databases
+- AWS S3 Buckets
+
+Once all the necessary resources are fetched, the Teleport Discovery
+Service pushes them to the Teleport Access Graph (TAG) service, 
+ensuring that the Access Graph remains updated with the latest
+information from your AWS environment.
+
+### Importing resources
+
+Teleport Access Graph delves into the IAM policies, identities,
+and resources retrieved from your AWS account, crafting a 
+graphical representation thereof.
+
+Throughout this procedure, Access Graph seamlessly aligns
+Teleport resources operating within the AWS account with
+their corresponding AWS IAM identities. This integration
+provides an enriched perspective, facilitating a deeper
+comprehension of users' AWS access patterns, especially
+when utilizing one of the nodes as a jump host.
+
+
+## Prerequisites
+
+- A running Teleport Enterprise cluster v14.3.9/v15.2.0 or later.
+- An updated `license.pem` with Teleport Policy enabled.
+- Docker version v(=docker.version=) or later.
+- A running Teleport Access Graph node v1.7.0 or later.
+- The node running the Access Graph service must be reachable
+from Teleport Auth Service and Discovery Service. Check 
+[Access Graph page](../access-graph.mdx) for details on
+how to setup Teleport Access Graph.
+
+## Step 1/2. Configure Discovery Service (On-Prem only)
+
+<Notice type="warning">
+
+If you have a Teleport Cloud cluster, please disregard
+this step, as Teleport Cloud already operates a properly configured 
+Discovery Service within your cluster.
+</Notice>
+
+To activate the Teleport Discovery Service, it's necessary to
+add the provided snippet to your Auth Service configuration. 
+This service monitors dynamic `discovery_config` resources
+that are set up with the `discovery_group` matching 
+<Var name="access-graph-disc" />.
+
+
+```code
+discovery_service:
+  enabled: true
+  discovery_group: <Var name="access-graph-disc" />
+
+```
+
+Notice that if you already operate a Discovery Service within your cluster,
+it's possible to reuse it as long as the following requirements are met:
+
+- On step 2, you match the `discovery_group` with the existing Discovery Service's
+`discovery_group`.
+- Access Graph service is reachable from the machine where Discovery Service runs.
+
+## Step 2/2. Set up Access Graph AWS Sync
+
+To initiate the setup wizard for configuring AWS Sync, access the Teleport UI,
+navigate to the Management tab, and choose the Access Graph option within the
+Permission Management section.
+
+If both Teleport and Access Graph support AWS sync, you'll notice a new button
+adjacent to the Access Graph navigation bar labeled `Setup AWS sync with
+Access Graph`.
+
+The setup process is intuitive, guiding you through the steps. You'll be
+prompted to create a new Teleport AWS integration if you haven't configured
+one already. Alternatively, you can opt for a previously established integration.
+
+Upon selecting or creating the integration, you'll be instructed to execute a
+bash script within your AWS Cloud Shell to configure the necessary permissions.
+
+<Details title="List of IAM Policies required for AWS Sync" closed>
+
+As part of the setup process, you'll be prompted to execute a bash script
+within your AWS Cloud Shell. This script's purpose is to generate an IAM
+Policy within your AWS account and link it to the AWS Role designated for
+your Teleport AWS Integration. The policy is designed with a set of read-only
+actions, enabling Teleport to access and retrieve information from resources
+within your AWS Account.
+
+The IAM policy includes the following directives:
+
+
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        // EC2 IAM
+        "ec2:DescribeInstances",
+        "ec2:DescribeImages",
+        "ec2:DescribeTags",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeKeyPairs",
+
+        // EKS IAM
+        "eks:ListClusters",
+        "eks:DescribeCluster",
+        "eks:ListAccessEntries",
+        "eks:ListAccessPolicies",
+        "eks:ListAssociatedAccessPolicies",
+
+        // RDS IAM
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBClusters",
+        "rds:ListTagsForResource",
+        "rds:DescribeDBProxies",
+
+        // DynamoDB IAM
+        "dynamodb:ListTables",
+        "dynamodb:DescribeTable",
+        // Redshift IAM
+        "redshift:DescribeClusters",
+        "redshift:Describe*",
+        // S3 IAM
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketPolicy",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        // IAM IAM
+        "iam:ListUsers",
+        "iam:GetUser",
+        "iam:ListRoles",
+        "iam:ListGroups",
+        "iam:ListPolicies",
+        "iam:ListGroupsForUser",
+        "iam:ListInstanceProfiles",
+        "iam:ListUserPolicies",
+        "iam:GetUserPolicy",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListGroupPolicies",
+        "iam:GetGroupPolicy",
+        "iam:ListAttachedGroupPolicies",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:GetRolePolicy"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+
+```
+</Details>
+
+
+Once the IAM Policy has been successfully linked to the IAM role
+utilized by Teleport, you'll be prompted to specify the regions from
+which Teleport should import resources. This selection solely pertains
+to regional resources and does not impact global resources such as S3
+Buckets, IAM Policies, or IAM Users.
+
+If you're operating an on-premises cluster, you'll additionally need to
+provide input for the `discovery_group` configured during Step 1.
+
+

--- a/docs/pages/access-controls/access-graph/aws-sync.mdx
+++ b/docs/pages/access-controls/access-graph/aws-sync.mdx
@@ -66,12 +66,11 @@ graphical representation thereof.
 
 - A running Teleport Enterprise cluster v14.3.9/v15.2.0 or later.
 - For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.
-- Docker version v(=docker.version=) or later.
-- A running Teleport Access Graph node v1.7.0 or later.
-- The node running the Access Graph service must be reachable
-from Teleport Auth Service and Discovery Service. Check 
-[Access Graph page](../access-graph.mdx) for details on
+- For self-hosted clusters, a running Teleport Access Graph node v1.17.0 or later. 
+Check [Access Graph page](../access-graph.mdx) for details on
 how to setup Teleport Access Graph.
+- The node running the Access Graph service must be reachable
+from Teleport Auth Service and Discovery Service. 
 
 ## Step 1/2. Configure Discovery Service (Self-hosted only)
 
@@ -110,11 +109,9 @@ navigate to the Management tab, and choose the Access Graph option within the
 Permission Management section.
 
 If both Teleport and Access Graph support AWS sync, you'll notice a new button
-adjacent to the Access Graph navigation bar labeled `Set up AWS sync with
-Access Graph`.
+adjacent to the Access Graph navigation bar labeled `Analyze AWS IAM policies with Access Graph`.
 
-You'll be
-prompted to create a new Teleport AWS integration if you haven't configured
+You'll be prompted to create a new Teleport AWS integration if you haven't configured
 one already. Alternatively, you can opt for a previously established integration.
 
 Upon selecting or creating the integration, you'll be instructed to execute a
@@ -122,15 +119,10 @@ bash script within your AWS Cloud Shell to configure the necessary permissions.
 
 <Details title="List of IAM Policies required for AWS Sync" closed>
 
-As part of the setup process, you'll be prompted to execute a bash script
-within your AWS Cloud Shell. This script's purpose is to generate an IAM
-Policy within your AWS account and link it to the AWS Role designated for
-your Teleport AWS Integration. The policy is designed with a set of read-only
-actions, enabling Teleport to access and retrieve information from resources
-within your AWS Account.
+The policy is designed with a set of read-only actions, enabling Teleport
+to access and retrieve information from resources within your AWS Account.
 
 The IAM policy includes the following directives:
-
 
 
 ```json
@@ -140,38 +132,34 @@ The IAM policy includes the following directives:
     {
       "Effect": "Allow",
       "Action": [
-        // EC2 IAM
         "ec2:DescribeInstances",
         "ec2:DescribeImages",
         "ec2:DescribeTags",
         "ec2:DescribeSnapshots",
         "ec2:DescribeKeyPairs",
 
-        // EKS IAM
         "eks:ListClusters",
         "eks:DescribeCluster",
         "eks:ListAccessEntries",
         "eks:ListAccessPolicies",
         "eks:ListAssociatedAccessPolicies",
 
-        // RDS IAM
         "rds:DescribeDBInstances",
         "rds:DescribeDBClusters",
         "rds:ListTagsForResource",
         "rds:DescribeDBProxies",
 
-        // DynamoDB IAM
         "dynamodb:ListTables",
         "dynamodb:DescribeTable",
-        // Redshift IAM
+
         "redshift:DescribeClusters",
         "redshift:Describe*",
-        // S3 IAM
+
         "s3:ListAllMyBuckets",
         "s3:GetBucketPolicy",
         "s3:ListBucket",
         "s3:GetBucketLocation",
-        // IAM IAM
+
         "iam:ListUsers",
         "iam:GetUser",
         "iam:ListRoles",
@@ -208,5 +196,4 @@ Buckets, IAM Policies, or IAM Users.
 
 If you're operating a self-hosted cluster, you'll additionally need to
 provide input for the `discovery_group` configured during Step 1.
-
 

--- a/docs/pages/access-controls/access-graph/aws-sync.mdx
+++ b/docs/pages/access-controls/access-graph/aws-sync.mdx
@@ -41,14 +41,14 @@ by continuously scanning the configured AWS accounts.
 At intervals of 15 minutes, it retrieves the following resources from your
 AWS account:
 
-- AWS Users
-- AWS Groups
-- AWS User Groups
-- AWS IAM Roles
-- AWS IAM Policies
-- AWS EKS Clusters
-- AWS RDS Databases
-- AWS S3 Buckets
+- Users
+- Groups
+- User Groups
+- IAM Roles
+- IAM Policies
+- EKS Clusters
+- RDS Databases
+- S3 Buckets
 
 Once all the necessary resources are fetched, the Teleport Discovery
 Service pushes them to the Teleport Access Graph (TAG) service, 
@@ -61,18 +61,11 @@ Teleport Access Graph delves into the IAM policies, identities,
 and resources retrieved from your AWS account, crafting a 
 graphical representation thereof.
 
-Throughout this procedure, Access Graph seamlessly aligns
-Teleport resources operating within the AWS account with
-their corresponding AWS IAM identities. This integration
-provides an enriched perspective, facilitating a deeper
-comprehension of users' AWS access patterns, especially
-when utilizing one of the nodes as a jump host.
-
 
 ## Prerequisites
 
 - A running Teleport Enterprise cluster v14.3.9/v15.2.0 or later.
-- An updated `license.pem` with Teleport Policy enabled.
+- For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.
 - Docker version v(=docker.version=) or later.
 - A running Teleport Access Graph node v1.7.0 or later.
 - The node running the Access Graph service must be reachable


### PR DESCRIPTION
This PR adds the required documentation to setup AWS Sync with Teleport Access Graph.

Closes https://github.com/gravitational/access-graph/issues/550