### PR TITLE
Updates `RUST_VERSION` and bumps IronRDP rev to latest, adding `RUST_MIN_STACK` to fix ARM builds

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,4 +13,12 @@ jobs:
     with:
       base-ref: ${{ github.event.pull_request.base.sha || 'master' }}
       allow-ghsas: 'GHSA-xwh9-gc39-5298'
-      allow-dependencies-licenses: 'pkg:cargo/curve25519-dalek-derive, pkg:cargo/ring, pkg:cargo/sspi, pkg:cargo/tokio-boring'
+      allow-dependencies-licenses: >-
+        pkg:cargo/curve25519-dalek-derive,
+        pkg:cargo/ring,
+        pkg:cargo/sspi,
+        pkg:cargo/tokio-boring,
+        pkg:cargo/asn1-rs,
+        pkg:cargo/asn1-rs-derive,
+        pkg:cargo/asn1-rs-impl,
+        pkg:cargo/der-parser

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -102,25 +102,25 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
  "synstructure",
 ]
 
 [[package]]
 name = "asn1-rs-impl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "ironrdp-error",
  "ironrdp-pdu",
@@ -1263,12 +1263,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-error",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-session"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-connector",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bitflags 2.5.0",
  "ironrdp-pdu",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tls"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=c944674ecbb0952f9e7ecb964a6c79cdca669a08#c944674ecbb0952f9e7ecb964a6c79cdca669a08"
+source = "git+https://github.com/Devolutions/IronRDP?rev=a1d8bb246e69af3252dcae38497f495100775c93#a1d8bb246e69af3252dcae38497f495100775c93"
 dependencies = [
  "bytes",
  "ironrdp-async",
@@ -2664,14 +2664,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "unicode-xid",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2989,12 +2988,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ codegen-units = 1
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08", features = ["rustls"]}
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "c944674ecbb0952f9e7ecb964a6c79cdca669a08" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }
+ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93", features = ["rustls"]}
+ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "a1d8bb246e69af3252dcae38497f495100775c93" }

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,7 +9,7 @@ GOLANGCI_LINT_VERSION ?= v1.57.1
 NODE_VERSION ?= 20.11.1
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.71.1
+RUST_VERSION ?= 1.77.0
 WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport

--- a/web/packages/teleport/README.md
+++ b/web/packages/teleport/README.md
@@ -10,3 +10,11 @@ then you can start your local development server:
 ```
 $ yarn run start --target=https://example.com:3080/web
 ```
+
+#### wasm-pack
+
+The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required to build the WebAssembly module.
+
+When calling `wasm-pack`, we set the environment variable `RUST_MIN_STACK=16777216`. This is necessary to avoid a `SIGSEGV` error when building the module on some systems.
+
+`16777216` was chosen based on [the suggestion in the rust compiler error message](https://github.com/rust-lang/rust/blob/10a7aa14fed9b528b74b0f098c4899c37c09a9c7/compiler/rustc_driver_impl/src/signal_handler.rs#L104-L106) to double the [`DEFAULT_STACK_SIZE`](https://github.com/rust-lang/rust/blob/10a7aa14fed9b528b74b0f098c4899c37c09a9c7/compiler/rustc_interface/src/util.rs#L52) value.

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "yarn build-wasm && vite",
-    "build-wasm": "wasm-pack build ./src/ironrdp --target web",
+    "build-wasm": "RUST_MIN_STACK=16777216 wasm-pack build ./src/ironrdp --target web",
     "build": "yarn build-wasm && vite build",
     "test": "npx jest",
     "tdd": "jest . --watch"


### PR DESCRIPTION
We've been stuck on an older `RUST_VERSION` for a while, and thus an older IronRDP hash (because later hashes require more-recently-stabilized rust features), because updating rust was causing a `SIGSEGV` error when building the wasm on ARM/linux.

Following a [recent update](https://github.com/rust-lang/rust/pull/122847) to the rust compiler output, this PR solves all of that:

- [x] https://github.com/gravitational/teleport.e/actions/runs/8453504091

Fixes https://github.com/gravitational/teleport/issues/39772

changelog: Update Rust to `1.77.0`, enable RDP font smoothing